### PR TITLE
Package realpath is always in a folder named as the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,36 +36,37 @@ See [store layout](docs/store-layout.md) for an explanation.
 -> - a symlink (or junction on Windows)
 
 ~/.pnpm-store
-   ├─ chalk/1.1.1/
-   |  ├─ index.js
-   |  └─ package.json
-   ├─ ansi-styles/2.1.0/
-   |  ├─ index.js
-   |  └─ package.json
-   └─ has-ansi/2.0.0/
-      ├─ index.js
-      └─ package.json
+   └─ registry.npmjs.org/
+      ├─ chalk/1.1.1/
+      |  ├─ index.js
+      |  └─ package.json
+      ├─ ansi-styles/2.1.0/
+      |  ├─ index.js
+      |  └─ package.json
+      └─ has-ansi/2.0.0/
+         ├─ index.js
+         └─ package.json
 .
 └─ node_modules/
-   ├─ .resolutions/
+   ├─ .registry.npmjs.org/
    |   ├─ chalk/1.1.1/node_modules/
    |   |  ├─ chalk
-   |   |  |  ├─ index.js     => ~/.pnpm-store/chalk/1.1.1/index.js
-   |   |  |  └─ package.json => ~/.pnpm-store/chalk/1.1.1/package.json
+   |   |  |  ├─ index.js     => ~/.pnpm-store/registry.npmjs.org/chalk/1.1.1/index.js
+   |   |  |  └─ package.json => ~/.pnpm-store/registry.npmjs.org/chalk/1.1.1/package.json
    |   |  ├─ ansi-styles/    -> ../../ansi-styles/2.1.0/node_modules/ansi-styles
    |   |  └─ has-ansi/       -> ../../has-ansi/2.0.0/node_modules/has-ansi
    |   |
    |   ├─ has-ansi/2.0.0/node_modules/
    |   |  └─ has-ansi
-   |   |     ├─ index.js     => ~/.pnpm-store/has-ansi/2.0.0/index.js
-   |   |     └─ package.js   => ~/.pnpm-store/has-ansi/2.0.0/package.json
+   |   |     ├─ index.js     => ~/.pnpm-store/registry.npmjs.org/has-ansi/2.0.0/index.js
+   |   |     └─ package.js   => ~/.pnpm-store/registry.npmjs.org/has-ansi/2.0.0/package.json
    |   |
    |   └─ ansi-styles/2.1.0/node_modules/
    |      └─ ansi-styles
-   |         ├─ index.js     => ~/.pnpm-store/ansi-styles/2.1.0/index.js
-   |         └─ package.js   => ~/.pnpm-store/ansi-styles/2.1.0/package.json
+   |         ├─ index.js     => ~/.pnpm-store/registry.npmjs.org/ansi-styles/2.1.0/index.js
+   |         └─ package.js   => ~/.pnpm-store/registry.npmjs.org/ansi-styles/2.1.0/package.json
    |
-   └─ chalk/                 -> ./.resolutions/chalk/1.1.1/node_modules/chalk
+   └─ chalk/                 -> ./.registry.npmjs.org/chalk/1.1.1/node_modules/chalk
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -48,27 +48,24 @@ See [store layout](docs/store-layout.md) for an explanation.
 .
 └─ node_modules/
    ├─ .resolutions/
-   |   ├─ chalk/1.1.1/
-   |   |  ├─ node_modules/
-   |   |  |  ├─ chalk        -> ../package
-   |   |  |  ├─ ansi-styles/ -> ../../ansi-styles/2.1.0/package
-   |   |  |  └─ has-ansi/    -> ../../has-ansi/2.0.0/package
-   |   |  └─ package
-   |   |     ├─ index.js     => ~/.pnpm-store/chalk/1.1.1/index.js
-   |   |     └─ package.json => ~/.pnpm-store/chalk/1.1.1/package.json
-   |   ├─ has-ansi/2.0.0/
-   |   |  ├─ node_modules/
-   |   |  |  └─ has-ansi     -> ../package
-   |   |  └─ package
+   |   ├─ chalk/1.1.1/node_modules/
+   |   |  ├─ chalk
+   |   |  |  ├─ index.js     => ~/.pnpm-store/chalk/1.1.1/index.js
+   |   |  |  └─ package.json => ~/.pnpm-store/chalk/1.1.1/package.json
+   |   |  ├─ ansi-styles/    -> ../../ansi-styles/2.1.0/node_modules/ansi-styles
+   |   |  └─ has-ansi/       -> ../../has-ansi/2.0.0/node_modules/has-ansi
+   |   |
+   |   ├─ has-ansi/2.0.0/node_modules/
+   |   |  └─ has-ansi
    |   |     ├─ index.js     => ~/.pnpm-store/has-ansi/2.0.0/index.js
    |   |     └─ package.js   => ~/.pnpm-store/has-ansi/2.0.0/package.json
-   |   └─ ansi-styles/2.1.0/
-   |      ├─ node_modules/
-   |      |  └─ ansi-styles  -> ../package
-   |      └─ package
+   |   |
+   |   └─ ansi-styles/2.1.0/node_modules/
+   |      └─ ansi-styles
    |         ├─ index.js     => ~/.pnpm-store/ansi-styles/2.1.0/index.js
    |         └─ package.js   => ~/.pnpm-store/ansi-styles/2.1.0/package.json
-   └─ chalk/                 -> ./.resolutions/chalk/1.1.1/package
+   |
+   └─ chalk/                 -> ./.resolutions/chalk/1.1.1/node_modules/chalk
 ```
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pnpm",
   "description": "Fast, disk space efficient npm installs",
-  "version": "0.51.3",
+  "version": "0.52.0",
   "author": "Rico Sta. Cruz <rico@ricostacruz.com>",
   "bin": {
     "pnpm": "lib/bin/pnpm.js"
@@ -47,6 +47,7 @@
     "load-json-file": "2.0.0",
     "lodash.clonedeep": "4.5.0",
     "lodash.memoize": "4.1.2",
+    "lodash.union": "4.6.0",
     "loud-rejection": "1.6.0",
     "mem": "1.1.0",
     "meow": "3.7.0",

--- a/src/api/checkCompatibility.ts
+++ b/src/api/checkCompatibility.ts
@@ -69,6 +69,9 @@ function check (pnpmVersion: string, storePath: string, modulesPath: string) {
   if (semver.lt(pnpmVersion, '0.51.0')) {
     throw new ModulesBreakingChangeError({ modulesPath, relatedPR: 576 })
   }
+  if (semver.lt(pnpmVersion, '0.52.0')) {
+    throw new ModulesBreakingChangeError({ modulesPath, relatedPR: 593 })
+  }
 }
 
 class UnexpectedStoreError extends PnpmError {

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -92,7 +92,7 @@ async function installInContext (installType: string, packagesToInstall: Depende
         cacheTTL: opts.cacheTTL
       }),
       fetchingFiles: Promise.resolve(),
-      nodeModulesStore: path.join(nodeModulesPath, '.resolutions'),
+      baseNodeModules: nodeModulesPath,
     }
     const installedPkgs = await installMultiple(
       installCtx,

--- a/src/install/linkPeers.ts
+++ b/src/install/linkPeers.ts
@@ -44,7 +44,7 @@ export default async function linkPeers (installs: InstalledPackages) {
       }
       return symlinkDir(
         groupedPkgs[peerName][version].hardlinkedLocation,
-        path.join(pkgData.hardlinkedLocation, '..', 'node_modules', peerName)
+        path.join(pkgData.modules, peerName)
       )
     }))
   }))

--- a/test/install.ts
+++ b/test/install.ts
@@ -685,7 +685,7 @@ test('peer dependency is linked', async t => {
   const project = prepare(t)
   await installPkgs(['ajv@4.10.4', 'ajv-keywords@1.5.0'], testDefaults())
 
-  t.ok(await exists(path.join('node_modules', '.resolutions', 'localhost+4873', 'ajv-keywords', '1.5.0', 'node_modules', 'ajv')), 'peer dependency is linked')
+  t.ok(await exists(path.join('node_modules', '.localhost+4873', 'ajv-keywords', '1.5.0', 'node_modules', 'ajv')), 'peer dependency is linked')
 })
 
 test('create a pnpm-debug.log file when the command fails', async function (t) {
@@ -771,7 +771,7 @@ test('shrinkwrap locks npm dependencies', async function (t) {
 
   await install(testDefaults({cacheTTL: 0}))
 
-  const pkg = project.requireModule('.resolutions/localhost+4873/pkg-with-1-dep/100.0.0/node_modules/dep-of-pkg-with-1-dep/package.json')
+  const pkg = project.requireModule('.localhost+4873/pkg-with-1-dep/100.0.0/node_modules/dep-of-pkg-with-1-dep/package.json')
 
   t.equal(pkg.version, '100.0.0', 'dependency specified in shrinkwrap.yaml is installed')
 })

--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -138,6 +138,11 @@ declare module 'lodash.clonedeep' {
   export = anything;
 }
 
+declare module 'lodash.union' {
+  const anything: any;
+  export = anything;
+}
+
 declare module 'find-up' {
   const anything: any;
   export = anything;
@@ -214,6 +219,11 @@ declare module '@zkochan/hosted-git-info' {
 }
 
 declare module 'global-bin-path' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'module' {
   const anything: any;
   export = anything;
 }


### PR DESCRIPTION
This is a node_modules structure change. It combines changes from v0.50, where the package real location was moved under `node_modules` and changes from v0.51 for avoiding circular symlinks. This should solve #118.

Also made the realpath of modules shorter for nicer callstacks. Instead of 

`node_modules/.resolutions/registry.npmjs.org/<package name>/<version>`

it will be

`node_modules/.registry.npmjs.org/<package name>/<version>`
