### PR TITLE
fix: too many open files

### DIFF
--- a/src/bin/pnpm.ts
+++ b/src/bin/pnpm.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Patch the global fs module here at the app level
+import '../fs/gracefulify'
+
 import loudRejection = require('loud-rejection')
 loudRejection()
 import rc = require('rc')

--- a/src/fs/gracefulify.ts
+++ b/src/fs/gracefulify.ts
@@ -1,0 +1,4 @@
+import fs = require('fs')
+import gfs = require('graceful-fs')
+
+gfs.gracefulify(fs)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Patch the global fs module here at the app level
+import './fs/gracefulify'
+
 export * from './api'
 export {PnpmOptions} from './types'
 export {PnpmError, PnpmErrorCode} from './errorTypes'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
     "src/fs/dirsum.ts",
     "src/fs/expandTilde.ts",
     "src/fs/getPkgDirs.ts",
+    "src/fs/gracefulify.ts",
     "src/fs/graphController.ts",
     "src/fs/modulesController.ts",
     "src/fs/readPkg.ts",

--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -268,3 +268,8 @@ declare module 'normalize-ssh' {
   function normalizeSsh (url: string): string;
   export = normalizeSsh;
 }
+
+declare module 'graceful-fs' {
+  const anything: any;
+  export = anything;
+}


### PR DESCRIPTION
`graceful-fs` solves the issue of EMFILE errors. However, the global fs module has to be patched.

This same solution is used by npm.

Close #609