### PR TITLE
refactor(shrinkwrap): don't set the type prop for tarball resolutions

### DIFF
--- a/src/install/fetchResolution.ts
+++ b/src/install/fetchResolution.ts
@@ -35,6 +35,9 @@ export default async function fetchResolution (
 ): Promise<void> {
   switch (resolution.type) {
 
+    case undefined:
+    // this case is for backward compatibility only
+    // pnpm doesn't set the type for tarball deps
     case 'tarball':
       const dist = {
         tarball: resolution.tarball,

--- a/src/resolve/git.ts
+++ b/src/resolve/git.ts
@@ -1,5 +1,12 @@
 import execa = require('execa')
-import {PackageSpec, HostedPackageSpec, ResolveOptions, ResolveResult, Resolution} from '.'
+import {
+  PackageSpec,
+  HostedPackageSpec,
+  ResolveOptions,
+  ResolveResult,
+  TarballResolution,
+  GitRepositoryResolution,
+} from '.'
 import hostedGitInfo = require('@zkochan/hosted-git-info')
 import logger from 'pnpm-logger'
 import path = require('path')
@@ -19,7 +26,7 @@ export default async function resolveGit (parsedSpec: PackageSpec, opts: Resolve
 
   if (!isGitHubHosted || isSsh(parsedSpec.spec)) {
     const commitId = await resolveRef(repo, ref)
-    const resolution: Resolution = {
+    const resolution: GitRepositoryResolution = {
       type: 'git-repo',
       repo,
       commitId,
@@ -53,8 +60,7 @@ export default async function resolveGit (parsedSpec: PackageSpec, opts: Resolve
     commitId = await resolveRef(repo, ref)
   }
 
-  const resolution: Resolution = {
-    type: 'tarball',
+  const resolution: TarballResolution = {
     tarball: `https://codeload.github.com/${ghSpec.owner}/${ghSpec.repo}/tar.gz/${commitId}`,
   }
   return {

--- a/src/resolve/index.ts
+++ b/src/resolve/index.ts
@@ -12,7 +12,9 @@ export {PackageMeta}
  * tarball hosted remotely
  */
 export type TarballResolution = {
-  type: 'tarball',
+  // tarball is left for backward compatibility
+  // type should not be set for tarball resolutions
+  type?: 'tarball',
   tarball: string,
   shasum?: string,
 }

--- a/src/resolve/local.ts
+++ b/src/resolve/local.ts
@@ -1,7 +1,13 @@
 import {resolve} from 'path'
 import * as path from 'path'
 import readPkg from '../fs/readPkg'
-import {PackageSpec, ResolveOptions, Resolution, ResolveResult} from '.'
+import {
+  PackageSpec,
+  ResolveOptions,
+  TarballResolution,
+  DirectoryResolution,
+  ResolveResult,
+} from '.'
 import fs = require('mz/fs')
 
 /**
@@ -11,8 +17,7 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
   const dependencyPath = resolve(opts.root, spec.spec)
 
   if (dependencyPath.slice(-4) === '.tgz' || dependencyPath.slice(-7) === '.tar.gz') {
-    const resolution: Resolution = {
-      type: 'tarball',
+    const resolution: TarballResolution = {
       tarball: `file:${dependencyPath}`,
     }
     return {
@@ -22,7 +27,7 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
   }
 
   const localPkg = await readPkg(dependencyPath)
-  const resolution: Resolution = {
+  const resolution: DirectoryResolution = {
     type: 'directory',
     root: dependencyPath,
   }

--- a/src/resolve/npm/index.ts
+++ b/src/resolve/npm/index.ts
@@ -42,7 +42,6 @@ export default async function resolveNpm (spec: PackageSpec, opts: ResolveOption
     const id = createPkgId(registryHost, correctPkg.name, correctPkg.version)
 
     const resolution: TarballResolution = {
-      type: 'tarball',
       shasum: correctPkg.dist.shasum,
       tarball: correctPkg.dist.tarball,
     }

--- a/src/resolve/tarball.ts
+++ b/src/resolve/tarball.ts
@@ -1,4 +1,4 @@
-import {PackageSpec, ResolveOptions, Resolution, ResolveResult} from '.'
+import {PackageSpec, ResolveOptions, TarballResolution, ResolveResult} from '.'
 import parseNpmTarballUrl from 'parse-npm-tarball-url'
 
 /**
@@ -15,8 +15,7 @@ import parseNpmTarballUrl from 'parse-npm-tarball-url'
  *     resolveTarball(pkg)
  */
 export default async function resolveTarball (spec: PackageSpec, opts: ResolveOptions): Promise<ResolveResult> {
-  const resolution: Resolution = {
-    type: 'tarball',
+  const resolution: TarballResolution = {
     tarball: spec.rawSpec,
   }
 

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -44,7 +44,6 @@ test('fail when shasum from shrinkwrap does not match with the actual one', asyn
         resolution: {
           shasum: '00000000000000000000000000000000000000000',
           tarball: 'http://localhost:4873/is-negative/-/is-negative-2.1.0.tgz',
-          type: 'tarball',
         },
       },
     },


### PR DESCRIPTION
Most of the resolutions are tarball files. Skipping the type property for these, decreases the size of `shrinkwrap.yaml` significantly.