### PR TITLE
Fix/shrinkwrap deps of deps should satisfy package.json semver

### DIFF
--- a/src/api/extendOptions.ts
+++ b/src/api/extendOptions.ts
@@ -22,7 +22,7 @@ const defaults = () => (<StrictPnpmOptions>{
   cwd: process.cwd(),
   nodeVersion: process.version,
   force: false,
-  depth: 0,
+  depth: -1, // respect everything that is in shrinkwrap.yaml by default
   engineStrict: false,
   metaCache: new Map(),
   networkConcurrency: 16,

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -148,7 +148,7 @@ async function installInContext (installType: string, packagesToInstall: Depende
     }
   }
 
-  if (pkgs && pkgs.length && newPkg) {
+  if (newPkg) {
     ctx.shrinkwrap.dependencies = ctx.shrinkwrap.dependencies || {}
 
     const deps = newPkg.dependencies || {}

--- a/src/fs/shrinkwrap.ts
+++ b/src/fs/shrinkwrap.ts
@@ -6,6 +6,7 @@ import loadYamlFile = require('load-yaml-file')
 import writeYamlFile = require('write-yaml-file')
 import values = require('lodash.values')
 import union = require('lodash.union')
+import rimraf = require('rimraf-then')
 
 const shrinkwrapLogger = logger('shrinkwrap')
 
@@ -67,7 +68,14 @@ export async function read (pkgPath: string, opts: {force: boolean}): Promise<Sh
 
 export function save (pkgPath: string, shrinkwrap: Shrinkwrap) {
   const shrinkwrapPath = path.join(pkgPath, SHRINKWRAP_FILENAME)
+
+  // empty shrinkwrap is not saved
+  if (Object.keys(shrinkwrap.dependencies).length === 0) {
+    return rimraf(shrinkwrapPath)
+  }
+
   const prunedShr = prune(shrinkwrap)
+
   return writeYamlFile(shrinkwrapPath, prunedShr, {
     sortKeys: true,
     lineWidth: 1000,

--- a/src/fs/shrinkwrap.ts
+++ b/src/fs/shrinkwrap.ts
@@ -10,7 +10,7 @@ import union = require('lodash.union')
 const shrinkwrapLogger = logger('shrinkwrap')
 
 const SHRINKWRAP_FILENAME = 'shrinkwrap.yaml'
-const SHRINKWRAP_VERSION = 0
+const SHRINKWRAP_VERSION = 1
 
 function getDefaultShrinkwrap () {
   return {

--- a/src/install/fetchResolution.ts
+++ b/src/install/fetchResolution.ts
@@ -35,7 +35,7 @@ export default async function fetchResolution (
 ): Promise<void> {
   switch (resolution.type) {
 
-    case 'tarball':
+    case undefined:
       const dist = {
         tarball: resolution.tarball,
         shasum: resolution.shasum,

--- a/src/resolve/git.ts
+++ b/src/resolve/git.ts
@@ -1,5 +1,12 @@
 import execa = require('execa')
-import {PackageSpec, HostedPackageSpec, ResolveOptions, ResolveResult, Resolution} from '.'
+import {
+  PackageSpec,
+  HostedPackageSpec,
+  ResolveOptions,
+  ResolveResult,
+  TarballResolution,
+  GitRepositoryResolution,
+} from '.'
 import hostedGitInfo = require('@zkochan/hosted-git-info')
 import logger from 'pnpm-logger'
 import path = require('path')
@@ -19,7 +26,7 @@ export default async function resolveGit (parsedSpec: PackageSpec, opts: Resolve
 
   if (!isGitHubHosted || isSsh(parsedSpec.spec)) {
     const commitId = await resolveRef(repo, ref)
-    const resolution: Resolution = {
+    const resolution: GitRepositoryResolution = {
       type: 'git-repo',
       repo,
       commitId,
@@ -53,8 +60,7 @@ export default async function resolveGit (parsedSpec: PackageSpec, opts: Resolve
     commitId = await resolveRef(repo, ref)
   }
 
-  const resolution: Resolution = {
-    type: 'tarball',
+  const resolution: TarballResolution = {
     tarball: `https://codeload.github.com/${ghSpec.owner}/${ghSpec.repo}/tar.gz/${commitId}`,
   }
   return {

--- a/src/resolve/index.ts
+++ b/src/resolve/index.ts
@@ -12,7 +12,7 @@ export {PackageMeta}
  * tarball hosted remotely
  */
 export type TarballResolution = {
-  type: 'tarball',
+  type?: undefined,
   tarball: string,
   shasum?: string,
 }

--- a/src/resolve/local.ts
+++ b/src/resolve/local.ts
@@ -1,7 +1,13 @@
 import {resolve} from 'path'
 import * as path from 'path'
 import readPkg from '../fs/readPkg'
-import {PackageSpec, ResolveOptions, Resolution, ResolveResult} from '.'
+import {
+  PackageSpec,
+  ResolveOptions,
+  TarballResolution,
+  DirectoryResolution,
+  ResolveResult,
+} from '.'
 import fs = require('mz/fs')
 
 /**
@@ -11,8 +17,7 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
   const dependencyPath = resolve(opts.root, spec.spec)
 
   if (dependencyPath.slice(-4) === '.tgz' || dependencyPath.slice(-7) === '.tar.gz') {
-    const resolution: Resolution = {
-      type: 'tarball',
+    const resolution: TarballResolution = {
       tarball: `file:${dependencyPath}`,
     }
     return {
@@ -22,7 +27,7 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
   }
 
   const localPkg = await readPkg(dependencyPath)
-  const resolution: Resolution = {
+  const resolution: DirectoryResolution = {
     type: 'directory',
     root: dependencyPath,
   }

--- a/src/resolve/npm/index.ts
+++ b/src/resolve/npm/index.ts
@@ -42,7 +42,6 @@ export default async function resolveNpm (spec: PackageSpec, opts: ResolveOption
     const id = createPkgId(registryHost, correctPkg.name, correctPkg.version)
 
     const resolution: TarballResolution = {
-      type: 'tarball',
       shasum: correctPkg.dist.shasum,
       tarball: correctPkg.dist.tarball,
     }

--- a/src/resolve/tarball.ts
+++ b/src/resolve/tarball.ts
@@ -1,4 +1,4 @@
-import {PackageSpec, ResolveOptions, Resolution, ResolveResult} from '.'
+import {PackageSpec, ResolveOptions, TarballResolution, ResolveResult} from '.'
 import parseNpmTarballUrl from 'parse-npm-tarball-url'
 
 /**
@@ -15,8 +15,7 @@ import parseNpmTarballUrl from 'parse-npm-tarball-url'
  *     resolveTarball(pkg)
  */
 export default async function resolveTarball (spec: PackageSpec, opts: ResolveOptions): Promise<ResolveResult> {
-  const resolution: Resolution = {
-    type: 'tarball',
+  const resolution: TarballResolution = {
     tarball: spec.rawSpec,
   }
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -2,8 +2,14 @@ import {ignoreCache as readPkg} from './fs/readPkg'
 import writePkg = require('write-pkg')
 import {DependenciesType} from './getSaveType'
 import {InstalledPackage} from './install/installMultiple'
+import {Package} from './types'
 
-export default async function save (pkgJsonPath: string, installedPackages: InstalledPackage[], saveType: DependenciesType, useExactVersion: boolean) {
+export default async function save (
+  pkgJsonPath: string,
+  installedPackages: InstalledPackage[],
+  saveType: DependenciesType,
+  useExactVersion: boolean
+): Promise<Package> {
   // Read the latest version of package.json to avoid accidental overwriting
   const packageJson = await readPkg(pkgJsonPath)
   packageJson[saveType] = packageJson[saveType] || {}
@@ -12,5 +18,6 @@ export default async function save (pkgJsonPath: string, installedPackages: Inst
     packageJson[saveType][dependency.pkg.name] = semverCharacter + dependency.pkg.version
   })
 
-  return writePkg(pkgJsonPath, packageJson)
+  await writePkg(pkgJsonPath, packageJson)
+  return packageJson
 }

--- a/test/cache.ts
+++ b/test/cache.ts
@@ -10,18 +10,17 @@ const test = promisifyTape(tape)
 test('should fail to update when requests are cached', async function (t) {
   const project = prepare(t)
 
-  const latest = 'stable'
   const metaCache = new Map()
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', latest)
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
 
-  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true, tag: latest, metaCache}))
+  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true, metaCache}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', latest)
+  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', 'latest')
 
-  await install(testDefaults({depth: 1, tag: latest, metaCache}))
+  await install(testDefaults({depth: 1, metaCache}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 })
@@ -29,17 +28,15 @@ test('should fail to update when requests are cached', async function (t) {
 test('should not cache when cache is not used', async function (t) {
   const project = prepare(t)
 
-  const latest = 'stable'
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', latest)
-
-  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true, tag: latest}))
+  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', latest)
+  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', 'latest')
 
-  await install(testDefaults({depth: 1, tag: latest}))
+  await install(testDefaults({depth: 1}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.1.0')
 })

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -22,17 +22,15 @@ test('return error status code when underlying command fails', t => {
 test('update', async function (t) {
   const project = prepare(t)
 
-  const latest = 'stable'
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', latest)
-
-  await execPnpm('install', 'pkg-with-1-dep', '-S', '--tag', latest, '--cache-ttl', '0')
+  await execPnpm('install', 'pkg-with-1-dep', '-S')
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', latest)
+  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', 'latest')
 
-  await execPnpm('update', '--depth', '1', '--tag', latest)
+  await execPnpm('update', '--depth', '1')
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.1.0')
 })

--- a/test/install.ts
+++ b/test/install.ts
@@ -759,11 +759,9 @@ test('building native addons', async function (t) {
 test('should update subdep on second install', async function (t) {
   const project = prepare(t)
 
-  const latest = 'stable'
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', latest)
-
-  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true, tag: latest}))
+  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 
@@ -771,9 +769,9 @@ test('should update subdep on second install', async function (t) {
 
   t.ok(shr.packages['localhost+4873/dep-of-pkg-with-1-dep/100.0.0'], 'shrinkwrap has resolution for package')
 
-  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', latest)
+  await addDistTag('dep-of-pkg-with-1-dep', '100.1.0', 'latest')
 
-  await install(testDefaults({depth: 1, tag: latest}))
+  await install(testDefaults({depth: 1}))
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.1.0')
 

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -45,7 +45,6 @@ test('fail when shasum from shrinkwrap does not match with the actual one', asyn
         resolution: {
           shasum: '00000000000000000000000000000000000000000',
           tarball: 'http://localhost:4873/is-negative/-/is-negative-2.1.0.tgz',
-          type: 'tarball',
         },
       },
     },

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -9,15 +9,15 @@ const test = promisifyTape(tape)
 test('shrinkwrap file has correct format', async t => {
   const project = prepare(t)
 
-  await installPkgs(['pkg-with-1-dep'], testDefaults())
+  await installPkgs(['pkg-with-1-dep'], testDefaults({save: true}))
 
   const shr = await project.loadShrinkwrap()
   const id = 'localhost+4873/pkg-with-1-dep/100.0.0'
 
-  t.equal(shr.version, 0, 'correct shrinkwrap version')
+  t.equal(shr.version, 1, 'correct shrinkwrap version')
 
   t.ok(shr.dependencies, 'has dependencies field')
-  t.equal(shr.dependencies['pkg-with-1-dep'], id, 'has dependency resolved')
+  t.equal(shr.dependencies['pkg-with-1-dep@^100.0.0'], id, 'has dependency resolved')
 
   t.ok(shr.packages, 'has packages field')
   t.ok(shr.packages[id], `has resolution for ${id}`)
@@ -35,9 +35,9 @@ test('fail when shasum from shrinkwrap does not match with the actual one', asyn
   })
 
   await writeYamlFile('shrinkwrap.yaml', {
-    version: 0,
+    version: 1,
     dependencies: {
-      'is-negative': 'localhost+4873/is-negative/2.1.0',
+      'is-negative@2.1.0': 'localhost+4873/is-negative/2.1.0',
     },
     packages: {
       'localhost+4873/is-negative/2.1.0': {
@@ -71,4 +71,8 @@ test("shrinkwrap doesn't lock subdependencies that don't satisfy the new specs",
     project.requireModule('.localhost+4873/react-datetime/1.3.0/node_modules/react-onclickoutside/package.json').version,
     '0.3.4',
     'react-datetime@1.3.0 has react-onclickoutside@0.3.4 in its node_modules')
+
+  const shr = await project.loadShrinkwrap()
+
+  t.equal(Object.keys(shr.dependencies).length, 1, 'resolutions not duplicated')
 })

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -57,3 +57,18 @@ test('fail when shasum from shrinkwrap does not match with the actual one', asyn
     t.ok(err.message.indexOf('Incorrect shasum') !== -1, 'failed with expected error')
   }
 })
+
+test("shrinkwrap doesn't lock subdependencies that don't satisfy the new specs", async t => {
+  const project = prepare(t)
+
+  // dependends on react-onclickoutside@5.9.0
+  await installPkgs(['react-datetime@2.8.8'], testDefaults({save: true}))
+
+  // dependends on react-onclickoutside@0.3.4
+  await installPkgs(['react-datetime@1.3.0'], testDefaults({save: true}))
+
+  t.equal(
+    project.requireModule('.localhost+4873/react-datetime/1.3.0/node_modules/react-onclickoutside/package.json').version,
+    '0.3.4',
+    'react-datetime@1.3.0 has react-onclickoutside@0.3.4 in its node_modules')
+})

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -85,6 +85,28 @@ test('shrinkwrap not created when no deps in package.json', async t => {
   t.ok(!await project.loadShrinkwrap(), 'shrinkwrap file not created')
 })
 
+test('shrinkwrap removed when no deps in package.json', async t => {
+  const project = prepare(t)
+
+  await writeYamlFile('shrinkwrap.yaml', {
+    version: 1,
+    dependencies: {
+      'is-negative@2.1.0': 'localhost+4873/is-negative/2.1.0',
+    },
+    packages: {
+      'localhost+4873/is-negative/2.1.0': {
+        resolution: {
+          tarball: 'http://localhost:4873/is-negative/-/is-negative-2.1.0.tgz',
+        },
+      },
+    },
+  })
+
+  await install(testDefaults())
+
+  t.ok(!await project.loadShrinkwrap(), 'shrinkwrap file removed')
+})
+
 test('respects shrinkwrap.yaml for top dependencies', async t => {
   const project = prepare(t)
 

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -1,6 +1,7 @@
 import tape = require('tape')
 import promisifyTape from 'tape-promise'
 import writeYamlFile = require('write-yaml-file')
+import exists = require('path-exists')
 import {prepare, testDefaults} from './utils'
 import {installPkgs, install} from '../src'
 
@@ -75,4 +76,12 @@ test("shrinkwrap doesn't lock subdependencies that don't satisfy the new specs",
   const shr = await project.loadShrinkwrap()
 
   t.equal(Object.keys(shr.dependencies).length, 1, 'resolutions not duplicated')
+})
+
+test('shrinkwrap not created when no deps in package.json', async t => {
+  const project = prepare(t)
+
+  await installPkgs(['pkg-with-1-dep'], testDefaults({save: false}))
+
+  t.ok(!await project.loadShrinkwrap(), 'shrinkwrap file not created')
 })

--- a/test/uninstall.ts
+++ b/test/uninstall.ts
@@ -69,8 +69,7 @@ test('uninstall package with dependencies and do not touch other deps', async fu
   t.deepEqual(pkgJson.dependencies, {'is-negative': '^2.1.0'}, 'camelcase-keys has been removed from dependencies')
 
   const shr = await project.loadShrinkwrap()
-  t.ok(!shr.dependencies['camelcase-keys'], 'camelcase-keys removed from shrinkwrap dependencies')
-  t.ok(!shr.packages['localhost+4873/camelcase-keys/3.0.0'], 'camelcase-keys removed from shrinkwrap packages')
+  t.ok(!shr, 'camelcase-keys removed from shrinkwrap dependencies')
 })
 
 test('uninstall package with its bin files', async function (t) {

--- a/test/utils/prepare.ts
+++ b/test/utils/prepare.ts
@@ -82,8 +82,13 @@ export default function prepare (t: Test, pkg?: Object) {
     isExecutable: function (pathToExe: string) {
       return isExecutable(t, path.join(modules, pathToExe))
     },
-    loadShrinkwrap () {
-      return loadYamlFile<any>('shrinkwrap.yaml') // tslint:disable-line
+    loadShrinkwrap: async () => {
+      try {
+        return await loadYamlFile<any>('shrinkwrap.yaml') // tslint:disable-line
+      } catch (err) {
+        if (err.code === 'ENOENT') return null
+        throw err
+      }
     },
   }
   return project


### PR DESCRIPTION
The previous format had no specs in the entry point of the shrinkwrap file:

```yaml
dependencies:
  react-datetime: localhost+4873/react-datetime/2.8.8
```

Hence if `react-datetime` was updated in package.json, it was reused from shrinkwrap.yaml anyway. The new version has the package name + the spec.

```yaml
dependencies:
  react-datetime@^2.8.8: localhost+4873/react-datetime/2.8.8
```

This is needed only in the entry point. Other resolutions are package/version specific, so their spec will never change. E.g.

```yaml
packages:
  localhost+4873/object-assign/3.0.0:
    resolution:
      shasum: 9bedd5ca0897949bca47e7ff408062d549f587f2
      tarball: 'http://localhost:4873/object-assign/-/object-assign-3.0.0.tgz'
      type: tarball
```

- [ ] create a test for https://github.com/pnpm/pnpm/issues/648#issuecomment-284172866