### PR TITLE
feat: proper resolving of peer dependencies

### DIFF
--- a/docs/vs-npm.md
+++ b/docs/vs-npm.md
@@ -42,7 +42,6 @@ have the possibility of prunning specific packages. pnpm's prune always removes 
 ## Limitations
 
 - You can't install from [shrinkwrap][] (yet).
-- Peer dependencies are a little trickier to deal with.
 - You can't publish npm modules with `bundleDependencies` managed by pnpm.
 
 Got an idea for workarounds for these issues? [Share them.](https://github.com/pnpm/pnpm/issues/new)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pnpm",
   "description": "Fast, disk space efficient npm installs",
-  "version": "0.63.0",
+  "version": "0.64.0",
   "author": "Rico Sta. Cruz <rico@ricostacruz.com>",
   "bin": {
     "pnpm": "lib/bin/pnpm.js"
@@ -98,7 +98,7 @@
     "ncp": "^2.0.0",
     "npm-run-all": "^4.0.1",
     "npm-scripts-info": "^0.3.6",
-    "pnpm-registry-mock": "^0.2.3",
+    "pnpm-registry-mock": "^0.5.0",
     "rimraf": "^2.5.4",
     "sepia": "^2.0.2",
     "tape": "^4.6.3",

--- a/src/api/checkCompatibility.ts
+++ b/src/api/checkCompatibility.ts
@@ -79,6 +79,14 @@ function check (pnpmVersion: string, storePath: string, modulesPath: string) {
       additionalInformation: 'Information about the node_modules structure is stored in a node_modules/.shrinkwrap.yaml file instead of a node_modules/.graph.yaml file'
     })
   }
+  if (semver.lt(pnpmVersion, '0.64.0')) {
+    throw new ModulesBreakingChangeError({
+      modulesPath,
+      relatedPR: 694,
+      relatedIssue: 678,
+      additionalInformation: 'Packages having peer dependencies are linked to different variations. The variations depend on the set of resolved peer dependencies'
+    })
+  }
 }
 
 class UnexpectedStoreError extends PnpmError {

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -217,7 +217,7 @@ async function install (
     )
     const shortId = pkgShortId(fetchedPkg.id, ctx.shrinkwrap.registry)
     ctx.shrinkwrap.packages[shortId] = toShrDependency(shortId, fetchedPkg.resolution, dependencies, ctx.shrinkwrap.registry)
-    dependencyIds = dependencies.map(dep => dep.id)
+    dependencyIds = dependencies.filter(dep => dep.isInstallable).map(dep => dep.id)
   }
 
   if (isInstallable && ctx.installationSequence.indexOf(fetchedPkg.id) === -1) {
@@ -321,6 +321,7 @@ function getNotBundledDeps (bundledDeps: string[], deps: Dependencies) {
 }
 
 function addInstalledPkg (installs: InstalledPackages, newPkg: InstalledPackage) {
+  if (!newPkg.isInstallable) return
   if (!installs[newPkg.id]) {
     installs[newPkg.id] = newPkg
     return

--- a/src/link/resolvePeers.ts
+++ b/src/link/resolvePeers.ts
@@ -1,39 +1,162 @@
-import path = require('path')
-import semver = require('semver')
-import {LinkedPackagesMap} from '.'
-import logger from 'pnpm-logger'
+import {LinkedPackagesMap, LinkedPackage} from '.'
+import {Dependencies, Package} from '../types'
 import R = require('ramda')
+import semver = require('semver')
+import logger from 'pnpm-logger'
+import path = require('path')
 
-type PackageVersions = {
-  [version: string]: string
+export type DependencyTreeNode = {
+  name: string,
+  hasBundledDependencies: boolean,
+  path: string,
+  modules: string,
+  peerModules?: string,
+  fetchingFiles: Promise<boolean>,
+  hardlinkedLocation: string,
+  children: string[],
+  resolvedPeers: string[],
+  depth: number,
+  id: string,
 }
 
-type InstalledPackageVersions = {
-  [pkgName: string]: PackageVersions
+export type DependencyTreeNodeMap = {
+  [nodeId: string]: DependencyTreeNode
 }
 
-export default async function linkPeers (pkgs: LinkedPackagesMap): Promise<LinkedPackagesMap> {
-  const groupedPkgs: InstalledPackageVersions = {}
+export default function (
+  pkgsMap: LinkedPackagesMap,
+  topPkgIds: string[]
+): DependencyTreeNodeMap {
+  const tree = createTree(pkgsMap, topPkgIds, [])
 
-  R.values(pkgs).forEach(pkgData => {
-    if (!pkgData.pkg.version) return
+  const pkgsByName = toPkgByName(R.props<TreeNode>(tree.rootNodeIds, tree.nodes))
+  const resolvedTreeMap = R.reduce(R.merge, {}, tree.rootNodeIds.map(rootNodeId => resolvePeersOfNode(rootNodeId, pkgsByName, tree.nodes)))
+  return resolvedTreeMap
+}
 
-    const pkgName = pkgData.pkg.name
-    groupedPkgs[pkgName] = groupedPkgs[pkgName] || {}
-    groupedPkgs[pkgName][pkgData.pkg.version] = pkgData.id
-  })
+type Tree = {
+  nodes: {[nodeId: string]: TreeNode},
+  rootNodeIds: string[],
+}
 
-  await Promise.all(R.values(pkgs).map(async pkgData => {
-    const peerDependencies = pkgData.pkg.peerDependencies || {}
-    await Promise.all(Object.keys(peerDependencies).map(async peerName => {
-      const version = semver.maxSatisfying(Object.keys(groupedPkgs[peerName] || {}), peerDependencies[peerName], true)
-      if (!version) {
-        logger.warn(`${pkgData.id} requires a peer of ${peerName}@${peerDependencies[peerName]} but none was installed.`)
-        return
+type TreeNode = {
+  nodeId: string,
+  children: string[],
+  pkg: LinkedPackage,
+  depth: number,
+}
+
+function createTree (
+  pkgsMap: LinkedPackagesMap,
+  pkgIds: string[],
+  keypath: string[]
+): Tree {
+  return R.props(pkgIds, pkgsMap)
+    .reduce((acc: Tree, pkg: LinkedPackage) => {
+      const node = createTreeNode(pkgsMap, pkg, keypath)
+      return {
+        rootNodeIds: R.append(node.nodeId, acc.rootNodeIds),
+        nodes: R.merge(acc.nodes, node.childNodes)
       }
-      pkgData.dependencies.push(groupedPkgs[peerName][version])
-    }))
-  }))
+    }, {rootNodeIds: [], nodes: {}})
+}
 
-  return pkgs
+function createTreeNode (
+  pkgsMap: LinkedPackagesMap,
+  pkg: LinkedPackage,
+  keypath: string[]
+): {
+  nodeId: string,
+  childNodes: {[nodeId: string]: TreeNode},
+} {
+  const nonCircularDeps = getNonCircularDependencies(pkg.id, pkg.dependencies, keypath)
+  const newKeypath = R.append(pkg.id, keypath)
+  const nodeId = newKeypath.join('/')
+  const tree = createTree(pkgsMap, nonCircularDeps, newKeypath)
+  return {
+    nodeId,
+    childNodes: R.merge(R.objOf(nodeId, {
+      pkg,
+      nodeId,
+      children: tree.rootNodeIds,
+      depth: keypath.length,
+    }), tree.nodes)
+  }
+}
+
+function getNonCircularDependencies (
+  parentId: string,
+  dependencyIds: string[],
+  keypath: string[]
+) {
+  const relations = R.aperture(2, keypath)
+  const isCircular = R.partialRight(R.contains, [relations])
+  return dependencyIds.filter(depId => !isCircular([parentId, depId]))
+}
+
+function resolvePeersOfNode (
+  nodeId: string,
+  parentPkgs: {[name: string]: TreeNode},
+  tree: {[nodeId: string]: TreeNode}
+): DependencyTreeNodeMap {
+  const node = tree[nodeId]
+  const newParentPkgs = Object.assign({}, parentPkgs,
+    {[node.pkg.name]: node},
+    toPkgByName(R.props<TreeNode>(node.children, tree))
+  )
+
+  const resolvedPeers = resolvePeers(node.pkg.peerDependencies, node.pkg.id, newParentPkgs)
+
+  const modules = path.join(node.pkg.localLocation, 'node_modules')
+  const peerModules = !R.isEmpty(node.pkg.peerDependencies)
+    ? path.join(node.pkg.localLocation, createPeersFolderName(R.props<TreeNode>(resolvedPeers, tree).map(node => node.pkg)), 'node_modules')
+    : undefined
+
+  const hardlinkedLocation = path.join(peerModules || modules, node.pkg.name)
+
+  return R.reduce(R.merge, R.objOf(nodeId, {
+    name: node.pkg.name,
+    hasBundledDependencies: node.pkg.hasBundledDependencies,
+    fetchingFiles: node.pkg.fetchingFiles,
+    path: node.pkg.path,
+    peerModules,
+    modules,
+    hardlinkedLocation,
+    resolvedPeers,
+    children: node.children,
+    depth: node.depth,
+    id: node.pkg.id,
+  }), node.children.map(child => resolvePeersOfNode(child, newParentPkgs, tree)))
+}
+
+function resolvePeers (
+  peerDependencies: Dependencies,
+  pkgId: string,
+  parentPkgs: {[name: string]: TreeNode},
+): string[] {
+  return R.toPairs(peerDependencies)
+    .map(R.apply((peerName: string, peerVersionRange: string) => {
+      const resolved = parentPkgs[peerName]
+
+      if (!resolved) {
+        logger.warn(`${pkgId} requires a peer of ${peerName}@${peerVersionRange} but none was installed.`)
+        return null
+      }
+
+      if (!semver.satisfies(resolved.pkg.version, peerVersionRange)) {
+        logger.warn(`${pkgId} requires a peer of ${peerName}@${peerVersionRange} but version ${resolved.pkg.version} was installed.`)
+      }
+
+      return resolved && resolved.nodeId
+    }))
+    .filter(Boolean) as string[]
+}
+
+function toPkgByName(pkgs: TreeNode[]): {[pkgName: string]: TreeNode} {
+  const toNameAndPkg = R.map((node: TreeNode): R.KeyValuePair<string, TreeNode> => [node.pkg.name, node])
+  return R.fromPairs(toNameAndPkg(pkgs))
+}
+
+function createPeersFolderName(peers: LinkedPackage[]) {
+  return peers.map(peer => `${peer.name.replace('/', '!')}@${peer.version}`).sort().join('+')
 }

--- a/test/install/peerDependencies.ts
+++ b/test/install/peerDependencies.ts
@@ -9,6 +9,7 @@ import {
 } from '../utils'
 
 const test = promisifyTape(tape)
+const NM = 'node_modules'
 
 test("don't fail when peer dependency is fetched from GitHub", t => {
   const project = prepare(t)
@@ -19,5 +20,66 @@ test('peer dependency is linked', async t => {
   const project = prepare(t)
   await installPkgs(['ajv@4.10.4', 'ajv-keywords@1.5.0'], testDefaults())
 
-  t.ok(await exists(path.join('node_modules', '.localhost+4873', 'ajv-keywords', '1.5.0', 'node_modules', 'ajv')), 'peer dependency is linked')
+  t.ok(await exists(path.join(NM, '.localhost+4873', 'ajv-keywords', '1.5.0', 'ajv@4.10.4', NM, 'ajv')), 'peer dependency is linked')
+})
+
+test('peer dependencies are linked', async t => {
+  const project = prepare(t)
+  await installPkgs(['abc-parent-with-ab', 'abc-grand-parent-with-c', 'peer-c@2.0.0'], testDefaults())
+
+  const pkgVariationsDir = path.join(NM, '.localhost+4873', 'abc', '1.0.0')
+  t.ok(await exists(path.join(pkgVariationsDir, NM, 'dep-of-pkg-with-1-dep')))
+
+  const pkgVariation1 = path.join(pkgVariationsDir, 'peer-a@1.0.0+peer-b@1.0.0+peer-c@1.0.0', NM)
+  t.ok(await exists(path.join(pkgVariation1, 'abc')))
+  t.ok(await exists(path.join(pkgVariation1, 'peer-a')))
+  t.ok(await exists(path.join(pkgVariation1, 'peer-b')))
+  t.ok(await exists(path.join(pkgVariation1, 'peer-c')))
+
+  const pkgVariation2 = path.join(pkgVariationsDir, 'peer-a@1.0.0+peer-b@1.0.0+peer-c@2.0.0', NM)
+  t.ok(await exists(path.join(pkgVariation2, 'abc')))
+  t.ok(await exists(path.join(pkgVariation2, 'peer-a')))
+  t.ok(await exists(path.join(pkgVariation2, 'peer-b')))
+  t.ok(await exists(path.join(pkgVariation2, 'peer-c')))
+})
+
+test('scoped peer dependency is linked', async t => {
+  const project = prepare(t)
+  await installPkgs(['@having/scoped-peer', '@scoped/peer'], testDefaults())
+
+  const pkgVariation = path.join(NM, '.localhost+4873', '@having', 'scoped-peer', '1.0.0', '@scoped!peer@1.0.0', NM)
+  t.ok(await exists(path.join(pkgVariation, '@having', 'scoped-peer')))
+  t.ok(await exists(path.join(pkgVariation, '@scoped', 'peer')))
+})
+
+test('peer bins are linked', async t => {
+  const project = prepare(t)
+
+  await installPkgs(['pkg-with-peer-having-bin', 'peer-with-bin'], testDefaults())
+
+  const pkgVariation = path.join('.localhost+4873', 'pkg-with-peer-having-bin', '1.0.0', 'peer-with-bin@1.0.0', NM)
+
+  await project.isExecutable(path.join(pkgVariation, 'pkg-with-peer-having-bin', NM, '.bin', 'peer-with-bin'))
+
+  await project.isExecutable(path.join(pkgVariation, 'pkg-with-peer-having-bin', NM, '.bin', 'hello-world-js-bin'))
+})
+
+test('run pre/postinstall scripts of each variations of packages with peer dependencies', async t => {
+  const project = prepare(t)
+  await installPkgs(['parent-of-pkg-with-events-and-peers', 'pkg-with-events-and-peers', 'peer-c@2.0.0'], testDefaults())
+
+  const pkgVariation1 = path.join(NM, '.localhost+4873', 'pkg-with-events-and-peers', '1.0.0', 'peer-c@1.0.0', NM)
+  t.ok(await exists(path.join(pkgVariation1, 'pkg-with-events-and-peers', 'generated-by-preinstall.js')))
+  t.ok(await exists(path.join(pkgVariation1, 'pkg-with-events-and-peers', 'generated-by-postinstall.js')))
+
+  const pkgVariation2 = path.join(NM, '.localhost+4873', 'pkg-with-events-and-peers', '1.0.0', 'peer-c@2.0.0', NM)
+  t.ok(await exists(path.join(pkgVariation2, 'pkg-with-events-and-peers', 'generated-by-preinstall.js')))
+  t.ok(await exists(path.join(pkgVariation2, 'pkg-with-events-and-peers', 'generated-by-postinstall.js')))
+})
+
+test('package that resolves its own peer dependency', async t => {
+  const project = prepare(t)
+  await installPkgs(['pkg-with-resolved-peer', 'peer-c@2.0.0'], testDefaults())
+
+  t.ok(await exists(path.join(NM, '.localhost+4873', 'pkg-with-resolved-peer', '1.0.0', 'peer-c@1.0.0', NM, 'pkg-with-resolved-peer')))
 })


### PR DESCRIPTION
BREAKING CHANGE: structure of node_modules changed

Close #678 

Example
```
.
└─ node_modules
   ├─ a             -> .registry.npmjs.org/b/1.0.0/node_modules/a
   ├─ b             -> .registry.npmjs.org/b/1.1.0/node_modules/b
   ├─ abc           -> .registry.npmjs.org/abc/1.0.0/a@1.0.0+b@1.1.0/node_modules/abc
   ├─ abc-carrier   -> .registry.npmjs.org/abc-carrier/1.0.0/node_modules/abc-carrier
   └─ .registry.npmjs.org
       ├─ a ...
       ├─ b ...
       ├─ c ...
       ├─ abc-carrier/1.0.0/node_modules
       |     ├─ abc-carrier   
       |     ├─ b             -> .registry.npmjs.org/b/1.1.0/node_modules/b
       |     └─ abc           -> .registry.npmjs.org/abc/1.0.0/a@1.0.0+b@1.0.0/node_modules/abc
       └─ abc/1.0.0
          ├─ node_modules (the non-peer dependencies of abc)
          |  └─ c   -> .registry.npmjs.org/c/1.0.0/node_modules/c
          ├─ a@1.0.0+b@1.0.0/node_modules
          |  ├─ abc   
          |  ├─ a     -> .registry.npmjs.org/a/1.0.0/node_modules/a
          |  └─ b     -> .registry.npmjs.org/b/1.0.0/node_modules/b
          └─ a@1.0.0+b@1.1.0/node_modules
             ├─ abc   
             ├─ a     -> .registry.npmjs.org/a/1.0.0/node_modules/a
             └─ b     -> .registry.npmjs.org/b/1.1.0/node_modules/b
```