### PR TITLE
fix: store status doesn't fail on skipped optional deps

### DIFF
--- a/src/api/getContext.ts
+++ b/src/api/getContext.ts
@@ -25,7 +25,7 @@ export type PnpmContext = {
   root: string,
   privateShrinkwrap: Shrinkwrap,
   shrinkwrap: Shrinkwrap,
-  isFirstInstallation: boolean,
+  skipped: string[],
 }
 
 export default async function getContext (opts: StrictPnpmOptions, installType?: 'named' | 'general'): Promise<PnpmContext> {
@@ -37,7 +37,6 @@ export default async function getContext (opts: StrictPnpmOptions, installType?:
 
   const modulesPath = path.join(root, 'node_modules')
   let modules = await readModules(modulesPath)
-  const isFirstInstallation: boolean = !modules
 
   if (modules) {
     try {
@@ -60,7 +59,7 @@ export default async function getContext (opts: StrictPnpmOptions, installType?:
     storePath,
     shrinkwrap,
     privateShrinkwrap: await readPrivateShrinkwrap(root, {force: opts.force, registry: opts.registry}),
-    isFirstInstallation,
+    skipped: modules && modules.skipped || [],
   }
 
   await mkdirp(ctx.storePath)

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -210,12 +210,14 @@ async function installInContext (
   const newShr = pruneShrinkwrap(ctx.shrinkwrap)
   await removeOrphanPkgs(ctx.privateShrinkwrap, newShr, ctx.root, ctx.storePath)
   await saveShrinkwrap(ctx.root, newShr)
-  if (ctx.isFirstInstallation) {
-    await saveModules(path.join(ctx.root, 'node_modules'), {
-      packageManager: `${pnpmPkgJson.name}@${pnpmPkgJson.version}`,
-      storePath: ctx.storePath,
-    })
-  }
+  await saveModules(path.join(ctx.root, 'node_modules'), {
+    packageManager: `${pnpmPkgJson.name}@${pnpmPkgJson.version}`,
+    storePath: ctx.storePath,
+    skipped: R.uniq(
+      R.concat(
+        ctx.skipped.filter(skippedPkgId => !installCtx.installed.has(skippedPkgId)),
+        Array.from(installCtx.installed).filter(pkgId => !installCtx.installs[pkgId]))),
+  })
 
   // postinstall hooks
   if (!(opts.ignoreScripts || !installCtx.installationSequence || !installCtx.installationSequence.length)) {

--- a/src/api/removeOrphanPkgs.ts
+++ b/src/api/removeOrphanPkgs.ts
@@ -16,7 +16,7 @@ export default async function removeOrphanPkgs (
   newShr: Shrinkwrap,
   root: string,
   storePath: string
-) {
+): Promise<string[]> {
   const oldPkgNames = Object.keys(oldShr.dependencies).map(npa).map((spec: PackageSpec) => spec.name)
   const newPkgNames = Object.keys(newShr.dependencies).map(npa).map((spec: PackageSpec) => spec.name)
 
@@ -54,6 +54,8 @@ export default async function removeOrphanPkgs (
   })
 
   await saveStore(storePath, store)
+
+  return notDependents
 }
 
 async function removeBins (uninstalledPkg: string, root: string) {

--- a/src/api/storeStatus.ts
+++ b/src/api/storeStatus.ts
@@ -13,6 +13,7 @@ export default async function (maybeOpts: PnpmOptions) {
 
   const pkgPaths = Object.keys(ctx.shrinkwrap.packages || {})
     .map(id => shortIdToFullId(id, ctx.shrinkwrap.registry))
+    .filter(pkgId => ctx.skipped.indexOf(pkgId) === -1)
     .map(pkgPath => path.join(ctx.storePath, pkgPath))
 
   return await pFilter(pkgPaths, async (pkgPath: string) => !await untouched(pkgPath))

--- a/src/fs/modulesController.ts
+++ b/src/fs/modulesController.ts
@@ -9,6 +9,7 @@ const modulesFileName = '.modules.yaml'
 export type Modules = {
   packageManager: string,
   storePath: string,
+  skipped: string[],
 }
 
 export async function read (modulesPath: string): Promise<Modules | null> {

--- a/test/storeStatus.ts
+++ b/test/storeStatus.ts
@@ -17,6 +17,17 @@ test('store status returns empty array when store was not modified', async funct
   t.equal(mutatedPkgs && mutatedPkgs.length, 0, 'no packages were modified')
 })
 
+test('store status does not fail on not installed optional dependencies', async function (t: tape.Test) {
+  const project = prepare(t)
+
+  const opts = testDefaults({saveOptional: true})
+  await installPkgs(['not-compatible-with-any-os'], opts)
+
+  const mutatedPkgs = await storeStatus(opts)
+
+  t.equal(mutatedPkgs && mutatedPkgs.length, 0, 'no packages were modified')
+})
+
 test('store status returns path to the modified package', async function (t: tape.Test) {
   const project = prepare(t)
 


### PR DESCRIPTION
A new property called `skipped` added to
`node_modules/.modules.yaml`. The property is an array of
package IDs, of those packages that are optional an were
skipped during installation.

Close #681