### PR TITLE
fix: peers are resolved similarly during named and general install

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ncp": "^2.0.0",
     "npm-run-all": "^4.0.1",
     "npm-scripts-info": "^0.3.6",
-    "pnpm-registry-mock": "^0.6.1",
+    "pnpm-registry-mock": "^0.7.0",
     "rimraf": "^2.5.4",
     "sepia": "^2.0.2",
     "tape": "^4.6.3",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -66,7 +66,7 @@ dependencies:
   pnpm-file-reporter@^0.0.1: 0.0.1
   pnpm-install-checks@^1.1.0: 1.1.0
   pnpm-logger@^0.3.0: 0.3.0
-  pnpm-registry-mock@^0.6.1: 0.6.1
+  pnpm-registry-mock@^0.7.0: 0.7.0
   proper-lockfile@^2.0.0: 2.0.1
   ramda@^0.23.0: 0.23.0
   read-pkg@^2.0.0: 2.0.0
@@ -1551,12 +1551,12 @@ packages:
     dependencies:
       bole: 3.0.2
     resolution: eaecea5a037f053a64c50bda7eda3cb87f5ed661
-  /pnpm-registry-mock/0.6.1:
+  /pnpm-registry-mock/0.7.0:
     dependencies:
       cpr: 2.0.2
       rimraf: 2.6.1
       verdaccio: 2.1.5
-    resolution: babaab1dbadc1662f43c0bab47f549db8c403b23
+    resolution: 81eae7eccb503f39896a34e9beb6f9e8a836b62b
   /prepend-http/1.0.4: d4f4562b0ce3696e41ac52d0e002e57a635dc6dc
   /preserve/0.2.0: 815ed1f6ebc65926f865b310c0713bcb3315ce4b
   /process-nextick-args/1.0.7: 150e20b756590ad3f91093f25a4f2ad8bff30ba3

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -119,17 +119,12 @@ export async function installPkgs (fuzzyDeps: string[] | Dependencies, maybeOpts
     ? packagesToInstall.map(spec => spec.name)
     : []
 
-  const currentSpecs = ctx.pkg ? specsToInstallFromPackage(ctx.pkg, {
-    production: opts.production,
-    prefix: opts.prefix,
-  }) : []
-
   return lock(
     ctx.storePath,
     () => installInContext(
       installType,
-      R.uniqBy(spec => spec.name, packagesToInstall.concat(currentSpecs)),
-      R.uniq(optionalDependencies.concat(R.keys(ctx.pkg && ctx.pkg.optionalDependencies))),
+      packagesToInstall,
+      optionalDependencies,
       packagesToInstall.map(spec => spec.name),
       ctx,
       installCtx,

--- a/src/api/uninstall.ts
+++ b/src/api/uninstall.ts
@@ -3,7 +3,6 @@ import path = require('path')
 import getContext, {PnpmContext} from './getContext'
 import getSaveType from '../getSaveType'
 import removeDeps from '../removeDeps'
-import binify from '../binify'
 import extendOptions from './extendOptions'
 import readPkg from '../fs/readPkg'
 import {PnpmOptions, StrictPnpmOptions, Package} from '../types'

--- a/src/fs/safeReadPkg.ts
+++ b/src/fs/safeReadPkg.ts
@@ -1,5 +1,5 @@
 import {Package} from '../types'
-import readPkg from './readPkg'
+import {ignoreCache as readPkg} from './readPkg'
 
 export default async function safeReadPkg (pkgPath: string): Promise<Package | null> {
   try {

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -37,6 +37,7 @@ export default async function (
     global: boolean,
     baseNodeModules: string,
     bin: string,
+    topParents: {name: string, version: string}[],
   }
 ): Promise<DependencyTreeNodeMap> {
   const pkgsToLinkMap = R.values(installedPkgs)
@@ -55,7 +56,7 @@ export default async function (
       return pkgsToLink
     }, {})
   const topPkgIds = topPkgs.filter(pkg => pkg.isInstallable).map(pkg => pkg.id)
-  const pkgsToLink = await resolvePeers(pkgsToLinkMap, topPkgIds)
+  const pkgsToLink = await resolvePeers(pkgsToLinkMap, topPkgIds, opts.topParents)
 
   const flatResolvedDeps =  R.values(pkgsToLink).sort((a, b) => a.depth - b.depth)
 

--- a/src/link/resolvePeers.ts
+++ b/src/link/resolvePeers.ts
@@ -147,6 +147,11 @@ function resolvePeers (
         logger.warn(`${pkgId} requires a peer of ${peerName}@${peerVersionRange} but version ${resolved.version} was installed.`)
       }
 
+      if (resolved.depth === 0) {
+        // if the resolved package is a top dependency then there is no need to link it in
+        return null
+      }
+
       return resolved && resolved.nodeId
     }))
     .filter(Boolean) as string[]
@@ -159,12 +164,17 @@ type ParentRefs = {
 type ParentRef = {
   version: string,
   nodeId: string,
+  depth: number,
 }
 
 function toPkgByName(pkgs: TreeNode[]): ParentRefs {
   const toNameAndPkg = R.map((node: TreeNode): R.KeyValuePair<string, ParentRef> => [
     node.pkg.name,
-    {version: node.pkg.version, nodeId: node.nodeId}
+    {
+      version: node.pkg.version,
+      nodeId: node.nodeId,
+      depth: node.depth,
+    }
   ])
   return R.fromPairs(toNameAndPkg(pkgs))
 }

--- a/src/removeTopDependency.ts
+++ b/src/removeTopDependency.ts
@@ -5,8 +5,8 @@ import safeReadPkg from './fs/safeReadPkg'
 
 export default async function removeTopDependency (dependencyName: string, modules: string) {
   return Promise.all([
-    rimraf(path.join(modules, dependencyName)),
     removeBins(dependencyName, modules),
+    rimraf(path.join(modules, dependencyName)),
   ])
 }
 


### PR DESCRIPTION
There is no need to always run a general installation for
creating a predictable `node_modules` structure. If peers are
resolved from top dependencies, the peers are not linked to
the dependent package. The dependent package can see such peers
w/o additional manipulations

Ref #724