### PR TITLE
	fix(linking): packages should not loose their peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Follow the [pnpm Twitter account](https://twitter.com/pnpmjs) for updates.
   * [Continuous Integration](docs/recipes/continuous-integration.md)
 * Advanced
   * [About the package store](docs/about-the-package-store.md)
+  * [How peers are resolved](docs/how-peers-are-resolved.md)
 
 ## Background
 

--- a/docs/how-peers-are-resolved.md
+++ b/docs/how-peers-are-resolved.md
@@ -9,40 +9,40 @@ in the same project. To make it possible, pnpm has to hard link `foo@1.0.0` as m
 
 Normally, if a package does not have peer dependencies, it is hard linked to a `node_modules` folder next to symlinks of its dependencies.
 
-```
+<pre>
 - .registry.npmjs.org / foo / 1.0.0 / node_modules
-  ( hard link to the specific foo package in the store, for instance foo@1.0.0 )
+  <sub>hard link to the specific foo package in the store</sub>
   - foo
-  ( dependencies of foo, symlinks to folders where these deps are resolved with their deps )
+  <sub>dependencies of foo, symlinks to folders where these deps are resolved with their deps</sub>
   - qux
   - plugh
-```
+</pre>
 
 However, if `foo` has peer dependencies, there cannot be one single set of dependencies for it, so
 we create different sets, for different peer deps resolutions:
 
-```
+<pre>
 - .registry.npmjs.org / foo / 1.0.0
 
-  ( regular dependencies of foo )
+  <sub>regular dependencies of foo</sub>
   - node_modules
     - qux
     - plugh
 
   - bar@1.0.0+baz@1.0.0 / node_modules
-    ( hard link  )
+    <sub>hard link</sub>
     - foo
-    ( symlinks to peer dependencies )
-    - bar ( version 1.0.0 )
-    - baz ( version 1.0.0 )
+    <sub>symlinks to peer dependencies</sub>
+    - bar <sub>v1.0.0</sub>
+    - baz <sub>v1.0.0</sub>
 
   - bar@1.0.0+baz@1.1.0 / node_modules
-    ( hard link  )
+    <sub>hard link</sub>
     - foo
-    ( symlinks to peer dependencies )
-    - bar ( version 1.0.0 )
-    - baz ( version 1.1.0 )
-```
+    <sub>symlinks to peer dependencies</sub>
+    - bar <sub>v1.0.0</sub>
+    - baz <sub>v1.1.0</sub>
+</pre>
 
 We create symlinks either to the `foo` that is inside `bar@1.0.0+bar@1.0.0/node_modules` or to the one in `bar@1.0.0+bar@1.1.0/node_modules`.
 As a consequence, the Node.js module resolver algorithm will find the correct peers.
@@ -51,27 +51,27 @@ As a consequence, the Node.js module resolver algorithm will find the correct pe
 This is done to make it easier to make predictable and fast named (`pnpm i foo`) and general (`pnpm i`) installations.
 So if the project dependends on `bar@1.0.0`, the dependencies from our example will be grouped like this:
 
-```
-- bar (version 1.0.0)
+<pre>
+- bar <sub>v1.0.0</sub>
 - .registry.npmjs.org / foo / 1.0.0
 
-  ( regular dependencies of foo )
+  <sub>regular dependencies of foo</sub>
   - node_modules
     - qux
     - plugh
 
   - baz@1.0.0 / node_modules
-    ( hard link  )
+    <sub>hard link</sub>
     - foo
-    ( symlinks to peer dependencies )
-    - baz ( version 1.0.0 )
+    <sub>symlinks to peer dependencies</sub>
+    - baz <sub>v1.0.0</sub>
 
   - baz@1.1.0 / node_modules
-    ( hard link  )
+    <sub>hard link</sub>
     - foo
-    ( symlinks to peer dependencies )
-    - baz ( version 1.1.0 )
-```
+    <sub>symlinks to peer dependencies</sub>
+    - baz <sub>v1.1.0</sub>
+</pre>
 
 *If a package has no peer dependencies but has dependencies with peers that are resolved higher in the tree*, then
 that transitive package can appear in the project with different sets of dependencies. For instance, there's package `a@1.0.0`
@@ -81,27 +81,27 @@ peers of `framework@1.0.0`, so it becomes dependent from the peers of `framework
 Here's how it will look like in `node_modules/.registry.npmjs.org`, in case if `a@1.0.0` will need to appear twice in the project's
 `node_modules`, once resolved with `plugin@1.0.0` and once with `plugin@1.1.0`.
 
-```
+<pre>
 - .registry.npmjs.org
   - a / 1.0.0
     - plugin@1.0.0 / node_modules
       - a
-      ( symlink to .registry.npmjs.org / framework / 1.0.0 / plugin@1.0.0 / node_modules / framework )
-      - framework ( version 1.0.0 but dependent on plugin@1.0.0 )
+      <sub>-> .registry.npmjs.org / framework / 1.0.0 / plugin@1.0.0 / node_modules / framework</sub>
+      - framework <sub>v1.0.0 but dependent on plugin@1.0.0</sub>
     - plugin@1.1.0 / node_modules
       - a
-      ( symlink to .registry.npmjs.org / framework / 1.0.0 / plugin@1.1.0 / node_modules / framework )
-      - framework ( version 1.0.0 but dependent on plugin@1.1.0 )
+      <sub>-> .registry.npmjs.org / framework / 1.0.0 / plugin@1.1.0 / node_modules / framework</sub>
+      - framework <sub>v1.0.0 but dependent on plugin@1.1.0</sub>
 
   - framework / 1.0.0
     - plugin@1.0.0 / node_modules
       - framework
-      - plugin ( version 1.0.0 )
+      - plugin <sub>v1.0.0</sub>
     - plugin@1.1.0 / node_modules
       - framework
-      - plugin ( version 1.1.0 )
+      - plugin <sub>v1.1.0</sub>
 
   - plugin
     - 1.0.0 / node_modules / plugin
     - 1.1.0 / node_modules / plugin
-```
+</pre>

--- a/docs/how-peers-are-resolved.md
+++ b/docs/how-peers-are-resolved.md
@@ -1,0 +1,107 @@
+# How peers are resolved
+
+One of the very great features of pnpm is that in one project, a specific version of a package will always have
+one set of dependencies. There is one exclusion from it though - packages with [peer dependencies](https://docs.npmjs.com/files/package.json#peerdependencies).
+
+Peer dependencies are resolved from dependencies installed higher in the dependency tree.
+That means if `foo@1.0.0` has two peers (`bar@^1` and `baz@^1`) then it might have different sets of dependencies
+in the same project. To make it possible, pnpm has to hard link `foo@1.0.0` as many times as many different dependency sets it has.
+
+Normally, if a package does not have peer dependencies, it is hard linked to a `node_modules` folder next to symlinks of its dependencies.
+
+```
+- .registry.npmjs.org / foo / 1.0.0 / node_modules
+  ( hard link to the specific foo package in the store, for instance foo@1.0.0 )
+  - foo
+  ( dependencies of foo, symlinks to folders where these deps are resolved with their deps )
+  - qux
+  - plugh
+```
+
+However, if `foo` has peer dependencies, there cannot be one single set of dependencies for it, so
+we create different sets, for different peer deps resolutions:
+
+```
+- .registry.npmjs.org / foo / 1.0.0
+
+  ( regular dependencies of foo )
+  - node_modules
+    - qux
+    - plugh
+
+  - bar@1.0.0+baz@1.0.0 / node_modules
+    ( hard link  )
+    - foo
+    ( symlinks to peer dependencies )
+    - bar ( version 1.0.0 )
+    - baz ( version 1.0.0 )
+
+  - bar@1.0.0+baz@1.1.0 / node_modules
+    ( hard link  )
+    - foo
+    ( symlinks to peer dependencies )
+    - bar ( version 1.0.0 )
+    - baz ( version 1.1.0 )
+```
+
+We create symlinks either to the `foo` that is inside `bar@1.0.0+bar@1.0.0/node_modules` or to the one in `bar@1.0.0+bar@1.1.0/node_modules`.
+As a consequence, the Node.js module resolver algorithm will find the correct peers.
+
+*If the resolved peer is a direct dependency of the project*, it is not grouped separately with the dependent package.
+This is done to make it easier to make predictable and fast named (`pnpm i foo`) and general (`pnpm i`) installations.
+So if the project dependends on `bar@1.0.0`, the dependencies from our example will be grouped like this:
+
+```
+- bar (version 1.0.0)
+- .registry.npmjs.org / foo / 1.0.0
+
+  ( regular dependencies of foo )
+  - node_modules
+    - qux
+    - plugh
+
+  - baz@1.0.0 / node_modules
+    ( hard link  )
+    - foo
+    ( symlinks to peer dependencies )
+    - baz ( version 1.0.0 )
+
+  - baz@1.1.0 / node_modules
+    ( hard link  )
+    - foo
+    ( symlinks to peer dependencies )
+    - baz ( version 1.1.0 )
+```
+
+*If a package has no peer dependencies but has dependencies with peers that are resolved higher in the tree*, then
+that transitive package can appear in the project with different sets of dependencies. For instance, there's package `a@1.0.0`
+with a single dependency `framework@1.0.0`. `framework@1.0.0` has a peer dependency `plugin@^1`. `a@1.0.0` will never resolve the
+peers of `framework@1.0.0`, so it becomes dependent from the peers of `framework@1.0.0` as well.
+
+Here's how it will look like in `node_modules/.registry.npmjs.org`, in case if `a@1.0.0` will need to appear twice in the project's
+`node_modules`, once resolved with `plugin@1.0.0` and once with `plugin@1.1.0`.
+
+```
+- .registry.npmjs.org
+  - a / 1.0.0
+    - plugin@1.0.0 / node_modules
+      - a
+      ( symlink to .registry.npmjs.org / framework / 1.0.0 / plugin@1.0.0 / node_modules / framework )
+      - framework ( version 1.0.0 but dependent on plugin@1.0.0 )
+    - plugin@1.1.0 / node_modules
+      - a
+      ( symlink to .registry.npmjs.org / framework / 1.0.0 / plugin@1.1.0 / node_modules / framework )
+      - framework ( version 1.0.0 but dependent on plugin@1.1.0 )
+
+  - framework / 1.0.0
+    - plugin@1.0.0 / node_modules
+      - framework
+      - plugin ( version 1.0.0 )
+    - plugin@1.1.0 / node_modules
+      - framework
+      - plugin ( version 1.1.0 )
+
+  - plugin
+    - 1.0.0 / node_modules / plugin
+    - 1.1.0 / node_modules / plugin
+```

--- a/docs/how-peers-are-resolved.md
+++ b/docs/how-peers-are-resolved.md
@@ -5,7 +5,23 @@ one set of dependencies. There is one exclusion from it though - packages with [
 
 Peer dependencies are resolved from dependencies installed higher in the dependency tree.
 That means if `foo@1.0.0` has two peers (`bar@^1` and `baz@^1`) then it might have different sets of dependencies
-in the same project. To make it possible, pnpm has to hard link `foo@1.0.0` as many times as many different dependency sets it has.
+in the same project.
+
+```
+- foo-parent-1
+  - bar@1.0.0
+  - baz@1.0.0
+  - foo@1.0.0
+- foo-parent-2
+  - bar@1.0.0
+  - baz@1.1.0
+  - foo@1.0.0
+```
+
+In the example above, `foo@1.0.0` is installed for `foo-parent-1` and `foo-parent-2`. Both packages have `bar` and `baz` as well, but
+they dependend on different versions of `baz`. As a result, `foo@1.0.0` has two different sets of dependencies: one with `baz@1.0.0`
+and the other one with `baz@1.1.0`. In order to support these use cases, pnpm has to hard link `foo@1.0.0` as many times as many different
+dependency sets it has.
 
 Normally, if a package does not have peer dependencies, it is hard linked to a `node_modules` folder next to symlinks of its dependencies.
 
@@ -19,7 +35,7 @@ Normally, if a package does not have peer dependencies, it is hard linked to a `
 </pre>
 
 However, if `foo` has peer dependencies, there cannot be one single set of dependencies for it, so
-we create different sets, for different peer deps resolutions:
+we create different sets, for different peer dependency resolutions:
 
 <pre>
 - .registry.npmjs.org / foo / 1.0.0

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "caw": "^2.0.0",
     "commitizen": "^2.8.6",
     "cz-conventional-changelog": "^2.0.0",
+    "deep-require-cwd": "^1.0.0",
     "exists-link": "^2.0.0",
     "husky": "^0.13.2",
     "in-publish": "^2.0.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -24,6 +24,7 @@ dependencies:
   common-tags@^1.4.0: 1.4.0
   cross-spawn@^5.0.0: 5.1.0
   cz-conventional-changelog@^2.0.0: 2.0.0
+  deep-require-cwd@^1.0.0: 1.0.0
   execa@^0.6.3: 0.6.3
   exists-link@^2.0.0: 2.0.0
   find-up@^2.1.0: 2.1.0
@@ -506,6 +507,18 @@ packages:
   /dedent/0.6.0: 0e6da8f0ce52838ef5cec5c8f9396b0c1b64a3cb
   /deep-equal/1.0.1: f5d260292b660e084eff4cdbc9f08ad3247448b5
   /deep-extend/0.4.1: efe4113d08085f4e6f9687759810f807469e2253
+  /deep-require-cwd/1.0.0:
+    dependencies:
+      deep-require-from: 1.0.0
+    resolution: 6569a2b66c93ee606543676e7d486a93a1f76977
+  /deep-require-from/1.0.0:
+    dependencies:
+      deep-resolve-from: 1.1.0
+    resolution: 0645d35c6cbe0637cd422b18769b3b1e7246dd89
+  /deep-resolve-from/1.1.0:
+    dependencies:
+      resolve-from: 3.0.0
+    resolution: 821951ec8df359dba5f615f35d76be5c9d58f4e7
   /define-properties/1.1.2:
     dependencies:
       foreach: 2.0.5
@@ -1715,6 +1728,7 @@ packages:
       expand-tilde: 1.2.2
       global-modules: 0.2.3
     resolution: b219259a5602fac5c5c496ad894a6e8cc430261e
+  /resolve-from/3.0.0: b22c7af7d9d6881bc8b6e653335eebcb0a188748
   /resolve/1.1.7: 203114d82ad2c5ed9e8e0411b3932875e889e97b
   /resolve/1.3.3:
     dependencies:

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -157,6 +157,10 @@ async function linkModules (
     R.props<DependencyTreeNode>(dependency.resolvedPeers, pkgMap)
       .map(peer => symlinkDependencyTo(peer, <string>dependency.peerModules))
   )
+  await Promise.all(
+    R.props<DependencyTreeNode>(dependency.childrenWithUnknownPeers, pkgMap)
+      .map(peer => symlinkDependencyTo(peer, <string>dependency.peerModules))
+  )
 
   const binPath = path.join(dependency.hardlinkedLocation, 'node_modules', '.bin')
   await linkBins(dependency.modules, binPath, dependency.name)

--- a/test/install/peerDependencies.ts
+++ b/test/install/peerDependencies.ts
@@ -8,6 +8,7 @@ import {
   testDefaults,
 } from '../utils'
 import streamParser from '../../src/logging/streamParser'
+import deepRequireCwd = require('deep-require-cwd')
 
 const test = promisifyTape(tape)
 const NM = 'node_modules'
@@ -22,6 +23,7 @@ test('peer dependency is grouped with dependency when peer is resolved not from 
   await installPkgs(['using-ajv'], testDefaults())
 
   t.ok(await exists(path.join(NM, '.localhost+4873', 'ajv-keywords', '1.5.0', 'ajv@4.10.4', NM, 'ajv')), 'peer dependency is linked')
+  t.equal(deepRequireCwd(['using-ajv', 'ajv-keywords', 'ajv', './package.json']).version, '4.10.4')
 })
 
 test('peer dependency is not grouped with dependent when the peer is a top dependency', async (t: tape.Test) => {
@@ -96,6 +98,9 @@ test('peer dependencies are linked', async (t: tape.Test) => {
   await okFile(t, path.join(pkgVariation2, 'abc'))
   await okFile(t, path.join(pkgVariation2, 'peer-a'))
   await okFile(t, path.join(pkgVariation2, 'peer-b'))
+
+  t.equal(deepRequireCwd(['abc-parent-with-ab', 'abc', 'peer-c', './package.json']).version, '2.0.0')
+  t.equal(deepRequireCwd(['abc-grand-parent-with-c', 'abc-parent-with-ab', 'abc', 'peer-c', './package.json']).version, '1.0.0')
 })
 
 test('scoped peer dependency is linked', async (t: tape.Test) => {


### PR DESCRIPTION
When a peer dependency is resolved not from the direct parent,
dependent packages should be duplicated with hard links in order
to preserve the correct set of resolved peer dependencies.

Semi-breaking change. The node_modules structure is changed but
doesn't need a complete removal of a node_modules created with
previous version of pnpm.