### PR TITLE
fix(shrinkwrap): don't save absolute path shrinkwrap.yaml

### DIFF
--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -224,6 +224,8 @@ async function installInContext (
     nodeModules: nodeModulesPath,
     update: opts.update,
     keypath: [],
+    referencedFrom: opts.prefix,
+    prefix: opts.prefix,
   }
   const nonLinkedPkgs = await pFilter(packagesToInstall, (spec: PackageSpec) => !spec.name || safeIsInnerLink(nodeModulesPath, spec.name))
   const pkgs: InstalledPackage[] = await installMultiple(

--- a/src/fs/pkgIdToFilename.ts
+++ b/src/fs/pkgIdToFilename.ts
@@ -1,0 +1,8 @@
+import path = require('path')
+import normalize = require('normalize-path')
+
+export default function pkgIdToFilename (pkgId: string) {
+  if (pkgId.indexOf('file:') !== 0) return pkgId
+
+  return `local/${encodeURIComponent(normalize(path.resolve(pkgId.slice(5))))}`
+}

--- a/src/fs/shrinkwrap.ts
+++ b/src/fs/shrinkwrap.ts
@@ -9,16 +9,19 @@ import rimraf = require('rimraf-then')
 import isCI = require('is-ci')
 import getRegistryName from '../resolve/npm/getRegistryName'
 import npa = require('npm-package-arg')
+import pnpmPkgJson from '../pnpmPkgJson'
 
 const shrinkwrapLogger = logger('shrinkwrap')
 
 export const SHRINKWRAP_FILENAME = 'shrinkwrap.yaml'
 export const PRIVATE_SHRINKWRAP_FILENAME = path.join('node_modules', '.shrinkwrap.yaml')
 const SHRINKWRAP_VERSION = 2
+const CREATED_WITH = `${pnpmPkgJson.name}@${pnpmPkgJson.version}`
 
 function getDefaultShrinkwrap (registry: string) {
   return {
     version: SHRINKWRAP_VERSION,
+    createdWith: CREATED_WITH,
     dependencies: {},
     packages: {},
     registry,
@@ -27,6 +30,7 @@ function getDefaultShrinkwrap (registry: string) {
 
 export type Shrinkwrap = {
   version: number,
+  createdWith: string,
   dependencies: ResolvedDependencies,
   packages: ResolvedPackages,
   registry: string,
@@ -130,6 +134,7 @@ export function save (pkgPath: string, shrinkwrap: Shrinkwrap) {
 export function prune (shr: Shrinkwrap): Shrinkwrap {
   return {
     version: SHRINKWRAP_VERSION,
+    createdWith: shr.createdWith || CREATED_WITH,
     dependencies: shr.dependencies,
     registry: shr.registry,
     packages: copyDependencyTree(shr, shr.registry),

--- a/src/install/fetch.ts
+++ b/src/install/fetch.ts
@@ -9,6 +9,7 @@ import resolve, {
   PackageMeta,
 } from '../resolve'
 import mkdirp = require('mkdirp-promise')
+import pkgIdToFilename from '../fs/pkgIdToFilename'
 import readPkg from '../fs/readPkg'
 import exists = require('path-exists')
 import memoize, {MemoizedFunc} from '../memoize'
@@ -33,7 +34,7 @@ export type FetchedPackage = {
 export default async function fetch (
   spec: PackageSpec,
   options: {
-    root: string,
+    prefix: string,
     storePath: string,
     localRegistry: string,
     registry: string,
@@ -54,7 +55,7 @@ export default async function fetch (
     if (!resolution || options.update) {
       const resolveResult = await resolve(spec, {
         loggedPkg: options.loggedPkg,
-        root: options.root,
+        prefix: options.prefix,
         got: options.got,
         localRegistry: options.localRegistry,
         registry: options.registry,
@@ -75,7 +76,7 @@ export default async function fetch (
 
     logStatus({status: 'resolved', pkgId: id, pkg: options.loggedPkg})
 
-    const target = path.join(options.storePath, id)
+    const target = path.join(options.storePath, pkgIdToFilename(id))
 
     const fetchingFiles = options.fetchingLocker(id, () => fetchToStore({
       target,
@@ -97,7 +98,7 @@ export default async function fetch (
       resolution,
       path: target,
       srcPath: resolution.type == 'directory'
-        ? resolution.root
+        ? path.join(options.prefix, resolution.root)
         : undefined,
       abort: async () => {
         try {

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -44,7 +44,8 @@ export default async function installMultiple (
   specs: PackageSpec[],
   options: {
     force: boolean,
-    root: string,
+    prefix: string,
+    referencedFrom: string,
     storePath: string,
     localRegistry: string,
     registry: string,
@@ -125,7 +126,8 @@ async function install (
   ctx: InstallContext,
   options: {
     force: boolean,
-    root: string,
+    prefix: string,
+    referencedFrom: string,
     storePath: string,
     localRegistry: string,
     registry: string,
@@ -170,7 +172,7 @@ async function install (
     update: options.update,
     fetchingLocker: ctx.fetchingLocker,
     registry,
-    root: options.root,
+    prefix: options.prefix,
     storePath: options.storePath,
     localRegistry: options.localRegistry,
     metaCache: options.metaCache,
@@ -202,7 +204,7 @@ async function install (
       fetchedPkg.id,
       ctx,
       Object.assign({}, options, {
-        root: fetchedPkg.srcPath,
+        referencedFrom: fetchedPkg.srcPath,
         isInstallable,
       })
     )
@@ -304,7 +306,8 @@ async function installDependencies (
   ctx: InstallContext,
   opts: {
     force: boolean,
-    root: string,
+    prefix: string,
+    referencedFrom: string,
     storePath: string,
     localRegistry: string,
     registry: string,
@@ -331,7 +334,7 @@ async function installDependencies (
   const deps = depsToSpecs(
     filterDeps(Object.assign({}, pkg.optionalDependencies, pkg.dependencies)),
     {
-      where: opts.root,
+      where: opts.referencedFrom,
       devDependencies: pkg.devDependencies || {},
       optionalDependencies: pkg.optionalDependencies || {},
     }

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -12,6 +12,7 @@ import linkBins from './linkBins'
 import {Package, Dependencies} from '../types'
 import resolvePeers, {DependencyTreeNode, DependencyTreeNodeMap} from './resolvePeers'
 import logStatus from '../logging/logInstallStatus'
+import pkgIdToFilename from '../fs/pkgIdToFilename'
 
 export type LinkedPackage = {
   id: string,
@@ -49,7 +50,7 @@ export default async function (
         peerDependencies: installedPkg.pkg.peerDependencies || {},
         hasBundledDependencies: !!(installedPkg.pkg.bundledDependencies || installedPkg.pkg.bundleDependencies),
         fetchingFiles: installedPkg.fetchingFiles,
-        localLocation: path.join(opts.baseNodeModules, `.${installedPkg.id}`),
+        localLocation: path.join(opts.baseNodeModules, `.${pkgIdToFilename(installedPkg.id)}`),
         path: installedPkg.path,
         dependencies: installedPkg.dependencies,
       }

--- a/src/resolve/index.ts
+++ b/src/resolve/index.ts
@@ -92,7 +92,7 @@ export type ResolveOptions = {
   localRegistry: string,
   registry: string,
   metaCache: Map<string, PackageMeta>,
-  root: string,
+  prefix: string,
   offline: boolean,
 }
 

--- a/src/resolve/local.ts
+++ b/src/resolve/local.ts
@@ -1,5 +1,4 @@
-import {resolve} from 'path'
-import * as path from 'path'
+import path = require('path')
 import readPkg from '../fs/readPkg'
 import {
   PackageSpec,
@@ -9,19 +8,21 @@ import {
   ResolveResult,
 } from '.'
 import fs = require('mz/fs')
+import normalize = require('normalize-path')
 
 /**
  * Resolves a package hosted on the local filesystem
  */
 export default async function resolveLocal (spec: PackageSpec, opts: ResolveOptions): Promise<ResolveResult> {
-  const dependencyPath = resolve(opts.root, spec.fetchSpec)
+  const dependencyPath = normalize(path.relative(opts.prefix, spec.fetchSpec))
+  const id = `file:${dependencyPath}`
 
   if (spec.type === 'file') {
     const resolution: TarballResolution = {
-      tarball: `file:${dependencyPath}`,
+      tarball: id,
     }
     return {
-      id: createLocalPkgId(dependencyPath),
+      id,
       resolution,
     }
   }
@@ -32,11 +33,7 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
     root: dependencyPath,
   }
   return {
-    id: createLocalPkgId(dependencyPath),
+    id,
     resolution,
   }
-}
-
-function createLocalPkgId (dependencyPath: string): string {
-  return 'local/' + encodeURIComponent(dependencyPath)
 }

--- a/test/install/local.ts
+++ b/test/install/local.ts
@@ -12,6 +12,7 @@ import {
   pathToLocalPkg,
   local,
 } from '../utils'
+import pnpmPkgJson from '../../src/pnpmPkgJson'
 
 const ncp = thenify(ncpCB.ncp)
 const test = promisifyTape(tape)
@@ -51,6 +52,7 @@ test('local file', async function (t: tape.Test) {
     },
     registry: 'http://localhost:4873/',
     version: 2,
+    createdWith: `${pnpmPkgJson.name}@${pnpmPkgJson.version}`
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,6 +52,7 @@
     "src/fs/getPkgDirs.ts",
     "src/fs/gracefulify.ts",
     "src/fs/modulesController.ts",
+    "src/fs/pkgIdToFilename.ts",
     "src/fs/readPkg.ts",
     "src/fs/safeReadPkg.ts",
     "src/fs/shrinkwrap.ts",


### PR DESCRIPTION
Relative path to the current working directory is saved
in the `shrinkwrap.yaml`.

Close #744