### PR TITLE
perf: symlink leaf dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "graceful-fs": "^4.1.11",
     "is-ci": "^1.0.10",
     "is-inner-link": "^2.0.0",
+    "is-subdir": "^1.0.0",
     "is-windows": "^1.0.0",
     "link-dir": "^2.0.1",
     "load-json-file": "^2.0.0",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -25,6 +25,7 @@ dependencies:
   graceful-fs: 4.1.11
   is-ci: 1.0.10
   is-inner-link: 2.0.0
+  is-subdir: 1.0.0
   is-windows: 1.0.1
   isexe: 2.0.0
   link-dir: 2.0.1
@@ -3512,6 +3513,7 @@ specifiers:
   in-publish: ^2.0.0
   is-ci: ^1.0.10
   is-inner-link: ^2.0.0
+  is-subdir: ^1.0.0
   is-windows: ^1.0.0
   isexe: ^2.0.0
   link-dir: ^2.0.1

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -245,7 +245,8 @@ async function installInContext (
     parentNodeId: ':/:',
     currentDepth: 0,
   }
-  const nonLinkedPkgs = await pFilter(packagesToInstall, (spec: PackageSpec) => !spec.name || safeIsInnerLink(nodeModulesPath, spec.name))
+  const nonLinkedPkgs = await pFilter(packagesToInstall,
+    (spec: PackageSpec) => !spec.name || safeIsInnerLink(nodeModulesPath, spec.name, {storePath: ctx.storePath}))
   const rootPkgs = await installMultiple(
     installCtx,
     nonLinkedPkgs,

--- a/src/api/uninstall.ts
+++ b/src/api/uninstall.ts
@@ -62,7 +62,7 @@ export async function uninstallInContext (pkgsToUninstall: string[], pkg: Packag
       storePath: ctx.storePath,
       skipped: Array.from(ctx.skipped).filter(pkgId => removedPkgIds.indexOf(pkgId) === -1),
     })
-    await removeOuterLinks(pkgsToUninstall, path.join(ctx.root, 'node_modules'))
+    await removeOuterLinks(pkgsToUninstall, path.join(ctx.root, 'node_modules'), {storePath: ctx.storePath})
   }
 }
 
@@ -75,9 +75,15 @@ function isDependentOn (pkg: Package, depName: string): boolean {
   .some(deptype => pkg[deptype] && pkg[deptype][depName])
 }
 
-async function removeOuterLinks (pkgsToUninstall: string[], modules: string) {
+async function removeOuterLinks (
+  pkgsToUninstall: string[],
+  modules: string,
+  opts: {
+    storePath: string,
+  }
+) {
   for (const pkgToUninstall of pkgsToUninstall) {
-    if (!await safeIsInnerLink(modules, pkgToUninstall)) {
+    if (!await safeIsInnerLink(modules, pkgToUninstall, opts)) {
       await removeTopDependency(pkgToUninstall, modules)
     }
   }

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -203,7 +203,13 @@ async function linkPkg (
   const newlyFetched = await dependency.fetchingFiles
 
   const pkgJsonPath = path.join(dependency.hardlinkedLocation, 'package.json')
-  if (newlyFetched || opts.force || !await exists(pkgJsonPath) || !await pkgLinkedToStore(pkgJsonPath, dependency)) {
+  if (newlyFetched || opts.force || !await exists(pkgJsonPath)) {
+    if (dependency.independent) return
+
+    await linkDir(dependency.path, dependency.hardlinkedLocation)
+    return
+  }
+  if (!await pkgLinkedToStore(pkgJsonPath, dependency)) {
     await linkDir(dependency.path, dependency.hardlinkedLocation)
   }
 }

--- a/src/link/resolvePeers.ts
+++ b/src/link/resolvePeers.ts
@@ -16,6 +16,9 @@ export type DependencyTreeNode = {
   resolution: Resolution,
   hardlinkedLocation: string,
   children: string[],
+  // an independent package is a package that
+  // has neither regular nor peer dependencies
+  independent: boolean,
   optionalDependencies: Set<string>,
   depth: number,
   resolvedId: string,
@@ -94,7 +97,10 @@ function resolvePeersOfNode (
 
   nodeIdToResolvedId[nodeId] = resolvedId
   if (!resolvedTree[resolvedId] || resolvedTree[resolvedId].depth > node.depth) {
-    const hardlinkedLocation = path.join(modules, node.pkg.name)
+    const independent = !node.children.length && R.isEmpty(node.pkg.peerDependencies)
+    const hardlinkedLocation = !independent
+      ? path.join(modules, node.pkg.name)
+      : node.pkg.path
     resolvedTree[resolvedId] = {
       name: node.pkg.name,
       hasBundledDependencies: node.pkg.hasBundledDependencies,
@@ -103,6 +109,7 @@ function resolvePeersOfNode (
       path: node.pkg.path,
       modules,
       hardlinkedLocation,
+      independent,
       optionalDependencies: node.pkg.optionalDependencies,
       children: R.union(node.children, resolvedPeers),
       depth: node.depth,

--- a/src/safeIsInnerLink.ts
+++ b/src/safeIsInnerLink.ts
@@ -3,12 +3,21 @@ import path = require('path')
 import isInnerLink = require('is-inner-link')
 import fs = require('mz/fs')
 import mkdirp = require('mkdirp-promise')
+import isSubdir = require('is-subdir')
 
-export default async function safeIsInnerLink (modules: string, depName: string) {
+export default async function safeIsInnerLink (
+  modules: string,
+  depName: string,
+  opts: {
+    storePath: string,
+  }
+) {
   try {
     const link = await isInnerLink(modules, depName)
 
     if (link.isInner) return true
+
+    if (isSubdir(opts.storePath, link.target)) return true
 
     logger.info(`${depName} is linked to ${modules} from ${link.target}`)
     return false

--- a/test/shrinkwrap.ts
+++ b/test/shrinkwrap.ts
@@ -268,21 +268,30 @@ test('repeat install with shrinkwrap should not mutate shrinkwrap when dependenc
 test('package is not marked dev if it is also a subdep of a regular dependency', async (t: tape.Test) => {
   const project = prepare(t)
 
-  await installPkgs(['pkg-with-1-dep'])
-  await installPkgs(['dep-of-pkg-with-1-dep'], {saveDev: true})
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
+
+  await installPkgs(['pkg-with-1-dep'], testDefaults())
+
+  t.pass('installed pkg-with-1-dep')
+
+  await installPkgs(['dep-of-pkg-with-1-dep'], testDefaults({saveDev: true}))
+
+  t.pass('installed optional dependency which is also a dependency of pkg-with-1-dep')
 
   const shr = await project.loadShrinkwrap()
 
-  t.notOk(shr.packages['/dep-of-pkg-with-1-dep/1.1.0']['dev'])
+  t.notOk(shr.packages['/dep-of-pkg-with-1-dep/100.0.0']['dev'], 'package is not marked as dev')
 })
 
 test('package is not marked optional if it is also a subdep of a regular dependency', async (t: tape.Test) => {
   const project = prepare(t)
 
-  await installPkgs(['pkg-with-1-dep'])
-  await installPkgs(['dep-of-pkg-with-1-dep'], {saveOptional: true})
+  await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
+
+  await installPkgs(['pkg-with-1-dep'], testDefaults())
+  await installPkgs(['dep-of-pkg-with-1-dep'], testDefaults({saveOptional: true}))
 
   const shr = await project.loadShrinkwrap()
 
-  t.notOk(shr.packages['/dep-of-pkg-with-1-dep/1.1.0']['optional'])
+  t.notOk(shr.packages['/dep-of-pkg-with-1-dep/100.0.0']['optional'], 'package is not marked as optional')
 })

--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -258,3 +258,8 @@ declare module 'ssri' {
   const anything: any;
   export = anything;
 }
+
+declare module 'is-subdir' {
+  const anything: any;
+  export = anything;
+}


### PR DESCRIPTION
Close #789

Independent packages (the ones that have neither regular nor peer dependencies) can be symlinked from the global store. Symlinking the folder is faster than creating a separate hard link for each file in the package.

This might break some packages if they use real path for doing some manipulations with the dependent package. I don't know how likely that is.

The performance improvement on packages from [our](https://github.com/pnpm/node-package-manager-benchmark) benchmark repo is ~8%.