### PR TITLE
feat: symlink file dependencies instead of copying them

### DIFF
--- a/docs/vs-npm.md
+++ b/docs/vs-npm.md
@@ -31,6 +31,8 @@ On the other hand, pnpm manages `node_modules` as an addressable storage in its 
 
 ## Differences
 
+### Installation
+
 pnpm does not allow installations of packages without saving them to `package.json`.
 If no parameters are passed to `pnpm install`, packages are saved as regular dependencies.
 Like with npm, `--save-dev` and `--save-optional` can be used to install packages as dev or optional dependencies.
@@ -38,6 +40,14 @@ Like with npm, `--save-dev` and `--save-optional` can be used to install package
 As a consequence of this limitation, projects won't have any extraneous packages when they use pnpm.
 That's why pnpm's implementation of the [prune command](https://docs.npmjs.com/cli/prune) does not
 have the possibility of prunning specific packages. pnpm's prune always removes all the extraneous packages.
+
+### Directory dependencies
+
+Directory dependencies are the ones that start with the `file:` prefix and point to a directory in the filesystem.
+Like npm, pnpm symlinks those dependencies. Unlike npm, pnpm does not perform installation for the file dependencies.
+So if you have package `foo` (in `home/src/foo`), that has a dependency `bar@file:../bar`, pnpm won't perform installation in `/home/src/bar`.
+
+If you need to run installations in several packages at the same time (maybe you have a monorepo), you might want to use [pnpmr](https://github.com/pnpm/pnpmr). pnpmr searches for packages and runs `pnpm install` for them in the correct order.
 
 [npm ls]: https://docs.npmjs.com/cli/ls
 [npm prune]: https://docs.npmjs.com/cli/prune

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "pnpm-default-reporter": "^0.6.0",
     "pnpm-file-reporter": "^0.0.1",
     "pnpm-install-checks": "^1.1.0",
-    "pnpm-lockfile": "^0.1.1",
+    "pnpm-lockfile": "^0.2.0",
     "pnpm-logger": "^0.3.0",
     "proper-lockfile": "^2.0.0",
     "ramda": "^0.24.1",

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -53,7 +53,7 @@ dependencies:
   pnpm-default-reporter: 0.6.0
   pnpm-file-reporter: 0.0.1
   pnpm-install-checks: 1.1.0
-  pnpm-lockfile: 0.1.1
+  pnpm-lockfile: 0.2.0
   pnpm-logger: 0.3.0
   proper-lockfile: 2.0.1
   ramda: 0.24.1
@@ -2456,7 +2456,7 @@ packages:
       semver: 5.3.0
     resolution:
       integrity: sha1-dB2ZeXYv362T8+Rp3rSoFNNDAAg=
-  /pnpm-lockfile/0.1.1:
+  /pnpm-lockfile/0.2.0:
     dependencies:
       '@types/ramda': 0.0.11
       is-ci: 1.0.10
@@ -2466,7 +2466,7 @@ packages:
       rimraf-then: 1.0.1
       write-yaml-file: 1.0.0
     resolution:
-      integrity: sha1-A2c/TrsUCqRJkHGi47J8yjqGAh4=
+      integrity: sha1-MxfTo4RLW0qmGxWGRcJ1YTvkt/c=
   /pnpm-logger/0.0.0:
     dependencies:
       bole: 3.0.2
@@ -3533,7 +3533,7 @@ specifiers:
   pnpm-default-reporter: ^0.6.0
   pnpm-file-reporter: ^0.0.1
   pnpm-install-checks: ^1.1.0
-  pnpm-lockfile: ^0.1.1
+  pnpm-lockfile: ^0.2.0
   pnpm-logger: ^0.3.0
   pnpm-registry-mock: ^0.12.0
   proper-lockfile: ^2.0.0

--- a/src/api/link.ts
+++ b/src/api/link.ts
@@ -13,11 +13,13 @@ const linkLogger = logger('link')
 export default async function link (
   linkFrom: string,
   linkTo: string,
-  maybeOpts?: PnpmOptions
+  maybeOpts?: PnpmOptions & {skipInstall?: boolean}
 ) {
   const opts = extendOptions(maybeOpts)
 
-  await install(Object.assign({}, opts, { prefix: linkFrom, global: false }))
+  if (!maybeOpts || !maybeOpts.skipInstall) {
+    await install(Object.assign({}, opts, { prefix: linkFrom, global: false }))
+  }
 
   const destModules = path.join(linkTo, 'node_modules')
   await linkToModules(linkFrom, destModules)

--- a/src/api/removeOrphanPkgs.ts
+++ b/src/api/removeOrphanPkgs.ts
@@ -23,8 +23,8 @@ export default async function removeOrphanPkgs (
   const rootModules = path.join(root, 'node_modules')
   await Promise.all(removedTopDeps.map(depName => removeTopDependency(depName, rootModules)))
 
-  const oldPkgIds = Object.keys(oldShr.packages).map(shortId => shortIdToFullId(shortId, oldShr.registry))
-  const newPkgIds = Object.keys(newShr.packages).map(shortId => shortIdToFullId(shortId, newShr.registry))
+  const oldPkgIds = R.keys(oldShr.packages).map(shortId => shortIdToFullId(shortId, oldShr.registry))
+  const newPkgIds = R.keys(newShr.packages).map(shortId => shortIdToFullId(shortId, newShr.registry))
 
   const store = await readStore(storePath) || {}
   const notDependents = R.difference(oldPkgIds, newPkgIds)

--- a/src/install/installMultiple.ts
+++ b/src/install/installMultiple.ts
@@ -77,7 +77,7 @@ export default async function installMultiple (
         .map(async (spec: PackageSpec) => {
           const reference = resolvedDependencies[spec.name]
           const pkgShortId = reference && getPkgShortId(reference, spec.name)
-          const dependencyShrinkwrap = pkgShortId && ctx.shrinkwrap.packages[pkgShortId]
+          const dependencyShrinkwrap = pkgShortId && ctx.shrinkwrap.packages && ctx.shrinkwrap.packages[pkgShortId]
           const pkgId = dependencyShrinkwrap && dependencyShrinkwrap.id ||
             reference && getPkgId(reference, spec.name, ctx.shrinkwrap.registry)
           const shrinkwrapResolution: Resolution | undefined = pkgShortId && dependencyShrinkwrap

--- a/src/link/index.ts
+++ b/src/link/index.ts
@@ -139,7 +139,7 @@ async function linkNewPackages (
 
   const newPkgs = R.props<DependencyTreeNode>(newPkgResolvedIds, pkgsToLink)
 
-  if (!opts.force) {
+  if (!opts.force && privateShrinkwrap.packages && shrinkwrap.packages) {
     // add subdependencies that have been updated
     // TODO: no need to relink everything. Can be relinked only what was changed
     for (const shortId of nextPkgResolvedIds) {

--- a/src/link/updateShrinkwrap.ts
+++ b/src/link/updateShrinkwrap.ts
@@ -19,6 +19,7 @@ export default function (
   shrinkwrap: Shrinkwrap,
   pkg: Package
 ): Shrinkwrap {
+  shrinkwrap.packages = shrinkwrap.packages || {}
   for (const resolvedId of R.keys(pkgsToLink)) {
     const shortId = pkgShortId(resolvedId, shrinkwrap.registry)
     const result = R.partition((childResolvedId: string) => pkgsToLink[resolvedId].optionalDependencies.has(pkgsToLink[childResolvedId].name), pkgsToLink[resolvedId].children)

--- a/src/resolve/local.ts
+++ b/src/resolve/local.ts
@@ -35,5 +35,6 @@ export default async function resolveLocal (spec: PackageSpec, opts: ResolveOpti
   return {
     id,
     resolution,
+    package: localPkg,
   }
 }

--- a/test/install/local.ts
+++ b/test/install/local.ts
@@ -46,7 +46,6 @@ test('local file', async function (t: tape.Test) {
     dependencies: {
       'local-pkg': 'file:../local-pkg',
     },
-    packages: {},
     registry: 'http://localhost:4873/',
     version: 3,
   })

--- a/test/install/local.ts
+++ b/test/install/local.ts
@@ -31,6 +31,10 @@ test('local file', async function (t: tape.Test) {
 
   await installPkgs(['file:../local-pkg'], testDefaults())
 
+  const pkgJson = await readPkg()
+  const expectedSpecs = {'local-pkg': `file:..${path.sep}local-pkg`}
+  t.deepEqual(pkgJson.dependencies, expectedSpecs, 'local-pkg has been added to dependencies')
+
   const m = project.requireModule('local-pkg')
 
   t.ok(m, 'localPkg() is available')
@@ -38,20 +42,11 @@ test('local file', async function (t: tape.Test) {
   const shr = await project.loadShrinkwrap()
 
   t.deepEqual(shr, {
-    specifiers: {
-      'local-pkg': `file:..${path.sep}local-pkg`,
-    },
+    specifiers: expectedSpecs,
     dependencies: {
       'local-pkg': 'file:../local-pkg',
     },
-    packages: {
-      'file:../local-pkg': {
-        resolution: {
-          directory: '../local-pkg',
-          type: 'directory',
-        },
-      },
-    },
+    packages: {},
     registry: 'http://localhost:4873/',
     version: 3,
   })
@@ -64,17 +59,6 @@ test('package with a broken symlink', async function (t) {
   const m = project.requireModule('has-broken-symlink')
 
   t.ok(m, 'has-broken-symlink is available')
-})
-
-test('nested local dependency of a local dependency', async function (t: tape.Test) {
-  const project = prepare(t)
-  await installPkgs([local('pkg-with-local-dep')], testDefaults())
-
-  const m = project.requireModule('pkg-with-local-dep')
-
-  t.ok(m, 'pkgWithLocalDep() is available')
-
-  t.equal(m(), 'local-pkg', 'pkgWithLocalDep() returns data from local-pkg')
 })
 
 test('tarball local package', async function (t) {

--- a/test/packages/pkg-with-local-dep/index.js
+++ b/test/packages/pkg-with-local-dep/index.js
@@ -1,4 +1,0 @@
-'use strict'
-const localPkg = require('local-pkg')
-
-module.exports = () => localPkg()

--- a/test/packages/pkg-with-local-dep/package.json
+++ b/test/packages/pkg-with-local-dep/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "pkg-with-local-dep",
-  "version": "1.0.0",
-  "dependencies": {
-    "local-pkg": "file:../local-pkg"
-  }
-}


### PR DESCRIPTION
This is roughly how `npm@5` handles it. However, pnpm does not try to install dependencies of the file dependency, just a symlink is created and the binstubs are linked into `node_modules/.bin` if there are any.

**BREAKING CHANGE:**

file dependencies are symlinked instead of copied (packed/unpacked)

Ref #772