### PR TITLE
fix: wait for recursive package installation

### DIFF
--- a/src/cmd/recursive.ts
+++ b/src/cmd/recursive.ts
@@ -70,12 +70,12 @@ export default async (
   const limitInstallation = pLimit(concurrency)
 
   for (const chunk of chunks) {
-    await chunk.map((prefix: string) =>
+    await Promise.all(chunk.map((prefix: string) =>
       limitInstallation(() => {
         const hooks = opts.ignorePnpmfile ? {} : requireHooks(prefix)
         return install({...installOpts, hooks, storeController, prefix})
       }),
-    )
+    ))
   }
 
   await saveState()


### PR DESCRIPTION
`await [Promise]` returns immediately; we want to wait for each
installation to complete before advancing to the next chunk.

enabling tslint's `await-promise` rule could have caught this, but
only if the typings for p-limit and graph-sequencer were improved.