### PR TITLE
feat(recursive): running commands on a subset of packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
     "cross-spawn": "^6.0.3",
     "delay": "^2.0.0",
     "diable": "^4.0.1",
-    "find-packages": "^2.1.2",
+    "find-packages": "^2.2.0",
     "get-port": "^3.2.0",
     "graceful-fs": "^4.1.11",
     "graph-sequencer": "^2.0.0",
     "is-ci": "^1.0.10",
     "is-windows": "^1.0.1",
     "load-json-file": "^4.0.0",
+    "load-yaml-file": "^0.1.0",
     "loud-rejection": "^1.6.0",
     "mkdirp-promise": "^5.0.1",
     "nopt": "^4.0.1",
@@ -91,7 +92,6 @@
     "execa": "^0.9.0",
     "exists-link": "^2.0.0",
     "isexe": "^2.0.0",
-    "load-yaml-file": "^0.1.0",
     "mkdirp": "^0.5.1",
     "mz": "^2.6.0",
     "normalize-newline": "^3.0.0",
@@ -110,7 +110,8 @@
     "ts-node": "^4.0.0",
     "tslint": "^5.4.2",
     "typescript": "^2.7.1",
-    "write-pkg": "^3.1.0"
+    "write-pkg": "^3.1.0",
+    "write-yaml-file": "^1.0.0"
   },
   "directories": {
     "test": "test"

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -25,6 +25,7 @@ dependencies:
   is-ci: 1.1.0
   is-windows: 1.0.2
   load-json-file: 4.0.0
+  load-yaml-file: 0.1.0
   loud-rejection: 1.6.0
   mkdirp-promise: 5.0.1
   nopt: 4.0.1
@@ -69,7 +70,6 @@ devDependencies:
   execa: 0.9.0
   exists-link: 2.0.0
   isexe: 2.0.0
-  load-yaml-file: 0.1.0
   mkdirp: 0.5.1
   mz: 2.7.0
   normalize-newline: 3.0.0
@@ -89,6 +89,7 @@ devDependencies:
   tslint: 5.9.1
   typescript: 2.7.2
   write-pkg: 3.1.0
+  write-yaml-file: 1.0.0
 packages:
   /@commitlint/cli/4.3.0:
     dependencies:
@@ -3784,6 +3785,7 @@ packages:
       js-yaml: 3.10.0
       pify: 2.3.0
       strip-bom: 3.0.0
+    dev: false
     engines:
       node: '>=4'
     resolution:
@@ -6914,7 +6916,6 @@ packages:
       graceful-fs: 4.1.11
       imurmurhash: 0.1.4
       slide: 1.1.6
-    dev: false
     resolution:
       integrity: sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
   /write-file-atomic/2.3.0:
@@ -6951,7 +6952,6 @@ packages:
       mkdirp: 0.5.1
       pify: 2.3.0
       write-file-atomic: 1.3.4
-    dev: false
     resolution:
       integrity: sha1-e0vQ33LKE/vp1rAXj9g8B3uOqGs=
   /x256/0.0.2:
@@ -7076,7 +7076,7 @@ specifiers:
   diable: ^4.0.1
   execa: ^0.9.0
   exists-link: ^2.0.0
-  find-packages: ^2.1.2
+  find-packages: ^2.2.0
   get-port: ^3.2.0
   graceful-fs: ^4.1.11
   graph-sequencer: ^2.0.0
@@ -7125,3 +7125,4 @@ specifiers:
   util.promisify: ^1.0.0
   write-json-file: ^2.3.0
   write-pkg: ^3.1.0
+  write-yaml-file: ^1.0.0


### PR DESCRIPTION
A ~`packages.yaml`~`pnpm-workspace.yaml` file can be used in the root of a multi-package
repository to specify an array of globs to use as package locations

Example of a ~`packages.yaml`~`pnpm-workspace.yaml` file:

```yaml
packages:
  - 'packages/**'
  - 'components/**'
```

close #1038