### PR TITLE
feat: pass a log() function to readPackage hooks

### DIFF
--- a/src/requirePnpmfile.ts
+++ b/src/requirePnpmfile.ts
@@ -9,6 +9,7 @@ export default (pnpmFilePath: string) => {
     if (pnpmfile && pnpmfile.hooks && pnpmfile.hooks.readPackage && typeof pnpmfile.hooks.readPackage !== 'function') {
       throw new TypeError('hooks.readPackage should be a function')
     }
+    pnpmfile.filename = pnpmFilePath
     return pnpmfile
   } catch (err) {
     if (err instanceof SyntaxError) {


### PR DESCRIPTION
close #1074

This passe a second parameter to the readPackage() hook. The second parameter is a context object that contain a log function. The log function can be called to print messages to the console. For example:

```js
module.exports = {hooks: {readPackage}}

function readPackage (pkg, context) {
  if (pkg.dependencies && pkg.dependencies.foo) {
    pkg.dependencies.foo = '1.0.0'
    context.log(`foo pinned to v1.0.0 in ${pkg.name}`)
  }
  return pkg
}
```
