### PR TITLE
fix(reporting): fix exception on err.code.startsWith

### DIFF
--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -30,7 +30,7 @@ export default function reportError (logObj: Log) {
         return formatNoMatchingVersion(err, logObj['message'])
       default:
         // Errors with known error codes are printed w/o stack trace
-        if (err.code && err.code.startsWith('ERR_PNPM_')) {
+        if (err.code && err.code.startsWith && err.code.startsWith('ERR_PNPM_')) {
           return formatErrorSummary(err.message)
         }
         return formatGenericError(err.message || logObj['message'], err.stack)


### PR DESCRIPTION
When execa throws error, the err object has code in number, not string.

When you try install a non-exist git dep (for instance typo)
```
⋊> ~/p/tp pnpm i fewofn/fdson
err.code.startsWith is not a function
```