### PR TITLE
fix: call linkBins after we flattened the graph

### DIFF
--- a/packages/supi/src/link/index.ts
+++ b/packages/supi/src/link/index.ts
@@ -134,10 +134,6 @@ export default async function linkPackages (
     }
   }
 
-  if (!opts.dryRun) {
-    await linkBins(opts.baseNodeModules, opts.bin)
-  }
-
   if (opts.updateShrinkwrapMinorVersion) {
     // Setting `shrinkwrapMinorVersion` is a temporary solution to
     // have new backward-compatible versions of `shrinkwrap.yaml`
@@ -184,9 +180,13 @@ export default async function linkPackages (
     currentShrinkwrap = newCurrentShrinkwrap
   }
 
-  // Important: shamefullyFlattenGraph changes depGraph, so keep this at the end
+  // Important: shamefullyFlattenGraph changes depGraph, so keep this at the end, right before linkBins
   if (opts.shamefullyFlatten && (opts.reinstallForFlatten || newDepPaths.length > 0 || removedDepPaths.size > 0)) {
     opts.hoistedAliases = await shamefullyFlattenGraph(depNodes, currentShrinkwrap, opts)
+  }
+
+  if (!opts.dryRun) {
+    await linkBins(opts.baseNodeModules, opts.bin)
   }
 
   return {

--- a/packages/supi/test/install/shamefullyFlatten.ts
+++ b/packages/supi/test/install/shamefullyFlatten.ts
@@ -16,6 +16,9 @@ test('should flatten dependencies', async (t) => {
   await project.has('express')
   await project.has('debug')
   await project.has('cookie')
+
+  // should also flatten bins
+  await project.isExecutable('.bin/mime')
 })
 
 test('should remove flattened dependencies', async (t) => {


### PR DESCRIPTION
I just moved `linkBins` below the flattening of the graph.

I've also added a check in the test.