### PR TITLE
fix: issue with passing properly args to the comannd

### DIFF
--- a/packages/pnpm/test/run.ts
+++ b/packages/pnpm/test/run.ts
@@ -18,3 +18,15 @@ test('pnpm run: returns correct exit code', async (t: tape.Test) => {
   t.equal(execPnpmSync('run', 'exit0').status, 0)
   t.equal(execPnpmSync('run', 'exit1').status, 1)
 })
+
+test('pass the args to the command that is specfied in the build script', async t => {
+  prepare(t, {
+    scripts: {
+      test: 'ts-node test'
+    },
+  })
+
+  const result = execPnpmSync('run', 'test', '--', '--flag=true')
+
+  t.ok((result.stdout as Buffer).toString('utf8').match(/ts-node test "--flag=true"/), 'command was successful')
+})


### PR DESCRIPTION
pnpm does not properly pass arguments to command that is specified in the build script as npm does, with this change pnpm behaves exactly like npm.

Closes #1124