### PR TITLE
Clarify wording of error messages

### DIFF
--- a/packages/supi/src/api/getContext.ts
+++ b/packages/supi/src/api/getContext.ts
@@ -57,28 +57,28 @@ export default async function getContext (
         if (modules.independentLeaves) {
           throw new PnpmError(
             'ERR_PNPM_INDEPENDENT_LEAVES_WANTED',
-            `This node_modules was installed with --independent-leaves option.
-            Use this option or run same command with --force to recreated node_modules`,
+            'This "node_modules" folder was created using the --independent-leaves option.'
+            + ' You must add that option, or else add the --force option to recreate the "node_modules" folder.',
           )
         }
         throw new PnpmError(
           'ERR_PNPM_INDEPENDENT_LEAVES_NOT_WANTED',
-          `This node_modules was not installed with the --independent-leaves option.
-          Don't use --independent-leaves run same command with --force to recreated node_modules`,
+          'This "node_modules" folder was created without the --independent-leaves option.'
+          + ' You must remove that option, or else add the --force option to recreate the "node_modules" folder.',
         )
       }
       if (Boolean(modules.shamefullyFlatten) !== opts.shamefullyFlatten) {
         if (modules.shamefullyFlatten) {
           throw new PnpmError(
             'ERR_PNPM_SHAMEFULLY_FLATTEN_WANTED',
-            `This node_modules was installed with --shamefully-flatten option.
-            Use this option or run same command with --force to recreated node_modules`,
+            'This "node_modules" folder was created using the --shamefully-flatten option.'
+            + ' You must add this option, or else add the --force option to recreate the "node_modules" folder.',
           )
         }
         throw new PnpmError(
           'ERR_PNPM_SHAMEFULLY_FLATTEN_NOT_WANTED',
-          `This node_modules was not installed with the --shamefully-flatten option.
-          Don't use --shamefully-flatten or run same command with --force to recreated node_modules`,
+          'This "node_modules" folder was created without the --shamefully-flatten option.'
+          + ' You must remove that option, or else add the --force option to recreate the "node_modules" folder.',
         )
       }
       checkCompatibility(modules, {storePath, modulesPath})

--- a/packages/supi/test/install/independentLeaves.ts
+++ b/packages/supi/test/install/independentLeaves.ts
@@ -27,7 +27,7 @@ test('--independent-leaves throws exception when executed on node_modules instal
     t.fail('installation should have failed')
   } catch (err) {
     t.equal(err['code'], 'ERR_PNPM_INDEPENDENT_LEAVES_NOT_WANTED') // tslint:disable-line:no-string-literal
-    t.ok(err.message.indexOf('This node_modules was not installed with the --independent-leaves option.') === 0)
+    t.ok(err.message.indexOf('This "node_modules" folder was created without the --independent-leaves option.') === 0)
   }
 })
 
@@ -40,6 +40,6 @@ test('--no-independent-leaves throws exception when executed on node_modules ins
     t.fail('installation should have failed')
   } catch (err) {
     t.equal(err['code'], 'ERR_PNPM_INDEPENDENT_LEAVES_WANTED') // tslint:disable-line:no-string-literal
-    t.ok(err.message.indexOf('This node_modules was installed with --independent-leaves option.') === 0)
+    t.ok(err.message.indexOf('This "node_modules" folder was created using the --independent-leaves option.') === 0)
   }
 })

--- a/packages/supi/test/install/shamefullyFlatten.ts
+++ b/packages/supi/test/install/shamefullyFlatten.ts
@@ -103,7 +103,7 @@ test('--shamefully-flatten throws exception when executed on node_modules instal
     t.fail('installation should have failed')
   } catch (err) {
     t.ok(err['code'], 'ERR_PNPM_SHAMEFULLY_FLATTEN_NOT_WANTED') // tslint:disable-line:no-string-literal
-    t.ok(err.message.indexOf('This node_modules was not installed with the --shamefully-flatten option.') === 0)
+    t.ok(err.message.indexOf('This "node_modules" folder was created without the --shamefully-flatten option.') === 0)
   }
 })
 
@@ -116,7 +116,7 @@ test('--no-shamefully-flatten throws exception when executed on node_modules ins
     t.fail('installation should have failed')
   } catch (err) {
     t.ok(err['code'], 'ERR_PNPM_SHAMEFULLY_FLATTEN_WANTED') // tslint:disable-line:no-string-literal
-    t.ok(err.message.indexOf('This node_modules was installed with --shamefully-flatten option.') === 0)
+    t.ok(err.message.indexOf('This "node_modules" folder was created using the --shamefully-flatten option.') === 0)
   }
 })
 


### PR DESCRIPTION
I found the `--shamefully-flatten` error messages to be confusing because the grammar is odd.

This is a small fix to improve the wording, since we're experimenting with supporting this option.