### PR TITLE
fix: ignore filtered packages when sorting topologically

### DIFF
--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -323,47 +323,69 @@ export async function recursive (
 
 function sortPackages (pkgGraph: {[nodeId: string]: PackageNode}): string[][] {
   const keys = Object.keys(pkgGraph)
+  const setOfKeys = new Set(keys)
   const graph = new Map(
     keys.map((pkgPath) => [
       pkgPath,
-      /* remove cycles of length 1 (ie., package 'a' depends on 'a').  They
-      confuse the graph-sequencer, but can be ignored when ordering packages
-      topologically.
+      pkgGraph[pkgPath].dependencies.filter(
+        /* remove cycles of length 1 (ie., package 'a' depends on 'a').  They
+        confuse the graph-sequencer, but can be ignored when ordering packages
+        topologically.
 
-      See the following example where 'b' and 'c' depend on themselves:
+        See the following example where 'b' and 'c' depend on themselves:
 
-        graphSequencer({graph: new Map([
-          ['a', ['b', 'c']],
-          ['b', ['b']],
-          ['c', ['b', 'c']]]
-        ),
-        groups: [['a', 'b', 'c']]})
+          graphSequencer({graph: new Map([
+            ['a', ['b', 'c']],
+            ['b', ['b']],
+            ['c', ['b', 'c']]]
+          ),
+          groups: [['a', 'b', 'c']]})
 
-      returns chunks:
+        returns chunks:
 
-          [['b'],['a'],['c']]
+            [['b'],['a'],['c']]
 
-      But both 'b' and 'c' should be executed _before_ 'a', because 'a' depends on
-      them.  It works (and is considered 'safe' if we run:)
+        But both 'b' and 'c' should be executed _before_ 'a', because 'a' depends on
+        them.  It works (and is considered 'safe' if we run:)
 
-        graphSequencer({graph: new Map([
-          ['a', ['b', 'c']],
-          ['b', []],
-          ['c', ['b']]]
-        ), groups: [['a', 'b', 'c']]})
+          graphSequencer({graph: new Map([
+            ['a', ['b', 'c']],
+            ['b', []],
+            ['c', ['b']]]
+          ), groups: [['a', 'b', 'c']]})
 
-      returning:
+        returning:
 
-          [['b'], ['c'], ['a']]
+            [['b'], ['c'], ['a']]
 
-      */
-      pkgGraph[pkgPath].dependencies.filter(d => d !== pkgPath)]
+        */
+        d => d !== pkgPath &&
+        /* remove unused dependencies that we can ignore due to a filter expression.
+
+        Again, the graph sequencer used to behave weirdly in the following edge case:
+
+          graphSequencer({graph: new Map([
+            ['a', ['b', 'c']],
+            ['d', ['a']],
+            ['e', ['a', 'b', 'c']]]
+          ),
+          groups: [['a', 'e', 'e']]})
+
+        returns chunks:
+
+            [['d'],['a'],['e']]
+
+        But we really want 'a' to be executed first.
+        */
+        setOfKeys.has(d))]
     ) as Array<[string, string[]]>,
   )
+  console.log(graph, 'keys', keys)
   const graphSequencerResult = graphSequencer({
     graph,
-    groups: [keys],
+    groups: [[keys[0]], keys.slice(1)],
   })
+  console.log(graphSequencerResult)
   return graphSequencerResult.chunks
 }
 

--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -380,12 +380,10 @@ function sortPackages (pkgGraph: {[nodeId: string]: PackageNode}): string[][] {
         setOfKeys.has(d))]
     ) as Array<[string, string[]]>,
   )
-  console.log(graph, 'keys', keys)
   const graphSequencerResult = graphSequencer({
     graph,
     groups: [[keys[0]], keys.slice(1)],
   })
-  console.log(graphSequencerResult)
   return graphSequencerResult.chunks
 }
 

--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -382,7 +382,7 @@ function sortPackages (pkgGraph: {[nodeId: string]: PackageNode}): string[][] {
   )
   const graphSequencerResult = graphSequencer({
     graph,
-    groups: [[keys[0]], keys.slice(1)],
+    groups: [keys],
   })
   return graphSequencerResult.chunks
 }

--- a/packages/pnpm/test/monorepo/index.ts
+++ b/packages/pnpm/test/monorepo/index.ts
@@ -176,7 +176,7 @@ test('linking a package inside a monorepo with --link-workspace-packages', async
   }
 })
 
-test('Regression: topological order of packages with self-dependencies in monorepo is correct', async (t: tape.Test) => {
+test('topological order of packages with self-dependencies in monorepo is correct', async (t: tape.Test) => {
   preparePackages(t, [
     {
       name: 'project-1',
@@ -226,7 +226,7 @@ test('Regression: topological order of packages with self-dependencies in monore
 
 })
 
-test('Regression: Do not get confused by filtered dependencies when searching for dependents in monorepo', async (t: tape.Test) => {
+test('do not get confused by filtered dependencies when searching for dependents in monorepo', async (t: tape.Test) => {
   /*
    In this test case, we are filtering for 'project-2' and its dependents with
    two projects in the dependency hierarchy, that can be ignored for this query,

--- a/packages/pnpm/test/monorepo/index.ts
+++ b/packages/pnpm/test/monorepo/index.ts
@@ -226,6 +226,64 @@ test('Regression: topological order of packages with self-dependencies in monore
 
 })
 
+test('Regression: Do not get confused by filtered dependencies when searching for dependents in monorepo', async (t: tape.Test) => {
+  /*
+   In this test case, we are filtering for 'project-2' and its dependents with
+   two projects in the dependency hierarchy, that can be ignored for this query,
+   as they do not depend on 'project-2'.
+  */
+  preparePackages(t, [
+    {
+      name: 'unused-project-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'unused-project-2',
+      version: '1.0.0',
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+      dependencies: { 'unused-project-1': '1.0.0', 'unused-project-2': '1.0.0' },
+      devDependencies: { 'json-append': '1' },
+      scripts: {
+        test: `node -e "process.stdout.write('project-2')" | json-append ../output.json`,
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+      dependencies: { 'project-2': '1.0.0' },
+      devDependencies: { 'json-append': '1' },
+      scripts: {
+        test: `node -e "process.stdout.write('project-3')" | json-append ../output.json`,
+      },
+    },
+    {
+      name: 'project-4',
+      version: '1.0.0',
+      dependencies: { 'project-2': '1.0.0', 'unused-project-1': '1.0.0', 'unused-project-2': '1.0.0' },
+      devDependencies: { 'json-append': '1' },
+      scripts: {
+        test: `node -e "process.stdout.write('project-4')" | json-append ../output.json`,
+      },
+    },
+  ]);
+  await fs.writeFile('.npmrc', 'link-workspace-packages = true', 'utf8')
+  await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  await execPnpm('install')
+
+  process.chdir('project-2')
+
+  await execPnpm('recursive', '--filter=...project-2', 'run', 'test')
+
+  const outputs = await import(path.resolve('..', 'output.json')) as string[]
+  // project-2 should be executed first, we cannot say anything about the order
+  // of the last two packages.
+  t.equal(outputs[0], 'project-2')
+
+})
 // TODO: make it pass
 test['skip']('installation with --link-workspace-packages links packages even if they were previously installed from registry', async (t: tape.Test) => {
   const projects = preparePackages(t, [


### PR DESCRIPTION
This is another issue with the graph-sequencer producing strange results when
sorting topologically, but everything should be fine. (

*I hope so*, because I really would like to use the `--filter=...package` feature!) 

Case that is fixed here:

- Package 'a' depends on 'b' and 'c'
- Package 'd' depends on 'a'
- Package 'e' depends on 'a', 'b' and 'c'

Command that has the wrong behavior:

	pnpm recursive --filter=...a [command]

**Expected behavior**:

Packages are executed in order `['a', ['d', 'e']]` ('d' and 'e' can be
executed in parallel.)

**Actual behavior**:

Packages are executed in order `[['e', 'a', 'd']]`

**Fix to get expected behavior**:

Remove the unused dependencies 'b' and 'c' from the graph when sorting.