### PR TITLE
fix(config): only install to APPDATA on Windows

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -128,7 +128,7 @@ export default async (
     }, {} as PnpmConfigs)
   pnpmConfig.rawNpmConfig = Object.assign.apply(Object, npmConfig.list.reverse().concat([cliArgs]))
   const npmGlobalPrefix: string = pnpmConfig.rawNpmConfig['pnpm-prefix'] ||
-    (process.env.APPDATA
+    (process.platform === 'win32' && process.env.APPDATA
       ? path.join(process.env.APPDATA, 'npm')
       : npmConfig.globalPrefix)
   pnpmConfig.globalBin = process.platform === 'win32'


### PR DESCRIPTION
Fixes #1425.

As far as I can tell, this is all that was actually going on in that issue. I've tested this out locally and `pnpx install -g` and `pnpx` both seem to be working on Linux even in the presence of an APPDATA variable.