### PR TITLE
feat: when filters are used, commands are automatically recursive

### DIFF
--- a/packages/pnpm/src/cmd/help.ts
+++ b/packages/pnpm/src/cmd/help.ts
@@ -23,6 +23,10 @@ function getHelpText (command: string) {
 
         Aliases: i, install, add
 
+        Installs all dependencies of the project in the current working directory.
+        To install dependencies in every project of a monorepo, run \`pnpm recursive install\`
+        or \`pnpm install\` with filtering. For instance, \`pnpm install -- .\`.
+
         Options:
 
           -P, --save-prod                    save package to your \`dependencies\`
@@ -74,6 +78,29 @@ function getHelpText (command: string) {
 
         Discouraged options:
           --shamefully-flatten               Attempt to flatten the dependency tree, similar to what npm does
+
+        Filtering options:
+          -- <package selector>..., --filter <package selector>
+            Run the command only on packages that satisfy at least one of the selectors.
+
+            Example: pnpm recursive install -- foo... ...@bar/* qar ./components
+
+            These selectors may be used:
+
+            <pattern>
+              Restricts the scope to package names matching the given pattern. E.g.: foo, @bar/*
+
+            <pattern>...
+              Includes all direct and indirect dependencies of the matched packages. E.g.: foo...
+
+            ...<pattern>
+              Includes all direct and indirect dependents of the matched packages. E.g.: ...foo, ...@bar/*
+
+            ./<directory>
+              Includes all packages that are inside a given subdirectory. E.g.: ./components
+
+            .
+              Includes all packages that are under the current working directory.
       `
 
     case 'import':

--- a/packages/pnpm/test/recursive/misc.ts
+++ b/packages/pnpm/test/recursive/misc.ts
@@ -706,6 +706,57 @@ test('recursive filter package with dependents and filter with dependencies, usi
   projects['project-4'].hasNot('minimatch')
 })
 
+test('recursive filter package with dependents and filter with dependencies, using dash-dash, omitting the recursive command', async (t: tape.Test) => {
+  const projects = preparePackages(t, [
+    {
+      name: 'project-0',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+        'project-1': '1.0.0',
+      },
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+        'project-2': '1.0.0',
+        'project-3': '1.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+      dependencies: {
+        minimatch: '*',
+      },
+    },
+    {
+      name: 'project-4',
+      version: '1.0.0',
+      dependencies: {
+        minimatch: '*',
+      },
+    },
+  ])
+
+  await execPnpm('--link-workspace-packages', 'install', '--', '...project-2', 'project-1...')
+
+  projects['project-0'].has('is-positive')
+  projects['project-1'].has('is-positive')
+  projects['project-2'].has('is-negative')
+  projects['project-3'].has('minimatch')
+  projects['project-4'].hasNot('minimatch')
+})
+
 test('recursive filter multiple times', async (t: tape.Test) => {
   const projects = preparePackages(t, [
     {


### PR DESCRIPTION
`pnpm [command] -- [filters]` is converted to
`pnpm recursive [command] -- [filters]`

ref #1444