### PR TITLE
test(supi): abstract store assertions via assert-store

### DIFF
--- a/packages/supi/package.json
+++ b/packages/supi/package.json
@@ -88,6 +88,7 @@
   },
   "devDependencies": {
     "@pnpm/assert-project": "link:../../privatePackages/assert-project",
+    "@pnpm/assert-store": "link:../../privatePackages/assert-store",
     "@pnpm/default-fetcher": "2.0.6",
     "@pnpm/default-resolver": "2.0.7",
     "@pnpm/logger": "2.1.0",

--- a/packages/supi/test/install/installationChecks.ts
+++ b/packages/supi/test/install/installationChecks.ts
@@ -5,6 +5,7 @@ import promisifyTape from 'tape-promise'
 import { testDefaults } from '../utils'
 
 const test = promisifyTape(tape)
+const testOnly = promisifyTape(tape.only)
 
 test('fail if installed package does not support the current engine and engine-strict = true', async (t) => {
   const project = prepare(t)

--- a/packages/supi/test/storeAdd.ts
+++ b/packages/supi/test/storeAdd.ts
@@ -1,8 +1,8 @@
+import assertStore from '@pnpm/assert-store'
 import { tempDir } from '@pnpm/prepare'
 import fs = require('fs')
 import loadJsonFile from 'load-json-file'
 import path = require('path')
-import exists = require('path-exists')
 import { storeAdd } from 'supi'
 import tape = require('tape')
 import promisifyTape from 'tape-promise'
@@ -17,12 +17,15 @@ test('add packages to the store', async (t: tape.Test) => {
   process.chdir('_')
 
   const opts = await testDefaults()
+  const store = assertStore(t, opts.store)
+
   opts['registry'] = opts.registries!.default // tslint:disable-line
   await storeAdd(['express@4.16.3'], opts)
 
-  const pathToCheck = path.join(opts.store, 'localhost+4873', 'express', '4.16.3')
-  t.ok(await exists(pathToCheck), `express@4.16.3 is in store (at ${pathToCheck})`)
+  // Assert package in file structure
+  await store.storeHas('express', '4.16.3')
 
+  // Assert package in store index
   const storeIndex = await loadJsonFile(path.join(opts.store, 'store.json'))
   t.deepEqual(
     storeIndex,

--- a/packages/supi/test/storeUsages.ts
+++ b/packages/supi/test/storeUsages.ts
@@ -1,3 +1,4 @@
+import assertStore from '@pnpm/assert-store'
 import prepare from '@pnpm/prepare'
 import {
   addDependenciesToPackage,
@@ -51,9 +52,12 @@ test('find usages for single package in store (by version) and in a project', as
 
 test('find usages for package not in store', async (t: tape.Test) => {
   const project = prepare(t)
+  const opts = await testDefaults()
+  const store = assertStore(t, opts.store)
 
   // Find usages
-  const packageUsagesBySelectors = await storeUsages(['should-not-exist-uhsalzkj'], await testDefaults())
+  await store.storeHasNot('should-not-exist-uhsalzkj')
+  const packageUsagesBySelectors = await storeUsages(['should-not-exist-uhsalzkj'], opts)
 
   t.deepEqual(packageUsagesBySelectors, {
     'should-not-exist-uhsalzkj': [],
@@ -102,6 +106,7 @@ test('find usages for package in store but not in any projects', async (t: tape.
   const registries = opts.registries || {
     default: 'null'
   }
+  const store = assertStore(t, opts.store)
 
   // Add dependency directly to store (not to the project)
   await storeAdd(['is-negative'], {
@@ -109,6 +114,7 @@ test('find usages for package in store but not in any projects', async (t: tape.
     tag: '2.1.0',
     ...opts
   })
+  await store.storeHas('is-negative', '2.1.0')
 
   // Find usages
   const packageUsagesBySelectors = await storeUsages(['is-negative'], opts)
@@ -132,6 +138,7 @@ test('find usages for multiple packages in store but not in any projects', async
   const registries = opts.registries || {
     default: 'null'
   }
+  const store = assertStore(t, opts.store)
 
   // Add dependencies directly to store (not to the project). Note we add different versions of the same package
   await storeAdd(['is-negative'], {
@@ -139,11 +146,13 @@ test('find usages for multiple packages in store but not in any projects', async
     tag: '2.0.0',
     ...opts
   })
+  await store.storeHas('is-negative', '2.0.0')
   await storeAdd(['is-negative'], {
     registry: registries.default,
     tag: '2.1.0',
     ...opts
   })
+  await store.storeHas('is-negative', '2.1.0')
 
   // Find usages
   const packageUsagesBySelectors = await storeUsages(['is-negative'], opts)

--- a/packages/supi/test/uninstall.ts
+++ b/packages/supi/test/uninstall.ts
@@ -115,11 +115,11 @@ test('uninstall scoped package', async (t) => {
 test('uninstall tarball dependency', async (t: tape.Test) => {
   const project = prepare(t)
   const opts = await testDefaults({ save: true })
+
   await addDependenciesToPackage(['http://localhost:4873/is-array/-/is-array-1.0.1.tgz'], opts)
   await uninstall(['is-array'], opts)
 
-  t.ok(await exists(path.join(await project.getStorePath(), 'localhost+4873', 'is-array', '1.0.1')))
-
+  await project.storeHas('is-array', '1.0.1')
   await project.hasNot('is-array')
 
   const pkgJson = await readPkg()

--- a/privatePackages/assert-project/package.json
+++ b/privatePackages/assert-project/package.json
@@ -44,6 +44,7 @@
     "test": "npm run lint && npm run lint-test && npm run tsc && ts-node test"
   },
   "dependencies": {
+    "@pnpm/assert-store": "link:../assert-store",
     "@pnpm/modules-yaml": "2.0.1",
     "@types/mz": "0.0.32",
     "@types/node": "10.12.12",

--- a/privatePackages/assert-project/src/index.ts
+++ b/privatePackages/assert-project/src/index.ts
@@ -14,7 +14,7 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
   const modules = path.join(projectPath, 'node_modules')
 
   let cachedStore: {
-    getStorePath (): Promise<string>;
+    storePath: string;
     storeHas (pkgName: string, version?: string | undefined): Promise<void>;
     storeHasNot (pkgName: string, version?: string | undefined): Promise<void>;
     resolve (pkgName: string, version?: string | undefined, relativePath?: string | undefined): Promise<string>
@@ -26,7 +26,10 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
         throw new Error(`Cannot find module store. No .modules.yaml found at "${modules}"`)
       }
       const storePath = modulesYaml.store
-      cachedStore = assertStore(t, storePath, ern)
+      cachedStore = {
+        storePath,
+        ...assertStore(t, storePath, ern),
+      }
     }
     return cachedStore
   }
@@ -43,7 +46,7 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
     },
     async getStorePath () {
       const store = await getStoreInstance()
-      return store.getStorePath()
+      return store.storePath
     },
     async resolve (pkgName: string, version?: string, relativePath?: string) {
       const store = await getStoreInstance()

--- a/privatePackages/assert-project/src/index.ts
+++ b/privatePackages/assert-project/src/index.ts
@@ -57,8 +57,16 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
       return store.resolve(pkgName, version)
     },
     async storeHasNot (pkgName: string, version?: string) {
-      const store = await getStoreInstance()
-      return store.storeHasNot(pkgName, version)
+      try {
+        const store = await getStoreInstance()
+        return store.storeHasNot(pkgName, version)
+      } catch (err) {
+        if (err.message.startsWith('Cannot find module store')) {
+          t.pass(`${pkgName}@${version} is not in store (store does not even exist)`)
+          return
+        }
+        throw err
+      }
     },
     isExecutable (pathToExe: string) {
       return isExecutable(t, path.join(modules, pathToExe))

--- a/privatePackages/assert-project/src/index.ts
+++ b/privatePackages/assert-project/src/index.ts
@@ -1,3 +1,4 @@
+import assertStore from '@pnpm/assert-store'
 import { read as readModules } from '@pnpm/modules-yaml'
 import path = require('path')
 import exists = require('path-exists')
@@ -11,8 +12,26 @@ export { isExecutable }
 export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
   const ern = encodedRegistryName || 'localhost+4873'
   const modules = path.join(projectPath, 'node_modules')
-  let cachedStorePath: string
-  const project = {
+
+  let cachedStore: {
+    getStorePath (): Promise<string>;
+    storeHas (pkgName: string, version?: string | undefined): Promise<void>;
+    storeHasNot (pkgName: string, version?: string | undefined): Promise<void>;
+    resolve (pkgName: string, version?: string | undefined, relativePath?: string | undefined): Promise<string>
+  }
+  async function getStoreInstance () {
+    if (!cachedStore) {
+      const modulesYaml = await readModules(modules)
+      if (!modulesYaml) {
+        throw new Error(`Cannot find module store. No .modules.yaml found at "${modules}"`)
+      }
+      const storePath = modulesYaml.store
+      cachedStore = assertStore(t, storePath, ern)
+    }
+    return cachedStore
+  }
+
+  return {
     requireModule (pkgName: string) {
       return require(path.join(modules, pkgName))
     },
@@ -23,37 +42,20 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
       t.notOk(await exists(path.join(modules, pkgName)), `${pkgName} is not in node_modules`)
     },
     async getStorePath () {
-      if (!cachedStorePath) {
-        const modulesYaml = await readModules(modules)
-        if (!modulesYaml) {
-          throw new Error(`Cannot find module store. No .modules.yaml found at "${modules}"`)
-        }
-        cachedStorePath = modulesYaml.store
-      }
-      return cachedStorePath
+      const store = await getStoreInstance()
+      return store.getStorePath()
     },
     async resolve (pkgName: string, version?: string, relativePath?: string) {
-      const pkgFolder = version ? path.join(ern, pkgName, version) : pkgName
-      if (relativePath) {
-        return path.join(await project.getStorePath(), pkgFolder, 'package', relativePath)
-      }
-      return path.join(await project.getStorePath(), pkgFolder, 'package')
+      const store = await getStoreInstance()
+      return store.resolve(pkgName, version, relativePath)
     },
     async storeHas (pkgName: string, version?: string) {
-      const pathToCheck = await project.resolve(pkgName, version)
-      t.ok(await exists(pathToCheck), `${pkgName}@${version} is in store (at ${pathToCheck})`)
+      const store = await getStoreInstance()
+      return store.resolve(pkgName, version)
     },
     async storeHasNot (pkgName: string, version?: string) {
-      try {
-        const pathToCheck = await project.resolve(pkgName, version)
-        t.notOk(await exists(pathToCheck), `${pkgName}@${version} is not in store (at ${pathToCheck})`)
-      } catch (err) {
-        if (err.message.startsWith('Cannot find module store')) {
-          t.pass(`${pkgName}@${version} is not in store`)
-          return
-        }
-        throw err
-      }
+      const store = await getStoreInstance()
+      return store.storeHasNot(pkgName, version)
     },
     isExecutable (pathToExe: string) {
       return isExecutable(t, path.join(modules, pathToExe))
@@ -79,5 +81,4 @@ export default (t: Test, projectPath: string, encodedRegistryName?: string) => {
       await writePkg(projectPath, pkgJson)
     },
   }
-  return project
 }

--- a/privatePackages/assert-store/src/index.ts
+++ b/privatePackages/assert-store/src/index.ts
@@ -5,9 +5,6 @@ import { Test } from 'tape'
 export default (t: Test, storePath: string, encodedRegistryName?: string) => {
   const ern = encodedRegistryName || 'localhost+4873'
   const store = {
-    async getStorePath (): Promise<string> {
-      return storePath
-    },
     async storeHas (pkgName: string, version?: string): Promise<void> {
       const pathToCheck = await store.resolve(pkgName, version)
       t.ok(await exists(pathToCheck), `${pkgName}@${version} is in store (at ${pathToCheck})`)

--- a/privatePackages/assert-store/src/index.ts
+++ b/privatePackages/assert-store/src/index.ts
@@ -5,15 +5,18 @@ import { Test } from 'tape'
 export default (t: Test, storePath: string, encodedRegistryName?: string) => {
   const ern = encodedRegistryName || 'localhost+4873'
   const store = {
-    async storeHas (pkgName: string, version?: string) {
+    async getStorePath (): Promise<string> {
+      return storePath
+    },
+    async storeHas (pkgName: string, version?: string): Promise<void> {
       const pathToCheck = await store.resolve(pkgName, version)
       t.ok(await exists(pathToCheck), `${pkgName}@${version} is in store (at ${pathToCheck})`)
     },
-    async storeHasNot (pkgName: string, version: string) {
+    async storeHasNot (pkgName: string, version?: string): Promise<void> {
       const pathToCheck = await store.resolve(pkgName, version)
       t.notOk(await exists(pathToCheck), `${pkgName}@${version} is not in store (at ${pathToCheck})`)
     },
-    async resolve (pkgName: string, version?: string, relativePath?: string) {
+    async resolve (pkgName: string, version?: string, relativePath?: string): Promise<string> {
       const pkgFolder = version ? path.join(ern, pkgName, version) : pkgName
       if (relativePath) {
         return path.join(await storePath, pkgFolder, 'package', relativePath)

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1410,6 +1410,7 @@ importers:
       write-pkg: 3.2.0
     devDependencies:
       '@pnpm/assert-project': 'link:../../privatePackages/assert-project'
+      '@pnpm/assert-store': 'link:../../privatePackages/assert-store'
       '@pnpm/default-fetcher': 'link:../default-fetcher'
       '@pnpm/default-resolver': 'link:../default-resolver'
       '@pnpm/logger': 2.1.0
@@ -1451,6 +1452,7 @@ importers:
       write-yaml-file: 2.0.0
     specifiers:
       '@pnpm/assert-project': 'link:../../privatePackages/assert-project'
+      '@pnpm/assert-store': 'link:../../privatePackages/assert-store'
       '@pnpm/check-package': 2.0.0
       '@pnpm/core-loggers': 1.0.0
       '@pnpm/default-fetcher': 2.0.6
@@ -1631,6 +1633,7 @@ importers:
       typescript: 3.2.2
   privatePackages/assert-project:
     dependencies:
+      '@pnpm/assert-store': 'link:../assert-store'
       '@pnpm/modules-yaml': 'link:../../packages/modules-yaml'
       '@types/mz': 0.0.32
       '@types/node': 10.12.12
@@ -1653,6 +1656,7 @@ importers:
       typescript: 3.2.2
     specifiers:
       '@pnpm/assert-project': 'link:'
+      '@pnpm/assert-store': 'link:../assert-store'
       '@pnpm/modules-yaml': 2.0.1
       '@types/mz': 0.0.32
       '@types/node': 10.12.12


### PR DESCRIPTION
Closes #1536 

## Overview

- Modifies `assert-project` to use `assert-store` for store-related assertions
- Modifies tests in `supi` to use `assert-store` directly when no project is configured (`pnpm install` is not run in tests)

## Why?

If store structure changes in the future:

- **Currently**: We must change all tests that hard-code paths to the store
- **With the change**: We would just change the functions in `assert-store`. All tests use this as a facade, meaning they would not need to be changed.

## Testing Done

- Added new unit tests
- `pnpm test` on `assert-store` and `assert-project`
- `pnpm test` on changed files in `supi`