### PR TITLE
Catch exception from package.json containing an invalid name

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -240,7 +240,14 @@ export default async function run (argv: string[]) {
           resolve()
         }
       } catch (err) {
-        reject(err)
+        if (err.message.startsWith("Invalid Name: ")) {
+          logger.warn({
+            message: err.message,
+            prefix: opts.prefix,
+          });
+        } else {
+          reject(err);
+        }
       }
     }, 0)
   })


### PR DESCRIPTION
This is probably not where you really want to catch this exception - this is just to say that normalize-package-json does throw exceptions if, for example, package.json contains a name with spaces in it instead of hyphens. I don't know where you do want to catch this exception, but the stack trace (from loud-rejection?) makes it look like something has gone wrong inside of pnpm instead of simply unexpected data.