### PR TITLE
feat: when a version spec is specified, add it to package.json

### DIFF
--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -121,3 +121,15 @@ test('install --save-exact', async (t: tape.Test) => {
 
   t.deepEqual(pkg.devDependencies, { 'is-positive': '3.1.0' })
 })
+
+test('install save new dep with the specified spec', async (t: tape.Test) => {
+  const project = prepare(t)
+
+  await execPnpm('install', 'is-positive@~3.1.0')
+
+  await project.has('is-positive')
+
+  const pkg = await readPackageJsonFromDir(process.cwd())
+
+  t.deepEqual(pkg.dependencies, { 'is-positive': '~3.1.0' })
+})

--- a/packages/pnpm/test/monorepo/index.ts
+++ b/packages/pnpm/test/monorepo/index.ts
@@ -445,7 +445,7 @@ test('recursive install with link-workspace-packages and shared-workspace-shrink
   const storeJson = await loadJsonFile<object>(path.resolve('store', '2', 'store.json'))
   t.deepEqual(storeJson['localhost+4873/is-negative/1.0.0'].length, 1, 'new connections saved in store.json')
 
-  await execPnpm('recursive', 'install', 'pkg-with-1-dep@100.0.0', '--link-workspace-packages', '--shared-workspace-shrinkwrap=true', '--store', 'store')
+  await execPnpm('recursive', 'install', 'pkg-with-1-dep', '--link-workspace-packages', '--shared-workspace-shrinkwrap=true', '--store', 'store')
 
   {
     const pkg = await readPackageJsonFromDir(path.resolve('is-positive'))
@@ -882,8 +882,8 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
         'bar': 'link:../bar',
       },
       specifiers: {
-        'ajv': '^4.10.4',
-        'ajv-keywords': '^1.5.0',
+        'ajv': '4.10.4',
+        'ajv-keywords': '1.5.0',
         'bar': '1.0.0',
       },
     })
@@ -899,7 +899,7 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
         'bar': 'link:../bar',
       },
       specifiers: {
-        'ajv-keywords': '^1.5.0',
+        'ajv-keywords': '1.5.0',
         'bar': '1.0.0',
       },
     })

--- a/packages/supi/package.json
+++ b/packages/supi/package.json
@@ -85,6 +85,7 @@
     "symlink-dir": "2.0.2",
     "util.promisify": "1.0.0",
     "validate-npm-package-name": "3.0.0",
+    "version-selector-type": "2.0.0",
     "write-pkg": "3.2.0"
   },
   "devDependencies": {

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -707,6 +707,7 @@ async function installInContext (
             name: dep.alias,
             pref: dep.normalizedPref || getPref(dep.alias, dep.name, dep.version, {
               pinnedVersion: importer.pinnedVersion,
+              rawSpec: dep.specRaw,
             }),
             saveType: importer.targetDependenciesField,
           }

--- a/packages/supi/src/utils/getPref.ts
+++ b/packages/supi/src/utils/getPref.ts
@@ -1,12 +1,21 @@
+import versionSelectorType = require('version-selector-type')
+
 export default function getPref (
   alias: string,
   name: string,
   version: string,
   opts: {
+    rawSpec?: string,
     pinnedVersion?: 'major' | 'minor' | 'patch',
   },
 ) {
   const prefix = alias !== name ? `npm:${name}@` : ''
+  if (opts.rawSpec && opts.rawSpec.startsWith(`${alias}@${prefix}`)) {
+    const selector = versionSelectorType(opts.rawSpec.substr(`${alias}@${prefix}`.length))
+    if (selector && (selector.type === 'version' || selector.type === 'range')) {
+      return opts.rawSpec.substr(alias.length + 1)
+    }
+  }
   switch (opts.pinnedVersion || 'major') {
     case 'major':
       return `${prefix}^${version}`

--- a/packages/supi/test/install/aliases.ts
+++ b/packages/supi/test/install/aliases.ts
@@ -46,7 +46,7 @@ test('installing aliased dependency', async (t: tape.Test) => {
     },
     shrinkwrapVersion: 5,
     specifiers: {
-      negative: 'npm:is-negative@^1.0.0',
+      negative: 'npm:is-negative@1.0.0',
       positive: 'npm:is-positive@^3.1.0',
     },
   }, 'correct shrinkwrap.yaml')

--- a/packages/supi/test/install/misc.ts
+++ b/packages/supi/test/install/misc.ts
@@ -150,7 +150,7 @@ test('no dependencies (lodash)', async (t: tape.Test) => {
     name: 'pnpm:package-json',
     updated: {
       dependencies: {
-        lodash: '^4.0.0',
+        lodash: '4.0.0',
       },
       name: 'project',
       version: '0.0.0',
@@ -877,7 +877,7 @@ test('create a package.json if there is none', async (t: tape.Test) => {
 
   t.deepEqual(await readPkg({ normalize: false }), {
     dependencies: {
-      'dep-of-pkg-with-1-dep': '^100.1.0',
+      'dep-of-pkg-with-1-dep': '100.1.0',
     },
   }, 'package.json created')
 })

--- a/packages/supi/test/install/multipleImporters.ts
+++ b/packages/supi/test/install/multipleImporters.ts
@@ -187,7 +187,7 @@ test('adding a new dev dependency to project that uses a shared shrinkwrap', asy
   const pkg = await readPkg({ cwd: 'project-1' })
 
   t.deepEqual(pkg.dependencies, { 'is-positive': '1.0.0' }, 'prod deps unchanged in package.json')
-  t.deepEqual(pkg.devDependencies, { 'is-negative': '^1.0.0' }, 'dev deps have a new dependency in package.json')
+  t.deepEqual(pkg.devDependencies, { 'is-negative': '1.0.0' }, 'dev deps have a new dependency in package.json')
 })
 
 test('headless install is used when package link to another package in the workspace', async (t) => {

--- a/packages/supi/test/install/peerDependencies.ts
+++ b/packages/supi/test/install/peerDependencies.ts
@@ -396,8 +396,8 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
       'ajv-keywords': '1.5.0_ajv@4.10.4',
     },
     specifiers: {
-      'ajv': '^4.10.4',
-      'ajv-keywords': '^1.5.0',
+      'ajv': '4.10.4',
+      'ajv-keywords': '1.5.0',
     },
   }, 'correct shrinkwrap.yaml created')
 })
@@ -435,8 +435,8 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
         'ajv-keywords': '1.5.0_ajv@4.10.4',
       },
       specifiers: {
-        'ajv': '^4.10.4',
-        'ajv-keywords': '^1.5.0',
+        'ajv': '4.10.4',
+        'ajv-keywords': '1.5.0',
       },
     })
   }
@@ -451,8 +451,8 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
         'ajv-keywords': '1.5.0_ajv@4.10.4',
       },
       specifiers: {
-        'ajv': '^4.10.4',
-        'ajv-keywords': '^1.5.0',
+        'ajv': '4.10.4',
+        'ajv-keywords': '1.5.0',
       },
     })
   }
@@ -478,7 +478,7 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
         'ajv-keywords': '1.5.0',
       },
       specifiers: {
-        'ajv-keywords': '^1.5.0',
+        'ajv-keywords': '1.5.0',
       },
     })
   }
@@ -500,8 +500,8 @@ test('external shrinkwrap: peer dependency is grouped with dependent even after 
         'ajv-keywords': '1.4.0_ajv@4.10.4',
       },
       specifiers: {
-        'ajv': '^4.10.4',
-        'ajv-keywords': '^1.4.0',
+        'ajv': '4.10.4',
+        'ajv-keywords': '1.4.0',
       },
     })
   }
@@ -516,8 +516,8 @@ test('external shrinkwrap: peer dependency is grouped with dependent even after 
         'ajv-keywords': '1.5.0_ajv@4.10.4',
       },
       specifiers: {
-        'ajv': '^4.10.4',
-        'ajv-keywords': '^1.5.0',
+        'ajv': '4.10.4',
+        'ajv-keywords': '1.5.0',
       },
     })
   }
@@ -539,8 +539,8 @@ test('external shrinkwrap: peer dependency is grouped with dependent even after 
         'peer-c': '1.0.0',
       },
       specifiers: {
-        'abc-parent-with-ab': '^1.0.0',
-        'peer-c': '^1.0.0',
+        'abc-parent-with-ab': '1.0.0',
+        'peer-c': '1.0.0',
       },
     })
   }
@@ -555,8 +555,8 @@ test('external shrinkwrap: peer dependency is grouped with dependent even after 
         'peer-c': '2.0.0',
       },
       specifiers: {
-        'abc-parent-with-ab': '^1.0.0',
-        'peer-c': '^2.0.0',
+        'abc-parent-with-ab': '1.0.0',
+        'peer-c': '2.0.0',
       },
     })
   }

--- a/packages/supi/test/install/updatingPkgJson.ts
+++ b/packages/supi/test/install/updatingPkgJson.ts
@@ -17,7 +17,7 @@ const testOnly = promisifyTape(tape.only)
 
 test('save to package.json (rimraf@2.5.1)', async (t) => {
   const project = prepare(t)
-  await addDependenciesToPackage(['rimraf@2.5.1'], await testDefaults({ save: true }))
+  await addDependenciesToPackage(['rimraf@^2.5.1'], await testDefaults({ save: true }))
 
   const m = project.requireModule('rimraf')
   t.ok(typeof m === 'function', 'rimraf() is available')
@@ -214,8 +214,8 @@ test('multiple save to package.json with `exact` versions (@rstacruz/tap-spec & 
 
 test('save to package.json with save prefix ~', async (t: tape.Test) => {
   const project = prepare(t)
-  await addDependenciesToPackage(['rimraf@2.5.1'], await testDefaults({ pinnedVersion: 'minor' }))
+  await addDependenciesToPackage(['pkg-with-1-dep'], await testDefaults({ pinnedVersion: 'minor' }))
 
   const pkgJson = await readPkg()
-  t.deepEqual(pkgJson.dependencies, { rimraf: '~2.5.1' }, 'rimraf have been added to dependencies')
+  t.deepEqual(pkgJson.dependencies, { 'pkg-with-1-dep': '~100.0.0' }, 'rimraf have been added to dependencies')
 })

--- a/packages/supi/test/uninstall.ts
+++ b/packages/supi/test/uninstall.ts
@@ -43,7 +43,7 @@ test('uninstall package with no dependencies', async (t: tape.Test) => {
   t.ok(reporter.calledWithMatch({
     initial: {
       dependencies: {
-        'is-negative': '^2.1.0',
+        'is-negative': '2.1.0',
       },
       name: 'project',
       version: '0.0.0',
@@ -148,14 +148,14 @@ test('uninstall package with dependencies and do not touch other deps', async (t
   await project.has('is-negative')
 
   const pkgJson = await readPkg()
-  t.deepEqual(pkgJson.dependencies, { 'is-negative': '^2.1.0' }, 'camelcase-keys has been removed from dependencies')
+  t.deepEqual(pkgJson.dependencies, { 'is-negative': '2.1.0' }, 'camelcase-keys has been removed from dependencies')
 
   const shr = await project.loadShrinkwrap()
   t.deepEqual(shr.dependencies, {
     'is-negative': '2.1.0',
   }, 'camelcase-keys removed from shrinkwrap dependencies')
   t.deepEqual(shr.specifiers, {
-    'is-negative': '^2.1.0',
+    'is-negative': '2.1.0',
   }, 'camelcase-keys removed from shrinkwrap specifiers')
 })
 

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -1654,6 +1654,7 @@ importers:
       symlink-dir: 2.0.2
       util.promisify: 1.0.0
       validate-npm-package-name: 3.0.0
+      version-selector-type: 2.0.0
       write-pkg: 3.2.0
     devDependencies:
       '@pnpm/assert-project': 'link:../../privatePackages/assert-project'
@@ -1803,6 +1804,7 @@ importers:
       typescript: 3.2.4
       util.promisify: 1.0.0
       validate-npm-package-name: 3.0.0
+      version-selector-type: 2.0.0
       write-json-file: 3.0.2
       write-pkg: 3.2.0
       write-yaml-file: 2.0.0


### PR DESCRIPTION
close #1633

BREAKING CHANGE:

the specified version spec is prefered. It doesn't matter what are
the values of the save-exact and save-prefix configs.