### PR TITLE
feat(pnpm): Use `‑‑depth 0` by default for `pnpm ‑‑global list`

### DIFF
--- a/packages/pnpm/src/cmd/list.ts
+++ b/packages/pnpm/src/cmd/list.ts
@@ -6,6 +6,7 @@ export default async function (
     alwaysPrintRootPackage?: boolean,
     depth?: number,
     development: boolean,
+    global?: boolean,
     long?: boolean,
     parseable?: boolean,
     prefix: string,
@@ -14,6 +15,12 @@ export default async function (
   },
   command: string,
 ) {
+  if (opts.global && !('depth' in opts)) {
+    // Copy opts as they're effectively frozen
+    opts = JSON.parse(JSON.stringify(opts))
+    opts.depth = 0
+  }
+
   const output = await render(args, opts, command)
 
   if (output) console.log(output)


### PR DESCRIPTION
This makes it so that when doing `pnpm --global list`, the `--depth` argument defaults to `0`.

The reasoning behind this is that most usage of `pnpm ls ‑g` is to see which packages are installed globally, and there’s usually little need to see the sub‑dependencies of globally installed packages.