### PR TITLE
fix: "pnpm store add" should read the registries of scoped pkgs

### DIFF
--- a/packages/package-store/typings/index.d.ts
+++ b/packages/package-store/typings/index.d.ts
@@ -208,11 +208,6 @@ declare module 'is-subdir' {
   export = anything;
 }
 
-declare module 'normalize-registry-url' {
-  function normalizeRegistryUrl (registry: string): string
-  export = normalizeRegistryUrl;
-}
-
 declare module 'rename-overwrite' {
   const anything: any;
   export = anything;

--- a/packages/pnpm/src/cmd/store.ts
+++ b/packages/pnpm/src/cmd/store.ts
@@ -37,7 +37,7 @@ export default async function (input: string[], opts: PnpmOptions) {
       store = await createStoreController(opts)
       return storeAdd(input.slice(1), {
         prefix: opts.prefix,
-        registry: opts.registry,
+        registries: opts.registries,
         reporter: opts.reporter,
         storeController: store.ctrl,
         tag: opts.tag,

--- a/packages/pnpm/src/types.ts
+++ b/packages/pnpm/src/types.ts
@@ -1,6 +1,7 @@
 import {
   LogBase,
   PackageManifest,
+  Registries,
 } from '@pnpm/types'
 
 export type ReadPackageHook = (pkg: PackageManifest) => PackageManifest
@@ -35,6 +36,7 @@ export interface PnpmOptions {
   engineStrict?: boolean,
   nodeVersion?: string,
   offline?: boolean,
+  registries?: Registries,
   registry?: string,
   optional?: boolean,
   unsafePerm?: boolean,

--- a/packages/pnpm/test/storeAdd.ts
+++ b/packages/pnpm/test/storeAdd.ts
@@ -1,4 +1,5 @@
 import { tempDir } from '@pnpm/prepare'
+import fs = require('mz/fs')
 import loadJsonFile from 'load-json-file'
 import path = require('path')
 import exists = require('path-exists')
@@ -7,6 +8,7 @@ import promisifyTape from 'tape-promise'
 import { execPnpm } from './utils'
 
 const test = promisifyTape(tape)
+const testOnly = promisifyTape(tape.only)
 
 test('pnpm store add express@4.16.3', async function (t: tape.Test) {
   tempDir(t)
@@ -23,6 +25,27 @@ test('pnpm store add express@4.16.3', async function (t: tape.Test) {
     storeIndex,
     {
       'localhost+4873/express/4.16.3': [],
+    },
+    'package has been added to the store index',
+  )
+})
+
+test('pnpm store add scoped package that uses not the standard registry', async function (t: tape.Test) {
+  tempDir(t)
+  await fs.writeFile('.npmrc', '@foo:registry=http://localhost:4873/', 'utf8')
+
+  const storeDir = path.resolve('store')
+
+  await execPnpm('store', 'add', '@foo/no-deps@1.0.0', '--registry', 'https://registry.npmjs.org/', '--store', storeDir)
+
+  const pathToCheck = path.join(storeDir, '2', 'localhost+4873', '@foo', 'no-deps', '1.0.0')
+  t.ok(await exists(pathToCheck), `@foo/no-deps@1.0.0 is in store (at ${pathToCheck})`)
+
+  const storeIndex = await loadJsonFile(path.join(storeDir, '2', 'store.json'))
+  t.deepEqual(
+    storeIndex,
+    {
+      'localhost+4873/@foo/no-deps/1.0.0': [],
     },
     'package has been added to the store index',
   )

--- a/packages/pnpm/typings/local.d.ts
+++ b/packages/pnpm/typings/local.d.ts
@@ -213,11 +213,6 @@ declare module 'is-subdir' {
   export = anything;
 }
 
-declare module 'normalize-registry-url' {
-  function normalizeRegistryUrl (registry: string): string
-  export = normalizeRegistryUrl;
-}
-
 declare module 'encode-registry' {
   function encodeRegistry (registry: string): string
   export = encodeRegistry;

--- a/packages/supi/package.json
+++ b/packages/supi/package.json
@@ -69,7 +69,6 @@
     "mkdirp-promise": "5.0.1",
     "mz": "2.7.0",
     "normalize-path": "3.0.0",
-    "normalize-registry-url": "1.0.0",
     "p-every": "2.0.0",
     "p-filter": "2.0.0",
     "p-limit": "2.2.0",

--- a/packages/supi/test/storeUsages.ts
+++ b/packages/supi/test/storeUsages.ts
@@ -110,7 +110,7 @@ test('find usages for package in store but not in any projects', async (t: tape.
 
   // Add dependency directly to store (not to the project)
   await storeAdd(['is-negative'], {
-    registry: registries.default,
+    registries,
     tag: '2.1.0',
     ...opts
   })
@@ -142,13 +142,13 @@ test('find usages for multiple packages in store but not in any projects', async
 
   // Add dependencies directly to store (not to the project). Note we add different versions of the same package
   await storeAdd(['is-negative'], {
-    registry: registries.default,
+    registries,
     tag: '2.0.0',
     ...opts
   })
   await store.storeHas('is-negative', '2.0.0')
   await storeAdd(['is-negative'], {
-    registry: registries.default,
+    registries,
     tag: '2.1.0',
     ...opts
   })

--- a/packages/supi/typings/local.d.ts
+++ b/packages/supi/typings/local.d.ts
@@ -207,11 +207,6 @@ declare module 'is-subdir' {
   export = anything;
 }
 
-declare module 'normalize-registry-url' {
-  function normalizeRegistryUrl (registry: string): string
-  export = normalizeRegistryUrl;
-}
-
 declare module 'rename-overwrite' {
   const anything: any;
   export = anything;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 import getAllDependenciesFromPackage from './getAllDependenciesFromPackage'
 import getSaveType from './getSaveType'
 import normalizeRegistries, { DEFAULT_REGISTRIES } from './normalizeRegistries'
+import pickRegistryForPackage from './pickRegistryForPackage'
 import realNodeModulesDir from './realNodeModulesDir'
 import safeReadPackage, { fromDir as safeReadPackageFromDir } from './safeReadPkg'
 
@@ -11,6 +12,7 @@ export {
   getAllDependenciesFromPackage,
   getSaveType,
   normalizeRegistries,
+  pickRegistryForPackage,
   realNodeModulesDir,
   safeReadPackage,
   safeReadPackageFromDir,

--- a/packages/utils/src/pickRegistryForPackage.ts
+++ b/packages/utils/src/pickRegistryForPackage.ts
@@ -1,0 +1,13 @@
+import { Registries } from '@pnpm/types'
+
+export default (registries: Registries, packageName: string) => {
+  const scope = getScope(packageName)
+  return scope && registries[scope] || registries.default
+}
+
+function getScope (pkgName: string): string | null {
+  if (pkgName[0] === '@') {
+    return pkgName.substr(0, pkgName.indexOf('/'))
+  }
+  return null
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1836,7 +1836,6 @@ importers:
       mkdirp-promise: 5.0.1
       mz: 2.7.0
       normalize-path: 3.0.0
-      normalize-registry-url: 1.0.0
       p-every: 2.0.0
       p-filter: 2.0.0
       p-limit: 2.2.0
@@ -1971,7 +1970,6 @@ importers:
       mz: 2.7.0
       ncp: 2.0.0
       normalize-path: 3.0.0
-      normalize-registry-url: 1.0.0
       npm-run-all: 4.1.5
       npm-scripts-info: 0.3.9
       p-every: 2.0.0


### PR DESCRIPTION
close #1737