### PR TITLE
fix: a non-optional package's install script fails

### DIFF
--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -52,6 +52,7 @@ export interface Importer {
   shamefullyFlatten: boolean,
   topParents: Array<{name: string, version: string}>,
   usesExternalLockfile: boolean,
+  writePackageJson: boolean,
 }
 
 export default async function linkPackages (

--- a/packages/supi/src/save.ts
+++ b/packages/supi/src/save.ts
@@ -15,6 +15,9 @@ export default async function save (
     pref?: string,
     saveType?: DependenciesField,
   }>,
+  opts?: {
+    dryRun?: boolean,
+  }
 ): Promise<PackageJson> {
   // Read the latest version of package.json to avoid accidental overwriting
   let packageJson: object
@@ -42,7 +45,9 @@ export default async function save (
     }
   })
 
-  await writePkg(pkgJsonPath, packageJson)
+  if (!opts || opts.dryRun !== true) {
+    await writePkg(pkgJsonPath, packageJson)
+  }
   packageJsonLogger.debug({
     prefix,
     updated: packageJson,


### PR DESCRIPTION
When a non-optional package is not built successfully, the
package.json, pnpm-lock.yaml and node_modules/.pnpm-lock.yaml
should not be updated.

close #1397