### PR TITLE
refactor(default‑resolver): Use `ResolverFactoryOptions`

### DIFF
--- a/packages/default-resolver/src/index.ts
+++ b/packages/default-resolver/src/index.ts
@@ -4,47 +4,23 @@ import createResolveFromNpm, {
   PackageMeta,
   PackageMetaCache,
   ResolveFromNpmOptions,
+  ResolverFactoryOptions,
 } from '@pnpm/npm-resolver'
-import {
-  ResolveFunction,
-  ResolveOptions,
-} from '@pnpm/resolver-base'
+import { ResolveFunction } from '@pnpm/resolver-base'
 import resolveFromTarball from '@pnpm/tarball-resolver'
 
 export {
   PackageMeta,
   PackageMetaCache,
+  ResolverFactoryOptions,
 }
 
 export default function createResolver (
-  pnpmOpts: {
-    rawNpmConfig: object,
-    metaCache: PackageMetaCache,
-    store: string,
-    // TODO: export options type from @pnpm/npm-resolver
-    cert?: string,
-    fullMetadata?: boolean,
-    key?: string,
-    ca?: string,
-    strictSsl?: boolean,
-    proxy?: string,
-    httpsProxy?: string,
-    localAddress?: string,
-    userAgent?: string,
-    offline?: boolean,
-    preferOffline?: boolean,
-    fetchRetries?: number,
-    fetchRetryFactor?: number,
-    fetchRetryMintimeout?: number,
-    fetchRetryMaxtimeout?: number,
-  },
+  pnpmOpts: ResolverFactoryOptions,
 ): ResolveFunction {
   const resolveFromNpm = createResolveFromNpm(pnpmOpts)
   const resolveFromGit = createResolveFromGit(pnpmOpts)
-  return async (
-    wantedDependency,
-    opts: ResolveOptions,
-  ) => {
+  return async (wantedDependency, opts) => {
     const resolution = await resolveFromNpm(wantedDependency, opts as ResolveFromNpmOptions)
       || wantedDependency.pref && (
         await resolveFromTarball(wantedDependency as {pref: string})

--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -33,27 +33,29 @@ export {
 const META_FILENAME = 'index.json'
 const FULL_META_FILENAME = 'index-full.json'
 
+export interface ResolverFactoryOptions {
+  rawNpmConfig: object,
+  metaCache: PackageMetaCache,
+  store: string,
+  cert?: string,
+  fullMetadata?: boolean,
+  key?: string,
+  ca?: string,
+  strictSsl?: boolean,
+  proxy?: string,
+  httpsProxy?: string,
+  localAddress?: string,
+  userAgent?: string,
+  offline?: boolean,
+  preferOffline?: boolean,
+  fetchRetries?: number,
+  fetchRetryFactor?: number,
+  fetchRetryMintimeout?: number,
+  fetchRetryMaxtimeout?: number,
+}
+
 export default function createResolver (
-  opts: {
-    cert?: string,
-    fullMetadata?: boolean,
-    key?: string,
-    ca?: string,
-    strictSsl?: boolean,
-    rawNpmConfig: object,
-    metaCache: PackageMetaCache,
-    store: string,
-    proxy?: string,
-    httpsProxy?: string,
-    localAddress?: string,
-    userAgent?: string,
-    offline?: boolean,
-    preferOffline?: boolean,
-    fetchRetries?: number,
-    fetchRetryFactor?: number,
-    fetchRetryMintimeout?: number,
-    fetchRetryMaxtimeout?: number,
-  },
+  opts: ResolverFactoryOptions,
 ) {
   if (typeof opts.rawNpmConfig !== 'object') { // tslint:disable-line
     throw new TypeError('`opts.rawNpmConfig` is required and needs to be an object')


### PR DESCRIPTION
This exports the options of `@pnpm/npm‑resolver` as an interface so that they can be used by `@pnpm/default‑resolver`.