### PR TITLE
refactor: Use shared `tsconfig.json`

### DIFF
--- a/packages/build-modules/tsconfig.json
+++ b/packages/build-modules/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/core-loggers/tsconfig.json
+++ b/packages/core-loggers/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/default-fetcher/tsconfig.json
+++ b/packages/default-fetcher/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/default-reporter/tsconfig.json
+++ b/packages/default-reporter/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/default-resolver/tsconfig.json
+++ b/packages/default-resolver/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/dependencies-hierarchy/tsconfig.json
+++ b/packages/dependencies-hierarchy/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/dependency-path/tsconfig.json
+++ b/packages/dependency-path/tsconfig.json
@@ -1,28 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
-  "filesGlob": [
+  "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  },
-  "files": [
-    "src/index.ts",
-    "typings/index.d.ts"
   ]
 }

--- a/packages/fetch-from-npm-registry/tsconfig.json
+++ b/packages/fetch-from-npm-registry/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/fetch/tsconfig.json
+++ b/packages/fetch/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/fetcher-base/tsconfig.json
+++ b/packages/fetcher-base/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/filter-lockfile/tsconfig.json
+++ b/packages/filter-lockfile/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/git-fetcher/tsconfig.json
+++ b/packages/git-fetcher/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/git-resolver/tsconfig.json
+++ b/packages/git-resolver/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/headless/test/tsconfig.json
+++ b/packages/headless/test/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/lifecycle/tsconfig.json
+++ b/packages/lifecycle/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/list/tsconfig.json
+++ b/packages/list/tsconfig.json
@@ -1,28 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
-  "filesGlob": [
+  "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  },
-  "files": [
-    "src/index.ts",
-    "typings/index.d.ts"
   ]
 }

--- a/packages/local-resolver/tsconfig.json
+++ b/packages/local-resolver/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/lockfile-file/tsconfig.json
+++ b/packages/lockfile-file/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/lockfile-types/tsconfig.json
+++ b/packages/lockfile-types/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/lockfile-utils/tsconfig.json
+++ b/packages/lockfile-utils/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/modules-cleaner/tsconfig.json
+++ b/packages/modules-cleaner/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/modules-yaml/tsconfig.json
+++ b/packages/modules-yaml/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/npm-registry-agent/tsconfig.json
+++ b/packages/npm-registry-agent/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/npm-resolver/tsconfig.json
+++ b/packages/npm-resolver/tsconfig.json
@@ -1,23 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": false,
     "strictBindCallApply": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/outdated/tsconfig.json
+++ b/packages/outdated/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/package-is-installable/tsconfig.json
+++ b/packages/package-is-installable/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/package-requester/tsconfig.json
+++ b/packages/package-requester/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/package-store/tsconfig.json
+++ b/packages/package-store/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/pnpm/tsconfig.json
+++ b/packages/pnpm/tsconfig.json
@@ -1,24 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
     "declaration": false,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/prune-lockfile/tsconfig.json
+++ b/packages/prune-lockfile/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/read-manifests/tsconfig.json
+++ b/packages/read-manifests/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/read-modules-dir/tsconfig.json
+++ b/packages/read-modules-dir/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/resolve-dependencies/tsconfig.json
+++ b/packages/resolve-dependencies/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/resolver-base/tsconfig.json
+++ b/packages/resolver-base/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/shamefully-flatten/tsconfig.json
+++ b/packages/shamefully-flatten/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/store-controller-types/tsconfig.json
+++ b/packages/store-controller-types/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/supi/tsconfig.json
+++ b/packages/supi/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/symlink-dependency/tsconfig.json
+++ b/packages/symlink-dependency/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/tarball-fetcher/tsconfig.json
+++ b/packages/tarball-fetcher/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/tarball-resolver/tsconfig.json
+++ b/packages/tarball-resolver/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/privatePackages/assert-project/test/tsconfig.json
+++ b/privatePackages/assert-project/test/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/privatePackages/assert-project/test/tsconfig.json
+++ b/privatePackages/assert-project/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../utils/tsconfig.json",
+  "extends": "../../../utils/tsconfig.json",
   "compilerOptions": {
     "outDir": "lib"
   },

--- a/privatePackages/assert-project/tsconfig.json
+++ b/privatePackages/assert-project/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/privatePackages/assert-store/tsconfig.json
+++ b/privatePackages/assert-store/tsconfig.json
@@ -1,25 +1,11 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts",
     "typings/**/*.d.ts",
     "test/typings/**/*.d.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/privatePackages/prepare/tsconfig.json
+++ b/privatePackages/prepare/tsconfig.json
@@ -1,23 +1,9 @@
 {
+  "extends": "../../utils/tsconfig.json",
   "compilerOptions": {
-    "removeComments": false,
-    "preserveConstEnums": true,
-    "sourceMap": true,
-    "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true,
-    "strictNullChecks": true,
-    "target": "es2017",
-    "outDir": "lib",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "outDir": "lib"
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "atom": {
-    "rewriteTsconfig": true
-  }
+  ]
 }

--- a/utils/tsconfig.json
+++ b/utils/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true,
+    "strictNullChecks": true,
+    "target": "es2017",
+    "module": "commonjs",
+    "moduleResolution": "node"
+  },
+  "atom": {
+    "rewriteTsconfig": true
+  }
+}


### PR DESCRIPTION
This refactors the project to use one shared `tsconfig.json` in the `utils` directory, which can be overwritten by sub‑packages.