### PR TITLE
feat: Create `@pnpm/hook‑utils` package for `pnpmfile.js` files

### DIFF
--- a/packages/hook-utils/package.json
+++ b/packages/hook-utils/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@pnpm/hook-utils",
+  "description": "A helper for pnpmfile.js files",
+  "version": "0.0.0",
+  "author": {
+    "name": "ExE Boss",
+    "url": "https://ExE-Boss.tech/"
+  },
+  "license": "CC0",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "files": [
+    "lib/"
+  ],
+  "directories": {
+    "test": "test"
+  },
+
+  "engines": {
+    "node": ">=4"
+  },
+  "scripts": {
+    "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
+    "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",
+    "test": "npm run lint && npm run tsc && ts-node test --type-check",
+    "tsc": "rimraf lib && tsc",
+    "prepublishOnly": "npm run tsc"
+  },
+  "keywords": [
+    "pnpm",
+    "hook",
+    "hooks"
+  ],
+
+  "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/hook-utils#readme",
+  "repository": "https://github.com/pnpm/pnpm/blob/master/packages/hook-utils",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+
+  "dependencies": {
+    "@pnpm/lockfile-types": "1.0.0",
+    "@pnpm/types": "3.0.0"
+  },
+  "devDependencies": {
+    "@pnpm/hook-utils": "link:",
+    "@pnpm/tslint-config": "0.0.0",
+    "rimraf": "2.6.3",
+    "tslint": "5.16.0",
+    "typescript": "3.4.3"
+  }
+}

--- a/packages/hook-utils/package.json
+++ b/packages/hook-utils/package.json
@@ -45,7 +45,10 @@
   "devDependencies": {
     "@pnpm/hook-utils": "link:",
     "@pnpm/tslint-config": "0.0.0",
+    "@types/tape": "4.2.33",
     "rimraf": "2.6.3",
+    "tape": "4.10.1",
+    "ts-node": "8.1.0",
     "tslint": "5.16.0",
     "typescript": "3.4.3"
   }

--- a/packages/hook-utils/src/index.ts
+++ b/packages/hook-utils/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export * from './readPackage'

--- a/packages/hook-utils/src/readPackage.ts
+++ b/packages/hook-utils/src/readPackage.ts
@@ -1,0 +1,169 @@
+import {
+  DependencyType,
+  Logger,
+  NullableDependencies,
+  PackageJson,
+  ReadPackageUtils,
+} from './types'
+
+const VALID_DEPENDENCY_TYPES = ([
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as unknown) as TypeGuardReadonlyArray<DependencyType>
+/** @see https://github.com/Microsoft/TypeScript/issues/31018 */
+interface TypeGuardReadonlyArray<T extends string> extends ReadonlyArray<T> {
+  includes (searchElement: string, fromIndex?: number): searchElement is T
+}
+
+/** A custom `typeof` function which handles `null` correctly. */
+function _typeof (obj: unknown) {
+  return obj === null ? 'null' : typeof obj
+}
+
+interface WrappedLogger {
+  log (message?: unknown, ...optionalParams: unknown[]): void
+}
+
+export function createReadPackageUtils (
+  pkg: PackageJson,
+  logger: Logger,
+): ReadPackageUtils {
+  const messages: string[] = []
+  const wrappedLogger: WrappedLogger = {
+    log () {
+      messages.push(
+        arguments.length > 0
+          ? `   - ${Array.prototype.join.call(arguments, ' ')}`
+          : '',
+      )
+    },
+  }
+
+  const _setDep = setDep.bind(null, pkg, wrappedLogger)
+  const _setDeps = (
+    dependencyMap: NullableDependencies,
+    type: DependencyType,
+  ) => {
+    for (const dependency of Object.keys(dependencyMap)) {
+      let target = dependencyMap[dependency]
+      if (typeof target === 'undefined') {
+        continue
+      }
+      if (typeof target !== 'string' && target !== null) {
+        throw new TypeError(
+          `Type of ${dependency}'s value must be a string or null, got ${typeof target}`,
+        )
+      }
+      _setDep(dependency, target, type)
+    }
+  }
+
+  return {
+    setDependency (dependency, target, type) {
+      if (typeof target !== 'string') {
+        throw new TypeError('Target must be a string')
+      }
+      if (type !== undefined && !VALID_DEPENDENCY_TYPES.includes(type)) {
+        throw new TypeError(
+          `Type must be one of ${VALID_DEPENDENCY_TYPES}, got "${type}"`,
+        )
+      }
+      _setDep(dependency, target, type)
+    },
+    removeDependency (dependency, type) {
+      if (type !== undefined && !VALID_DEPENDENCY_TYPES.includes(type)) {
+        throw new TypeError(
+          `Type must be one of ${VALID_DEPENDENCY_TYPES}, got "${type}"`,
+        )
+      }
+      _setDep(dependency, null, type)
+    },
+    setDependencies (dependencyMap: unknown, type?: unknown) {
+      if (typeof type === 'string') {
+        if (!VALID_DEPENDENCY_TYPES.includes(type)) {
+          throw new TypeError(
+            `Type must be one of ${VALID_DEPENDENCY_TYPES} or undefined, got "${type}"`,
+          )
+        }
+        if (typeof dependencyMap !== 'object' || dependencyMap === null) {
+          throw new TypeError(
+            `DependencyMap must be an object, got ${_typeof(dependencyMap)}`,
+          )
+        }
+        return _setDeps(dependencyMap as NullableDependencies, type)
+      } else if (typeof type !== 'undefined') {
+        throw new TypeError(
+          `Type must be one of ${VALID_DEPENDENCY_TYPES} or undefined, got "${type}"`,
+        )
+      }
+      if (typeof dependencyMap !== 'object' || dependencyMap === null) {
+        throw new TypeError(
+          `DependencyMap must be an object, got ${_typeof(dependencyMap)}`,
+        )
+      }
+      const types = Object.keys(dependencyMap)
+      for (const type of types) {
+        if (!VALID_DEPENDENCY_TYPES.includes(type)) {
+          continue
+        }
+        const dependencies = dependencyMap[type] as NullableDependencies
+        if (typeof dependencies === 'undefined') {
+          continue
+        }
+        if (typeof dependencies !== 'object' || dependencies === null) {
+          throw new TypeError(
+            `DependencyMap's ${type} property must be an object, got ${_typeof(dependencies)}`,
+          )
+        }
+        _setDeps(dependencies, type)
+      }
+    },
+    log: wrappedLogger.log.bind(wrappedLogger),
+    logChanges () {
+      if (messages.length > 0) {
+        logger.log(`\n  Editing "${pkg.name}@${pkg.version}":\n${
+          messages.join('\n')
+        }`)
+        messages.splice(0)
+        return true
+      }
+      return false
+    },
+  }
+}
+
+/**
+ * @param pkg The `package.json` file's contents
+ * @param logger The `Logger`
+ * @param dependency The dependency name
+ * @param target The target version, or `null` to remove
+ * @param type The dependency type.
+ */
+function setDep (
+  pkg: PackageJson,
+  logger: WrappedLogger,
+  dependency: string,
+  target: string | null = null,
+  type: DependencyType = 'dependencies',
+) {
+  const dependencies = pkg[type]
+  if (target !== null) {
+    if (dependencies[dependency]) {
+      if (dependency[dependency] !== target)
+        logger.log(
+          'Setting',
+          JSON.stringify(dependency),
+          'to',
+          JSON.stringify(target),
+        )
+    } else {
+      logger.log('Adding', JSON.stringify(`${dependency}@${target}`))
+    }
+    dependencies[dependency] = target
+  } else if (dependencies[dependency]) {
+    logger.log('Removing', JSON.stringify(dependency))
+    delete dependencies[dependency]
+  }
+}

--- a/packages/hook-utils/src/types.ts
+++ b/packages/hook-utils/src/types.ts
@@ -1,0 +1,84 @@
+import { Lockfile } from '@pnpm/lockfile-types'
+import {
+  Dependencies as StrictDependencies,
+  PackageManifest,
+} from '@pnpm/types'
+interface PackageJson extends PackageManifest {
+  dependencies: StrictDependencies
+  devDependencies: StrictDependencies
+  optionalDependencies: StrictDependencies
+  peerDependencies: StrictDependencies
+}
+export { PackageJson, StrictDependencies }
+export interface Logger {
+  log (msg: string): void
+}
+
+export type DependencyType =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'optionalDependencies'
+  | 'peerDependencies'
+export interface NullableDependencies {
+  [name: string]: string | null
+}
+export interface DependencyMap {
+  dependencies?: NullableDependencies
+  devDependencies?: NullableDependencies
+  optionalDependencies?: NullableDependencies
+  peerDependencies?: NullableDependencies
+}
+
+export interface HookContext extends Logger {
+}
+export type ReadPackageHook = (pkg: PackageJson, context: HookContext) => PackageJson
+export type AfterAllResolvedHook = (lockfile: Lockfile, context: HookContext) => Lockfile
+
+export interface PnpmHooks {
+  readPackage?: ReadPackageHook
+  afterAllResolved?: AfterAllResolvedHook
+}
+
+export interface ReadPackageUtils {
+  /**
+   * @param dependency The dependency name.
+   * @param target The target version, must be a valid string.
+   * @param type The dependency type, defaults to `dependencies`.
+   * @throws If `target` isn't a string or `type` isn't a valid dependency type.
+   */
+  setDependency (dependency: string, target: string, type?: DependencyType): void
+
+  /**
+   * Set multiple dependencies at once
+   * @param dependencyMap
+   * @param type
+   * @throws If `type` isn't a valid dependency type.
+   */
+  setDependencies (
+    dependencyMap: NullableDependencies,
+    type: DependencyType,
+  ): void
+
+  /**
+   * @param dependencyMap
+   */
+  setDependencies (dependencyMap: DependencyMap): void
+
+  /**
+   * @param dependency The dependency name.
+   * @param type The dependency type.
+   * @throws If `type` isn't a valid dependency type.
+   */
+  removeDependency (dependency: string, type?: DependencyType): void
+
+  /**
+   * Appends the message to the internal list of messages to be printed
+   * as part of the `logChanges()` call.
+   */
+  log (message?: unknown, ...optionalParams: unknown[]): void
+
+  /**
+   * @returns `true` if there were changes to be logged, `false` otherwise.
+   */
+  logChanges (): boolean
+}

--- a/packages/hook-utils/test/index.ts
+++ b/packages/hook-utils/test/index.ts
@@ -1,0 +1,37 @@
+import pnpmHookUtils = require('@pnpm/hook-utils')
+import test = require('tape')
+
+const NOOP_FUNCTION = () => {/* no-op */}
+
+const hooks: Required<pnpmHookUtils.PnpmHooks> = {
+  readPackage (pkg, ctx) {
+    const utils = pnpmHookUtils.createReadPackageUtils(pkg, ctx)
+
+    switch (pkg.name) {
+      case 'stuff':
+        utils.setDependencies({
+          pnpm: '^3.1.0',
+        }, 'dependencies')
+    }
+
+    utils.logChanges()
+    return pkg
+  },
+  afterAllResolved: lockfile => lockfile,
+}
+
+test('readPackage hook utils work', t => {
+  const pkg = hooks.readPackage({
+    name: 'stuff',
+    version: '0.0.0',
+
+    dependencies: {},
+    devDependencies: {},
+    optionalDependencies: {},
+    peerDependencies: {},
+  }, {
+    log: NOOP_FUNCTION,
+  })
+  t.isEqual(pkg.dependencies.pnpm, '^3.1.0')
+  t.end()
+})

--- a/packages/hook-utils/tsconfig.json
+++ b/packages/hook-utils/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../utils/tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": false,
+    "lib": [
+      "es2015"
+    ],
+    "outDir": "lib",
+    "strict": true,
+    "target": "es5"
+  },
+  "include": [
+    "src/**/*.ts",
+    "typings/**/*.d.ts"
+  ]
+}

--- a/packages/hook-utils/tslint.json
+++ b/packages/hook-utils/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@pnpm/tslint-config"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,7 +662,10 @@ importers:
     devDependencies:
       '@pnpm/hook-utils': 'link:'
       '@pnpm/tslint-config': 'link:../../utils/tslint-config'
+      '@types/tape': 4.2.33
       rimraf: 2.6.3
+      tape: 4.10.1
+      ts-node: 8.1.0_typescript@3.4.3
       tslint: 5.16.0_typescript@3.4.3
       typescript: 3.4.3
     specifiers:
@@ -670,7 +673,10 @@ importers:
       '@pnpm/lockfile-types': 1.0.0
       '@pnpm/tslint-config': 0.0.0
       '@pnpm/types': 3.0.0
+      '@types/tape': 4.2.33
       rimraf: 2.6.3
+      tape: 4.10.1
+      ts-node: 8.1.0
       tslint: 5.16.0
       typescript: 3.4.3
   packages/lifecycle:
@@ -2815,6 +2821,9 @@ packages:
   /@types/node/11.13.4:
     resolution:
       integrity: sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+  /@types/node/11.13.5:
+    resolution:
+      integrity: sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==
   /@types/node/8.10.45:
     dev: false
     resolution:
@@ -2895,7 +2904,7 @@ packages:
       integrity: sha512-JSUkNxrI06sLQKDKVJG5nuZyTuKWm58d+zf8xiadQ7L2BSMSQW8KoLb0GrL2hz6y40huq1mduZOClXqLpxLXfA==
   /@types/tape/4.2.33:
     dependencies:
-      '@types/node': 11.13.4
+      '@types/node': 11.13.5
     resolution:
       integrity: sha512-ltfyuY5BIkYlGuQfwqzTDT8f0q8Z5DGppvUnWGs39oqDmMd6/UWhNpX3ZMh/VYvfxs3rFGHMrLC/eGRdLiDGuw==
   /@types/tempy/0.2.0:
@@ -9750,6 +9759,22 @@ packages:
       typescript: '>=2.0'
     resolution:
       integrity: sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==
+  /ts-node/8.1.0_typescript@3.4.3:
+    dependencies:
+      arg: 4.1.0
+      diff: 3.5.0
+      make-error: 1.3.5
+      source-map-support: 0.5.12
+      typescript: 3.4.3
+      yn: 3.1.0
+    dev: true
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.0'
+    resolution:
+      integrity: sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==
   /tslib/1.9.0:
     resolution:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,24 @@ importers:
       ts-node: 8.0.3
       tslint: 5.15.0
       typescript: 3.4.3
+  packages/hook-utils:
+    dependencies:
+      '@pnpm/lockfile-types': 'link:../lockfile-types'
+      '@pnpm/types': 'link:../types'
+    devDependencies:
+      '@pnpm/hook-utils': 'link:'
+      '@pnpm/tslint-config': 'link:../../utils/tslint-config'
+      rimraf: 2.6.3
+      tslint: 5.16.0_typescript@3.4.3
+      typescript: 3.4.3
+    specifiers:
+      '@pnpm/hook-utils': 'link:'
+      '@pnpm/lockfile-types': 1.0.0
+      '@pnpm/tslint-config': 0.0.0
+      '@pnpm/types': 3.0.0
+      rimraf: 2.6.3
+      tslint: 5.16.0
+      typescript: 3.4.3
   packages/lifecycle:
     dependencies:
       '@pnpm/core-loggers': 'link:../core-loggers'
@@ -2352,6 +2370,20 @@ importers:
       typescript: 3.4.3
 lockfileVersion: 5
 packages:
+  /@babel/code-frame/7.0.0:
+    dependencies:
+      '@babel/highlight': 7.0.0
+    dev: true
+    resolution:
+      integrity: sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  /@babel/highlight/7.0.0:
+    dependencies:
+      chalk: 2.4.2
+      esutils: 2.0.2
+      js-tokens: 4.0.0
+    dev: true
+    resolution:
+      integrity: sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
   /@commitlint/cli/7.5.2:
     dependencies:
       '@commitlint/format': 7.5.0
@@ -9769,6 +9801,30 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
       integrity: sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==
+  /tslint/5.16.0_typescript@3.4.3:
+    dependencies:
+      '@babel/code-frame': 7.0.0
+      builtin-modules: 1.1.1
+      chalk: 2.4.2
+      commander: 2.20.0
+      diff: 3.5.0
+      glob: 7.1.3
+      js-yaml: 3.13.1
+      minimatch: 3.0.4
+      mkdirp: 0.5.1
+      resolve: 1.10.0
+      semver: 5.7.0
+      tslib: 1.9.3
+      tsutils: 2.29.0_typescript@3.4.3
+      typescript: 3.4.3
+    dev: true
+    engines:
+      node: '>=4.8.0'
+    hasBin: true
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
+    resolution:
+      integrity: sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
   /tsutils/2.29.0_typescript@3.4.3:
     dependencies:
       tslib: 1.9.3


### PR DESCRIPTION
This is a publication of my, originally internal, `pnpmfile.js` helpers which I tend to declare within my `pnpmfile.js` files.

I’ve decided to publish them as `@pnpm/hook‑utils` (name TBD), this is because `@pnpm/pnpmfile‑utils` feels odd to say and `@pnpm/file‑utils` implies something unrelated to `pnpmfile.js`.

Unlike other pnpm packages, `@pnpm/hook‑utils` is being transpiled to ES5 for pnpm v1 compatibility due to it being the only pnpm release available for Node 4.

---

The purpose of `@pnpm/hook‑utils` is to be installed by packages which use `pnpmfile.js` and annotate their hooks with:
```js
const pnpmHookUtils = require('@pnpm/hook-utils');

exports.hooks = {
	/** @type {pnpmHookUtils} */
	readPackage(pkg, ctx) {
		const utils = pnpmHookUtils.createReadPackageUtils(pkg, ctx);
		switch (pkg.name) {
			case 'npm':
				utils.setDependency('cmd-shim', '@zkochan/cmd-shim@^3.1.0');
				break;
		}
		utils.logChanges();
		return pkg;
	}
}
```