### PR TITLE
fix: recursive update --latest should use specs from local .npmrc

### DIFF
--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -361,6 +361,10 @@ export async function recursive (
               bin: path.join(prefix, 'node_modules', '.bin'),
               hooks,
               ignoreScripts: true,
+              pinnedVersion: getPinnedVersion({
+                saveExact: typeof localConfigs.saveExact === 'boolean' ? localConfigs.saveExact : opts.saveExact,
+                savePrefix: typeof localConfigs.savePrefix === 'string' ? localConfigs.savePrefix : opts.savePrefix,
+              }),
               prefix,
               rawNpmConfig: {
                 ...installOpts.rawNpmConfig,

--- a/packages/pnpm/test/recursive/update.ts
+++ b/packages/pnpm/test/recursive/update.ts
@@ -2,6 +2,7 @@ import { Lockfile } from '@pnpm/lockfile-types'
 import { preparePackages } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/registry-mock'
 import fs = require('mz/fs')
+import path = require('path')
 import readYamlFile from 'read-yaml-file'
 import tape = require('tape')
 import promisifyTape from 'tape-promise'
@@ -159,4 +160,53 @@ test('recursive update should not add new dependencies', async (t: tape.Test) =>
 
   projects['project-1'].hasNot('is-positive')
   projects['project-2'].hasNot('is-positive')
+})
+
+test('recursive update --latest should update deps with correct specs', async (t: tape.Test) => {
+  await addDistTag({ package: 'foo', version: '100.1.0', distTag: 'latest' })
+
+  const projects = preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        foo: '100.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        foo: '100.0.0',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+
+      dependencies: {
+        foo: '100.0.0',
+      },
+    },
+  ])
+
+  await fs.writeFile(
+    'project-2/.npmrc',
+    'save-exact = true',
+    'utf8',
+  )
+
+  await fs.writeFile(
+    'project-3/.npmrc',
+    'save-prefix = ~',
+    'utf8',
+  )
+
+  await execPnpm('recursive', 'update', '--latest')
+
+  t.deepEqual((await import(path.resolve('project-1/package.json'))).dependencies, { foo: '^100.1.0' })
+  t.deepEqual((await import(path.resolve('project-2/package.json'))).dependencies, { foo: '100.1.0' })
+  t.deepEqual((await import(path.resolve('project-3/package.json'))).dependencies, { foo: '~100.1.0' })
 })


### PR DESCRIPTION
close #1861