### PR TITLE
fix: install should fail with out-of-date local tarball

### DIFF
--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -49,6 +49,7 @@
     "path-exists": "4.0.0",
     "rename-overwrite": "2.0.1",
     "rimraf-then": "1.0.1",
+    "ssri": "6.0.1",
     "symlink-dir": "3.1.0",
     "write-json-file": "4.0.0"
   },
@@ -62,6 +63,7 @@
     "@types/ncp": "2.0.1",
     "@types/nock": "^10.0.0",
     "@types/sinon": "^7.0.10",
+    "@types/ssri": "6.0.1",
     "delay": "4.3.0",
     "ncp": "2.0.0",
     "nock": "10.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,6 +848,7 @@ importers:
       path-exists: 4.0.0
       rename-overwrite: 2.0.1
       rimraf-then: 1.0.1
+      ssri: 6.0.1
       symlink-dir: 3.1.0
       write-json-file: 4.0.0
     devDependencies:
@@ -860,6 +861,7 @@ importers:
       '@types/ncp': 2.0.1
       '@types/nock': 10.0.3
       '@types/sinon': 7.0.13
+      '@types/ssri': 6.0.1
       delay: 4.3.0
       ncp: 2.0.0
       nock: 10.0.6
@@ -886,6 +888,7 @@ importers:
       '@types/ncp': 2.0.1
       '@types/nock': ^10.0.0
       '@types/sinon': ^7.0.10
+      '@types/ssri': 6.0.1
       delay: 4.3.0
       load-json-file: 6.0.0
       make-dir: 3.0.0
@@ -900,6 +903,7 @@ importers:
       rimraf: 2.6.3
       rimraf-then: 1.0.1
       sinon: 7.3.2
+      ssri: 6.0.1
       symlink-dir: 3.1.0
       tape: 4.10.2
       tempy: 0.3.0


### PR DESCRIPTION
"pnpm install --frozen-lockfile" should fail if a local tarball's
integrity doesn't match the integrity in the lockfile.

close #1882