### PR TITLE
fix: prunning by partial installation in a workspace

### DIFF
--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -158,11 +158,13 @@ export default async (opts: HeadlessOptions) => {
     await prune({
       dryRun: false,
       importers: opts.importers,
+      include: opts.include,
       lockfileDirectory,
       newLockfile: filterLockfile(wantedLockfile, filterOpts),
       oldLockfile: currentLockfile,
       pruneStore: opts.pruneStore,
       registries: opts.registries,
+      skipped: opts.skipped,
       storeController: opts.storeController,
       virtualStoreDir,
     })

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -149,24 +149,19 @@ export default async (opts: HeadlessOptions) => {
   }
 
   const skipped = opts.skipped || new Set<string>()
-  const filterOpts = {
-    include: opts.include,
-    registries: opts.registries,
-    skipped,
-  }
   if (currentLockfile) {
     await prune({
+      currentLockfile,
       dryRun: false,
       importers: opts.importers,
       include: opts.include,
       lockfileDirectory,
-      newLockfile: filterLockfile(wantedLockfile, filterOpts),
-      oldLockfile: currentLockfile,
       pruneStore: opts.pruneStore,
       registries: opts.registries,
-      skipped: opts.skipped,
+      skipped,
       storeController: opts.storeController,
       virtualStoreDir,
+      wantedLockfile,
     })
   } else {
     statsLogger.debug({
@@ -180,6 +175,11 @@ export default async (opts: HeadlessOptions) => {
     stage: 'importing_started',
   })
 
+  const filterOpts = {
+    include: opts.include,
+    registries: opts.registries,
+    skipped,
+  }
   const filteredLockfile = filterLockfileByImportersAndEngine(wantedLockfile, opts.importers.map(({ id }) => id), {
     ...filterOpts,
     currentEngine: opts.currentEngine,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -150,19 +150,21 @@ export default async (opts: HeadlessOptions) => {
 
   const skipped = opts.skipped || new Set<string>()
   if (currentLockfile) {
-    await prune({
-      currentLockfile,
-      dryRun: false,
-      importers: opts.importers,
-      include: opts.include,
-      lockfileDirectory,
-      pruneStore: opts.pruneStore,
-      registries: opts.registries,
-      skipped,
-      storeController: opts.storeController,
-      virtualStoreDir,
-      wantedLockfile,
-    })
+    await prune(
+      opts.importers,
+      {
+        currentLockfile,
+        dryRun: false,
+        include: opts.include,
+        lockfileDirectory,
+        pruneStore: opts.pruneStore,
+        registries: opts.registries,
+        skipped,
+        storeController: opts.storeController,
+        virtualStoreDir,
+        wantedLockfile,
+      },
+    )
   } else {
     statsLogger.debug({
       prefix: lockfileDirectory,

--- a/packages/modules-cleaner/package.json
+++ b/packages/modules-cleaner/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@pnpm/core-loggers": "3.0.3",
+    "@pnpm/filter-lockfile": "1.0.10",
     "@pnpm/lockfile-types": "1.1.0",
     "@pnpm/lockfile-utils": "1.0.9",
     "@pnpm/package-bins": "3.1.1",

--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -152,11 +152,13 @@ export default async function linkPackages (
   const removedDepPaths = await prune({
     dryRun: opts.dryRun,
     importers,
+    include: opts.include,
     lockfileDirectory: opts.lockfileDirectory,
     newLockfile: filterLockfile(newWantedLockfile, filterOpts),
     oldLockfile: opts.currentLockfile,
     pruneStore: opts.pruneStore,
     registries: opts.registries,
+    skipped: opts.skipped,
     storeController: opts.storeController,
     virtualStoreDir: opts.virtualStoreDir,
   })

--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -144,10 +144,9 @@ export default async function linkPackages (
   if (!opts.include.optionalDependencies) {
     depNodes = depNodes.filter(({ optional }) => !optional)
   }
-  const removedDepPaths = await prune({
+  const removedDepPaths = await prune(importers, {
     currentLockfile: opts.currentLockfile,
     dryRun: opts.dryRun,
-    importers,
     include: opts.include,
     lockfileDirectory: opts.lockfileDirectory,
     pruneStore: opts.pruneStore,

--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -7,7 +7,7 @@ import {
   stageLogger,
   statsLogger,
 } from '@pnpm/core-loggers'
-import filterLockfile, {
+import {
   filterLockfileByImporters,
 } from '@pnpm/filter-lockfile'
 import { Lockfile } from '@pnpm/lockfile-file'
@@ -144,23 +144,18 @@ export default async function linkPackages (
   if (!opts.include.optionalDependencies) {
     depNodes = depNodes.filter(({ optional }) => !optional)
   }
-  const filterOpts = {
-    include: opts.include,
-    registries: opts.registries,
-    skipped: opts.skipped,
-  }
   const removedDepPaths = await prune({
+    currentLockfile: opts.currentLockfile,
     dryRun: opts.dryRun,
     importers,
     include: opts.include,
     lockfileDirectory: opts.lockfileDirectory,
-    newLockfile: filterLockfile(newWantedLockfile, filterOpts),
-    oldLockfile: opts.currentLockfile,
     pruneStore: opts.pruneStore,
     registries: opts.registries,
     skipped: opts.skipped,
     storeController: opts.storeController,
     virtualStoreDir: opts.virtualStoreDir,
+    wantedLockfile: newWantedLockfile,
   })
 
   stageLogger.debug({
@@ -169,6 +164,11 @@ export default async function linkPackages (
   })
 
   const importerIds = importers.map(({ id }) => id)
+  const filterOpts = {
+    include: opts.include,
+    registries: opts.registries,
+    skipped: opts.skipped,
+  }
   const newCurrentLockfile = filterLockfileByImporters(newWantedLockfile, importerIds, {
     ...filterOpts,
     failOnMissingDependencies: true,

--- a/packages/supi/src/link/index.ts
+++ b/packages/supi/src/link/index.ts
@@ -52,7 +52,7 @@ export default async function link (
   const ctx = await getContextForSingleImporter(opts.manifest, opts)
 
   const importerId = getLockfileImporterId(ctx.lockfileDirectory, opts.prefix)
-  const oldLockfile = R.clone(ctx.currentLockfile)
+  const currentLockfile = R.clone(ctx.currentLockfile)
   const linkedPkgs: Array<{path: string, manifest: DependencyManifest, alias: string}> = []
   const specsToUpsert = [] as Array<{name: string, pref: string, saveType: DependenciesField}>
   const saveType = getSaveType(opts)
@@ -100,6 +100,7 @@ export default async function link (
   })
 
   await prune({
+    currentLockfile,
     importers: [
       {
         bin: opts.bin,
@@ -116,12 +117,11 @@ export default async function link (
       optionalDependencies: true,
     },
     lockfileDirectory: opts.lockfileDirectory,
-    newLockfile: updatedCurrentLockfile,
-    oldLockfile,
     registries: ctx.registries,
     skipped: new Set(),
     storeController: opts.storeController,
     virtualStoreDir: ctx.virtualStoreDir,
+    wantedLockfile: updatedCurrentLockfile,
   })
 
   // Linking should happen after removing orphans

--- a/packages/supi/src/link/index.ts
+++ b/packages/supi/src/link/index.ts
@@ -110,10 +110,16 @@ export default async function link (
         shamefullyFlatten: opts.shamefullyFlatten,
       },
     ],
+    include: {
+      dependencies: true,
+      devDependencies: true,
+      optionalDependencies: true,
+    },
     lockfileDirectory: opts.lockfileDirectory,
     newLockfile: updatedCurrentLockfile,
     oldLockfile,
     registries: ctx.registries,
+    skipped: new Set(),
     storeController: opts.storeController,
     virtualStoreDir: ctx.virtualStoreDir,
   })

--- a/packages/supi/src/link/index.ts
+++ b/packages/supi/src/link/index.ts
@@ -99,9 +99,8 @@ export default async function link (
     warn,
   })
 
-  await prune({
-    currentLockfile,
-    importers: [
+  await prune(
+    [
       {
         bin: opts.bin,
         hoistedAliases: ctx.hoistedAliases,
@@ -111,18 +110,17 @@ export default async function link (
         shamefullyFlatten: opts.shamefullyFlatten,
       },
     ],
-    include: {
-      dependencies: true,
-      devDependencies: true,
-      optionalDependencies: true,
+    {
+      currentLockfile,
+      include: ctx.include,
+      lockfileDirectory: opts.lockfileDirectory,
+      registries: ctx.registries,
+      skipped: ctx.skipped,
+      storeController: opts.storeController,
+      virtualStoreDir: ctx.virtualStoreDir,
+      wantedLockfile: updatedCurrentLockfile,
     },
-    lockfileDirectory: opts.lockfileDirectory,
-    registries: ctx.registries,
-    skipped: new Set(),
-    storeController: opts.storeController,
-    virtualStoreDir: ctx.virtualStoreDir,
-    wantedLockfile: updatedCurrentLockfile,
-  })
+  )
 
   // Linking should happen after removing orphans
   // Otherwise would've been removed

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,6 +647,7 @@ importers:
   packages/modules-cleaner:
     dependencies:
       '@pnpm/core-loggers': 'link:../core-loggers'
+      '@pnpm/filter-lockfile': 'link:../filter-lockfile'
       '@pnpm/lockfile-types': 'link:../lockfile-types'
       '@pnpm/lockfile-utils': 'link:../lockfile-utils'
       '@pnpm/package-bins': 3.1.1
@@ -665,6 +666,7 @@ importers:
       rimraf: 2.6.3
     specifiers:
       '@pnpm/core-loggers': 3.0.3
+      '@pnpm/filter-lockfile': 1.0.10
       '@pnpm/lockfile-types': 1.1.0
       '@pnpm/lockfile-utils': 1.0.9
       '@pnpm/logger': 2.1.1


### PR DESCRIPTION
When running install on a subset of workspace packages, only
those dependencies may be prunned which were only used by the
selected subset of workspace packages.