### PR TITLE
feat: pnpm should fail if the project needs another version

### DIFF
--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -247,8 +247,8 @@ function reportEngineError (
       This is happening because the package's manifest has an engines.pnpm field specified.
       To fix this issue, install the required pnpm version globally.
 
-      To install the latest version of pnpm, run: ${chalk.bold('pnpm i -g pnpm')}
-      To check your pnpm version, run: ${chalk.bold('pnpm -v')}
+      To install the latest version of pnpm, run "pnpm i -g pnpm".
+      To check your pnpm version, run "pnpm -v".
     `
   }
   if (msg.wanted.node) {

--- a/packages/default-reporter/test/reportingErrors.ts
+++ b/packages/default-reporter/test/reportingErrors.ts
@@ -227,3 +227,113 @@ test('prints command error without exit code', async (t) => {
   err['code'] = 'ELIFECYCLE'
   logger.error(err, err)
 })
+
+test('prints unsupported pnpm version error', async (t) => {
+  const output$ = toOutput$({
+    context: { argv: ['install'] },
+    streamParser: createStreamParser(),
+  })
+
+  t.plan(1)
+
+  output$.take(1).map(normalizeNewline).subscribe({
+    complete: () => t.end(),
+    error: t.end,
+    next: output => {
+      t.equal(output, stripIndent`
+        ${ERROR} ${chalk.red('Your pnpm version is incompatible with "/home/zoltan/project".')}
+
+        Expected version: 2
+        Got: 3.0.0
+
+        This is happening because the package's manifest has an engines.pnpm field specified.
+        To fix this issue, install the required pnpm version globally.
+
+        To install the latest version of pnpm, run "pnpm i -g pnpm".
+        To check your pnpm version, run "pnpm -v".
+      `)
+    },
+  })
+
+  const err = new Error('Unsupported pnpm version')
+  err['code'] = 'ERR_PNPM_UNSUPPORTED_ENGINE'
+  err['packageId'] = '/home/zoltan/project'
+  err['wanted'] = { pnpm: '2' }
+  err['current'] = { pnpm: '3.0.0', node: '10.0.0' }
+  logger.error(err, err)
+})
+
+test('prints unsupported Node version error', async (t) => {
+  const output$ = toOutput$({
+    context: { argv: ['install'] },
+    streamParser: createStreamParser(),
+  })
+
+  t.plan(1)
+
+  output$.take(1).map(normalizeNewline).subscribe({
+    complete: () => t.end(),
+    error: t.end,
+    next: output => {
+      t.equal(output, stripIndent`
+        ${ERROR} ${chalk.red('Your Node version is incompatible with "/home/zoltan/project".')}
+
+        Expected version: >=12
+        Got: 10.0.0
+
+        This is happening because the package's manifest has an engines.node field specified.
+        To fix this issue, install the required Node version.
+      `)
+    },
+  })
+
+  const err = new Error('Unsupported pnpm version')
+  err['code'] = 'ERR_PNPM_UNSUPPORTED_ENGINE'
+  err['packageId'] = '/home/zoltan/project'
+  err['wanted'] = { node: '>=12' }
+  err['current'] = { pnpm: '3.0.0', node: '10.0.0' }
+  logger.error(err, err)
+})
+
+test('prints unsupported pnpm and Node versions error', async (t) => {
+  const output$ = toOutput$({
+    context: { argv: ['install'] },
+    streamParser: createStreamParser(),
+  })
+
+  t.plan(1)
+
+  output$.take(1).map(normalizeNewline).subscribe({
+    complete: () => t.end(),
+    error: t.end,
+    next: output => {
+      t.equal(output, stripIndent`
+        ${ERROR} ${chalk.red('Your pnpm version is incompatible with "/home/zoltan/project".')}
+
+        Expected version: 2
+        Got: 3.0.0
+
+        This is happening because the package's manifest has an engines.pnpm field specified.
+        To fix this issue, install the required pnpm version globally.
+
+        To install the latest version of pnpm, run "pnpm i -g pnpm".
+        To check your pnpm version, run "pnpm -v".
+
+        ${ERROR} ${chalk.red('Your Node version is incompatible with "/home/zoltan/project".')}
+
+        Expected version: >=12
+        Got: 10.0.0
+
+        This is happening because the package's manifest has an engines.node field specified.
+        To fix this issue, install the required Node version.
+      `)
+    },
+  })
+
+  const err = new Error('Unsupported pnpm version')
+  err['code'] = 'ERR_PNPM_UNSUPPORTED_ENGINE'
+  err['packageId'] = '/home/zoltan/project'
+  err['wanted'] = { pnpm: '2', node: '>=12' }
+  err['current'] = { pnpm: '3.0.0', node: '10.0.0' }
+  logger.error(err, err)
+})

--- a/packages/default-reporter/test/reportingErrors.ts
+++ b/packages/default-reporter/test/reportingErrors.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk'
 import { stripIndent, stripIndents } from 'common-tags'
 import loadJsonFile = require('load-json-file')
 import normalizeNewline = require('normalize-newline')
+import { EOL } from 'os'
 import path = require('path')
 import StackTracey = require('stacktracey')
 import test = require('tape')
@@ -317,8 +318,7 @@ test('prints unsupported pnpm and Node versions error', async (t) => {
         To fix this issue, install the required pnpm version globally.
 
         To install the latest version of pnpm, run "pnpm i -g pnpm".
-        To check your pnpm version, run "pnpm -v".
-
+        To check your pnpm version, run "pnpm -v".` + '\n\n' + stripIndent`
         ${ERROR} ${chalk.red('Your Node version is incompatible with "/home/zoltan/project".')}
 
         Expected version: >=12

--- a/packages/package-is-installable/src/checkEngine.ts
+++ b/packages/package-is-installable/src/checkEngine.ts
@@ -4,9 +4,11 @@ class UnsupportedEngineError extends Error {
   public code: 'ERR_PNPM_UNSUPPORTED_ENGINE' = 'ERR_PNPM_UNSUPPORTED_ENGINE'
   public wanted: WantedEngine
   public current: Engine
+  public packageId: string
 
   constructor (packageId: string, wanted: WantedEngine, current: Engine) {
     super(`Unsupported engine for ${packageId}: wanted: ${JSON.stringify(wanted)} (current: ${JSON.stringify(current)})`)
+    this.packageId = packageId
     this.wanted = wanted
     this.current = current
   }
@@ -18,11 +20,15 @@ export default function checkEngine (
   currentEngine: Engine,
 ) {
   if (!wantedEngine) return null
-  if (
-    (wantedEngine.node && !semver.satisfies(currentEngine.node, wantedEngine.node)) ||
-    (wantedEngine.pnpm && !semver.satisfies(currentEngine.pnpm, wantedEngine.pnpm))
-  ) {
-    return new UnsupportedEngineError(packageId, wantedEngine, currentEngine)
+  const unsatisfiedWanted: WantedEngine = {}
+  if (wantedEngine.node && !semver.satisfies(currentEngine.node, wantedEngine.node)) {
+    unsatisfiedWanted.node = wantedEngine.node
+  }
+  if (wantedEngine.pnpm && !semver.satisfies(currentEngine.pnpm, wantedEngine.pnpm)) {
+    unsatisfiedWanted.pnpm = wantedEngine.pnpm
+  }
+  if (Object.keys(unsatisfiedWanted).length) {
+    return new UnsupportedEngineError(packageId, unsatisfiedWanted, currentEngine)
   }
   return null
 }

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -19,7 +19,7 @@ export default function packageIsInstallable (
   },
   options: {
     engineStrict: boolean,
-    nodeVersion: string,
+    nodeVersion?: string,
     optional: boolean,
     pnpmVersion: string,
     prefix: string,
@@ -30,7 +30,7 @@ export default function packageIsInstallable (
     os: pkg.os || ['any'],
   })
   || pkg.engines && checkEngine(pkgId, pkg.engines, {
-    node: options.nodeVersion,
+    node: options.nodeVersion || process.version,
     pnpm: options.pnpmVersion,
   })
 

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -32,6 +32,7 @@
     "@pnpm/list": "1.0.13",
     "@pnpm/logger": "2.1.1",
     "@pnpm/outdated": "2.0.19",
+    "@pnpm/package-is-installable": "2.0.8",
     "@pnpm/package-store": "4.0.14",
     "@pnpm/read-importer-manifest": "1.0.5",
     "@pnpm/server": "3.0.5",

--- a/packages/pnpm/src/cmd/install.ts
+++ b/packages/pnpm/src/cmd/install.ts
@@ -1,4 +1,3 @@
-import { readImporterManifestOnly, tryReadImporterManifest } from '@pnpm/read-importer-manifest'
 import { getSaveType } from '@pnpm/utils'
 import {
   install,
@@ -8,6 +7,7 @@ import {
 import createStoreController from '../createStoreController'
 import findWorkspacePackages, { arrayOfLocalPackagesToMap } from '../findWorkspacePackages'
 import getPinnedVersion from '../getPinnedVersion'
+import { readImporterManifestOnly, tryReadImporterManifest } from '../readImporterManifest'
 import requireHooks from '../requireHooks'
 import { PnpmOptions } from '../types'
 import updateToLatestSpecsFromManifest, { createLatestSpecs } from '../updateToLatestSpecsFromManifest'

--- a/packages/pnpm/src/cmd/link.ts
+++ b/packages/pnpm/src/cmd/link.ts
@@ -1,8 +1,4 @@
 import { StoreController } from '@pnpm/package-store'
-import readImporterManifest, {
-  readImporterManifestOnly,
-  tryReadImporterManifest,
-} from '@pnpm/read-importer-manifest'
 import pLimit from 'p-limit'
 import path = require('path')
 import pathAbsolute = require('path-absolute')
@@ -17,6 +13,10 @@ import {
 import { cached as createStoreController } from '../createStoreController'
 import findWorkspacePackages, { arrayOfLocalPackagesToMap } from '../findWorkspacePackages'
 import getConfigs from '../getConfigs'
+import readImporterManifest, {
+  readImporterManifestOnly,
+  tryReadImporterManifest,
+} from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 
 const installLimit = pLimit(4)

--- a/packages/pnpm/src/cmd/prune.ts
+++ b/packages/pnpm/src/cmd/prune.ts
@@ -1,6 +1,6 @@
-import { readImporterManifestOnly } from '@pnpm/read-importer-manifest'
 import { InstallOptions, mutateModules } from 'supi'
 import createStoreController from '../createStoreController'
+import { readImporterManifestOnly } from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 
 export default async (input: string[], opts: PnpmOptions) => {

--- a/packages/pnpm/src/cmd/publish.ts
+++ b/packages/pnpm/src/cmd/publish.ts
@@ -1,4 +1,3 @@
-import readImporterManifest from '@pnpm/read-importer-manifest'
 import { ImporterManifest } from '@pnpm/types'
 import cpFile = require('cp-file')
 import fg = require('fast-glob')
@@ -7,6 +6,7 @@ import path = require('path')
 import R = require('ramda')
 import rimraf = require('rimraf-then')
 import writeJsonFile = require('write-json-file')
+import readImporterManifest from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 import runNpm from './runNpm'
 

--- a/packages/pnpm/src/cmd/rebuild.ts
+++ b/packages/pnpm/src/cmd/rebuild.ts
@@ -1,9 +1,9 @@
-import { readImporterManifestOnly } from '@pnpm/read-importer-manifest'
 import {
   rebuild,
   rebuildPkgs,
 } from 'supi'
 import createStoreController from '../createStoreController'
+import { readImporterManifestOnly } from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 
 export default async function (

--- a/packages/pnpm/src/cmd/run.ts
+++ b/packages/pnpm/src/cmd/run.ts
@@ -1,8 +1,8 @@
 import runLifecycleHooks from '@pnpm/lifecycle'
-import { readImporterManifestOnly } from '@pnpm/read-importer-manifest'
 import { ImporterManifest } from '@pnpm/types'
 import { realNodeModulesDir } from '@pnpm/utils'
 import R = require('ramda')
+import { readImporterManifestOnly } from '../readImporterManifest'
 
 export default async function run (
   args: string[],

--- a/packages/pnpm/src/cmd/uninstall.ts
+++ b/packages/pnpm/src/cmd/uninstall.ts
@@ -1,9 +1,9 @@
-import readImporterManifest from '@pnpm/read-importer-manifest'
 import {
   mutateModules,
 } from 'supi'
 import createStoreController from '../createStoreController'
 import findWorkspacePackages, { arrayOfLocalPackagesToMap } from '../findWorkspacePackages'
+import readImporterManifest from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 
 export default async function uninstallCmd (

--- a/packages/pnpm/src/cmd/unlink.ts
+++ b/packages/pnpm/src/cmd/unlink.ts
@@ -1,6 +1,6 @@
-import { readImporterManifestOnly } from '@pnpm/read-importer-manifest'
 import { mutateModules } from 'supi'
 import createStoreController from '../createStoreController'
+import { readImporterManifestOnly } from '../readImporterManifest'
 import { PnpmOptions } from '../types'
 
 export default async function (input: string[], opts: PnpmOptions) {

--- a/packages/pnpm/src/readImporterManifest.ts
+++ b/packages/pnpm/src/readImporterManifest.ts
@@ -1,0 +1,46 @@
+import packageIsInstallable from '@pnpm/package-is-installable'
+import _readImporterManifest, * as utils from '@pnpm/read-importer-manifest'
+import { ImporterManifest } from '@pnpm/types'
+import packageManager from './pnpmPkgJson'
+
+export default async function readImporterManifest (importerDir: string): Promise<{
+  fileName: string,
+  manifest: ImporterManifest,
+  writeImporterManifest: (manifest: ImporterManifest, force?: boolean) => Promise<void>,
+}> {
+  const { fileName, manifest, writeImporterManifest } = await _readImporterManifest(importerDir)
+  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
+    engineStrict: true,
+    optional: false,
+    pnpmVersion: packageManager.version,
+    prefix: importerDir,
+  })
+  return { fileName, manifest, writeImporterManifest }
+}
+
+export async function readImporterManifestOnly (importerDir: string): Promise<ImporterManifest> {
+  const manifest = await utils.readImporterManifestOnly(importerDir)
+  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
+    engineStrict: true,
+    optional: false,
+    pnpmVersion: packageManager.version,
+    prefix: importerDir,
+  })
+  return manifest
+}
+
+export async function tryReadImporterManifest (importerDir: string): Promise<{
+  fileName: string,
+  manifest: ImporterManifest | null,
+  writeImporterManifest: (manifest: ImporterManifest, force?: boolean) => Promise<void>,
+}> {
+  const { fileName, manifest, writeImporterManifest } = await utils.tryReadImporterManifest(importerDir)
+  if (!manifest) return { fileName, manifest, writeImporterManifest }
+  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
+    engineStrict: true,
+    optional: false,
+    pnpmVersion: packageManager.version,
+    prefix: importerDir,
+  })
+  return { fileName, manifest, writeImporterManifest }
+}

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -1,14 +1,14 @@
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { Lockfile } from '@pnpm/lockfile-types'
-import prepare, { prepareEmpty } from '@pnpm/prepare'
+import prepare, { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import readImporterManifest from '@pnpm/read-importer-manifest'
 import { fromDir as readPackageJsonFromDir } from '@pnpm/read-package-json'
 import writeImporterManifest from '@pnpm/write-importer-manifest'
 import crossSpawn = require('cross-spawn')
 import delay = require('delay')
 import dirIsCaseSensitive from 'dir-is-case-sensitive'
-import fs = require('fs')
 import loadJsonFile = require('load-json-file')
+import fs = require('mz/fs')
 import path = require('path')
 import exists = require('path-exists')
 import readYamlFile from 'read-yaml-file'
@@ -300,4 +300,102 @@ test('pnpm install --save-peer', async (t) => {
       },
     )
   }
+})
+
+test('install should fail if the used pnpm version does not satisfy the pnpm version specified in engines', async (t: tape.Test) => {
+  prepare(t, {
+    name: 'project',
+    version: '1.0.0',
+
+    engines: {
+      pnpm: '99999',
+    },
+  })
+
+  const { status, stdout } = execPnpmSync('recursive', 'install')
+
+  t.equal(status, 1)
+  t.ok(stdout.toString().includes('wanted: {"pnpm":"99999"}'))
+})
+
+test('install should fail if the used Node version does not satisfy the Node version specified in engines', async (t: tape.Test) => {
+  prepare(t, {
+    name: 'project',
+    version: '1.0.0',
+
+    engines: {
+      node: '99999',
+    },
+  })
+
+  const { status, stdout } = execPnpmSync('recursive', 'install')
+
+  t.equal(status, 1)
+  t.ok(stdout.toString().includes('wanted: {"node":"99999"}'))
+})
+
+test('recursive install should fail if the used pnpm version does not satisfy the pnpm version specified in engines of any of the workspace packages', async (t: tape.Test) => {
+  preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+      engines: {
+        pnpm: '99999',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+  ])
+
+  await fs.writeFile('pnpm-workspace.yaml', '', 'utf8')
+
+  process.chdir('project-1')
+
+  const { status, stdout } = execPnpmSync('recursive', 'install')
+
+  t.equal(status, 1)
+  t.ok(stdout.toString().includes('wanted: {"pnpm":"99999"}'))
+})
+
+test('recursive install should fail if the used Node version does not satisfy the Node version specified in engines of any of the workspace packages', async (t: tape.Test) => {
+  preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+      engines: {
+        node: '99999',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+  ])
+
+  await fs.writeFile('pnpm-workspace.yaml', '', 'utf8')
+
+  process.chdir('project-1')
+
+  const { status, stdout } = execPnpmSync('recursive', 'install')
+
+  t.equal(status, 1)
+  t.ok(stdout.toString().includes('wanted: {"node":"99999"}'))
 })

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -312,10 +312,10 @@ test('install should fail if the used pnpm version does not satisfy the pnpm ver
     },
   })
 
-  const { status, stdout } = execPnpmSync('recursive', 'install')
+  const { status, stdout } = execPnpmSync('install')
 
   t.equal(status, 1)
-  t.ok(stdout.toString().includes('wanted: {"pnpm":"99999"}'))
+  t.ok(stdout.toString().includes('Your pnpm version is incompatible with'))
 })
 
 test('install should fail if the used Node version does not satisfy the Node version specified in engines', async (t: tape.Test) => {
@@ -328,10 +328,10 @@ test('install should fail if the used Node version does not satisfy the Node ver
     },
   })
 
-  const { status, stdout } = execPnpmSync('recursive', 'install')
+  const { status, stdout } = execPnpmSync('install')
 
   t.equal(status, 1)
-  t.ok(stdout.toString().includes('wanted: {"node":"99999"}'))
+  t.ok(stdout.toString().includes('Your Node version is incompatible with'))
 })
 
 test('recursive install should fail if the used pnpm version does not satisfy the pnpm version specified in engines of any of the workspace packages', async (t: tape.Test) => {
@@ -364,7 +364,7 @@ test('recursive install should fail if the used pnpm version does not satisfy th
   const { status, stdout } = execPnpmSync('recursive', 'install')
 
   t.equal(status, 1)
-  t.ok(stdout.toString().includes('wanted: {"pnpm":"99999"}'))
+  t.ok(stdout.toString().includes('Your pnpm version is incompatible with'))
 })
 
 test('recursive install should fail if the used Node version does not satisfy the Node version specified in engines of any of the workspace packages', async (t: tape.Test) => {
@@ -397,5 +397,5 @@ test('recursive install should fail if the used Node version does not satisfy th
   const { status, stdout } = execPnpmSync('recursive', 'install')
 
   t.equal(status, 1)
-  t.ok(stdout.toString().includes('wanted: {"node":"99999"}'))
+  t.ok(stdout.toString().includes('Your Node version is incompatible with'))
 })

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -68,6 +68,7 @@ interface BaseManifest {
   engines?: {
     node?: string,
     npm?: string,
+    pnpm?: string,
   },
   cpu?: string[],
   os?: string[],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,7 @@ importers:
       '@pnpm/list': 'link:../list'
       '@pnpm/logger': 2.1.1
       '@pnpm/outdated': 'link:../outdated'
+      '@pnpm/package-is-installable': 'link:../package-is-installable'
       '@pnpm/package-store': 'link:../package-store'
       '@pnpm/read-importer-manifest': 'link:../read-importer-manifest'
       '@pnpm/server': 'link:../server'
@@ -1111,6 +1112,7 @@ importers:
       '@pnpm/logger': 2.1.1
       '@pnpm/modules-yaml': 3.0.3
       '@pnpm/outdated': 2.0.19
+      '@pnpm/package-is-installable': 2.0.8
       '@pnpm/package-store': 4.0.14
       '@pnpm/prepare': 0.0.0
       '@pnpm/read-importer-manifest': 1.0.5


### PR DESCRIPTION
pnpm should fail if the project has an engines.pnpm field in its
package.json and the running pnpm's version does not satisfy the
range.

pnpm should also fail it the project has an engines.node field
and process.version does not satisfy it.

close #1382