### PR TITLE
fix: engines.node causes a fail only with engine-strict

### DIFF
--- a/packages/package-is-installable/src/checkEngine.ts
+++ b/packages/package-is-installable/src/checkEngine.ts
@@ -1,6 +1,6 @@
 import semver = require('semver')
 
-class UnsupportedEngineError extends Error {
+export class UnsupportedEngineError extends Error {
   public code: 'ERR_PNPM_UNSUPPORTED_ENGINE' = 'ERR_PNPM_UNSUPPORTED_ENGINE'
   public wanted: WantedEngine
   public current: Engine

--- a/packages/package-is-installable/src/checkPlatform.ts
+++ b/packages/package-is-installable/src/checkPlatform.ts
@@ -1,4 +1,4 @@
-class UnsupportedPlatformError extends Error {
+export class UnsupportedPlatformError extends Error {
   public code: 'ERR_PNPM_UNSUPPORTED_PLATFORM' = 'ERR_PNPM_UNSUPPORTED_PLATFORM'
   public wanted: Platform
   public current: Platform

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -2,8 +2,13 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
-import checkEngine from './checkEngine'
-import checkPlatform from './checkPlatform'
+import checkEngine, { UnsupportedEngineError } from './checkEngine'
+import checkPlatform, { UnsupportedPlatformError } from './checkPlatform'
+
+export {
+  UnsupportedEngineError,
+  UnsupportedPlatformError,
+}
 
 export default function packageIsInstallable (
   pkgId: string,
@@ -18,13 +23,13 @@ export default function packageIsInstallable (
     os?: string[],
   },
   options: {
-    engineStrict: boolean,
+    engineStrict?: boolean,
     nodeVersion?: string,
     optional: boolean,
     pnpmVersion: string,
     prefix: string,
   },
-): boolean | null {
+): boolean | UnsupportedEngineError | UnsupportedPlatformError {
   const warn = checkPlatform(pkgId, {
     cpu: pkg.cpu || ['any'],
     os: pkg.os || ['any'],
@@ -58,5 +63,5 @@ export default function packageIsInstallable (
 
   if (options.engineStrict) throw warn
 
-  return null
+  return warn
 }

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -29,15 +29,8 @@ export default function packageIsInstallable (
     pnpmVersion: string,
     prefix: string,
   },
-): boolean | UnsupportedEngineError | UnsupportedPlatformError {
-  const warn = checkPlatform(pkgId, {
-    cpu: pkg.cpu || ['any'],
-    os: pkg.os || ['any'],
-  })
-  || pkg.engines && checkEngine(pkgId, pkg.engines, {
-    node: options.nodeVersion || process.version,
-    pnpm: options.pnpmVersion,
-  })
+): boolean | null {
+  const warn = checkPackage(pkgId, pkg, options)
 
   if (!warn) return true
 
@@ -63,5 +56,32 @@ export default function packageIsInstallable (
 
   if (options.engineStrict) throw warn
 
-  return warn
+  return null
+}
+
+export function checkPackage (
+  pkgId: string,
+  manifest: {
+    engines?: {
+      node?: string,
+      npm?: string,
+    },
+    cpu?: string[],
+    os?: string[],
+  },
+  options: {
+    nodeVersion?: string,
+    pnpmVersion: string,
+  },
+): null | UnsupportedEngineError | UnsupportedPlatformError {
+  return checkPlatform(pkgId, {
+    cpu: manifest.cpu || ['any'],
+    os: manifest.os || ['any'],
+  }) || (
+    manifest.engines &&
+    checkEngine(pkgId, manifest.engines, {
+      node: options.nodeVersion || process.version,
+      pnpm: options.pnpmVersion,
+    })
+  ) || null
 }

--- a/packages/pnpm/src/cmd/install.ts
+++ b/packages/pnpm/src/cmd/install.ts
@@ -35,7 +35,9 @@ export default async function installCmd (
   const prefix = opts.prefix || process.cwd()
 
   const localPackages = opts.linkWorkspacePackages && opts.workspacePrefix
-    ? arrayOfLocalPackagesToMap(await findWorkspacePackages(opts.workspacePrefix))
+    ? arrayOfLocalPackagesToMap(
+      await findWorkspacePackages(opts.workspacePrefix, opts),
+    )
     : undefined
 
   if (!opts.ignorePnpmfile) {
@@ -53,7 +55,7 @@ export default async function installCmd (
     storeController: store.ctrl,
   }
 
-  let { manifest, writeImporterManifest } = await tryReadImporterManifest(opts.prefix)
+  let { manifest, writeImporterManifest } = await tryReadImporterManifest(opts.prefix, opts)
   if (manifest === null) {
     if (opts.update) {
       const err = new Error('No package.json found')
@@ -93,7 +95,7 @@ export default async function installCmd (
   if (opts.linkWorkspacePackages && opts.workspacePrefix && manifest.name) {
     // TODO: reuse somehow the previous read of packages
     // this is not optimal
-    const allWorkspacePkgs = await findWorkspacePackages(opts.workspacePrefix)
+    const allWorkspacePkgs = await findWorkspacePackages(opts.workspacePrefix, opts)
     await recursive(allWorkspacePkgs, [], {
       ...opts,
       ...OVERWRITE_UPDATE_OPTIONS,
@@ -113,7 +115,7 @@ export default async function installCmd (
       [
         {
           buildIndex: 0,
-          manifest: await readImporterManifestOnly(opts.prefix),
+          manifest: await readImporterManifestOnly(opts.prefix, opts),
           prefix: opts.prefix,
         },
       ], {

--- a/packages/pnpm/src/cmd/link.ts
+++ b/packages/pnpm/src/cmd/link.ts
@@ -31,7 +31,7 @@ export default async (
   let workspacePackages
   let localPackages!: LocalPackages
   if (opts.linkWorkspacePackages && opts.workspacePrefix) {
-    workspacePackages = await findWorkspacePackages(opts.workspacePrefix)
+    workspacePackages = await findWorkspacePackages(opts.workspacePrefix, opts)
     localPackages = arrayOfLocalPackagesToMap(workspacePackages)
   } else {
     localPackages = {}
@@ -46,7 +46,7 @@ export default async (
 
   // pnpm link
   if (!input || !input.length) {
-    const { manifest, writeImporterManifest } = await tryReadImporterManifest(opts.globalPrefix)
+    const { manifest, writeImporterManifest } = await tryReadImporterManifest(opts.globalPrefix, opts)
     const newManifest = await linkToGlobal(cwd, {
       ...linkOpts,
       manifest: manifest || {},
@@ -60,7 +60,7 @@ export default async (
   if (pkgNames.length) {
     let globalPkgNames!: string[]
     if (opts.workspacePrefix) {
-      workspacePackages = await findWorkspacePackages(opts.workspacePrefix)
+      workspacePackages = await findWorkspacePackages(opts.workspacePrefix, opts)
 
       const pkgsFoundInWorkspace = workspacePackages.filter((pkg) => pkgNames.includes(pkg.manifest.name))
       pkgsFoundInWorkspace.forEach((pkgFromWorkspace) => pkgPaths.push(pkgFromWorkspace.path))
@@ -81,7 +81,7 @@ export default async (
     pkgPaths.map((prefix) => installLimit(async () => {
       const s = await createStoreController(storeControllerCache, opts)
       await install(
-        await readImporterManifestOnly(prefix), {
+        await readImporterManifestOnly(prefix, opts), {
           ...await getConfigs(
             { ...opts.cliArgs, prefix },
             {
@@ -96,7 +96,7 @@ export default async (
       )
     })),
   )
-  const { manifest, writeImporterManifest } = await readImporterManifest(cwd)
+  const { manifest, writeImporterManifest } = await readImporterManifest(cwd, opts)
   const newManifest = await link(pkgPaths, path.join(cwd, 'node_modules'), {
     ...linkOpts,
     manifest,

--- a/packages/pnpm/src/cmd/outdated.ts
+++ b/packages/pnpm/src/cmd/outdated.ts
@@ -20,6 +20,7 @@ export default async function (
     alwaysAuth: boolean,
     ca?: string,
     cert?: string,
+    engineStrict?: boolean,
     fetchRetries: number,
     fetchRetryFactor: number,
     fetchRetryMaxtimeout: number,
@@ -45,7 +46,7 @@ export default async function (
 ) {
   const packages = [
     {
-      manifest: await readImporterManifestOnly(opts.prefix),
+      manifest: await readImporterManifestOnly(opts.prefix, opts),
       path: opts.prefix,
     },
   ]

--- a/packages/pnpm/src/cmd/prune.ts
+++ b/packages/pnpm/src/cmd/prune.ts
@@ -8,7 +8,7 @@ export default async (input: string[], opts: PnpmOptions) => {
   return mutateModules([
     {
       buildIndex: 0,
-      manifest: await readImporterManifestOnly(process.cwd()),
+      manifest: await readImporterManifestOnly(process.cwd(), opts),
       mutation: 'install',
       prefix: process.cwd(),
       pruneDirectDependencies: true,

--- a/packages/pnpm/src/cmd/rebuild.ts
+++ b/packages/pnpm/src/cmd/rebuild.ts
@@ -22,7 +22,7 @@ export default async function (
       [
         {
           buildIndex: 0,
-          manifest: await readImporterManifestOnly(rebuildOpts.prefix),
+          manifest: await readImporterManifestOnly(rebuildOpts.prefix, opts),
           prefix: rebuildOpts.prefix,
         },
       ],
@@ -32,7 +32,7 @@ export default async function (
   await rebuildPkgs(
     [
       {
-        manifest: await readImporterManifestOnly(rebuildOpts.prefix),
+        manifest: await readImporterManifestOnly(rebuildOpts.prefix, opts),
         prefix: rebuildOpts.prefix,
       },
     ],

--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -75,7 +75,7 @@ export default async (
   }
 
   const workspacePrefix = opts.workspacePrefix || process.cwd()
-  const allWorkspacePkgs = await findWorkspacePackages(workspacePrefix)
+  const allWorkspacePkgs = await findWorkspacePackages(workspacePrefix, opts)
 
   if (!allWorkspacePkgs.length) {
     logger.info({ message: `No packages found in "${workspacePrefix}"`, prefix: workspacePrefix })

--- a/packages/pnpm/src/cmd/run.ts
+++ b/packages/pnpm/src/cmd/run.ts
@@ -7,13 +7,14 @@ import { readImporterManifestOnly } from '../readImporterManifest'
 export default async function run (
   args: string[],
   opts: {
+    engineStrict?: boolean,
     extraBinPaths: string[],
     localPrefix: string,
     rawNpmConfig: object,
   },
 ) {
   const prefix = opts.localPrefix
-  const manifest = await readImporterManifestOnly(prefix)
+  const manifest = await readImporterManifestOnly(prefix, opts)
   const scriptName = args[0]
   if (!scriptName) {
     printProjectCommands(manifest)

--- a/packages/pnpm/src/cmd/uninstall.ts
+++ b/packages/pnpm/src/cmd/uninstall.ts
@@ -16,9 +16,9 @@ export default async function uninstallCmd (
     storeController: store.ctrl,
   })
   uninstallOpts['localPackages'] = opts.linkWorkspacePackages && opts.workspacePrefix
-    ? arrayOfLocalPackagesToMap(await findWorkspacePackages(opts.workspacePrefix))
+    ? arrayOfLocalPackagesToMap(await findWorkspacePackages(opts.workspacePrefix, opts))
     : undefined
-  const currentManifest = await readImporterManifest(opts.prefix)
+  const currentManifest = await readImporterManifest(opts.prefix, opts)
   const [mutationResult] = await mutateModules(
     [
       {

--- a/packages/pnpm/src/cmd/unlink.ts
+++ b/packages/pnpm/src/cmd/unlink.ts
@@ -14,7 +14,7 @@ export default async function (input: string[], opts: PnpmOptions) {
     return mutateModules([
       {
         dependencyNames: input,
-        manifest: await readImporterManifestOnly(opts.prefix),
+        manifest: await readImporterManifestOnly(opts.prefix, opts),
         mutation: 'unlinkSome',
         prefix: opts.prefix,
       },
@@ -22,7 +22,7 @@ export default async function (input: string[], opts: PnpmOptions) {
   }
   return mutateModules([
     {
-      manifest: await readImporterManifestOnly(opts.prefix),
+      manifest: await readImporterManifestOnly(opts.prefix, opts),
       mutation: 'unlink',
       prefix: opts.prefix,
     },

--- a/packages/pnpm/src/findWorkspacePackages.ts
+++ b/packages/pnpm/src/findWorkspacePackages.ts
@@ -1,12 +1,14 @@
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
-import packageIsInstallable from '@pnpm/package-is-installable'
 import { DependencyManifest, ImporterManifest } from '@pnpm/types'
 import findPackages from 'find-packages'
 import path = require('path')
 import readYamlFile from 'read-yaml-file'
-import packageManager from './pnpmPkgJson'
+import packageIsInstallable from './packageIsInstallable'
 
-export default async (workspaceRoot: string): Promise<Array<{path: string, manifest: DependencyManifest, writeImporterManifest: (manifest: ImporterManifest) => Promise<void>}>> => {
+export default async (
+  workspaceRoot: string,
+  opts: { engineStrict?: boolean },
+): Promise<Array<{path: string, manifest: DependencyManifest, writeImporterManifest: (manifest: ImporterManifest) => Promise<void>}>> => {
   const packagesManifest = await requirePackagesManifest(workspaceRoot)
   const pkgs = await findPackages(workspaceRoot, {
     ignore: [
@@ -17,12 +19,7 @@ export default async (workspaceRoot: string): Promise<Array<{path: string, manif
   })
   pkgs.sort((pkg1: {path: string}, pkg2: {path: string}) => pkg1.path.localeCompare(pkg2.path))
   for (const pkg of pkgs) {
-    packageIsInstallable(pkg.path, pkg.manifest as any, { // tslint:disable-line:no-any
-      engineStrict: true,
-      optional: false,
-      pnpmVersion: packageManager.stableVersion,
-      prefix: pkg.path,
-    })
+    packageIsInstallable(pkg.path, pkg.manifest as any, opts) // tslint:disable-line:no-any
   }
 
   return pkgs

--- a/packages/pnpm/src/packageIsInstallable.ts
+++ b/packages/pnpm/src/packageIsInstallable.ts
@@ -1,3 +1,4 @@
+import logger from '@pnpm/logger'
 import { checkPackage, UnsupportedEngineError } from '@pnpm/package-is-installable'
 import packageManager from './pnpmPkgJson'
 
@@ -25,4 +26,10 @@ export default function (
     (err instanceof UnsupportedEngineError && err.wanted.pnpm) ||
     opts.engineStrict
   ) throw err
+  logger.warn({
+    message: `Unsupported ${
+      err instanceof UnsupportedEngineError ? 'engine' : 'platform'
+    }: wanted: ${JSON.stringify(err.wanted)} (current: ${JSON.stringify(err.current)})`,
+    prefix: pkgPath,
+  })
 }

--- a/packages/pnpm/src/packageIsInstallable.ts
+++ b/packages/pnpm/src/packageIsInstallable.ts
@@ -1,4 +1,4 @@
-import packageIsInstallable from '@pnpm/package-is-installable'
+import { checkPackage, UnsupportedEngineError } from '@pnpm/package-is-installable'
 import packageManager from './pnpmPkgJson'
 
 export default function (
@@ -17,12 +17,12 @@ export default function (
     engineStrict?: boolean,
   },
 ) {
-  const warn = packageIsInstallable(pkgPath, pkg, {
-    engineStrict: false,
-    optional: false,
+  const err = checkPackage(pkgPath, pkg, {
     pnpmVersion: packageManager.version,
-    prefix: pkgPath,
   })
-  if (warn === true) return
-  if (warn['wanted'].pnpm || opts.engineStrict) throw warn
+  if (err === null) return
+  if (
+    (err instanceof UnsupportedEngineError && err.wanted.pnpm) ||
+    opts.engineStrict
+  ) throw err
 }

--- a/packages/pnpm/src/packageIsInstallable.ts
+++ b/packages/pnpm/src/packageIsInstallable.ts
@@ -1,0 +1,28 @@
+import packageIsInstallable from '@pnpm/package-is-installable'
+import packageManager from './pnpmPkgJson'
+
+export default function (
+  pkgPath: string,
+  pkg: {
+    name: string,
+    version: string,
+    engines?: {
+      node?: string,
+      npm?: string,
+    },
+    cpu?: string[],
+    os?: string[],
+  },
+  opts: {
+    engineStrict?: boolean,
+  },
+) {
+  const warn = packageIsInstallable(pkgPath, pkg, {
+    engineStrict: false,
+    optional: false,
+    pnpmVersion: packageManager.version,
+    prefix: pkgPath,
+  })
+  if (warn === true) return
+  if (warn['wanted'].pnpm || opts.engineStrict) throw warn
+}

--- a/packages/pnpm/src/readImporterManifest.ts
+++ b/packages/pnpm/src/readImporterManifest.ts
@@ -1,46 +1,39 @@
-import packageIsInstallable from '@pnpm/package-is-installable'
 import _readImporterManifest, * as utils from '@pnpm/read-importer-manifest'
 import { ImporterManifest } from '@pnpm/types'
-import packageManager from './pnpmPkgJson'
+import packageIsInstallable from './packageIsInstallable'
 
-export default async function readImporterManifest (importerDir: string): Promise<{
+export default async function readImporterManifest (
+  importerDir: string,
+  opts: { engineStrict?: boolean },
+): Promise<{
   fileName: string,
   manifest: ImporterManifest,
   writeImporterManifest: (manifest: ImporterManifest, force?: boolean) => Promise<void>,
 }> {
   const { fileName, manifest, writeImporterManifest } = await _readImporterManifest(importerDir)
-  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
-    engineStrict: true,
-    optional: false,
-    pnpmVersion: packageManager.stableVersion,
-    prefix: importerDir,
-  })
+  packageIsInstallable(importerDir, manifest as any, opts) // tslint:disable-line:no-any
   return { fileName, manifest, writeImporterManifest }
 }
 
-export async function readImporterManifestOnly (importerDir: string): Promise<ImporterManifest> {
+export async function readImporterManifestOnly (
+  importerDir: string,
+  opts: { engineStrict?: boolean },
+): Promise<ImporterManifest> {
   const manifest = await utils.readImporterManifestOnly(importerDir)
-  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
-    engineStrict: true,
-    optional: false,
-    pnpmVersion: packageManager.stableVersion,
-    prefix: importerDir,
-  })
+  packageIsInstallable(importerDir, manifest as any, opts) // tslint:disable-line:no-any
   return manifest
 }
 
-export async function tryReadImporterManifest (importerDir: string): Promise<{
+export async function tryReadImporterManifest (
+  importerDir: string,
+  opts: { engineStrict?: boolean },
+): Promise<{
   fileName: string,
   manifest: ImporterManifest | null,
   writeImporterManifest: (manifest: ImporterManifest, force?: boolean) => Promise<void>,
 }> {
   const { fileName, manifest, writeImporterManifest } = await utils.tryReadImporterManifest(importerDir)
   if (!manifest) return { fileName, manifest, writeImporterManifest }
-  packageIsInstallable(importerDir, manifest as any, { // tslint:disable-line:no-any
-    engineStrict: true,
-    optional: false,
-    pnpmVersion: packageManager.stableVersion,
-    prefix: importerDir,
-  })
+  packageIsInstallable(importerDir, manifest as any, opts) // tslint:disable-line:no-any
   return { fileName, manifest, writeImporterManifest }
 }

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -331,6 +331,7 @@ test('engine-strict=false: install should not fail if the used Node version does
   const { status, stdout } = execPnpmSync('install')
 
   t.equal(status, 0)
+  t.ok(stdout.toString().includes('Unsupported engine'))
 })
 
 test('engine-strict=true: install should fail if the used Node version does not satisfy the Node version specified in engines', async (t: tape.Test) => {
@@ -445,4 +446,5 @@ test('engine-strict=false: recursive install should not fail if the used Node ve
   const { status, stdout } = execPnpmSync('recursive', 'install')
 
   t.equal(status, 0)
+  t.ok(stdout.toString().includes('Unsupported engine'))
 })


### PR DESCRIPTION
related #1914

- [x] print warnings when engine-strict is false
- [x] refactor `@pnpm/package-is-installable`