### PR TITLE
fix(headless): should work with --no-optional

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -73,7 +73,7 @@
     "test": "pnpm run lint && pnpm run tsc && pnpm run test:e2e",
     "tsc": "rimraf lib && tsc",
     "prepublishOnly": "pnpm run tsc",
-    "runPrepareFixtures": "cd test/fixtures && node ../../../pnpm/lib/bin/pnpm.js m i --lockfile-only --registry http://localhost:4873/ --ignore-scripts --force",
+    "runPrepareFixtures": "cd test/fixtures && node ../../../pnpm/lib/bin/pnpm.js m i --no-shared-workspace-lockfile --no-link-workspace-packages --lockfile-only --registry http://localhost:4873/ --ignore-scripts --force",
     "prepareFixtures": "registry-mock prepare && run-p -r registry-mock runPrepareFixtures"
   },
   "dependencies": {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -450,6 +450,7 @@ async function linkRootPackages (
 
 interface LockfileToDepGraphOptions {
   force: boolean,
+  include: IncludedDependencies,
   independentLeaves: boolean,
   importerIds: string[],
   lockfileDirectory: string,
@@ -561,13 +562,20 @@ async function lockfileToDepGraph (
     }
     for (const peripheralLocation of R.keys(graph)) {
       const pkgSnapshot = pkgSnapshotByLocation[peripheralLocation]
-      const allDeps = { ...pkgSnapshot.dependencies, ...pkgSnapshot.optionalDependencies }
+      const allDeps = {
+        ...pkgSnapshot.dependencies,
+        ...(opts.include.optionalDependencies ? pkgSnapshot.optionalDependencies : {}),
+      }
 
       graph[peripheralLocation].children = await getChildrenPaths(ctx, allDeps)
     }
     for (const importerId of opts.importerIds) {
       const lockfileImporter = lockfile.importers[importerId]
-      const rootDeps = { ...lockfileImporter.devDependencies, ...lockfileImporter.dependencies, ...lockfileImporter.optionalDependencies }
+      const rootDeps = {
+        ...(opts.include.devDependencies ? lockfileImporter.devDependencies : {}),
+        ...(opts.include.dependencies ? lockfileImporter.dependencies : {}),
+        ...(opts.include.optionalDependencies ? lockfileImporter.optionalDependencies : {}),
+      }
       directDependenciesByImporterId[importerId] = await getChildrenPaths(ctx, rootDeps)
     }
   }

--- a/packages/headless/test/fixtures/simple-with-optional-dep/package.json
+++ b/packages/headless/test/fixtures/simple-with-optional-dep/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simple-with-optional-dep",
+  "version": "1.0.0",
+  "dependencies": {
+    "pkg-with-good-optional": "*"
+  },
+  "optionalDependencies": {
+    "is-positive": "1.0.0"
+  }
+}

--- a/packages/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
+++ b/packages/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
@@ -1,0 +1,28 @@
+dependencies:
+  pkg-with-good-optional: 1.0.0
+lockfileVersion: 5.1
+optionalDependencies:
+  is-positive: 1.0.0
+packages:
+  /dep-of-pkg-with-1-dep/100.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-RWObNQIluSr56fVbOwD75Dt5CE2aiPReTMMUblYEMEqUI+iJw5ovTyO7LzUG/VJ4iVL2uUrbkQ6+rq4z4WOdDw==
+  /is-positive/1.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    optional: true
+    resolution:
+      integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=
+  /pkg-with-good-optional/1.0.0:
+    dependencies:
+      dep-of-pkg-with-1-dep: 100.0.0
+    dev: false
+    optionalDependencies:
+      is-positive: 1.0.0
+    resolution:
+      integrity: sha512-8R+sVXJbtWl0aNu6HwqtMg36mOkwGgHcE5YECx53WylyvnO+SKSVsofRJpbCov/Gl01bqQyzmaSfqmg0IXWeSQ==
+specifiers:
+  is-positive: 1.0.0
+  pkg-with-good-optional: '*'

--- a/packages/headless/test/index.ts
+++ b/packages/headless/test/index.ts
@@ -220,6 +220,27 @@ test('installing only optional deps', async (t) => {
   t.end()
 })
 
+// Covers https://github.com/pnpm/pnpm/issues/1958
+test('not installing optional deps', async (t) => {
+  const prefix = path.join(fixtures, 'simple-with-optional-dep')
+  await rimraf(path.join(prefix, 'node_modules'))
+
+  await headless(await testDefaults({
+    include: {
+      dependencies: true,
+      devDependencies: true,
+      optionalDependencies: false,
+    },
+    lockfileDirectory: prefix,
+  }))
+
+  const project = assertProject(t, prefix)
+  await project.hasNot('is-positive')
+  await project.has('pkg-with-good-optional')
+
+  t.end()
+})
+
 // Covers https://github.com/pnpm/pnpm/issues/1547
 test('installing with independent-leaves and shamefully-flatten', async (t) => {
   const prefix = path.join(fixtures, 'with-1-dep')


### PR DESCRIPTION
"pnpm install --no-optional" should not fail on a project that
has an up-to-date lockfile.

close #1958