### PR TITLE
feat(outdated): add long option, no details by default

### DIFF
--- a/packages/pnpm/src/cmd/help.ts
+++ b/packages/pnpm/src/cmd/help.ts
@@ -617,12 +617,19 @@ function getHelpText (command: string) {
 
           Examples:
           pnpm outdated
+          pnpm outdated --long
           pnpm outdated gulp-* @babel/core`,
         descriptionLists: [
           {
             title: 'Options',
 
             list: [
+              {
+                description: oneLine`
+                By default, details about the outdated packages (such as a link to the repo) are not displayed.
+                To display the details, pass this option.`,
+                name: '--long'
+              },
               {
                 description: oneLine`
                   Check for outdated dependencies in every package found in subdirectories

--- a/packages/pnpm/src/cmd/outdated.ts
+++ b/packages/pnpm/src/cmd/outdated.ts
@@ -63,6 +63,7 @@ export default async function (
     independentLeaves: boolean,
     key?: string,
     localAddress?: string,
+    long?: boolean,
     networkConcurrency: number,
     offline: boolean,
     prefix: string,
@@ -87,18 +88,27 @@ export default async function (
 
   if (!outdatedPackages.length) return
 
-  const columnNames = [
+  let columnNames = [
     'Package',
     'Current',
-    'Latest',
-    'Details',
-  ].map((name: string) => chalk.blueBright(name))
+    'Latest'
+  ]
+
+  if (opts.long) {
+    columnNames.push('Details')
+  }
+
+  columnNames = columnNames.map((name: string) => chalk.blueBright(name))
   let columnFns: Array<(outdatedPkg: OutdatedWithVersionDiff) => string> = [
     renderPackageName,
     renderCurrent,
     renderLatest,
-    renderDetails,
   ]
+
+  if (opts.long) {
+    columnFns.push(renderDetails)
+  }
+
   return table([
     columnNames,
     ...R.sortWith(

--- a/packages/pnpm/src/cmd/recursive/outdated.ts
+++ b/packages/pnpm/src/cmd/recursive/outdated.ts
@@ -48,6 +48,7 @@ export default async (
     independentLeaves: boolean,
     key?: string,
     localAddress?: string,
+    long?: boolean,
     networkConcurrency: number,
     offline: boolean,
     prefix: string,
@@ -88,13 +89,18 @@ export default async (
     }))
   }
 
-  const columnNames = [
+  let columnNames = [
     'Package',
     'Current',
     'Latest',
-    'Dependents',
-    'Details'
-  ].map((name: string) => chalk.blueBright(name))
+    'Dependents'
+  ]
+
+  if (opts.long) {
+    columnNames.push('Details')
+  }
+
+  columnNames = columnNames.map((name: string) => chalk.blueBright(name))
   const data = [
     columnNames,
     ...R.sortWith(
@@ -114,9 +120,8 @@ export default async (
         outdatedPkg.dependentPkgs
           .map(({ manifest, location }) => manifest.name || location)
           .sort()
-          .join(', '),
-        renderDetails(outdatedPkg),
-      ]),
+          .join(', ')
+      ].concat(opts.long ? [renderDetails(outdatedPkg)] : [])),
   ]
   process.stdout.write(
     table(data, {

--- a/packages/pnpm/test/outdated.ts
+++ b/packages/pnpm/test/outdated.ts
@@ -34,7 +34,6 @@ test('pnpm outdated', async (t: tape.Test) => {
       fetchRetryMintimeout: 10000,
       global: false,
       independentLeaves: false,
-      long: true,
       networkConcurrency: 16,
       offline: false,
       prefix: process.cwd(),
@@ -45,13 +44,13 @@ test('pnpm outdated', async (t: tape.Test) => {
       userAgent: '',
     }, 'outdated'),
     stripIndent`
-    ┌─────────────┬──────────────────────┬────────┬─────────────────────────────────────────────┐
-    │ ${chalk.blueBright.bold('Package')}     │ ${chalk.blueBright.bold('Current')}              │ ${chalk.blueBright.bold('Latest')} │ ${chalk.blueBright.bold('Details')}                                     │
-    ├─────────────┼──────────────────────┼────────┼─────────────────────────────────────────────┤
-    │ is-positive │ 1.0.0 (wanted 3.1.0) │ 3.1.0  │ https://github.com/kevva/is-positive#readme │
-    ├─────────────┼──────────────────────┼────────┼─────────────────────────────────────────────┤
-    │ is-negative │ 1.0.0 (wanted 1.1.0) │ ${chalk.redBright.bold('2.1.0')}  │ https://github.com/kevva/is-negative#readme │
-    └─────────────┴──────────────────────┴────────┴─────────────────────────────────────────────┘
+    ┌─────────────┬──────────────────────┬────────┐
+    │ ${chalk.blueBright.bold('Package')}     │ ${chalk.blueBright.bold('Current')}              │ ${chalk.blueBright.bold('Latest')} │
+    ├─────────────┼──────────────────────┼────────┤
+    │ is-positive │ 1.0.0 (wanted 3.1.0) │ 3.1.0  │
+    ├─────────────┼──────────────────────┼────────┤
+    │ is-negative │ 1.0.0 (wanted 1.1.0) │ ${chalk.redBright.bold('2.1.0')}  │
+    └─────────────┴──────────────────────┴────────┘
     ` + '\n',
   )
 })

--- a/packages/pnpm/test/outdated.ts
+++ b/packages/pnpm/test/outdated.ts
@@ -34,6 +34,7 @@ test('pnpm outdated', async (t: tape.Test) => {
       fetchRetryMintimeout: 10000,
       global: false,
       independentLeaves: false,
+      long: true,
       networkConcurrency: 16,
       offline: false,
       prefix: process.cwd(),
@@ -55,14 +56,14 @@ test('pnpm outdated', async (t: tape.Test) => {
   )
 })
 
-test('pnpm outdated: only current lockfile is available', async (t: tape.Test) => {
+test('pnpm outdated: show details', async (t: tape.Test) => {
   tempDir(t)
 
   await makeDir(path.resolve('node_modules'))
   await fs.copyFile(path.join(hasOutdatedDepsFixture, 'node_modules/.pnpm-lock.yaml'), path.resolve('node_modules/.pnpm-lock.yaml'))
   await fs.copyFile(path.join(hasOutdatedDepsFixture, 'package.json'), path.resolve('package.json'))
 
-  const result = execPnpmSync('outdated')
+  const result = execPnpmSync('outdated', '--long')
 
   t.equal(result.status, 0)
 
@@ -81,6 +82,30 @@ test('pnpm outdated: only current lockfile is available', async (t: tape.Test) =
   ` + '\n')
 })
 
+test('pnpm outdated: only current lockfile is available', async (t: tape.Test) => {
+  tempDir(t)
+
+  await makeDir(path.resolve('node_modules'))
+  await fs.copyFile(path.join(hasOutdatedDepsFixture, 'node_modules/.pnpm-lock.yaml'), path.resolve('node_modules/.pnpm-lock.yaml'))
+  await fs.copyFile(path.join(hasOutdatedDepsFixture, 'package.json'), path.resolve('package.json'))
+
+  const result = execPnpmSync('outdated')
+
+  t.equal(result.status, 0)
+
+  t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
+  ┌─────────────┬─────────┬────────────┐
+  │ Package     │ Current │ Latest     │
+  ├─────────────┼─────────┼────────────┤
+  │ flatten     │ 1.0.2   │ Deprecated │
+  ├─────────────┼─────────┼────────────┤
+  │ is-negative │ 1.0.0   │ 2.1.0      │
+  ├─────────────┼─────────┼────────────┤
+  │ is-positive │ 1.0.0   │ 3.1.0      │
+  └─────────────┴─────────┴────────────┘
+  ` + '\n')
+})
+
 test('pnpm outdated: only wanted lockfile is available', async (t: tape.Test) => {
   tempDir(t)
 
@@ -92,17 +117,15 @@ test('pnpm outdated: only wanted lockfile is available', async (t: tape.Test) =>
   t.equal(result.status, 0)
 
   t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-  ┌─────────────┬────────────────────────┬────────────┬──────────────────────────────────────────────────────┐
-  │ Package     │ Current                │ Latest     │ Details                                              │
-  ├─────────────┼────────────────────────┼────────────┼──────────────────────────────────────────────────────┤
-  │ flatten     │ missing (wanted 1.0.2) │ Deprecated │ I wrote this module a very long time                 │
-  │             │                        │            │ ago; you should use something else.                  │
-  │             │                        │            │ https://github.com/jesusabdullah/node-flatten#readme │
-  ├─────────────┼────────────────────────┼────────────┼──────────────────────────────────────────────────────┤
-  │ is-positive │ missing (wanted 3.1.0) │ 3.1.0      │ https://github.com/kevva/is-positive#readme          │
-  ├─────────────┼────────────────────────┼────────────┼──────────────────────────────────────────────────────┤
-  │ is-negative │ missing (wanted 1.1.0) │ 2.1.0      │ https://github.com/kevva/is-negative#readme          │
-  └─────────────┴────────────────────────┴────────────┴──────────────────────────────────────────────────────┘
+  ┌─────────────┬────────────────────────┬────────────┐
+  │ Package     │ Current                │ Latest     │
+  ├─────────────┼────────────────────────┼────────────┤
+  │ flatten     │ missing (wanted 1.0.2) │ Deprecated │
+  ├─────────────┼────────────────────────┼────────────┤
+  │ is-positive │ missing (wanted 3.1.0) │ 3.1.0      │
+  ├─────────────┼────────────────────────┼────────────┤
+  │ is-negative │ missing (wanted 1.1.0) │ 2.1.0      │
+  └─────────────┴────────────────────────┴────────────┘
   ` + '\n')
 })
 
@@ -124,13 +147,13 @@ test('pnpm outdated with external lockfile', async (t: tape.Test) => {
   t.equal(result.status, 0)
 
   t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-  ┌─────────────┬──────────────────────┬────────┬─────────────────────────────────────────────┐
-  │ Package     │ Current              │ Latest │ Details                                     │
-  ├─────────────┼──────────────────────┼────────┼─────────────────────────────────────────────┤
-  │ is-positive │ 1.0.0 (wanted 3.1.0) │ 3.1.0  │ https://github.com/kevva/is-positive#readme │
-  ├─────────────┼──────────────────────┼────────┼─────────────────────────────────────────────┤
-  │ is-negative │ 1.0.0 (wanted 1.1.0) │ 2.1.0  │ https://github.com/kevva/is-negative#readme │
-  └─────────────┴──────────────────────┴────────┴─────────────────────────────────────────────┘
+  ┌─────────────┬──────────────────────┬────────┐
+  │ Package     │ Current              │ Latest │
+  ├─────────────┼──────────────────────┼────────┤
+  │ is-positive │ 1.0.0 (wanted 3.1.0) │ 3.1.0  │
+  ├─────────────┼──────────────────────┼────────┤
+  │ is-negative │ 1.0.0 (wanted 1.1.0) │ 2.1.0  │
+  └─────────────┴──────────────────────┴────────┘
   ` + '\n')
 })
 
@@ -148,13 +171,13 @@ test('pnpm outdated on global packages', async (t: tape.Test) => {
   t.equal(result.status, 0)
 
   t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-  ┌─────────────┬─────────┬────────┬─────────────────────────────────────────────┐
-  │ Package     │ Current │ Latest │ Details                                     │
-  ├─────────────┼─────────┼────────┼─────────────────────────────────────────────┤
-  │ is-negative │ 1.0.0   │ 2.1.0  │ https://github.com/kevva/is-negative#readme │
-  ├─────────────┼─────────┼────────┼─────────────────────────────────────────────┤
-  │ is-positive │ 1.0.0   │ 3.1.0  │ https://github.com/kevva/is-positive#readme │
-  └─────────────┴─────────┴────────┴─────────────────────────────────────────────┘
+  ┌─────────────┬─────────┬────────┐
+  │ Package     │ Current │ Latest │
+  ├─────────────┼─────────┼────────┤
+  │ is-negative │ 1.0.0   │ 2.1.0  │
+  ├─────────────┼─────────┼────────┤
+  │ is-positive │ 1.0.0   │ 3.1.0  │
+  └─────────────┴─────────┴────────┘
   ` + '\n')
 })
 

--- a/packages/pnpm/test/recursive/outdated.ts
+++ b/packages/pnpm/test/recursive/outdated.ts
@@ -51,6 +51,72 @@ test('pnpm recursive outdated', async (t: tape.Test) => {
     t.equal(result.status, 0)
 
     t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
+    ┌───────────────────┬─────────┬────────┬──────────────────────┐
+    │ Package           │ Current │ Latest │ Dependents           │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-negative       │ 1.0.0   │ 2.1.0  │ project-2            │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-negative (dev) │ 1.0.0   │ 2.1.0  │ project-3            │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-positive       │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
+    └───────────────────┴─────────┴────────┴──────────────────────┘
+    ` + '\n')
+  }
+
+  {
+    const result = execPnpmSync('recursive', 'outdated', 'is-positive')
+
+    t.equal(result.status, 0)
+
+    t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
+    ┌─────────────┬─────────┬────────┬──────────────────────┐
+    │ Package     │ Current │ Latest │ Dependents           │
+    ├─────────────┼─────────┼────────┼──────────────────────┤
+    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
+    └─────────────┴─────────┴────────┴──────────────────────┘
+    ` + '\n')
+  }
+})
+
+test('pnpm recursive outdated: show details', async (t: tape.Test) => {
+  preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+      devDependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+  ])
+
+  await execPnpm('recursive', 'install')
+
+  {
+    const result = execPnpmSync('recursive', 'outdated', '--long')
+
+    t.equal(result.status, 0)
+
+    t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
     ┌───────────────────┬─────────┬────────┬──────────────────────┬─────────────────────────────────────────────┐
     │ Package           │ Current │ Latest │ Dependents           │ Details                                     │
     ├───────────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
@@ -119,15 +185,15 @@ test('pnpm recursive outdated in workspace with shared lockfile', async (t: tape
     t.equal(result.status, 0)
 
     t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-    ┌───────────────────┬─────────┬────────┬──────────────────────┬─────────────────────────────────────────────┐
-    │ Package           │ Current │ Latest │ Dependents           │ Details                                     │
-    ├───────────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
-    │ is-negative       │ 1.0.0   │ 2.1.0  │ project-2            │ https://github.com/kevva/is-negative#readme │
-    ├───────────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
-    │ is-negative (dev) │ 1.0.0   │ 2.1.0  │ project-3            │ https://github.com/kevva/is-negative#readme │
-    ├───────────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
-    │ is-positive       │ 1.0.0   │ 3.1.0  │ project-1, project-3 │ https://github.com/kevva/is-positive#readme │
-    └───────────────────┴─────────┴────────┴──────────────────────┴─────────────────────────────────────────────┘
+    ┌───────────────────┬─────────┬────────┬──────────────────────┐
+    │ Package           │ Current │ Latest │ Dependents           │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-negative       │ 1.0.0   │ 2.1.0  │ project-2            │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-negative (dev) │ 1.0.0   │ 2.1.0  │ project-3            │
+    ├───────────────────┼─────────┼────────┼──────────────────────┤
+    │ is-positive       │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
+    └───────────────────┴─────────┴────────┴──────────────────────┘
     ` + '\n')
   }
 
@@ -137,11 +203,11 @@ test('pnpm recursive outdated in workspace with shared lockfile', async (t: tape
     t.equal(result.status, 0)
 
     t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-    ┌─────────────┬─────────┬────────┬──────────────────────┬─────────────────────────────────────────────┐
-    │ Package     │ Current │ Latest │ Dependents           │ Details                                     │
-    ├─────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
-    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │ https://github.com/kevva/is-positive#readme │
-    └─────────────┴─────────┴────────┴──────────────────────┴─────────────────────────────────────────────┘
+    ┌─────────────┬─────────┬────────┬──────────────────────┐
+    │ Package     │ Current │ Latest │ Dependents           │
+    ├─────────────┼─────────┼────────┼──────────────────────┤
+    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
+    └─────────────┴─────────┴────────┴──────────────────────┘
     ` + '\n')
   }
 })

--- a/packages/pnpm/test/recursive/outdated.ts
+++ b/packages/pnpm/test/recursive/outdated.ts
@@ -64,54 +64,6 @@ test('pnpm recursive outdated', async (t: tape.Test) => {
   }
 
   {
-    const result = execPnpmSync('recursive', 'outdated', 'is-positive')
-
-    t.equal(result.status, 0)
-
-    t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-    ┌─────────────┬─────────┬────────┬──────────────────────┐
-    │ Package     │ Current │ Latest │ Dependents           │
-    ├─────────────┼─────────┼────────┼──────────────────────┤
-    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
-    └─────────────┴─────────┴────────┴──────────────────────┘
-    ` + '\n')
-  }
-})
-
-test('pnpm recursive outdated: show details', async (t: tape.Test) => {
-  preparePackages(t, [
-    {
-      name: 'project-1',
-      version: '1.0.0',
-
-      dependencies: {
-        'is-positive': '1.0.0',
-      },
-    },
-    {
-      name: 'project-2',
-      version: '1.0.0',
-
-      dependencies: {
-        'is-negative': '1.0.0',
-      },
-    },
-    {
-      name: 'project-3',
-      version: '1.0.0',
-
-      dependencies: {
-        'is-positive': '1.0.0',
-      },
-      devDependencies: {
-        'is-negative': '1.0.0',
-      },
-    },
-  ])
-
-  await execPnpm('recursive', 'install')
-
-  {
     const result = execPnpmSync('recursive', 'outdated', '--long')
 
     t.equal(result.status, 0)
@@ -135,11 +87,11 @@ test('pnpm recursive outdated: show details', async (t: tape.Test) => {
     t.equal(result.status, 0)
 
     t.equal(normalizeNewline(result.stdout.toString()), stripIndent`
-    ┌─────────────┬─────────┬────────┬──────────────────────┬─────────────────────────────────────────────┐
-    │ Package     │ Current │ Latest │ Dependents           │ Details                                     │
-    ├─────────────┼─────────┼────────┼──────────────────────┼─────────────────────────────────────────────┤
-    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │ https://github.com/kevva/is-positive#readme │
-    └─────────────┴─────────┴────────┴──────────────────────┴─────────────────────────────────────────────┘
+    ┌─────────────┬─────────┬────────┬──────────────────────┐
+    │ Package     │ Current │ Latest │ Dependents           │
+    ├─────────────┼─────────┼────────┼──────────────────────┤
+    │ is-positive │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
+    └─────────────┴─────────┴────────┴──────────────────────┘
     ` + '\n')
   }
 })


### PR DESCRIPTION
Previously, by default the `outdated` commands displayed a “Details” column which usually contained the URL to the package repo. As the URL could be quite long, on narrow terminals it would cause the table to wrap in a way which ruined the table borders.

This commit hides the “Details” column by default, and displays the column if `--long` is passed to the command.