### PR TITLE
refactor(pnpm): Unify more of `outdated` and `recursive outdated`

### DIFF
--- a/packages/pnpm/src/cmd/outdated.ts
+++ b/packages/pnpm/src/cmd/outdated.ts
@@ -47,35 +47,45 @@ for (let [key, value] of Object.entries(TABLE_OPTIONS.border)) {
   TABLE_OPTIONS.border[key] = chalk.grey(value)
 }
 
+/**
+ * Default comparators used as the argument to `ramda.sortWith()`.
+ */
+export const DEFAULT_COMPARATORS = [
+  sortBySemverChange,
+  (o1: OutdatedWithVersionDiff, o2: OutdatedWithVersionDiff) => o1.packageName.localeCompare(o2.packageName),
+] as const
+
+export interface OutdatedOptions {
+  alwaysAuth: boolean
+  ca?: string
+  cert?: string
+  engineStrict?: boolean
+  fetchRetries: number
+  fetchRetryFactor: number
+  fetchRetryMaxtimeout: number
+  fetchRetryMintimeout: number
+  global: boolean
+  httpsProxy?: string
+  independentLeaves: boolean
+  key?: string
+  localAddress?: string
+  long?: boolean
+  networkConcurrency: number
+  offline: boolean
+  prefix: string
+  proxy?: string
+  rawNpmConfig: object
+  registries: Registries
+  lockfileDirectory?: string
+  store?: string
+  strictSsl: boolean
+  tag: string
+  userAgent: string
+}
+
 export default async function (
   args: string[],
-  opts: {
-    alwaysAuth: boolean,
-    ca?: string,
-    cert?: string,
-    engineStrict?: boolean,
-    fetchRetries: number,
-    fetchRetryFactor: number,
-    fetchRetryMaxtimeout: number,
-    fetchRetryMintimeout: number,
-    global: boolean,
-    httpsProxy?: string,
-    independentLeaves: boolean,
-    key?: string,
-    localAddress?: string,
-    long?: boolean,
-    networkConcurrency: number,
-    offline: boolean,
-    prefix: string,
-    proxy?: string,
-    rawNpmConfig: object,
-    registries: Registries,
-    lockfileDirectory?: string,
-    store?: string,
-    strictSsl: boolean,
-    tag: string,
-    userAgent: string,
-  },
+  opts: OutdatedOptions,
   command: string,
 ) {
   const packages = [
@@ -88,38 +98,41 @@ export default async function (
 
   if (!outdatedPackages.length) return
 
+  // TODO: Try and de-duplicate the following code from ./recursive/outdated.ts
+
   let columnNames = [
     'Package',
     'Current',
     'Latest'
   ]
 
-  if (opts.long) {
-    columnNames.push('Details')
-  }
-
-  columnNames = columnNames.map((name: string) => chalk.blueBright(name))
-  let columnFns: Array<(outdatedPkg: OutdatedWithVersionDiff) => string> = [
+  let columnFns = [
     renderPackageName,
     renderCurrent,
     renderLatest,
   ]
 
   if (opts.long) {
+    columnNames.push('Details')
     columnFns.push(renderDetails)
   }
 
+  // Avoid the overhead of allocating a new array caused by calling `array.map()`
+  for (let i = 0; i < columnNames.length; i++)
+    columnNames[i] = chalk.blueBright(columnNames[i])
+
   return table([
     columnNames,
-    ...R.sortWith(
-      [
-        sortBySemverChange,
-        (o1, o2) => o1.packageName.localeCompare(o2.packageName),
-      ],
-      outdatedPackages.map(toOutdatedWithVersionDiff)
-    )
+    ...sortOutdatedPackages(outdatedPackages)
       .map((outdatedPkg) => columnFns.map((fn) => fn(outdatedPkg))),
   ], TABLE_OPTIONS)
+}
+
+function sortOutdatedPackages (outdatedPackages: ReadonlyArray<OutdatedPackage>) {
+  return R.sortWith(
+    DEFAULT_COMPARATORS,
+    outdatedPackages.map(toOutdatedWithVersionDiff),
+  )
 }
 
 export function getCellWidth (data: string[][], columnNumber: number, maxWidth: number) {
@@ -139,7 +152,7 @@ export function toOutdatedWithVersionDiff<T> (outdated: T & OutdatedPackage): T 
   }
 }
 
-export function renderPackageName ({ belongsTo, packageName }: OutdatedWithVersionDiff) {
+export function renderPackageName ({ belongsTo, packageName }: OutdatedPackage) {
   switch (belongsTo) {
     case 'devDependencies': return `${packageName} ${chalk.dim('(dev)')}`
     case 'optionalDependencies': return `${packageName} ${chalk.dim('(optional)')}`
@@ -147,7 +160,7 @@ export function renderPackageName ({ belongsTo, packageName }: OutdatedWithVersi
   }
 }
 
-export function renderCurrent ({ current, wanted }: OutdatedWithVersionDiff) {
+export function renderCurrent ({ current, wanted }: OutdatedPackage) {
   let output = current || 'missing'
   if (current === wanted) return output
   return `${output} (wanted ${wanted})`
@@ -158,7 +171,8 @@ const DIFF_COLORS = {
   fix: chalk.greenBright.bold,
 }
 
-export function renderLatest ({ latestManifest, change, diff }: OutdatedWithVersionDiff) {
+export function renderLatest (outdatedPkg: OutdatedWithVersionDiff): string {
+  const { latestManifest, change, diff } = outdatedPkg
   if (!latestManifest) return ''
   if (change === null || !diff) {
     return latestManifest.deprecated
@@ -203,7 +217,7 @@ function pkgPriority (pkg: OutdatedWithVersionDiff) {
   }
 }
 
-export function renderDetails ({ latestManifest }: OutdatedWithVersionDiff) {
+export function renderDetails ({ latestManifest }: OutdatedPackage) {
   if (!latestManifest) return ''
   const outputs = []
   if (latestManifest.deprecated) {
@@ -218,31 +232,7 @@ export function renderDetails ({ latestManifest }: OutdatedWithVersionDiff) {
 export async function outdatedDependenciesOfWorkspacePackages (
   pkgs: Array<{path: string, manifest: PackageJson}>,
   args: string[],
-  opts: {
-    alwaysAuth: boolean,
-    ca?: string,
-    cert?: string,
-    fetchRetries: number,
-    fetchRetryFactor: number,
-    fetchRetryMaxtimeout: number,
-    fetchRetryMintimeout: number,
-    global: boolean,
-    httpsProxy?: string,
-    independentLeaves: boolean,
-    key?: string,
-    localAddress?: string,
-    networkConcurrency: number,
-    offline: boolean,
-    prefix: string,
-    proxy?: string,
-    rawNpmConfig: object,
-    registries: Registries,
-    lockfileDirectory?: string,
-    store?: string,
-    strictSsl: boolean,
-    tag: string,
-    userAgent: string,
-  },
+  opts: OutdatedOptions,
 ) {
   const lockfileDirectory = opts.lockfileDirectory || opts.prefix
   const currentLockfile = await readCurrentLockfile(lockfileDirectory, { ignoreIncompatible: false })


### PR DESCRIPTION
This makes the following changes:
- Creates the `OutdatedOptions` interface
- Creates `sortOutdatedPackages(…)` helper functions
- Uses a `columnFns` array in both implementations
  - `recursive outdated` used to directly pass an array to `R.sortWith()`
- Uses a `for`‑loop when applying the style to the table header to avoid the overhead of allocating a new array when calling `Array.map(…)`.