### PR TITLE
feat: use file: instead of link: for compatibility with npm

### DIFF
--- a/packages/local-resolver/src/parsePref.ts
+++ b/packages/local-resolver/src/parsePref.ts
@@ -65,13 +65,13 @@ function fromLocal (
   if (/^~[/]/.test(spec)) {
     // this is needed for windows and for file:~/foo/bar
     fetchSpec = resolvePath(os.homedir(), spec.slice(2))
-    normalizedPref = `${protocol}${spec}`
+    normalizedPref = `file:${spec}`
   } else {
     fetchSpec = resolvePath(importerPrefix, spec)
     if (isAbsolute(spec)) {
-      normalizedPref = `${protocol}${spec}`
+      normalizedPref = `file:${spec}`
     } else {
-      normalizedPref = `${protocol}${path.relative(importerPrefix, fetchSpec)}`
+      normalizedPref = `file:${path.relative(importerPrefix, fetchSpec)}`
     }
   }
 

--- a/packages/local-resolver/test/index.ts
+++ b/packages/local-resolver/test/index.ts
@@ -6,7 +6,7 @@ import test = require('tape')
 test('resolve directory', async t => {
   const resolveResult = await resolveFromLocal({ pref: '..' }, { prefix: __dirname })
   t.equal(resolveResult!.id, 'link:..')
-  t.equal(resolveResult!.normalizedPref, 'link:..')
+  t.equal(resolveResult!.normalizedPref, 'file:..')
   t.equal(resolveResult!['package']!.name, '@pnpm/local-resolver')
   t.equal(resolveResult!.resolution!['directory'], '..')
   t.equal(resolveResult!.resolution!['type'], 'directory')
@@ -16,7 +16,7 @@ test('resolve directory', async t => {
 test('resolve directory specified using the file: protocol', async t => {
   const resolveResult = await resolveFromLocal({ pref: 'file:..' }, { prefix: __dirname })
   t.equal(resolveResult!.id, 'link:..')
-  t.equal(resolveResult!.normalizedPref, 'link:..')
+  t.equal(resolveResult!.normalizedPref, 'file:..')
   t.equal(resolveResult!['package']!.name, '@pnpm/local-resolver')
   t.equal(resolveResult!.resolution!['directory'], '..')
   t.equal(resolveResult!.resolution!['type'], 'directory')
@@ -26,7 +26,7 @@ test('resolve directory specified using the file: protocol', async t => {
 test('resolve directoty specified using the link: protocol', async t => {
   const resolveResult = await resolveFromLocal({ pref: 'link:..' }, { prefix: __dirname })
   t.equal(resolveResult!.id, 'link:..')
-  t.equal(resolveResult!.normalizedPref, 'link:..')
+  t.equal(resolveResult!.normalizedPref, 'file:..')
   t.equal(resolveResult!['package']!.name, '@pnpm/local-resolver')
   t.equal(resolveResult!.resolution!['directory'], '..')
   t.equal(resolveResult!.resolution!['type'], 'directory')

--- a/packages/supi/test/install/local.ts
+++ b/packages/supi/test/install/local.ts
@@ -41,7 +41,7 @@ test('local file', async (t: tape.Test) => {
 
   const manifest = await addDependenciesToPackage({}, ['file:../local-pkg'], await testDefaults())
 
-  const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
+  const expectedSpecs = { 'local-pkg': `file:..${path.sep}local-pkg` }
   t.deepEqual(manifest.dependencies, expectedSpecs, 'local-pkg has been added to dependencies')
 
   const m = project.requireModule('local-pkg')
@@ -65,7 +65,7 @@ test('local file via link:', async (t: tape.Test) => {
 
   const manifest = await addDependenciesToPackage({}, ['link:../local-pkg'], await testDefaults())
 
-  const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
+  const expectedSpecs = { 'local-pkg': `file:..${path.sep}local-pkg` }
   t.deepEqual(manifest.dependencies, expectedSpecs, 'local-pkg has been added to dependencies')
 
   const m = project.requireModule('local-pkg')
@@ -91,7 +91,7 @@ test('local file with symlinked node_modules', async (t: tape.Test) => {
 
   const manifest = await addDependenciesToPackage({}, ['file:../local-pkg'], await testDefaults())
 
-  const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
+  const expectedSpecs = { 'local-pkg': `file:..${path.sep}local-pkg` }
   t.deepEqual(manifest.dependencies, expectedSpecs, 'local-pkg has been added to dependencies')
 
   const m = project.requireModule('local-pkg')


### PR DESCRIPTION
BREAKING CHANGE: dir deps are saved via file:

close #1332