### PR TITLE
feat: cmds should fail on unsupported flags

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -95,9 +95,11 @@ type CLI_OPTIONS = 'access'
   | 'port'
   | 'prefer-frozen-lockfile'
   | 'prefer-offline'
+  | 'prefix'
   | 'production'
   | 'protocol'
   | 'recursive'
+  | 'registry'
   | 'reporter'
   | 'resolution-strategy'
   | 'save-dev'
@@ -119,8 +121,9 @@ type CLI_OPTIONS = 'access'
   | 'use-store-server'
   | 'verify-store-integrity'
   | 'workspace-concurrency'
+  | 'workspace-prefix'
 
-const GLOBAL_OPTIONS = new Set<CLI_OPTIONS>(['filter', 'help'])
+const GLOBAL_OPTIONS = new Set<CLI_OPTIONS>(['filter', 'help', 'prefix'])
 
 const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
   'child-concurrency',
@@ -130,9 +133,12 @@ const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
   'force',
   'global-pnpmfile',
   'global',
+  'hoist',
   'ignore-pnpmfile',
   'ignore-scripts',
   'ignore-workspace-root-check',
+  'independent-leaves',
+  'link-workspace-packages',
   'lockfile-directory',
   'lockfile-only',
   'lockfile',
@@ -142,6 +148,7 @@ const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
   'prefer-offline',
   'production',
   'recursive',
+  'registry',
   'reporter',
   'save-dev',
   'save-exact',
@@ -157,8 +164,10 @@ const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
   'offline',
   'only',
   'optional',
+  'use-running-store-server',
   'use-store-server',
   'verify-store-integrity',
+  'workspace-prefix',
 ])
 
 const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> = {
@@ -171,6 +180,7 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'only',
     'package-import-method',
     'production',
+    'registry',
     'reporter',
     'save-dev',
     'save-exact',
@@ -190,9 +200,10 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
   ]),
   'outdated': new Set([
     'depth',
+    'global',
     'long',
-    'table',
     'recursive',
+    'table',
   ]),
   'pack': new Set([]),
   'prune': new Set([]),
@@ -208,7 +219,9 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'workspace-concurrency',
   ]),
   'restart': new Set([]),
-  'root': new Set([]),
+  'root': new Set([
+    'global',
+  ]),
   'run': new Set([
     'recursive',
   ]),
@@ -222,13 +235,16 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
   ]),
   'start': new Set([]),
   'stop': new Set([]),
-  'store': new Set([]),
+  'store': new Set([
+    'registry',
+  ]),
   'test': new Set([
     'recursive',
   ]),
   'uninstall': new Set([
     'force',
     'global-pnpmfile',
+    'global',
     'lockfile-directory',
     'lockfile-only',
     'lockfile',
@@ -254,20 +270,22 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'lockfile-directory',
     'lockfile-only',
     'lockfile',
+    'offline',
     'only',
     'optional',
     'package-import-method',
+    'pnpmfile',
     'prefer-offline',
     'production',
-    'pnpmfile',
     'recursive',
+    'registry',
     'reporter',
     'shamefully-hoist',
     'shared-workspace-lockfile',
     'side-effects-cache-readonly',
     'side-effects-cache',
     'store',
-    'offline',
+    'use-running-store-server',
   ]),
   'why': new Set([
     'recursive',

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -62,7 +62,7 @@ type CLI_OPTIONS = 'access'
   | 'bail'
   | 'child-concurrency'
   | 'depth'
-  | 'development'
+  | 'dev'
   | 'engine-strict'
   | 'filter'
   | 'force'
@@ -124,7 +124,7 @@ const GLOBAL_OPTIONS = new Set<CLI_OPTIONS>(['filter', 'help'])
 
 const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
   'child-concurrency',
-  'development',
+  'dev',
   'engine-strict',
   'frozen-lockfile',
   'force',
@@ -178,7 +178,7 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
   ]),
   'list': new Set([
     'depth',
-    'development',
+    'dev',
     'global',
     'json',
     'long',
@@ -244,7 +244,7 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'recursive',
   ]),
   'update': new Set([
-    'development',
+    'dev',
     'engine-strict',
     'force',
     'global-pnpmfile',

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -57,6 +57,223 @@ type CANONICAL_COMMAND_NAMES = 'help'
   | 'update'
   | 'why'
 
+type CLI_OPTIONS = 'access'
+  | 'background'
+  | 'bail'
+  | 'child-concurrency'
+  | 'depth'
+  | 'development'
+  | 'engine-strict'
+  | 'filter'
+  | 'force'
+  | 'frozen-lockfile'
+  | 'global-pnpmfile'
+  | 'global'
+  | 'help'
+  | 'hoist-pattern'
+  | 'hoist'
+  | 'ignore-pnpmfile'
+  | 'ignore-scripts'
+  | 'ignore-stop-requests'
+  | 'ignore-upload-requests'
+  | 'ignore-workspace-root-check'
+  | 'independent-leaves'
+  | 'json'
+  | 'latest'
+  | 'link-workspace-packages'
+  | 'lockfile-directory'
+  | 'lockfile-only'
+  | 'lockfile'
+  | 'long'
+  | 'network-concurrency'
+  | 'offline'
+  | 'only'
+  | 'optional'
+  | 'package-import-method'
+  | 'parseable'
+  | 'pnpmfile'
+  | 'port'
+  | 'prefer-frozen-lockfile'
+  | 'prefer-offline'
+  | 'production'
+  | 'protocol'
+  | 'recursive'
+  | 'reporter'
+  | 'resolution-strategy'
+  | 'save-dev'
+  | 'save-exact'
+  | 'save-optional'
+  | 'save-peer'
+  | 'save-prod'
+  | 'shamefully-flatten'
+  | 'shamefully-hoist'
+  | 'shared-workspace-lockfile'
+  | 'side-effects-cache-readonly'
+  | 'side-effects-cache'
+  | 'silent'
+  | 'sort'
+  | 'store'
+  | 'strict-peer-dependencies'
+  | 'table'
+  | 'use-running-store-server'
+  | 'use-store-server'
+  | 'verify-store-integrity'
+  | 'workspace-concurrency'
+
+const GLOBAL_OPTIONS = new Set<CLI_OPTIONS>(['filter', 'help'])
+
+const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
+  'child-concurrency',
+  'development',
+  'engine-strict',
+  'frozen-lockfile',
+  'force',
+  'global-pnpmfile',
+  'global',
+  'ignore-pnpmfile',
+  'ignore-scripts',
+  'ignore-workspace-root-check',
+  'lockfile-directory',
+  'lockfile-only',
+  'lockfile',
+  'package-import-method',
+  'pnpmfile',
+  'prefer-frozen-lockfile',
+  'prefer-offline',
+  'production',
+  'recursive',
+  'reporter',
+  'save-dev',
+  'save-exact',
+  'save-optional',
+  'save-peer',
+  'save-prod',
+  'shamefully-hoist',
+  'shared-workspace-lockfile',
+  'side-effects-cache-readonly',
+  'side-effects-cache',
+  'store',
+  'strict-peer-dependencies',
+  'offline',
+  'only',
+  'optional',
+  'use-store-server',
+  'verify-store-integrity',
+])
+
+const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> = {
+  'help': new Set([]),
+  'add': INSTALL_CLI_OPTIONS,
+  'import': new Set([]),
+  'install-test': INSTALL_CLI_OPTIONS,
+  'install': INSTALL_CLI_OPTIONS,
+  'link': new Set([
+    'only',
+    'package-import-method',
+    'production',
+    'reporter',
+    'save-dev',
+    'save-exact',
+    'save-optional',
+  ]),
+  'list': new Set([
+    'depth',
+    'development',
+    'global',
+    'json',
+    'long',
+    'only',
+    'optional',
+    'parseable',
+    'production',
+    'recursive',
+  ]),
+  'outdated': new Set([
+    'depth',
+    'long',
+    'table',
+    'recursive',
+  ]),
+  'pack': new Set([]),
+  'prune': new Set([]),
+  'publish': new Set([]),
+  'rebuild': new Set([
+    'recursive',
+  ]),
+  'recursive': new Set([
+    'bail',
+    'link-workspace-packages',
+    'shared-workspace-lockfile',
+    'sort',
+    'workspace-concurrency',
+  ]),
+  'restart': new Set([]),
+  'root': new Set([]),
+  'run': new Set([
+    'recursive',
+  ]),
+  'server': new Set([
+    'background',
+    'ignore-stop-requests',
+    'ignore-upload-requests',
+    'port',
+    'protocol',
+    'store',
+  ]),
+  'start': new Set([]),
+  'stop': new Set([]),
+  'store': new Set([]),
+  'test': new Set([
+    'recursive',
+  ]),
+  'uninstall': new Set([
+    'force',
+    'global-pnpmfile',
+    'lockfile-directory',
+    'lockfile-only',
+    'lockfile',
+    'package-import-method',
+    'pnpmfile',
+    'recursive',
+    'reporter',
+    'shamefully-hoist',
+    'shared-workspace-lockfile',
+    'store',
+  ]),
+  'unlink': new Set([
+    'recursive',
+  ]),
+  'update': new Set([
+    'development',
+    'engine-strict',
+    'force',
+    'global-pnpmfile',
+    'ignore-pnpmfile',
+    'ignore-scripts',
+    'latest',
+    'lockfile-directory',
+    'lockfile-only',
+    'lockfile',
+    'only',
+    'optional',
+    'package-import-method',
+    'prefer-offline',
+    'production',
+    'pnpmfile',
+    'recursive',
+    'reporter',
+    'shamefully-hoist',
+    'shared-workspace-lockfile',
+    'side-effects-cache-readonly',
+    'side-effects-cache',
+    'store',
+    'offline',
+  ]),
+  'why': new Set([
+    'recursive',
+  ]),
+}
+
 const COMMANDS_WITH_NO_DASHDASH_FILTER = new Set(['run', 'exec', 'restart', 'start', 'stop', 'test'])
 
 const supportedCmds = new Set<CANONICAL_COMMAND_NAMES>([
@@ -185,6 +402,18 @@ export default async function run (inputArgv: string[]) {
     cliArgs.unshift(subCmd)
   } else if (subCmd && !supportedCmds.has(subCmd as CANONICAL_COMMAND_NAMES)) {
     subCmd = null
+  }
+
+  const allowedOptions = !subCmd
+    ? SUPPORTED_CLI_OPTIONS[cmd]
+    : new Set([...Array.from(SUPPORTED_CLI_OPTIONS[cmd]), ...Array.from(SUPPORTED_CLI_OPTIONS[subCmd])])
+  for (const cliOption of Object.keys(cliConf)) {
+    if (!GLOBAL_OPTIONS.has(cliOption as CLI_OPTIONS) && !allowedOptions.has(cliOption)) {
+      console.error(`${chalk.bgRed.black('\u2009ERROR\u2009')} ${chalk.red(`Unknown option '${cliOption}'`)}`)
+      console.log(`For help, run: pnpm help ${cmd}`)
+      process.exit(1)
+      return
+    }
   }
 
   let opts!: PnpmConfigs

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -171,8 +171,8 @@ const INSTALL_CLI_OPTIONS = new Set<CLI_OPTIONS>([
 ])
 
 const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> = {
-  'help': new Set([]),
   'add': INSTALL_CLI_OPTIONS,
+  'help': new Set([]),
   'import': new Set([]),
   'install-test': INSTALL_CLI_OPTIONS,
   'install': INSTALL_CLI_OPTIONS,

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -260,6 +260,7 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'recursive',
   ]),
   'update': new Set([
+    'depth',
     'dev',
     'engine-strict',
     'force',
@@ -280,6 +281,7 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
     'recursive',
     'registry',
     'reporter',
+    'save-exact',
     'shamefully-hoist',
     'shared-workspace-lockfile',
     'side-effects-cache-readonly',

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -174,8 +174,8 @@ const SUPPORTED_CLI_OPTIONS: Record<CANONICAL_COMMAND_NAMES, Set<CLI_OPTIONS>> =
   'add': INSTALL_CLI_OPTIONS,
   'help': new Set([]),
   'import': new Set([]),
-  'install-test': INSTALL_CLI_OPTIONS,
   'install': INSTALL_CLI_OPTIONS,
+  'install-test': INSTALL_CLI_OPTIONS,
   'link': new Set([
     'only',
     'package-import-method',

--- a/packages/pnpm/test/cli.ts
+++ b/packages/pnpm/test/cli.ts
@@ -88,3 +88,12 @@ test('pass through to npm with all the args', async t => {
 
   t.equal(result.status, 0, 'command was successfull')
 })
+
+test('command fails when unsupport flag is used', async (t) => {
+  const project = prepare(t)
+
+  const { status, stderr } = execPnpmSync('update', '--save-dev')
+
+  t.equal(status, 1, 'command failed')
+  t.ok(stderr.toString().includes("Unknown option 'save-dev'"))
+})

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -74,10 +74,12 @@ test('install --no-lockfile', async (t: tape.Test) => {
   t.notOk(await project.readLockfile(), `${WANTED_LOCKFILE} not created`)
 })
 
-test('install --no-package-lock', async (t: tape.Test) => {
+test('install with package-lock=false in .npmrc', async (t: tape.Test) => {
   const project = prepare(t)
 
-  await execPnpm('install', 'is-positive', '--no-package-lock')
+  await fs.writeFile('.npmrc', 'package-lock=false', 'utf8')
+
+  await execPnpm('add', 'is-positive')
 
   await project.has('is-positive')
 

--- a/packages/pnpm/test/publish.ts
+++ b/packages/pnpm/test/publish.ts
@@ -10,11 +10,9 @@ import { execPnpm, execPnpmSync } from './utils'
 const test = promisifyTape(tape)
 const testOnly = promisifyTape(tape.only)
 
-const CREDENTIALS = [
-  '--//localhost:4873/:username=username',
-  `--//localhost:4873/:_password=${Buffer.from('password').toString('base64')}`,
-  '--//localhost:4873/:email=foo@bar.net',
-]
+const CREDENTIALS = `//localhost:4873/:username=username
+//localhost:4873/:_password=${Buffer.from('password').toString('base64')}
+//localhost:4873/:email=foo@bar.net`
 
 test('publish: package with package.json', async (t: tape.Test) => {
   prepare(t, {
@@ -22,7 +20,9 @@ test('publish: package with package.json', async (t: tape.Test) => {
     version: '0.0.0',
   })
 
-  await execPnpm('publish', ...CREDENTIALS)
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+
+  await execPnpm('publish')
 })
 
 test('publish: package with package.yaml', async (t: tape.Test) => {
@@ -31,7 +31,9 @@ test('publish: package with package.yaml', async (t: tape.Test) => {
     version: '0.0.0',
   }, { manifestFormat: 'YAML' })
 
-  await execPnpm('publish', ...CREDENTIALS)
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+
+  await execPnpm('publish')
 
   t.ok(await exists('package.yaml'))
   t.notOk(await exists('package.json'))
@@ -43,7 +45,9 @@ test('publish: package with package.json5', async (t: tape.Test) => {
     version: '0.0.0',
   }, { manifestFormat: 'JSON5' })
 
-  await execPnpm('publish', ...CREDENTIALS)
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+
+  await execPnpm('publish')
 
   t.ok(await exists('package.json5'))
   t.notOk(await exists('package.json'))
@@ -55,9 +59,11 @@ test('publish: package with package.json5 running publish from different folder'
     version: '0.0.1',
   }, { manifestFormat: 'JSON5' })
 
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+
   process.chdir('..')
 
-  await execPnpm('publish', 'project', ...CREDENTIALS)
+  await execPnpm('publish', 'project')
 
   t.ok(await exists('project/package.json5'))
   t.notOk(await exists('project/package.json'))
@@ -120,12 +126,13 @@ test('publish packages with workspace LICENSE if no own LICENSE is present', asy
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
   await fs.writeFile('LICENSE', 'workspace license', 'utf8')
   await fs.writeFile('project-200/LICENSE', 'project-200 license', 'utf8')
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
 
   process.chdir('project-100')
-  await execPnpm('publish', ...CREDENTIALS)
+  await execPnpm('publish')
 
   process.chdir('../project-200')
-  await execPnpm('publish', ...CREDENTIALS)
+  await execPnpm('publish')
 
   process.chdir('../target')
 
@@ -164,7 +171,8 @@ test('publish: package with main, module, typings and types in publishConfig', a
   ])
 
   process.chdir('test-publish-config')
-  await execPnpm('publish', ...CREDENTIALS)
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+  await execPnpm('publish')
 
   const originalManifests = await import(path.resolve('package.json'))
   t.deepEqual(originalManifests, {
@@ -244,7 +252,8 @@ test['skip']('publish package that calls executable from the workspace .bin fold
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
 
   process.chdir('test-publish-scripts')
-  await execPnpm('publish', ...CREDENTIALS)
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+  await execPnpm('publish')
 
   t.deepEqual(
     await import(path.resolve('output.json')),
@@ -299,10 +308,11 @@ test('convert specs with workspace protocols to regular version ranges', async (
   ])
 
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
 
   process.chdir('workspace-protocol-package')
 
-  const { status, stdout } = execPnpmSync('publish', ...CREDENTIALS)
+  const { status, stdout } = execPnpmSync('publish')
 
   t.equal(status, 1, 'publish fails if cannot resolve workspace:*')
   t.ok(
@@ -315,7 +325,7 @@ test('convert specs with workspace protocols to regular version ranges', async (
   await execPnpm('multi', 'install', '--store', 'store')
 
   process.chdir('workspace-protocol-package')
-  await execPnpm('publish', ...CREDENTIALS)
+  await execPnpm('publish')
 
   process.chdir('../target')
 

--- a/packages/pnpm/test/publish.ts
+++ b/packages/pnpm/test/publish.ts
@@ -10,6 +10,8 @@ import { execPnpm, execPnpmSync } from './utils'
 const test = promisifyTape(tape)
 const testOnly = promisifyTape(tape.only)
 
+const testFromNode10 = parseInt(process.version.split('.')[0].substr(1), 10) >= 10 ? test : promisifyTape(test['skip'])
+
 const CREDENTIALS = `//localhost:4873/:username=username
 //localhost:4873/:_password=${Buffer.from('password').toString('base64')}
 //localhost:4873/:email=foo@bar.net`
@@ -53,7 +55,7 @@ test('publish: package with package.json5', async (t: tape.Test) => {
   t.notOk(await exists('package.json'))
 })
 
-test('publish: package with package.json5 running publish from different folder', async (t: tape.Test) => {
+testFromNode10('publish: package with package.json5 running publish from different folder', async (t: tape.Test) => {
   prepare(t, {
     name: 'test-publish-package.json5',
     version: '0.0.1',
@@ -107,7 +109,7 @@ test('pack packages with workspace LICENSE if no own LICENSE is present', async 
   t.ok(await exists('project-2/LICENSE'))
 })
 
-test('publish packages with workspace LICENSE if no own LICENSE is present', async (t: tape.Test) => {
+testFromNode10('publish packages with workspace LICENSE if no own LICENSE is present', async (t: tape.Test) => {
   preparePackages(t, [
     {
       name: 'project-100',
@@ -269,7 +271,7 @@ test['skip']('publish package that calls executable from the workspace .bin fold
   )
 })
 
-test('convert specs with workspace protocols to regular version ranges', async (t: tape.Test) => {
+testFromNode10('convert specs with workspace protocols to regular version ranges', async (t: tape.Test) => {
   preparePackages(t, [
     {
       name: 'workspace-protocol-package',

--- a/packages/pnpm/test/uninstall.ts
+++ b/packages/pnpm/test/uninstall.ts
@@ -40,7 +40,7 @@ test('uninstall global package with its bin files', async (t: tape.Test) => {
   if (process.env.APPDATA) process.env.APPDATA = global
   process.env.NPM_CONFIG_PREFIX = global
 
-  await execPnpm('install', '-g', 'sh-hello-world@1.0.1')
+  await execPnpm('add', '-g', 'sh-hello-world@1.0.1')
 
   let stat = await exists(path.resolve(globalBin, 'sh-hello-world'))
   t.ok(stat, 'sh-hello-world is in .bin')

--- a/packages/pnpm/test/update.ts
+++ b/packages/pnpm/test/update.ts
@@ -502,7 +502,7 @@ test('deep update', async function (t: tape.Test) {
 
   await addDistTag('dep-of-pkg-with-1-dep', '100.0.0', 'latest')
 
-  await execPnpm('install', 'pkg-with-1-dep', '-S')
+  await execPnpm('add', 'pkg-with-1-dep')
 
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 


### PR DESCRIPTION
close #1645

BREAKING CHANGES:
* the CLI fails when unknown options are used
* the CLI only accepts canonical forms of options:
  * `pnpm install --no-package-lock` fails
  * but `package-lock=false` in `.npmrc` is OK