### PR TITLE
feat(dependency‑path): Expose `peersSuffix`

### DIFF
--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -8,8 +8,8 @@
     "lib"
   ],
   "scripts": {
-    "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",
-    "test": "pnpm run tsc && pnpm link . && pnpm run lint && ts-node test.ts",
+    "lint": "tslint --project tsconfig.json -c tslint.json src/**/*.ts test/**/*.ts",
+    "test": "pnpm run tsc && pnpm link . && pnpm run lint && ts-node test",
     "prepublishOnly": "pnpm run tsc",
     "tsc": "tsc"
   },
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/semver": "6",
+    "dependency-path": "link:",
     "tape": "4.11.0"
   }
 }

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -88,8 +88,12 @@ export function refToRelative (
 }
 
 export function parse (dependencyPath: string) {
+  // tslint:disable-next-line: strict-type-predicates
   if (typeof dependencyPath !== 'string') {
-    throw new TypeError(`Expected \`dependencyPath\` to be of type \`string\`, got \`${typeof dependencyPath}\``)
+    throw new TypeError(`Expected \`dependencyPath\` to be of type \`string\`, got \`${
+      // tslint:disable-next-line: strict-type-predicates
+      dependencyPath === null ? 'null' : typeof dependencyPath
+    }\``)
   }
   const _isAbsolute = isAbsolute(dependencyPath)
   const parts = dependencyPath.split('/')
@@ -101,14 +105,17 @@ export function parse (dependencyPath: string) {
   let version = parts.shift()
   if (version) {
     const underscoreIndex = version.indexOf('_')
+    let peersSuffix: string | undefined
     if (underscoreIndex !== -1) {
-      version = version.substr(0, underscoreIndex)
+      peersSuffix = version.substring(underscoreIndex + 1)
+      version = version.substring(0, underscoreIndex)
     }
     if (semver.valid(version)) {
       return {
         host,
         isAbsolute: _isAbsolute,
         name,
+        peersSuffix,
         version,
       }
     }

--- a/packages/dependency-path/test/index.ts
+++ b/packages/dependency-path/test/index.ts
@@ -1,13 +1,14 @@
-///<reference path="../../typings/index.d.ts"/>
-import test = require('tape')
+///<reference path="../../../typings/index.d.ts"/>
+// tslint:disable: no-any
 import {
-  refToAbsolute,
-  refToRelative,
   isAbsolute,
   parse,
+  refToAbsolute,
+  refToRelative,
   relative,
   resolve,
 } from 'dependency-path'
+import test = require('tape')
 
 test('isAbsolute()', t => {
   t.notOk(isAbsolute('/foo/1.0.0'))
@@ -17,53 +18,61 @@ test('isAbsolute()', t => {
 
 test('parse()', t => {
   t.throws(() => parse(undefined as any), /got `undefined`/)
+  t.throws(() => parse(null as any), /got `null`/)
+  t.throws(() => parse({} as any), /got `object`/)
   t.throws(() => parse(1 as any), /got `number`/)
 
   t.deepEqual(parse('/foo/1.0.0'), {
+    host: undefined,
     isAbsolute: false,
     name: 'foo',
+    peersSuffix: undefined,
     version: '1.0.0',
-    host: undefined,
   })
 
   t.deepEqual(parse('/@foo/bar/1.0.0'), {
+    host: undefined,
     isAbsolute: false,
     name: '@foo/bar',
+    peersSuffix: undefined,
     version: '1.0.0',
-    host: undefined,
   })
 
   t.deepEqual(parse('registry.npmjs.org/foo/1.0.0'), {
+    host: 'registry.npmjs.org',
     isAbsolute: true,
     name: 'foo',
+    peersSuffix: undefined,
     version: '1.0.0',
-    host: 'registry.npmjs.org',
   })
 
   t.deepEqual(parse('registry.npmjs.org/@foo/bar/1.0.0'), {
+    host: 'registry.npmjs.org',
     isAbsolute: true,
     name: '@foo/bar',
+    peersSuffix: undefined,
     version: '1.0.0',
-    host: 'registry.npmjs.org',
   })
 
   t.deepEqual(parse('github.com/kevva/is-positive'), {
-    isAbsolute: true,
     host: 'github.com',
+    isAbsolute: true,
   })
 
   t.deepEqual(parse('example.com/foo/1.0.0'), {
+    host: 'example.com',
     isAbsolute: true,
     name: 'foo',
+    peersSuffix: undefined,
     version: '1.0.0',
-    host: 'example.com',
   })
 
   t.deepEqual(parse('example.com/foo/1.0.0_bar@2.0.0'), {
+    host: 'example.com',
     isAbsolute: true,
     name: 'foo',
+    peersSuffix: 'bar@2.0.0',
     version: '1.0.0',
-    host: 'example.com',
   })
 
   t.throws(() => parse('/foo/bar'), /\/foo\/bar is an invalid relative dependency path/)
@@ -73,8 +82,8 @@ test('parse()', t => {
 
 test('refToAbsolute()', t => {
   const registries = {
-    'default': 'https://registry.npmjs.org/',
     '@foo': 'http://foo.com/',
+    'default': 'https://registry.npmjs.org/',
   }
   t.equal(refToAbsolute('1.0.0', 'foo', registries), 'registry.npmjs.org/foo/1.0.0')
   t.equal(refToAbsolute('1.0.0', '@foo/foo', registries), 'foo.com/@foo/foo/1.0.0')
@@ -94,8 +103,8 @@ test('refToRelative()', t => {
 
 test('relative()', t => {
   const registries = {
-    'default': 'https://registry.npmjs.org/',
     '@foo': 'http://localhost:4873/',
+    'default': 'https://registry.npmjs.org/',
   }
   t.equal(relative(registries, 'foo', 'registry.npmjs.org/foo/1.0.0'), '/foo/1.0.0')
   t.equal(relative(registries, '@foo/foo', 'localhost+4873/@foo/foo/1.0.0'), '/@foo/foo/1.0.0')
@@ -106,8 +115,8 @@ test('relative()', t => {
 
 test('resolve()', (t) => {
   const registries = {
-    'default': 'htts://foo.com/',
     '@bar': 'https://bar.com/',
+    'default': 'https://foo.com/',
   }
   t.equal(resolve(registries, '/foo/1.0.0'), 'foo.com/foo/1.0.0')
   t.equal(resolve(registries, '/@bar/bar/1.0.0'), 'bar.com/@bar/bar/1.0.0')

--- a/packages/lockfile-utils/src/nameVerFromPkgSnapshot.ts
+++ b/packages/lockfile-utils/src/nameVerFromPkgSnapshot.ts
@@ -9,11 +9,13 @@ export default (
     const pkgInfo = dp.parse(relDepPath)
     return {
       name: pkgInfo.name as string,
+      peersSuffix: pkgInfo.peersSuffix,
       version: pkgInfo.version as string,
     }
   }
   return {
     name: pkgSnapshot.name,
+    peersSuffix: undefined,
     version: pkgSnapshot.version as string,
   }
 }

--- a/packages/lockfile-utils/test/nameVerFromPkgSnapshot.ts
+++ b/packages/lockfile-utils/test/nameVerFromPkgSnapshot.ts
@@ -11,6 +11,7 @@ test('nameVerFromPkgSnapshot()', (t) => {
     },
   }), {
     name: 'foo',
+    peersSuffix: undefined,
     version: '1.0.0',
   })
 
@@ -20,6 +21,17 @@ test('nameVerFromPkgSnapshot()', (t) => {
     },
   }), {
     name: 'foo',
+    peersSuffix: undefined,
+    version: '1.0.0',
+  })
+
+  t.deepEqual(nameVerFromPkgSnapshot('/foo/1.0.0_bar@2.0.0', {
+    resolution: {
+      integrity: 'AAA',
+    },
+  }), {
+    name: 'foo',
+    peersSuffix: 'bar@2.0.0',
     version: '1.0.0',
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,10 +244,12 @@ importers:
       semver: 6.3.0
     devDependencies:
       '@types/semver': 6.0.2
+      dependency-path: 'link:'
       tape: 4.11.0
     specifiers:
       '@pnpm/types': 'workspace:3.2.0'
       '@types/semver': '6'
+      dependency-path: 'link:'
       encode-registry: 2.0.1
       semver: 6.3.0
       tape: 4.11.0


### PR DESCRIPTION
This exposes the `peersSuffix` value from the `dependencyPath`.

## Blocks:
- #1874