### PR TITLE
feat: use the fewer-dependencies resolution strategy by default

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -157,7 +157,7 @@ export default async (
     'pending': false,
     'prefix': npmDefaults.prefix,
     'registry': npmDefaults.registry,
-    'resolution-strategy': 'fast',
+    'resolution-strategy': 'fewer-dependencies',
     'save-peer': false,
     'save-workspace-protocol': true,
     'shamefully-hoist': false,


### PR DESCRIPTION
This change is making pnpm a little bit slower but the resulting node_modules will have fewer duplicates of packages. Our Twitter poll results show that deduplication is more important for our users the speed: https://twitter.com/pnpmjs/status/1109800824744656898

BREAKING CHANGE:

by default resolution-strategy=fewer-dependencies