### PR TITLE
feat: use cross-platform solution to clone packages

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -85,7 +85,7 @@ export interface Config {
   ignorePnpmfile?: boolean,
   pnpmfile: string,
   independentLeaves?: boolean,
-  packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'reflink',
+  packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone',
   hoistPattern?: string,
   useStoreServer?: boolean,
   useRunningStoreServer?: boolean,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -47,7 +47,7 @@ export const types = Object.assign({
   'lockfile-only': Boolean,
   'network-concurrency': Number,
   'offline': Boolean,
-  'package-import-method': ['auto', 'hardlink', 'reflink', 'copy'],
+  'package-import-method': ['auto', 'hardlink', 'clone', 'copy'],
   'pending': Boolean,
   'pnpmfile': String,
   'port': Number,

--- a/packages/package-store/package.json
+++ b/packages/package-store/package.json
@@ -46,8 +46,12 @@
     "@pnpm/package-store": "link:",
     "@pnpm/tarball-fetcher": "file:../tarball-fetcher",
     "@types/mz": "0.0.32",
+    "@types/proxyquire": "1.3.28",
     "@types/ramda": "0.26.21",
+    "@types/sinon": "7.5.0",
+    "proxyquire": "2.1.3",
     "rimraf": "3.0.0",
+    "sinon": "7.5.0",
     "tape": "4.11.0",
     "tempy": "0.3.0"
   },

--- a/packages/package-store/src/fs/importIndexedDir.ts
+++ b/packages/package-store/src/fs/importIndexedDir.ts
@@ -7,13 +7,13 @@ import pathTemp = require('path-temp')
 
 const importingLogger = pnpmLogger('_package-file-already-exists')
 
-type ImporterFunction = (src: string, dest: string) => Promise<void>
+type ImportFile = (src: string, dest: string) => Promise<void>
 
-export default async function linkIndexedDir (importer: ImporterFunction, existingDir: string, newDir: string, filenames: string[]) {
+export default async function importIndexedDir (importFile: ImportFile, existingDir: string, newDir: string, filenames: string[]) {
   const stage = pathTemp(path.dirname(newDir))
   try {
     await rimraf(stage)
-    await tryLinkIndexedDir(importer, existingDir, stage, filenames)
+    await tryImportIndexedDir(importFile, existingDir, stage, filenames)
     await rimraf(newDir)
     await fs.rename(stage, newDir)
   } catch (err) {
@@ -22,7 +22,7 @@ export default async function linkIndexedDir (importer: ImporterFunction, existi
   }
 }
 
-async function tryLinkIndexedDir (importer: ImporterFunction, existingDir: string, newDir: string, filenames: string[]) {
+async function tryImportIndexedDir (importFile: ImportFile, existingDir: string, newDir: string, filenames: string[]) {
   const alldirs = new Set<string>()
   filenames
     .forEach((f) => {
@@ -38,7 +38,7 @@ async function tryLinkIndexedDir (importer: ImporterFunction, existingDir: strin
         const src = path.join(existingDir, f)
         const dest = path.join(newDir, f)
         try {
-          await importer(src, dest)
+          await importFile(src, dest)
         } catch (err) {
           if (err['code'] !== 'EEXIST') throw err
           // If the file is already linked, we ignore the error.

--- a/packages/package-store/src/storeController/createImportPackage.ts
+++ b/packages/package-store/src/storeController/createImportPackage.ts
@@ -27,7 +27,7 @@ function createImportPackage (packageImportMethod?: 'auto' | 'hardlink' | 'copy'
   // this works in the following way:
   // - hardlink: hardlink the packages, no fallback
   // - clone: clone the packages, no fallback
-  // - auto: try to hardlink the packages, if it fails, fallback to copy
+  // - auto: try to clone or hardlink the packages, if it fails, fallback to copy
   // - copy: copy the packages, do not try to link them first
   switch (packageImportMethod || 'auto') {
     case 'clone':

--- a/packages/package-store/src/storeController/createImportPackage.ts
+++ b/packages/package-store/src/storeController/createImportPackage.ts
@@ -13,7 +13,7 @@ import exists = require('path-exists')
 import pathTemp = require('path-temp')
 import renameOverwrite = require('rename-overwrite')
 import { promisify } from 'util'
-import linkIndexedDir from '../fs/linkIndexedDir'
+import importIndexedDir from '../fs/importIndexedDir'
 
 const ncp = promisify(ncpCB)
 const limitLinking = pLimit(16)
@@ -88,7 +88,7 @@ async function clonePkg (
 
   if (!opts.filesResponse.fromStore || opts.force || !await exists(pkgJsonPath)) {
     importingLogger.debug({ from, to, method: 'clone' })
-    await linkIndexedDir(cloneFile, from, to, opts.filesResponse.filenames)
+    await importIndexedDir(cloneFile, from, to, opts.filesResponse.filenames)
   }
 }
 
@@ -108,7 +108,7 @@ async function hardlinkPkg (
 
   if (!opts.filesResponse.fromStore || opts.force || !await exists(pkgJsonPath) || !await pkgLinkedToStore(pkgJsonPath, from, to)) {
     importingLogger.debug({ from, to, method: 'hardlink' })
-    await linkIndexedDir(fs.link, from, to, opts.filesResponse.filenames)
+    await importIndexedDir(fs.link, from, to, opts.filesResponse.filenames)
   }
 }
 

--- a/packages/package-store/src/storeController/createImportPackage.ts
+++ b/packages/package-store/src/storeController/createImportPackage.ts
@@ -81,11 +81,12 @@ async function clonePkg (
 
   if (!opts.filesResponse.fromStore || opts.force || !await exists(pkgJsonPath)) {
     importingLogger.debug({ from, to, method: 'clone' })
-    const staging = pathTemp(path.dirname(to))
-    await makeDir(staging)
-    await fs.copyFile(from, staging, fs.constants.COPYFILE_FICLONE_FORCE)
-    await renameOverwrite(staging, to)
+    await linkIndexedDir(cloneFile, from, to, opts.filesResponse.filenames)
   }
+}
+
+async function cloneFile (from: string, to: string) {
+  await fs.copyFile(from, to, fs.constants.COPYFILE_FICLONE_FORCE)
 }
 
 async function hardlinkPkg (
@@ -100,7 +101,7 @@ async function hardlinkPkg (
 
   if (!opts.filesResponse.fromStore || opts.force || !await exists(pkgJsonPath) || !await pkgLinkedToStore(pkgJsonPath, from, to)) {
     importingLogger.debug({ from, to, method: 'hardlink' })
-    await linkIndexedDir(from, to, opts.filesResponse.filenames)
+    await linkIndexedDir(fs.link, from, to, opts.filesResponse.filenames)
   }
 }
 

--- a/packages/package-store/src/storeController/createImportPackage.ts
+++ b/packages/package-store/src/storeController/createImportPackage.ts
@@ -20,7 +20,7 @@ const limitLinking = pLimit(16)
 
 export default (packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone'): ImportPackageFunction => {
   const importPackage = createImportPackage(packageImportMethod)
-  return (filesResponse, dependency, opts) => limitLinking(() => importPackage(filesResponse, dependency, opts))
+  return (from, to, opts) => limitLinking(() => importPackage(from, to, opts))
 }
 
 function createImportPackage (packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone') {
@@ -60,12 +60,14 @@ function createAutoImporter () {
     try {
       await clonePkg(from, to, opts)
       auto = clonePkg
+      return
     } catch (err) {
       // ignore
     }
     try {
       await hardlinkPkg(from, to, opts)
       auto = hardlinkPkg
+      return
     } catch (err) {
       if (!err.message.startsWith('EXDEV: cross-device link not permitted')) throw err
       storeLogger.warn(err.message)

--- a/packages/package-store/src/storeController/index.ts
+++ b/packages/package-store/src/storeController/index.ts
@@ -30,7 +30,7 @@ export default async function (
     lockStaleDuration?: number,
     store: string,
     networkConcurrency?: number,
-    packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'reflink',
+    packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone',
     verifyStoreIntegrity: boolean,
   },
 ): Promise<StoreController & { closeSync: () => void, saveStateSync: () => void }> {

--- a/packages/package-store/test/createImportPackage.spec.ts
+++ b/packages/package-store/test/createImportPackage.spec.ts
@@ -20,15 +20,15 @@ test('packageImportMethod=auto: clone files by default', async (t) => {
   const importPackage = createImportPackage('auto')
   fsMock.copyFile = sinon.spy()
   fsMock.rename = sinon.spy()
-  await importPackage('/store/package', '/project/package', {
+  await importPackage('store/package', 'project/package', {
     filesResponse: {
       filenames: ['package.json', 'index.js'],
       fromStore: false,
     },
     force: false,
   })
-  t.ok(fsMock.copyFile.calledWith('/store/package/package.json', '/project/_tmp/package.json', fs.constants.COPYFILE_FICLONE_FORCE))
-  t.ok(fsMock.copyFile.calledWith('/store/package/index.js', '/project/_tmp/index.js', fs.constants.COPYFILE_FICLONE_FORCE))
+  t.ok(fsMock.copyFile.calledWith(path.join('store', 'package', 'package.json'), path.join('project', '_tmp', 'package.json'), fs.constants.COPYFILE_FICLONE_FORCE))
+  t.ok(fsMock.copyFile.calledWith(path.join('store', 'package', 'index.js'), path.join('project', '_tmp', 'index.js'), fs.constants.COPYFILE_FICLONE_FORCE))
   t.end()
 })
 
@@ -37,14 +37,14 @@ test('packageImportMethod=auto: link files if cloning fails', async (t) => {
   fsMock.copyFile = () => { throw new Error('This file system does not support cloning') }
   fsMock.link = sinon.spy()
   fsMock.rename = sinon.spy()
-  await importPackage('/store/package', '/project/package', {
+  await importPackage('store/package', 'project/package', {
     filesResponse: {
       filenames: ['package.json', 'index.js'],
       fromStore: false,
     },
     force: false,
   })
-  t.ok(fsMock.link.calledWith('/store/package/package.json', '/project/_tmp/package.json'))
-  t.ok(fsMock.link.calledWith('/store/package/index.js', '/project/_tmp/index.js'))
+  t.ok(fsMock.link.calledWith(path.join('store', 'package', 'package.json'), path.join('project', '_tmp', 'package.json')))
+  t.ok(fsMock.link.calledWith(path.join('store', 'package', 'index.js'), path.join('project', '_tmp', 'index.js')))
   t.end()
 })

--- a/packages/package-store/test/createImportPackage.spec.ts
+++ b/packages/package-store/test/createImportPackage.spec.ts
@@ -1,13 +1,13 @@
 import fs = require('fs')
 import path = require('path')
-import proxiquire = require('proxyquire')
+import proxyquire = require('proxyquire')
 import sinon = require('sinon')
 import test = require('tape')
 
 const fsMock = {} as any // tslint:disable-line
 const makeDirMock = sinon.spy()
-const createImportPackage = proxiquire('@pnpm/package-store/lib/storeController/createImportPackage', {
-  '../fs/importIndexedDir': proxiquire('@pnpm/package-store/lib/fs/importIndexedDir', {
+const createImportPackage = proxyquire('@pnpm/package-store/lib/storeController/createImportPackage', {
+  '../fs/importIndexedDir': proxyquire('@pnpm/package-store/lib/fs/importIndexedDir', {
     'make-dir': makeDirMock,
     'mz/fs': fsMock,
     'path-temp': (dir: string) => path.join(dir, '_tmp')

--- a/packages/package-store/test/createImportPackage.spec.ts
+++ b/packages/package-store/test/createImportPackage.spec.ts
@@ -1,0 +1,50 @@
+import fs = require('fs')
+import path = require('path')
+import proxiquire = require('proxyquire')
+import sinon = require('sinon')
+import test = require('tape')
+
+const fsMock = {} as any // tslint:disable-line
+const makeDirMock = sinon.spy()
+const createImportPackage = proxiquire('@pnpm/package-store/lib/storeController/createImportPackage', {
+  '../fs/importIndexedDir': proxiquire('@pnpm/package-store/lib/fs/importIndexedDir', {
+    'make-dir': makeDirMock,
+    'mz/fs': fsMock,
+    'path-temp': (dir: string) => path.join(dir, '_tmp')
+  }),
+  'make-dir': makeDirMock,
+  'mz/fs': fsMock,
+}).default
+
+test('packageImportMethod=auto: clone files by default', async (t) => {
+  const importPackage = createImportPackage('auto')
+  fsMock.copyFile = sinon.spy()
+  fsMock.rename = sinon.spy()
+  await importPackage('/store/package', '/project/package', {
+    filesResponse: {
+      filenames: ['package.json', 'index.js'],
+      fromStore: false,
+    },
+    force: false,
+  })
+  t.ok(fsMock.copyFile.calledWith('/store/package/package.json', '/project/_tmp/package.json', fs.constants.COPYFILE_FICLONE_FORCE))
+  t.ok(fsMock.copyFile.calledWith('/store/package/index.js', '/project/_tmp/index.js', fs.constants.COPYFILE_FICLONE_FORCE))
+  t.end()
+})
+
+test('packageImportMethod=auto: link files if cloning fails', async (t) => {
+  const importPackage = createImportPackage('auto')
+  fsMock.copyFile = () => { throw new Error('This file system does not support cloning') }
+  fsMock.link = sinon.spy()
+  fsMock.rename = sinon.spy()
+  await importPackage('/store/package', '/project/package', {
+    filesResponse: {
+      filenames: ['package.json', 'index.js'],
+      fromStore: false,
+    },
+    force: false,
+  })
+  t.ok(fsMock.link.calledWith('/store/package/package.json', '/project/_tmp/package.json'))
+  t.ok(fsMock.link.calledWith('/store/package/index.js', '/project/_tmp/index.js'))
+  t.end()
+})

--- a/packages/package-store/test/index.ts
+++ b/packages/package-store/test/index.ts
@@ -6,6 +6,7 @@ import createFetcher from '@pnpm/tarball-fetcher'
 import path = require('path')
 import test = require('tape')
 import tempy = require('tempy')
+import './createImportPackage.spec'
 
 test('public API', t => {
   t.equal(typeof packageStore.read, 'function')

--- a/packages/pnpm/src/cmd/help.ts
+++ b/packages/pnpm/src/cmd/help.ts
@@ -158,7 +158,7 @@ function getHelpText (command: string) {
                 name: '--use-running-store-server',
               },
               {
-                description: 'Try to hardlink packages from the store. If it fails, fallback to copy',
+                description: 'Clones/hardlinks or copies packages. The selected method depends from the file system',
                 name: '--package-import-method auto',
               },
               {
@@ -170,8 +170,8 @@ function getHelpText (command: string) {
                 name: '--package-import-method copy',
               },
               {
-                description: 'Reflink (aka copy-on-write) packages from the store',
-                name: '--package-import-method reflink',
+                description: 'Clone (aka copy-on-write) packages from the store',
+                name: '--package-import-method clone',
               },
               {
                 description: 'The default resolution strategy. Speed is preferred over deduplication',

--- a/packages/supi/test/install/misc.ts
+++ b/packages/supi/test/install/misc.ts
@@ -834,17 +834,17 @@ test("don't fail on case insensitive filesystems when package has 2 files with s
 
   await project.has('with-same-file-in-different-cases')
 
-  const hardlinkAlreadyExistsReported = reporter.calledWithMatch({
+  const packageFileAlreadyExistsReported = reporter.calledWithMatch({
     level: 'debug',
-    name: 'pnpm:_hardlink-already-exists',
+    name: 'pnpm:_package-file-already-exists',
   })
 
   if (await dirIsCaseSensitive(opts.store)) {
     t.comment('store is not case sensitive')
-    t.notOk(hardlinkAlreadyExistsReported, 'hard link already exists not reported')
+    t.notOk(packageFileAlreadyExistsReported, 'hard link already exists not reported')
   } else {
     t.comment('store is not case sensitive')
-    t.ok(hardlinkAlreadyExistsReported, 'hard link already exists reported')
+    t.ok(packageFileAlreadyExistsReported, 'hard link already exists reported')
   }
 })
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -79,7 +79,7 @@ export type StrictPnpmOptions = {
   ignorePnpmfile: boolean,
   independentLeaves: boolean,
   locks: string,
-  packageImportMethod: 'auto' | 'hardlink' | 'copy' | 'reflink',
+  packageImportMethod: 'auto' | 'hardlink' | 'copy' | 'clone',
 
   // cannot be specified via config
   update: boolean,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,8 +1000,12 @@ importers:
       '@pnpm/package-store': 'link:'
       '@pnpm/tarball-fetcher': 'link:../tarball-fetcher'
       '@types/mz': 0.0.32
+      '@types/proxyquire': 1.3.28
       '@types/ramda': 0.26.21
+      '@types/sinon': 7.5.0
+      proxyquire: 2.1.3
       rimraf: 3.0.0
+      sinon: 7.5.0
       tape: 4.11.0
       tempy: 0.3.0
     specifiers:
@@ -1018,7 +1022,9 @@ importers:
       '@pnpm/tarball-fetcher': 'file:../tarball-fetcher'
       '@pnpm/types': 'workspace:3.2.0'
       '@types/mz': 0.0.32
+      '@types/proxyquire': 1.3.28
       '@types/ramda': 0.26.21
+      '@types/sinon': 7.5.0
       '@zkochan/rimraf': 1.0.0
       load-json-file: 6.2.0
       make-dir: 3.0.0
@@ -1028,9 +1034,11 @@ importers:
       p-limit: 2.2.1
       path-exists: 4.0.0
       path-temp: 2.0.0
+      proxyquire: 2.1.3
       ramda: 0.26.1
       rename-overwrite: 2.0.2
       rimraf: 3.0.0
+      sinon: 7.5.0
       tape: 4.11.0
       tempy: 0.3.0
       write-json-file: 4.0.0
@@ -2467,6 +2475,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==
+  /@types/sinon/7.5.0:
+    dev: true
+    resolution:
+      integrity: sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
   /@types/ssri/6.0.1:
     resolution:
       integrity: sha512-Sf5NnDETSFGTHXIfG4zTTczRFhGEjSCfwfvHZ5oFmyX0fUA5BJKV/hdQ2zDnfcC6WXvE78ZTh+/18VzMyMM1QQ==


### PR DESCRIPTION
New config value for package-import-method: clone

close #1505

BREAKING CHANGE:

reflink is not supported by package-import-method

BREAKING CHANGE:

by default, try to clone packages instead of hard linking