### PR TITLE
feat: drop Node.js 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - 8.15
-  - 10
+  - 10.0
   - 12
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - git fetch --unshallow
   - curl -L https://unpkg.com/@pnpm/self-installer | PNPM_VERSION=1.33.2 node
   # Testing whether pnpm can upgrade itself
+  - npm install --global npm@latest
   - pnpm i -g pnpm@next
   - pnpm -v
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,11 @@
 environment:
   matrix:
-    - nodejs_version: 10.0
+    - nodejs_version: 10
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set verify-store-integrity false
   - set PNPM_VERSION=next
   - curl -L https://unpkg.com/@pnpm/self-installer | node
-  - npm install --global npm@latest
   - pnpm -v
   - pnpm recursive install --no-lock
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
   - npm set verify-store-integrity false
   - set PNPM_VERSION=next
   - curl -L https://unpkg.com/@pnpm/self-installer | node
+  - npm install --global npm@latest
   - pnpm -v
   - pnpm recursive install --no-lock
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - nodejs_version: 8.15
+    - nodejs_version: 10.0
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm set verify-store-integrity false

--- a/packages/build-modules/package.json
+++ b/packages/build-modules/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -21,7 +21,7 @@
     "config"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
   "license": "MIT",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -28,7 +28,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/core-loggers",
   "scripts": {

--- a/packages/default-fetcher/package.json
+++ b/packages/default-fetcher/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/default-reporter/package.json
+++ b/packages/default-reporter/package.json
@@ -27,7 +27,7 @@
     "twitter": "ZoltanKochan"
   },
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/default-resolver/package.json
+++ b/packages/default-resolver/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/dependencies-hierarchy/package.json
+++ b/packages/dependencies-hierarchy/package.json
@@ -16,7 +16,7 @@
     "tsc": "tsc"
   },
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/dependencies-hierarchy",
   "keywords": [

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -25,7 +25,7 @@
     "url": "https://www.kochan.io/"
   },
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/fetch-from-npm-registry/package.json
+++ b/packages/fetch-from-npm-registry/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/fetcher-base/package.json
+++ b/packages/fetcher-base/package.json
@@ -20,7 +20,7 @@
     "fetcher"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
   "license": "MIT",

--- a/packages/filter-lockfile/package.json
+++ b/packages/filter-lockfile/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib/"

--- a/packages/find-packages/package.json
+++ b/packages/find-packages/package.json
@@ -24,7 +24,7 @@
     "url": "https://www.kochan.io"
   },
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/git-fetcher/package.json
+++ b/packages/git-fetcher/package.json
@@ -15,7 +15,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/git-fetcher",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "keywords": [
     "pnpm",

--- a/packages/git-resolver/package.json
+++ b/packages/git-resolver/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -57,7 +57,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/headless",
   "scripts": {

--- a/packages/hoist/package.json
+++ b/packages/hoist/package.json
@@ -33,7 +33,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/hoist",
   "scripts": {

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -28,7 +28,7 @@
     "url": "https://www.kochan.io/"
   },
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/local-resolver/package.json
+++ b/packages/local-resolver/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/lockfile-file/package.json
+++ b/packages/lockfile-file/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib/"

--- a/packages/lockfile-types/package.json
+++ b/packages/lockfile-types/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Types for the pnpm-lock.yaml lockfile",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "index.d.ts"

--- a/packages/lockfile-utils/package.json
+++ b/packages/lockfile-utils/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib/"

--- a/packages/modules-cleaner/package.json
+++ b/packages/modules-cleaner/package.json
@@ -18,7 +18,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/modules-cleaner",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/modules-cleaner#readme",

--- a/packages/modules-yaml/package.json
+++ b/packages/modules-yaml/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/npm-registry-agent/package.json
+++ b/packages/npm-registry-agent/package.json
@@ -32,7 +32,7 @@
     "socks-proxy-agent": "4.0.2"
   },
   "env": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/npm-registry-agent",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/npm-registry-agent#readme",

--- a/packages/npm-resolver/package.json
+++ b/packages/npm-resolver/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/outdated/package.json
+++ b/packages/outdated/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/package-is-installable/package.json
+++ b/packages/package-is-installable/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "peerDependencies": {
     "@pnpm/logger": "^2.1.0"

--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "start": "pnpm run tsc -- --watch",

--- a/packages/package-store/package.json
+++ b/packages/package-store/package.json
@@ -66,7 +66,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/package-store",
   "scripts": {

--- a/packages/pkgs-graph/package.json
+++ b/packages/pkgs-graph/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -165,7 +165,7 @@
   "license": "MIT",
   "preferGlobal": true,
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": {
     "type": "git",

--- a/packages/prune-lockfile/package.json
+++ b/packages/prune-lockfile/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib/"

--- a/packages/read-importer-manifest/package.json
+++ b/packages/read-importer-manifest/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/read-importers-context/package.json
+++ b/packages/read-importers-context/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "peerDependencies": {
     "@pnpm/logger": "^2.1.0"

--- a/packages/read-modules-dir/package.json
+++ b/packages/read-modules-dir/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/read-modules-dir",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/read-modules-dir#readme",

--- a/packages/read-package-json/package.json
+++ b/packages/read-package-json/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/resolve-dependencies/package.json
+++ b/packages/resolve-dependencies/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "peerDependencies": {
     "@pnpm/logger": "^2.1.0"

--- a/packages/resolver-base/package.json
+++ b/packages/resolver-base/package.json
@@ -20,7 +20,7 @@
     "resolver"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/store-controller-types/package.json
+++ b/packages/store-controller-types/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/supi/package.json
+++ b/packages/supi/package.json
@@ -142,7 +142,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/supi",
   "scripts": {

--- a/packages/symlink-dependency/package.json
+++ b/packages/symlink-dependency/package.json
@@ -32,7 +32,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/symlink-dependency",
   "scripts": {

--- a/packages/tarball-fetcher/package.json
+++ b/packages/tarball-fetcher/package.json
@@ -20,7 +20,7 @@
     "tarball"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
   "license": "MIT",

--- a/packages/tarball-resolver/package.json
+++ b/packages/tarball-resolver/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "scripts": {
     "lint": "tslint -c tslint.json src/**/*.ts test/**/*.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,7 +30,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/utils",
   "scripts": {

--- a/packages/write-importer-manifest/package.json
+++ b/packages/write-importer-manifest/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "files": [
     "lib"

--- a/privatePackages/assert-project/package.json
+++ b/privatePackages/assert-project/package.json
@@ -27,7 +27,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/assert-project",
   "scripts": {

--- a/privatePackages/assert-store/package.json
+++ b/privatePackages/assert-store/package.json
@@ -33,7 +33,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/assert-store",
   "scripts": {

--- a/utils/tslint-config/package.json
+++ b/utils/tslint-config/package.json
@@ -23,7 +23,7 @@
   "keywords": [],
   "license": "MIT",
   "engines": {
-    "node": ">=8.15"
+    "node": ">=10"
   },
   "repository": "https://github.com/pnpm/tslint-config/blob/master/packages/supi",
   "scripts": {}


### PR DESCRIPTION
BREAKING CHANGE:

at least Node.js 10 is  required for pnpm to run

End of life of  Node.js 8 is this December and the majority of our users don't really care if we support  Node.js 8 (https://twitter.com/pnpmjs/status/1171758382434398208).