### PR TITLE
fix: show emptry string instead of undefined when package.json has no name

### DIFF
--- a/packages/lifecycle/src/runLifecycleHook.ts
+++ b/packages/lifecycle/src/runLifecycleHook.ts
@@ -91,6 +91,8 @@ export default async function runLifecycleHook (
 
 function getId (manifest: ImporterManifest | DependencyManifest) {
   if (!manifest.name) {
+    // Using an empty string instead of undefined or null
+    // because this gets printed to the console
     return ''
   }
   if (!manifest.version) {

--- a/packages/lifecycle/src/runLifecycleHook.ts
+++ b/packages/lifecycle/src/runLifecycleHook.ts
@@ -91,7 +91,7 @@ export default async function runLifecycleHook (
 
 function getId (manifest: ImporterManifest | DependencyManifest) {
   if (!manifest.name) {
-    return undefined
+    return ''
   }
   if (!manifest.version) {
     return manifest.name


### PR DESCRIPTION
fix #2005 