### PR TITLE
docs: fix typo in monorepo section

### DIFF
--- a/packages/pnpm/src/cmd/help.ts
+++ b/packages/pnpm/src/cmd/help.ts
@@ -1030,7 +1030,7 @@ function getHelpText (command: string) {
             ],
           },
           {
-            title: 'Manage you monorepo',
+            title: 'Manage your monorepo',
 
             list: [
               {


### PR DESCRIPTION
Changes 'Manage you monorepo' to 'Manage your monorepo'. Simple fix I saw when I was trying to do some unrelated work.