### PR TITLE
refactor(typings): Rename `tape‑promise.d.ts` to `typed.d.ts`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,2 +1,2 @@
 /// <reference path="local.d.ts" />
-/// <reference path="tape-promise.d.ts" />
+/// <reference path="typed.d.ts" />

--- a/typings/typed.d.ts
+++ b/typings/typed.d.ts
@@ -1,3 +1,5 @@
+// This file contains type definitions that aren't just `export = any`
+
 declare module 'tape-promise' {
     import tape = require('tape')
     export = tapePromise;


### PR DESCRIPTION
Blocks #2019

This is done to preserve `git blame` and file history.