### PR TITLE
refactor(typings): Sort third‑party type definitions

### DIFF
--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -1,3 +1,53 @@
+declare module '@zeit/fetch-retry' {
+  const anything: any;
+  export = anything;
+}
+
+declare module '@zkochan/libnpx/index' {
+  const anything: any;
+  export = anything;
+}
+
+declare module '@zkochan/npm-conf' {
+  const anything: any;
+  export = anything;
+}
+
+declare module '@zkochan/npm-conf/lib/types' {
+  const anything: any;
+  export = anything;
+}
+
+declare module '@zkochan/npm-lifecycle' {
+  const anything: any;
+  export = anything;
+}
+
+declare module '@zkochan/npm-package-arg' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'anonymous-npm-registry-client' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'ansi-diff' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'better-path-resolve' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'bole' {
+  const anything: any;
+  export = anything;
+}
+
 declare module 'camelcase' {
   const anything: any;
   export = anything;
@@ -8,9 +58,89 @@ declare module 'cross-spawn' {
   export = anything;
 }
 
-declare module 'is-ci' {
-  const isCI: boolean;
-  export = isCI;
+declare module 'diable' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'dint' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'encode-registry' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'execa' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'exists-link' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'fast-glob' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'fs-vacuum' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'fs-write-stream-atomic' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'graceful-fs' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'graceful-git' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'graph-sequencer' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'hosted-git-info' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'https-proxy-agent' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'import-from' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'is-inner-link' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'is-port-reachable' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'isexe' {
+  const anything: any;
+  export = anything;
 }
 
 declare module 'loud-rejection' {
@@ -28,57 +158,7 @@ declare module 'mz/fs' {
   export = anything;
 }
 
-declare module 'node-gyp' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'normalize-path' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zkochan/npm-package-arg' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'observatory' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'isexe' {
-  const anything: any;
-  export = anything;
-}
-
 declare module 'ncp' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'npm-registry-client' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'anonymous-npm-registry-client' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'exists-link' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'path-name' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'bole' {
   const anything: any;
   export = anything;
 }
@@ -88,37 +168,27 @@ declare module 'ndjson' {
   export = anything;
 }
 
-declare module 'execa' {
+declare module 'node-fetch-unix' {
   const anything: any;
   export = anything;
 }
 
-declare module 'p-filter' {
+declare module 'node-gyp' {
   const anything: any;
   export = anything;
 }
 
-declare module 'normalize-ssh' {
-  function normalizeSsh (url: string): string;
-  export = normalizeSsh;
-}
-
-declare module 'graceful-fs' {
+declare module 'normalize-newline' {
   const anything: any;
   export = anything;
 }
 
-declare module 'fs-write-stream-atomic' {
+declare module 'normalize-path' {
   const anything: any;
   export = anything;
 }
 
-declare module 'remove-all-except-outer-links' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'is-inner-link' {
+declare module 'npm-registry-client' {
   const anything: any;
   export = anything;
 }
@@ -133,56 +203,17 @@ declare module 'npm/lib/config/get-credentials-by-uri' {
   export = anything;
 }
 
-declare namespace pnpmRegistryMock {
-  function getIntegrity (pkgName: string, pkgVersion: string): string
-  function addDistTag (opts: {package: string, version: string, distTag: string}): Promise<void>
-}
-
-declare module '@pnpm/registry-mock' {
-  export = pnpmRegistryMock
-}
-
-declare module 'dint' {
+declare module 'observatory' {
   const anything: any;
   export = anything;
 }
 
-declare module 'encode-registry' {
+declare module 'p-filter' {
   const anything: any;
   export = anything;
 }
 
-declare module 'validate-npm-package-name' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'graph-sequencer' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'import-from' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'is-windows' {
-  function isWindows(): boolean;
-  export = isWindows;
-}
-
-declare module 'diable' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'signal-exit' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zkochan/libnpx/index' {
+declare module 'path-name' {
   const anything: any;
   export = anything;
 }
@@ -192,97 +223,12 @@ declare module 'process-exists' {
   export = anything;
 }
 
-declare module 'read-ini-file' {
-  function readIniFile (filename: string): Promise<Object>;
-  export = readIniFile;
-}
-
-declare module 'better-path-resolve' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zkochan/npm-conf' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zkochan/npm-conf/lib/types' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zeit/fetch-retry' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'node-fetch-unix' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'https-proxy-agent' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'socks-proxy-agent' {
-  const anything: any;
-  export = anything;
-}
-
 declare module 'read-package-json' {
   const anything: any;
   export = anything;
 }
 
-declare module 'write-file-atomic' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'graceful-git' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'hosted-git-info' {
-  const anything: any;
-  export = anything;
-}
-
-declare module '@zkochan/npm-lifecycle' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'pretty-time' {
-  function prettyTime (time: [number, number]): string;
-  export = prettyTime;
-}
-
-declare module 'right-pad' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'stacktracey' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'ansi-diff' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'normalize-registry-url' {
-  function normalizeRegistryUrl (registry: string): string
-  export = normalizeRegistryUrl;
-}
-
-declare module 'fs-vacuum' {
+declare module 'remove-all-except-outer-links' {
   const anything: any;
   export = anything;
 }
@@ -292,12 +238,32 @@ declare module 'rename-overwrite' {
   export = anything;
 }
 
-declare module 'is-port-reachable' {
+declare module 'right-pad' {
   const anything: any;
   export = anything;
 }
 
-declare module 'fast-glob' {
+declare module 'signal-exit' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'socks-proxy-agent' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'stacktracey' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'validate-npm-package-name' {
+  const anything: any;
+  export = anything;
+}
+
+declare module 'write-file-atomic' {
   const anything: any;
   export = anything;
 }
@@ -305,14 +271,4 @@ declare module 'fast-glob' {
 declare module 'yaml-tag' {
   const anything: any;
   export = anything;
-}
-
-declare module 'normalize-newline' {
-  const anything: any;
-  export = anything;
-}
-
-declare module 'cli-columns' {
-  function cliColumns (values: string[], opts?: { newline?: string, width?: number }): string
-  export = cliColumns;
 }

--- a/typings/typed.d.ts
+++ b/typings/typed.d.ts
@@ -1,11 +1,49 @@
 // This file contains type definitions that aren't just `export = any`
 
-declare module 'tape-promise' {
-    import tape = require('tape')
-    export = tapePromise;
+declare module '@pnpm/registry-mock' {
+  export function getIntegrity (pkgName: string, pkgVersion: string): string
+  export function addDistTag (opts: {package: string, version: string, distTag: string}): Promise<void>
+}
 
-    function tapePromise(tape: any): (name: string, cb: tape.TestCase) => void;
-    function tapePromise(tape: any): (name: string, opts: tape.TestOptions, cb: tape.TestCase) => void;
-    function tapePromise(tape: any): (cb: tape.TestCase) => void;
-    function tapePromise(tape: any): (opts: tape.TestOptions, cb: tape.TestCase) => void;
+declare module 'cli-columns' {
+  function cliColumns (values: string[], opts?: { newline?: string, width?: number }): string
+  export = cliColumns;
+}
+
+// TODO: Has @types declaration
+declare module 'is-ci' {
+  const isCI: boolean;
+  export = isCI;
+}
+
+// TODO: Has @types declaration
+declare module 'is-windows' {
+  function isWindows(): boolean;
+  export = isWindows;
+}
+
+declare module 'normalize-registry-url' {
+  function normalizeRegistryUrl (registry: string): string
+  export = normalizeRegistryUrl;
+}
+
+// TODO: Has @types declaration
+declare module 'pretty-time' {
+  function prettyTime (time: [number, number]): string;
+  export = prettyTime;
+}
+
+declare module 'read-ini-file' {
+  function readIniFile (filename: string): Promise<Object>;
+  export = readIniFile;
+}
+
+declare module 'tape-promise' {
+  import tape = require('tape')
+  export = tapePromise;
+
+  function tapePromise(tape: any): (name: string, cb: tape.TestCase) => void;
+  function tapePromise(tape: any): (name: string, opts: tape.TestOptions, cb: tape.TestCase) => void;
+  function tapePromise(tape: any): (cb: tape.TestCase) => void;
+  function tapePromise(tape: any): (opts: tape.TestOptions, cb: tape.TestCase) => void;
 }


### PR DESCRIPTION
Blocks #2019

This ensures that any patches which switch from the `declare module {export = any}` type definition to a `@types/` or official type declaration don’t cause merge conflicts with #2019.