### PR TITLE
feat(pnpm): don't fail 'recursive run' if no selected packages have script

### DIFF
--- a/packages/pnpm/src/cmd/recursive/index.ts
+++ b/packages/pnpm/src/cmd/recursive/index.ts
@@ -73,7 +73,10 @@ export default async (
       `"recursive ${cmdFullName}" is not a pnpm command. See "pnpm help recursive".`)
   }
 
-  const workspacePrefix = opts.workspacePrefix || process.cwd()
+  if (!opts.workspacePrefix) {
+    opts.workspacePrefix = process.cwd()
+  }
+  const { workspacePrefix } = opts
   const allWorkspacePkgs = await findWorkspacePackages(workspacePrefix, opts)
 
   if (!allWorkspacePkgs.length) {
@@ -123,6 +126,8 @@ export async function recursive (
     pkgs = allPkgs
   }
 
+  const allPackagesAreSelected = pkgs.length === allPkgs.length
+
   if (pkgs.length === 0) {
     return false
   }
@@ -163,7 +168,7 @@ export async function recursive (
       throwOnFail(await run(chunks, pkgGraphResult.graph, ['test', ...input], cmd, opts as any)) // tslint:disable-line:no-any
       return true
     case 'run':
-      throwOnFail(await run(chunks, pkgGraphResult.graph, input, cmd, opts as any)) // tslint:disable-line:no-any
+      throwOnFail(await run(chunks, pkgGraphResult.graph, input, cmd, { ...opts, allPackagesAreSelected } as any)) // tslint:disable-line:no-any
       return true
     case 'update':
       opts = { ...opts, update: true, allowNew: false } as any // tslint:disable-line:no-any

--- a/packages/pnpm/src/cmd/recursive/run.ts
+++ b/packages/pnpm/src/cmd/recursive/run.ts
@@ -18,6 +18,8 @@ export default async <T> (
     workspaceConcurrency: number,
     unsafePerm: boolean,
     rawConfig: object,
+    workspacePrefix: string,
+    allPackagesAreSelected: boolean,
   },
 ) => {
   const scriptName = args[0]
@@ -85,7 +87,14 @@ export default async <T> (
   }
 
   if (scriptName !== 'test' && !hasCommand) {
-    throw new PnpmError('RECURSIVE_RUN_NO_SCRIPT', `None of the packages has a "${scriptName}" script`)
+    if (opts.allPackagesAreSelected) {
+      throw new PnpmError('RECURSIVE_RUN_NO_SCRIPT', `None of the packages has a "${scriptName}" script`)
+    } else {
+      logger.info({
+        message: `None of the selected packages has a "${scriptName}" script`,
+        prefix: opts.workspacePrefix
+      })
+    }
   }
 
   return result

--- a/packages/pnpm/test/recursive/run.ts
+++ b/packages/pnpm/test/recursive/run.ts
@@ -127,8 +127,6 @@ test('`pnpm recursive run` fails when run without filters and no package has the
     {
       name: 'project-0',
       version: '1.0.0',
-
-      dependencies: {},
     },
   ])
 
@@ -167,8 +165,6 @@ test('`pnpm recursive run` fails when run with a filter that includes all packag
     {
       name: 'project-0',
       version: '1.0.0',
-
-      dependencies: {},
     },
   ])
 
@@ -207,8 +203,6 @@ test('`pnpm recursive run` succeeds when run against a subset of packages and no
     {
       name: 'project-0',
       version: '1.0.0',
-
-      dependencies: {},
     },
   ])
 

--- a/packages/pnpm/test/recursive/run.ts
+++ b/packages/pnpm/test/recursive/run.ts
@@ -102,29 +102,18 @@ test('pnpm recursive run concurrently', async (t: tape.Test) => {
   t.ok(Math.max(outputs1[0], outputs2[0]) < Math.min(outputs1[outputs1.length - 1], outputs2[outputs2.length - 1]))
 })
 
-test('`pnpm recursive run` fails if none of the packaegs has the desired command', async (t: tape.Test) => {
+test('`pnpm recursive run` fails when run without filters and no package has the desired command', async (t: tape.Test) => {
   const projects = preparePackages(t, [
     {
       name: 'project-1',
       version: '1.0.0',
-
-      dependencies: {
-        'json-append': '1',
-      },
-      scripts: {
-        build: `node -e "process.stdout.write('project-1')" | json-append ../output.json`,
-      },
     },
     {
       name: 'project-2',
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-1': '1'
-      },
-      scripts: {
-        build: `node -e "process.stdout.write('project-2')" | json-append ../output.json`,
       },
     },
     {
@@ -132,11 +121,7 @@ test('`pnpm recursive run` fails if none of the packaegs has the desired command
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-1': '1'
-      },
-      scripts: {
-        build: `node -e "process.stdout.write('project-3')" | json-append ../output.json`,
       },
     },
     {
@@ -154,6 +139,86 @@ test('`pnpm recursive run` fails if none of the packaegs has the desired command
     t.fail('should have failed')
   } catch (err) {
     t.pass('`recursive run` failed because none of the packages has the wanted script')
+  }
+})
+
+test('`pnpm recursive run` fails when run with a filter that includes all packages and no package has the desired command', async (t: tape.Test) => {
+  const projects = preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1'
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1'
+      },
+    },
+    {
+      name: 'project-0',
+      version: '1.0.0',
+
+      dependencies: {},
+    },
+  ])
+
+  await execPnpm('recursive', 'install')
+
+  try {
+    await execPnpm('recursive', 'run', 'this-command-does-not-exist', '--filter', '*')
+    t.fail('should have failed')
+  } catch (err) {
+    t.pass('`recursive run` failed because none of the packages has the wanted script')
+  }
+})
+
+test('`pnpm recursive run` succeeds when run against a subset of packages and no package has the desired command', async (t: tape.Test) => {
+  const projects = preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1'
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1'
+      },
+    },
+    {
+      name: 'project-0',
+      version: '1.0.0',
+
+      dependencies: {},
+    },
+  ])
+
+  await execPnpm('recursive', 'install')
+
+  try {
+    await execPnpm('recursive', 'run', 'this-command-does-not-exist', '--filter', 'project-1')
+    t.pass('`recursive run` succeeded although none of the selected packages has the wanted script')
+  } catch (err) {
+    t.fail('should have passed')
   }
 })
 


### PR DESCRIPTION
This changes the behavior of of `pnpm recursive run ...` so that it no
longer throws an error when run against a subset of packages and none of
the selected packages have the provided script.

Previously, running a command like `pnpm m run --filter foo build` would
throw an error if the `foo` package did not have a `build` script, even
if other workspace packages have a `build` script.

With this change, running `pnpm recursive run --filter foo build` will
not throw an error.

Note that if the provided package selectors match all packages (e.g.
`'*'`), then `pnpm recursive run` will fail if none of the packages have
the script. This is because the behavior depends on whether we're
running against a subset of packages or not, _not_ whether any package
selectors were provided.

Closes #1763