### PR TITLE
fix(config): settings are merged in correct order

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -185,7 +185,7 @@ export default async (
     }, {} as Config)
   pnpmConfig.rawLocalConfig = Object.assign.apply(Object, [
     {},
-    ...npmConfig.list.slice(3, pnpmConfig.workspacePrefix && pnpmConfig.workspacePrefix !== pnpmConfig.localPrefix ? 5 : 4),
+    ...npmConfig.list.slice(3, pnpmConfig.workspacePrefix && pnpmConfig.workspacePrefix !== pnpmConfig.localPrefix ? 5 : 4).reverse(),
     cliArgs,
   ] as any) // tslint:disable-line:no-any
   pnpmConfig.userAgent = pnpmConfig.rawLocalConfig['user-agent']
@@ -193,7 +193,7 @@ export default async (
     : `${packageManager.name}/${packageManager.version} npm/? node/${process.version} ${process.platform} ${process.arch}`
   pnpmConfig.rawConfig = Object.assign.apply(Object, [
     { registry: 'https://registry.npmjs.org/' },
-    ...npmConfig.list,
+    ...[...npmConfig.list].reverse(),
     cliArgs,
     { 'user-agent': pnpmConfig.userAgent },
   ] as any) // tslint:disable-line:no-any


### PR DESCRIPTION
This fixes 2 issues:

1. local registry settings should have bigger priority than global
2. package settings should have bigger priority than workspace set-
   tings (this was only an issue with rawLocalConfig)

close #2096