### PR TITLE
fix(package‑is‑installable): Use `WantedEngine` and `WantedPlatform`

### DIFF
--- a/packages/package-is-installable/src/checkEngine.ts
+++ b/packages/package-is-installable/src/checkEngine.ts
@@ -38,7 +38,4 @@ export type Engine = {
   pnpm: string,
 }
 
-export type WantedEngine = {
-  node?: string,
-  pnpm?: string,
-}
+export type WantedEngine = Partial<Engine>

--- a/packages/package-is-installable/src/checkPlatform.ts
+++ b/packages/package-is-installable/src/checkPlatform.ts
@@ -1,17 +1,17 @@
 import PnpmError from '@pnpm/error'
 
 export class UnsupportedPlatformError extends PnpmError {
-  public wanted: Platform
+  public wanted: WantedPlatform
   public current: Platform
 
-  constructor (packageId: string, wanted: Platform, current: Platform) {
+  constructor (packageId: string, wanted: WantedPlatform, current: Platform) {
     super('UNSUPPORTED_PLATFORM', `Unsupported platform for ${packageId}: wanted ${JSON.stringify(wanted)} (current: ${JSON.stringify(current)})`)
     this.wanted = wanted
     this.current = current
   }
 }
 
-export default function checkPlatform (packageId: string, wantedPlatform: Platform) {
+export default function checkPlatform (packageId: string, wantedPlatform: WantedPlatform) {
   const platform = process.platform
   const arch = process.arch
   let osOk = true
@@ -32,6 +32,11 @@ export default function checkPlatform (packageId: string, wantedPlatform: Platfo
 export type Platform = {
   cpu: string | string[],
   os: string | string[],
+}
+
+export type WantedPlatform = {
+  cpu?: string | string[],
+  os?: string | string[],
 }
 
 function checkList (value: string, list: string | string[]) {

--- a/packages/package-is-installable/src/checkPlatform.ts
+++ b/packages/package-is-installable/src/checkPlatform.ts
@@ -11,7 +11,10 @@ export class UnsupportedPlatformError extends PnpmError {
   }
 }
 
-export default function checkPlatform (packageId: string, wantedPlatform: WantedPlatform) {
+export default function checkPlatform (
+  packageId: string,
+  wantedPlatform: WantedPlatform,
+) {
   const platform = process.platform
   const arch = process.arch
   let osOk = true
@@ -34,10 +37,7 @@ export type Platform = {
   os: string | string[],
 }
 
-export type WantedPlatform = {
-  cpu?: string | string[],
-  os?: string | string[],
-}
+export type WantedPlatform = Partial<Platform>
 
 function checkList (value: string, list: string | string[]) {
   let tmp

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -2,12 +2,16 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
-import checkEngine, { UnsupportedEngineError } from './checkEngine'
+import checkEngine, { UnsupportedEngineError, WantedEngine } from './checkEngine'
 import checkPlatform, { UnsupportedPlatformError } from './checkPlatform'
+
+export { Engine } from './checkEngine'
+export { Platform, WantedPlatform } from './checkPlatform'
 
 export {
   UnsupportedEngineError,
   UnsupportedPlatformError,
+  WantedEngine,
 }
 
 export default function packageIsInstallable (
@@ -15,10 +19,7 @@ export default function packageIsInstallable (
   pkg: {
     name: string,
     version: string,
-    engines?: {
-      node?: string,
-      npm?: string,
-    },
+    engines?: WantedEngine,
     cpu?: string[],
     os?: string[],
   },
@@ -62,10 +63,7 @@ export default function packageIsInstallable (
 export function checkPackage (
   pkgId: string,
   manifest: {
-    engines?: {
-      node?: string,
-      npm?: string,
-    },
+    engines?: WantedEngine,
     cpu?: string[],
     os?: string[],
   },

--- a/packages/pnpm/src/packageIsInstallable.ts
+++ b/packages/pnpm/src/packageIsInstallable.ts
@@ -1,14 +1,11 @@
 import logger from '@pnpm/logger'
-import { checkPackage, UnsupportedEngineError } from '@pnpm/package-is-installable'
+import { checkPackage, UnsupportedEngineError, WantedEngine } from '@pnpm/package-is-installable'
 import packageManager from './pnpmPkgJson'
 
-export default function (
+export default function packageIsInstallable (
   pkgPath: string,
   pkg: {
-    engines?: {
-      node?: string,
-      npm?: string,
-    },
+    engines?: WantedEngine,
     cpu?: string[],
     os?: string[],
   },


### PR DESCRIPTION
This updates `@pnpm/package‑is‑installable` to use the `WantedEngine` and `WantedPlatform` types where appropriate.