### PR TITLE
feat(lockfile‑file): Add return type to `getLockfileImporterId(…)`

### DIFF
--- a/packages/lockfile-file/src/getLockfileImporterId.ts
+++ b/packages/lockfile-file/src/getLockfileImporterId.ts
@@ -1,4 +1,4 @@
 import normalize = require('normalize-path')
 import path = require('path')
 
-export default (lockfileDirectory: string, prefix: string) => normalize(path.relative(lockfileDirectory, prefix)) || '.'
+export default (lockfileDirectory: string, prefix: string): string => normalize(path.relative(lockfileDirectory, prefix)) || '.'


### PR DESCRIPTION
This adds a return type to `getLockfileImporterId(…)`.

It would previously return `any` because of the untyped `normalize‑path` definition in `typings/local.d.ts`.