### PR TITLE
feat(publishConfig): add additional well-known fields

### DIFF
--- a/packages/pnpm/test/publish.ts
+++ b/packages/pnpm/test/publish.ts
@@ -149,22 +149,30 @@ testFromNode10('publish packages with workspace LICENSE if no own LICENSE is pre
   t.ok(await exists('project-200/LICENSE'))
 })
 
-test('publish: package with main, module, typings and types in publishConfig', async (t: tape.Test) => {
+test('publish: package with all possible fields in publishConfig', async (t: tape.Test) => {
   preparePackages(t, [
     {
       name: 'test-publish-config',
       version: '1.0.0',
 
+      bin: './bin.js',
       main: './index.js',
       module: './index.mjs',
       types: `./types.d.ts`,
       typings: `./typings.d.ts`,
 
       publishConfig: {
+        bin: './published-bin.js',
+        browser: './published-browser.js',
+        es2015: './published-es2015.js',
+        esnext: './published-esnext.js',
+        exports: './published-exports.js',
         main: './published.js',
         module: './published.mjs',
         types: `./published-types.d.ts`,
         typings: `./published-typings.d.ts`,
+        'umd:main': './published-umd.js',
+        unpkg: './published-unpkg.js',
       },
     },
     {
@@ -175,6 +183,7 @@ test('publish: package with main, module, typings and types in publishConfig', a
 
   process.chdir('test-publish-config')
   await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+  await fs.writeFile('published-bin.js', `#!/usr/bin/env node`, 'utf8')
   await execPnpm('publish')
 
   const originalManifests = await import(path.resolve('package.json'))
@@ -182,16 +191,24 @@ test('publish: package with main, module, typings and types in publishConfig', a
     name: 'test-publish-config',
     version: '1.0.0',
 
+    bin: './bin.js',
     main: './index.js',
     module: './index.mjs',
     types: `./types.d.ts`,
     typings: `./typings.d.ts`,
 
     publishConfig: {
+      bin: './published-bin.js',
+      browser: './published-browser.js',
+      es2015: './published-es2015.js',
+      esnext: './published-esnext.js',
+      exports: './published-exports.js',
       main: './published.js',
       module: './published.mjs',
       types: `./published-types.d.ts`,
       typings: `./published-typings.d.ts`,
+      'umd:main': './published-umd.js',
+      unpkg: './published-unpkg.js',
     },
   })
 
@@ -203,17 +220,32 @@ test('publish: package with main, module, typings and types in publishConfig', a
     name: 'test-publish-config',
     version: '1.0.0',
 
+    bin: './published-bin.js',
     main: './published.js',
     module: './published.mjs',
-    types: `./published-types.d.ts`,
-    typings: `./published-typings.d.ts`,
+    types: './published-types.d.ts',
+    typings: './published-typings.d.ts',
 
     publishConfig: {
+      bin: './published-bin.js',
+      browser: './published-browser.js',
+      es2015: './published-es2015.js',
+      esnext: './published-esnext.js',
+      exports: './published-exports.js',
       main: './published.js',
       module: './published.mjs',
-      types: `./published-types.d.ts`,
-      typings: `./published-typings.d.ts`,
+      types: './published-types.d.ts',
+      typings: './published-typings.d.ts',
+      'umd:main': './published-umd.js',
+      unpkg: './published-unpkg.js',
     },
+
+    browser: './published-browser.js',
+    es2015: './published-es2015.js',
+    esnext: './published-esnext.js',
+    exports: './published-exports.js',
+    'umd:main': './published-umd.js',
+    unpkg: './published-unpkg.js',
   })
 })
 

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -76,12 +76,7 @@ interface BaseManifest {
   module?: string,
   typings?: string,
   types?: string,
-  publishConfig?: {
-    main?: string,
-    module?: string,
-    typings?: string,
-    types?: string,
-  },
+  publishConfig?: Record<string, unknown>,
 }
 
 export type DependencyManifest = BaseManifest & Required<Pick<BaseManifest, 'name' | 'version'>>


### PR DESCRIPTION
Overriding some fields in the manifest, before the package is packed is a great
feature. [Package Bundlers](stereobooster/package.json#package-bundlers) support several additional fields.

This commit adds some of those well-known additional fields:

- [`browser`](stereobooster/package.json#browser)
- [`esnext`](stereobooster/package.json#esnext)
- [`es2015`](stereobooster/package.json#es2015)
- [`unpkg`](stereobooster/package.json#unpkg)
- `umd:main`: used by [microbundle](developit/microbundle)
- `exports`: Node.js [Package Exports](nodejs.org/api/esm.html#esm_package_exports)

Additionally the `bin` field may be overridden.