### PR TITLE
Fixes #2171

### DIFF
--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -265,7 +265,10 @@ function pickMatchingLocalVersionOrNull (
     case 'version':
       return versions[spec.fetchSpec] ? spec.fetchSpec : null
     case 'range':
-      return semver.maxSatisfying(localVersions, spec.fetchSpec, true)
+      return semver.maxSatisfying(localVersions, spec.fetchSpec, {
+        loose: true,
+        includePrerelease: true
+      })
     default:
       return null
   }

--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -266,8 +266,8 @@ function pickMatchingLocalVersionOrNull (
       return versions[spec.fetchSpec] ? spec.fetchSpec : null
     case 'range':
       return semver.maxSatisfying(localVersions, spec.fetchSpec, {
+        includePrerelease: true,
         loose: true,
-        includePrerelease: true
       })
     default:
       return null

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -1264,6 +1264,43 @@ test('workspace protocol: resolve from local directory even when it does not mat
   t.end()
 })
 
+test('workspace protocol: resolve from local package that has a pre-release version', async t => {
+  const storeDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    metaCache: new Map(),
+    rawConfig: { registry },
+    storeDir,
+  })
+  const resolveResult = await resolve({ alias: 'is-positive', pref: '*' }, {
+    importerDir: '/home/istvan/src',
+    localPackages: {
+      'is-positive': {
+        '3.0.0-alpha.1.2.3': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '3.0.0-alpha.1.2.3',
+          },
+        },
+      },
+    },
+    registry,
+  })
+
+  t.equal(resolveResult!.resolvedVia, 'local-filesystem')
+  t.equal(resolveResult!.id, 'link:is-positive')
+  t.notOk(resolveResult!.latest)
+  t.deepEqual(resolveResult!.resolution, {
+    directory: '/home/istvan/src/is-positive',
+    type: 'directory',
+  })
+  t.ok(resolveResult!.manifest)
+  t.equal(resolveResult!.manifest!.name, 'is-positive')
+  t.equal(resolveResult!.manifest!.version, '3.0.0-alpha.1.2.3')
+
+  t.end()
+})
+
 test('workspace protocol: resolution fails if there is no matching local package', async t => {
   const storeDir = tempy.directory()
   const resolve = createResolveFromNpm({


### PR DESCRIPTION
I saw, that the `loose` options was already provided by using `true` as the last parameter https://github.com/npm/node-semver#functions.

Additionally adding `includePrerelease: true` also adds support for prerelease versions like `2.0.0-alpha.123`.

What is obviously missing in this PR is a test.

@zkochan would be great to get your advice on how to test this with the current setup :)