### PR TITLE
fix(publish): remove workspace from devDependencies

### DIFF
--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -122,6 +122,7 @@ async function makePublishManifest (dir: string, originalManifest: ImporterManif
     ...originalManifest,
     dependencies: await makePublishDependencies(dir, originalManifest.dependencies),
     optionalDependencies: await makePublishDependencies(dir, originalManifest.optionalDependencies),
+    devDependencies: await makePublishDependencies(dir, originalManifest.devDependencies),
   }
 
   const { publishConfig } = originalManifest

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -121,8 +121,8 @@ async function makePublishManifest (dir: string, originalManifest: ImporterManif
   const publishManifest = {
     ...originalManifest,
     dependencies: await makePublishDependencies(dir, originalManifest.dependencies),
-    optionalDependencies: await makePublishDependencies(dir, originalManifest.optionalDependencies),
     devDependencies: await makePublishDependencies(dir, originalManifest.devDependencies),
+    optionalDependencies: await makePublishDependencies(dir, originalManifest.optionalDependencies),
   }
 
   const { publishConfig } = originalManifest

--- a/packages/plugin-commands-publishing/test/publish.ts
+++ b/packages/plugin-commands-publishing/test/publish.ts
@@ -314,11 +314,11 @@ test('convert specs with workspace protocols to regular version ranges', async (
         'is-positive': '1.0.0',
         'lodash.delay': '~4.1.0',
       },
-      optionalDependencies: {
-        'lodash.deburr': 'workspace:^4.1.0',
-      },
       devDependencies: {
         'random-package': 'workspace:^1.2.3'
+      },
+      optionalDependencies: {
+        'lodash.deburr': 'workspace:^4.1.0',
       }
     },
     {
@@ -377,11 +377,11 @@ test('convert specs with workspace protocols to regular version ranges', async (
     'is-positive': '1.0.0',
     'lodash.delay': '~4.1.0',
   })
-  t.deepEqual(publishedManifest.optionalDependencies, {
-    'lodash.deburr': '^4.1.0',
-  })
   t.deepEqual(publishedManifest.devDependencies, {
     'random-package': '^1.2.3',
+  })
+  t.deepEqual(publishedManifest.optionalDependencies, {
+    'lodash.deburr': '^4.1.0',
   })
   t.end()
 })

--- a/packages/plugin-commands-publishing/test/publish.ts
+++ b/packages/plugin-commands-publishing/test/publish.ts
@@ -338,6 +338,10 @@ test('convert specs with workspace protocols to regular version ranges', async (
       version: '4.1.0',
     },
     {
+      name: 'random-package',
+      version: '1.2.3',
+    },
+    {
       name: 'target',
       version: '1.0.0',
     }

--- a/packages/plugin-commands-publishing/test/publish.ts
+++ b/packages/plugin-commands-publishing/test/publish.ts
@@ -316,6 +316,9 @@ test('convert specs with workspace protocols to regular version ranges', async (
       },
       optionalDependencies: {
         'lodash.deburr': 'workspace:^4.1.0',
+      },
+      devDependencies: {
+        'random-package': 'workspace:^1.2.3'
       }
     },
     {
@@ -376,6 +379,9 @@ test('convert specs with workspace protocols to regular version ranges', async (
   })
   t.deepEqual(publishedManifest.optionalDependencies, {
     'lodash.deburr': '^4.1.0',
+  })
+  t.deepEqual(publishedManifest.devDependencies, {
+    'random-package': '^1.2.3',
   })
   t.end()
 })


### PR DESCRIPTION
Closes #2202

This PR makes sure, that the `workspace:` version protocol is not only cleaned up from the `dependencies` and `optionalDependencies`, but also from `devDependencies`.