### PR TITLE
refactor: plugin-commands-recursive

### DIFF
--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -1,8 +1,19 @@
-import { IncludedDependencies, Registries } from '@pnpm/types'
+import { ImporterManifest, IncludedDependencies, Registries } from '@pnpm/types'
 
 export type UniversalOptions = Pick<Config, 'color' | 'dir' | 'rawConfig' | 'rawLocalConfig'>
 
+export type WsPkg = {
+  dir: string,
+  manifest: ImporterManifest,
+  writeImporterManifest: (manifest: ImporterManifest) => Promise<void>,
+}
+
+export type WsPkgsGraph = Record<string, { dependencies: string[], package: WsPkg }>
+
 export interface Config {
+  allWsPkgs?: WsPkg[],
+  selectedWsPkgsGraph?: WsPkgsGraph,
+
   allowNew: boolean,
   bail: boolean,
   color: 'always' | 'auto' | 'never',

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,11 +6,11 @@ import camelcase from 'camelcase'
 import path = require('path')
 import R = require('ramda')
 import whichcb = require('which')
-import { Config, ConfigWithDeprecatedSettings, UniversalOptions } from './Config'
+import { Config, ConfigWithDeprecatedSettings, UniversalOptions, WsPkg, WsPkgsGraph } from './Config'
 import findBestGlobalPrefixOnWindows from './findBestGlobalPrefixOnWindows'
 import getScopeRegistries, { normalizeRegistry } from './getScopeRegistries'
 
-export { Config, UniversalOptions }
+export { Config, UniversalOptions, WsPkg, WsPkgsGraph }
 
 const npmDefaults = loadNpmConf.defaults
 

--- a/packages/find-workspace-packages/src/index.ts
+++ b/packages/find-workspace-packages/src/index.ts
@@ -1,13 +1,13 @@
 import { packageIsInstallable } from '@pnpm/cli-utils'
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
-import { DependencyManifest, ImporterManifest } from '@pnpm/types'
+import { ImporterManifest } from '@pnpm/types'
 import findPackages from 'find-packages'
 import path = require('path')
 import readYamlFile from 'read-yaml-file'
 
 interface WorkspaceDependencyPackage {
   dir: string
-  manifest: DependencyManifest
+  manifest: ImporterManifest
   writeImporterManifest (manifest: ImporterManifest, force?: boolean | undefined): Promise<void>
 }
 
@@ -29,7 +29,6 @@ export default async (
     packageIsInstallable(pkg.dir, pkg.manifest, opts)
   }
 
-  // FIXME: `name` and `version` might be missing from entries in `pkgs`.
   return pkgs as WorkspaceDependencyPackage[]
 }
 
@@ -48,6 +47,7 @@ export function arrayOfWorkspacePackagesToMap (
   pkgs: WorkspaceDependencyPackage[],
 ) {
   return pkgs.reduce((acc, pkg) => {
+    if (!pkg.manifest.name || !pkg.manifest.version) return acc
     if (!acc[pkg.manifest.name]) {
       acc[pkg.manifest.name] = {}
     }

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -4,8 +4,8 @@ import R = require('ramda')
 import semver = require('semver')
 
 export type Manifest = {
-  name: string,
-  version: string,
+  name?: string,
+  version?: string,
   dependencies?: {
     [name: string]: string,
   },
@@ -75,7 +75,8 @@ export default function<T> (pkgs: Array<Package & T>): {
 
         const pkgs = R.values(pkgMap).filter(pkg => pkg.manifest.name === depName)
         if (!pkgs.length) return ''
-        const versions = pkgs.map(pkg => pkg.manifest.version)
+        const versions = pkgs.filter(({ manifest }) => manifest.version)
+          .map(pkg => pkg.manifest.version) as string[]
         if (versions.includes(rawSpec)) {
           const matchedPkg = pkgs.find(pkg => pkg.manifest.name === depName && pkg.manifest.version === rawSpec)
           return matchedPkg!.dir

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -41,6 +41,7 @@
     "@pnpm/config": "workspace:6.0.0",
     "@pnpm/constants": "workspace:3.0.0",
     "@pnpm/error": "workspace:1.0.0",
+    "@pnpm/filter-workspace-packages": "workspace:1.0.1",
     "@pnpm/find-workspace-dir": "workspace:1.0.0",
     "@pnpm/find-workspace-packages": "workspace:2.0.8",
     "@pnpm/package-store": "workspace:7.0.2",

--- a/packages/plugin-commands-installation/src/link.ts
+++ b/packages/plugin-commands-installation/src/link.ts
@@ -122,7 +122,8 @@ export async function handler (
     if (opts.workspaceDir) {
       workspacePackagesArr = await findWorkspacePackages(opts.workspaceDir, opts)
 
-      const pkgsFoundInWorkspace = workspacePackagesArr.filter((pkg) => pkgNames.includes(pkg.manifest.name))
+      const pkgsFoundInWorkspace = workspacePackagesArr
+        .filter(({ manifest }) => manifest.name && pkgNames.includes(manifest.name))
       pkgsFoundInWorkspace.forEach((pkgFromWorkspace) => pkgPaths.push(pkgFromWorkspace.dir))
 
       if (pkgsFoundInWorkspace.length && !linkOpts.targetDependenciesField) {

--- a/packages/plugin-commands-recursive/src/exec.ts
+++ b/packages/plugin-commands-recursive/src/exec.ts
@@ -1,12 +1,12 @@
+import { WsPkgsGraph } from '@pnpm/config'
 import logger from '@pnpm/logger'
 import execa = require('execa')
 import pLimit from 'p-limit'
-import { PackageNode } from 'pkgs-graph'
 import RecursiveSummary from './recursiveSummary'
 
 export default async <T> (
   packageChunks: string[][],
-  graph: {[id: string]: PackageNode<T>},
+  graph: WsPkgsGraph,
   args: string[],
   cmd: string,
   opts: {

--- a/packages/plugin-commands-recursive/src/run.ts
+++ b/packages/plugin-commands-recursive/src/run.ts
@@ -1,15 +1,15 @@
+import { WsPkgsGraph } from '@pnpm/config'
 import PnpmError from '@pnpm/error'
 import runLifecycleHooks from '@pnpm/lifecycle'
 import logger from '@pnpm/logger'
 import { PackageManifest } from '@pnpm/types'
 import { realNodeModulesDir } from '@pnpm/utils'
 import pLimit from 'p-limit'
-import { PackageNode } from 'pkgs-graph'
 import RecursiveSummary from './recursiveSummary'
 
 export default async <T> (
   packageChunks: string[][],
-  graph: {[id: string]: PackageNode<T>},
+  graph: WsPkgsGraph,
   args: string[],
   cmd: string,
   opts: {

--- a/packages/plugin-commands-recursive/test/exec.ts
+++ b/packages/plugin-commands-recursive/test/exec.ts
@@ -5,7 +5,7 @@ import rimraf = require('@zkochan/rimraf')
 import fs = require('mz/fs')
 import path = require('path')
 import test = require('tape')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 test('pnpm recursive exec', async (t) => {
   const projects = preparePackages(t, [
@@ -48,13 +48,18 @@ test('pnpm recursive exec', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
   await recursive.handler(['exec', 'npm', 'run', 'build'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   const outputs1 = await import(path.resolve('output1.json')) as string[]
@@ -74,9 +79,12 @@ test('pnpm recursive exec sets PNPM_PACKAGE_NAME env var', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['exec', 'node', '-e', `require('fs').writeFileSync('pkgname', process.env.PNPM_PACKAGE_NAME, 'utf8')`], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   t.equal(await fs.readFile('foo/pkgname', 'utf8'), 'foo', '$PNPM_PACKAGE_NAME is correct')
@@ -122,9 +130,12 @@ test('testing the bail config with "pnpm recursive exec"', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   let failed = false
@@ -132,7 +143,9 @@ test('testing the bail config with "pnpm recursive exec"', async (t) => {
   try {
     await recursive.handler(['exec', 'npm', 'run', 'build', '--no-bail'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
   } catch (_err) {
     err1 = _err
@@ -151,7 +164,9 @@ test('testing the bail config with "pnpm recursive exec"', async (t) => {
   try {
     await recursive.handler(['exec', 'npm', 'run', 'build'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
   } catch (_err) {
     err2 = _err
@@ -190,14 +205,19 @@ test('pnpm recursive exec --no-sort', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
     linkWorkspacePackages: true,
+    selectedWsPkgsGraph,
   })
   await recursive.handler(['exec', 'npm', 'run', 'build'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
     sort: false,
     workspaceConcurrency: 1,
   })

--- a/packages/plugin-commands-recursive/test/link.ts
+++ b/packages/plugin-commands-recursive/test/link.ts
@@ -4,7 +4,7 @@ import { preparePackages } from '@pnpm/prepare'
 import path = require('path')
 import exists = require('path-exists')
 import test = require('tape')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 test('recursive linking/unlinking', async (t) => {
   const projects = preparePackages(t, [
@@ -26,9 +26,12 @@ test('recursive linking/unlinking', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   t.ok(projects['is-positive'].requireModule('is-negative'))
@@ -41,7 +44,9 @@ test('recursive linking/unlinking', async (t) => {
 
   await recursive.handler(['unlink'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   process.chdir('project-1')
@@ -80,9 +85,12 @@ test('recursive unlink specific package', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   t.ok(projects['is-positive'].requireModule('is-negative'))
@@ -95,7 +103,9 @@ test('recursive unlink specific package', async (t) => {
 
   await recursive.handler(['unlink', 'is-positive'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   process.chdir('project-1')

--- a/packages/plugin-commands-recursive/test/outdated.ts
+++ b/packages/plugin-commands-recursive/test/outdated.ts
@@ -4,7 +4,7 @@ import { stripIndent } from 'common-tags'
 import stripAnsi = require('strip-ansi')
 import test = require('tape')
 import writeYamlFile = require('write-yaml-file')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 test('pnpm recursive outdated', async (t) => {
   preparePackages(t, [
@@ -37,15 +37,20 @@ test('pnpm recursive outdated', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   {
     const output = await recursive.handler(['outdated'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
 
     t.equal(stripAnsi(output as unknown as string), stripIndent`
@@ -64,8 +69,10 @@ test('pnpm recursive outdated', async (t) => {
   {
     const output = await recursive.handler(['outdated'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
       long: true,
+      selectedWsPkgsGraph,
     })
 
     t.equal(stripAnsi(output as unknown as string), stripIndent`
@@ -84,7 +91,9 @@ test('pnpm recursive outdated', async (t) => {
   {
     const output = await recursive.handler(['outdated'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
       table: false,
     })
 
@@ -106,8 +115,10 @@ test('pnpm recursive outdated', async (t) => {
   {
     const output = await recursive.handler(['outdated'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
       long: true,
+      selectedWsPkgsGraph,
       table: false,
     })
 
@@ -132,7 +143,9 @@ test('pnpm recursive outdated', async (t) => {
   {
     const output = await recursive.handler(['outdated', 'is-positive'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
 
     t.equal(stripAnsi(output as unknown as string), stripIndent`
@@ -179,15 +192,20 @@ test('pnpm recursive outdated in workspace with shared lockfile', async (t) => {
 
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   {
     const output = await recursive.handler(['outdated'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
 
     t.equal(stripAnsi(output as unknown as string), stripIndent`
@@ -206,7 +224,9 @@ test('pnpm recursive outdated in workspace with shared lockfile', async (t) => {
   {
     const output = await recursive.handler(['outdated', 'is-positive'], {
       ...DEFAULT_OPTS,
+      allWsPkgs,
       dir: process.cwd(),
+      selectedWsPkgsGraph,
     })
 
     t.equal(stripAnsi(output as unknown as string), stripIndent`

--- a/packages/plugin-commands-recursive/test/publish.ts
+++ b/packages/plugin-commands-recursive/test/publish.ts
@@ -4,7 +4,7 @@ import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import execa = require('execa')
 import fs = require('mz/fs')
 import test = require('tape')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 const CREDENTIALS = [
   `--registry=http://localhost:${REGISTRY_MOCK_PORT}/`,
@@ -67,6 +67,7 @@ test('recursive publish', async (t) => {
 
   await recursive.handler(['publish'], {
     ...DEFAULT_OPTS,
+    ...await readWsPkgs(process.cwd(), []),
     dir: process.cwd(),
   })
 
@@ -83,6 +84,7 @@ test('recursive publish', async (t) => {
 
   await recursive.handler(['publish'], {
     ...DEFAULT_OPTS,
+    ...await readWsPkgs(process.cwd(), []),
     dir: process.cwd(),
     tag: 'next',
   })

--- a/packages/plugin-commands-recursive/test/rebuild.ts
+++ b/packages/plugin-commands-recursive/test/rebuild.ts
@@ -4,7 +4,7 @@ import { PackageManifest } from '@pnpm/types'
 import path = require('path')
 import test = require('tape')
 import writeYamlFile = require('write-yaml-file')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 test('pnpm recursive rebuild', async (t) => {
   const projects = preparePackages(t, [
@@ -26,10 +26,13 @@ test('pnpm recursive rebuild', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
     ignoreScripts: true,
+    selectedWsPkgsGraph,
   })
 
   await projects['project-1'].hasNot('pre-and-postinstall-scripts-example/generated-by-preinstall.js')
@@ -39,7 +42,9 @@ test('pnpm recursive rebuild', async (t) => {
 
   await recursive.handler(['rebuild'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   await projects['project-1'].has('pre-and-postinstall-scripts-example/generated-by-preinstall.js')
@@ -97,15 +102,20 @@ test.skip('rebuild multiple packages in correct order', async (t) => {
   preparePackages(t, pkgs)
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['project-1'] })
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
     ignoreScripts: true,
+    selectedWsPkgsGraph,
   })
 
   await recursive.handler(['rebuild'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   const outputs1 = await import(path.resolve('output1.json')) as string[]

--- a/packages/plugin-commands-recursive/test/test.ts
+++ b/packages/plugin-commands-recursive/test/test.ts
@@ -1,8 +1,9 @@
+import { filterPkgsBySelectorObjects } from '@pnpm/filter-workspace-packages'
 import { recursive } from '@pnpm/plugin-commands-recursive'
 import { preparePackages } from '@pnpm/prepare'
 import path = require('path')
 import test = require('tape')
-import { DEFAULT_OPTS } from './utils'
+import { DEFAULT_OPTS, readWsPkgs } from './utils'
 
 test('pnpm recursive test', async (t) => {
   const projects = preparePackages(t, [
@@ -49,13 +50,18 @@ test('pnpm recursive test', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
   await recursive.handler(['test'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   const outputs1 = await import(path.resolve('output1.json')) as string[]
@@ -96,14 +102,19 @@ test('`pnpm recursive test` does not fail if none of the packaegs has a test com
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   await recursive.handler(['test'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
 
   t.pass('command did not fail')
@@ -137,14 +148,22 @@ test('pnpm recursive test with filtering', async (t) => {
     },
   ])
 
+  const { allWsPkgs, selectedWsPkgsGraph } = await readWsPkgs(process.cwd(), [])
   await recursive.handler(['install'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
+    selectedWsPkgsGraph,
   })
   await recursive.handler(['test'], {
     ...DEFAULT_OPTS,
+    allWsPkgs,
     dir: process.cwd(),
-    filter: ['project-1'],
+    selectedWsPkgsGraph: await filterPkgsBySelectorObjects(
+      allWsPkgs,
+      [{ namePattern: 'project-1' }],
+      { workspaceDir: process.cwd() },
+    ),
   })
 
   const outputs = await import(path.resolve('output.json')) as string[]

--- a/packages/plugin-commands-recursive/test/utils.ts
+++ b/packages/plugin-commands-recursive/test/utils.ts
@@ -1,3 +1,5 @@
+import { filterPkgsBySelectorObjects, PackageSelector } from '@pnpm/filter-workspace-packages'
+import findWorkspacePackages from '@pnpm/find-workspace-packages'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 
 const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}`
@@ -43,4 +45,19 @@ export const DEFAULT_OPTS = {
   useRunningStoreServer: false,
   useStoreServer: false,
   workspaceConcurrency: 4,
+}
+
+export async function readWsPkgs (
+  workspaceDir: string,
+  pkgSelectors: PackageSelector[],
+) {
+  const allWsPkgs = await findWorkspacePackages(workspaceDir, {})
+  const selectedWsPkgsGraph = await filterPkgsBySelectorObjects(
+    allWsPkgs,
+    pkgSelectors,
+    {
+      workspaceDir,
+    },
+  )
+  return { allWsPkgs, selectedWsPkgsGraph }
 }

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -26,6 +26,7 @@
     "@pnpm/core-loggers": "workspace:4.0.0",
     "@pnpm/default-reporter": "workspace:5.0.5",
     "@pnpm/file-reporter": "0.1.0",
+    "@pnpm/filter-workspace-packages": "workspace:1.0.1",
     "@pnpm/find-workspace-dir": "workspace:1.0.0",
     "@pnpm/logger": "3.1.0",
     "@pnpm/parse-cli-args": "workspace:0.1.3",
@@ -48,6 +49,7 @@
     "graceful-fs": "4.2.1",
     "is-ci": "2.0.0",
     "loud-rejection": "2.2.0",
+    "pkgs-graph": "workspace:5.0.1",
     "ramda": "0.26.1",
     "render-help": "0.0.0",
     "update-notifier": "4.0.0"

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -172,17 +172,18 @@ export default async function run (inputArgv: string[]) {
     await pnpmCmds.server(['stop'], config as any) // tslint:disable-line:no-any
   }
 
-  if (workspaceDir && cmd === 'recursive') {
-    const allWsPkgs = await findWorkspacePackages(workspaceDir, config)
+  if (cmd === 'recursive') {
+    const wsDir = workspaceDir ?? process.cwd()
+    const allWsPkgs = await findWorkspacePackages(wsDir, config)
 
     if (!allWsPkgs.length) {
-      console.log(`No packages found in "${workspaceDir}"`)
+      console.log(`No packages found in "${wsDir}"`)
       process.exit(0)
       return
     }
     config.selectedWsPkgsGraph = await filterPackages(allWsPkgs, config.filter ?? [], {
       prefix: process.cwd(),
-      workspaceDir,
+      workspaceDir: wsDir,
     })
     config.allWsPkgs = allWsPkgs
   }

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -19,6 +19,8 @@ import {
   types as allTypes,
 } from '@pnpm/config'
 import { scopeLogger } from '@pnpm/core-loggers'
+import { filterPackages } from '@pnpm/filter-workspace-packages'
+import findWorkspacePackages from '@pnpm/find-workspace-packages'
 import logger from '@pnpm/logger'
 import parseCliArgs from '@pnpm/parse-cli-args'
 import isCI = require('is-ci')
@@ -168,6 +170,21 @@ export default async function run (inputArgv: string[]) {
 
   if (selfUpdate) {
     await pnpmCmds.server(['stop'], config as any) // tslint:disable-line:no-any
+  }
+
+  if (workspaceDir && cmd === 'recursive') {
+    const allWsPkgs = await findWorkspacePackages(workspaceDir, config)
+
+    if (!allWsPkgs.length) {
+      console.log(`No packages found in "${workspaceDir}"`)
+      process.exit(0)
+      return
+    }
+    config.selectedWsPkgsGraph = await filterPackages(allWsPkgs, config.filter ?? [], {
+      prefix: process.cwd(),
+      workspaceDir,
+    })
+    config.allWsPkgs = allWsPkgs
   }
 
   // NOTE: we defer the next stage, otherwise reporter might not catch all the logs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1338,6 +1338,7 @@ importers:
       '@pnpm/config': 'link:../config'
       '@pnpm/constants': 'link:../constants'
       '@pnpm/error': 'link:../error'
+      '@pnpm/filter-workspace-packages': 'link:../filter-workspace-packages'
       '@pnpm/find-workspace-dir': 'link:../find-workspace-dir'
       '@pnpm/find-workspace-packages': 'link:../find-workspace-packages'
       '@pnpm/package-store': 'link:../package-store'
@@ -1365,6 +1366,7 @@ importers:
       '@pnpm/config': 'workspace:6.0.0'
       '@pnpm/constants': 'workspace:3.0.0'
       '@pnpm/error': 'workspace:1.0.0'
+      '@pnpm/filter-workspace-packages': 'workspace:1.0.1'
       '@pnpm/find-workspace-dir': 'workspace:1.0.0'
       '@pnpm/find-workspace-packages': 'workspace:2.0.8'
       '@pnpm/package-store': 'workspace:7.0.2'
@@ -1910,6 +1912,7 @@ importers:
       '@pnpm/core-loggers': 'link:../core-loggers'
       '@pnpm/default-reporter': 'link:../default-reporter'
       '@pnpm/file-reporter': 0.1.0
+      '@pnpm/filter-workspace-packages': 'link:../filter-workspace-packages'
       '@pnpm/find-workspace-dir': 'link:../find-workspace-dir'
       '@pnpm/logger': 3.1.0
       '@pnpm/parse-cli-args': 'link:../parse-cli-args'
@@ -1932,6 +1935,7 @@ importers:
       graceful-fs: 4.2.1
       is-ci: 2.0.0
       loud-rejection: 2.2.0
+      pkgs-graph: 'link:../pkgs-graph'
       ramda: 0.26.1
       render-help: 0.0.0
       update-notifier: 4.0.0
@@ -1996,6 +2000,7 @@ importers:
       '@pnpm/core-loggers': 'workspace:4.0.0'
       '@pnpm/default-reporter': 'workspace:5.0.5'
       '@pnpm/file-reporter': 0.1.0
+      '@pnpm/filter-workspace-packages': 'workspace:1.0.1'
       '@pnpm/find-workspace-dir': 'workspace:1.0.0'
       '@pnpm/find-workspace-packages': 'workspace:2.0.8'
       '@pnpm/lockfile-types': 'workspace:1.1.0'
@@ -2057,6 +2062,7 @@ importers:
       npm-run-all: 4.1.5
       p-any: 2.1.0
       path-exists: 4.0.0
+      pkgs-graph: 'workspace:5.0.1'
       pnpm: 'link:'
       ramda: 0.26.1
       read-yaml-file: 1.1.0


### PR DESCRIPTION
This changes will allow to move the recursive commands to the
plugins they belong to.

For instance, "pnpm install -r" should be handled by the same
plugin as "pnpm install"