### PR TITLE
feat: outdated --dev | --production | --no-optional

### DIFF
--- a/fixtures/has-outdated-deps/node_modules/.pnpm/lock.yaml
+++ b/fixtures/has-outdated-deps/node_modules/.pnpm/lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   deprecated: 1.0.0
   is-negative: 1.0.0
+devDependencies:
   is-positive: 1.0.0
 lockfileVersion: 5
 packages:
@@ -13,6 +14,7 @@ packages:
     resolution:
       integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
   /is-positive/1.0.0:
+    dev:  true
     resolution:
       integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=
 specifiers:

--- a/fixtures/has-outdated-deps/package.json
+++ b/fixtures/has-outdated-deps/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "dependencies": {
     "deprecated": "1.0.0",
-    "is-negative": "^2.1.0",
+    "is-negative": "^2.1.0"
+  },
+  "devDependencies": {
     "is-positive": "^3.1.0"
   }
 }

--- a/fixtures/has-outdated-deps/pnpm-lock.yaml
+++ b/fixtures/has-outdated-deps/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   deprecated: 1.0.0
   is-negative: 1.1.0
+devDependencies:
   is-positive: 3.1.0
 lockfileVersion: 5
 packages:
@@ -13,6 +14,7 @@ packages:
     resolution:
       integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
   /is-positive/3.1.0:
+    dev: true
     resolution:
       integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
 specifiers:

--- a/packages/outdated/src/index.ts
+++ b/packages/outdated/src/index.ts
@@ -7,6 +7,7 @@ import { nameVerFromPkgSnapshot } from '@pnpm/lockfile-utils'
 import {
   DEPENDENCIES_FIELDS,
   DependenciesField,
+  IncludedDependencies,
   PackageManifest,
   ProjectManifest,
 } from '@pnpm/types'
@@ -27,11 +28,12 @@ export interface OutdatedPackage {
 export default async function outdated (
   opts: {
     currentLockfile: Lockfile | null,
-    match?: (dependencyName: string) => boolean,
-    manifest: ProjectManifest,
-    prefix: string,
     getLatestManifest: GetLatestManifestFunction,
+    include?: IncludedDependencies,
     lockfileDir: string,
+    manifest: ProjectManifest,
+    match?: (dependencyName: string) => boolean,
+    prefix: string,
     wantedLockfile: Lockfile,
   },
 ): Promise<OutdatedPackage[]> {
@@ -43,7 +45,10 @@ export default async function outdated (
 
   await Promise.all(
     DEPENDENCIES_FIELDS.map(async (depType) => {
-      if (!opts.wantedLockfile.importers[importerId][depType]) return
+      if (
+        opts.include?.[depType] === false ||
+        !opts.wantedLockfile.importers[importerId][depType]
+      ) return
 
       let pkgs = Object.keys(opts.wantedLockfile.importers[importerId][depType]!)
 

--- a/packages/plugin-commands-outdated/src/outdated.ts
+++ b/packages/plugin-commands-outdated/src/outdated.ts
@@ -84,15 +84,15 @@ export function help () {
             name: '--no-table',
           },
           {
-            description: 'Analyze only "dependencies" and "optionalDependencies"',
+            description: 'Check only "dependencies" and "optionalDependencies"',
             name: '--production',
           },
           {
-            description: 'Analyze only "devDependencies"',
+            description: 'Check only "devDependencies"',
             name: '--dev',
           },
           {
-            description: `Don't analyze "optionalDependencies"`,
+            description: `Don't check "optionalDependencies"`,
             name: '--no-optional',
           },
           OPTIONS.globalDir,

--- a/packages/plugin-commands-outdated/test/index.ts
+++ b/packages/plugin-commands-outdated/test/index.ts
@@ -52,19 +52,63 @@ test('pnpm outdated: show details', async (t) => {
   })
 
   t.equal(stripAnsi(output), stripIndent`
-  ┌─────────────┬─────────┬────────────┬─────────────────────────────────────────────┐
-  │ Package     │ Current │ Latest     │ Details                                     │
-  ├─────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
-  │ deprecated  │ 1.0.0   │ Deprecated │ This package is deprecated. Lorem ipsum     │
-  │             │         │            │ dolor sit amet, consectetur adipiscing      │
-  │             │         │            │ elit.                                       │
-  │             │         │            │ https://foo.bar/qar                         │
-  ├─────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
-  │ is-negative │ 1.0.0   │ 2.1.0      │ https://github.com/kevva/is-negative#readme │
-  ├─────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
-  │ is-positive │ 1.0.0   │ 3.1.0      │ https://github.com/kevva/is-positive#readme │
-  └─────────────┴─────────┴────────────┴─────────────────────────────────────────────┘
+  ┌───────────────────┬─────────┬────────────┬─────────────────────────────────────────────┐
+  │ Package           │ Current │ Latest     │ Details                                     │
+  ├───────────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
+  │ deprecated        │ 1.0.0   │ Deprecated │ This package is deprecated. Lorem ipsum     │
+  │                   │         │            │ dolor sit amet, consectetur adipiscing      │
+  │                   │         │            │ elit.                                       │
+  │                   │         │            │ https://foo.bar/qar                         │
+  ├───────────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
+  │ is-negative       │ 1.0.0   │ 2.1.0      │ https://github.com/kevva/is-negative#readme │
+  ├───────────────────┼─────────┼────────────┼─────────────────────────────────────────────┤
+  │ is-positive (dev) │ 1.0.0   │ 3.1.0      │ https://github.com/kevva/is-positive#readme │
+  └───────────────────┴─────────┴────────────┴─────────────────────────────────────────────┘
   ` + '\n')
+  t.end()
+})
+
+test('pnpm outdated: showing only prod or dev dependencies', async (t) => {
+  tempDir(t)
+
+  await makeDir(path.resolve('node_modules/.pnpm'))
+  await copyFile(path.join(hasOutdatedDepsFixture, 'node_modules/.pnpm/lock.yaml'), path.resolve('node_modules/.pnpm/lock.yaml'))
+  await copyFile(path.join(hasOutdatedDepsFixture, 'package.json'), path.resolve('package.json'))
+
+  {
+    const output = await outdated.handler([], {
+      ...OUTDATED_OPTIONS,
+      dir: process.cwd(),
+      production: false,
+    })
+
+    t.equal(stripAnsi(output), stripIndent`
+    ┌───────────────────┬─────────┬────────┐
+    │ Package           │ Current │ Latest │
+    ├───────────────────┼─────────┼────────┤
+    │ is-positive (dev) │ 1.0.0   │ 3.1.0  │
+    └───────────────────┴─────────┴────────┘
+    ` + '\n')
+  }
+
+  {
+    const output = await outdated.handler([], {
+      ...OUTDATED_OPTIONS,
+      dev: false,
+      dir: process.cwd(),
+    })
+
+    t.equal(stripAnsi(output), stripIndent`
+    ┌─────────────┬─────────┬────────────┐
+    │ Package     │ Current │ Latest     │
+    ├─────────────┼─────────┼────────────┤
+    │ deprecated  │ 1.0.0   │ Deprecated │
+    ├─────────────┼─────────┼────────────┤
+    │ is-negative │ 1.0.0   │ 2.1.0      │
+    └─────────────┴─────────┴────────────┘
+    ` + '\n')
+  }
+
   t.end()
 })
 
@@ -89,7 +133,7 @@ test('pnpm outdated: no table', async (t) => {
     is-negative
     1.0.0 => 2.1.0
 
-    is-positive
+    is-positive (dev)
     1.0.0 => 3.1.0
     ` + '\n')
   }
@@ -114,7 +158,7 @@ test('pnpm outdated: no table', async (t) => {
     1.0.0 => 2.1.0
     https://github.com/kevva/is-negative#readme
 
-    is-positive
+    is-positive (dev)
     1.0.0 => 3.1.0
     https://github.com/kevva/is-positive#readme
     ` + '\n')
@@ -135,15 +179,15 @@ test('pnpm outdated: only current lockfile is available', async (t) => {
   })
 
   t.equal(stripAnsi(output), stripIndent`
-  ┌─────────────┬─────────┬────────────┐
-  │ Package     │ Current │ Latest     │
-  ├─────────────┼─────────┼────────────┤
-  │ deprecated  │ 1.0.0   │ Deprecated │
-  ├─────────────┼─────────┼────────────┤
-  │ is-negative │ 1.0.0   │ 2.1.0      │
-  ├─────────────┼─────────┼────────────┤
-  │ is-positive │ 1.0.0   │ 3.1.0      │
-  └─────────────┴─────────┴────────────┘
+  ┌───────────────────┬─────────┬────────────┐
+  │ Package           │ Current │ Latest     │
+  ├───────────────────┼─────────┼────────────┤
+  │ deprecated        │ 1.0.0   │ Deprecated │
+  ├───────────────────┼─────────┼────────────┤
+  │ is-negative       │ 1.0.0   │ 2.1.0      │
+  ├───────────────────┼─────────┼────────────┤
+  │ is-positive (dev) │ 1.0.0   │ 3.1.0      │
+  └───────────────────┴─────────┴────────────┘
   ` + '\n')
   t.end()
 })
@@ -160,15 +204,15 @@ test('pnpm outdated: only wanted lockfile is available', async (t) => {
   })
 
   t.equal(stripAnsi(output), stripIndent`
-  ┌─────────────┬────────────────────────┬────────────┐
-  │ Package     │ Current                │ Latest     │
-  ├─────────────┼────────────────────────┼────────────┤
-  │ deprecated  │ missing (wanted 1.0.0) │ Deprecated │
-  ├─────────────┼────────────────────────┼────────────┤
-  │ is-positive │ missing (wanted 3.1.0) │ 3.1.0      │
-  ├─────────────┼────────────────────────┼────────────┤
-  │ is-negative │ missing (wanted 1.1.0) │ 2.1.0      │
-  └─────────────┴────────────────────────┴────────────┘
+  ┌───────────────────┬────────────────────────┬────────────┐
+  │ Package           │ Current                │ Latest     │
+  ├───────────────────┼────────────────────────┼────────────┤
+  │ deprecated        │ missing (wanted 1.0.0) │ Deprecated │
+  ├───────────────────┼────────────────────────┼────────────┤
+  │ is-positive (dev) │ missing (wanted 3.1.0) │ 3.1.0      │
+  ├───────────────────┼────────────────────────┼────────────┤
+  │ is-negative       │ missing (wanted 1.1.0) │ 2.1.0      │
+  └───────────────────┴────────────────────────┴────────────┘
   ` + '\n')
   t.end()
 })

--- a/packages/plugin-commands-outdated/test/recursive.ts
+++ b/packages/plugin-commands-outdated/test/recursive.ts
@@ -75,6 +75,25 @@ test('pnpm recursive outdated', async (t) => {
       ...DEFAULT_OPTS,
       allProjects,
       dir: process.cwd(),
+      production: false,
+      recursive: true,
+      selectedProjectsGraph,
+    })
+
+    t.equal(stripAnsi(output as unknown as string), stripIndent`
+    ┌───────────────────┬─────────┬────────┬────────────┐
+    │ Package           │ Current │ Latest │ Dependents │
+    ├───────────────────┼─────────┼────────┼────────────┤
+    │ is-negative (dev) │ 1.0.0   │ 2.1.0  │ project-3  │
+    └───────────────────┴─────────┴────────┴────────────┘
+    ` + '\n')
+  }
+
+  {
+    const output = await outdated.handler([], {
+      ...DEFAULT_OPTS,
+      allProjects,
+      dir: process.cwd(),
       long: true,
       recursive: true,
       selectedProjectsGraph,
@@ -227,6 +246,25 @@ test('pnpm recursive outdated in workspace with shared lockfile', async (t) => {
     ├───────────────────┼─────────┼────────┼──────────────────────┤
     │ is-positive       │ 1.0.0   │ 3.1.0  │ project-1, project-3 │
     └───────────────────┴─────────┴────────┴──────────────────────┘
+    ` + '\n')
+  }
+
+  {
+    const output = await outdated.handler([], {
+      ...DEFAULT_OPTS,
+      allProjects,
+      dir: process.cwd(),
+      production: false,
+      recursive: true,
+      selectedProjectsGraph,
+    })
+
+    t.equal(stripAnsi(output as unknown as string), stripIndent`
+    ┌───────────────────┬─────────┬────────┬────────────┐
+    │ Package           │ Current │ Latest │ Dependents │
+    ├───────────────────┼─────────┼────────┼────────────┤
+    │ is-negative (dev) │ 1.0.0   │ 2.1.0  │ project-3  │
+    └───────────────────┴─────────┴────────┴────────────┘
     ` + '\n')
   }
 


### PR DESCRIPTION
This adds the ability to show only outdated dev or prod dependencies

```
pnpm [-r] outdated --dev
pnpm [-r] outdated --production [--no-optional]
pnpm [-r] outdated --no-optional
```