### PR TITLE
feat: filtering by location including deps/dependents

### DIFF
--- a/packages/common-cli-options-help/src/index.ts
+++ b/packages/common-cli-options-help/src/index.ts
@@ -72,7 +72,7 @@ export const FILTERING = {
       name: '--filter .',
     },
     {
-      description: 'Includes all projects that are under the specified directory. Can be used with "..." to select dependents/dependencies as well. Can be combined with [<since>], for instance, all changed projects inside a directory: {packages}[origin/master]',
+      description: 'Includes all projects that are under the specified directory. It may be used with "..." to select dependents/dependencies as well. It also may be combined with [<since>]. For instance, all changed projects inside a directory: {packages}[origin/master]',
       name: '--filter {<dir>}',
     },
     {

--- a/packages/common-cli-options-help/src/index.ts
+++ b/packages/common-cli-options-help/src/index.ts
@@ -72,7 +72,7 @@ export const FILTERING = {
       name: '--filter .',
     },
     {
-      description: 'Includes all projects that are under the specified directory. Can be used with "..." to select dependents/dependencies as well',
+      description: 'Includes all projects that are under the specified directory. Can be used with "..." to select dependents/dependencies as well. Can be combined with [<since>], for instance, all changed projects inside a directory: {packages}[origin/master]',
       name: '--filter {<dir>}',
     },
     {

--- a/packages/common-cli-options-help/src/index.ts
+++ b/packages/common-cli-options-help/src/index.ts
@@ -72,6 +72,10 @@ export const FILTERING = {
       name: '--filter .',
     },
     {
+      description: 'Includes all projects that are under the specified directory. Can be used with "..." to select dependents/dependencies as well',
+      name: '--filter {<dir>}',
+    },
+    {
       description: 'Includes all packages changed since the specified commit/branch. E.g.: [master], [HEAD~2]. It may be used together with "...". So, for instance, ...[HEAD~1] selects all packages changed in the last commit and their dependents',
       name: '--filter [<since>]',
     },

--- a/packages/filter-workspace-packages/src/index.ts
+++ b/packages/filter-workspace-packages/src/index.ts
@@ -78,10 +78,11 @@ export default async function filterGraph<T> (
     let entryPackages: string[]
     if (selector.namePattern) {
       entryPackages = matchPackages(pkgGraph, selector.namePattern)
+    } else if (selector.diff) {
+      entryPackages = await getChangedPkgs(Object.keys(pkgGraph),
+        selector.diff, { workspaceDir: selector.parentDir ?? opts.workspaceDir })
     } else if (selector.parentDir) {
       entryPackages = matchPackagesByPath(pkgGraph, selector.parentDir)
-    } else if (selector.diff) {
-      entryPackages = await getChangedPkgs(Object.keys(pkgGraph), selector.diff, { workspaceDir: opts.workspaceDir })
     } else {
       throw new Error(`Unsupported package selector: ${JSON.stringify(selector)}`)
     }

--- a/packages/filter-workspace-packages/src/index.ts
+++ b/packages/filter-workspace-packages/src/index.ts
@@ -75,15 +75,22 @@ export default async function filterGraph<T> (
   const graph = pkgGraphToGraph(pkgGraph)
   let reversedGraph: Graph | undefined
   for (const selector of packageSelectors) {
-    let entryPackages: string[]
-    if (selector.namePattern) {
-      entryPackages = matchPackages(pkgGraph, selector.namePattern)
-    } else if (selector.diff) {
+    let entryPackages: string[] | null = null
+    if (selector.diff) {
       entryPackages = await getChangedPkgs(Object.keys(pkgGraph),
         selector.diff, { workspaceDir: selector.parentDir ?? opts.workspaceDir })
     } else if (selector.parentDir) {
       entryPackages = matchPackagesByPath(pkgGraph, selector.parentDir)
-    } else {
+    }
+    if (selector.namePattern) {
+      if (!entryPackages) {
+        entryPackages = matchPackages(pkgGraph, selector.namePattern)
+      } else {
+        entryPackages = matchPackages(R.pick(entryPackages, pkgGraph), selector.namePattern)
+      }
+    }
+
+    if (!entryPackages) {
       throw new Error(`Unsupported package selector: ${JSON.stringify(selector)}`)
     }
 

--- a/packages/filter-workspace-packages/src/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/src/parsePackageSelector.ts
@@ -27,40 +27,27 @@ export default (rawSelector: string, prefix: string): PackageSelector => {
       rawSelector = rawSelector.substr(1)
     }
   }
-  if (rawSelector.startsWith('{') && rawSelector.endsWith('}')) {
-    return {
-      excludeSelf,
-      includeDependencies,
-      includeDependents,
-      parentDir: path.join(prefix, rawSelector.substr(1, rawSelector.length - 2)),
+  const matches = rawSelector.match(/^([^.][^{}[\]]*)?(\{[^\}]+\})?(\[[^\]]+\])?$/)
+  if (matches === null) {
+    if (isSelectorByLocation(rawSelector)) {
+      return {
+        excludeSelf: false,
+        parentDir: path.join(prefix, rawSelector),
+      }
     }
-  }
-  if (rawSelector.startsWith('[') && rawSelector.endsWith(']')) {
     return {
-      diff: rawSelector.substr(1, rawSelector.length - 2),
-      excludeSelf,
-      includeDependencies,
-      includeDependents,
-    }
-  }
-  if (includeDependencies || includeDependents) {
-    return {
-      excludeSelf,
-      includeDependencies,
-      includeDependents,
+      excludeSelf: false,
       namePattern: rawSelector,
     }
   }
 
-  if (isSelectorByLocation(rawSelector)) {
-    return {
-      excludeSelf: false,
-      parentDir: path.join(prefix, rawSelector),
-    }
-  }
   return {
-    excludeSelf: false,
-    namePattern: rawSelector,
+    diff: matches[3] && matches[3].substr(1, matches[3].length - 2),
+    excludeSelf,
+    includeDependencies,
+    includeDependents,
+    namePattern: matches[1],
+    parentDir: matches[2] && path.join(prefix, matches[2].substr(1, matches[2].length - 2)),
   }
 }
 

--- a/packages/filter-workspace-packages/src/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/src/parsePackageSelector.ts
@@ -27,6 +27,14 @@ export default (rawSelector: string, prefix: string): PackageSelector => {
       rawSelector = rawSelector.substr(1)
     }
   }
+  if (rawSelector.startsWith('{') && rawSelector.endsWith('}')) {
+    return {
+      excludeSelf,
+      includeDependencies,
+      includeDependents,
+      parentDir: path.join(prefix, rawSelector.substr(1, rawSelector.length - 2)),
+    }
+  }
   if (rawSelector.startsWith('[') && rawSelector.endsWith(']')) {
     return {
       diff: rawSelector.substr(1, rawSelector.length - 2),

--- a/packages/filter-workspace-packages/test/index.ts
+++ b/packages/filter-workspace-packages/test/index.ts
@@ -229,6 +229,8 @@ test('select changed packages', async (t) => {
   await execa('git', ['add', '.'], { cwd: workspaceDir })
   await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: workspaceDir })
 
+  const pkg20Dir = path.join(workspaceDir, 'package-20')
+
   const pkgsGraph = {
     [workspaceDir]: {
       dependencies: [],
@@ -260,6 +262,16 @@ test('select changed packages', async (t) => {
         },
       },
     },
+    [pkg20Dir]: {
+      dependencies: [],
+      package: {
+        dir: pkg20Dir,
+        manifest: {
+          name: 'package-20',
+          version: '0.0.0',
+        },
+      },
+    },
   }
 
   {
@@ -273,6 +285,14 @@ test('select changed packages', async (t) => {
     const selection = await filterWorkspacePackages(pkgsGraph, [{
       diff: 'HEAD~1',
       parentDir: pkg2Dir,
+    }], { workspaceDir })
+
+    t.deepEqual(Object.keys(selection), [pkg2Dir])
+  }
+  {
+    const selection = await filterWorkspacePackages(pkgsGraph, [{
+      diff: 'HEAD~1',
+      namePattern: 'package-2*',
     }], { workspaceDir })
 
     t.deepEqual(Object.keys(selection), [pkg2Dir])

--- a/packages/filter-workspace-packages/test/index.ts
+++ b/packages/filter-workspace-packages/test/index.ts
@@ -221,10 +221,15 @@ test('select changed packages', async (t) => {
   await mkdir(pkg1Dir)
   await touch(path.join(pkg1Dir, 'file.js'))
 
-  await execa('git', ['add', '.'], { cwd: workspaceDir })
-  await execa('git', ['commit', '--allow-empty', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: workspaceDir })
+  const pkg2Dir = path.join(workspaceDir, 'package-2')
 
-  const selection = await filterWorkspacePackages({
+  await mkdir(pkg2Dir)
+  await touch(path.join(pkg2Dir, 'file.js'))
+
+  await execa('git', ['add', '.'], { cwd: workspaceDir })
+  await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: workspaceDir })
+
+  const pkgsGraph = {
     [workspaceDir]: {
       dependencies: [],
       package: {
@@ -245,11 +250,33 @@ test('select changed packages', async (t) => {
         },
       },
     },
-  }, [{
-    diff: 'HEAD~1',
-  }], { workspaceDir })
+    [pkg2Dir]: {
+      dependencies: [],
+      package: {
+        dir: pkg2Dir,
+        manifest: {
+          name: 'package-2',
+          version: '0.0.0',
+        },
+      },
+    },
+  }
 
-  t.deepEqual(Object.keys(selection), [pkg1Dir])
+  {
+    const selection = await filterWorkspacePackages(pkgsGraph, [{
+      diff: 'HEAD~1',
+    }], { workspaceDir })
+
+    t.deepEqual(Object.keys(selection), [pkg1Dir, pkg2Dir])
+  }
+  {
+    const selection = await filterWorkspacePackages(pkgsGraph, [{
+      diff: 'HEAD~1',
+      parentDir: pkg2Dir,
+    }], { workspaceDir })
+
+    t.deepEqual(Object.keys(selection), [pkg2Dir])
+  }
 
   t.end()
 })

--- a/packages/filter-workspace-packages/test/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/test/parsePackageSelector.ts
@@ -37,6 +37,10 @@ const fixtures: Array<[string, PackageSelector]> = [
     { excludeSelf: false, parentDir: path.resolve('../foo') },
   ],
   [
+    '...{./foo}',
+    { excludeSelf: false, includeDependencies: false, includeDependents: true, parentDir: path.resolve('foo') },
+  ],
+  [
     '.',
     { excludeSelf: false, parentDir: process.cwd() },
   ],

--- a/packages/filter-workspace-packages/test/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/test/parsePackageSelector.ts
@@ -132,6 +132,17 @@ const fixtures: Array<[string, PackageSelector]> = [
     },
   ],
   [
+    'pattern{foo}[master]',
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: false,
+      namePattern: 'pattern',
+      parentDir: path.resolve('foo'),
+    },
+  ],
+  [
     '[master]...',
     {
       diff: 'master',

--- a/packages/filter-workspace-packages/test/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/test/parsePackageSelector.ts
@@ -6,63 +6,163 @@ import test = require('tape')
 const fixtures: Array<[string, PackageSelector]> = [
   [
     'foo',
-    { excludeSelf: false, namePattern: 'foo' },
+    {
+      diff: undefined,
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: false,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     'foo...',
-    { excludeSelf: false, namePattern: 'foo', includeDependencies: true, includeDependents: false },
+    {
+      diff: undefined,
+      excludeSelf: false,
+      includeDependencies: true,
+      includeDependents: false,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     '...foo',
-    { excludeSelf: false, namePattern: 'foo', includeDependencies: false, includeDependents: true },
+    {
+      diff: undefined,
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: true,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     '...foo...',
-    { excludeSelf: false, namePattern: 'foo', includeDependencies: true, includeDependents: true },
+    {
+      diff: undefined,
+      excludeSelf: false,
+      includeDependencies: true,
+      includeDependents: true,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     'foo^...',
-    { excludeSelf: true, namePattern: 'foo', includeDependencies: true, includeDependents: false },
+    {
+      diff: undefined,
+      excludeSelf: true,
+      includeDependencies: true,
+      includeDependents: false,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     '...^foo',
-    { excludeSelf: true, namePattern: 'foo', includeDependencies: false, includeDependents: true },
+    {
+      diff: undefined,
+      excludeSelf: true,
+      includeDependencies: false,
+      includeDependents: true,
+      namePattern: 'foo',
+      parentDir: undefined,
+    },
   ],
   [
     './foo',
-    { excludeSelf: false, parentDir: path.resolve('foo') },
+    {
+      excludeSelf: false,
+      parentDir: path.resolve('foo'),
+    },
   ],
   [
     '../foo',
-    { excludeSelf: false, parentDir: path.resolve('../foo') },
+    {
+      excludeSelf: false,
+      parentDir: path.resolve('../foo'),
+    },
   ],
   [
     '...{./foo}',
-    { excludeSelf: false, includeDependencies: false, includeDependents: true, parentDir: path.resolve('foo') },
+    {
+      diff: undefined,
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: true,
+      namePattern: undefined,
+      parentDir: path.resolve('foo'),
+    },
   ],
   [
     '.',
-    { excludeSelf: false, parentDir: process.cwd() },
+    {
+      excludeSelf: false,
+      parentDir: process.cwd(),
+    },
   ],
   [
     '..',
-    { excludeSelf: false, parentDir: path.resolve('..') },
+    {
+      excludeSelf: false,
+      parentDir: path.resolve('..'),
+    },
   ],
   [
     '[master]',
-    { diff: 'master', excludeSelf: false, includeDependencies: false, includeDependents: false },
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: false,
+      namePattern: undefined,
+      parentDir: undefined,
+    },
+  ],
+  [
+    '{foo}[master]',
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: false,
+      namePattern: undefined,
+      parentDir: path.resolve('foo'),
+    },
   ],
   [
     '[master]...',
-    { diff: 'master', excludeSelf: false, includeDependencies: true, includeDependents: false },
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: true,
+      includeDependents: false,
+      namePattern: undefined,
+      parentDir: undefined,
+    },
   ],
   [
     '...[master]',
-    { diff: 'master', excludeSelf: false, includeDependencies: false, includeDependents: true },
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: false,
+      includeDependents: true,
+      namePattern: undefined,
+      parentDir: undefined,
+    },
   ],
   [
     '...[master]...',
-    { diff: 'master', excludeSelf: false, includeDependencies: true, includeDependents: true },
+    {
+      diff: 'master',
+      excludeSelf: false,
+      includeDependencies: true,
+      includeDependents: true,
+      namePattern: undefined,
+      parentDir: undefined,
+    },
   ],
 ]
 


### PR DESCRIPTION
close #1651

Filtering by directory: `pnpm --filter {dir}`
Including dependents: `pnpm --filter ...{dir}`
Including dependencies: `pnpm --filter {dir}...`
Filtering changed projects inside a directory: `pnpm --filter {dir}[origin/master]`