### PR TITLE
fix: resolving packages in a monorepo

### DIFF
--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -263,8 +263,12 @@ function pickMatchingLocalVersionOrNull (
     case 'version':
       return versions[spec.fetchSpec] ? spec.fetchSpec : null
     case 'range':
+      if (spec.fetchSpec === '*') {
+        return semver.maxSatisfying(localVersions, '*', {
+          includePrerelease: true,
+        })
+      }
       return semver.maxSatisfying(localVersions, spec.fetchSpec, {
-        includePrerelease: true,
         loose: true,
       })
     default:

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -524,8 +524,10 @@ async function linkedPackagesAreUpToDate (
         : workspacePackages?.[depName]?.[importerDeps[depName]]?.dir
       if (!dir) continue
       const linkedPkg = workspacePackagesByDirectory[dir] || await safeReadPkgFromDir(dir)
-      const availableVersion = pkgDeps[depName].startsWith('workspace:') ? pkgDeps[depName].substr(10) : pkgDeps[depName]
-      const localPackageSatisfiesRange = linkedPkg && semver.satisfies(linkedPkg.version, availableVersion)
+      const availableRange = pkgDeps[depName].startsWith('workspace:') ? pkgDeps[depName].substr(10) : pkgDeps[depName]
+      // This should pass the same options to semver as @pnpm/npm-resolver
+      const localPackageSatisfiesRange = availableRange === '*' ||
+        linkedPkg && semver.satisfies(linkedPkg.version, availableRange, { loose: true })
       if (isLinked !== localPackageSatisfiesRange) return false
     }
   }


### PR DESCRIPTION
This fixes a regression introduced by #2172 (pnpm v4.3.3).

Local prerelease version of packages should be linked
only if the range is *