### PR TITLE
fix: CLI output with --parseable

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -162,7 +162,9 @@ export default async function run (inputArgv: string[]) {
     const allProjects = await findWorkspacePackages(wsDir, config)
 
     if (!allProjects.length) {
-      console.log(`No projects found in "${wsDir}"`)
+      if (!config['parseable']) {
+        console.log(`No projects found in "${wsDir}"`)
+      }
       process.exit(0)
       return
     }
@@ -171,7 +173,9 @@ export default async function run (inputArgv: string[]) {
       workspaceDir: wsDir,
     })
     if (R.isEmpty(config.selectedProjectsGraph)) {
-      console.log(`No projects matched the filters in "${wsDir}"`)
+      if (!config['parseable']) {
+        console.log(`No projects matched the filters in "${wsDir}"`)
+      }
       process.exit(0)
       return
     }


### PR DESCRIPTION
Don't print an info message about projects not
being found when --parseable is used.

close #2265
close #1650