### PR TITLE
feat: add validation for readPackage hook's return manifest's dependencies property

### DIFF
--- a/packages/pnpmfile/src/requirePnpmfile.ts
+++ b/packages/pnpmfile/src/requirePnpmfile.ts
@@ -52,9 +52,12 @@ export default (pnpmFilePath: string, prefix: string) => {
         if (!newPkg) {
           throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook did not return a package manifest object.')
         }
-        if (typeof newPkg.dependencies !== 'object') {
-          throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook returned package manifest object\'s property \'dependecies\' must be an object.')
-        }
+        const dependencies = ['dependencies', 'optionalDependencies', 'peerDependencies']
+        dependencies.forEach(dep => {
+          if (newPkg[dep] && typeof newPkg[dep] !== 'object') {
+            throw new BadReadPackageHookError(pnpmFilePath, `readPackage hook returned package manifest object's property '${dep}' must be an object.`)
+          }
+        })
         return newPkg
       }
     }

--- a/packages/pnpmfile/src/requirePnpmfile.ts
+++ b/packages/pnpmfile/src/requirePnpmfile.ts
@@ -53,11 +53,11 @@ export default (pnpmFilePath: string, prefix: string) => {
           throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook did not return a package manifest object.')
         }
         const dependencies = ['dependencies', 'optionalDependencies', 'peerDependencies']
-        dependencies.forEach(dep => {
+        for (let dep of dependencies) {
           if (newPkg[dep] && typeof newPkg[dep] !== 'object') {
             throw new BadReadPackageHookError(pnpmFilePath, `readPackage hook returned package manifest object's property '${dep}' must be an object.`)
           }
-        })
+        }
         return newPkg
       }
     }

--- a/packages/pnpmfile/src/requirePnpmfile.ts
+++ b/packages/pnpmfile/src/requirePnpmfile.ts
@@ -7,8 +7,8 @@ import fs = require('fs')
 class BadReadPackageHookError extends PnpmError {
   public readonly pnpmfile: string
 
-  constructor (pnpmfile: string) {
-    super('BAD_READ_PACKAGE_HOOK_RESULT', `readPackage hook did not return a package manifest object. Hook imported via ${pnpmfile}`)
+  constructor (pnpmfile: string, message: string) {
+    super('BAD_READ_PACKAGE_HOOK_RESULT', `${message} Hook imported via ${pnpmfile}`)
     this.pnpmfile = pnpmfile
   }
 }
@@ -50,7 +50,10 @@ export default (pnpmFilePath: string, prefix: string) => {
         pkg.peerDependencies = pkg.peerDependencies || {}
         const newPkg = readPackage(pkg, ...args)
         if (!newPkg) {
-          throw new BadReadPackageHookError(pnpmFilePath)
+          throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook did not return a package manifest object.')
+        }
+        if (typeof newPkg.dependencies !== 'object') {
+          throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook returned package manifest object\'s property \'dependecies\' must be an object.')
         }
         return newPkg
       }

--- a/packages/pnpmfile/test/index.ts
+++ b/packages/pnpmfile/test/index.ts
@@ -28,7 +28,7 @@ test('readPackage hook run fails when returned dependencies is not an object ', 
     pnpmfile.hooks.readPackage({})
     t.fail('readPackage hook run should fail')
   } catch (err) {
-    t.equal(err.message, `readPackage hook returned package manifest object\'s property \'dependecies\' must be an object. Hook imported via ${pnpmfilePath}`)
+    t.equal(err.message, `readPackage hook returned package manifest object\'s property \'dependencies\' must be an object. Hook imported via ${pnpmfilePath}`)
     t.equal(err.code, 'ERR_PNPM_BAD_READ_PACKAGE_HOOK_RESULT')
     t.end()
   }

--- a/packages/pnpmfile/test/index.ts
+++ b/packages/pnpmfile/test/index.ts
@@ -7,3 +7,29 @@ test('ignoring a pnpmfile that exports undefined', (t) => {
   t.equal(typeof pnpmfile, 'undefined')
   t.end()
 })
+
+test('readPackage hook run fails when returns undefined ', (t) => {
+  const pnpmfilePath = path.join(__dirname, 'pnpmfiles/readPackageNoReturn.js')
+  const pnpmfile = requirePnpmfile(pnpmfilePath, __dirname)
+  try {
+    pnpmfile.hooks.readPackage({})
+    t.fail('readPackage hook run should fail')
+  } catch (err) {
+    t.equal(err.message, `readPackage hook did not return a package manifest object. Hook imported via ${pnpmfilePath}`)
+    t.equal(err.code, 'ERR_PNPM_BAD_READ_PACKAGE_HOOK_RESULT')
+    t.end()
+  }
+})
+
+test('readPackage hook run fails when returned dependencies is not an object ', (t) => {
+  const pnpmfilePath = path.join(__dirname, 'pnpmfiles/readPackageNoObject.js')
+  const pnpmfile = requirePnpmfile(pnpmfilePath, __dirname)
+  try {
+    pnpmfile.hooks.readPackage({})
+    t.fail('readPackage hook run should fail')
+  } catch (err) {
+    t.equal(err.message, `readPackage hook returned package manifest object\'s property \'dependecies\' must be an object. Hook imported via ${pnpmfilePath}`)
+    t.equal(err.code, 'ERR_PNPM_BAD_READ_PACKAGE_HOOK_RESULT')
+    t.end()
+  }
+})

--- a/packages/pnpmfile/test/pnpmfiles/readPackageNoObject.js
+++ b/packages/pnpmfile/test/pnpmfiles/readPackageNoObject.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: {readPackage}
+}
+
+function readPackage(pkg) {
+  pkg.dependencies = ''
+  return pkg
+}

--- a/packages/pnpmfile/test/pnpmfiles/readPackageNoObject.js
+++ b/packages/pnpmfile/test/pnpmfiles/readPackageNoObject.js
@@ -3,6 +3,6 @@ module.exports = {
 }
 
 function readPackage(pkg) {
-  pkg.dependencies = ''
+  pkg.dependencies = '@oclif/errors'
   return pkg
 }

--- a/packages/pnpmfile/test/pnpmfiles/readPackageNoReturn.js
+++ b/packages/pnpmfile/test/pnpmfiles/readPackageNoReturn.js
@@ -1,0 +1,5 @@
+module.exports = {
+  hooks: {readPackage}
+}
+
+function readPackage() { }


### PR DESCRIPTION
manifest's dependencies property must be an object, otherwise it will return an error message

Close #1296