### PR TITLE
fix: add --save-dev -r

### DIFF
--- a/packages/cli-utils/src/getSaveType.ts
+++ b/packages/cli-utils/src/getSaveType.ts
@@ -1,8 +1,10 @@
 import { Config } from '@pnpm/config'
 import { DependenciesField } from '@pnpm/types'
 
-export default function getSaveType (opts: Pick<Config, 'saveDev' | 'saveOptional' | 'saveProd'>): DependenciesField | undefined {
-  if (opts.saveDev) return 'devDependencies'
+export default function getSaveType (
+  opts: Pick<Config, 'saveDev' | 'saveOptional' | 'saveProd' | 'savePeer'>,
+): DependenciesField | undefined {
+  if (opts.saveDev || opts.savePeer) return 'devDependencies'
   if (opts.saveOptional) return 'optionalDependencies'
   if (opts.saveProd) return 'dependencies'
   return undefined

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -280,7 +280,6 @@ export default async (
       throw new PnpmError('CONFIG_CONFLICT_PEER_CANNOT_BE_OPTIONAL_DEP',
         'A package cannot be a peer dependency and an optional dependency at the same time')
     }
-    pnpmConfig.saveDev = true
   }
   if (pnpmConfig.sharedWorkspaceLockfile && !pnpmConfig.lockfileDir && pnpmConfig.workspaceDir) {
     pnpmConfig.lockfileDir = pnpmConfig.workspaceDir

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -44,6 +44,7 @@
     "@types/ramda": "^0.26.40",
     "@types/sinon": "^7.5.1",
     "@types/table": "^4.0.7",
+    "load-json-file": "6.2.0",
     "make-dir": "3.0.0",
     "proxyquire": "2.1.3",
     "read-yaml-file": "1.1.0",

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -116,6 +116,7 @@ export default async function recursive (
   const workspacePackages = cmdFullName !== 'unlink'
     ? arrayOfWorkspacePackagesToMap(allProjects)
     : {}
+  const targetDependenciesField = getSaveType(opts)
   const installOpts = Object.assign(opts, {
     ownLifecycleHooksStdio: 'pipe',
     peer: opts.savePeer,
@@ -123,7 +124,7 @@ export default async function recursive (
       && pkgs.length === allProjects.length,
     storeController,
     storeDir: store.dir,
-    targetDependenciesField: getSaveType(opts) ?? (opts.savePeer ? 'devDependencies' : undefined),
+    targetDependenciesField,
     workspacePackages,
 
     forceHoistPattern: typeof opts.rawLocalConfig['hoist-pattern'] !== 'undefined' || typeof opts.rawLocalConfig['hoist'] !== 'undefined',
@@ -216,7 +217,7 @@ export default async function recursive (
             manifest,
             mutation,
             rootDir,
-            targetDependenciesField: getSaveType(opts),
+            targetDependenciesField,
           } as MutatedProject)
           return
         case 'installSome':
@@ -231,7 +232,7 @@ export default async function recursive (
               savePrefix: typeof localConfig.savePrefix === 'string' ? localConfig.savePrefix : opts.savePrefix,
             }),
             rootDir,
-            targetDependenciesField: getSaveType(opts) ?? (opts.savePeer ? 'devDependencies' : undefined),
+            targetDependenciesField,
           } as MutatedProject)
           return
         case 'install':

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -231,7 +231,7 @@ export default async function recursive (
               savePrefix: typeof localConfig.savePrefix === 'string' ? localConfig.savePrefix : opts.savePrefix,
             }),
             rootDir,
-            targetDependenciesField: getSaveType(opts),
+            targetDependenciesField: getSaveType(opts) ?? (opts.savePeer ? 'devDependencies' : undefined),
           } as MutatedProject)
           return
         case 'install':

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -261,6 +261,8 @@ export default async function recursive (
     ? chunks[0]
     : Object.keys(opts.selectedProjectsGraph).sort()
 
+  installOpts['targetDependenciesField'] = getSaveType(opts)
+
   const limitInstallation = pLimit(opts.workspaceConcurrency ?? 4)
   await Promise.all(pkgPaths.map((rootDir: string) =>
     limitInstallation(async () => {

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -123,6 +123,7 @@ export default async function recursive (
       && pkgs.length === allProjects.length,
     storeController,
     storeDir: store.dir,
+    targetDependenciesField: getSaveType(opts) ?? (opts.savePeer ? 'devDependencies' : undefined),
     workspacePackages,
 
     forceHoistPattern: typeof opts.rawLocalConfig['hoist-pattern'] !== 'undefined' || typeof opts.rawLocalConfig['hoist'] !== 'undefined',
@@ -260,8 +261,6 @@ export default async function recursive (
   let pkgPaths = chunks.length === 0
     ? chunks[0]
     : Object.keys(opts.selectedProjectsGraph).sort()
-
-  installOpts['targetDependenciesField'] = getSaveType(opts)
 
   const limitInstallation = pLimit(opts.workspaceConcurrency ?? 4)
   await Promise.all(pkgPaths.map((rootDir: string) =>

--- a/packages/plugin-commands-installation/test/addRecursive.ts
+++ b/packages/plugin-commands-installation/test/addRecursive.ts
@@ -28,23 +28,46 @@ test('recursive add --save-dev on workspace with multiple lockfiles', async (t) 
     selectedProjectsGraph,
     workspaceDir: process.cwd(),
   })
+  await add.handler(['is-negative@1.0.0'], {
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    recursive: true,
+    savePeer: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
 
-  t.deepEqual(
-    (await import(path.resolve('project-1/package.json'))).devDependencies,
-    { 'is-positive': '1.0.0' },
-  )
-  t.deepEqual(
-    (await projects['project-1'].readLockfile()).devDependencies,
-    { 'is-positive': '1.0.0' },
-  )
+  {
+    const manifest = (await import(path.resolve('project-1/package.json')))
+    t.deepEqual(
+      manifest.devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      manifest.peerDependencies,
+      { 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      (await projects['project-1'].readLockfile()).devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+  }
 
-  t.deepEqual(
-    (await import(path.resolve('project-2/package.json'))).devDependencies,
-    { 'is-positive': '1.0.0' },
-  )
-  t.deepEqual(
-    (await projects['project-2'].readLockfile()).devDependencies,
-    { 'is-positive': '1.0.0' },
-  )
+  {
+    const manifest = (await import(path.resolve('project-2/package.json')))
+    t.deepEqual(
+      manifest.devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      manifest.peerDependencies,
+      { 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      (await projects['project-2'].readLockfile()).devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+  }
   t.end()
 })

--- a/packages/plugin-commands-installation/test/addRecursive.ts
+++ b/packages/plugin-commands-installation/test/addRecursive.ts
@@ -1,0 +1,50 @@
+import { readProjects } from '@pnpm/filter-workspace-packages'
+import { add } from '@pnpm/plugin-commands-installation'
+import { preparePackages } from '@pnpm/prepare'
+import path = require('path')
+import test = require('tape')
+import { DEFAULT_OPTS } from './utils'
+
+test('recursive add --save-dev on workspace with multiple lockfiles', async (t) => {
+  const projects = preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await readProjects(process.cwd(), [])
+
+  await add.handler(['is-positive@1.0.0'], {
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    recursive: true,
+    saveDev: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+
+  t.deepEqual(
+    (await import(path.resolve('project-1/package.json'))).devDependencies,
+    { 'is-positive': '1.0.0' },
+  )
+  t.deepEqual(
+    (await projects['project-1'].readLockfile()).devDependencies,
+    { 'is-positive': '1.0.0' },
+  )
+
+  t.deepEqual(
+    (await import(path.resolve('project-2/package.json'))).devDependencies,
+    { 'is-positive': '1.0.0' },
+  )
+  t.deepEqual(
+    (await projects['project-2'].readLockfile()).devDependencies,
+    { 'is-positive': '1.0.0' },
+  )
+  t.end()
+})

--- a/packages/plugin-commands-installation/test/addRecursive.ts
+++ b/packages/plugin-commands-installation/test/addRecursive.ts
@@ -1,11 +1,13 @@
 import { readProjects } from '@pnpm/filter-workspace-packages'
+import { Lockfile } from '@pnpm/lockfile-types'
 import { add } from '@pnpm/plugin-commands-installation'
 import { preparePackages } from '@pnpm/prepare'
 import path = require('path')
+import readYamlFile from 'read-yaml-file'
 import test = require('tape')
 import { DEFAULT_OPTS } from './utils'
 
-test('recursive add --save-dev on workspace with multiple lockfiles', async (t) => {
+test('recursive add --save-dev, --save-peer on workspace with multiple lockfiles', async (t) => {
   const projects = preparePackages(t, [
     {
       name: 'project-1',
@@ -69,5 +71,72 @@ test('recursive add --save-dev on workspace with multiple lockfiles', async (t) 
       { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
     )
   }
+  t.end()
+})
+
+test('recursive add --save-dev, --save-peer on workspace with single lockfile', async (t) => {
+  const projects = preparePackages(t, [
+    {
+      name: 'project-1',
+      version: '1.0.0',
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+    },
+  ])
+
+  const { allProjects, selectedProjectsGraph } = await readProjects(process.cwd(), [])
+
+  await add.handler(['is-positive@1.0.0'], {
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    lockfileDir: process.cwd(),
+    recursive: true,
+    saveDev: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+  await add.handler(['is-negative@1.0.0'], {
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    lockfileDir: process.cwd(),
+    recursive: true,
+    savePeer: true,
+    selectedProjectsGraph,
+    workspaceDir: process.cwd(),
+  })
+
+  {
+    const manifest = (await import(path.resolve('project-1/package.json')))
+    t.deepEqual(
+      manifest.devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      manifest.peerDependencies,
+      { 'is-negative': '1.0.0' },
+    )
+  }
+
+  {
+    const manifest = (await import(path.resolve('project-2/package.json')))
+    t.deepEqual(
+      manifest.devDependencies,
+      { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+    )
+    t.deepEqual(
+      manifest.peerDependencies,
+      { 'is-negative': '1.0.0' },
+    )
+  }
+
+  const lockfile = await readYamlFile<Lockfile>('./pnpm-lock.yaml')
+  t.deepEqual(
+    lockfile.importers['project-1'].devDependencies,
+    { 'is-positive': '1.0.0', 'is-negative': '1.0.0' },
+  )
   t.end()
 })

--- a/packages/plugin-commands-installation/test/index.ts
+++ b/packages/plugin-commands-installation/test/index.ts
@@ -1,5 +1,6 @@
 ///<reference path="../../../typings/index.d.ts" />
 import './add'
+import './addRecursive'
 import './linkRecursive'
 import './miscRecursive'
 import './prune'

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -266,45 +266,6 @@ test('create a package.json if there is none', async (t: tape.Test) => {
   }, 'package.json created')
 })
 
-test('pnpm install --save-peer', async (t) => {
-  const project = prepare(t)
-
-  await execPnpm('add', 'is-positive@1.0.0', '--save-peer')
-
-  {
-    const manifest = await loadJsonFile('package.json')
-
-    t.deepEqual(
-      manifest,
-      {
-        name: 'project',
-        version: '0.0.0',
-
-        devDependencies: { 'is-positive': '1.0.0' },
-        peerDependencies: { 'is-positive': '1.0.0' },
-      },
-    )
-  }
-
-  await project.has('is-positive')
-
-  await execPnpm('uninstall', 'is-positive')
-
-  await project.hasNot('is-positive')
-
-  {
-    const manifest = await loadJsonFile('package.json')
-
-    t.deepEqual(
-      manifest,
-      {
-        name: 'project',
-        version: '0.0.0',
-      },
-    )
-  }
-})
-
 test('`pnpm add` should fail if no package name was provided', (t: tape.Test) => {
   prepare(t)
 

--- a/packages/supi/src/utils/getPref.ts
+++ b/packages/supi/src/utils/getPref.ts
@@ -31,7 +31,7 @@ export async function updateProjectManifest (
       specsToUpsert.push({
         alias: pkgToInstall.alias,
         peer: importer['peer'],
-        saveType: importer['targetDependenciesField'] ?? (importer['peer'] ? 'devDependencies' : undefined),
+        saveType: importer['targetDependenciesField'],
       })
     }
   }

--- a/packages/supi/src/utils/getPref.ts
+++ b/packages/supi/src/utils/getPref.ts
@@ -31,7 +31,7 @@ export async function updateProjectManifest (
       specsToUpsert.push({
         alias: pkgToInstall.alias,
         peer: importer['peer'],
-        saveType: importer['targetDependenciesField'],
+        saveType: importer['targetDependenciesField'] ?? (importer['peer'] ? 'devDependencies' : undefined),
       })
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1410,6 +1410,7 @@ importers:
       '@types/ramda': 0.26.40
       '@types/sinon': 7.5.1
       '@types/table': 4.0.7
+      load-json-file: 6.2.0
       make-dir: 3.0.0
       proxyquire: 2.1.3
       read-yaml-file: 1.1.0
@@ -1455,6 +1456,7 @@ importers:
       common-tags: 1.8.0
       enquirer: 2.3.4
       is-subdir: 1.1.1
+      load-json-file: 6.2.0
       make-dir: 3.0.0
       mem: 6.0.1
       mz: 2.7.0


### PR DESCRIPTION
Recursively adding dependencies using --save-dev,
--save-optional, or --save-prod should work on
workspaces that don't use a central, shared
lockfile.

close #2294

- [x] also fix `-r --save-peer`