### PR TITLE
feat(pnpm): Deprecate `pnpm r` alias of `pnpm remove`

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -71,6 +71,15 @@ export default async function run (inputArgv: string[]) {
     process.env['FORCE_COLOR'] = '0'
   }
 
+  if (config.useBetaCli && cmd === 'remove' && config.argv.remain[0] === 'r') {
+    // Reporting is not initialized at this point, so just printing the error
+    console.error(`${chalk.bgRed.black('\u2009ERROR\u2009')} ${
+      chalk.red("The 'r' alias for 'pnpm remove' is deprecated.")}`)
+    console.log(`For help, run: pnpm help ${cmd}`)
+    process.exit(1)
+    return
+  }
+
   const selfUpdate = config.global && (cmd === 'add' || cmd === 'update') && argv.remain.includes(packageManager.name)
 
   // Don't check for updates


### PR DESCRIPTION
Suggested&nbsp;here: <https://github.com/pnpm/pnpm/issues/2169#issuecomment-581623835>

This&nbsp;makes&nbsp;`pnpm` exit&nbsp;with an&nbsp;error&nbsp;message when&nbsp;<code>pnpm&nbsp;r&nbsp;‑‑use‑beta‑cli</code>&nbsp;is&nbsp;run.