### PR TITLE
fix: pnpm should exit with non-zero code

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -188,4 +188,7 @@ export default async function run (inputArgv: string[]) {
       }
     }, 0)
   })
+  if (!cmd) {
+    process.exit(1)
+  }
 }

--- a/packages/pnpm/test/cli.ts
+++ b/packages/pnpm/test/cli.ts
@@ -77,6 +77,15 @@ test('pnpm fails when an unsupported command is used', async (t) => {
   t.ok(stderr.toString().includes("Unknown command 'unsupported-command'"))
 })
 
+test('pnpm fails when no command is specified', async (t) => {
+  const project = prepare(t)
+
+  const { status, stdout } = execPnpmSync()
+
+  t.equal(status, 1, 'command failed')
+  t.ok(stdout.toString().includes('Usage:'))
+})
+
 test('command fails when an unsupported flag is used', async (t) => {
   const project = prepare(t)
 


### PR DESCRIPTION
Running "pnpm" without any command should print help
and exit with a non-zero exit code.

ref #2325