### PR TITLE
fix(cli-utils): move logger to dependencies

### DIFF
--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -29,7 +29,6 @@
   "homepage": "https://pnpm.js.org",
   "devDependencies": {
     "@pnpm/cli-utils": "link:",
-    "@pnpm/logger": "^3.1.0",
     "@pnpm/types": "workspace:5.0.0",
     "@types/nopt": "^3.0.29",
     "@types/ramda": "^0.26.40"
@@ -38,6 +37,7 @@
     "@pnpm/command": "workspace:0.1.0-0",
     "@pnpm/config": "workspace:8.0.1",
     "@pnpm/error": "workspace:1.0.0",
+    "@pnpm/logger": "^3.1.0",
     "@pnpm/package-is-installable": "workspace:4.0.3",
     "@pnpm/read-project-manifest": "workspace:1.0.0",
     "@pnpm/utils": "workspace:0.12.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,7 @@ importers:
       '@pnpm/command': 'link:../command'
       '@pnpm/config': 'link:../config'
       '@pnpm/error': 'link:../error'
+      '@pnpm/logger': 3.1.0
       '@pnpm/package-is-installable': 'link:../package-is-installable'
       '@pnpm/read-project-manifest': 'link:../read-project-manifest'
       '@pnpm/utils': 'link:../utils'
@@ -95,7 +96,6 @@ importers:
       version-selector-type: 2.0.1
     devDependencies:
       '@pnpm/cli-utils': 'link:'
-      '@pnpm/logger': 3.1.0
       '@pnpm/types': 'link:../types'
       '@types/nopt': 3.0.29
       '@types/ramda': 0.26.40


### PR DESCRIPTION
Hello! I just realized running the `@pnpm/find-workspace-packages` module doesn't work, because `@pnpm/cli-utils` declares `@pnpm/logger` a devDependency, but is used as a production dependency: 

https://github.com/pnpm/pnpm/blob/10020d5cff32300347fcfadb494f10290e80828b/packages/cli-utils/src/packageIsInstallable.ts#L1

This PR fixes the issue by moving `@pnpm/logger` to the dependencies.