### PR TITLE
fix: don't create a broken lockfile

### DIFF
--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -86,7 +86,7 @@ function reportUnexpectedStore (err: Error, msg: object) {
 
     pnpm now wants to use the store at "${msg['actualStorePath']}" to link dependencies.
 
-    If you want to use the new store location, reinstall your dependencies with "pnpm install --force".
+    If you want to use the new store location, reinstall your dependencies with "pnpm install".
 
     You may change the global store location by running "pnpm config set store-dir <dir>".
       (This error may happen if the node_modules was installed with a different major version of pnpm)
@@ -101,7 +101,7 @@ function reportUnexpectedVirtualStoreDir (err: Error, msg: object) {
 
     pnpm now wants to use the virtual store at "${msg['actual']}" to link dependencies from the store.
 
-    If you want to use the new virtual store location, reinstall your dependencies with "pnpm install --force".
+    If you want to use the new virtual store location, reinstall your dependencies with "pnpm install".
 
     You may change the virtual store location by changing the value of the virtual-store-dir config.
     `
@@ -112,7 +112,7 @@ function reportStoreBreakingChange (msg: object) {
     ${formatErrorSummary(`The store used for the current node_modules is incomatible with the current version of pnpm`)}
     Store path: ${colorPath(msg['storePath'])}
 
-    Try running the same command with the ${highlight('--force')} parameter.
+    Run "pnpm install" to recreate node_modules.
   `
 
   if (msg['additionalInformation']) {
@@ -128,7 +128,7 @@ function reportModulesBreakingChange (msg: object) {
     ${formatErrorSummary(`The current version of pnpm is not compatible with the available node_modules structure`)}
     node_modules path: ${colorPath(msg['modulesPath'])}
 
-    Run ${highlight('pnpm install --force')} to recreate node_modules.
+    Run ${highlight('pnpm install')} to recreate node_modules.
   `
 
   if (msg['additionalInformation']) {

--- a/packages/get-context/src/index.ts
+++ b/packages/get-context/src/index.ts
@@ -199,13 +199,13 @@ async function validateNodeModules (
       throw new PnpmError(
         'SHAMEFULLY_HOIST_WANTED',
         'This "node_modules" folder was created using the --shamefully-hoist option.'
-        + ' You must add that option, or else run "pnpm install --force" to recreate the "node_modules" folder.',
+        + ' You must add that option, or else run "pnpm install" to recreate the "node_modules" folder.',
       )
     }
     throw new PnpmError(
       'SHAMEFULLY_HOIST_NOT_WANTED',
       'This "node_modules" folder was created without the --shamefully-hoist option.'
-      + ' You must remove that option, or else "pnpm install --force" to recreate the "node_modules" folder.',
+      + ' You must remove that option, or else "pnpm install" to recreate the "node_modules" folder.',
     )
   }
   if (opts.forceIndependentLeaves && Boolean(modules.independentLeaves) !== opts.independentLeaves) {
@@ -218,13 +218,13 @@ async function validateNodeModules (
       throw new PnpmError(
         'INDEPENDENT_LEAVES_WANTED',
         'This "node_modules" folder was created using the --independent-leaves option.'
-        + ' You must add that option, or else run "pnpm install --force" to recreate the "node_modules" folder.',
+        + ' You must add that option, or else run "pnpm install" to recreate the "node_modules" folder.',
       )
     }
     throw new PnpmError(
       'INDEPENDENT_LEAVES_NOT_WANTED',
       'This "node_modules" folder was created without the --independent-leaves option.'
-      + ' You must remove that option, or else "pnpm install --force" to recreate the "node_modules" folder.',
+      + ' You must remove that option, or else "pnpm install" to recreate the "node_modules" folder.',
     )
   }
   if (opts.forceHoistPattern && rootProject) {
@@ -240,7 +240,7 @@ async function validateNodeModules (
         throw new PnpmError(
           'HOISTING_NOT_WANTED',
           'This "node_modules" folder was created without the --hoist-pattern option.'
-          + ' You must remove that option, or else add the --force option to recreate the "node_modules" folder.',
+          + ' You must remove that option, or else run "pnpm install" to recreate the "node_modules" folder.',
         )
       }
     } catch (err) {
@@ -275,7 +275,7 @@ async function validateNodeModules (
       await Promise.all(projects.map(purgeModulesDirsOfImporter))
       return
     }
-    throw new PnpmError('REGISTRIES_MISMATCH', `This "node_modules" directory was created using the following registries configuration: ${JSON.stringify(modules.registries)}. The current configuration is ${JSON.stringify(opts.registries)}. To recreate "node_modules" using the new settings, run "pnpm install --force".`)
+    throw new PnpmError('REGISTRIES_MISMATCH', `This "node_modules" directory was created using the following registries configuration: ${JSON.stringify(modules.registries)}. The current configuration is ${JSON.stringify(opts.registries)}. To recreate "node_modules" using the new settings, run "pnpm install".`)
   }
 }
 

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -149,6 +149,8 @@ export async function mutateModules (
     throw new PnpmError('OPTIONAL_DEPS_REQUIRE_PROD_DEPS', 'Optional dependencies cannot be installed without production dependencies')
   }
 
+  const installsOnly = projects.every((project) => project.mutation === 'install')
+  opts['forceNewNodeModules'] = installsOnly
   const ctx = await getContext(projects, opts)
 
   for (const { manifest, rootDir } of ctx.projects) {
@@ -180,7 +182,6 @@ export async function mutateModules (
   return result
 
   async function _install (): Promise<Array<{ rootDir: string, manifest: ProjectManifest }>> {
-    const installsOnly = projects.every((project) => project.mutation === 'install')
     if (
       !opts.lockfileOnly &&
       !opts.update &&

--- a/packages/supi/test/breakingChanges.ts
+++ b/packages/supi/test/breakingChanges.ts
@@ -1,4 +1,5 @@
 import { WANTED_LOCKFILE } from '@pnpm/constants'
+import PnpmError from '@pnpm/error'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import rimraf = require('@zkochan/rimraf')
 import isCI = require('is-ci')
@@ -61,11 +62,20 @@ test("don't fail on non-compatible node_modules when forced in a workspace", asy
 
 test('do not fail on non-compatible node_modules when forced with a named installation', async (t: tape.Test) => {
   prepareEmpty(t)
-  const opts = await testDefaults({ force: true })
+  const opts = await testDefaults()
 
   await saveModulesYaml('0.50.0', opts.storeDir)
 
-  await addDependenciesToPackage({}, ['is-negative'], opts)
+  let err!: PnpmError
+  try {
+    await addDependenciesToPackage({}, ['is-negative'], opts)
+  } catch (_err) {
+    err = _err
+  }
+  t.ok(err)
+  t.equal(err.code, 'ERR_PNPM_MODULES_BREAKING_CHANGE')
+
+  await install({}, opts)
 })
 
 test("don't fail on non-compatible store when forced", async (t: tape.Test) => {
@@ -81,11 +91,20 @@ test("don't fail on non-compatible store when forced", async (t: tape.Test) => {
 
 test('do not fail on non-compatible store when forced during named installation', async (t: tape.Test) => {
   prepareEmpty(t)
-  const opts = await testDefaults({ force: true })
+  const opts = await testDefaults()
 
   await saveModulesYaml('0.32.0', opts.storeDir)
 
-  await addDependenciesToPackage({}, ['is-negative'], opts)
+  let err!: PnpmError
+  try {
+    await addDependenciesToPackage({}, ['is-negative'], opts)
+  } catch (_err) {
+    err = _err
+  }
+  t.ok(err)
+  t.equal(err.code, 'ERR_PNPM_MODULES_BREAKING_CHANGE')
+
+  await install({}, opts)
 })
 
 async function saveModulesYaml (pnpmVersion: string, storeDir: string) {


### PR DESCRIPTION
When registries config settings change, don't create a broken
lockfile.

close #2379

TODO:
- [x] autorecreate node_modules when the store location changed.
- [x] update tests to not require `--force`