### PR TITLE
fix: pnpm run --filter <project>

### DIFF
--- a/packages/plugin-commands-script-runners/src/run.ts
+++ b/packages/plugin-commands-script-runners/src/run.ts
@@ -92,13 +92,18 @@ export async function handler (
   opts: RunOpts,
   params: string[],
 ) {
+  let dir: string
+  const [scriptName, ...passedThruArgs] = params
   if (opts.recursive) {
-    await runRecursive(params, opts)
-    return
+    if (scriptName || Object.keys(opts.selectedProjectsGraph).length > 1) {
+      await runRecursive(params, opts)
+      return
+    }
+    dir = Object.keys(opts.selectedProjectsGraph)[0]
+  } else {
+    dir = opts.dir
   }
-  const dir = opts.dir
   const manifest = await readProjectManifestOnly(dir, opts)
-  const scriptName = params[0]
   if (!scriptName) {
     return printProjectCommands(manifest)
   }
@@ -118,7 +123,7 @@ export async function handler (
   if (manifest.scripts?.[`pre${scriptName}`]) {
     await runLifecycleHooks(`pre${scriptName}`, manifest, lifecycleOpts)
   }
-  await runLifecycleHooks(scriptName, manifest, { ...lifecycleOpts, args: params.slice(1) })
+  await runLifecycleHooks(scriptName, manifest, { ...lifecycleOpts, args: passedThruArgs })
   if (manifest.scripts?.[`post${scriptName}`]) {
     await runLifecycleHooks(`post${scriptName}`, manifest, lifecycleOpts)
   }

--- a/packages/plugin-commands-script-runners/src/runRecursive.ts
+++ b/packages/plugin-commands-script-runners/src/runRecursive.ts
@@ -19,6 +19,9 @@ export default async (
   opts: RecursiveRunOpts,
 ) => {
   const [scriptName, ...passedThruArgs] = params
+  if (!scriptName) {
+    throw new PnpmError('SCRIPT_NAME_IS_REQUIRED', 'You must specify the script you want to run')
+  }
   let hasCommand = 0
   const packageChunks = opts.sort
     ? sortPackages(opts.selectedProjectsGraph)

--- a/packages/plugin-commands-script-runners/test/runRecursive.ts
+++ b/packages/plugin-commands-script-runners/test/runRecursive.ts
@@ -287,7 +287,7 @@ test('`pnpm recursive run` succeeds when run against a subset of packages and no
   t.end()
 })
 
-test('"pnpm run --filter <pkg>" prints the list of available commands', async (t) => {
+test('"pnpm run --filter <pkg>" without specifying the script name', async (t) => {
   preparePackages(t, [
     {
       name: 'project-1',
@@ -329,84 +329,15 @@ test('"pnpm run --filter <pkg>" prints the list of available commands', async (t
     '--store-dir',
     path.resolve(DEFAULT_OPTS.storeDir),
   ])
-  const { selectedProjectsGraph } = await filterPkgsBySelectorObjects(
-    allProjects,
-    [{ namePattern: 'project-1' }],
-    { workspaceDir: process.cwd() },
-  )
 
-  const output = await run.handler({
-    ...DEFAULT_OPTS,
-    allProjects,
-    dir: process.cwd(),
-    recursive: true,
-    selectedProjectsGraph,
-    workspaceDir: process.cwd(),
-  }, [])
-
-  t.equal(output, stripIndent`
-    Lifecycle scripts:
-      test
-        ts-node test
-
-    Commands available via "pnpm run":
-      foo
-        echo hi`,
-  )
-  t.end()
-})
-
-test('"pnpm run --filter <pkg>" prints the list of available commands', async (t) => {
-  preparePackages(t, [
-    {
-      name: 'project-1',
-      version: '1.0.0',
-
-      scripts: {
-        foo: 'echo hi',
-        test: 'ts-node test',
-      },
-    },
-    {
-      name: 'project-2',
-      version: '1.0.0',
-
-      dependencies: {
-        'project-1': '1',
-      },
-    },
-    {
-      name: 'project-3',
-      version: '1.0.0',
-
-      dependencies: {
-        'project-1': '1',
-      },
-    },
-    {
-      name: 'project-0',
-      version: '1.0.0',
-    },
-  ])
-
-  const { allProjects } = await readProjects(process.cwd(), [])
-  await execa('pnpm', [
-    'install',
-    '-r',
-    '--registry',
-    REGISTRY,
-    '--store-dir',
-    path.resolve(DEFAULT_OPTS.storeDir),
-  ])
-  const { selectedProjectsGraph } = await filterPkgsBySelectorObjects(
-    allProjects,
-    [{ includeDependents: true, namePattern: 'project-1' }],
-    { workspaceDir: process.cwd() },
-  )
-
-  let err!: PnpmError
-  try {
-    await run.handler({
+  t.comment('prints the list of available commands if a single project is selected')
+  {
+    const { selectedProjectsGraph } = await filterPkgsBySelectorObjects(
+      allProjects,
+      [{ namePattern: 'project-1' }],
+      { workspaceDir: process.cwd() },
+    )
+    const output = await run.handler({
       ...DEFAULT_OPTS,
       allProjects,
       dir: process.cwd(),
@@ -414,13 +345,43 @@ test('"pnpm run --filter <pkg>" prints the list of available commands', async (t
       selectedProjectsGraph,
       workspaceDir: process.cwd(),
     }, [])
-  } catch (_err) {
-    err = _err
-  }
 
-  t.ok(err)
-  t.equal(err.code, 'ERR_PNPM_SCRIPT_NAME_IS_REQUIRED')
-  t.equal(err.message, 'You must specify the script you want to run')
+    t.equal(output, stripIndent`
+      Lifecycle scripts:
+        test
+          ts-node test
+
+      Commands available via "pnpm run":
+        foo
+          echo hi`,
+    )
+  }
+  t.comment('throws an error if several projects are selected')
+  {
+    const { selectedProjectsGraph } = await filterPkgsBySelectorObjects(
+      allProjects,
+      [{ includeDependents: true, namePattern: 'project-1' }],
+      { workspaceDir: process.cwd() },
+    )
+
+    let err!: PnpmError
+    try {
+      await run.handler({
+        ...DEFAULT_OPTS,
+        allProjects,
+        dir: process.cwd(),
+        recursive: true,
+        selectedProjectsGraph,
+        workspaceDir: process.cwd(),
+      }, [])
+    } catch (_err) {
+      err = _err
+    }
+
+    t.ok(err)
+    t.equal(err.code, 'ERR_PNPM_SCRIPT_NAME_IS_REQUIRED')
+    t.equal(err.message, 'You must specify the script you want to run')
+  }
   t.end()
 })
 


### PR DESCRIPTION
`pnpm run --filter <project>` should list available scripts of the project
`pnpm run --filter <project 1> --filter <project 2>` should fail

close #2357