### PR TITLE
fix(recursive): sorting prerelease packages

### DIFF
--- a/packages/npm-resolver/package.json
+++ b/packages/npm-resolver/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@pnpm/error": "workspace:1.2.0",
+    "@pnpm/resolve-workspace-range": "workspace:0.0.0",
     "@pnpm/resolver-base": "workspace:7.0.0",
     "@pnpm/types": "workspace:5.0.0",
     "credentials-by-uri": "2.0.0",

--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -1,4 +1,5 @@
 import PnpmError from '@pnpm/error'
+import resolveWorkspaceRange from '@pnpm/resolve-workspace-range'
 import {
   PreferredVersions,
   ResolveResult,
@@ -272,14 +273,7 @@ function pickMatchingLocalVersionOrNull (
     case 'version':
       return versions[spec.fetchSpec] ? spec.fetchSpec : null
     case 'range':
-      if (spec.fetchSpec === '*') {
-        return semver.maxSatisfying(localVersions, '*', {
-          includePrerelease: true,
-        })
-      }
-      return semver.maxSatisfying(localVersions, spec.fetchSpec, {
-        loose: true,
-      })
+      return resolveWorkspaceRange(spec.fetchSpec, localVersions)
     default:
       return null
   }

--- a/packages/npm-resolver/tsconfig.json
+++ b/packages/npm-resolver/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../error"
     },
     {
+      "path": "../resolve-workspace-range"
+    },
+    {
       "path": "../resolver-base"
     },
     {

--- a/packages/pkgs-graph/package.json
+++ b/packages/pkgs-graph/package.json
@@ -27,13 +27,12 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/pkgs-graph#readme",
   "devDependencies": {
     "@types/ramda": "^0.27.0",
-    "@types/semver": "^7.1.0",
     "better-path-resolve": "1.0.0",
     "pkgs-graph": "link:"
   },
   "dependencies": {
+    "@pnpm/resolve-workspace-range": "workspace:0.0.0",
     "@zkochan/npm-package-arg": "^1.0.2",
-    "ramda": "^0.27.0",
-    "semver": "7.1.3"
+    "ramda": "^0.27.0"
   }
 }

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -1,7 +1,7 @@
+import resolveWorkspaceRange from '@pnpm/resolve-workspace-range'
 import npa = require('@zkochan/npm-package-arg')
 import path = require('path')
 import R = require('ramda')
-import semver = require('semver')
 
 export type Manifest = {
   name?: string,
@@ -81,9 +81,7 @@ export default function<T> (pkgs: Array<Package & T>): {
           const matchedPkg = pkgs.find(pkg => pkg.manifest.name === depName && pkg.manifest.version === rawSpec)
           return matchedPkg!.dir
         }
-        const matched = rawSpec === '*'
-          ? semver.maxSatisfying(versions, rawSpec, { includePrerelease: true })
-          : semver.maxSatisfying(versions, rawSpec)
+        const matched = resolveWorkspaceRange(rawSpec, versions)
         if (!matched) {
           unmatched.push({ pkgName: depName, range: rawSpec })
           return ''

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -81,7 +81,9 @@ export default function<T> (pkgs: Array<Package & T>): {
           const matchedPkg = pkgs.find(pkg => pkg.manifest.name === depName && pkg.manifest.version === rawSpec)
           return matchedPkg!.dir
         }
-        const matched = semver.maxSatisfying(versions, rawSpec)
+        const matched = rawSpec === '*'
+          ? semver.maxSatisfying(versions, rawSpec, { includePrerelease: true })
+          : semver.maxSatisfying(versions, rawSpec)
         if (!matched) {
           unmatched.push({ pkgName: depName, range: rawSpec })
           return ''

--- a/packages/pkgs-graph/test/index.ts
+++ b/packages/pkgs-graph/test/index.ts
@@ -318,3 +318,54 @@ test('create package graph ignoring the workspace protocol', t => {
   })
   t.end()
 })
+
+test('* matches prerelease versions', t => {
+  const result = createPkgGraph([
+    {
+      dir: BAR1_PATH,
+      manifest: {
+        name: 'bar',
+        version: '1.0.0',
+
+        dependencies: {
+          'foo': '*',
+        },
+      },
+    },
+    {
+      dir: FOO1_PATH,
+      manifest: {
+        name: 'foo',
+        version: '1.0.0-0',
+      },
+    },
+  ])
+  t.deepEqual(result.unmatched, [])
+  t.deepEqual(result.graph, {
+    [BAR1_PATH]: {
+      dependencies: [FOO1_PATH],
+      package: {
+        dir: BAR1_PATH,
+        manifest: {
+          name: 'bar',
+          version: '1.0.0',
+
+          dependencies: {
+            'foo': '*',
+          },
+        },
+      },
+    },
+    [FOO1_PATH]: {
+      dependencies: [],
+      package: {
+        dir: FOO1_PATH,
+        manifest: {
+          name: 'foo',
+          version: '1.0.0-0',
+        },
+      },
+    },
+  })
+  t.end()
+})

--- a/packages/plugin-commands-publishing/tsconfig.json
+++ b/packages/plugin-commands-publishing/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../error"
     },
     {
+      "path": "../lifecycle"
+    },
+    {
       "path": "../npm-resolver"
     },
     {
@@ -29,6 +32,9 @@
     },
     {
       "path": "../run-npm"
+    },
+    {
+      "path": "../sort-packages"
     },
     {
       "path": "../types"

--- a/packages/resolve-workspace-range/README.md
+++ b/packages/resolve-workspace-range/README.md
@@ -1,0 +1,17 @@
+# @pnpm/resolve-workspace-range
+
+> Resolves a range from versions that are present inside a workspace
+
+## Install
+
+```
+pnpm add @pnpm/resolve-workspace-range
+```
+
+### API
+
+### `resolveWorkspaceRange(range, versions)`
+
+## LICENSE
+
+MIT

--- a/packages/resolve-workspace-range/package.json
+++ b/packages/resolve-workspace-range/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@pnpm/resolve-workspace-range",
+  "version": "0.0.0",
+  "author": "Zoltan Kochan <z@kochan.io> (https://www.kochan.io/)",
+  "description": "Resolves a range from versions that are present inside a workspace",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "keywords": [],
+  "license": "MIT",
+  "engines": {
+    "node": ">=10.13"
+  },
+  "repository": "https://github.com/pnpm/pnpm/blob/master/packages/resolve-workspace-range",
+  "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/resolve-workspace-range#readme",
+  "scripts": {
+    "start": "pnpm run tsc -- --watch",
+    "test": "pnpm run compile",
+    "lint": "tslint -c ../../tslint.json --project .",
+    "prepublishOnly": "pnpm run compile",
+    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build"
+  },
+  "dependencies": {
+    "semver": "7.1.3"
+  },
+  "devDependencies": {
+    "@pnpm/resolve-workspace-range": "link:",
+    "@types/semver": "^7.1.0"
+  },
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  }
+}

--- a/packages/resolve-workspace-range/src/index.ts
+++ b/packages/resolve-workspace-range/src/index.ts
@@ -1,0 +1,12 @@
+import semver = require('semver')
+
+export default function (range: string, versions: string[]) {
+  if (range === '*') {
+    return semver.maxSatisfying(versions, '*', {
+      includePrerelease: true,
+    })
+  }
+  return semver.maxSatisfying(versions, range, {
+    loose: true,
+  })
+}

--- a/packages/resolve-workspace-range/tsconfig.json
+++ b/packages/resolve-workspace-range/tsconfig.json
@@ -8,9 +8,5 @@
     "src/**/*.ts",
     "../../typings/**/*.d.ts"
   ],
-  "references": [
-    {
-      "path": "../resolve-workspace-range"
-    }
-  ]
+  "references": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,6 +995,7 @@ importers:
   packages/npm-resolver:
     dependencies:
       '@pnpm/error': 'link:../error'
+      '@pnpm/resolve-workspace-range': 'link:../resolve-workspace-range'
       '@pnpm/resolver-base': 'link:../resolver-base'
       '@pnpm/types': 'link:../types'
       credentials-by-uri: 2.0.0
@@ -1023,6 +1024,7 @@ importers:
       '@pnpm/error': 'workspace:1.2.0'
       '@pnpm/logger': 3.1.0
       '@pnpm/npm-resolver': 'link:'
+      '@pnpm/resolve-workspace-range': 'workspace:0.0.0'
       '@pnpm/resolver-base': 'workspace:7.0.0'
       '@pnpm/types': 'workspace:5.0.0'
       '@types/normalize-path': ^3.0.0
@@ -1290,22 +1292,20 @@ importers:
       nopt: 4.0.3
   packages/pkgs-graph:
     dependencies:
+      '@pnpm/resolve-workspace-range': 'link:../resolve-workspace-range'
       '@zkochan/npm-package-arg': 1.0.2
       ramda: 0.27.0
-      semver: 7.1.3
     devDependencies:
       '@types/ramda': 0.27.0
-      '@types/semver': 7.1.0
       better-path-resolve: 1.0.0
       pkgs-graph: 'link:'
     specifiers:
+      '@pnpm/resolve-workspace-range': 'workspace:0.0.0'
       '@types/ramda': ^0.27.0
-      '@types/semver': ^7.1.0
       '@zkochan/npm-package-arg': ^1.0.2
       better-path-resolve: 1.0.0
       pkgs-graph: 'link:'
       ramda: ^0.27.0
-      semver: 7.1.3
   packages/plugin-commands-audit:
     dependencies:
       '@pnpm/audit': 'link:../audit'
@@ -2299,6 +2299,16 @@ importers:
       path-exists: 4.0.0
       ramda: 0.27.0
       replace-string: 3.0.0
+      semver: 7.1.3
+  packages/resolve-workspace-range:
+    dependencies:
+      semver: 7.1.3
+    devDependencies:
+      '@pnpm/resolve-workspace-range': 'link:'
+      '@types/semver': 7.1.0
+    specifiers:
+      '@pnpm/resolve-workspace-range': 'link:'
+      '@types/semver': ^7.1.0
       semver: 7.1.3
   packages/resolver-base:
     dependencies:

--- a/utils/updater/src/index.ts
+++ b/utils/updater/src/index.ts
@@ -107,7 +107,6 @@ async function updateManifest (dir: string, manifest: ProjectManifest) {
   let homepage: string
   let repository: string | { type: 'git', url: string }
   if (manifest.name === 'pnpm') {
-    delete scripts.prepublishOnly
     homepage = 'https://pnpm.js.org'
     repository = {
       type: 'git',


### PR DESCRIPTION
close #2279

We should use the same version matching algorithm when installing a new package inside the workspace and when sorting packages inside the workspace. This change is moving the version matcher to a new package and uses it in `@pnpm/npm-resolver` and `pkgs-graph`.