### PR TITLE
V5 breaking changes

### DIFF
--- a/.changeset/blue-wombats-help.md
+++ b/.changeset/blue-wombats-help.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": major
+---
+
+Git checks are on by default.

--- a/.changeset/mighty-buckets-study.md
+++ b/.changeset/mighty-buckets-study.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": major
+"pnpm": major
+---
+
+`pnpm r` is not an alias of `pnpm remove`.

--- a/packages/plugin-commands-installation/src/remove.ts
+++ b/packages/plugin-commands-installation/src/remove.ts
@@ -118,7 +118,9 @@ export function help () {
   })
 }
 
-export const commandNames = ['remove', 'uninstall', 'r', 'rm', 'un']
+// Unlike npm, pnpm does not treat "r" as an alias of "remove".
+// This way we avoid the confusion about whether "pnpm r" means remove, run, or recursive.
+export const commandNames = ['remove', 'uninstall', 'rm', 'un']
 
 export const completion: CompletionFunc = (cliOpts, params) => {
   return readDepNameCompletions(cliOpts.dir as string)

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -52,8 +52,8 @@ export function help () {
 
         list: [
           {
-            description: 'Checks if current branch is your publish branch, clean, and up-to-date',
-            name: '--git-checks',
+            description: "Don't check if current branch is your publish branch, clean, and up-to-date",
+            name: '--no-git-checks',
           },
           {
             description: 'Sets branch name to publish. Default is master',
@@ -94,7 +94,7 @@ export async function handler (
   } & Pick<Config, 'allProjects' | 'gitChecks' | 'ignoreScripts' | 'publishBranch'>,
   params: string[],
 ) {
-  if (opts.gitChecks && await isGitRepo()) {
+  if (opts.gitChecks !== false && await isGitRepo()) {
     const branch = opts.publishBranch ?? 'master'
     if (await getCurrentBranch() !== branch) {
       const { confirm } = await prompt({

--- a/packages/plugin-commands-publishing/test/gitChecks.ts
+++ b/packages/plugin-commands-publishing/test/gitChecks.ts
@@ -41,7 +41,6 @@ test('publish: fails git check if branch is not on master', async (t) => {
       ...DEFAULT_OPTS,
       argv: { original: ['publish', ...CREDENTIALS] },
       dir: process.cwd(),
-      gitChecks: true,
     }, [])
   } catch (_err) {
     err = _err
@@ -72,7 +71,6 @@ test('publish: fails git check if branch is not on specified branch', async (t) 
       ...DEFAULT_OPTS,
       argv: { original: ['publish', ...CREDENTIALS] },
       dir: process.cwd(),
-      gitChecks: true,
       publishBranch: 'latest',
     }, [])
   } catch (_err) {
@@ -103,7 +101,6 @@ test('publish: fails git check if branch is not clean', async (t) => {
       ...DEFAULT_OPTS,
       argv: { original: ['publish', ...CREDENTIALS] },
       dir: process.cwd(),
-      gitChecks: true,
     }, [])
   } catch (_err) {
     err = _err
@@ -138,7 +135,6 @@ test('publish: fails git check if branch is not up-to-date', async (t) => {
       ...DEFAULT_OPTS,
       argv: { original: ['publish', ...CREDENTIALS] },
       dir: process.cwd(),
-      gitChecks: true,
     }, [])
   } catch (_err) {
     err = _err

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -87,15 +87,6 @@ export default async function run (inputArgv: string[]) {
     process.env['FORCE_COLOR'] = '0'
   }
 
-  if (config.useBetaCli && cmd === 'remove' && config.argv.remain[0] === 'r') {
-    // Reporting is not initialized at this point, so just printing the error
-    console.error(`${chalk.bgRed.black('\u2009ERROR\u2009')} ${
-      chalk.red("The 'r' alias for 'pnpm remove' is deprecated.")}`)
-    console.log(`For help, run: pnpm help ${cmd}`)
-    process.exit(1)
-    return
-  }
-
   const selfUpdate = config.global && (cmd === 'add' || cmd === 'update') && cliParams.includes(packageManager.name)
 
   // Don't check for updates


### PR DESCRIPTION
1. git checks before publish are on by default
2. `pnpm r` is not an alias of `pnpm remove`