### PR TITLE
fix: print a meaningful error on unsupported Node.js versions

### DIFF
--- a/.changeset/swift-ties-cross.md
+++ b/.changeset/swift-ties-cross.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Print a meaningful error on unsupported Node.js versions.

--- a/packages/pnpm/bin/pnpm.js
+++ b/packages/pnpm/bin/pnpm.js
@@ -1,2 +1,10 @@
 #!/usr/bin/env node
+const [major, minor] = process.version.substr(1).split('.')
+
+if (major < 10 || major == 10 && minor < 13) {
+  console.log(`ERROR: This version of pnpm requires at least Node.js v10.13
+The current version of Node.js is ${process.version}`)
+  process.exit(1)
+}
+
 require('../lib/bin/pnpm')


### PR DESCRIPTION
close #2508