### PR TITLE
perf: keep all the metadata files in the same dir

### DIFF
--- a/.changeset/fifty-horses-change.md
+++ b/.changeset/fifty-horses-change.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": major
+---
+
+Reduce the number of directories in the store by keeping all the metadata json files in the same directory.

--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -44,8 +44,8 @@ export {
 // This file contains meta information
 // about all the packages published by the same name, not just the manifest
 // of one package/version
-const META_FILENAME = 'index.json'
-const FULL_META_FILENAME = 'index-full.json'
+const META_DIR = 'metadata'
+const FULL_META_DIR = 'metadata-full'
 
 export interface ResolverFactoryOptions {
   rawConfig: object,
@@ -111,7 +111,7 @@ export default function createResolver (
     pickPackage: pickPackage.bind(null, {
       fetch,
       metaCache: opts.metaCache,
-      metaFileName: opts.fullMetadata ? FULL_META_FILENAME : META_FILENAME,
+      metaDir: opts.fullMetadata ? FULL_META_DIR : META_DIR,
       offline: opts.offline,
       preferOffline: opts.preferOffline,
       storeDir: opts.storeDir,

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -46,7 +46,7 @@ test('resolveFromNpm()', async t => {
   // The resolve function does not wait for the package meta cache file to be saved
   // so we must delay for a bit in order to read it
   setTimeout(async () => {
-    const meta = await loadJsonFile<any>(path.join(storeDir, resolveResult!.id, '..', 'index.json')) // tslint:disable-line:no-any
+    const meta = await loadJsonFile<any>(path.join(storeDir, 'metadata/registry.npmjs.org/is-positive.json')) // tslint:disable-line:no-any
     t.ok(meta.name)
     t.ok(meta.versions)
     t.ok(meta['dist-tags'])
@@ -895,7 +895,7 @@ test('resolve when tarball URL is requested from the registry', async t => {
   // The resolve function does not wait for the package meta cache file to be saved
   // so we must delay for a bit in order to read it
   setTimeout(async () => {
-    const meta = await loadJsonFile<any>(path.join(storeDir, resolveResult!.id, '..', 'index.json')) // tslint:disable-line:no-any
+    const meta = await loadJsonFile<any>(path.join(storeDir, 'metadata/registry.npmjs.org/is-positive.json')) // tslint:disable-line:no-any
     t.ok(meta.name)
     t.ok(meta.versions)
     t.ok(meta['dist-tags'])
@@ -934,7 +934,7 @@ test('resolve when tarball URL is requested from the registry and alias is not s
   // The resolve function does not wait for the package meta cache file to be saved
   // so we must delay for a bit in order to read it
   setTimeout(async () => {
-    const meta = await loadJsonFile<any>(path.join(storeDir, resolveResult!.id, '..', 'index.json')) // tslint:disable-line:no-any
+    const meta = await loadJsonFile<any>(path.join(storeDir, 'metadata/registry.npmjs.org/is-positive.json')) // tslint:disable-line:no-any
     t.ok(meta.name)
     t.ok(meta.versions)
     t.ok(meta['dist-tags'])

--- a/packages/supi/test/install/lockfileOnly.ts
+++ b/packages/supi/test/install/lockfileOnly.ts
@@ -4,6 +4,7 @@ import { prepareEmpty } from '@pnpm/prepare'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import fs = require('mz/fs')
 import path = require('path')
+import exists = require('path-exists')
 import sinon = require('sinon')
 import {
   addDependenciesToPackage,
@@ -23,9 +24,9 @@ test('install with lockfileOnly = true', async (t: tape.Test) => {
   const { cafsHas } = assertStore(t, opts.storeDir)
 
   await cafsHas('pkg-with-1-dep', '100.0.0')
-  t.deepEqual(await fs.readdir(path.join(opts.storeDir, `localhost+${REGISTRY_MOCK_PORT}`, 'pkg-with-1-dep')), ['index.json'])
+  t.ok(await exists(path.join(opts.storeDir, `metadata/localhost+${REGISTRY_MOCK_PORT}/pkg-with-1-dep.json`)))
   await cafsHas('dep-of-pkg-with-1-dep', '100.1.0')
-  t.deepEqual(await fs.readdir(path.join(opts.storeDir, `localhost+${REGISTRY_MOCK_PORT}`, 'dep-of-pkg-with-1-dep')), ['index.json'])
+  t.ok(await exists(path.join(opts.storeDir, `metadata/localhost+${REGISTRY_MOCK_PORT}/dep-of-pkg-with-1-dep.json`)))
   await project.hasNot('pkg-with-1-dep')
 
   t.ok(manifest.dependencies!['pkg-with-1-dep'], 'the new dependency added to package.json')
@@ -42,9 +43,9 @@ test('install with lockfileOnly = true', async (t: tape.Test) => {
   await install(manifest, opts)
 
   await cafsHas('pkg-with-1-dep', '100.0.0')
-  t.deepEqual(await fs.readdir(path.join(opts.storeDir, `localhost+${REGISTRY_MOCK_PORT}`, 'pkg-with-1-dep')), ['index.json'])
+  t.ok(await exists(path.join(opts.storeDir, `metadata/localhost+${REGISTRY_MOCK_PORT}/pkg-with-1-dep.json`)))
   await cafsHas('dep-of-pkg-with-1-dep', '100.1.0')
-  t.deepEqual(await fs.readdir(path.join(opts.storeDir, `localhost+${REGISTRY_MOCK_PORT}`, 'dep-of-pkg-with-1-dep')), ['index.json'])
+  t.ok(await exists(path.join(opts.storeDir, `metadata/localhost+${REGISTRY_MOCK_PORT}/dep-of-pkg-with-1-dep.json`)))
   await project.hasNot('pkg-with-1-dep')
 
   t.notOk(await project.readCurrentLockfile(), 'current lockfile not created')


### PR DESCRIPTION
Reduce the number of directories in the store by keeping all the metadata json
files in the same directory.

Previously the metadata file of express would be stored at:

`<store>/registry.npmjs.org/express/index.json`

Now it will be stored at:

`<store>/metadata/registry.npmjs.org/express.json`

ref #2521