### PR TITLE
perf: use a suffix for exec files in CAFS, not a dir

### DIFF
--- a/.changeset/lovely-ducks-judge.md
+++ b/.changeset/lovely-ducks-judge.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/cafs": major
+---
+
+Instead of creating a separate subdir for executables in the content-addressable storage, use the directory where all the files are stored but suffix the executable files with `-exec`. Also suffix the package index files with `-index.json`.

--- a/packages/cafs/src/getFilePathInCafs.ts
+++ b/packages/cafs/src/getFilePathInCafs.ts
@@ -35,10 +35,10 @@ export function contentPathFromHex (fileType: FileType, hex: string) {
   const p = path.join(hex.slice(0, 2), hex.slice(2))
   switch (fileType) {
     case 'exec':
-      return `x${path.sep}${p}`
+      return `${p}-exec`
     case 'nonexec':
       return p
     case 'index':
-      return `${p}.json`
+      return `${p}-index.json`
   }
 }

--- a/packages/plugin-commands-store/test/storeAdd.ts
+++ b/packages/plugin-commands-store/test/storeAdd.ts
@@ -25,8 +25,8 @@ test('pnpm store add express@4.16.3', async function (t) {
     storeDir,
   }, ['add', 'express@4.16.3'])
 
-  const pathToCheck = path.join(storeDir, STORE_VERSION, 'files/6a/f8a502350db3246ecc4becf6b5a34d22f7ed53.json')
-  t.ok(await exists(pathToCheck), `express@4.16.3 is in store (at ${pathToCheck})`)
+  const { cafsHas } = assertStore(t, path.join(storeDir, STORE_VERSION))
+  await cafsHas('sha1-avilAjUNsyRuzEvs9rWjTSL37VM=')
 
   const storeIndex = await loadJsonFile(path.join(storeDir, STORE_VERSION, 'store.json'))
   t.deepEqual(


### PR DESCRIPTION
Instead of creating a separate subdir for executables in the content-addressable storage, use the directory where all the files are stored but suffix the executable files with `-exec`. Also suffix the package index files with `-index.json`.

ref #2521