### PR TITLE
feat!: make the package index file more extendable

### DIFF
--- a/.changeset/three-moles-end.md
+++ b/.changeset/three-moles-end.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/cafs": major
+"@pnpm/package-requester": major
+"@pnpm/plugin-commands-store": major
+---
+
+Change the format of the package index file. Move all the files info into a "files" property.

--- a/packages/cafs/src/checkFilesIntegrity.ts
+++ b/packages/cafs/src/checkFilesIntegrity.ts
@@ -15,11 +15,11 @@ export type PackageFileInfo = {
   size: number,
 }
 
-export type PackageFilesIndex = Record<string, PackageFileInfo>
+export type PackageFilesIndex = { files: Record<string, PackageFileInfo> }
 
 export default async function (
   cafsDir: string,
-  pkgIndex: PackageFilesIndex,
+  pkgIndex: Record<string, PackageFileInfo>,
   manifest?: DeferredManifestPromise,
 ) {
   let verified = true

--- a/packages/package-requester/test/index.ts
+++ b/packages/package-requester/test/index.ts
@@ -349,8 +349,8 @@ test('refetch local tarball if its integrity has changed. The requester does not
       files: () => Promise<PackageFilesResponse>,
       finishing: () => Promise<void>,
     }
-    await response.files
-    await response.finishing
+    await response.files()
+    await response.finishing()
 
     t.ok((await response.files!()).fromStore, 'do not reunpack tarball if its integrity is up-to-date')
     t.ok(await response.bundledManifest!())

--- a/packages/package-store/src/storeController/prune.ts
+++ b/packages/package-store/src/storeController/prune.ts
@@ -36,7 +36,7 @@ export default async function prune (storeDir: string) {
 
   let pkgCounter = 0
   for (const pkgIndexFilePath of pkgIndexFiles) {
-    const pkgFilesIndex = await loadJsonFile<object>(pkgIndexFilePath)
+    const { files: pkgFilesIndex } = await loadJsonFile<{ files: object }>(pkgIndexFilePath)
     if (removedHashes.has(pkgFilesIndex['package.json'].integrity)) {
       await fs.unlink(pkgIndexFilePath)
       pkgCounter++

--- a/packages/plugin-commands-store/src/storeStatus/index.ts
+++ b/packages/plugin-commands-store/src/storeStatus/index.ts
@@ -46,8 +46,8 @@ export default async function (maybeOpts: StoreStatusOptions) {
     const pkgIndexFilePath = integrity
       ? getFilePathInCafs(cafsDir, integrity, 'index')
       : path.join(storeDir, pkgPath, 'integrity.json')
-    const pkgIndex = await loadJsonFile(pkgIndexFilePath)
-    return (await dint.check(path.join(virtualStoreDir, pkgIdToFilename(pkgPath, opts.dir), 'node_modules', name), pkgIndex)) === false
+    const { files } = await loadJsonFile(pkgIndexFilePath)
+    return (await dint.check(path.join(virtualStoreDir, pkgIdToFilename(pkgPath, opts.dir), 'node_modules', name), files)) === false
   })
 
   if (reporter) {

--- a/packages/plugin-commands-store/test/storePrune.ts
+++ b/packages/plugin-commands-store/test/storePrune.ts
@@ -13,13 +13,14 @@ import test = require('tape')
 
 const STORE_VERSION = 'v3'
 const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}/`
+const pnpmBin = path.join(__dirname, '../../pnpm/bin/pnpm.js')
 
 test('remove unreferenced packages', async (t) => {
   const project = prepare(t)
   const storeDir = path.resolve('store')
 
-  await execa('pnpm', ['add', 'is-negative@2.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
-  await execa('pnpm', ['remove', 'is-negative', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
+  await execa('node', [pnpmBin, 'add', 'is-negative@2.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
+  await execa('node', [pnpmBin, 'remove', 'is-negative', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
 
   await project.storeHas('is-negative', '2.1.0')
 
@@ -66,7 +67,7 @@ test.skip('remove packages that are used by project that no longer exist', async
   const storeDir = path.resolve('store', STORE_VERSION)
   const { cafsHas, cafsHasNot } = assertStore(t, storeDir)
 
-  await execa('pnpm', ['add', 'is-negative@2.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
+  await execa('node', [pnpmBin, 'add', 'is-negative@2.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
 
   await rimraf('node_modules')
 
@@ -96,9 +97,9 @@ test.skip('remove packages that are used by project that no longer exist', async
 test('keep dependencies used by others', async (t) => {
   const project = prepare(t)
   const storeDir = path.resolve('store')
-  await execa('pnpm', ['add', 'camelcase-keys@3.0.0', '--store-dir', storeDir, '--registry', REGISTRY])
-  await execa('pnpm', ['add', 'hastscript@3.0.0', '--save-dev', '--store-dir', storeDir, '--registry', REGISTRY])
-  await execa('pnpm', ['remove', 'camelcase-keys', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
+  await execa('node', [pnpmBin, 'add', 'camelcase-keys@3.0.0', '--store-dir', storeDir, '--registry', REGISTRY])
+  await execa('node', [pnpmBin, 'add', 'hastscript@3.0.0', '--save-dev', '--store-dir', storeDir, '--registry', REGISTRY])
+  await execa('node', [pnpmBin, 'remove', 'camelcase-keys', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
 
   await project.storeHas('camelcase-keys', '3.0.0')
   await project.hasNot('camelcase-keys')
@@ -133,8 +134,8 @@ test('keep dependencies used by others', async (t) => {
 test('keep dependency used by package', async (t) => {
   const project = prepare(t)
   const storeDir = path.resolve('store')
-  await execa('pnpm', ['add', 'is-not-positive@1.0.0', 'is-positive@3.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
-  await execa('pnpm', ['remove', 'is-not-positive', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
+  await execa('node', [pnpmBin, 'add', 'is-not-positive@1.0.0', 'is-positive@3.1.0', '--store-dir', storeDir, '--registry', REGISTRY])
+  await execa('node', [pnpmBin, 'remove', 'is-not-positive', '--store-dir', storeDir], { env: { npm_config_registry: REGISTRY } })
 
   await store.handler({
     dir: process.cwd(),

--- a/packages/pnpm/test/install/misc.ts
+++ b/packages/pnpm/test/install/misc.ts
@@ -160,7 +160,7 @@ test("don't fail on case insensitive filesystems when package has 2 files with s
 
   await project.has('with-same-file-in-different-cases')
 
-  const integrityFile = await loadJsonFile(await project.getPkgIndexFilePath('with-same-file-in-different-cases', '1.0.0'))
+  const { files: integrityFile } = await loadJsonFile(await project.getPkgIndexFilePath('with-same-file-in-different-cases', '1.0.0'))
   const packageFiles = Object.keys(integrityFile).sort()
 
   t.deepEqual(packageFiles, ['Foo.js', 'foo.js', 'package.json'])


### PR DESCRIPTION
Move all the info in the package index file into a "files" property.
This will allow to store more information without breaking changes
in the future.