### PR TITLE
Linking packages to subdependencies

### DIFF
--- a/.changeset/beige-ducks-rescue.md
+++ b/.changeset/beige-ducks-rescue.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config": minor
+"@pnpm/plugin-commands-installation": minor
+---
+
+The `link-workspace-packages` setting may be set to `deep`. When using `deep`,
+workspace packages are linked into subdependencies, not only to direct dependencies of projects.

--- a/.changeset/heavy-eyes-ring.md
+++ b/.changeset/heavy-eyes-ring.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/resolve-dependencies": major
+---
+
+The `alwaysTryWorkspacePackages` option is removed. A new option called `linkWorkspacePackagesDepth` is added.
+When `linkWorkspacePackageDepth` is `0`, workspace packages are linked to direct dependencies even if these direct
+dependencies are not using workspace ranges (so this is similar to the old `alwaysTryWorkspacePackages=true`).
+`linkWorkspacePackageDepth` also allows to link workspace packages to subdependencies by setting the max depth.
+Setting it to `Infinity` will make the resolution algorithm always prefer packages from the workspace over packages
+from the registry.

--- a/.changeset/serious-geckos-taste.md
+++ b/.changeset/serious-geckos-taste.md
@@ -1,0 +1,10 @@
+---
+"supi": minor
+---
+
+The `linkWorkspacePackages` option is removed. A new option called `linkWorkspacePackagesDepth` is added.
+When `linkWorkspacePackageDepth` is `0`, workspace packages are linked to direct dependencies even if these direct
+dependencies are not using workspace ranges (so this is similar to the old `linkWorkspacePackages=true`).
+`linkWorkspacePackageDepth` also allows to link workspace packages to subdependencies by setting the max depth.
+Setting it to `Infinity` will make the resolution algorithm always prefer packages from the workspace over packages
+from the registry.

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -104,7 +104,7 @@ export interface Config {
   workspaceConcurrency: number,
   workspaceDir?: string,
   reporter?: string,
-  linkWorkspacePackages: boolean,
+  linkWorkspacePackages: boolean | 'deep',
   sort: boolean,
   strictPeerDependencies: boolean,
   lockfileDir?: string,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -45,7 +45,7 @@ export const types = Object.assign({
   'ignore-pnpmfile': Boolean,
   'ignore-workspace-root-check': Boolean,
   'independent-leaves': Boolean,
-  'link-workspace-packages': Boolean,
+  'link-workspace-packages': [Boolean, 'deep'],
   'lockfile': Boolean,
   'lockfile-dir': String,
   'lockfile-directory': String, // TODO: deprecate

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -138,6 +138,7 @@ export default async function handler (
     // The dependencies should be built first,
     // so ignoring scripts for now
     ignoreScripts: !!workspacePackages || opts.ignoreScripts,
+    linkWorkspacePackagesDepth: opts.linkWorkspacePackages === 'deep' ? Infinity : opts.linkWorkspacePackages ? 0 : -1,
     sideEffectsCacheRead: opts.sideEffectsCache || opts.sideEffectsCacheReadonly,
     sideEffectsCacheWrite: opts.sideEffectsCache,
     storeController: store.ctrl,

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -109,6 +109,7 @@ export default async function recursive (
     : {}
   const targetDependenciesField = getSaveType(opts)
   const installOpts = Object.assign(opts, {
+    linkWorkspacePackagesDepth: opts.linkWorkspacePackages === 'deep' ? Infinity : opts.linkWorkspacePackages ? 0 : -1,
     ownLifecycleHooksStdio: 'pipe',
     peer: opts.savePeer,
     pruneLockfileImporters: (!opts.ignoredPackages || opts.ignoredPackages.size === 0)

--- a/packages/supi/src/install/extendInstallOptions.ts
+++ b/packages/supi/src/install/extendInstallOptions.ts
@@ -14,12 +14,12 @@ import pnpmPkgJson from '../pnpmPkgJson'
 import { ReporterFunction } from '../types'
 
 export interface StrictInstallOptions {
-  linkWorkspacePackages?: boolean,
   forceSharedLockfile: boolean,
   frozenLockfile: boolean,
   frozenLockfileIfExists: boolean,
   extraBinPaths: string[],
   useLockfile: boolean,
+  linkWorkspacePackagesDepth: number,
   lockfileOnly: boolean,
   preferFrozenLockfile: boolean,
   saveWorkspaceProtocol: boolean,

--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -505,6 +505,10 @@ async function linkAllModules (
         await Promise.all(
           Object.keys(childrenToLink)
             .map(async (childAlias) => {
+              if (childrenToLink[childAlias].startsWith('link:')) {
+                await limitLinking(() => symlinkDependency(path.resolve(opts.lockfileDir, childrenToLink[childAlias].substr(5)), modules, childAlias))
+                return
+              }
               const pkg = depGraph[childrenToLink[childAlias]]
               if (!pkg.installable && pkg.optional) return
               if (childAlias === name) {

--- a/packages/supi/src/install/updateLockfile.ts
+++ b/packages/supi/src/install/updateLockfile.ts
@@ -32,7 +32,7 @@ export default function (
   for (const depPath of Object.keys(depGraph)) {
     const depNode = depGraph[depPath]
     const [updatedOptionalDeps, updatedDeps] = R.partition(
-      (child) => depNode.optionalDependencies.has(depGraph[child.depPath].name),
+      (child) => depNode.optionalDependencies.has(child.alias),
       Object.keys(depNode.children).map((alias) => ({ alias, depPath: depNode.children[alias] }))
     )
     lockfile.packages[depPath] = toLockfileDependency(pendingRequiresBuilds, depNode.additionalInfo, {
@@ -196,6 +196,9 @@ function updateResolvedDeps (
   const newResolvedDeps = R.fromPairs<string>(
     updatedDeps
       .map(({ alias, depPath }): R.KeyValuePair<string, string> => {
+        if (depPath.startsWith('link:')) {
+          return [alias, depPath]
+        }
         const depNode = depGraph[depPath]
         return [
           alias,


### PR DESCRIPTION
Setting the `link-workspace-packages` to `deep` makes pnpm resolve subdependencies from workspace packages.

- [ ] update the lockfile version
- [x] make it opt-in