### PR TITLE
docs(README): update speed description

### DIFF
--- a/packages/pnpm/README.md
+++ b/packages/pnpm/README.md
@@ -14,7 +14,7 @@
 
 Features:
 
-* **Fast.** As fast as npm and Yarn.
+* **Fast.** Almost always under 20s with cold cache and under 10s with hot cache ([benchmarks](https://github.com/pnpm/benchmarks-of-javascript-package-managers)).
 * **Efficient.** Files inside `node_modules` are linked from a single content-addressable storage.
 * **[Great for monorepos](https://pnpm.js.org/en/workspaces).**
 * **Strict.** A package can access only dependencies that are specified in its `package.json`.

--- a/packages/pnpm/README.md
+++ b/packages/pnpm/README.md
@@ -14,7 +14,7 @@
 
 Features:
 
-* **Fast.** Almost always under 20s with cold cache and under 10s with hot cache ([benchmarks](https://github.com/pnpm/benchmarks-of-javascript-package-managers)).
+* **Fast.** Up to 2x faster than the alternatives (see [benchmarks](https://github.com/pnpm/benchmarks-of-javascript-package-managers)).
 * **Efficient.** Files inside `node_modules` are linked from a single content-addressable storage.
 * **[Great for monorepos](https://pnpm.js.org/en/workspaces).**
 * **Strict.** A package can access only dependencies that are specified in its `package.json`.


### PR DESCRIPTION
pnpm v5 is significantly faster than npm and Yarn, so "as fast as" is not true anymore.

However, it is not as simple as that. I did not measure Yarn v2 with Plug'n'Play yet. And with the new Yarn, the workflow is a bit different. So we cannot compare Yarn v2 to pnpm v5.

So I think we need to explain pnpm's speed without mentioning Yarn and npm. At least not at the top of the page.