### PR TITLE
fix: installing git-hosted dependencies

### DIFF
--- a/.changeset/violet-steaks-burn.md
+++ b/.changeset/violet-steaks-burn.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/git-fetcher": patch
+---
+
+Adhere to the new FetchFunction API. cafs should be the first argument of the a fetch function.

--- a/packages/git-fetcher/src/index.ts
+++ b/packages/git-fetcher/src/index.ts
@@ -7,12 +7,13 @@ import tempy = require('tempy')
 export default () => {
   return {
     git: async function fetchFromGit (
+      cafs: Cafs,
       resolution: {
-        repo: string,
         commit: string,
+        repo: string,
+        type: 'git',
       },
       opts: {
-        cafs: Cafs,
         manifest?: DeferredManifestPromise,
       }
     ) {
@@ -22,7 +23,7 @@ export default () => {
       // removing /.git to make directory integrity calculation faster
       await rimraf(path.join(tempLocation, '.git'))
       return {
-        filesIndex: await opts.cafs.addFilesFromDir(tempLocation, opts.manifest),
+        filesIndex: await cafs.addFilesFromDir(tempLocation, opts.manifest),
       }
     },
   }

--- a/packages/git-fetcher/test/index.ts
+++ b/packages/git-fetcher/test/index.ts
@@ -11,13 +11,17 @@ test('fetch', async t => {
   t.comment(`cafs at ${cafsDir}`)
   const fetch = createFetcher().git
   const manifest = pDefer<DependencyManifest>()
-  const { filesIndex } = await fetch({
-    commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
-    repo: 'https://github.com/kevva/is-positive.git',
-  }, {
-    cafs: createCafs(cafsDir),
-    manifest,
-  })
+  const { filesIndex } = await fetch(
+    createCafs(cafsDir),
+    {
+      commit: 'c9b30e71d704cd30fa71f2edd1ecc7dcc4985493',
+      repo: 'https://github.com/kevva/is-positive.git',
+      type: 'git',
+    },
+    {
+      manifest,
+    }
+  )
   t.ok(filesIndex['package.json'])
   t.ok(await filesIndex['package.json'].generatingIntegrity)
   t.equal((await manifest.promise).name, 'is-positive')

--- a/packages/headless/test/utils/testDefaults.ts
+++ b/packages/headless/test/utils/testDefaults.ts
@@ -51,7 +51,7 @@ export default async function testDefaults (
       registry,
       ...retryOpts,
       ...fetchOpts,
-    }) as {},
+    }),
     {
       storeDir,
       ...storeOpts,

--- a/packages/store-connection-manager/src/createNewStoreController.ts
+++ b/packages/store-connection-manager/src/createNewStoreController.ts
@@ -25,7 +25,7 @@ export default async (
   await fs.mkdir(sopts.storeDir, { recursive: true })
   const fetchers = createFetcher(sopts)
   return {
-    ctrl: await createStore(resolve, fetchers as {}, {
+    ctrl: await createStore(resolve, fetchers, {
       ignoreFile: sopts.ignoreFile,
       networkConcurrency: sopts.networkConcurrency,
       packageImportMethod: sopts.packageImportMethod,

--- a/packages/supi/test/utils/testDefaults.ts
+++ b/packages/supi/test/utils/testDefaults.ts
@@ -54,7 +54,7 @@ export default async function testDefaults<T> (
       registry,
       ...retryOpts,
       ...fetchOpts,
-    }) as {},
+    }),
     {
       ignoreFile: opts?.fastUnpack === false ? undefined : (filename) => filename !== 'package.json',
       storeDir,


### PR DESCRIPTION
Fixing a regression caused by breaking changes in the fetch function
API.
`@pnpm/git-fetcher` was not correctly updated.

As a result, git-hosted dependencies were not being installed.

- [x] add an integration test - created #2582