### PR TITLE
fix(run): infinite recursion

### DIFF
--- a/.changeset/nine-ants-add.md
+++ b/.changeset/nine-ants-add.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lifecycle": minor
+---
+
+Run lifecycle scripts with the PNPM_SCRIPT_SRC_DIR env variable set. This new env variable contains the directory of the package.json file that contains the executed lifecycle script.

--- a/.changeset/three-cobras-wave.md
+++ b/.changeset/three-cobras-wave.md
@@ -1,0 +1,18 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+A recursive run should not rerun the same package script which started the lifecycle event.
+
+For instance, let's say one of the workspace projects has the following script:
+
+```json
+"scripts": {
+  "build": "pnpm run -r build"
+}
+```
+
+Running `pnpm run build` in this project should not start an infinite recursion.
+`pnpm run -r build` in this case should run `build` in all the workspace projects except the one that started the build.
+
+Related issue: #2528

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -38,7 +38,7 @@
     "@pnpm/core-loggers": "workspace:4.0.2",
     "@pnpm/read-package-json": "workspace:3.1.1",
     "@pnpm/types": "workspace:6.0.0",
-    "@zkochan/npm-lifecycle": "3.1.4",
+    "@zkochan/npm-lifecycle": "3.2.0",
     "path-exists": "4.0.0",
     "run-groups": "2.0.3"
   },

--- a/packages/lifecycle/src/runLifecycleHook.ts
+++ b/packages/lifecycle/src/runLifecycleHook.ts
@@ -48,6 +48,7 @@ export default async function runLifecycleHook (
     config: opts.rawConfig,
     dir: opts.rootModulesDir,
     extraBinPaths: opts.extraBinPaths || [],
+    extraEnv: { PNPM_SCRIPT_SRC_DIR: opts.pkgRoot },
     log: {
       clearProgress: noop,
       info: noop,

--- a/packages/plugin-commands-script-runners/src/runRecursive.ts
+++ b/packages/plugin-commands-script-runners/src/runRecursive.ts
@@ -46,7 +46,11 @@ export default async (
     await Promise.all(chunk.map((prefix: string) =>
       limitRun(async () => {
         const pkg = opts.selectedProjectsGraph[prefix]
-        if (!pkg.package.manifest.scripts || !pkg.package.manifest.scripts[scriptName]) {
+        if (
+          !pkg.package.manifest.scripts?.[scriptName] ||
+          process.env.npm_lifecycle_event === scriptName &&
+          process.env.PNPM_SCRIPT_SRC_DIR === prefix
+        ) {
           return
         }
         hasCommand++

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,7 +733,7 @@ importers:
       '@pnpm/core-loggers': 'link:../core-loggers'
       '@pnpm/read-package-json': 'link:../read-package-json'
       '@pnpm/types': 'link:../types'
-      '@zkochan/npm-lifecycle': 3.1.4
+      '@zkochan/npm-lifecycle': 3.2.0
       path-exists: 4.0.0
       run-groups: 2.0.3
     devDependencies:
@@ -749,7 +749,7 @@ importers:
       '@pnpm/read-package-json': 'workspace:3.1.1'
       '@pnpm/types': 'workspace:6.0.0'
       '@types/rimraf': ^3.0.0
-      '@zkochan/npm-lifecycle': 3.1.4
+      '@zkochan/npm-lifecycle': 3.2.0
       json-append: 1.1.1
       load-json-file: 6.2.0
       path-exists: 4.0.0
@@ -3908,7 +3908,7 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-RMFanFCfD7KSqokE8DZV9Vx/WCqxp5Zfvco2oIBPv9PPa01Z61Gy6VwFxTNmszUWQpaeNvdZBJFdjtFcXUq8GA==
-  /@zkochan/npm-lifecycle/3.1.4:
+  /@zkochan/npm-lifecycle/3.2.0:
     dependencies:
       byline: 5.0.0
       graceful-fs: 4.2.4
@@ -3922,7 +3922,7 @@ packages:
     engines:
       node: '>=8.15'
     resolution:
-      integrity: sha512-s+Uk93fCpRRNWmiG5RDH7N81TIgQEsokCChy7e/Wcq0fB593eUreIo2U+DkKnMRBqJh8NLJxsJ7HNPw5HMyw2A==
+      integrity: sha512-YdcFbrJ5n0P2/1XMEVa3rOdiSKFo2DbVDNiZOyD008uTdkqit+eKEyjJIoYBXTLUeT/QC0nXSqW4W4trrb+yCg==
   /@zkochan/npm-package-arg/1.0.2:
     dependencies:
       hosted-git-info: 2.8.8


### PR DESCRIPTION
A recursive run should not rerun the same package script which started the lifecycle event.

For instance, let's say one of the workspace projects has the following script:

```json
"scripts": {
  "build": "pnpm run -r build"
}
```

Running `pnpm run build` in this project should not start an infinite recursion.
`pnpm run -r build` in this case should run `build` in all the workspace projects except the one that started the build.

Related issue: #2528