### PR TITLE
feat(reporter): color the child output prefixes

### DIFF
--- a/.changeset/green-olives-visit.md
+++ b/.changeset/green-olives-visit.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": minor
+---
+
+Color the different output prefixes differently.

--- a/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
+++ b/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
@@ -35,10 +35,10 @@ export default (
   // When the reporter is not append-only, the length of output is limited
   // in order to reduce flickering
   if (opts.appendOnly) {
-    const streamLifecycleOutput = createStreamLifecycleOutput()
+    const streamLifecycleOutput = createStreamLifecycleOutput(opts.cwd)
     return log$.lifecycle
       .map((log: LifecycleLog) => most.of({
-        msg: streamLifecycleOutput(opts.cwd, log),
+        msg: streamLifecycleOutput(log),
       }))
   }
   const lifecycleMessages: {
@@ -199,10 +199,10 @@ function highlightLastFolder (p: string) {
 
 const ANSI_ESCAPES_LENGTH_OF_PREFIX = hlValue(' ').length - 1
 
-function createStreamLifecycleOutput () {
+function createStreamLifecycleOutput (cwd: string) {
   currentColor = 0
   const colorByPrefix: ColorByPkg = new Map()
-  return streamLifecycleOutput.bind(null, colorByPrefix)
+  return streamLifecycleOutput.bind(null, colorByPrefix, cwd)
 }
 
 function streamLifecycleOutput (

--- a/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
+++ b/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
@@ -17,7 +17,7 @@ const NODE_MODULES = `${path.sep}node_modules${path.sep}`
 const colorWheel = ['cyan', 'magenta', 'blue', 'yellow', 'green', 'red']
 const NUM_COLORS = colorWheel.length
 
-// ever-increasing index ensures colors are always sequential
+// Ever-increasing index ensures colors are always sequential
 let currentColor = 0
 
 type ColorByPkg = Map<string, (txt: string) => string>
@@ -35,11 +35,10 @@ export default (
   // When the reporter is not append-only, the length of output is limited
   // in order to reduce flickering
   if (opts.appendOnly) {
-    currentColor = 0
-    const colorByPrefix: ColorByPkg = new Map()
+    const streamLifecycleOutput = createStreamLifecycleOutput()
     return log$.lifecycle
       .map((log: LifecycleLog) => most.of({
-        msg: formatLifecycleHideOverflowForAppendOnly(colorByPrefix, opts.cwd, log),
+        msg: streamLifecycleOutput(opts.cwd, log),
       }))
   }
   const lifecycleMessages: {
@@ -200,7 +199,13 @@ function highlightLastFolder (p: string) {
 
 const ANSI_ESCAPES_LENGTH_OF_PREFIX = hlValue(' ').length - 1
 
-function formatLifecycleHideOverflowForAppendOnly (
+function createStreamLifecycleOutput () {
+  currentColor = 0
+  const colorByPrefix: ColorByPkg = new Map()
+  return streamLifecycleOutput.bind(null, colorByPrefix)
+}
+
+function streamLifecycleOutput (
   colorByPkg: ColorByPkg,
   cwd: string,
   logObj: LifecycleLog

--- a/packages/default-reporter/test/reportingLifecycleScripts.ts
+++ b/packages/default-reporter/test/reportingLifecycleScripts.ts
@@ -240,17 +240,17 @@ test('groups lifecycle output when append-only is used', t => {
   output$.take(11).map(normalizeNewline).subscribe({
     complete: () => {
       t.equal(allOutputs.join(EOL), stripIndents`
-        packages/foo ${PREINSTALL}$ node foo
-        packages/foo ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
-        packages/foo ${PREINSTALL}: Failed
-        packages/foo ${POSTINSTALL}$ node foo
-        packages/foo ${POSTINSTALL}: foo I
-        packages/bar ${POSTINSTALL}$ node bar
-        packages/bar ${POSTINSTALL}: bar I
-        packages/foo ${POSTINSTALL}: foo II
-        packages/foo ${POSTINSTALL}: foo III
-        packages/qar ${INSTALL}$ node qar
-        packages/qar ${INSTALL}: Done
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}$ node foo
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}: Failed
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}$ node foo
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo I
+        ${chalk.magenta('packages/bar')} ${POSTINSTALL}$ node bar
+        ${chalk.magenta('packages/bar')} ${POSTINSTALL}: bar I
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo II
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo III
+        ${chalk.blue('packages/qar')} ${INSTALL}$ node qar
+        ${chalk.blue('packages/qar')} ${INSTALL}: Done
       `)
       t.end()
     },
@@ -361,18 +361,18 @@ test('groups lifecycle output when streamLifecycleOutput is used', t => {
     error: t.end,
     next: (output: string) => {
       t.equal(output, stripIndents`
-        packages/foo ${PREINSTALL}$ node foo
-        packages/foo ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
-        packages/foo ${PREINSTALL}: Failed
-        packages/foo ${POSTINSTALL}$ node foo
-        packages/foo ${POSTINSTALL}: foo I
-        packages/bar ${POSTINSTALL}$ node bar
-        packages/bar ${POSTINSTALL}: bar I
-        packages/foo ${POSTINSTALL}: foo II
-        packages/foo ${POSTINSTALL}: foo III
-        packages/qar ${INSTALL}$ node qar
-        packages/qar ${INSTALL}: Done
-        packages/foo ${POSTINSTALL}: Done
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}$ node foo
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+        ${chalk.cyan('packages/foo')} ${PREINSTALL}: Failed
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}$ node foo
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo I
+        ${chalk.magenta('packages/bar')} ${POSTINSTALL}$ node bar
+        ${chalk.magenta('packages/bar')} ${POSTINSTALL}: bar I
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo II
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo III
+        ${chalk.blue('packages/qar')} ${INSTALL}$ node qar
+        ${chalk.blue('packages/qar')} ${INSTALL}: Done
+        ${chalk.cyan('packages/foo')} ${POSTINSTALL}: Done
       `)
     },
   })


### PR DESCRIPTION
This is how it looks (inspired by Lerna):

![image](https://user-images.githubusercontent.com/1927579/83360236-74485a80-a388-11ea-8648-8dad1998e64e.png)
