### PR TITLE
feat: --parallel

### DIFF
--- a/.changeset/rich-rabbits-drum.md
+++ b/.changeset/rich-rabbits-drum.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+---
+
+The `run` and `exec` commands may use the `--parallel` option.
+
+`--parallel` completely disregards concurrency and topological sorting,
+running a given script immediately in all matching packages
+with prefixed streaming output. This is the preferred flag
+for long-running processes such as watch run over many packages.
+
+For example: `pnpm run --parallel watch`

--- a/.changeset/swift-hotels-approve.md
+++ b/.changeset/swift-hotels-approve.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/parse-cli-args": minor
+---
+
+The mapping of CLI option shorthands may use arrays of string.

--- a/packages/parse-cli-args/src/index.ts
+++ b/packages/parse-cli-args/src/index.ts
@@ -22,9 +22,9 @@ export default async function parseCliArgs (
     getCommandLongName: (commandName: string) => string | null,
     getTypesByCommandName: (commandName: string) => object,
     renamedOptions?: Record<string, string>,
-    shorthandsByCommandName: Record<string, Record<string, string>>,
+    shorthandsByCommandName: Record<string, Record<string, string | string[]>>,
     universalOptionsTypes: Record<string, unknown>,
-    universalShorthands: Record<string, string>,
+    universalShorthands: Record<string, string | string[]>,
   },
   inputArgv: string[]
 ): Promise<ParsedCliArgs> {

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -7,6 +7,14 @@ import execa = require('execa')
 import pLimit from 'p-limit'
 import R = require('ramda')
 import renderHelp = require('render-help')
+import {
+  PARALLEL_OPTION_HELP,
+  shorthands as runShorthands,
+} from './run'
+
+export const shorthands = {
+  parallel: runShorthands.parallel,
+}
 
 export const commandNames = ['exec']
 
@@ -27,6 +35,15 @@ export const cliOptionsTypes = () => ({
 export function help () {
   return renderHelp({
     description: 'Run a command in each package.',
+    descriptionLists: [
+      {
+        title: 'Options',
+
+        list: [
+          PARALLEL_OPTION_HELP,
+        ],
+      },
+    ],
     usages: ['-r exec -- <command> [args...]'],
   })
 }

--- a/packages/plugin-commands-script-runners/src/run.ts
+++ b/packages/plugin-commands-script-runners/src/run.ts
@@ -21,6 +21,23 @@ export const IF_PRESENT_OPTION_HELP = {
   name: '--if-present',
 }
 
+export const PARALLEL_OPTION_HELP = {
+  description: oneLine`Completely disregard concurrency and topological sorting,
+    running a given script immediately in all matching packages
+    with prefixed streaming output. This is the preferred flag
+    for long-running processes such as watch run over many packages.`,
+  name: '--parallel',
+}
+
+export const shorthands = {
+  'parallel': [
+    '--workspace-concurrency=Infinity',
+    '--no-sort',
+    '--stream',
+    '--recursive',
+  ],
+}
+
 export function rcOptionsTypes () {
   return {
     ...R.pick([
@@ -69,6 +86,7 @@ export function help () {
             shortAlias: '-r',
           },
           IF_PRESENT_OPTION_HELP,
+          PARALLEL_OPTION_HELP,
           ...UNIVERSAL_OPTIONS,
         ],
       },
@@ -79,15 +97,16 @@ export function help () {
   })
 }
 
-export type RunOpts = Omit<RecursiveRunOpts, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'> & {
-  recursive?: boolean,
-} & Pick<Config, 'dir' | 'engineStrict'> & (
-  { recursive?: false } &
-  Partial<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>>
-  |
-  { recursive: true } &
-  Required<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>>
-)
+export type RunOpts =
+  & Omit<RecursiveRunOpts, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>
+  & { recursive?: boolean }
+  & Pick<Config, 'dir' | 'engineStrict'>
+  & (
+    & { recursive?: false }
+    & Partial<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>>
+    | { recursive: true }
+    & Required<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>>
+  )
 
 export async function handler (
   opts: RunOpts,

--- a/packages/pnpm/src/cmd/complete.ts
+++ b/packages/pnpm/src/cmd/complete.ts
@@ -10,7 +10,7 @@ export default async function complete (
     cliOptionsTypesByCommandName: Record<string, () => Object>,
     completionByCommandName: Record<string, CompletionFunc>,
     initialCompletion: () => Completion[],
-    shorthandsByCommandName: Record<string, Record<string, string>>,
+    shorthandsByCommandName: Record<string, Record<string, string | string[]>>,
     universalOptionsTypes: Record<string, Object>,
   },
   input: {

--- a/packages/pnpm/src/cmd/completion.ts
+++ b/packages/pnpm/src/cmd/completion.ts
@@ -13,7 +13,7 @@ export default function (
     cliOptionsTypesByCommandName: Record<string, () => Object>,
     completionByCommandName: Record<string, CompletionFunc>,
     initialCompletion: () => Completion[],
-    shorthandsByCommandName: Record<string, Record<string, string>>,
+    shorthandsByCommandName: Record<string, Record<string, string | string[]>>,
     universalOptionsTypes: Record<string, Object>,
   }
 ) {

--- a/packages/pnpm/src/cmd/index.ts
+++ b/packages/pnpm/src/cmd/index.ts
@@ -50,7 +50,7 @@ const commands: Array<{
   handler: Function,
   help: () => string,
   rcOptionsTypes: () => Record<string, unknown>,
-  shorthands?: Record<string, string>,
+  shorthands?: Record<string, string | string[]>,
 }> = [
   add,
   audit,
@@ -86,7 +86,7 @@ const cliOptionsTypesByCommandName: Record<string, () => Object> = {}
 const rcOptionsTypesByCommandName: Record<string, () => Record<string, unknown>> = {}
 const aliasToFullName: Map<string, string> = new Map()
 const completionByCommandName: Record<string, CompletionFunc> = {}
-const shorthandsByCommandName: Record<string, Record<string, string>> = {}
+const shorthandsByCommandName: Record<string, Record<string, string | string[]>> = {}
 
 for (let i = 0; i < commands.length; i++) {
   const {


### PR DESCRIPTION
The `run` and `exec` commands may use the `--parallel` option.

`--parallel` completely disregards concurrency and topological sorting,
running a given script immediately in all matching packages
with prefixed streaming output. This is the preferred flag
for long-running processes such as watch run over many packages.

For example: `pnpm run --parallel watch`

close #2528