### PR TITLE
fix: don't always remove auth headers when redirecting

### DIFF
--- a/.changeset/polite-lions-sneeze.md
+++ b/.changeset/polite-lions-sneeze.md
@@ -1,0 +1,5 @@
+---
+"fetch-from-npm-registry": patch
+---
+
+Don't remove authorization headers when redirecting requests to the same host.

--- a/packages/fetch-from-npm-registry/test/index.ts
+++ b/packages/fetch-from-npm-registry/test/index.ts
@@ -21,7 +21,7 @@ test('fetchFromNpmRegistry fullMetadata', async t => {
   t.end()
 })
 
-test('authorization headers are removed before redirection', async (t) => {
+test('authorization headers are removed before redirection if the target is on a different host', async (t) => {
   nock('http://registry.pnpm.js.org/', {
     reqheaders: { authorization: 'Bearer 123' },
   })
@@ -29,6 +29,29 @@ test('authorization headers are removed before redirection', async (t) => {
     .reply(302, '', { location: 'http://registry.other.org/is-positive' })
   nock('http://registry.other.org/', { badheaders: ['authorization'] })
     .get('/is-positive')
+    .reply(200, { ok: true })
+
+  const fetchFromNpmRegistry = createRegClient({ fullMetadata: true })
+  const res = await fetchFromNpmRegistry(
+    'http://registry.pnpm.js.org/is-positive',
+    { authHeaderValue: 'Bearer 123' }
+  )
+
+  t.deepEqual(await res.json(), { ok: true })
+  t.ok(nock.isDone())
+  t.end()
+})
+
+test('authorization headers are not removed before redirection if the target is on the same host', async (t) => {
+  nock('http://registry.pnpm.js.org/', {
+    reqheaders: { authorization: 'Bearer 123' },
+  })
+    .get('/is-positive')
+    .reply(302, '', { location: 'http://registry.pnpm.js.org/is-positive-new' })
+  nock('http://registry.pnpm.js.org/', {
+    reqheaders: { authorization: 'Bearer 123' },
+  })
+    .get('/is-positive-new')
     .reply(200, { ok: true })
 
   const fetchFromNpmRegistry = createRegClient({ fullMetadata: true })


### PR DESCRIPTION
Don't remove authorization headers when redirecting requests
to the same host.

close #2602