### PR TITLE
fix(resolution): respect linked-workspaces = false in up-to-date check

### DIFF
--- a/.changeset/long-squids-wash.md
+++ b/.changeset/long-squids-wash.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Perform headless installation when dependencies should not be linked from the workspace, and they are not indeed linked from the workspace.

--- a/packages/supi/src/install/allProjectsAreUpToDate.ts
+++ b/packages/supi/src/install/allProjectsAreUpToDate.ts
@@ -19,19 +19,27 @@ import semver = require('semver')
 export default async function allProjectsAreUpToDate (
   projects: Array<ProjectOptions & { id: string }>,
   opts: {
-    preserveWorkspaceProtocol: boolean,
+    linkWorkspacePackages: boolean,
     wantedLockfile: Lockfile,
     workspacePackages: WorkspacePackages,
   }
 ) {
   const manifestsByDir = opts.workspacePackages ? getWorkspacePackagesByDirectory(opts.workspacePackages) : {}
   const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, opts.wantedLockfile)
-  const _linkedPackagesAreUpToDate = linkedPackagesAreUpToDate.bind(null, manifestsByDir, opts.workspacePackages)
+  const _linkedPackagesAreUpToDate = linkedPackagesAreUpToDate.bind(null, {
+    linkWorkspacePackages: opts.linkWorkspacePackages,
+    manifestsByDir,
+    workspacePackages: opts.workspacePackages,
+  })
   return pEvery(projects, async (project) => {
     const importer = opts.wantedLockfile.importers[project.id]
     return importer && !hasLocalTarballDepsInRoot(importer) &&
       _satisfiesPackageManifest(project.manifest, project.id) &&
-      _linkedPackagesAreUpToDate(project.manifest, importer, project.rootDir, opts.preserveWorkspaceProtocol)
+      _linkedPackagesAreUpToDate({
+        dir: project.rootDir,
+        manifest: project.manifest,
+        snapshot: importer,
+      })
   })
 }
 
@@ -46,16 +54,24 @@ function getWorkspacePackagesByDirectory (workspacePackages: WorkspacePackages) 
 }
 
 async function linkedPackagesAreUpToDate (
-  manifestsByDir: Record<string, DependencyManifest>,
-  workspacePackages: WorkspacePackages,
-  manifest: ProjectManifest,
-  projectSnapshot: ProjectSnapshot,
-  projectDir: string,
-  preserveWorkspaceProtocol: boolean
+  {
+    linkWorkspacePackages,
+    manifestsByDir,
+    workspacePackages,
+  }: {
+    linkWorkspacePackages: boolean,
+    manifestsByDir: Record<string, DependencyManifest>,
+    workspacePackages: WorkspacePackages,
+  },
+  project: {
+    dir: string,
+    manifest: ProjectManifest,
+    snapshot: ProjectSnapshot,
+  }
 ) {
   for (const depField of DEPENDENCIES_FIELDS) {
-    const lockfileDeps = projectSnapshot[depField]
-    const manifestDeps = manifest[depField]
+    const lockfileDeps = project.snapshot[depField]
+    const manifestDeps = project.manifest[depField]
     if (!lockfileDeps || !manifestDeps) continue
     const depNames = Object.keys(lockfileDeps)
     for (const depName of depNames) {
@@ -73,10 +89,10 @@ async function linkedPackagesAreUpToDate (
         continue
       }
       const linkedDir = isLinked
-        ? path.join(projectDir, lockfileRef.substr(5))
+        ? path.join(project.dir, lockfileRef.substr(5))
         : workspacePackages?.[depName]?.[lockfileRef]?.dir
       if (!linkedDir) continue
-      if (preserveWorkspaceProtocol && !currentSpec.startsWith('workspace:')) {
+      if (!linkWorkspacePackages && !currentSpec.startsWith('workspace:')) {
         // we found a linked dir, but we don't want to use it, because it's not specified as a
         // workspace:x.x.x dependency
         continue

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -170,7 +170,11 @@ export async function mutateModules (
         (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === ctx.projects.length) &&
         ctx.existsWantedLockfile &&
         ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
-        await allProjectsAreUpToDate(ctx.projects, { wantedLockfile: ctx.wantedLockfile, workspacePackages: opts.workspacePackages })
+        await allProjectsAreUpToDate(ctx.projects, {
+          preserveWorkspaceProtocol: opts.preserveWorkspaceProtocol,
+          wantedLockfile: ctx.wantedLockfile,
+          workspacePackages: opts.workspacePackages,
+        })
       )
     ) {
       if (!ctx.existsWantedLockfile) {

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -171,7 +171,7 @@ export async function mutateModules (
         ctx.existsWantedLockfile &&
         ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
         await allProjectsAreUpToDate(ctx.projects, {
-          preserveWorkspaceProtocol: opts.preserveWorkspaceProtocol,
+          linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
           wantedLockfile: ctx.wantedLockfile,
           workspacePackages: opts.workspacePackages,
         })

--- a/packages/supi/test/allProjectsAreUpToDate.test.ts
+++ b/packages/supi/test/allProjectsAreUpToDate.test.ts
@@ -34,7 +34,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies', async (t
       rootDir: 'foo',
     },
   ], {
-    preserveWorkspaceProtocol: false,
+    linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
         bar: {
@@ -72,7 +72,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies that speci
       rootDir: 'foo',
     },
   ], {
-    preserveWorkspaceProtocol: false,
+    linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
         bar: {
@@ -110,7 +110,7 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
       rootDir: 'foo',
     },
   ], {
-    preserveWorkspaceProtocol: false,
+    linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
         bar: {
@@ -131,7 +131,7 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
   }))
 })
 
-test('allProjectsAreUpToDate(): use link and registry version if preserveWorkspaceProtocol = true', async (t: tape.Test) => {
+test('allProjectsAreUpToDate(): use link and registry version if linkWorkspacePackages = false', async (t: tape.Test) => {
   t.ok(
     await allProjectsAreUpToDate(
       [
@@ -160,7 +160,7 @@ test('allProjectsAreUpToDate(): use link and registry version if preserveWorkspa
         },
       ],
       {
-        preserveWorkspaceProtocol: true,
+        linkWorkspacePackages: false,
         wantedLockfile: {
           importers: {
             bar: {

--- a/packages/supi/test/allProjectsAreUpToDate.test.ts
+++ b/packages/supi/test/allProjectsAreUpToDate.test.ts
@@ -34,6 +34,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies', async (t
       rootDir: 'foo',
     },
   ], {
+    preserveWorkspaceProtocol: false,
     wantedLockfile: {
       importers: {
         bar: {
@@ -71,6 +72,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies that speci
       rootDir: 'foo',
     },
   ], {
+    preserveWorkspaceProtocol: false,
     wantedLockfile: {
       importers: {
         bar: {
@@ -108,6 +110,7 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
       rootDir: 'foo',
     },
   ], {
+    preserveWorkspaceProtocol: false,
     wantedLockfile: {
       importers: {
         bar: {
@@ -126,4 +129,64 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
     },
     workspacePackages,
   }))
+})
+
+test('allProjectsAreUpToDate(): use link and registry version if preserveWorkspaceProtocol = true', async (t: tape.Test) => {
+  t.ok(
+    await allProjectsAreUpToDate(
+      [
+        {
+          id: 'bar',
+          manifest: {
+            dependencies: {
+              foo: 'workspace:*',
+            },
+          },
+          rootDir: 'bar',
+        },
+        {
+          id: 'bar2',
+          manifest: {
+            dependencies: {
+              foo: '1.0.0',
+            },
+          },
+          rootDir: 'bar2',
+        },
+        {
+          id: 'foo',
+          manifest: fooManifest,
+          rootDir: 'foo',
+        },
+      ],
+      {
+        preserveWorkspaceProtocol: true,
+        wantedLockfile: {
+          importers: {
+            bar: {
+              dependencies: {
+                foo: 'link:../foo',
+              },
+              specifiers: {
+                foo: 'workspace:*',
+              },
+            },
+            bar2: {
+              dependencies: {
+                foo: '1.0.0',
+              },
+              specifiers: {
+                foo: '1.0.0',
+              },
+            },
+            foo: {
+              specifiers: {},
+            },
+          },
+          lockfileVersion: 5,
+        },
+        workspacePackages,
+      }
+    )
+  )
 })


### PR DESCRIPTION
When linked-workspaces = false and the lockfile is up to date, the projects up-to-date check is incorrectly re-running the resolution step.
This happens in workspaces where packages are using both the workspace version of a package, and a registry version of the package.

Fixes #2618