### PR TITLE
fix(filtering): Support linked-workspace- packages='false' in workspace filtering

### DIFF
--- a/.changeset/modern-cheetahs-doubt.md
+++ b/.changeset/modern-cheetahs-doubt.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/filter-workspace-packages": minor
+"pkgs-graph": minor
+"@pnpm/plugin-commands-listing": minor
+"pnpm": minor
+---
+
+Support linked-workspace- packages='false' in workspace filtering

--- a/.changeset/modern-cheetahs-doubt.md
+++ b/.changeset/modern-cheetahs-doubt.md
@@ -1,8 +1,6 @@
 ---
 "@pnpm/filter-workspace-packages": minor
 "pkgs-graph": minor
-"@pnpm/plugin-commands-listing": minor
-"pnpm": minor
 ---
 
-Support linked-workspace- packages='false' in workspace filtering
+Support linkedWorkspacePackages=false.

--- a/.changeset/perfect-walls-run.md
+++ b/.changeset/perfect-walls-run.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+When `link-workspace-packages` is `false`, filtering by dependencies/dependents, should ignore any packages that are not specified via `workspace:` ranges.

--- a/.changeset/perfect-walls-run.md
+++ b/.changeset/perfect-walls-run.md
@@ -2,4 +2,4 @@
 "pnpm": patch
 ---
 
-When `link-workspace-packages` is `false`, filtering by dependencies/dependents, should ignore any packages that are not specified via `workspace:` ranges.
+When `link-workspace-packages` is `false`, filtering by dependencies/dependents should ignore any packages that are not specified via `workspace:` ranges.

--- a/packages/filter-workspace-packages/src/index.ts
+++ b/packages/filter-workspace-packages/src/index.ts
@@ -18,13 +18,17 @@ interface Graph {
 
 export async function readProjects (
   workspaceDir: string,
-  pkgSelectors: PackageSelector[]
+  pkgSelectors: PackageSelector[],
+  opts?: {
+    linkWorkspacePackages?: boolean,
+  }
 ) {
   const allProjects = await findWorkspacePackages(workspaceDir, {})
   const { selectedProjectsGraph } = await filterPkgsBySelectorObjects(
     allProjects,
     pkgSelectors,
     {
+      linkWorkspacePackages: opts?.linkWorkspacePackages,
       workspaceDir,
     }
   )
@@ -35,6 +39,7 @@ export async function filterPackages<T> (
   pkgs: Array<Package & T>,
   filter: string[],
   opts: {
+    linkWorkspacePackages?: boolean,
     prefix: string,
     workspaceDir: string,
   }
@@ -52,13 +57,14 @@ export async function filterPkgsBySelectorObjects<T> (
   pkgs: Array<Package & T>,
   packageSelectors: PackageSelector[],
   opts: {
+    linkWorkspacePackages?: boolean,
     workspaceDir: string,
   }
 ): Promise<{
   selectedProjectsGraph: PackageGraph<T>,
   unmatchedFilters: string[],
 }> {
-  const { graph } = createPkgGraph<T>(pkgs)
+  const { graph } = createPkgGraph<T>(pkgs, { linkWorkspacePackages: opts.linkWorkspacePackages })
   if (packageSelectors && packageSelectors.length) {
     return filterGraph(graph, packageSelectors, {
       workspaceDir: opts.workspaceDir,

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -27,7 +27,9 @@ export type PackageNode<T> = {
   dependencies: string[],
 }
 
-export default function<T> (pkgs: Array<Package & T>): {
+export default function<T> (pkgs: Array<Package & T>, opts?: {
+  linkWorkspacePackages?: boolean
+}): {
   graph: {[id: string]: PackageNode<T>},
   unmatched: Array<{pkgName: string, range: string}>,
 } {
@@ -54,8 +56,9 @@ export default function<T> (pkgs: Array<Package & T>): {
       .map(depName => {
         let spec!: { fetchSpec: string, type: string }
         let rawSpec = dependencies[depName]
+        const isWorkspaceSpec = rawSpec.startsWith('workspace:')
         try {
-          if (rawSpec.startsWith('workspace:')) {
+          if (isWorkspaceSpec) {
             rawSpec = rawSpec.substr(10)
           }
           spec = npa.resolve(depName, rawSpec, pkg.dir)
@@ -75,8 +78,15 @@ export default function<T> (pkgs: Array<Package & T>): {
 
         const pkgs = R.values(pkgMap).filter(pkg => pkg.manifest.name === depName)
         if (!pkgs.length) return ''
-        const versions = pkgs.filter(({ manifest }) => manifest.version)
+        let versions = pkgs.filter(({ manifest }) => manifest.version)
           .map(pkg => pkg.manifest.version) as string[]
+
+        // explicitly check if false, backwards-compatibility (can be undefined)
+        const strictWorkspaceMatching = opts?.linkWorkspacePackages === false && !isWorkspaceSpec
+        if (strictWorkspaceMatching) {
+          // keep any versions that do not equal the raw spec
+          versions = versions.filter(v => v !== rawSpec)
+        }
         if (versions.includes(rawSpec)) {
           const matchedPkg = pkgs.find(pkg => pkg.manifest.name === depName && pkg.manifest.version === rawSpec)
           return matchedPkg!.dir

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -78,14 +78,14 @@ export default function<T> (pkgs: Array<Package & T>, opts?: {
 
         const pkgs = R.values(pkgMap).filter(pkg => pkg.manifest.name === depName)
         if (!pkgs.length) return ''
-        let versions = pkgs.filter(({ manifest }) => manifest.version)
+        const versions = pkgs.filter(({ manifest }) => manifest.version)
           .map(pkg => pkg.manifest.version) as string[]
 
         // explicitly check if false, backwards-compatibility (can be undefined)
         const strictWorkspaceMatching = opts?.linkWorkspacePackages === false && !isWorkspaceSpec
         if (strictWorkspaceMatching) {
-          // keep any versions that do not equal the raw spec
-          versions = versions.filter(v => v !== rawSpec)
+          unmatched.push({ pkgName: depName, range: rawSpec })
+          return ''
         }
         if (versions.includes(rawSpec)) {
           const matchedPkg = pkgs.find(pkg => pkg.manifest.name === depName && pkg.manifest.version === rawSpec)

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -150,6 +150,7 @@ export default async function run (inputArgv: string[]) {
       return
     }
     const filterResults = await filterPackages(allProjects, config.filter ?? [], {
+      linkWorkspacePackages: !!config.linkWorkspacePackages,
       prefix: process.cwd(),
       workspaceDir: wsDir,
     })


### PR DESCRIPTION
Pass the linkedWorkspacePackages config to the pkg-graph,
only select packages that are explicitly referred to as workspace:...
when this setting is on.

Fixes #2625