### PR TITLE
fix: don't fail when a manifest starts with BOM

### DIFF
--- a/.changeset/calm-camels-bathe.md
+++ b/.changeset/calm-camels-bathe.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Don't fail when the installed package's manifest (`package.json`) starts with a byte order mark (BOM). This is a fix for a regression that appeared in v5.0.0.

--- a/.changeset/nine-zoos-listen.md
+++ b/.changeset/nine-zoos-listen.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/cafs": patch
+---
+
+Strip byte order mark (BOM) before parsing the content of a package manifest (package.json).

--- a/packages/cafs/package.json
+++ b/packages/cafs/package.json
@@ -26,6 +26,7 @@
     "path-temp": "2.0.0",
     "rename-overwrite": "^3.0.0",
     "ssri": "6.0.1",
+    "strip-bom": "^4.0.0",
     "tar-stream": "^2.1.2"
   },
   "devDependencies": {

--- a/packages/cafs/src/parseJson.ts
+++ b/packages/cafs/src/parseJson.ts
@@ -1,13 +1,14 @@
 import { DeferredManifestPromise } from '@pnpm/fetcher-base'
 import concatStream = require('concat-stream')
 import { PassThrough } from 'stream'
+import stripBom = require('strip-bom')
 
 export function parseJsonBuffer (
   buffer: Buffer,
   deferred: DeferredManifestPromise
 ) {
   try {
-    deferred.resolve(JSON.parse(buffer.toString()))
+    deferred.resolve(JSON.parse(stripBom(buffer.toString())))
   } catch (err) {
     deferred.reject(err)
   }

--- a/packages/supi/test/install/misc.ts
+++ b/packages/supi/test/install/misc.ts
@@ -1135,3 +1135,16 @@ test('globally installed package which don\'t have bins should log warning messa
 
   t.end()
 })
+
+// Covers issue: https://github.com/pnpm/pnpm/issues/2629
+test('installing a package that has a manifest with byte order mark (BOM)', async (t: tape.Test) => {
+  const project = prepareEmpty(t)
+
+  await install({
+    dependencies: {
+      'paralleljs': '0.2.1',
+    },
+  }, await testDefaults())
+
+  await project.has('paralleljs')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,7 @@ importers:
       path-temp: 2.0.0
       rename-overwrite: 3.0.0
       ssri: 6.0.1
+      strip-bom: 4.0.0
       tar-stream: 2.1.2
     devDependencies:
       '@types/concat-stream': 1.6.0
@@ -134,6 +135,7 @@ importers:
       path-temp: 2.0.0
       rename-overwrite: ^3.0.0
       ssri: 6.0.1
+      strip-bom: ^4.0.0
       tar-stream: ^2.1.2
       tempy: ^0.5.0
   packages/cli-meta:


### PR DESCRIPTION
This fixes a regression that appeared in v5.0.0.

close #2629