### PR TITLE
fix: root -g should not fail

### DIFF
--- a/.changeset/eight-penguins-hunt.md
+++ b/.changeset/eight-penguins-hunt.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli-utils": minor
+"@pnpm/config": minor
+---
+
+A new option added that allows to resolve the global bin directory from directories to which there is no write access.

--- a/.changeset/orange-clocks-pretend.md
+++ b/.changeset/orange-clocks-pretend.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/global-bin-dir": minor
+---
+
+Add a new optional argument. When the argument is `false`, a global bin directory is returned even if the process has no write access to it.

--- a/packages/cli-utils/src/getConfig.ts
+++ b/packages/cli-utils/src/getConfig.ts
@@ -5,12 +5,14 @@ export default async function (
   cliOptions: CliOptions,
   opts: {
     excludeReporter: boolean,
+    globalBinDirShouldAllowWrite?: boolean,
     rcOptionsTypes: Record<string, unknown>,
     workspaceDir: string | undefined,
   }
 ) {
   const { config, warnings } = await getConfig({
     cliOptions,
+    globalBinDirShouldAllowWrite: opts.globalBinDirShouldAllowWrite,
     packageManager,
     rcOptionsTypes: opts.rcOptionsTypes,
     workspaceDir: opts.workspaceDir,

--- a/packages/cli-utils/src/getConfig.ts
+++ b/packages/cli-utils/src/getConfig.ts
@@ -5,14 +5,14 @@ export default async function (
   cliOptions: CliOptions,
   opts: {
     excludeReporter: boolean,
-    globalBinDirShouldAllowWrite?: boolean,
+    globalDirShouldAllowWrite?: boolean,
     rcOptionsTypes: Record<string, unknown>,
     workspaceDir: string | undefined,
   }
 ) {
   const { config, warnings } = await getConfig({
     cliOptions,
-    globalBinDirShouldAllowWrite: opts.globalBinDirShouldAllowWrite,
+    globalDirShouldAllowWrite: opts.globalDirShouldAllowWrite,
     packageManager,
     rcOptionsTypes: opts.rcOptionsTypes,
     workspaceDir: opts.workspaceDir,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -91,7 +91,7 @@ export type CliOptions = Record<string, unknown> & { dir?: string }
 
 export default async (
   opts: {
-    globalBinDirShouldAllowWrite?: boolean,
+    globalDirShouldAllowWrite?: boolean,
     cliOptions: CliOptions,
     packageManager: {
       name: string,
@@ -230,7 +230,7 @@ export default async (
         process.platform === 'win32'
           ? cliOptions.dir : path.resolve(cliOptions.dir, 'bin')
       )
-      : globalBinDir([pnpmConfig.npmGlobalBinDir], { shouldAllowWrite: opts.globalBinDirShouldAllowWrite === true })
+      : globalBinDir([pnpmConfig.npmGlobalBinDir], { shouldAllowWrite: opts.globalDirShouldAllowWrite === true })
     pnpmConfig.allowNew = true
     pnpmConfig.ignoreCurrentPrefs = true
     pnpmConfig.saveProd = true

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -91,6 +91,7 @@ export type CliOptions = Record<string, unknown> & { dir?: string }
 
 export default async (
   opts: {
+    globalBinDirShouldAllowWrite?: boolean,
     cliOptions: CliOptions,
     packageManager: {
       name: string,
@@ -229,7 +230,7 @@ export default async (
         process.platform === 'win32'
           ? cliOptions.dir : path.resolve(cliOptions.dir, 'bin')
       )
-      : globalBinDir([pnpmConfig.npmGlobalBinDir])
+      : globalBinDir([pnpmConfig.npmGlobalBinDir], { shouldAllowWrite: opts.globalBinDirShouldAllowWrite === true })
     pnpmConfig.allowNew = true
     pnpmConfig.ignoreCurrentPrefs = true
     pnpmConfig.saveProd = true

--- a/packages/global-bin-dir/test/index.ts
+++ b/packages/global-bin-dir/test/index.ts
@@ -100,6 +100,12 @@ test('when the process has no write access to any of the suitable directories, t
   t.end()
 })
 
+test('when the process has no write access to any of the suitable directories, but opts.shouldAllowWrite is false, return the first match', (t) => {
+  canWriteToDir = (dir) => dir === otherDir
+  t.equal(globalBinDir([], { shouldAllowWrite: false }), nodeGlobalBin)
+  t.end()
+})
+
 test('throw an exception if non of the directories in the PATH are suitable', (t) => {
   const pathEnv = process.env[FAKE_PATH]
   process.env[FAKE_PATH] = [otherDir].join(path.delimiter)

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -80,10 +80,10 @@ export default async function run (inputArgv: string[]) {
   try {
     // When we just want to print the location of the global bin directory,
     // we don't need the write permission to it. Related issue: #2700
-    const globalBinDirShouldAllowWrite = cmd === 'root'
+    const globalDirShouldAllowWrite = cmd === 'root'
     config = await getConfig(cliOptions, {
       excludeReporter: false,
-      globalBinDirShouldAllowWrite,
+      globalDirShouldAllowWrite,
       rcOptionsTypes: getRCOptionsTypes(cmd),
       workspaceDir,
     }) as typeof config

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -78,8 +78,12 @@ export default async function run (inputArgv: string[]) {
     argv: { remain: string[], cooked: string[], original: string[] },
   }
   try {
+    // When we just want to print the location of the global bin directory,
+    // we don't need the write permission to it. Related issue: #2700
+    const globalBinDirShouldAllowWrite = cmd === 'root'
     config = await getConfig(cliOptions, {
       excludeReporter: false,
+      globalBinDirShouldAllowWrite,
       rcOptionsTypes: getRCOptionsTypes(cmd),
       workspaceDir,
     }) as typeof config


### PR DESCRIPTION
`pnpm root -g` should not fail if the pnpm process has no access
to the global bin directory.

close #2700