### PR TITLE
fix lockfile not updated when remove dependency with readPackage hook

### DIFF
--- a/.changeset/cold-feet-arrive.md
+++ b/.changeset/cold-feet-arrive.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"supi": patch
+---
+
+fix lockfile not updated when remove dependency in project with readPackage hook

--- a/packages/pnpm/test/hooks.ts
+++ b/packages/pnpm/test/hooks.ts
@@ -14,8 +14,10 @@ test('readPackage hook in single project doesn\'t modify manifest', async (t) =>
   const pnpmfile = `
       module.exports = { hooks: { readPackage } }
       function readPackage (pkg) {
-      pkg.dependencies = pkg.dependencies || {}
-      pkg.dependencies['dep-of-pkg-with-1-dep'] = '100.1.0'
+        if (pkg.name === 'project') {
+          pkg.dependencies = pkg.dependencies || {}
+          pkg.dependencies['dep-of-pkg-with-1-dep'] = '100.1.0'
+        }
       return pkg
       }
   `
@@ -36,9 +38,10 @@ test('readPackage hook in single project doesn\'t modify manifest', async (t) =>
   await execPnpm(['remove', 'is-positive'])
   pkg = await loadJsonFile(path.resolve('package.json'))
   t.notOk(pkg.dependencies, 'remove & readPackage hook work')
+  await project.hasNot('is-positive')
 })
 
-test.skip('readPackage hook in monorepo doesn\'t modify manifest', async (t) => {
+test('readPackage hook in monorepo doesn\'t modify manifest', async (t) => {
   const projects = preparePackages(t, [
     {
       name: 'project-a',
@@ -53,8 +56,10 @@ test.skip('readPackage hook in monorepo doesn\'t modify manifest', async (t) => 
   const pnpmfile = `
       module.exports = { hooks: { readPackage } }
       function readPackage (pkg) {
-        pkg.dependencies = pkg.dependencies || {}
-        pkg.dependencies['dep-of-pkg-with-1-dep'] = '100.1.0'
+        if (pkg.name === 'project-a') {
+          pkg.dependencies = pkg.dependencies || {}
+          pkg.dependencies['dep-of-pkg-with-1-dep'] = '100.1.0'
+        }
         return pkg
       }
     `

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -574,11 +574,11 @@ async function installInContext (
     projects
       .map(async (project) => {
         if (project.mutation !== 'uninstallSome') return
-        const field = project.originalManifest ? 'originalManifest' : 'manifest'
-        project[field] = await removeDeps(project[field] as ProjectManifest, project.dependencyNames, {
-          prefix: project.rootDir,
-          saveType: project.targetDependenciesField,
-        })
+        const _removeDeps = (manifest: ProjectManifest) => removeDeps(manifest, project.dependencyNames, { prefix: project.rootDir, saveType: project.targetDependenciesField })
+        project.manifest = await _removeDeps(project.manifest)
+        if (project.originalManifest) {
+          project.originalManifest = await _removeDeps(project.originalManifest)
+        }
       })
   )
 


### PR DESCRIPTION
This PR fixes a bug caused by #2693: when removing a dependency in a project with readPackage hook, lockfile is not updated as expected.

I fixed it by modifying both originalManifest and manifest when removing dependency. I just modified originalManifest before, which caused following dependency resolution wrong.

I have added another assertion to make sure this case is tested.

Additionally, the tests I added cause some other tests failling. I think I have found a workaround to get all tests pass. The problem seems becasuse pnpmfile.js added dep-of-pkg-with-1-dep to is-positive dependencies and saved it into pnpm store. So I should specify package in pnpmfile.js so that other packages not modified.