### PR TITLE
fix(git-resolver): avoid retries on bitbucket/gitlab private repos

### DIFF
--- a/.changeset/red-lamps-camp.md
+++ b/.changeset/red-lamps-camp.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/git-resolver": patch
+"pnpm": patch
+---
+
+Don't make unnecessary retries when fetching Git-hosted packages [#2731](https://github.com/pnpm/pnpm/pull/2731).

--- a/packages/git-resolver/src/parsePref.ts
+++ b/packages/git-resolver/src/parsePref.ts
@@ -78,7 +78,9 @@ async function fromHostedGit (hosted: any): Promise<HostedPackageSpec> { // esli
   let fetchSpec: string | null = null
   // try git/https url before fallback to ssh url
 
-  const gitUrl = hosted.git({ noCommittish: true })
+  // Note only GitHub has gitTemplate (git://...) in hosted-git-info, has to use
+  // sshTemplate (git@...) for bitbucket and gitlab.
+  const gitUrl = hosted.git({ noCommittish: true }) || hosted.ssh({ noCommittish: true })
   if (gitUrl && await accessRepository(gitUrl)) {
     fetchSpec = gitUrl
   }

--- a/packages/git-resolver/src/parsePref.ts
+++ b/packages/git-resolver/src/parsePref.ts
@@ -80,7 +80,7 @@ async function fromHostedGit (hosted: any): Promise<HostedPackageSpec> { // esli
 
   // Note only GitHub has gitTemplate (git://...) in hosted-git-info, has to use
   // sshTemplate (git@...) for bitbucket and gitlab.
-  const gitUrl = hosted.git({ noCommittish: true }) || hosted.ssh({ noCommittish: true })
+  const gitUrl = hosted.git({ noCommittish: true }) ?? hosted.ssh({ noCommittish: true })
   if (gitUrl && await accessRepository(gitUrl)) {
     fetchSpec = gitUrl
   }

--- a/packages/git-resolver/src/parsePref.ts
+++ b/packages/git-resolver/src/parsePref.ts
@@ -107,7 +107,7 @@ async function fromHostedGit (hosted: any): Promise<HostedPackageSpec> { // esli
           // npm instead tries git ls-remote directly which prompts user for login credentials.
 
           // HTTP HEAD on https://domain/user/repo, strip out ".git"
-          const response = await fetch(httpsUrl.substr(0, httpsUrl.length - 4), { method: 'HEAD', follow: 0 })
+          const response = await fetch(httpsUrl.substr(0, httpsUrl.length - 4), { method: 'HEAD', follow: 0, retry: { retries: 0 } })
           if (response.ok) {
             fetchSpec = httpsUrl
           }


### PR DESCRIPTION
Recent retry feature exposed this bug. The hosted.git() only works with GitHub repos, bitbucket/gitlab has no gitTemplate defined in hosted-git-info.

-----

Before this fix, a `pnpm i` gave me:
```
⋊> ~/b/bcx-broker-au-frontend on new-ui ↑ pnpm i
 WARN  HEAD https://bitbucket.org/buttonwoodcx/bcx-ui error (undefined). Will retry in 10 milliseconds. 5 retries left.
 WARN  HEAD https://bitbucket.org/buttonwoodcx/bcx-ui error (undefined). Will retry in 60 milliseconds. 4 retries left.
 WARN  HEAD https://bitbucket.org/buttonwoodcx/bcx-ui error (undefined). Will retry in 360 milliseconds. 3 retries left.
 WARN  HEAD https://bitbucket.org/buttonwoodcx/bcx-ui error (undefined). Will retry in 2.1 seconds. 2 retries left.
 WARN  HEAD https://bitbucket.org/buttonwoodcx/bcx-ui error (undefined). Will retry in 12.9 seconds. 1 retries left.
Packages: +2 -1
++-
Resolving: total 381, reused 381, downloaded 0, done
 WARN  Cannot link binary 'gulp' of 'gulp-cli' to '/Users/huocp/bw/bcx-broker-au-frontend/node_modules/.bin': binary of 'gulp' is already linked

dependencies:
- bcx-ui 2.31.4
+ bcx-ui 4.13.6
```

I am not sure how exactly this bug manifested to those retry logs, but this fix did avoid all retry.
