### PR TITLE
fix: installing a new dependency with a trailing @

### DIFF
--- a/.changeset/witty-chicken-eat.md
+++ b/.changeset/witty-chicken-eat.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Don't fail when installing a dependency with a trailing @.

--- a/packages/supi/src/utils/getPref.ts
+++ b/packages/supi/src/utils/getPref.ts
@@ -129,9 +129,12 @@ function getPrefPreferSpecifiedSpec (
  ) {
   const prefix = getPrefix(opts.alias, opts.name)
   if (opts.specRaw?.startsWith(`${opts.alias}@${prefix}`)) {
-    const selector = versionSelectorType(opts.specRaw.substr(`${opts.alias}@${prefix}`.length))
-    if (selector && (selector.type === 'version' || selector.type === 'range')) {
-      return opts.specRaw.substr(opts.alias.length + 1)
+    const range = opts.specRaw.substr(`${opts.alias}@${prefix}`.length)
+    if (range) {
+      const selector = versionSelectorType(range)
+      if (selector && (selector.type === 'version' || selector.type === 'range')) {
+        return opts.specRaw.substr(opts.alias.length + 1)
+      }
     }
   }
   return `${prefix}${createVersionSpec(opts.version, opts.pinnedVersion)}`

--- a/packages/supi/test/install/misc.ts
+++ b/packages/supi/test/install/misc.ts
@@ -188,6 +188,22 @@ test('modules without version spec, with custom tag config', async (t) => {
   await project.storeHas('dep-of-pkg-with-1-dep', '100.0.0')
 })
 
+test('modules without version spec but with a trailing @', async (t) => {
+  const project = prepareEmpty(t)
+
+  await addDependenciesToPackage({}, ['dep-of-pkg-with-1-dep@'], await testDefaults())
+
+  await project.has('dep-of-pkg-with-1-dep')
+})
+
+test('aliased modules without version spec but with a trailing @', async (t) => {
+  const project = prepareEmpty(t)
+
+  await addDependenciesToPackage({}, ['foo@npm:dep-of-pkg-with-1-dep@'], await testDefaults())
+
+  await project.has('foo')
+})
+
 test('installing a package by specifying a specific dist-tag', async (t) => {
   const project = prepareEmpty(t)
 


### PR DESCRIPTION
`pnpm add foo@` should install the latest `foo`

close #2737