### PR TITLE
import yarn.lock

### DIFF
--- a/packages/plugin-commands-import/package.json
+++ b/packages/plugin-commands-import/package.json
@@ -38,6 +38,8 @@
     "@pnpm/plugin-commands-import": "link:",
     "@pnpm/prepare": "workspace:0.0.9",
     "@types/ncp": "^2.0.4",
+    "@types/yarnpkg__lockfile": "^1.1.3",
+    "@yarnpkg/lockfile": "^1.1.0",
     "ncp": "^2.0.0",
     "tempy": "^0.6.0"
   },

--- a/packages/plugin-commands-import/src/import.ts
+++ b/packages/plugin-commands-import/src/import.ts
@@ -54,7 +54,7 @@ export async function handler (
   await install(await readProjectManifestOnly(opts.dir), installOpts)
 }
 
-function loadYarnLockFile<T> (path: string): T {
+function loadYarnLockFile<T extends LockedPackage> (path: string): T {
   const o = parseYarnLock(fs.readFileSync(path, { encoding: 'utf-8' }))
   const d = Object.keys(o.object).reduce(
     (acc, key) => {
@@ -70,7 +70,7 @@ function loadYarnLockFile<T> (path: string): T {
     return {
       version: '*', // TODO? version of root package
       dependencies: d,
-    } as any
+    } as T
   } else {
     throw new Error('failed to parse yarn.lock')
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1539,6 +1539,8 @@ importers:
       '@pnpm/plugin-commands-import': 'link:'
       '@pnpm/prepare': 'link:../../privatePackages/prepare'
       '@types/ncp': 2.0.4
+      '@types/yarnpkg__lockfile': 1.1.3
+      '@yarnpkg/lockfile': 1.1.0
       ncp: 2.0.0
       tempy: 0.6.0
     specifiers:
@@ -1551,6 +1553,8 @@ importers:
       '@pnpm/read-project-manifest': 'workspace:1.0.13'
       '@pnpm/store-connection-manager': 'workspace:0.3.30'
       '@types/ncp': ^2.0.4
+      '@types/yarnpkg__lockfile': ^1.1.3
+      '@yarnpkg/lockfile': ^1.1.0
       '@zkochan/rimraf': ^1.0.0
       load-json-file: ^6.2.0
       ncp: ^2.0.0
@@ -3912,6 +3916,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-o5Pl/qux8JEuFpof5fUg/Fl6R3N26ExJlsmWpB67ayrEJDMIxWdM9NDJacisXeNB7YW+vij8onctH8Pr1Zhi5g==
+  /@types/yarnpkg__lockfile/1.1.3:
+    dev: true
+    resolution:
+      integrity: sha512-mhdQq10tYpiNncMkg1vovCud5jQm+rWeRVz6fxjCJlY6uhDlAn9GnMSmBa2DQwqPf/jS5YR0K/xChDEh1jdOQg==
   /@types/zen-observable/0.8.1:
     dev: false
     resolution:
@@ -4066,6 +4074,10 @@ packages:
       npm: '>=5'
     resolution:
       integrity: sha512-J9UEf6MkKugeq5sFhDfqPPGNy4dTSf3fVYK3Q2hGFQiKXvOw7hqovjz6PVOJRNMymBXb2fJuMPIXx1Br3kwD2Q==
+  /@yarnpkg/lockfile/1.1.0:
+    dev: true
+    resolution:
+      integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
   /@zkochan/cmd-shim/5.0.0:
     dependencies:
       is-windows: 1.0.2


### PR DESCRIPTION
start fixing issue #2707

~~code passes eslint~~, compiles, runs with success on project [jsdom](https://github.com/jsdom/jsdom)
which is using yarn.lock to force versions, otherwise jsdom fails to compile
jsdom compile is passing, so my patch cant be too bad : ]
but maybe other projects fail to compile with this `pnpm import`

TODO allow to set lockfile like `pnpm import [lockfile]`

TODO dont run scripts after `pnpm import`, only after `pnpm install`
import only creates the pnpm-lock.yaml file
maybe run install after import?

TODO why does `pnpm import` say 'Already up-to-date'?

TODO tell the user what lockfile is imported

```js
getAllVersionsByPackageNames(npmPackageLock.dependencies[packageName], versionsByPackageNames)
```
.... why make the deps-tree flat?
= pass versionsByPackageNames on recursion
not versionsByPackageNames[packageName].dependencies
npm lockfiles allow locking of top-level AND sub dependency versions
i also dont understand the [manpage on limitations](https://pnpm.js.org/en/limitations)

> npm can install the same name@version multiple times and with different sets of dependencies. npm's shrinkwrap file is designed to reflect the node_modules layout created by npm. pnpm cannot create a similar layout, so it cannot respect npm's lockfile format. However, see pnpm import.

my understanding was that pnpm can install different versions
in pnpm's nested (non-flat) node_modules tree

```js
import * as pnpmConst from '@pnpm/constants'
const WANTED_LOCKFILE: string = pnpmConst.WANTED_LOCKFILE
```
.... is needed to make eslint happy
see eslint rule @typescript-eslint/restrict-template-expressions

using 'foreign lockfile' as shortname for a non-pnpm lockfile
could use a better name. 'external lockfile'?
