### PR TITLE
fix: report an info log instead of a warning on binary conflicts

### DIFF
--- a/.changeset/neat-planets-return.md
+++ b/.changeset/neat-planets-return.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/headless": patch
+"@pnpm/hoist": patch
+"@pnpm/plugin-commands-rebuild": patch
+"supi": patch
+---
+
+Report an info log instead of a warning when some binaries cannot be linked.

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -234,7 +234,7 @@ export default async (opts: HeadlessOptions) => {
   })
 
   function warn (message: string) {
-    logger.warn({
+    logger.info({
       message,
       prefix: lockfileDir,
     })
@@ -369,7 +369,7 @@ function linkBinsOfImporter (
     rootDir: string
   }
 ) {
-  const warn = (message: string) => logger.warn({ message, prefix: rootDir })
+  const warn = (message: string) => logger.info({ message, prefix: rootDir })
   return linkBins(modulesDir, binsDir, {
     allowExoticManifests: true,
     warn,

--- a/packages/hoist/src/index.ts
+++ b/packages/hoist/src/index.ts
@@ -89,7 +89,7 @@ async function linkAllBins (modulesDir: string) {
   const bin = path.join(modulesDir, '.bin')
   const warn: WarnFunction = (message, code) => {
     if (code === 'BINARIES_CONFLICT') return
-    logger.warn({ message, prefix: path.join(modulesDir, '../..') })
+    logger.info({ message, prefix: path.join(modulesDir, '../..') })
   }
   try {
     await linkBins(modulesDir, bin, { allowExoticManifests: true, warn })

--- a/packages/plugin-commands-rebuild/src/implementation/index.ts
+++ b/packages/plugin-commands-rebuild/src/implementation/index.ts
@@ -259,7 +259,7 @@ async function _rebuild (
     groups: [nodesToBuildAndTransitiveArray],
   })
   const chunks = graphSequencerResult.chunks as string[][]
-  const warn = (message: string) => logger.warn({ message, prefix: opts.dir })
+  const warn = (message: string) => logger.info({ message, prefix: opts.dir })
   const groups = chunks.map((chunk) => chunk.filter((depPath) => ctx.pkgsToRebuild.has(depPath)).map((depPath) =>
     async () => {
       const pkgSnapshot = pkgSnapshots[depPath]

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -840,7 +840,7 @@ function prefIsLocalTarball (pref: string) {
 const limitLinking = pLimit(16)
 
 function linkBinsOfImporter ({ modulesDir, binsDir, rootDir }: ImporterToResolve) {
-  const warn = (message: string) => logger.warn({ message, prefix: rootDir })
+  const warn = (message: string) => logger.info({ message, prefix: rootDir })
   return linkBins(modulesDir, binsDir, { allowExoticManifests: true, warn })
 }
 

--- a/packages/supi/src/link/index.ts
+++ b/packages/supi/src/link/index.ts
@@ -141,7 +141,7 @@ export default async function link (
 
   const linkToBin = maybeOpts?.linkToBin ?? path.join(destModules, '.bin')
   await linkBinsOfPackages(linkedPkgs.map((p) => ({ manifest: p.manifest, location: p.path })), linkToBin, {
-    warn: (message: string) => logger.warn({ message, prefix: opts.dir }),
+    warn: (message: string) => logger.info({ message, prefix: opts.dir }),
   })
 
   let newPkg!: ProjectManifest


### PR DESCRIPTION
Yarn and npm are not printing any info in such cases,
when several dependencies try to create the same binary.
It is better if pnpm will print an info message, not a warning.

close #2823