### PR TITLE
refactor: migrate carfs to jest

### DIFF
--- a/packages/cafs/jest.config.js
+++ b/packages/cafs/jest.config.js
@@ -1,0 +1,3 @@
+const config = require('../../jest.config.js');
+
+module.exports = Object.assign({}, config, {});

--- a/packages/cafs/package.json
+++ b/packages/cafs/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/cafs/coverage ts-node packages/cafs/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build",
     "prepublishOnly": "pnpm run compile"

--- a/packages/cafs/test/index.ts
+++ b/packages/cafs/test/index.ts
@@ -6,12 +6,10 @@ import tempy = require('tempy')
 describe('unpack', () => {
   test('unpack', async () => {
     const dest = tempy.directory()
-    // t.comment(dest)
-    console.log(test)
     const cafs = createCafs(dest)
-    await cafs.addFilesFromTarball(
+    const listOfFiles = await cafs.addFilesFromTarball(
       fs.createReadStream(path.join(__dirname, '../__fixtures__/node-gyp-6.1.0.tgz'))
     )
-    //  t.end()
+    expect(Object.keys(listOfFiles)).toHaveLength(121)
   })
 })

--- a/packages/cafs/test/index.ts
+++ b/packages/cafs/test/index.ts
@@ -3,13 +3,13 @@ import fs = require('fs')
 import path = require('path')
 import tempy = require('tempy')
 
-describe('unpack', () => {
+describe('cafs', () => {
   test('unpack', async () => {
     const dest = tempy.directory()
     const cafs = createCafs(dest)
-    const listOfFiles = await cafs.addFilesFromTarball(
+    const filesIndex = await cafs.addFilesFromTarball(
       fs.createReadStream(path.join(__dirname, '../__fixtures__/node-gyp-6.1.0.tgz'))
     )
-    expect(Object.keys(listOfFiles)).toHaveLength(121)
+    expect(Object.keys(filesIndex)).toHaveLength(121)
   })
 })

--- a/packages/cafs/test/index.ts
+++ b/packages/cafs/test/index.ts
@@ -1,15 +1,17 @@
 import createCafs from '../src'
 import fs = require('fs')
 import path = require('path')
-import test = require('tape')
 import tempy = require('tempy')
 
-test('unpack', async (t) => {
-  const dest = tempy.directory()
-  t.comment(dest)
-  const cafs = createCafs(dest)
-  await cafs.addFilesFromTarball(
-    fs.createReadStream(path.join(__dirname, '../__fixtures__/node-gyp-6.1.0.tgz'))
-  )
-  t.end()
+describe('unpack', () => {
+  test('unpack', async () => {
+    const dest = tempy.directory()
+    // t.comment(dest)
+    console.log(test)
+    const cafs = createCafs(dest)
+    await cafs.addFilesFromTarball(
+      fs.createReadStream(path.join(__dirname, '../__fixtures__/node-gyp-6.1.0.tgz'))
+    )
+    //  t.end()
+  })
 })


### PR DESCRIPTION
A new package for https://github.com/pnpm/pnpm/issues/2858

Here I'm not sure how to migrate it correctly, there is no expect. Any ?