### PR TITLE
feat(lockfile‑to‑pnp): correct `lockfileToPackageRegistry` return type

### DIFF
--- a/.changeset/cold-seals-help.md
+++ b/.changeset/cold-seals-help.md
@@ -1,0 +1,5 @@
+---
+'@pnpm/lockfile-to-pnp': patch
+---
+
+Normalize `packageLocation` path.

--- a/.changeset/lovely-bobcats-invent.md
+++ b/.changeset/lovely-bobcats-invent.md
@@ -1,0 +1,5 @@
+---
+'@pnpm/lockfile-to-pnp': patch
+---
+
+Use correct return type for `lockfileToPackageRegistry`.

--- a/packages/lockfile-to-pnp/package.json
+++ b/packages/lockfile-to-pnp/package.json
@@ -39,6 +39,7 @@
     "@pnpm/logger": "^3.2.2",
     "@pnpm/types": "workspace:6.2.0",
     "@types/mz": "0.0.32",
+    "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.19",
     "rimraf": "^3.0.2",
     "tape": "^4.11.0"
@@ -52,6 +53,7 @@
     "@yarnpkg/pnp": "^2.2.1",
     "dependency-path": "workspace:5.0.3",
     "mz": "^2.7.0",
+    "normalize-path": "^3.0.0",
     "ramda": "^0.27.1"
   },
   "funding": "https://opencollective.com/pnpm"

--- a/packages/lockfile-to-pnp/src/index.ts
+++ b/packages/lockfile-to-pnp/src/index.ts
@@ -9,6 +9,7 @@ import { Registries } from '@pnpm/types'
 import { refToRelative } from 'dependency-path'
 import pnp = require('@yarnpkg/pnp')
 import fs = require('mz/fs')
+import normalizePath = require('normalize-path')
 import path = require('path')
 import R = require('ramda')
 
@@ -101,12 +102,12 @@ export function lockfileToPackageRegistry (
     }
 
     // Seems like this field should always contain a relative path
-    const packageLocation = `./${path.join(
+    const packageLocation = `./${normalizePath(path.join(
       opts.virtualStoreDir,
       pkgIdToFilename(relDepPath, opts.lockfileDirectory),
       'node_modules',
       name
-    )}`
+    ))}`
     packageStore.set(pnpVersion, {
       packageDependencies: new Map([
         [name, pnpVersion],

--- a/packages/lockfile-to-pnp/src/index.ts
+++ b/packages/lockfile-to-pnp/src/index.ts
@@ -7,7 +7,7 @@ import pkgIdToFilename from '@pnpm/pkgid-to-filename'
 import readImporterManifest from '@pnpm/read-project-manifest'
 import { Registries } from '@pnpm/types'
 import { refToRelative } from 'dependency-path'
-import pnp = require('@yarnpkg/pnp')
+import { generateInlinedScript, PackageRegistry } from '@yarnpkg/pnp'
 import fs = require('mz/fs')
 import normalizePath = require('normalize-path')
 import path = require('path')
@@ -16,7 +16,7 @@ import R = require('ramda')
 export async function lockfileToPnp (lockfileDirectory: string) {
   const lockfile = await readWantedLockfile(lockfileDirectory, { ignoreIncompatible: true })
   if (!lockfile) throw new Error('Cannot generate a .pnp.js without a lockfile')
-  const importerNames = {} as { [importerId: string]: string }
+  const importerNames: { [importerId: string]: string } = {}
   await Promise.all(
     Object.keys(lockfile.importers)
       .map(async (importerId) => {
@@ -36,7 +36,7 @@ export async function lockfileToPnp (lockfileDirectory: string) {
     virtualStoreDir: virtualStoreDir ?? path.join(lockfileDirectory, 'node_modules/.pnpm'),
   })
 
-  const loaderFile = pnp.generateInlinedScript({
+  const loaderFile = generateInlinedScript({
     blacklistedLocations: undefined,
     dependencyTreeRoots: [],
     ignorePattern: undefined,
@@ -54,7 +54,7 @@ export function lockfileToPackageRegistry (
     virtualStoreDir: string
     registries: Registries
   }
-) {
+): PackageRegistry {
   const packageRegistry = new Map()
   for (const importerId of Object.keys(lockfile.importers)) {
     const importer = lockfile.importers[importerId]

--- a/packages/lockfile-to-pnp/test/index.ts
+++ b/packages/lockfile-to-pnp/test/index.ts
@@ -61,23 +61,27 @@ test('lockfileToPackageRegistry', () => {
     virtualStoreDir: 'node_modules/.pnpm',
   })
 
-  const actual = Array
-    .from(packageRegistry.entries())
-    .map(([packageName, packageStoreMap]) => {
+  const actual = Array.from(
+    packageRegistry,
+    ([packageName, packageStoreMap]) => {
       return [
         packageName,
-        Array.from(packageStoreMap.entries())
-          .map(([pkgRef, packageInfo]: any) => { // eslint-disable-line
+        Array.from(
+          packageStoreMap,
+          ([pkgRef, packageInfo]) => {
             return [
               pkgRef,
               {
-                packageDependencies: Array.from(packageInfo.packageDependencies || new Map()),
+                packageDependencies: Array.from(packageInfo.packageDependencies),
                 packageLocation: packageInfo.packageLocation,
               },
             ]
-          }),
+          }
+        ),
       ]
-    })
+    }
+  )
+
   expect(actual).toStrictEqual([
     [
       'importer1',
@@ -208,23 +212,26 @@ test('lockfileToPackageRegistry packages that have peer deps', () => {
     virtualStoreDir: 'node_modules/.pnpm',
   })
 
-  const actual = Array
-    .from(packageRegistry.entries())
-    .map(([packageName, packageStoreMap]) => {
+  const actual = Array.from(
+    packageRegistry,
+    ([packageName, packageStoreMap]) => {
       return [
         packageName,
-        Array.from(packageStoreMap.entries())
-          .map(([pkgRef, packageInfo]: any) => { // eslint-disable-line
+        Array.from(
+          packageStoreMap,
+          ([pkgRef, packageInfo]) => {
             return [
               pkgRef,
               {
-                packageDependencies: Array.from(packageInfo.packageDependencies || new Map()),
+                packageDependencies: Array.from(packageInfo.packageDependencies),
                 packageLocation: packageInfo.packageLocation,
               },
             ]
-          }),
+          }
+        ),
       ]
-    })
+    }
+  )
 
   expect(actual).toStrictEqual([
     [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,11 +995,13 @@ importers:
       '@yarnpkg/pnp': 2.2.1
       dependency-path: 'link:../dependency-path'
       mz: 2.7.0
+      normalize-path: 3.0.0
       ramda: 0.27.1
     devDependencies:
       '@pnpm/logger': 3.2.2
       '@pnpm/types': 'link:../types'
       '@types/mz': 0.0.32
+      '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.19
       rimraf: 3.0.2
       tape: 4.13.3
@@ -1012,10 +1014,12 @@ importers:
       '@pnpm/read-project-manifest': 'workspace:1.0.13'
       '@pnpm/types': 'workspace:6.2.0'
       '@types/mz': 0.0.32
+      '@types/normalize-path': ^3.0.0
       '@types/ramda': ^0.27.19
       '@yarnpkg/pnp': ^2.2.1
       dependency-path: 'workspace:5.0.3'
       mz: ^2.7.0
+      normalize-path: ^3.0.0
       ramda: ^0.27.1
       rimraf: ^3.0.2
       tape: ^4.11.0


### PR DESCRIPTION
I’ve also fixed the tests so that they also work on **Windows** and use the `mapfn` parameter of `Array.from`, to avoid creating an intermediate array.

---

This PR should be merged using **rebase‑only** (no squashing).