### PR TITLE
Mention CLI flag in git checks hint

### DIFF
--- a/.changeset/plenty-socks-boil.md
+++ b/.changeset/plenty-socks-boil.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+Added more info to the Git check error hint.

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -83,7 +83,7 @@ export function help () {
   })
 }
 
-const GIT_CHECKS_HINT = 'If you want to disable Git checks on publish, set the "git-checks" setting to "false".'
+const GIT_CHECKS_HINT = 'If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".'
 
 export async function handler (
   opts: Omit<PublishRecursiveOpts, 'workspaceDir'> & {


### PR DESCRIPTION
Very minor - I hit this and initially thought I had to edit an `.npmrc` file or some other kind of global config, which would have been dangerous. The CLI flag is probably a better option most of the time because it has to be passed explicitly.