### PR TITLE
Migrate more tests to Jest

### DIFF
--- a/packages/lifecycle/jest.config.js
+++ b/packages/lifecycle/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/lifecycle/coverage ts-node packages/lifecycle/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",

--- a/packages/lifecycle/test/index.ts
+++ b/packages/lifecycle/test/index.ts
@@ -3,12 +3,11 @@ import runLifecycleHook, { runPostinstallHooks } from '@pnpm/lifecycle'
 import path = require('path')
 import loadJsonFile = require('load-json-file')
 import rimraf = require('rimraf')
-import test = require('tape')
 
 const fixtures = path.join(__dirname, 'fixtures')
 const rootModulesDir = path.join(__dirname, '..', 'node_modules')
 
-test('runLifecycleHook()', async (t) => {
+test('runLifecycleHook()', async () => {
   const pkgRoot = path.join(fixtures, 'simple')
   const pkg = await import(path.join(pkgRoot, 'package.json'))
   await runLifecycleHook('postinstall', pkg, {
@@ -20,12 +19,10 @@ test('runLifecycleHook()', async (t) => {
     unsafePerm: true,
   })
 
-  t.deepEqual(await import(path.join(pkgRoot, 'output.json')), ['install'])
-
-  t.end()
+  expect((await import(path.join(pkgRoot, 'output.json'))).default).toStrictEqual(['install'])
 })
 
-test('runPostinstallHooks()', async (t) => {
+test('runPostinstallHooks()', async () => {
   const pkgRoot = path.join(fixtures, 'with-many-scripts')
   rimraf.sync(path.join(pkgRoot, 'output.json'))
   await runPostinstallHooks({
@@ -37,12 +34,10 @@ test('runPostinstallHooks()', async (t) => {
     unsafePerm: true,
   })
 
-  t.deepEqual(loadJsonFile.sync(path.join(pkgRoot, 'output.json')), ['preinstall', 'install', 'postinstall'])
-
-  t.end()
+  expect(loadJsonFile.sync(path.join(pkgRoot, 'output.json'))).toStrictEqual(['preinstall', 'install', 'postinstall'])
 })
 
-test('runPostinstallHooks() with prepare = true', async (t) => {
+test('runPostinstallHooks() with prepare = true', async () => {
   const pkgRoot = path.join(fixtures, 'with-many-scripts')
   rimraf.sync(path.join(pkgRoot, 'output.json'))
   await runPostinstallHooks({
@@ -55,7 +50,5 @@ test('runPostinstallHooks() with prepare = true', async (t) => {
     unsafePerm: true,
   })
 
-  t.deepEqual(loadJsonFile.sync(path.join(pkgRoot, 'output.json')), ['preinstall', 'install', 'postinstall', 'prepare'])
-
-  t.end()
+  expect(loadJsonFile.sync(path.join(pkgRoot, 'output.json'))).toStrictEqual(['preinstall', 'install', 'postinstall', 'prepare'])
 })

--- a/packages/link-bins/jest.config.js
+++ b/packages/link-bins/jest.config.js
@@ -1,0 +1,5 @@
+const config = require('../../jest.config.js')
+module.exports = Object.assign({}, config, {
+  // Shallow so fixtures aren't matched
+  testMatch: ["**/test/*.[jt]s?(x)"]
+})

--- a/packages/link-bins/package.json
+++ b/packages/link-bins/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "pre_test": "ncp test/fixtures test/fixtures_for_testing",
     "post_test": "rimraf test/fixtures_for_testing",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/link-bins/coverage ts-node packages/link-bins/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json --project . --fix",
@@ -55,11 +55,8 @@
     "@types/node": "^12.12.56",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.15",
-    "@types/sinon": "^9.0.5",
-    "@types/tape": "^4.13.0",
     "ncp": "^2.0.0",
     "path-exists": "^4.0.0",
-    "sinon": "^9.0.3",
     "tempy": "^0.7.0"
   },
   "funding": "https://opencollective.com/pnpm"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,11 +842,8 @@ importers:
       '@types/node': 12.12.62
       '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.18
-      '@types/sinon': 9.0.5
-      '@types/tape': 4.13.0
       ncp: 2.0.0
       path-exists: 4.0.0
-      sinon: 9.0.3
       tempy: 0.7.0
     specifiers:
       '@pnpm/error': 'workspace:1.3.1'
@@ -862,8 +859,6 @@ importers:
       '@types/node': ^12.12.56
       '@types/normalize-path': ^3.0.0
       '@types/ramda': ^0.27.15
-      '@types/sinon': ^9.0.5
-      '@types/tape': ^4.13.0
       '@zkochan/cmd-shim': ^5.0.0
       is-subdir: ^1.1.1
       is-windows: ^1.0.2
@@ -873,7 +868,6 @@ importers:
       p-settle: ^4.1.1
       path-exists: ^4.0.0
       ramda: ^0.27.1
-      sinon: ^9.0.3
       tempy: ^0.7.0
   packages/list:
     dependencies:


### PR DESCRIPTION
Migrated `lifecycle` and `link-bins` to use Jest for testing.

Please let me know any corrections needed. Thanks!