### PR TITLE
Four packages to Jest

### DIFF
--- a/packages/manifest-utils/jest.config.js
+++ b/packages/manifest-utils/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/manifest-utils/package.json
+++ b/packages/manifest-utils/package.json
@@ -22,7 +22,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/manifest-utils",
   "scripts": {
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/manifest-utils/coverage ts-node packages/manifest-utils/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",

--- a/packages/manifest-utils/test/getSpecFromPackageManifest.test.ts
+++ b/packages/manifest-utils/test/getSpecFromPackageManifest.test.ts
@@ -1,8 +1,7 @@
 import { getSpecFromPackageManifest } from '@pnpm/manifest-utils'
-import test = require('tape')
 
-test('getSpecFromPackageManifest()', (t) => {
-  t.equal(
+test('getSpecFromPackageManifest()', () => {
+  expect(
     getSpecFromPackageManifest({
       dependencies: {
         foo: '3.0.0',
@@ -13,11 +12,9 @@ test('getSpecFromPackageManifest()', (t) => {
       optionalDependencies: {
         foo: '1.0.0',
       },
-    }, 'foo'),
-    '1.0.0',
-    'optionalDependencies is first priority'
-  )
-  t.equal(
+    }, 'foo')).toEqual('1.0.0')
+
+  expect(
     getSpecFromPackageManifest({
       dependencies: {
         foo: '3.0.0',
@@ -25,18 +22,12 @@ test('getSpecFromPackageManifest()', (t) => {
       devDependencies: {
         foo: '2.0.0',
       },
-    }, 'foo'),
-    '3.0.0',
-    'dependencies is second priority'
-  )
-  t.equal(
+    }, 'foo')).toEqual('3.0.0')
+
+  expect(
     getSpecFromPackageManifest({
       devDependencies: {
         foo: '2.0.0',
       },
-    }, 'foo'),
-    '2.0.0',
-    'devDependencies is third priority'
-  )
-  t.end()
+    }, 'foo')).toEqual('2.0.0')
 })

--- a/packages/matcher/jest.config.js
+++ b/packages/matcher/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/matcher/package.json
+++ b/packages/matcher/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/matcher/coverage ts-node packages/matcher/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build"

--- a/packages/matcher/test/index.ts
+++ b/packages/matcher/test/index.ts
@@ -1,35 +1,33 @@
 import matcher from '@pnpm/matcher'
-import test = require('tape')
 
-test('matcher()', (t) => {
+test('matcher()', () => {
   {
     const match = matcher('*')
-    t.ok(match('@eslint/plugin-foo'))
-    t.ok(match('express'))
+    expect(match('@eslint/plugin-foo')).toBe(true)
+    expect(match('express')).toBe(true)
   }
   {
     const match = matcher(['eslint-*'])
-    t.ok(match('eslint-plugin-foo'))
-    t.notOk(match('express'))
+    expect(match('eslint-plugin-foo')).toBe(true)
+    expect(match('express')).toBe(false)
   }
   {
     const match = matcher(['*plugin*'])
-    t.ok(match('@eslint/plugin-foo'))
-    t.notOk(match('express'))
+    expect(match('@eslint/plugin-foo')).toBe(true)
+    expect(match('express')).toBe(false)
   }
   {
     const match = matcher(['a*c'])
-    t.ok(match('abc'))
+    expect(match('abc')).toBe(true)
   }
   {
     const match = matcher(['*-positive'])
-    t.ok(match('is-positive'))
+    expect(match('is-positive')).toBe(true)
   }
   {
     const match = matcher(['foo', 'bar'])
-    t.ok(match('foo'))
-    t.ok(match('bar'))
-    t.notOk(match('express'))
+    expect(match('foo')).toBe(true)
+    expect(match('bar')).toBe(true)
+    expect(match('express')).toBe(false)
   }
-  t.end()
 })

--- a/packages/modules-yaml/jest.config.js
+++ b/packages/modules-yaml/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/modules-yaml/package.json
+++ b/packages/modules-yaml/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/modules-yaml/coverage ts-node packages/modules-yaml/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",

--- a/packages/modules-yaml/test/index.ts
+++ b/packages/modules-yaml/test/index.ts
@@ -3,10 +3,9 @@ import { read, write } from '@pnpm/modules-yaml'
 import readYamlFile from 'read-yaml-file'
 import path = require('path')
 import isWindows = require('is-windows')
-import test = require('tape')
 import tempy = require('tempy')
 
-test('write() and read()', async (t) => {
+test('write() and read()', async () => {
   const modulesDir = tempy.directory()
   const modulesYaml = {
     hoistedDependencies: {},
@@ -28,33 +27,35 @@ test('write() and read()', async (t) => {
     virtualStoreDir: path.join(modulesDir, '.pnpm'),
   }
   await write(modulesDir, modulesYaml)
-  t.deepEqual(await read(modulesDir), modulesYaml)
+  expect(await read(modulesDir)).toEqual(modulesYaml)
 
-  const raw = await readYamlFile(path.join(modulesDir, '.modules.yaml'))
-  t.ok(raw['virtualStoreDir'])
-  t.equal(path.isAbsolute(raw['virtualStoreDir']), isWindows())
-
-  t.end()
+  const raw = await readYamlFile<object>(path.join(modulesDir, '.modules.yaml'))
+  expect(raw['virtualStoreDir']).toBeDefined()
+  expect(path.isAbsolute(raw['virtualStoreDir'])).toEqual(isWindows())
 })
 
-test('backward compatible read of .modules.yaml created with shamefully-hoist=true', async (t) => {
+test('backward compatible read of .modules.yaml created with shamefully-hoist=true', async () => {
   const modulesYaml = await read(path.join(__dirname, 'fixtures/old-shamefully-hoist'))
-  t.deepEqual(modulesYaml.publicHoistPattern, ['*'])
-  t.deepEqual(modulesYaml.hoistedDependencies, {
+  if (modulesYaml == null) {
+    fail('modulesYaml was nullish')
+  }
+  expect(modulesYaml.publicHoistPattern).toEqual(['*'])
+  expect(modulesYaml.hoistedDependencies).toEqual({
     '/accepts/1.3.7': { accepts: 'public' },
     '/array-flatten/1.1.1': { 'array-flatten': 'public' },
     '/body-parser/1.19.0': { 'body-parser': 'public' },
   })
-  t.end()
 })
 
-test('backward compatible read of .modules.yaml created with shamefully-hoist=false', async (t) => {
+test('backward compatible read of .modules.yaml created with shamefully-hoist=false', async () => {
   const modulesYaml = await read(path.join(__dirname, 'fixtures/old-no-shamefully-hoist'))
-  t.deepEqual(modulesYaml.publicHoistPattern, [])
-  t.deepEqual(modulesYaml.hoistedDependencies, {
+  if (modulesYaml == null) {
+    fail('modulesYaml was nullish')
+  }
+  expect(modulesYaml.publicHoistPattern).toEqual([])
+  expect(modulesYaml.hoistedDependencies).toEqual({
     '/accepts/1.3.7': { accepts: 'private' },
     '/array-flatten/1.1.1': { 'array-flatten': 'private' },
     '/body-parser/1.19.0': { 'body-parser': 'private' },
   })
-  t.end()
 })

--- a/packages/npm-registry-agent/jest.config.js
+++ b/packages/npm-registry-agent/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/npm-registry-agent/package.json
+++ b/packages/npm-registry-agent/package.json
@@ -12,17 +12,16 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "cd ../.. && c8 --reporter lcov --reports-dir packages/npm-registry-agent/coverage ts-node packages/npm-registry-agent/test --type-check",
+    "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build"
   },
   "devDependencies": {
+    "@pnpm/npm-registry-agent": "link:",
     "@types/http-proxy-agent": "^2.0.2",
-    "@types/lru-cache": "^5.1.0",
-    "@types/proxyquire": "^1.3.28",
-    "proxyquire": "^2.1.3"
+    "@types/lru-cache": "^5.1.0"
   },
   "dependencies": {
     "agentkeepalive": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1193,19 +1193,17 @@ importers:
       lru-cache: 6.0.0
       socks-proxy-agent: 5.0.0
     devDependencies:
+      '@pnpm/npm-registry-agent': 'link:'
       '@types/http-proxy-agent': 2.0.2
       '@types/lru-cache': 5.1.0
-      '@types/proxyquire': 1.3.28
-      proxyquire: 2.1.3
     specifiers:
+      '@pnpm/npm-registry-agent': 'link:'
       '@types/http-proxy-agent': ^2.0.2
       '@types/lru-cache': ^5.1.0
-      '@types/proxyquire': ^1.3.28
       agentkeepalive: ^4.1.3
       http-proxy-agent: ^4.0.1
       https-proxy-agent: ^3.0.1
       lru-cache: ^6.0.0
-      proxyquire: ^2.1.3
       socks-proxy-agent: ^5.0.0
   packages/npm-resolver:
     dependencies:


### PR DESCRIPTION
Migrated some additional packages to Jest for testing

* `manifest-utils`
* `matcher`
* `modules-yaml`
* `npm-registry-agent`

Replaced `proxyquire` in `npm-registry-agent` with Jest's mocking.