### PR TITLE
fix: change "OS X" to "macOS"

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,4 +23,4 @@ If there was a fatal error also include a gist of your node_modules/.pnpm-debug.
 ### Additional information:
 
  - `node -v` prints:
- - Windows, OS X, or Linux?:
+ - Windows, macOS, or Linux?:


### PR DESCRIPTION
It was officially renamed a few years ago.