### PR TITLE
fix: lockfile flickering caused by build metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@commitlint/prompt-cli": "^11.0.0",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "^0.0.0",
-    "@pnpm/registry-mock": "^2.2.2",
+    "@pnpm/registry-mock": "^2.3.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^26.0.19",
     "@types/node": "^14.14.22",

--- a/packages/lockfile-utils/package.json
+++ b/packages/lockfile-utils/package.json
@@ -42,7 +42,7 @@
     "@pnpm/resolver-base": "workspace:7.1.0",
     "@pnpm/types": "workspace:6.3.1",
     "dependency-path": "workspace:5.1.0",
-    "get-npm-tarball-url": "^2.0.1",
+    "get-npm-tarball-url": "^2.0.2",
     "ramda": "^0.27.1"
   },
   "funding": "https://opencollective.com/pnpm"

--- a/packages/resolve-dependencies/package.json
+++ b/packages/resolve-dependencies/package.json
@@ -44,7 +44,7 @@
     "@pnpm/types": "workspace:6.3.1",
     "dependency-path": "workspace:5.1.0",
     "encode-registry": "^3.0.0",
-    "get-npm-tarball-url": "^2.0.1",
+    "get-npm-tarball-url": "^2.0.2",
     "import-from": "^3.0.0",
     "path-exists": "^4.0.0",
     "ramda": "^0.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
       '@commitlint/prompt-cli': 11.0.0
       '@pnpm/eslint-config': link:utils/eslint-config
       '@pnpm/meta-updater': 0.0.0
-      '@pnpm/registry-mock': 2.2.2
+      '@pnpm/registry-mock': 2.3.0
       '@pnpm/tsconfig': link:utils/tsconfig
       '@types/jest': 26.0.20
       '@types/node': 14.14.22
@@ -35,7 +35,7 @@ importers:
       '@commitlint/prompt-cli': ^11.0.0
       '@pnpm/eslint-config': workspace:*
       '@pnpm/meta-updater': ^0.0.0
-      '@pnpm/registry-mock': ^2.2.2
+      '@pnpm/registry-mock': ^2.3.0
       '@pnpm/tsconfig': workspace:*
       '@types/jest': ^26.0.19
       '@types/node': ^14.14.22
@@ -1059,7 +1059,7 @@ importers:
       '@pnpm/resolver-base': link:../resolver-base
       '@pnpm/types': link:../types
       dependency-path: link:../dependency-path
-      get-npm-tarball-url: 2.0.1
+      get-npm-tarball-url: 2.0.2
       ramda: 0.27.1
     devDependencies:
       '@pnpm/lockfile-utils': 'link:'
@@ -1076,7 +1076,7 @@ importers:
       '@types/js-yaml': ^4.0.0
       '@types/ramda': ^0.27.35
       dependency-path: workspace:5.1.0
-      get-npm-tarball-url: ^2.0.1
+      get-npm-tarball-url: ^2.0.2
       ramda: ^0.27.1
       tempy: ^1.0.0
       write-yaml-file: ^4.1.3
@@ -2598,7 +2598,7 @@ importers:
       '@pnpm/types': link:../types
       dependency-path: link:../dependency-path
       encode-registry: 3.0.0
-      get-npm-tarball-url: 2.0.1
+      get-npm-tarball-url: 2.0.2
       import-from: 3.0.0
       path-exists: 4.0.0
       ramda: 0.27.1
@@ -2631,7 +2631,7 @@ importers:
       '@types/semver': ^7.3.4
       dependency-path: workspace:5.1.0
       encode-registry: ^3.0.0
-      get-npm-tarball-url: ^2.0.1
+      get-npm-tarball-url: ^2.0.2
       import-from: ^3.0.0
       path-exists: ^4.0.0
       ramda: ^0.27.1
@@ -4281,7 +4281,7 @@ packages:
       node: '>=10.16'
     resolution:
       integrity: sha512-U0Mrg2UUl28OspWqggArUFcal5nVAM3K2+NW1+SpdOSbmpLruNMkL9dSM4wyfiaEz8T+EqKhE063FFrrUACQkw==
-  /@pnpm/registry-mock/2.2.2:
+  /@pnpm/registry-mock/2.3.0:
     dependencies:
       anonymous-npm-registry-client: 0.1.2
       cpr: 3.0.1
@@ -4295,7 +4295,7 @@ packages:
       node: '>=10.13'
     hasBin: true
     resolution:
-      integrity: sha512-RqtdO1dJw8F922Kt72B3kJiwTZAX4MVsT5u3X+8tCoI98BcsvBCzsoetnjQR4eD7mKqKMk9MDwUTV8SMSuDoWQ==
+      integrity: sha512-539rFHzTiEiqTbxo5GUH9x/eaM8l1gwNjWUrLr3xu87RVqXkdkhtwHJptkBsBi6AvbHSMk3kttN8HG9ukawaPw==
   /@pnpm/self-installer/2.1.0:
     dev: false
     engines:
@@ -8305,14 +8305,14 @@ packages:
       has-symbols: 1.0.1
     resolution:
       integrity: sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==
-  /get-npm-tarball-url/2.0.1:
+  /get-npm-tarball-url/2.0.2:
     dependencies:
       normalize-registry-url: 1.0.0
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-POrVRGyS9X5w+855/H46JGVYBGuVgJXyIkbsTCzW+sv5x2qH+rfQjc7652DzkgOskF+cqLevA2En7V0hu0gZCg==
+      integrity: sha512-2dPhgT0K4pVyciTqdS0gr9nEwyCQwt9ql1/t5MCUMvcjWjAysjGJgT7Sx4n6oq3tFBjBN238mxX4RfTjT3838Q==
   /get-package-type/0.1.0:
     dev: true
     engines:


### PR DESCRIPTION
close #2928

Actual fix in dependency: https://github.com/pnpm/get-npm-tarball-url/commit/d45342e799541aca06398dafa6df985b50f49216