### PR TITLE
End with \n when `pnpm audit` finds nothing

### DIFF
--- a/.changeset/gentle-geese-camp.md
+++ b/.changeset/gentle-geese-camp.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-audit": patch
+---
+
+Audit output should always have a new line at the end.

--- a/packages/plugin-commands-audit/src/audit.ts
+++ b/packages/plugin-commands-audit/src/audit.ts
@@ -141,7 +141,7 @@ export async function handler (
 }
 
 function reportSummary (vulnerabilities: AuditVulnerabilityCounts, totalVulnerabilityCount: number) {
-  if (totalVulnerabilityCount === 0) return 'No known vulnerabilities found'
+  if (totalVulnerabilityCount === 0) return 'No known vulnerabilities found\n'
   return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${
     Object.entries(vulnerabilities)
       .filter(([auditLevel, vulnerabilitiesCount]) => vulnerabilitiesCount > 0)

--- a/packages/plugin-commands-audit/test/index.ts
+++ b/packages/plugin-commands-audit/test/index.ts
@@ -69,7 +69,7 @@ test('audit: no vulnerabilities', async () => {
     },
   })
 
-  expect(stripAnsi(output)).toBe('No known vulnerabilities found')
+  expect(stripAnsi(output)).toBe('No known vulnerabilities found\n')
   expect(exitCode).toBe(0)
 })
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1634186/107441376-2fdfa200-6b46-11eb-9bf6-93a398b220d2.png)

Running `pnpm audit` and finding no vulnerabilities results in a `No known vulnerabilities found` message. It doesn't end with a line break character, so the prompt message is being printed on the same line.