### PR TITLE
feat: use ESM instead of commonjs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 git-checks = true
 hoist-pattern[] = jest-runner
-link-workspace-packages = true
+link-workspace-packages = false
 shared-workspace-lockfile = true
 use-beta-cli = true
 publish-branch = main

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,19 @@
-const path = require('path')
+import path from 'path'
+import { fileURLToPath } from 'url'
 
-module.exports = {
-  preset: 'ts-jest',
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
   testMatch: ["**/test/**/*.[jt]s?(x)", "**/src/**/*.test.ts"],
   testEnvironment: 'node',
   collectCoverage: true,
   coveragePathIgnorePatterns: ['node_modules'],
   testTimeout: 4 * 60 * 1000, // 4 minutes
-  setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.js')],
+  setupFilesAfterEnv: [path.join(dirname, 'jest.setup.js')],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,3 @@
-jest.retryTimes(1);
+import { jest } from '@jest/globals'
+
+jest.retryTimes(1)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
     "@commitlint/prompt-cli": "^12.0.1",
+    "@jest/globals": "^27.0.0-next.1",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "^0.0.0",
     "@pnpm/registry-mock": "^2.4.0",
@@ -62,5 +63,6 @@
       "core-js",
       "level"
     ]
-  }
+  },
+  "type": "module"
 }

--- a/packages/audit/jest.config.js
+++ b/packages/audit/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -42,5 +42,6 @@
     "@pnpm/lockfile-walker": "workspace:3.0.9",
     "@pnpm/types": "workspace:6.4.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/build-modules/package.json
+++ b/packages/build-modules/package.json
@@ -42,8 +42,9 @@
     "run-groups": "^3.0.1"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/cafs/jest.config.js
+++ b/packages/cafs/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/cafs/package.json
+++ b/packages/cafs/package.json
@@ -6,7 +6,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
     "prepublishOnly": "pnpm run compile"
@@ -47,5 +47,6 @@
   ],
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/cafs#readme",
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/cafs",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/cafs/test/index.ts
+++ b/packages/cafs/test/index.ts
@@ -5,6 +5,9 @@ import createCafs, {
   checkFilesIntegrity,
   getFilePathInCafs,
 } from '../src'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 describe('cafs', () => {
   it('unpack', async () => {

--- a/packages/cli-meta/package.json
+++ b/packages/cli-meta/package.json
@@ -6,7 +6,8 @@
   "typings": "lib/index.d.ts",
   "files": [
     "lib",
-    "!*.map"
+    "!*.map",
+    "requireMain.cjs"
   ],
   "engines": {
     "node": ">=12.17"
@@ -33,5 +34,6 @@
   "dependencies": {
     "load-json-file": "^6.2.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/cli-meta/requireMain.cjs
+++ b/packages/cli-meta/requireMain.cjs
@@ -1,0 +1,1 @@
+module.exports = require.main

--- a/packages/cli-meta/src/index.ts
+++ b/packages/cli-meta/src/index.ts
@@ -1,20 +1,22 @@
 import path from 'path'
 import { DependencyManifest } from '@pnpm/types'
 import loadJsonFile from 'load-json-file'
+// @ts-ignore
+import requireMain from '../requireMain.cjs'
 
 const defaultManifest = {
   name: 'unknown',
   version: '0.0.0',
 }
 let pkgJson
-if (require.main == null) {
+if (requireMain == null) {
   pkgJson = defaultManifest
 } else {
   try {
     pkgJson = {
       ...defaultManifest,
       ...loadJsonFile.sync<DependencyManifest>(
-        path.join(path.dirname(require.main.filename), '../package.json')
+        path.join(path.dirname(requireMain.filename), '../package.json')
       ),
     }
   } catch (err) {

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/cli-utils#readme",
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/types": "workspace:6.4.0",
     "@types/ramda": "^0.27.35"
   },
@@ -44,7 +44,8 @@
     "load-json-file": "^6.2.0"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -41,7 +41,8 @@
     "mem": "^8.0.0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -27,5 +27,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/command#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/common-cli-options-help/package.json
+++ b/packages/common-cli-options-help/package.json
@@ -27,5 +27,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/common-cli-options-help#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/config/jest.config.js
+++ b/packages/config/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "pnpm run compile",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "test-with-preview": "ts-node test",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
@@ -38,7 +38,7 @@
     "@zkochan/npm-conf": "2.0.2",
     "camelcase": "^6.2.0",
     "can-write-to-dir": "^1.1.1",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "ramda": "^0.27.1",
     "realpath-missing": "^1.1.0",
     "which": "^2.0.2"
@@ -49,5 +49,6 @@
     "@types/which": "^2.0.0",
     "symlink-dir": "^4.2.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/config/test/index.ts
+++ b/packages/config/test/index.ts
@@ -6,6 +6,9 @@ import PnpmError from '@pnpm/error'
 import prepare, { prepareEmpty } from '@pnpm/prepare'
 
 import symlinkDir from 'symlink-dir'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // To override any local settings,
 // we force the default values of config

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -27,5 +27,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/constants#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -13,10 +13,10 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "directories": {
     "test": "test"
@@ -38,5 +38,6 @@
     "@pnpm/types": "workspace:6.4.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/core-loggers#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/default-reporter/jest.config.js
+++ b/packages/default-reporter/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/default-reporter/package.json
+++ b/packages/default-reporter/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "pretty-test": "ts-node test | tap-diff",
     "just-test-preview": "ts-node test --type-check",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -49,7 +49,7 @@
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.35",
     "@types/semver": "^7.3.4",
@@ -58,5 +58,6 @@
     "normalize-newline": "3.0.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/default-reporter#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/default-reporter/src/reporterForClient/utils/formatPrefix.ts
+++ b/packages/default-reporter/src/reporterForClient/utils/formatPrefix.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import normalize from 'normalize-path'
 import { PREFIX_MAX_LENGTH } from '../outputConstants'
 
-export default function formatPrefix (cwd: string, prefix: string) {
+export default function formatPrefix(cwd: string, prefix: string) {
   prefix = formatPrefixNoTrim(cwd, prefix)
 
   if (prefix.length <= PREFIX_MAX_LENGTH) {

--- a/packages/default-resolver/jest.config.js
+++ b/packages/default-resolver/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/default-resolver/package.json
+++ b/packages/default-resolver/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -41,7 +41,8 @@
   },
   "devDependencies": {
     "@pnpm/fetch": "workspace:2.1.11",
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/dependencies-hierarchy/jest.config.js
+++ b/packages/dependencies-hierarchy/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/dependencies-hierarchy/package.json
+++ b/packages/dependencies-hierarchy/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -46,8 +46,9 @@
   },
   "devDependencies": {
     "@pnpm/constants": "workspace:4.1.0",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/normalize-path": "^3.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/dependency-path/jest.config.js
+++ b/packages/dependency-path/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -39,5 +39,6 @@
   "devDependencies": {
     "@types/semver": "^7.3.4"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -28,5 +28,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/error#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/exportable-manifest/jest.config.js
+++ b/packages/exportable-manifest/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/exportable-manifest/package.json
+++ b/packages/exportable-manifest/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
-    "_test": "jest"
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/exportable-manifest",
   "keywords": [
@@ -37,5 +37,6 @@
     "@pnpm/types": "workspace:6.4.0",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/fetch/jest.config.js
+++ b/packages/fetch/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -29,7 +29,7 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/fetch#readme",
   "dependencies": {
@@ -41,10 +41,11 @@
     "node-fetch-unix": "2.3.0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/node-fetch": "^2.5.7",
     "cpy-cli": "^3.1.1",
     "nock": "12.0.3"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/fetcher-base/package.json
+++ b/packages/fetcher-base/package.json
@@ -34,5 +34,6 @@
     "@pnpm/types": "workspace:6.4.0",
     "@types/ssri": "^7.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/fetching-types/package.json
+++ b/packages/fetching-types/package.json
@@ -31,5 +31,6 @@
   "dependencies": {
     "@types/node-fetch": "^2.5.7",
     "@zkochan/retry": "^0.2.0"
-  }
+  },
+  "type": "module"
 }

--- a/packages/filter-lockfile/jest.config.js
+++ b/packages/filter-lockfile/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/filter-lockfile/package.json
+++ b/packages/filter-lockfile/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/filter-lockfile#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35",
     "tempy": "^1.0.0",
     "write-yaml-file": "^4.2.0",
@@ -51,5 +51,6 @@
     "dependency-path": "workspace:5.1.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/filter-workspace-packages/package.json
+++ b/packages/filter-workspace-packages/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -34,7 +34,7 @@
     "@pnpm/matcher": "workspace:1.0.3",
     "execa": "^5.0.0",
     "find-up": "^5.0.0",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "micromatch": "^4.0.2",
     "pkgs-graph": "workspace:5.2.0",
     "ramda": "^0.27.1"
@@ -50,5 +50,6 @@
     "tempy": "^1.0.0",
     "touch": "3.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/find-packages/jest.config.js
+++ b/packages/find-packages/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/find-packages/package.json
+++ b/packages/find-packages/package.json
@@ -10,7 +10,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -35,5 +35,6 @@
     "fast-glob": "^3.2.4",
     "p-filter": "^2.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/find-workspace-dir/package.json
+++ b/packages/find-workspace-dir/package.json
@@ -31,5 +31,6 @@
     "@pnpm/error": "workspace:1.4.0",
     "find-up": "^5.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/find-workspace-packages/jest.config.js
+++ b/packages/find-workspace-packages/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/find-workspace-packages/package.json
+++ b/packages/find-workspace-packages/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -35,5 +35,6 @@
     "find-packages": "workspace:7.0.24",
     "read-yaml-file": "^2.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/get-context/package.json
+++ b/packages/get-context/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/get-context#readme",
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/is-ci": "^3.0.0",
     "@types/ramda": "^0.27.35"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/constants": "workspace:4.1.0",
@@ -49,5 +49,6 @@
     "path-absolute": "^1.0.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/git-fetcher/jest.config.js
+++ b/packages/git-fetcher/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/git-fetcher/package.json
+++ b/packages/git-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
@@ -40,5 +40,6 @@
     "@pnpm/types": "workspace:6.4.0",
     "p-defer": "^3.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/git-resolver/jest.config.js
+++ b/packages/git-resolver/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/git-resolver/package.json
+++ b/packages/git-resolver/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
@@ -44,5 +44,6 @@
     "@types/semver": "^7.3.4",
     "is-windows": "^1.0.2"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/git-resolver/src/parsePref.ts
+++ b/packages/git-resolver/src/parsePref.ts
@@ -1,6 +1,5 @@
 import url, { URL } from 'url'
 import fetch from '@pnpm/fetch'
-
 import git from 'graceful-git'
 import HostedGit from 'hosted-git-info'
 

--- a/packages/global-bin-dir/jest.config.js
+++ b/packages/global-bin-dir/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/global-bin-dir/package.json
+++ b/packages/global-bin-dir/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
-    "_test": "jest"
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/global-bin-dir",
   "keywords": [
@@ -36,5 +36,6 @@
   },
   "devDependencies": {
     "is-windows": "^1.0.2"
-  }
+  },
+  "type": "module"
 }

--- a/packages/headless/jest.config.js
+++ b/packages/headless/jest.config.js
@@ -1,6 +1,6 @@
-const config = require('../../jest.config.js')
+import config from '../../jest.config.js'
 
-module.exports = {
+export default {
   ...config,
   testMatch: ["**/test/index.ts"],
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -13,12 +13,12 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
     "@pnpm/assert-project": "workspace:*",
     "@pnpm/client": "workspace:2.0.24",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/package-store": "workspace:11.0.3",
     "@pnpm/prepare": "workspace:0.0.18",
     "@pnpm/read-projects-context": "workspace:4.0.16",
@@ -57,9 +57,9 @@
     "commitmsg": "commitlint -e",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "ts-node test/pretest && cross-env PNPM_REGISTRY_MOCK_PORT=7770 pnpm run test:e2e",
+    "_test": "node --loader=ts-node/esm test/pretest.ts && cross-env PNPM_REGISTRY_MOCK_PORT=7770 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "runPrepareFixtures": "node ../pnpm/lib/bin/pnpm.cjs i -r -C test/fixtures --no-shared-workspace-lockfile --no-link-workspace-packages --lockfile-only --registry http://localhost:4873/ --ignore-scripts --force",
@@ -94,5 +94,6 @@
     "ramda": "^0.27.1",
     "realpath-missing": "^1.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/headless/test/pretest.ts
+++ b/packages/headless/test/pretest.ts
@@ -1,10 +1,12 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import rimrafModule from 'rimraf'
+import { fileURLToPath } from 'url'
 
-const fixtures = path.join(__dirname, 'fixtures')
-const workspaceFixture = path.join(__dirname, 'workspace-fixture')
-const workspaceFixture2 = path.join(__dirname, 'workspace-fixture2')
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+const fixtures = path.join(DIRNAME, 'fixtures')
+const workspaceFixture = path.join(DIRNAME, 'workspace-fixture')
+const workspaceFixture2 = path.join(DIRNAME, 'workspace-fixture2')
 
 removeModules()
   .then(() => console.log('Done'))

--- a/packages/hoist/package.json
+++ b/packages/hoist/package.json
@@ -13,10 +13,10 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35"
   },
   "directories": {
@@ -50,5 +50,6 @@
     "dependency-path": "workspace:5.1.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lifecycle/jest.config.js
+++ b/packages/lifecycle/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/lifecycle#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:5.0.3",
@@ -43,10 +43,11 @@
     "run-groups": "^3.0.1"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/rimraf": "^3.0.0",
     "json-append": "1.1.1",
     "load-json-file": "^6.2.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lifecycle/test/index.ts
+++ b/packages/lifecycle/test/index.ts
@@ -3,6 +3,9 @@ import path from 'path'
 import runLifecycleHook, { runPostinstallHooks } from '@pnpm/lifecycle'
 import loadJsonFile from 'load-json-file'
 import rimraf from 'rimraf'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const fixtures = path.join(__dirname, 'fixtures')
 const rootModulesDir = path.join(__dirname, '..', 'node_modules')

--- a/packages/link-bins/jest.config.js
+++ b/packages/link-bins/jest.config.js
@@ -1,5 +1,7 @@
-const config = require('../../jest.config.js')
-module.exports = Object.assign({}, config, {
+import config from '../../jest.config.js'
+
+export default {
+  ...config,
   // Shallow so fixtures aren't matched
-  testMatch: ["**/test/*.[jt]s?(x)"]
-})
+  testMatch: ["**/test/*.[jt]s?(x)"],
+}

--- a/packages/link-bins/package.json
+++ b/packages/link-bins/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "pretest": "ncp test/fixtures test/fixtures_for_testing",
     "posttest": "rimraf test/fixtures_for_testing",
-    "_test": "pnpm pretest && jest && pnpm posttest",
+    "_test": "pnpm pretest && NODE_OPTIONS=--experimental-vm-modules jest && pnpm posttest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json --project . --fix",
@@ -40,7 +40,7 @@
     "@pnpm/read-project-manifest": "workspace:1.1.7",
     "@pnpm/types": "workspace:6.4.0",
     "@zkochan/cmd-shim": "^5.0.0",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "is-windows": "^1.0.2",
     "normalize-path": "^3.0.0",
     "p-settle": "^4.1.1",
@@ -56,5 +56,6 @@
     "path-exists": "^4.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/link-bins/test/index.ts
+++ b/packages/link-bins/test/index.ts
@@ -10,6 +10,9 @@ import ncpcb from 'ncp'
 import normalizePath from 'normalize-path'
 import exists from 'path-exists'
 import tempy from 'tempy'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const ncp = promisify(ncpcb)
 

--- a/packages/list/jest.config.js
+++ b/packages/list/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -14,7 +14,7 @@
     "prepareFixtures": "cd test && node ../../pnpm recursive install --no-link-workspace-packages --no-shared-workspace-lockfile -f && cd ..",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm run pretest --filter dependencies-hierarchy",
-    "_test": "pnpm pretest && jest",
+    "_test": "pnpm pretest && NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
@@ -48,10 +48,11 @@
     "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/archy": "0.0.31",
     "@types/ramda": "^0.27.35",
     "@types/semver": "^7.3.4"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/list/src/createPackagesSearcher.ts
+++ b/packages/list/src/createPackagesSearcher.ts
@@ -3,7 +3,7 @@ import { SearchFunction } from 'dependencies-hierarchy'
 import npa from '@zkochan/npm-package-arg'
 import semver from 'semver'
 
-export default function createPatternSearcher (queries: string[]) {
+export default function createPatternSearcher(queries: string[]) {
   const searchers: SearchFunction[] = queries
     .map(parseSearchQuery)
     .map((packageSelector) => search.bind(null, packageSelector))

--- a/packages/local-resolver/jest.config.js
+++ b/packages/local-resolver/jest.config.js
@@ -1,1 +1,2 @@
-module.exports = require('../../jest.config.js')
+import jest from '../../jest.config.js'
+export default jest

--- a/packages/local-resolver/package.json
+++ b/packages/local-resolver/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
@@ -43,5 +43,6 @@
     "@types/normalize-path": "^3.0.0",
     "@types/ssri": "^7.1.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/local-resolver/test/index.ts
+++ b/packages/local-resolver/test/index.ts
@@ -1,6 +1,9 @@
 /// <reference path="../../../typings/index.d.ts"/>
 import path from 'path'
 import resolveFromLocal from '@pnpm/local-resolver'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('resolve directory', async () => {
   const resolveResult = await resolveFromLocal({ pref: '..' }, { projectDir: __dirname })

--- a/packages/lockfile-file/jest.config.js
+++ b/packages/lockfile-file/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/lockfile-file/package.json
+++ b/packages/lockfile-file/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-file#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/js-yaml": "^4.0.0",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.35",
@@ -57,5 +57,6 @@
     "strip-bom": "^4.0.0",
     "write-file-atomic": "^3.0.3"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lockfile-file/test/read.ts
+++ b/packages/lockfile-file/test/read.ts
@@ -7,6 +7,9 @@ import {
   writeWantedLockfile,
 } from '@pnpm/lockfile-file'
 import tempy from 'tempy'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 process.chdir(__dirname)
 

--- a/packages/lockfile-to-pnp/jest.config.js
+++ b/packages/lockfile-to-pnp/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/lockfile-to-pnp/package.json
+++ b/packages/lockfile-to-pnp/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-to-pnp",
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-to-pnp#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/types": "workspace:6.4.0",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.35",
@@ -50,5 +50,6 @@
     "normalize-path": "^3.0.0",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lockfile-types/package.json
+++ b/packages/lockfile-types/package.json
@@ -26,5 +26,6 @@
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
     "prepublishOnly": "pnpm run compile"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lockfile-utils/jest.config.js
+++ b/packages/lockfile-utils/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/lockfile-utils/package.json
+++ b/packages/lockfile-utils/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -42,8 +42,9 @@
     "@pnpm/resolver-base": "workspace:7.1.1",
     "@pnpm/types": "workspace:6.4.0",
     "dependency-path": "workspace:5.1.1",
-    "get-npm-tarball-url": "^2.0.2",
+    "get-npm-tarball-url": "^3.0.0-0",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/lockfile-utils/src/pkgSnapshotToResolution.ts
+++ b/packages/lockfile-utils/src/pkgSnapshotToResolution.ts
@@ -36,6 +36,7 @@ export default (
     if (!name || !version) {
       throw new Error(`Couldn't get tarball URL from dependency path ${depPath}`)
     }
+    // @ts-ignore
     return getNpmTarballUrl(name, version, { registry })
   }
   /* eslint-enable @typescript-eslint/dot-notation */

--- a/packages/lockfile-walker/package.json
+++ b/packages/lockfile-walker/package.json
@@ -39,5 +39,6 @@
     "dependency-path": "workspace:5.1.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -37,7 +37,7 @@
     "@pnpm/exportable-manifest": "workspace:1.2.2",
     "@pnpm/find-workspace-dir": "workspace:2.0.0",
     "@pnpm/lockfile-file": "workspace:3.2.1",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prune-lockfile": "workspace:2.0.19",
     "@pnpm/read-project-manifest": "workspace:1.1.7",
     "@pnpm/types": "workspace:6.4.0",

--- a/packages/manifest-utils/package.json
+++ b/packages/manifest-utils/package.json
@@ -19,7 +19,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/manifest-utils",
   "scripts": {
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
@@ -31,5 +31,6 @@
     "@pnpm/types": "workspace:6.4.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/manifest-utils#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/matcher/package.json
+++ b/packages/matcher/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -34,5 +34,6 @@
   "dependencies": {
     "escape-string-regexp": "^4.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/merge-lockfile-changes/package.json
+++ b/packages/merge-lockfile-changes/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -39,5 +39,6 @@
   "devDependencies": {
     "@types/ramda": "^0.27.35",
     "@types/semver": "^7.3.4"
-  }
+  },
+  "type": "module"
 }

--- a/packages/modules-cleaner/package.json
+++ b/packages/modules-cleaner/package.json
@@ -10,7 +10,7 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "keywords": [],
   "license": "MIT",
@@ -40,11 +40,12 @@
     "ramda": "^0.27.1"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/modules-yaml/jest.config.js
+++ b/packages/modules-yaml/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/modules-yaml/package.json
+++ b/packages/modules-yaml/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
@@ -40,5 +40,6 @@
     "@types/is-windows": "^1.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/modules-yaml/test/index.ts
+++ b/packages/modules-yaml/test/index.ts
@@ -4,6 +4,9 @@ import { read, write } from '@pnpm/modules-yaml'
 import readYamlFile from 'read-yaml-file'
 import isWindows from 'is-windows'
 import tempy from 'tempy'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('write() and read()', async () => {
   const modulesDir = tempy.directory()

--- a/packages/mount-modules/jest.config.js
+++ b/packages/mount-modules/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/mount-modules/package.json
+++ b/packages/mount-modules/package.json
@@ -18,7 +18,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "pre_test": "pnpm install --dir=test/__fixtures__/simple",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/mount-modules",
@@ -34,10 +34,10 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/mount-modules#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "rimraf": "^3.0.2"
   },
   "dependencies": {
@@ -54,5 +54,6 @@
   "funding": "https://opencollective.com/pnpm",
   "optionalDependencies": {
     "fuse-native": "^2.2.6"
-  }
+  },
+  "type": "module"
 }

--- a/packages/mount-modules/test/makeVirtualNodeModules.test.ts
+++ b/packages/mount-modules/test/makeVirtualNodeModules.test.ts
@@ -1,9 +1,12 @@
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { readWantedLockfile } from '@pnpm/lockfile-file'
 import makeVirtualNodeModules from '../src/makeVirtualNodeModules'
 
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
 test('makeVirtualNodeModules', async () => {
-  const lockfile = await readWantedLockfile(path.join(__dirname, '__fixtures__/simple'), { ignoreIncompatible: true })
+  const lockfile = await readWantedLockfile(path.join(dirname, '__fixtures__/simple'), { ignoreIncompatible: true })
   const cafsDir = path.join(__dirname, '__fixtures__/simple/store/v3/files')
   expect(makeVirtualNodeModules(lockfile!, cafsDir)).toMatchSnapshot()
 })

--- a/packages/normalize-registries/package.json
+++ b/packages/normalize-registries/package.json
@@ -29,5 +29,6 @@
     "normalize-registry-url": "1.0.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/normalize-registries#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/npm-registry-agent/jest.config.js
+++ b/packages/npm-registry-agent/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/npm-registry-agent/package.json
+++ b/packages/npm-registry-agent/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
@@ -40,5 +40,6 @@
   "engines": {
     "node": ">=12.17"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/npm-resolver/jest.config.js
+++ b/packages/npm-resolver/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/npm-resolver/package.json
+++ b/packages/npm-resolver/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/npm-resolver#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:5.0.3",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@pnpm/fetch": "workspace:2.1.11",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/lru-cache": "^5.1.0",
     "@types/normalize-path": "^3.0.0",
     "@types/semver": "^7.3.4",
@@ -65,5 +65,6 @@
     "path-exists": "^4.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -10,6 +10,9 @@ import loadJsonFile from 'load-json-file'
 import nock from 'nock'
 import exists from 'path-exists'
 import tempy from 'tempy'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const isPositiveMeta = loadJsonFile.sync<any>(path.join(__dirname, 'meta', 'is-positive.json'))

--- a/packages/outdated/jest.config.js
+++ b/packages/outdated/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config.js');
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/outdated/package.json
+++ b/packages/outdated/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7771 pnpm run test:e2e",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/outdated#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/client": "workspace:2.0.24",
@@ -51,10 +51,11 @@
     "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35",
     "@types/semver": "^7.3.4",
     "npm-run-all": "^4.1.5"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/package-bins/package.json
+++ b/packages/package-bins/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json --project . --fix",
@@ -38,5 +38,6 @@
   "devDependencies": {
     "@types/node": "^14.14.33"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/package-is-installable/package.json
+++ b/packages/package-is-installable/package.json
@@ -15,13 +15,13 @@
     "node": ">=12.17"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/package-is-installable",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/package-is-installable#readme",
   "scripts": {
     "start": "pnpm run tsc -- --watch",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
@@ -34,11 +34,12 @@
     "semver": "^7.3.4"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/semver": "^7.3.4"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/package-requester/jest.config.js
+++ b/packages/package-requester/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "pnpm run tsc -- --watch",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/package-requester#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:2.1.0",
@@ -47,7 +47,7 @@
     "load-json-file": "^6.2.0",
     "p-defer": "^3.0.0",
     "p-limit": "^3.1.0",
-    "p-queue": "^6.6.2",
+    "p-queue": "^7.0.0",
     "path-temp": "^2.0.0",
     "promise-share": "^1.0.0",
     "ramda": "^0.27.1",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@pnpm/client": "workspace:2.0.24",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ncp": "^2.0.4",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "^0.27.35",
@@ -67,5 +67,6 @@
     "normalize-path": "^3.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/package-requester/test/index.ts
+++ b/packages/package-requester/test/index.ts
@@ -2,6 +2,8 @@
 import { promisify } from 'util'
 import { promises as fs, statSync } from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
+import { jest } from '@jest/globals'
 import { getFilePathInCafs, PackageFilesIndex } from '@pnpm/cafs'
 import createClient from '@pnpm/client'
 import { streamParser } from '@pnpm/logger'
@@ -15,8 +17,10 @@ import nock from 'nock'
 import normalize from 'normalize-path'
 import tempy from 'tempy'
 
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
 const registry = 'https://registry.npmjs.org/'
-const IS_POSTIVE_TARBALL = path.join(__dirname, 'is-positive-1.0.0.tgz')
+const IS_POSTIVE_TARBALL = path.join(dirname, 'is-positive-1.0.0.tgz')
 const ncp = promisify(ncpCB as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 
 const authConfig = { registry }
@@ -160,7 +164,7 @@ test('refetch local tarball if its integrity has changed', async () => {
   const projectDir = tempy.directory()
   const tarballPath = path.join(projectDir, 'tarball.tgz')
   const tarballRelativePath = path.relative(projectDir, tarballPath)
-  await ncp(path.join(__dirname, 'pnpm-package-requester-0.8.1.tgz'), tarballPath)
+  await ncp(path.join(dirname, 'pnpm-package-requester-0.8.1.tgz'), tarballPath)
   const tarball = `file:${tarballRelativePath}`
   const wantedPackage = { pref: tarball }
   const storeDir = tempy.directory()
@@ -204,7 +208,7 @@ test('refetch local tarball if its integrity has changed', async () => {
     expect(await response.bundledManifest!()).toBeTruthy()
   }
 
-  await ncp(path.join(__dirname, 'pnpm-package-requester-4.1.2.tgz'), tarballPath)
+  await ncp(path.join(dirname, 'pnpm-package-requester-4.1.2.tgz'), tarballPath)
   await delay(50)
 
   {
@@ -266,10 +270,10 @@ test('refetch local tarball if its integrity has changed', async () => {
 test('refetch local tarball if its integrity has changed. The requester does not know the correct integrity', async () => {
   const projectDir = tempy.directory()
   const tarballPath = path.join(projectDir, 'tarball.tgz')
-  await ncp(path.join(__dirname, 'pnpm-package-requester-0.8.1.tgz'), tarballPath)
+  await ncp(path.join(dirname, 'pnpm-package-requester-0.8.1.tgz'), tarballPath)
   const tarball = `file:${tarballPath}`
   const wantedPackage = { pref: tarball }
-  const storeDir = path.join(__dirname, '..', '.store')
+  const storeDir = path.join(dirname, '..', '.store')
   const requestPackageOpts = {
     downloadPriority: 0,
     lockfileDir: projectDir,
@@ -297,7 +301,7 @@ test('refetch local tarball if its integrity has changed. The requester does not
     expect(await response.bundledManifest!()).toBeTruthy()
   }
 
-  await ncp(path.join(__dirname, 'pnpm-package-requester-4.1.2.tgz'), tarballPath)
+  await ncp(path.join(dirname, 'pnpm-package-requester-4.1.2.tgz'), tarballPath)
   await delay(50)
 
   {

--- a/packages/package-store/jest.config.js
+++ b/packages/package-store/jest.config.js
@@ -1,3 +1,3 @@
-const config = require('../../jest.config.js');
+import config from '../../jest.config.js'
 
-module.exports = Object.assign({}, config, {});
+export default config

--- a/packages/package-store/package.json
+++ b/packages/package-store/package.json
@@ -13,7 +13,7 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:2.1.0",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@pnpm/client": "workspace:2.0.24",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prepare": "workspace:0.0.18",
     "@types/ramda": "^0.27.35",
     "@types/ssri": "^7.1.0",
@@ -66,10 +66,11 @@
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "pretest": "rimraf .tmp",
-    "_test": "pnpm pretest && jest",
+    "_test": "pnpm pretest && NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/parse-cli-args/package.json
+++ b/packages/parse-cli-args/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -38,5 +38,6 @@
     "didyoumean2": "^4.1.0",
     "nopt": "^5.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -31,5 +31,6 @@
     "validate-npm-package-name": "3.0.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/parse-wanted-dependency#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/pick-registry-for-package/package.json
+++ b/packages/pick-registry-for-package/package.json
@@ -19,7 +19,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/pick-registry-for-package",
   "scripts": {
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
@@ -29,5 +29,6 @@
     "@pnpm/types": "workspace:6.4.0"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/pick-registry-for-package#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/pkgs-graph/package.json
+++ b/packages/pkgs-graph/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -34,5 +34,6 @@
     "@zkochan/npm-package-arg": "^2.0.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-audit/jest.config.js
+++ b/packages/plugin-commands-audit/jest.config.js
@@ -1,4 +1,4 @@
-const config = require('../../jest.config.js')
+import config from '../../jest.config.js'
 
-module.exports = config
+export default config
 

--- a/packages/plugin-commands-audit/package.json
+++ b/packages/plugin-commands-audit/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -47,5 +47,6 @@
     "ramda": "^0.27.1",
     "render-help": "^1.0.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-audit/test/index.ts
+++ b/packages/plugin-commands-audit/test/index.ts
@@ -1,6 +1,9 @@
 import path from 'path'
 import { audit } from '@pnpm/plugin-commands-audit'
 import stripAnsi from 'strip-ansi'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const skipOnNode10 = process.version.split('.')[0] === 'v10' ? test.skip : test
 

--- a/packages/plugin-commands-import/package.json
+++ b/packages/plugin-commands-import/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7772 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -51,5 +51,6 @@
     "render-help": "^1.0.1",
     "supi": "workspace:0.45.4"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7773 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@pnpm/assert-project": "workspace:*",
     "@pnpm/lockfile-types": "workspace:2.2.0",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/matcher": "workspace:1.0.3",
     "@pnpm/prepare": "workspace:0.0.18",
     "@pnpm/test-fixtures": "workspace:*",
@@ -80,7 +80,7 @@
     "chalk": "^4.1.0",
     "enquirer": "^2.3.6",
     "is-ci": "^3.0.0",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "mem": "^8.0.0",
     "p-filter": "^2.1.0",
     "p-limit": "^3.1.0",
@@ -93,7 +93,8 @@
     "version-selector-type": "^3.0.0"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-listing/package.json
+++ b/packages/plugin-commands-listing/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@pnpm/constants": "workspace:4.1.0",
     "@pnpm/filter-workspace-packages": "workspace:2.3.14",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/plugin-commands-installation": "workspace:3.5.28",
     "@pnpm/prepare": "workspace:0.0.18",
     "@types/ramda": "^0.27.35",
@@ -53,7 +53,8 @@
     "render-help": "^1.0.1"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-outdated/jest.config.js
+++ b/packages/plugin-commands-outdated/jest.config.js
@@ -1,6 +1,6 @@
-const config = require('../../jest.config.js')
+import config from '../../jest.config.js'
 
-module.exports = {
+export default {
   ...config,
   testPathIgnorePatterns: [
     '<rootDir>/test/utils.ts',

--- a/packages/plugin-commands-outdated/package.json
+++ b/packages/plugin-commands-outdated/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7775 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -65,5 +65,6 @@
     "render-help": "^1.0.1",
     "wrap-ansi": "^7.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7776 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-publishing#readme",
   "devDependencies": {
     "@pnpm/filter-workspace-packages": "workspace:2.3.14",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prepare": "workspace:0.0.18",
     "@types/cross-spawn": "^6.0.2",
     "@types/proxyquire": "^1.3.28",
@@ -74,7 +74,8 @@
     "write-json-file": "^4.3.0"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7777 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-rebuild#readme",
   "devDependencies": {
     "@pnpm/filter-workspace-packages": "workspace:2.3.14",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prepare": "workspace:0.0.18",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "^0.27.35",
@@ -77,7 +77,8 @@
     "semver": "^7.3.4"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7778 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-script-runners#readme",
   "devDependencies": {
     "@pnpm/filter-workspace-packages": "workspace:2.3.14",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prepare": "workspace:0.0.18",
     "@types/ramda": "^0.27.35",
     "@zkochan/rimraf": "^2.0.0",
@@ -58,7 +58,8 @@
     "render-help": "^1.0.1"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-server/package.json
+++ b/packages/plugin-commands-server/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-server#readme",
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "^0.27.35",
     "@types/signal-exit": "^3.0.0"
@@ -54,7 +54,8 @@
     "tree-kill": "^1.2.2"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/plugin-commands-store/package.json
+++ b/packages/plugin-commands-store/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@pnpm/assert-store": "workspace:*",
     "@pnpm/lockfile-file": "workspace:3.2.1",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/prepare": "workspace:0.0.18",
     "@types/archy": "0.0.31",
     "@types/ramda": "^0.27.35",
@@ -71,7 +71,8 @@
     "render-help": "^1.0.1"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/pnpm/jest.config.js
+++ b/packages/pnpm/jest.config.js
@@ -1,6 +1,6 @@
-const config = require('../../jest.config.js')
+import config from '../../jest.config.js'
 
-module.exports = {
+export default {
   ...config,
   testPathIgnorePatterns: [
     '<rootDir>/test/utils/distTags.ts',
@@ -12,4 +12,3 @@ module.exports = {
   ],
   maxWorkers: 1,
 }
-

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -35,7 +35,7 @@
     "@pnpm/find-workspace-dir": "workspace:2.0.0",
     "@pnpm/find-workspace-packages": "workspace:2.3.42",
     "@pnpm/lockfile-types": "workspace:2.2.0",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/modules-yaml": "workspace:8.0.6",
     "@pnpm/parse-cli-args": "workspace:3.2.2",
     "@pnpm/pick-registry-for-package": "workspace:1.1.0",
@@ -147,13 +147,13 @@
     "url": "git+https://github.com/pnpm/pnpm.git"
   },
   "scripts": {
-    "bundle:pnpm": "esbuild lib/pnpm.js --bundle --platform=node --outfile=dist/pnpm.cjs --external:update-notifier --external:node-gyp",
-    "bundle:pnpx": "esbuild lib/pnpx.js --bundle --platform=node --outfile=dist/pnpx.cjs",
+    "bundle:pnpm": "esbuild lib/pnpm.js --bundle --platform=node --outfile=dist/pnpm.cjs --format=iife --external:node-gyp",
+    "bundle:pnpx": "esbuild lib/pnpx.js --bundle --platform=node --outfile=dist/pnpx.cjs --format=iife",
     "bundle": "pnpm bundle:pnpm && pnpm bundle:pnpx",
     "start": "pnpm tsc -- --watch",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "pretest:e2e": "rimraf node_modules/.bin/pnpm",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 pnpm run test:e2e",
@@ -165,5 +165,6 @@
   "publishconfig": {
     "tag": "next"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/pnpm/test/monorepo/index.ts
+++ b/packages/pnpm/test/monorepo/index.ts
@@ -548,8 +548,8 @@ test('recursive install with link-workspace-packages and shared-workspace-lockfi
 
   await execPnpm(['recursive', 'install', '--link-workspace-packages', '--shared-workspace-lockfile=true', '--store-dir', 'store'])
 
-  expect(projects['is-positive'].requireModule('is-negative')).toBeTruthy()
-  expect(projects['project-1'].requireModule('is-positive/package.json').author).toBeFalsy()
+  expect(await projects['is-positive'].requireModule('is-negative')).toBeTruthy()
+  expect((await projects['project-1'].requireModule('is-positive/package.json')).author).toBeFalsy()
 
   const sharedLockfile = await readYamlFile<Lockfile>(WANTED_LOCKFILE)
   expect(sharedLockfile.importers['project-1']!.devDependencies!['is-positive']).toBe('link:../is-positive')
@@ -1128,10 +1128,10 @@ test('dependencies of workspace projects are built during headless installation'
   await execPnpm(['recursive', 'install', '--frozen-lockfile'])
 
   {
-    const generatedByPreinstall = projects['project-1'].requireModule('pre-and-postinstall-scripts-example/generated-by-preinstall')
+    const generatedByPreinstall = await projects['project-1'].requireModule('pre-and-postinstall-scripts-example/generated-by-preinstall')
     expect(typeof generatedByPreinstall).toBe('function')
 
-    const generatedByPostinstall = projects['project-1'].requireModule('pre-and-postinstall-scripts-example/generated-by-postinstall')
+    const generatedByPostinstall = await projects['project-1'].requireModule('pre-and-postinstall-scripts-example/generated-by-postinstall')
     expect(typeof generatedByPostinstall).toBe('function')
   }
 })

--- a/packages/pnpm/test/utils/execPnpm.ts
+++ b/packages/pnpm/test/utils/execPnpm.ts
@@ -1,10 +1,12 @@
 import { ChildProcess as NodeChildProcess } from 'child_process'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import isWindows from 'is-windows'
 import crossSpawn from 'cross-spawn'
 
-const binDir = path.join(__dirname, '../..', isWindows() ? 'dist' : 'bin')
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+const binDir = path.join(DIRNAME, '../..', isWindows() ? 'dist' : 'bin')
 const pnpmBinLocation = path.join(binDir, 'pnpm.cjs')
 const pnpxBinLocation = path.join(binDir, 'pnpx.cjs')
 

--- a/packages/pnpmfile/package.json
+++ b/packages/pnpmfile/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/pnpmfile#readme",
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35"
   },
   "dependencies": {
@@ -41,7 +41,8 @@
     "ramda": "^0.27.1"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/prune-lockfile/package.json
+++ b/packages/prune-lockfile/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -41,5 +41,6 @@
     "dependency-path": "workspace:5.1.1",
     "ramda": "^0.27.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/read-modules-dir/package.json
+++ b/packages/read-modules-dir/package.json
@@ -26,5 +26,6 @@
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/read-package-json/jest.config.js
+++ b/packages/read-package-json/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/read-package-json/package.json
+++ b/packages/read-package-json/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -35,5 +35,6 @@
     "load-json-file": "^6.2.0",
     "normalize-package-data": "^3.0.2"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/read-project-manifest/jest.config.js
+++ b/packages/read-project-manifest/jest.config.js
@@ -1,6 +1,6 @@
-const config = require('../../jest.config')
+import config from '../../jest.config.js'
 
-module.exports = {
+export default {
   ...config,
   modulePathIgnorePatterns: ['\/fixtures\/.*'],
 }

--- a/packages/read-project-manifest/package.json
+++ b/packages/read-project-manifest/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -35,8 +35,8 @@
     "detect-indent": "^6.0.0",
     "fast-deep-equal": "^3.1.3",
     "is-windows": "^1.0.2",
-    "json5": "^2.1.3",
-    "parse-json": "^5.1.0",
+    "json5": "^2.2.0",
+    "parse-json": "^5.2.0",
     "read-yaml-file": "^2.1.0",
     "sort-keys": "^4.2.0",
     "strip-bom": "^4.0.0"
@@ -47,5 +47,6 @@
     "@types/parse-json": "^4.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/read-projects-context/package.json
+++ b/packages/read-projects-context/package.json
@@ -15,7 +15,7 @@
     "node": ">=12.17"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/read-projects-context",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/read-projects-context#readme",
@@ -34,10 +34,11 @@
     "realpath-missing": "^1.1.0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/remove-bins/package.json
+++ b/packages/remove-bins/package.json
@@ -10,7 +10,7 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "keywords": [],
   "license": "MIT",
@@ -35,12 +35,13 @@
     "is-windows": "^1.0.2"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "^0.27.35"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/resolve-dependencies/jest.config.js
+++ b/packages/resolve-dependencies/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/resolve-dependencies/package.json
+++ b/packages/resolve-dependencies/package.json
@@ -15,7 +15,7 @@
     "node": ">=12.17"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/resolve-dependencies",
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/resolve-dependencies#readme",
@@ -25,7 +25,7 @@
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
-    "_test": "jest"
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@pnpm/constants": "workspace:4.1.0",
@@ -44,7 +44,7 @@
     "@pnpm/types": "workspace:6.4.0",
     "dependency-path": "workspace:5.1.1",
     "encode-registry": "^3.0.0",
-    "get-npm-tarball-url": "^2.0.2",
+    "get-npm-tarball-url": "^3.0.0-0",
     "import-from": "^3.0.0",
     "path-exists": "^4.0.0",
     "ramda": "^0.27.1",
@@ -53,12 +53,13 @@
     "version-selector-type": "^3.0.0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/ramda": "^0.27.35",
     "@types/semver": "^7.3.4"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/resolve-workspace-range/package.json
+++ b/packages/resolve-workspace-range/package.json
@@ -32,5 +32,6 @@
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/resolver-base/package.json
+++ b/packages/resolver-base/package.json
@@ -32,5 +32,6 @@
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/run-npm/package.json
+++ b/packages/run-npm/package.json
@@ -32,5 +32,6 @@
     "cross-spawn": "^7.0.3",
     "path-name": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -30,11 +30,11 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/server#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
     "@pnpm/client": "workspace:2.0.24",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/package-requester": "workspace:13.0.1",
     "@pnpm/package-store": "workspace:11.0.3",
     "@types/mz": "^2.7.3",
@@ -54,5 +54,6 @@
     "promise-share": "^1.0.0",
     "uuid": "^3.4.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/sort-packages/package.json
+++ b/packages/sort-packages/package.json
@@ -31,5 +31,6 @@
     "@pnpm/types": "workspace:6.4.0",
     "graph-sequencer": "2.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/store-connection-manager/package.json
+++ b/packages/store-connection-manager/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/store-connection-manager#readme",
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/cli-meta": "workspace:1.0.2",
@@ -44,7 +44,8 @@
     "dir-is-case-sensitive": "^2.0.0"
   },
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/store-controller-types/package.json
+++ b/packages/store-controller-types/package.json
@@ -31,5 +31,6 @@
     "@pnpm/resolver-base": "workspace:7.1.1",
     "@pnpm/types": "workspace:6.4.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/supi/jest.config.js
+++ b/packages/supi/jest.config.js
@@ -1,6 +1,6 @@
-const config = require('../../jest.config.js')
+import config from '../../jest.config.js'
 
-module.exports = {
+export default {
   ...config,
   testPathIgnorePatterns: [
     '<rootDir>/test/utils/distTags.ts',

--- a/packages/supi/package.json
+++ b/packages/supi/package.json
@@ -13,7 +13,7 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/build-modules": "workspace:5.2.12",
@@ -51,7 +51,7 @@
     "dependency-path": "workspace:5.1.1",
     "graph-sequencer": "2.0.0",
     "is-inner-link": "^4.0.0",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "load-json-file": "^6.2.0",
     "normalize-path": "^3.0.0",
     "p-every": "^2.0.0",
@@ -69,7 +69,7 @@
     "@pnpm/assert-store": "workspace:*",
     "@pnpm/cafs": "workspace:2.1.0",
     "@pnpm/client": "workspace:2.0.24",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@pnpm/package-store": "workspace:11.0.3",
     "@pnpm/prepare": "workspace:0.0.18",
     "@pnpm/store-path": "5.0.0-1",
@@ -140,7 +140,7 @@
     "commitmsg": "commitlint -e",
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "test-with-preview": "preview && pnpm run test:e2e",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=4873 pnpm run test:e2e",
@@ -148,5 +148,6 @@
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/supi/src/safeIsInnerLink.ts
+++ b/packages/supi/src/safeIsInnerLink.ts
@@ -4,7 +4,7 @@ import logger from '@pnpm/logger'
 import isInnerLink from 'is-inner-link'
 import isSubdir from 'is-subdir'
 
-export default async function safeIsInnerLink (
+export default async function safeIsInnerLink(
   projectModulesDir: string,
   depName: string,
   opts: {

--- a/packages/supi/test/install/hoist.ts
+++ b/packages/supi/test/install/hoist.ts
@@ -104,7 +104,7 @@ test('should not override root packages with hoisted dependencies', async () => 
   // this installs express@4.16.2, that depends on debug 2.6.9, but we don't want to flatten debug@2.6.9
   await addDependenciesToPackage(manifest, ['express@4.16.2'], await testDefaults({ fastUnpack: false, hoistPattern: '*' }))
 
-  expect(project.requireModule('debug/package.json').version).toEqual('3.1.0')
+  expect((await project.requireModule('debug/package.json')).version).toEqual('3.1.0')
 })
 
 test('should rehoist when uninstalling a package', async () => {
@@ -122,8 +122,8 @@ test('should rehoist when uninstalling a package', async () => {
     },
   ], await testDefaults({ hoistPattern: '*' }))
 
-  expect(project.requireModule('.pnpm/node_modules/debug/package.json').version).toEqual('2.6.9')
-  expect(project.requireModule('express/package.json').version).toEqual('4.16.0')
+  expect((await project.requireModule('.pnpm/node_modules/debug/package.json')).version).toEqual('2.6.9')
+  expect((await project.requireModule('express/package.json')).version).toEqual('4.16.0')
 
   const modules = await project.readModulesManifest()
   expect(modules).toBeTruthy()
@@ -140,8 +140,8 @@ test('should rehoist after running a general install', async () => {
     },
   }, await testDefaults({ fastUnpack: false, hoistPattern: '*' }))
 
-  expect(project.requireModule('debug/package.json').version).toEqual('3.1.0')
-  expect(project.requireModule('express/package.json').version).toEqual('4.16.0')
+  expect((await project.requireModule('debug/package.json')).version).toEqual('3.1.0')
+  expect((await project.requireModule('express/package.json')).version).toEqual('4.16.0')
 
   await project.hasNot('.pnpm/node_modules/debug') // debug not hoisted because it is a direct dep
 
@@ -167,7 +167,7 @@ test('should not override aliased dependencies', async () => {
   // now I install is-negative, but aliased as "debug". I do not want the "debug" dependency of express to override my alias
   await addDependenciesToPackage({}, ['debug@npm:is-negative@1.0.0', 'express'], await testDefaults({ fastUnpack: false, hoistPattern: '*' }))
 
-  expect(project.requireModule('debug/package.json').version).toEqual('1.0.0')
+  expect((await project.requireModule('debug/package.json')).version).toEqual('1.0.0')
 })
 
 test('hoistPattern=* throws exception when executed on node_modules installed w/o the option', async () => {
@@ -270,8 +270,8 @@ test('should rehoist after pruning', async () => {
     },
   }, await testDefaults({ fastUnpack: false, hoistPattern: '*' }))
 
-  expect(project.requireModule('debug/package.json').version).toEqual('3.1.0')
-  expect(project.requireModule('express/package.json').version).toEqual('4.16.0')
+  expect((await project.requireModule('debug/package.json')).version).toEqual('3.1.0')
+  expect((await project.requireModule('express/package.json')).version).toEqual('4.16.0')
 
   await project.hasNot('.pnpm/node_modules/debug') // debug is not hoisted because it is a direct dep
   // read this module path because we can't use requireModule again, as it is cached

--- a/packages/supi/test/install/local.ts
+++ b/packages/supi/test/install/local.ts
@@ -18,7 +18,7 @@ test('scoped modules from a directory', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, [`file:${pathToLocalPkg('local-scoped-pkg')}`], await testDefaults())
 
-  const m = project.requireModule('@scope/local-scoped-pkg')
+  const m = await project.requireModule('@scope/local-scoped-pkg')
 
   expect(m()).toBe('@scope/local-scoped-pkg')
 })
@@ -32,7 +32,7 @@ test('local file', async () => {
   const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
   expect(manifest.dependencies).toStrictEqual(expectedSpecs)
 
-  const m = project.requireModule('local-pkg')
+  const m = await project.requireModule('local-pkg')
 
   expect(m).toBeTruthy()
 
@@ -56,7 +56,7 @@ test('local file via link:', async () => {
   const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
   expect(manifest.dependencies).toStrictEqual(expectedSpecs)
 
-  const m = project.requireModule('local-pkg')
+  const m = await project.requireModule('local-pkg')
 
   expect(m).toBeTruthy()
 
@@ -82,7 +82,7 @@ test('local file with symlinked node_modules', async () => {
   const expectedSpecs = { 'local-pkg': `link:..${path.sep}local-pkg` }
   expect(manifest.dependencies).toStrictEqual(expectedSpecs)
 
-  const m = project.requireModule('local-pkg')
+  const m = await project.requireModule('local-pkg')
 
   expect(m).toBeTruthy()
 
@@ -101,7 +101,7 @@ test('package with a broken symlink', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, [pathToLocalPkg('has-broken-symlink/has-broken-symlink.tar.gz')], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('has-broken-symlink')
+  const m = await project.requireModule('has-broken-symlink')
 
   expect(m).toBeTruthy()
 })
@@ -110,7 +110,7 @@ test('tarball local package', async () => {
   const project = prepareEmpty()
   const manifest = await addDependenciesToPackage({}, [pathToLocalPkg('tar-pkg/tar-pkg-1.0.0.tgz')], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('tar-pkg')
+  const m = await project.requireModule('tar-pkg')
 
   expect(m()).toBe('tar-pkg')
 
@@ -140,7 +140,7 @@ test('tarball local package from project directory', async () => {
     },
   }, await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('tar-pkg')
+  const m = await project.requireModule('tar-pkg')
 
   expect(m()).toBe('tar-pkg')
 

--- a/packages/supi/test/install/misc.ts
+++ b/packages/supi/test/install/misc.ts
@@ -143,7 +143,7 @@ test('no dependencies (lodash)', async () => {
     } as ProjectManifest,
   } as PackageManifestLog)).toBeTruthy()
 
-  const m = project.requireModule('lodash')
+  const m = await project.requireModule('lodash')
   expect(typeof m).toBe('function')
   expect(typeof m.clone).toBe('function')
 })
@@ -166,7 +166,7 @@ test('scoped package with custom registry', async () => {
     registry: 'http://localhost:9999/',
   }))
 
-  const m = project.requireModule('@scoped/peer/package.json')
+  const m = await project.requireModule('@scoped/peer/package.json')
   expect(m).toBeTruthy()
 })
 
@@ -259,15 +259,15 @@ test('multiple scoped modules (@rstacruz/...)', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['@rstacruz/tap-spec@*', '@rstacruz/travis-encrypt@*'], await testDefaults({ fastUnpack: false }))
 
-  expect(typeof project.requireModule('@rstacruz/tap-spec')).toBe('function')
-  expect(typeof project.requireModule('@rstacruz/travis-encrypt')).toBe('function')
+  expect(typeof (await project.requireModule('@rstacruz/tap-spec'))).toBe('function')
+  expect(typeof (await project.requireModule('@rstacruz/travis-encrypt'))).toBe('function')
 })
 
 test('nested scoped modules (test-pnpm-issue219 -> @zkochan/test-pnpm-issue219)', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['test-pnpm-issue219@1.0.2'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('test-pnpm-issue219')
+  const m = await project.requireModule('test-pnpm-issue219')
   expect(m).toBe('test-pnpm-issue219,@zkochan/test-pnpm-issue219')
 })
 
@@ -338,7 +338,7 @@ test('overwriting (magic-hook@2.0.0 and @0.1.0)', async () => {
   // store should be pruned to have this removed
   await project.storeHas('flatten', '1.0.2')
 
-  const m = project.requireModule('magic-hook/package.json')
+  const m = await project.requireModule('magic-hook/package.json')
   expect(m.version).toBe('0.1.0')
 })
 
@@ -449,7 +449,7 @@ test('circular deps', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['circular-deps-1-of-2'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('circular-deps-1-of-2/mirror')
+  const m = await project.requireModule('circular-deps-1-of-2/mirror')
 
   expect(m()).toEqual('circular-deps-1-of-2')
 
@@ -465,7 +465,7 @@ test('concurrent circular deps', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['es6-iterator@2.0.0'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('es6-iterator')
+  const m = await project.requireModule('es6-iterator')
 
   expect(m).toBeTruthy()
   expect(await exists(path.resolve('node_modules/.pnpm/es6-iterator@2.0.0/node_modules/es5-ext'))).toBeTruthy()
@@ -481,7 +481,7 @@ test('concurrent installation of the same packages', async () => {
   // of babek-core
   await addDependenciesToPackage({}, ['babel-core@6.21.0'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('babel-core')
+  const m = await project.requireModule('babel-core')
 
   expect(m).toBeTruthy()
 })
@@ -490,7 +490,7 @@ test('big with dependencies and circular deps (babel-preset-2015)', async () => 
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['babel-preset-es2015@6.3.13'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('babel-preset-es2015')
+  const m = await project.requireModule('babel-preset-es2015')
   expect(typeof m).toEqual('object')
 })
 
@@ -545,7 +545,7 @@ test('compiled modules (ursa@0.9.1)', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['ursa@0.9.1'], await testDefaults())
 
-  const m = project.requireModule('ursa')
+  const m = await project.requireModule('ursa')
   expect(typeof m).toEqual('object')
 })
 
@@ -635,13 +635,13 @@ test('should install dependency in second project', async () => {
   const project1 = prepareEmpty()
 
   await addDependenciesToPackage({}, ['pkg-with-1-dep'], await testDefaults({ fastUnpack: false, save: true, store: '../store' }))
-  expect(project1.requireModule('pkg-with-1-dep')().name).toEqual('dep-of-pkg-with-1-dep')
+  expect((await project1.requireModule('pkg-with-1-dep'))().name).toEqual('dep-of-pkg-with-1-dep')
 
   const project2 = prepareEmpty()
 
   await addDependenciesToPackage({}, ['pkg-with-1-dep'], await testDefaults({ fastUnpack: false, save: true, store: '../store' }))
 
-  expect(project2.requireModule('pkg-with-1-dep')().name).toEqual('dep-of-pkg-with-1-dep')
+  expect((await project2.requireModule('pkg-with-1-dep'))().name).toEqual('dep-of-pkg-with-1-dep')
 })
 
 test('should throw error when trying to install using a different store then the previous one', async () => {
@@ -737,7 +737,7 @@ test('lockfile locks npm dependencies', async () => {
     status: 'found_in_store',
   } as ProgressLog)).toBeTruthy()
 
-  const m = project.requireModule('.pnpm/pkg-with-1-dep@100.0.0/node_modules/dep-of-pkg-with-1-dep/package.json')
+  const m = await project.requireModule('.pnpm/pkg-with-1-dep@100.0.0/node_modules/dep-of-pkg-with-1-dep/package.json')
 
   expect(m.version).toEqual('100.0.0')
 })
@@ -746,7 +746,7 @@ test('self-require should work', async () => {
 
   await addDependenciesToPackage({}, ['uses-pkg-with-self-usage'], await testDefaults({ fastUnpack: false }))
 
-  expect(project.requireModule('uses-pkg-with-self-usage')).toBeTruthy()
+  expect(await project.requireModule('uses-pkg-with-self-usage')).toBeTruthy()
 })
 
 test('install on project with lockfile and no node_modules', async () => {
@@ -802,7 +802,7 @@ test('rewrites node_modules created by npm', async () => {
 
   const manifest = await install({}, await testDefaults())
 
-  const m = project.requireModule('rimraf')
+  const m = await project.requireModule('rimraf')
   expect(typeof m).toEqual('function')
   await project.isExecutable('.bin/rimraf')
 
@@ -1160,7 +1160,7 @@ test('ignore files in node_modules', async () => {
     await testDefaults({ fastUnpack: false, reporter })
   )
 
-  const m = project.requireModule('lodash')
+  const m = await project.requireModule('lodash')
   expect(typeof m).toEqual('function')
   expect(typeof m.clone).toEqual('function')
   expect(await fs.readFile('node_modules/foo', 'utf8')).toEqual('x')

--- a/packages/supi/test/install/optionalDependencies.ts
+++ b/packages/supi/test/install/optionalDependencies.ts
@@ -25,7 +25,7 @@ test('skip failing optional dependencies', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['pkg-with-failing-optional-dependency@1.0.1'], await testDefaults({ fastUnpack: false }))
 
-  const m = project.requireModule('pkg-with-failing-optional-dependency')
+  const m = await project.requireModule('pkg-with-failing-optional-dependency')
   expect(m(-1)).toBeTruthy()
 })
 

--- a/packages/supi/test/install/updatingPkgJson.ts
+++ b/packages/supi/test/install/updatingPkgJson.ts
@@ -31,8 +31,8 @@ test("don't override existing spec in package.json on named installation", async
   manifest = await addDependenciesToPackage(manifest, ['is-negative'], await testDefaults())
   manifest = await addDependenciesToPackage(manifest, ['sec'], await testDefaults())
 
-  expect(project.requireModule('is-positive/package.json').version).toBe('2.0.0')
-  expect(project.requireModule('is-negative/package.json').version).toBe('1.0.1')
+  expect((await project.requireModule('is-positive/package.json')).version).toBe('2.0.0')
+  expect((await project.requireModule('is-negative/package.json')).version).toBe('1.0.1')
 
   expect(manifest.dependencies).toStrictEqual({
     'is-negative': '^1.0.1',
@@ -45,7 +45,7 @@ test('saveDev scoped module to package.json (@rstacruz/tap-spec)', async () => {
   const project = prepareEmpty()
   const manifest = await addDependenciesToPackage({}, ['@rstacruz/tap-spec'], await testDefaults({ fastUnpack: false, targetDependenciesField: 'devDependencies' }))
 
-  const m = project.requireModule('@rstacruz/tap-spec')
+  const m = await project.requireModule('@rstacruz/tap-spec')
   expect(typeof m).toBe('function')
 
   expect(manifest.devDependencies).toStrictEqual({ '@rstacruz/tap-spec': '^4.1.1' })

--- a/packages/supi/test/link.ts
+++ b/packages/supi/test/link.ts
@@ -106,7 +106,7 @@ test('relative link is not rewritten by argumentless install', async () => {
 
   await install(manifest, opts)
 
-  expect(project.requireModule('hello-world-js-bin/package.json').isLocal).toBeTruthy()
+  expect((await project.requireModule('hello-world-js-bin/package.json')).isLocal).toBeTruthy()
 })
 
 test('relative link is rewritten by named installation to regular dependency', async () => {
@@ -147,7 +147,7 @@ test('relative link is rewritten by named installation to regular dependency', a
 
   expect(manifest.dependencies).toStrictEqual({ 'hello-world-js-bin': '^1.0.0' })
 
-  expect(project.requireModule('hello-world-js-bin/package.json').isLocal).toBeFalsy()
+  expect((await project.requireModule('hello-world-js-bin/package.json')).isLocal).toBeFalsy()
 
   const wantedLockfile = await project.readLockfile()
   expect(wantedLockfile.dependencies['hello-world-js-bin']).toBe('1.0.0')

--- a/packages/supi/test/lockfile.ts
+++ b/packages/supi/test/lockfile.ts
@@ -126,7 +126,7 @@ test("lockfile doesn't lock subdependencies that don't satisfy the new specs", a
   await addDependenciesToPackage(manifest, ['react-datetime@1.3.0'], await testDefaults({ save: true }))
 
   expect(
-    project.requireModule('.pnpm/react-datetime@1.3.0/node_modules/react-onclickoutside/package.json').version
+    (await project.requireModule('.pnpm/react-datetime@1.3.0/node_modules/react-onclickoutside/package.json')).version
   ).toBe('0.3.4') // react-datetime@1.3.0 has react-onclickoutside@0.3.4 in its node_modules
 
   const lockfile = await project.readLockfile()

--- a/packages/supi/test/unlink.ts
+++ b/packages/supi/test/unlink.ts
@@ -68,7 +68,7 @@ test('unlink 1 package that exists in package.json', async () => {
     opts
   )
 
-  expect(typeof project.requireModule('is-subdir')).toBe('function')
+  expect(typeof (await project.requireModule('is-subdir'))).toBe('function')
   expect((await isInnerLink('node_modules', 'is-positive')).isInner).toBeFalsy()
 })
 
@@ -102,7 +102,7 @@ test("don't update package when unlinking", async () => {
     opts
   )
 
-  expect(project.requireModule('foo/package.json').version).toBe('100.0.0')
+  expect((await project.requireModule('foo/package.json')).version).toBe('100.0.0')
 })
 
 test(`don't update package when unlinking. Initial link is done on a package w/o ${WANTED_LOCKFILE}`, async () => {
@@ -139,7 +139,7 @@ test(`don't update package when unlinking. Initial link is done on a package w/o
     opts
   )
 
-  expect(project.requireModule('foo/package.json').version).toBe('100.1.0')
+  expect((await project.requireModule('foo/package.json')).version).toBe('100.1.0')
   expect(unlinkResult[0].manifest.dependencies).toStrictEqual({ foo: '^100.0.0' })
 })
 
@@ -184,7 +184,7 @@ test('unlink 2 packages. One of them exists in package.json', async () => {
     opts
   )
 
-  expect(typeof project.requireModule('is-subdir')).toBe('function')
+  expect(typeof (await project.requireModule('is-subdir'))).toBe('function')
   expect(await exists(path.join('node_modules', 'is-positive'))).toBeFalsy()
 })
 
@@ -228,8 +228,8 @@ test('unlink all packages', async () => {
     opts
   )
 
-  expect(typeof project.requireModule('is-subdir')).toBe('function')
-  expect(typeof project.requireModule('@zkochan/logger')).toBe('object')
+  expect(typeof (await project.requireModule('is-subdir'))).toBe('function')
+  expect(typeof (await project.requireModule('@zkochan/logger'))).toBe('object')
 })
 
 test("don't warn about scoped packages when running unlink w/o params", async () => {

--- a/packages/symlink-dependency/package.json
+++ b/packages/symlink-dependency/package.json
@@ -13,10 +13,10 @@
     "!*.map"
   ],
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "devDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "directories": {
     "test": "test"
@@ -42,5 +42,6 @@
     "@pnpm/types": "workspace:6.4.0",
     "symlink-dir": "^4.2.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/tarball-fetcher/jest.config.js
+++ b/packages/tarball-fetcher/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/tarball-fetcher/package.json
+++ b/packages/tarball-fetcher/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/tarball-fetcher#readme",
   "peerDependencies": {
-    "@pnpm/logger": "^3.2.3"
+    "@pnpm/logger": "^4.0.0-0"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:5.0.3",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@pnpm/cafs": "workspace:2.1.0",
     "@pnpm/fetch": "workspace:2.1.11",
-    "@pnpm/logger": "^3.2.3",
+    "@pnpm/logger": "^4.0.0-0",
     "@types/retry": "^0.12.0",
     "@types/rimraf": "^3.0.0",
     "@types/ssri": "^7.1.0",
@@ -52,5 +52,6 @@
     "nock": "12.0.3",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/tarball-fetcher/test/download.ts
+++ b/packages/tarball-fetcher/test/download.ts
@@ -12,6 +12,9 @@ import cpFile from 'cp-file'
 import nock from 'nock'
 import ssri from 'ssri'
 import tempy from 'tempy'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const cafsDir = tempy.directory()
 const cafs = createCafs(cafsDir)

--- a/packages/tarball-resolver/package.json
+++ b/packages/tarball-resolver/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -29,5 +29,6 @@
   "dependencies": {
     "@pnpm/resolver-base": "workspace:7.1.1"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,5 +27,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/types#readme",
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/packages/write-project-manifest/jest.config.js
+++ b/packages/write-project-manifest/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/packages/write-project-manifest/package.json
+++ b/packages/write-project-manifest/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
-    "_test": "jest",
+    "_test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/write-project-manifest#readme",
   "dependencies": {
     "@pnpm/types": "workspace:6.4.0",
-    "json5": "^2.1.3",
+    "json5": "^2.2.0",
     "write-file-atomic": "^3.0.3",
     "write-yaml-file": "^4.2.0"
   },
@@ -39,5 +39,6 @@
     "@types/write-file-atomic": "^3.0.1",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ importers:
       '@commitlint/cli': ^12.0.1
       '@commitlint/config-conventional': ^12.0.1
       '@commitlint/prompt-cli': ^12.0.1
+      '@jest/globals': ^27.0.0-next.1
       '@pnpm/eslint-config': workspace:*
       '@pnpm/meta-updater': ^0.0.0
       '@pnpm/registry-mock': ^2.4.0
@@ -49,6 +50,7 @@ importers:
       '@commitlint/cli': 12.0.1
       '@commitlint/config-conventional': 12.0.1
       '@commitlint/prompt-cli': 12.0.1
+      '@jest/globals': 27.0.0-next.7
       '@pnpm/eslint-config': link:utils/eslint-config
       '@pnpm/meta-updater': 0.0.0
       '@pnpm/registry-mock': 2.4.0
@@ -104,7 +106,7 @@ importers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/lifecycle': workspace:9.6.5
       '@pnpm/link-bins': workspace:5.3.25
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/read-package-json': workspace:4.0.0
       '@pnpm/store-controller-types': workspace:10.0.0
       '@pnpm/types': workspace:6.4.0
@@ -125,7 +127,7 @@ importers:
       run-groups: 3.0.1
     devDependencies:
       '@pnpm/build-modules': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/ramda': 0.27.39
 
   packages/cafs:
@@ -187,7 +189,7 @@ importers:
       '@pnpm/config': workspace:11.14.2
       '@pnpm/default-reporter': workspace:7.10.7
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/manifest-utils': workspace:1.1.5
       '@pnpm/package-is-installable': workspace:4.0.19
       '@pnpm/read-project-manifest': workspace:1.1.7
@@ -207,7 +209,7 @@ importers:
       load-json-file: 6.2.0
     devDependencies:
       '@pnpm/cli-utils': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/types': link:../types
       '@types/ramda': 0.27.39
 
@@ -218,7 +220,7 @@ importers:
       '@pnpm/fetch': workspace:2.1.11
       '@pnpm/fetching-types': workspace:1.0.0
       '@pnpm/git-fetcher': workspace:3.0.13
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/resolver-base': workspace:7.1.1
       '@pnpm/tarball-fetcher': workspace:8.2.8
       credentials-by-uri: ^2.0.0
@@ -234,7 +236,7 @@ importers:
       mem: 8.1.0
     devDependencies:
       '@pnpm/client': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
 
   packages/command:
     specifiers:
@@ -261,7 +263,7 @@ importers:
       '@zkochan/npm-conf': 2.0.2
       camelcase: ^6.2.0
       can-write-to-dir: ^1.1.1
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       ramda: ^0.27.1
       realpath-missing: ^1.1.0
       symlink-dir: ^4.2.0
@@ -294,13 +296,13 @@ importers:
   packages/core-loggers:
     specifiers:
       '@pnpm/core-loggers': 'link:'
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/types': workspace:6.4.0
     dependencies:
       '@pnpm/types': link:../types
     devDependencies:
       '@pnpm/core-loggers': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
 
   packages/default-reporter:
     specifiers:
@@ -308,7 +310,7 @@ importers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/default-reporter': 'link:'
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/types': workspace:6.4.0
       '@types/normalize-path': ^3.0.0
       '@types/ramda': ^0.27.35
@@ -349,7 +351,7 @@ importers:
       strip-ansi: 6.0.0
     devDependencies:
       '@pnpm/default-reporter': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.39
       '@types/semver': 7.3.4
@@ -365,7 +367,7 @@ importers:
       '@pnpm/fetching-types': workspace:1.0.0
       '@pnpm/git-resolver': workspace:4.1.12
       '@pnpm/local-resolver': workspace:5.1.3
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/npm-resolver': workspace:10.2.2
       '@pnpm/resolver-base': workspace:7.1.1
       '@pnpm/tarball-resolver': workspace:4.0.8
@@ -380,14 +382,14 @@ importers:
     devDependencies:
       '@pnpm/default-resolver': 'link:'
       '@pnpm/fetch': link:../fetch
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
 
   packages/dependencies-hierarchy:
     specifiers:
       '@pnpm/constants': workspace:4.1.0
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/normalize-registries': workspace:1.0.6
       '@pnpm/read-modules-dir': workspace:2.0.3
@@ -413,7 +415,7 @@ importers:
       resolve-link-target: 2.0.0
     devDependencies:
       '@pnpm/constants': link:../constants
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/normalize-path': 3.0.0
       dependencies-hierarchy: 'link:'
 
@@ -462,7 +464,7 @@ importers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/fetch': 'link:'
       '@pnpm/fetching-types': workspace:1.0.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/npm-registry-agent': workspace:3.1.2
       '@types/node-fetch': ^2.5.7
       '@zkochan/retry': ^0.2.0
@@ -479,7 +481,7 @@ importers:
       node-fetch-unix: 2.3.0
     devDependencies:
       '@pnpm/fetch': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/node-fetch': 2.5.8
       cpy-cli: 3.1.1
       nock: 12.0.3
@@ -516,7 +518,7 @@ importers:
       '@pnpm/lockfile-types': workspace:2.2.0
       '@pnpm/lockfile-utils': workspace:2.0.22
       '@pnpm/lockfile-walker': workspace:3.0.9
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-is-installable': workspace:4.0.19
       '@pnpm/types': workspace:6.4.0
       '@types/ramda': ^0.27.35
@@ -537,7 +539,7 @@ importers:
       ramda: 0.27.1
     devDependencies:
       '@pnpm/filter-lockfile': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/ramda': 0.27.39
       tempy: 1.0.1
       write-yaml-file: 4.2.0
@@ -557,7 +559,7 @@ importers:
       execa: ^5.0.0
       find-up: ^5.0.0
       is-ci: ^3.0.0
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       is-windows: ^1.0.2
       micromatch: ^4.0.2
       pkgs-graph: workspace:5.2.0
@@ -636,7 +638,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/get-context': 'link:'
       '@pnpm/lockfile-file': workspace:3.2.1
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/read-projects-context': workspace:4.0.16
       '@pnpm/types': workspace:6.4.0
@@ -660,7 +662,7 @@ importers:
       ramda: 0.27.1
     devDependencies:
       '@pnpm/get-context': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/is-ci': 3.0.0
       '@types/ramda': 0.27.39
 
@@ -741,7 +743,7 @@ importers:
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-to-pnp': workspace:0.3.25
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-cleaner': workspace:10.0.23
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/package-is-installable': workspace:4.0.19
@@ -805,7 +807,7 @@ importers:
       '@pnpm/assert-project': link:../../privatePackages/assert-project
       '@pnpm/client': link:../client
       '@pnpm/headless': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-store': link:../package-store
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@pnpm/read-projects-context': link:../read-projects-context
@@ -832,7 +834,7 @@ importers:
       '@pnpm/lockfile-types': workspace:2.2.0
       '@pnpm/lockfile-utils': workspace:2.0.22
       '@pnpm/lockfile-walker': workspace:3.0.9
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/matcher': workspace:1.0.3
       '@pnpm/symlink-dependency': workspace:3.0.13
       '@pnpm/types': workspace:6.4.0
@@ -852,14 +854,14 @@ importers:
       ramda: 0.27.1
     devDependencies:
       '@pnpm/hoist': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/ramda': 0.27.39
 
   packages/lifecycle:
     specifiers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/lifecycle': 'link:'
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/read-package-json': workspace:4.0.0
       '@pnpm/types': workspace:6.4.0
       '@types/rimraf': ^3.0.0
@@ -877,7 +879,7 @@ importers:
       run-groups: 3.0.1
     devDependencies:
       '@pnpm/lifecycle': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/rimraf': 3.0.0
       json-append: 1.1.1
       load-json-file: 6.2.0
@@ -897,7 +899,7 @@ importers:
       '@types/normalize-path': ^3.0.0
       '@types/ramda': ^0.27.35
       '@zkochan/cmd-shim': ^5.0.0
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       is-windows: ^1.0.2
       ncp: ^2.0.0
       normalize-path: ^3.0.0
@@ -932,7 +934,7 @@ importers:
   packages/list:
     specifiers:
       '@pnpm/list': 'link:'
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/matcher': workspace:1.0.3
       '@pnpm/read-package-json': workspace:4.0.0
       '@pnpm/read-project-manifest': workspace:1.1.7
@@ -963,7 +965,7 @@ importers:
       semver: 7.3.5
     devDependencies:
       '@pnpm/list': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/archy': 0.0.31
       '@types/ramda': 0.27.39
       '@types/semver': 7.3.4
@@ -997,7 +999,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/lockfile-file': 'link:'
       '@pnpm/lockfile-types': workspace:2.2.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/merge-lockfile-changes': workspace:1.0.1
       '@pnpm/types': workspace:6.4.0
       '@types/js-yaml': ^4.0.0
@@ -1029,7 +1031,7 @@ importers:
       write-file-atomic: 3.0.3
     devDependencies:
       '@pnpm/lockfile-file': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@types/js-yaml': 4.0.0
       '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.39
@@ -1044,7 +1046,7 @@ importers:
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-to-pnp': 'link:'
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/read-project-manifest': workspace:1.1.7
       '@pnpm/types': workspace:6.4.0
       '@types/normalize-path': ^3.0.0
@@ -1065,7 +1067,7 @@ importers:
       ramda: 0.27.1
     devDependencies:
       '@pnpm/lockfile-to-pnp': 'link:'
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/types': link:../types
       '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.39
@@ -1086,7 +1088,7 @@ importers:
       '@types/js-yaml': ^4.0.0
       '@types/ramda': ^0.27.35
       dependency-path: workspace:5.1.1
-      get-npm-tarball-url: ^2.0.2
+      get-npm-tarball-url: ^3.0.0-0
       ramda: ^0.27.1
       tempy: ^1.0.0
       write-yaml-file: ^4.2.0
@@ -1096,7 +1098,7 @@ importers:
       '@pnpm/resolver-base': link:../resolver-base
       '@pnpm/types': link:../types
       dependency-path: link:../dependency-path
-      get-npm-tarball-url: 2.0.2
+      get-npm-tarball-url: 3.0.0-0
       ramda: 0.27.1
     devDependencies:
       '@pnpm/lockfile-utils': 'link:'
@@ -1132,7 +1134,7 @@ importers:
       '@pnpm/exportable-manifest': workspace:1.2.2
       '@pnpm/find-workspace-dir': workspace:2.0.0
       '@pnpm/lockfile-file': workspace:3.2.1
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/make-dedicated-lockfile': 'link:'
       '@pnpm/prepare': workspace:0.0.18
       '@pnpm/prune-lockfile': workspace:2.0.19
@@ -1149,7 +1151,7 @@ importers:
       '@pnpm/exportable-manifest': link:../exportable-manifest
       '@pnpm/find-workspace-dir': link:../find-workspace-dir
       '@pnpm/lockfile-file': link:../lockfile-file
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/prune-lockfile': link:../prune-lockfile
       '@pnpm/read-project-manifest': link:../read-project-manifest
       '@pnpm/types': link:../types
@@ -1207,7 +1209,7 @@ importers:
       '@pnpm/filter-lockfile': workspace:4.0.17
       '@pnpm/lockfile-types': workspace:2.2.0
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-cleaner': 'link:'
       '@pnpm/read-modules-dir': workspace:2.0.3
       '@pnpm/remove-bins': workspace:1.0.12
@@ -1230,7 +1232,7 @@ importers:
       dependency-path: link:../dependency-path
       ramda: 0.27.1
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/modules-cleaner': 'link:'
       '@types/ramda': 0.27.39
 
@@ -1258,7 +1260,7 @@ importers:
       '@pnpm/cafs': workspace:2.1.0
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/mount-modules': 'link:'
       '@pnpm/store-path': 5.0.0-1
       '@pnpm/types': workspace:6.4.0
@@ -1281,7 +1283,7 @@ importers:
     optionalDependencies:
       fuse-native: 2.2.6
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/mount-modules': 'link:'
       rimraf: 3.0.2
 
@@ -1323,7 +1325,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/fetch': workspace:2.1.11
       '@pnpm/fetching-types': workspace:1.0.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/npm-resolver': 'link:'
       '@pnpm/resolve-workspace-range': workspace:1.0.1
       '@pnpm/resolver-base': workspace:7.1.1
@@ -1370,7 +1372,7 @@ importers:
       version-selector-type: 3.0.0
     devDependencies:
       '@pnpm/fetch': link:../fetch
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/npm-resolver': 'link:'
       '@types/lru-cache': 5.1.0
       '@types/normalize-path': 3.0.0
@@ -1387,7 +1389,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/manifest-utils': workspace:1.1.5
       '@pnpm/matcher': workspace:1.0.3
       '@pnpm/modules-yaml': workspace:8.0.6
@@ -1417,7 +1419,7 @@ importers:
       ramda: 0.27.1
       semver: 7.3.5
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/outdated': 'link:'
       '@types/ramda': 0.27.39
       '@types/semver': 7.3.4
@@ -1442,7 +1444,7 @@ importers:
     specifiers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-is-installable': 'link:'
       '@pnpm/types': workspace:6.4.0
       '@types/semver': ^7.3.4
@@ -1453,7 +1455,7 @@ importers:
       '@pnpm/types': link:../types
       semver: 7.3.5
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-is-installable': 'link:'
       '@types/semver': 7.3.4
 
@@ -1464,7 +1466,7 @@ importers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/error': workspace:1.4.0
       '@pnpm/fetcher-base': workspace:9.0.4
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-requester': 'link:'
       '@pnpm/read-package-json': workspace:4.0.0
       '@pnpm/resolver-base': workspace:7.1.1
@@ -1482,7 +1484,7 @@ importers:
       normalize-path: ^3.0.0
       p-defer: ^3.0.0
       p-limit: ^3.1.0
-      p-queue: ^6.6.2
+      p-queue: ^7.0.0
       path-temp: ^2.0.0
       promise-share: ^1.0.0
       ramda: ^0.27.1
@@ -1502,7 +1504,7 @@ importers:
       load-json-file: 6.2.0
       p-defer: 3.0.0
       p-limit: 3.1.0
-      p-queue: 6.6.2
+      p-queue: 7.0.0
       path-temp: 2.0.0
       promise-share: 1.0.0
       ramda: 0.27.1
@@ -1510,7 +1512,7 @@ importers:
       ssri: 8.0.1
     devDependencies:
       '@pnpm/client': link:../client
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-requester': 'link:'
       '@types/ncp': 2.0.4
       '@types/normalize-path': 3.0.0
@@ -1528,7 +1530,7 @@ importers:
       '@pnpm/client': workspace:2.0.24
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/fetcher-base': workspace:9.0.4
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-requester': workspace:13.0.1
       '@pnpm/package-store': 'link:'
       '@pnpm/prepare': workspace:0.0.18
@@ -1570,7 +1572,7 @@ importers:
       write-json-file: 4.3.0
     devDependencies:
       '@pnpm/client': link:../client
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-store': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@types/ramda': 0.27.39
@@ -1717,7 +1719,7 @@ importers:
       '@pnpm/find-workspace-dir': workspace:2.0.0
       '@pnpm/find-workspace-packages': workspace:2.3.42
       '@pnpm/lockfile-types': workspace:2.2.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/manifest-utils': workspace:1.1.5
       '@pnpm/matcher': workspace:1.0.3
       '@pnpm/outdated': workspace:7.2.29
@@ -1743,7 +1745,7 @@ importers:
       chalk: ^4.1.0
       enquirer: ^2.3.6
       is-ci: ^3.0.0
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       load-json-file: ^6.2.0
       mem: ^8.0.0
       p-filter: ^2.1.0
@@ -1804,7 +1806,7 @@ importers:
     devDependencies:
       '@pnpm/assert-project': link:../../privatePackages/assert-project
       '@pnpm/lockfile-types': link:../lockfile-types
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/matcher': link:../matcher
       '@pnpm/plugin-commands-installation': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
@@ -1833,7 +1835,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/filter-workspace-packages': workspace:2.3.14
       '@pnpm/list': workspace:5.0.26
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/plugin-commands-installation': workspace:3.5.28
       '@pnpm/plugin-commands-listing': 'link:'
       '@pnpm/prepare': workspace:0.0.18
@@ -1856,7 +1858,7 @@ importers:
     devDependencies:
       '@pnpm/constants': link:../constants
       '@pnpm/filter-workspace-packages': link:../filter-workspace-packages
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-installation': link:../plugin-commands-installation
       '@pnpm/plugin-commands-listing': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
@@ -1939,7 +1941,7 @@ importers:
       '@pnpm/exportable-manifest': workspace:1.2.2
       '@pnpm/filter-workspace-packages': workspace:2.3.14
       '@pnpm/lifecycle': workspace:9.6.5
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/pick-registry-for-package': workspace:1.1.0
       '@pnpm/plugin-commands-publishing': 'link:'
       '@pnpm/prepare': workspace:0.0.18
@@ -1993,7 +1995,7 @@ importers:
       write-json-file: 4.3.0
     devDependencies:
       '@pnpm/filter-workspace-packages': link:../filter-workspace-packages
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-publishing': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@types/cross-spawn': 6.0.2
@@ -2023,7 +2025,7 @@ importers:
       '@pnpm/link-bins': workspace:5.3.25
       '@pnpm/lockfile-utils': workspace:2.0.22
       '@pnpm/lockfile-walker': workspace:3.0.9
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/normalize-registries': workspace:1.0.6
       '@pnpm/plugin-commands-rebuild': 'link:'
@@ -2084,7 +2086,7 @@ importers:
       semver: 7.3.5
     devDependencies:
       '@pnpm/filter-workspace-packages': link:../filter-workspace-packages
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-rebuild': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
@@ -2105,7 +2107,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/filter-workspace-packages': workspace:2.3.14
       '@pnpm/lifecycle': workspace:9.6.5
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/plugin-commands-script-runners': 'link:'
       '@pnpm/prepare': workspace:0.0.18
       '@pnpm/sort-packages': workspace:1.0.16
@@ -2136,7 +2138,7 @@ importers:
       render-help: 1.0.2
     devDependencies:
       '@pnpm/filter-workspace-packages': link:../filter-workspace-packages
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-script-runners': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@types/ramda': 0.27.39
@@ -2152,7 +2154,7 @@ importers:
       '@pnpm/common-cli-options-help': workspace:0.3.1
       '@pnpm/config': workspace:11.14.2
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/plugin-commands-server': 'link:'
       '@pnpm/server': workspace:10.0.1
       '@pnpm/store-connection-manager': workspace:1.0.4
@@ -2188,7 +2190,7 @@ importers:
       signal-exit: 3.0.3
       tree-kill: 1.2.2
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-server': 'link:'
       '@types/is-windows': 1.0.0
       '@types/ramda': 0.27.39
@@ -2204,7 +2206,7 @@ importers:
       '@pnpm/get-context': workspace:4.0.0
       '@pnpm/lockfile-file': workspace:3.2.1
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/normalize-registries': workspace:1.0.6
       '@pnpm/parse-wanted-dependency': workspace:1.0.0
       '@pnpm/pick-registry-for-package': workspace:1.1.0
@@ -2254,7 +2256,7 @@ importers:
     devDependencies:
       '@pnpm/assert-store': link:../../privatePackages/assert-store
       '@pnpm/lockfile-file': link:../lockfile-file
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/plugin-commands-store': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@types/archy': 0.0.31
@@ -2286,7 +2288,7 @@ importers:
       '@pnpm/find-workspace-dir': workspace:2.0.0
       '@pnpm/find-workspace-packages': workspace:2.3.42
       '@pnpm/lockfile-types': workspace:2.2.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/parse-cli-args': workspace:3.2.2
       '@pnpm/pick-registry-for-package': workspace:1.1.0
@@ -2377,7 +2379,7 @@ importers:
       '@pnpm/find-workspace-dir': link:../find-workspace-dir
       '@pnpm/find-workspace-packages': link:../find-workspace-packages
       '@pnpm/lockfile-types': link:../lockfile-types
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/modules-yaml': link:../modules-yaml
       '@pnpm/parse-cli-args': link:../parse-cli-args
       '@pnpm/pick-registry-for-package': link:../pick-registry-for-package
@@ -2454,7 +2456,7 @@ importers:
     specifiers:
       '@pnpm/core-loggers': workspace:5.0.3
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/pnpmfile': 'link:'
       '@pnpm/types': workspace:6.4.0
       '@types/ramda': ^0.27.35
@@ -2469,7 +2471,7 @@ importers:
       path-absolute: 1.0.1
       ramda: 0.27.1
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/pnpmfile': 'link:'
       '@types/ramda': 0.27.39
 
@@ -2527,8 +2529,8 @@ importers:
       detect-indent: ^6.0.0
       fast-deep-equal: ^3.1.3
       is-windows: ^1.0.2
-      json5: ^2.1.3
-      parse-json: ^5.1.0
+      json5: ^2.2.0
+      parse-json: ^5.2.0
       read-yaml-file: ^2.1.0
       sort-keys: ^4.2.0
       strip-bom: ^4.0.0
@@ -2555,7 +2557,7 @@ importers:
   packages/read-projects-context:
     specifiers:
       '@pnpm/lockfile-file': workspace:3.2.1
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/modules-yaml': workspace:8.0.6
       '@pnpm/normalize-registries': workspace:1.0.6
       '@pnpm/read-projects-context': 'link:'
@@ -2568,13 +2570,13 @@ importers:
       '@pnpm/types': link:../types
       realpath-missing: 1.1.0
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/read-projects-context': 'link:'
 
   packages/remove-bins:
     specifiers:
       '@pnpm/core-loggers': workspace:5.0.3
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-bins': workspace:4.1.0
       '@pnpm/read-package-json': workspace:4.0.0
       '@pnpm/remove-bins': 'link:'
@@ -2591,7 +2593,7 @@ importers:
       '@zkochan/rimraf': 2.0.0
       is-windows: 1.0.2
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/remove-bins': 'link:'
       '@types/is-windows': 1.0.0
       '@types/ramda': 0.27.39
@@ -2603,7 +2605,7 @@ importers:
       '@pnpm/error': workspace:1.4.0
       '@pnpm/lockfile-types': workspace:2.2.0
       '@pnpm/lockfile-utils': workspace:2.0.22
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/manifest-utils': workspace:1.1.5
       '@pnpm/npm-resolver': workspace:10.2.2
       '@pnpm/package-is-installable': workspace:4.0.19
@@ -2618,7 +2620,7 @@ importers:
       '@types/semver': ^7.3.4
       dependency-path: workspace:5.1.1
       encode-registry: ^3.0.0
-      get-npm-tarball-url: ^2.0.2
+      get-npm-tarball-url: ^3.0.0-0
       import-from: ^3.0.0
       path-exists: ^4.0.0
       ramda: ^0.27.1
@@ -2642,7 +2644,7 @@ importers:
       '@pnpm/types': link:../types
       dependency-path: link:../dependency-path
       encode-registry: 3.0.0
-      get-npm-tarball-url: 2.0.2
+      get-npm-tarball-url: 3.0.0-0
       import-from: 3.0.0
       path-exists: 4.0.0
       ramda: 0.27.1
@@ -2650,7 +2652,7 @@ importers:
       semver: 7.3.5
       version-selector-type: 3.0.0
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/resolve-dependencies': 'link:'
       '@types/ramda': 0.27.39
       '@types/semver': 7.3.4
@@ -2692,7 +2694,7 @@ importers:
     specifiers:
       '@pnpm/client': workspace:2.0.24
       '@pnpm/fetch': workspace:2.1.11
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-requester': workspace:13.0.1
       '@pnpm/package-store': workspace:11.0.3
       '@pnpm/server': 'link:'
@@ -2718,7 +2720,7 @@ importers:
       uuid: 3.4.0
     devDependencies:
       '@pnpm/client': link:../client
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-requester': link:../package-requester
       '@pnpm/package-store': link:../package-store
       '@pnpm/server': 'link:'
@@ -2748,7 +2750,7 @@ importers:
       '@pnpm/client': workspace:2.0.24
       '@pnpm/config': workspace:11.14.2
       '@pnpm/error': workspace:1.4.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/package-store': workspace:11.0.3
       '@pnpm/server': workspace:10.0.1
       '@pnpm/store-connection-manager': 'link:'
@@ -2768,7 +2770,7 @@ importers:
       delay: 5.0.0
       dir-is-case-sensitive: 2.0.0
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/store-connection-manager': 'link:'
 
   packages/store-controller-types:
@@ -2802,7 +2804,7 @@ importers:
       '@pnpm/lockfile-to-pnp': workspace:0.3.25
       '@pnpm/lockfile-utils': workspace:2.0.22
       '@pnpm/lockfile-walker': workspace:3.0.9
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/manifest-utils': workspace:1.1.5
       '@pnpm/modules-cleaner': workspace:10.0.23
       '@pnpm/modules-yaml': workspace:8.0.6
@@ -2843,7 +2845,7 @@ importers:
       graph-sequencer: 2.0.0
       is-ci: ^3.0.0
       is-inner-link: ^4.0.0
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       is-windows: ^1.0.2
       load-json-file: ^6.2.0
       ncp: ^2.0.0
@@ -2921,7 +2923,7 @@ importers:
       '@pnpm/assert-store': link:../../privatePackages/assert-store
       '@pnpm/cafs': link:../cafs
       '@pnpm/client': link:../client
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/package-store': link:../package-store
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@pnpm/store-path': 5.0.0-1
@@ -2958,7 +2960,7 @@ importers:
   packages/symlink-dependency:
     specifiers:
       '@pnpm/core-loggers': workspace:5.0.3
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/symlink-dependency': 'link:'
       '@pnpm/types': workspace:6.4.0
       symlink-dir: ^4.2.0
@@ -2967,7 +2969,7 @@ importers:
       '@pnpm/types': link:../types
       symlink-dir: 4.2.0
     devDependencies:
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/symlink-dependency': 'link:'
 
   packages/tarball-fetcher:
@@ -2978,7 +2980,7 @@ importers:
       '@pnpm/fetch': workspace:2.1.11
       '@pnpm/fetcher-base': workspace:9.0.4
       '@pnpm/fetching-types': workspace:1.0.0
-      '@pnpm/logger': ^3.2.3
+      '@pnpm/logger': ^4.0.0-0
       '@pnpm/tarball-fetcher': 'link:'
       '@types/retry': ^0.12.0
       '@types/rimraf': ^3.0.0
@@ -2998,7 +3000,7 @@ importers:
     devDependencies:
       '@pnpm/cafs': link:../cafs
       '@pnpm/fetch': link:../fetch
-      '@pnpm/logger': 3.2.3
+      '@pnpm/logger': 4.0.0-0
       '@pnpm/tarball-fetcher': 'link:'
       '@types/retry': 0.12.0
       '@types/rimraf': 3.0.0
@@ -3028,7 +3030,7 @@ importers:
       '@pnpm/write-project-manifest': 'link:'
       '@types/json5': ^2.2.0
       '@types/write-file-atomic': ^3.0.1
-      json5: ^2.1.3
+      json5: ^2.2.0
       tempy: ^1.0.0
       write-file-atomic: ^3.0.3
       write-yaml-file: ^4.2.0
@@ -3147,14 +3149,16 @@ importers:
   utils/updater:
     specifiers:
       '@pnpm/lockfile-file': workspace:3.2.1
+      '@pnpm/logger': '3'
       '@pnpm/types': workspace:6.4.0
       '@types/normalize-path': ^3.0.0
-      is-subdir: ^1.1.1
+      is-subdir: ^1.2.0
       normalize-path: ^3.0.0
       path-exists: ^4.0.0
       write-json-file: ^4.3.0
     dependencies:
       '@pnpm/lockfile-file': link:../../packages/lockfile-file
+      '@pnpm/logger': 3.2.3
       '@pnpm/types': link:../../packages/types
       '@types/normalize-path': 3.0.0
       is-subdir: 1.2.0
@@ -4265,6 +4269,13 @@ packages:
   /@pnpm/logger/3.2.3:
     resolution: {integrity: sha512-/nZCAUeKwlv1MldtOHSPDm5SuXBy4L4SoS30gYn9ti2N5XlUrVoXDE8Hq8EYfl+Knb1GQEDz04KjfFEDVsAsvg==}
     engines: {node: '>=10'}
+    dependencies:
+      bole: /@zkochan/bole/3.0.4
+      ndjson: 1.5.0
+
+  /@pnpm/logger/4.0.0-0:
+    resolution: {integrity: sha512-QRzWNPqN8c9+7lGrCHFIm2fYuBfkttGdS634onOVUQKeWUBYpNCFnVZ62liTywMfB7ItZ4zMS8Lddx2+qquvxw==}
+    engines: {node: '>=12'}
     dependencies:
       bole: /@zkochan/bole/3.0.4
       ndjson: 1.5.0
@@ -8048,9 +8059,9 @@ packages:
       has: 1.0.3
       has-symbols: 1.0.2
 
-  /get-npm-tarball-url/2.0.2:
-    resolution: {integrity: sha512-2dPhgT0K4pVyciTqdS0gr9nEwyCQwt9ql1/t5MCUMvcjWjAysjGJgT7Sx4n6oq3tFBjBN238mxX4RfTjT3838Q==}
-    engines: {node: '>=4'}
+  /get-npm-tarball-url/3.0.0-0:
+    resolution: {integrity: sha512-H7at0fXmQPyPnDAXfIfSrUOeMiCrcOOEqLMjRmAW780nc3oppaDTy7bylZ+bBIn3n9GKCLVaE6H2L4kxOgiwLQ==}
+    engines: {node: '>=12.17'}
     dependencies:
       normalize-registry-url: 1.0.0
     dev: false
@@ -11112,12 +11123,12 @@ packages:
       mimic-fn: 3.1.0
     dev: false
 
-  /p-queue/6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
+  /p-queue/7.0.0:
+    resolution: {integrity: sha512-Nm7BFnoAFw2BA6EdIbblm/HjTyagQQqOijAaT2jnGDz/wjn2dwnOk6GEiVlQvHfCJwcXFr2evMpkghLNZsonAQ==}
+    engines: {node: '>=12'}
     dependencies:
       eventemitter3: 4.0.7
-      p-timeout: 3.2.0
+      p-timeout: 4.1.0
     dev: false
 
   /p-reflect/2.1.0:
@@ -11146,6 +11157,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-finally: 1.0.0
+
+  /p-timeout/4.1.0:
+    resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
+    engines: {node: '>=10'}
+    dev: false
 
   /p-try/1.0.0:
     resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=}

--- a/privatePackages/assert-project/jest.config.js
+++ b/privatePackages/assert-project/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/privatePackages/assert-project/package.json
+++ b/privatePackages/assert-project/package.json
@@ -37,7 +37,7 @@
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install -C test/fixture/project --force --no-shared-workspace-lockfile",
-    "test": "pnpm pretest && pnpm run compile && jest"
+    "test": "pnpm pretest && pnpm run compile && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@pnpm/assert-store": "workspace:*",
@@ -50,5 +50,6 @@
     "path-exists": "^4.0.0",
     "read-yaml-file": "^2.1.0",
     "write-pkg": "4.0.0"
-  }
+  },
+  "type": "module"
 }

--- a/privatePackages/assert-project/src/index.ts
+++ b/privatePackages/assert-project/src/index.ts
@@ -15,7 +15,7 @@ export type RawLockfile = Lockfile & Partial<ProjectSnapshot>
 
 export interface Project {
   // eslint-disable-next-line
-  requireModule: (moduleName: string) => any
+  requireModule: (moduleName: string) => Promise<any>
   dir: () => string
   has: (pkgName: string, modulesDir?: string) => Promise<void>
   hasNot: (pkgName: string, modulesDir?: string) => Promise<void>
@@ -84,9 +84,8 @@ export default (projectPath: string, encodedRegistryName?: string): Project => {
   const notOk = (value: any) => expect(value).toBeFalsy()
   return {
     dir: () => projectPath,
-    requireModule (pkgName: string) {
-      // eslint-disable-next-line
-      return require(path.join(modules, pkgName))
+    async requireModule (pkgName: string) {
+      return (await import(path.join(modules, pkgName))).default
     },
     async has (pkgName: string, _modulesDir?: string) {
       const md = _modulesDir ? path.join(projectPath, _modulesDir) : modules

--- a/privatePackages/assert-project/test/index.ts
+++ b/privatePackages/assert-project/test/index.ts
@@ -1,13 +1,16 @@
 /// <reference path="../../../typings/index.d.ts"/>
 import path from 'path'
 import assertProject from '../src'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('assertProject()', async () => {
   const project = assertProject(path.join(__dirname, '../../..'))
 
   await project.has('rimraf')
   await project.hasNot('sfdsff3g34')
-  expect(typeof project.requireModule('rimraf')).toBe('function')
+  expect(typeof (await project.requireModule('rimraf')).default).toBe('function')
   await project.isExecutable('.bin/rimraf')
 })
 

--- a/privatePackages/assert-store/jest.config.js
+++ b/privatePackages/assert-store/jest.config.js
@@ -1,1 +1,3 @@
-module.exports = require('../../jest.config')
+import config from '../../jest.config.js'
+
+export default config

--- a/privatePackages/assert-store/package.json
+++ b/privatePackages/assert-store/package.json
@@ -38,10 +38,11 @@
     "lint": "tslint -c ../../tslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install -C test/fixture/project --force --no-shared-workspace-lockfile",
-    "test": "pnpm pretest && pnpm run compile && jest"
+    "test": "pnpm pretest && pnpm run compile && NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:2.1.0",
     "path-exists": "^4.0.0"
-  }
+  },
+  "type": "module"
 }

--- a/privatePackages/assert-store/test/index.ts
+++ b/privatePackages/assert-store/test/index.ts
@@ -1,6 +1,9 @@
 /// <reference path="../../../typings/index.d.ts"/>
 import path from 'path'
 import assertStore from '@pnpm/assert-store'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 test('assertStore() store assertions', async () => {
   const storePath = path.join(__dirname, 'fixture/store/v3/')

--- a/privatePackages/prepare/package.json
+++ b/privatePackages/prepare/package.json
@@ -22,5 +22,6 @@
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build"
-  }
+  },
+  "type": "module"
 }

--- a/privatePackages/prepare/src/index.ts
+++ b/privatePackages/prepare/src/index.ts
@@ -6,6 +6,9 @@ import uniqueString from 'unique-string'
 import { sync as writeJson5File } from 'write-json5-file'
 import { sync as writeYamlFile } from 'write-yaml-file'
 import writePkg from 'write-pkg'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export { Modules, Project }
 export type ManifestFormat = 'JSON' | 'JSON5' | 'YAML'

--- a/privatePackages/test-fixtures/package.json
+++ b/privatePackages/test-fixtures/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "type": "module",
   "files": [
     "lib/"
   ],
@@ -32,7 +33,7 @@
   "scripts": {
     "lint": "tslint -c ../../tslint.json --project .",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
-    "test": "pnpm run tsc"
+    "test": "pnpm run compile"
   },
   "dependencies": {
     "ncp": "^2.0.0"

--- a/privatePackages/test-fixtures/src/index.ts
+++ b/privatePackages/test-fixtures/src/index.ts
@@ -2,6 +2,9 @@ import { promisify } from 'util'
 import fs from 'fs'
 import path from 'path'
 import ncpCB from 'ncp'
+import { fileURLToPath } from 'url'
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
 
 const ncp = promisify(ncpCB)
 
@@ -12,7 +15,7 @@ export async function copyFixture (fixtureName: string, dest: string) {
 }
 
 export function pathToLocalPkg (pkgName: string) {
-  let dir = __dirname
+  let dir = DIRNAME
   const { root } = path.parse(dir)
   while (true) {
     const checkDir = path.join(dir, 'fixtures', pkgName)

--- a/renovate.json
+++ b/renovate.json
@@ -96,10 +96,6 @@
     {
       "packageNames": ["nock"],
       "allowedVersions": "12.0.3"
-    },
-    {
-      "packageNames": ["p-queue"],
-      "allowedVersions": "^6.6.2"
     }
   ],
   "pinVersions": false,

--- a/utils/tsconfig/tsconfig.json
+++ b/utils/tsconfig/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "declaration": true,
     "esModuleInterop": true,
-    "module": "commonjs",
+    "module": "ES2020",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/utils/updater/package.json
+++ b/utils/updater/package.json
@@ -7,9 +7,10 @@
   },
   "dependencies": {
     "@pnpm/lockfile-file": "workspace:3.2.1",
+    "@pnpm/logger": "3",
     "@pnpm/types": "workspace:6.4.0",
     "@types/normalize-path": "^3.0.0",
-    "is-subdir": "^1.1.1",
+    "is-subdir": "^1.2.0",
     "normalize-path": "^3.0.0",
     "path-exists": "^4.0.0",
     "write-json-file": "^4.3.0"

--- a/utils/updater/tsconfig.json
+++ b/utils/updater/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@pnpm/tsconfig",
   "compilerOptions": {
+    "module": "CommonJS",
     "outDir": "lib",
     "rootDir": "src"
   },
@@ -8,12 +9,5 @@
     "src/**/*.ts",
     "../../typings/**/*.d.ts"
   ],
-  "references": [
-    {
-      "path": "../../packages/lockfile-file"
-    },
-    {
-      "path": "../../packages/types"
-    }
-  ]
+  "references": []
 }


### PR DESCRIPTION
April 3 update:

There are too many issues with Jest.
I am postponing this. The v6 CLI will not need a breaking change when this will be merged (because it is bundled to a single cjs file). Other packages in the workspace will have to be major bumped.