### PR TITLE
[fix] import of ESM pnpmFile

### DIFF
--- a/packages/pnpmfile/requireOrImport.js
+++ b/packages/pnpmfile/requireOrImport.js
@@ -1,6 +1,6 @@
 import libUrl from 'url';
 
-async function esmFileLoader(filePath) => {
+async function esmFileLoader(filePath) {
   try {
     const result = await import(libUrl.pathToFileURL(filePath));
     return result.default ? result.default : result;

--- a/packages/pnpmfile/requireOrImport.js
+++ b/packages/pnpmfile/requireOrImport.js
@@ -1,7 +1,25 @@
-module.exports = async function requireOrImportPnpmfile (pnpmfilePath) {
+import libUrl from 'url';
+
+async function esmFileLoader(filePath) => {
   try {
-    return require(pnpmfilePath)
-  } catch (err) {
-    return (await import(pnpmfilePath)).default
+    const result = await import(libUrl.pathToFileURL(filePath));
+    return result.default ? result.default : result;
   }
+  catch (err) {
+    console.error(`Failed to load ESM configuration file ${filePath}`);
+    throw err;
+  }
+};
+
+async function requireOrImportPnpmfile (pnpmfilePath) {
+  try {
+    return require(pnpmfilePath);
+  } catch (err) {
+    if (err.code === 'ERR_REQUIRE_ESM') {
+      return esmFileLoader(pnpmfilePath);
+    }
+    throw err;
+   }
 }
+
+export default requireOrImportPnpmfile;

--- a/packages/pnpmfile/requireOrImport.js
+++ b/packages/pnpmfile/requireOrImport.js
@@ -1,4 +1,4 @@
-import libUrl from 'url';
+import libUrl = require('url');
 
 async function esmFileLoader(filePath) {
   try {
@@ -16,10 +16,10 @@ async function requireOrImportPnpmfile (pnpmfilePath) {
     return require(pnpmfilePath);
   } catch (err) {
     if (err.code === 'ERR_REQUIRE_ESM') {
-      return esmFileLoader(pnpmfilePath);
+      return await esmFileLoader(pnpmfilePath);
     }
     throw err;
    }
 }
 
-export default requireOrImportPnpmfile;
+module.exports = requireOrImportPnpmfile;

--- a/packages/pnpmfile/src/requirePnpmfile.ts
+++ b/packages/pnpmfile/src/requirePnpmfile.ts
@@ -1,9 +1,9 @@
 import PnpmError from '@pnpm/error'
 import logger from '@pnpm/logger'
 import { PackageManifest } from '@pnpm/types'
-import fs from 'fs'
-import chalk from 'chalk'
 import requireOrImport from '../requireOrImport.js'
+import fs = require('fs')
+import chalk = require('chalk')
 
 export class BadReadPackageHookError extends PnpmError {
   public readonly pnpmfile: string


### PR DESCRIPTION
+ We ESM export `requireOrImportPnpmfile` instead of CJS module.export.
+ Import gets a URL as argument.
+ Works with both default and named export.
+ ESM File Loader is only invoked when error is ERR_REQUIRE_ESM.