### PR TITLE
feat: pnpm publish -r --force

### DIFF
--- a/.changeset/good-terms-grow.md
+++ b/.changeset/good-terms-grow.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": minor
+---
+
+`pnpm publish -r --force` publishes packages even if their current version is already in the registry.

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -44,6 +44,7 @@
     "@types/sinon": "^9.0.9",
     "cross-spawn": "^7.0.3",
     "execa": "^5.0.0",
+    "load-json-file": "^6.2.0",
     "path-exists": "^4.0.0",
     "tempy": "^1.0.0",
     "write-yaml-file": "^4.1.3"

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -36,6 +36,7 @@ export function cliOptionsTypes () {
   return {
     ...rcOptionsTypes(),
     'dry-run': Boolean,
+    force: Boolean,
     json: Boolean,
     recursive: Boolean,
   }
@@ -74,6 +75,10 @@ export function help () {
           {
             description: 'Ignores any publish related lifecycle scripts (prepublishOnly, postpublish, and the like)',
             name: '--ignore-scripts',
+          },
+          {
+            description: 'Packages are proceeded to be published even if their current version is already in the registry. This is useful when a "prepublishOnly" script bumps the version of the package before it is published',
+            name: '--force',
           },
         ],
       },

--- a/packages/plugin-commands-publishing/src/recursivePublish.ts
+++ b/packages/plugin-commands-publishing/src/recursivePublish.ts
@@ -20,6 +20,7 @@ Partial<Pick<Config,
 | 'tag'
 | 'ca'
 | 'cert'
+| 'force'
 | 'dryRun'
 | 'extraBinPaths'
 | 'fetchRetries'
@@ -57,6 +58,7 @@ export default async function (
   })) as unknown as ResolveFunction
   const pkgsToPublish = await pFilter(pkgs, async (pkg) => {
     if (!pkg.manifest.name || !pkg.manifest.version || pkg.manifest.private) return false
+    if (opts.force) return true
     return !(await isAlreadyPublished({
       dir: pkg.dir,
       lockfileDir: opts.lockfileDir ?? pkg.dir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1942,6 +1942,7 @@ importers:
       '@types/sinon': 9.0.10
       cross-spawn: 7.0.3
       execa: 5.0.0
+      load-json-file: 6.2.0
       path-exists: 4.0.0
       tempy: 1.0.0
       write-yaml-file: 4.2.0
@@ -1973,6 +1974,7 @@ importers:
       enquirer: ^2.3.6
       execa: ^5.0.0
       fast-glob: ^3.2.4
+      load-json-file: ^6.2.0
       mz: ^2.7.0
       p-filter: ^2.1.0
       path-exists: ^4.0.0


### PR DESCRIPTION
`pnpm publish -r --force` publishes packages even if their current
version is already in the registry.

close #3154