### PR TITLE
fix: use of socks proxy

### DIFF
--- a/.changeset/cool-insects-retire.md
+++ b/.changeset/cool-insects-retire.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-registry-agent": patch
+---
+
+Creating a proper URL for socks proxy.

--- a/packages/npm-registry-agent/src/index.ts
+++ b/packages/npm-registry-agent/src/index.ts
@@ -125,8 +125,8 @@ function getProxyUri (
     return null
   }
 
-  if (!proxy.startsWith('http') && !proxy.startsWith('socks')) {
-    proxy = protocol + '//' + proxy
+  if (!proxy.includes('://')) {
+    proxy = `${protocol}//${proxy}`
   }
 
   const parsedProxy = (typeof proxy === 'string') ? new URL(proxy) : proxy

--- a/packages/npm-registry-agent/src/index.ts
+++ b/packages/npm-registry-agent/src/index.ts
@@ -125,7 +125,7 @@ function getProxyUri (
     return null
   }
 
-  if (!proxy.startsWith('http')) {
+  if (!proxy.startsWith('http') && !proxy.startsWith('socks')) {
     proxy = protocol + '//' + proxy
   }
 


### PR DESCRIPTION
When the registry uses the https protocol and the proxy uses socks,
its URL is changed from "socks://" to "https://socks://" in
getProxyUri(), which will not work. Fix it to work with a socks proxy.

close #3241