### PR TITLE
fix(headless): forward extraBinPaths to runLifecycleHookConcurrently

### DIFF
--- a/.changeset/nasty-lizards-dance.md
+++ b/.changeset/nasty-lizards-dance.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/headless": patch
+---
+
+fix bug that extraBinPaths does not take effect

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -156,6 +156,7 @@ export default async (opts: HeadlessOptions) => {
 
   const scriptsOpts = {
     optional: false,
+    extraBinPaths: opts.extraBinPaths,
     rawConfig: opts.rawConfig,
     scriptShell: opts.scriptShell,
     shellEmulator: opts.shellEmulator,


### PR DESCRIPTION
This make value of PATH environment alwasy contains node_modules/.bin of
workspace root, despite whether lockfile is up to date or not.

Fixes #2086