### PR TITLE
fix(build-modules): fix incorrect return in getSubgraphToBuild

### DIFF
--- a/.changeset/soft-dancers-happen.md
+++ b/.changeset/soft-dancers-happen.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/build-modules": patch
+---
+
+Fix incorrect return in getSubgraphToBuild

--- a/packages/build-modules/src/index.ts
+++ b/packages/build-modules/src/index.ts
@@ -145,13 +145,13 @@ function getSubgraphToBuild (
 ) {
   let currentShouldBeBuilt = false
   for (const depPath of entryNodes) {
-    if (!graph[depPath]) return // packages that are already in node_modules are skipped
+    if (!graph[depPath]) continue // packages that are already in node_modules are skipped
     if (nodesToBuild.has(depPath)) {
       currentShouldBeBuilt = true
     }
     if (walked.has(depPath)) continue
     walked.add(depPath)
-    const childShouldBeBuilt = getSubgraphToBuild(graph, R.values(graph[depPath].children), nodesToBuild, walked) === true ||
+    const childShouldBeBuilt = getSubgraphToBuild(graph, R.values(graph[depPath].children), nodesToBuild, walked) ||
       graph[depPath].requiresBuild
     if (childShouldBeBuilt) {
       nodesToBuild.add(depPath)


### PR DESCRIPTION
This PR fixes a bug I discovered recently that causes some dependencies to be skipped to build.
Minimal reproducible:
```json
{
    "name":"example",
    "dependencies": {
        "@mikro-orm/core":"^4.5.2",
        "@mikro-orm/knex":"^4.5.2"
    },  
    "devDependencies": {
        "@mikro-orm/sqlite":"^4.5.2"
    }   
}
```

Where `@mikro-orm/sqlite` depends on `sqlite3` which has an install script and `pnpm install` will build it normally as expected. However `sqlite3` will be skipped to build by the following steps:

```bash
pnpm install --prod
```

And then

```bash
pnpm install # sqlite3 will not be built in this step
```