### PR TITLE
fix(pkgs-graph): include workspace version aliases (#3400)

### DIFF
--- a/.changeset/two-socks-bathe.md
+++ b/.changeset/two-socks-bathe.md
@@ -1,0 +1,5 @@
+---
+"pkgs-graph": patch
+---
+
+Include dependencies with workspace version aliases in graph

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -62,6 +62,9 @@ export default function <T> (pkgs: Array<Package & T>, opts?: {
         try {
           if (isWorkspaceSpec) {
             rawSpec = rawSpec.substr(10)
+            if (rawSpec === '^' || rawSpec === '~') {
+              rawSpec = '*'
+            };
           }
           spec = npa.resolve(depName, rawSpec, pkg.dir)
         } catch (err) {

--- a/packages/pkgs-graph/test/index.ts
+++ b/packages/pkgs-graph/test/index.ts
@@ -7,6 +7,8 @@ const FOO1_PATH = pathResolve('/zkochan/src/foo')
 const BAR2_PATH = pathResolve('/zkochan/src/bar@2')
 const FOO2_PATH = pathResolve('/zkochan/src/foo@2')
 const BAR3_PATH = pathResolve('/zkochan/src/bar@3')
+const BAR4_PATH = pathResolve('/zkochan/src/bar@4')
+const BAR5_PATH = pathResolve('/zkochan/src/bar@5')
 
 test('create package graph', () => {
   const result = createPkgGraph([
@@ -257,6 +259,28 @@ test('create package graph ignoring the workspace protocol', () => {
         version: '2.0.0',
       },
     },
+    {
+      dir: BAR3_PATH,
+      manifest: {
+        name: 'bar',
+        version: '3.0.0',
+
+        dependencies: {
+          foo: 'workspace:^',
+        },
+      },
+    },
+    {
+      dir: BAR4_PATH,
+      manifest: {
+        name: 'bar',
+        version: '4.0.0',
+
+        dependencies: {
+          foo: 'workspace:~',
+        },
+      },
+    },
   ])
   expect(result.unmatched).toStrictEqual([{ pkgName: 'bar', range: '^10.0.0' }])
   expect(result.graph).toStrictEqual({
@@ -313,6 +337,34 @@ test('create package graph ignoring the workspace protocol', () => {
         },
       },
     },
+    [BAR3_PATH]: {
+      dependencies: [FOO2_PATH],
+      package: {
+        dir: BAR3_PATH,
+        manifest: {
+          name: 'bar',
+          version: '3.0.0',
+
+          dependencies: {
+            foo: 'workspace:^',
+          },
+        },
+      },
+    },
+    [BAR4_PATH]: {
+      dependencies: [FOO2_PATH],
+      package: {
+        dir: BAR4_PATH,
+        manifest: {
+          name: 'bar',
+          version: '4.0.0',
+
+          dependencies: {
+            foo: 'workspace:~',
+          },
+        },
+      },
+    },
   })
 })
 
@@ -356,6 +408,26 @@ test('create package graph respects linked-workspace-packages = false', () => {
         },
         name: 'bar',
         version: '3.0.0',
+      },
+    },
+    {
+      dir: BAR4_PATH,
+      manifest: {
+        dependencies: {
+          foo: 'workspace:^',
+        },
+        name: 'bar',
+        version: '4.0.0',
+      },
+    },
+    {
+      dir: BAR5_PATH,
+      manifest: {
+        dependencies: {
+          foo: 'workspace:~',
+        },
+        name: 'bar',
+        version: '5.0.0',
       },
     },
   ], { linkWorkspacePackages: false })
@@ -412,6 +484,32 @@ test('create package graph respects linked-workspace-packages = false', () => {
           },
           name: 'bar',
           version: '3.0.0',
+        },
+      },
+    },
+    [BAR4_PATH]: {
+      dependencies: [FOO1_PATH],
+      package: {
+        dir: BAR4_PATH,
+        manifest: {
+          dependencies: {
+            foo: 'workspace:^',
+          },
+          name: 'bar',
+          version: '4.0.0',
+        },
+      },
+    },
+    [BAR5_PATH]: {
+      dependencies: [FOO1_PATH],
+      package: {
+        dir: BAR5_PATH,
+        manifest: {
+          dependencies: {
+            foo: 'workspace:~',
+          },
+          name: 'bar',
+          version: '5.0.0',
         },
       },
     },


### PR DESCRIPTION
Fixes the graph to include dependencies with `workspace:^` and `workspace:~` specifications.