### PR TITLE
fix: setting child concurrency during headless install

### DIFF
--- a/.changeset/fluffy-goats-double.md
+++ b/.changeset/fluffy-goats-double.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Pass `childConcurrency` to headless. Setting childConcurrency should an effect during frozen lockfile installation.

--- a/.changeset/fluffy-goats-double.md
+++ b/.changeset/fluffy-goats-double.md
@@ -2,4 +2,4 @@
 "supi": patch
 ---
 
-Pass `childConcurrency` to headless. Setting childConcurrency should an effect during frozen lockfile installation.
+Pass `childConcurrency` option to `@pnpm/headless`. Setting `childConcurrency` should have an effect during frozen lockfile installation.

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -226,6 +226,7 @@ export async function mutateModules (
         }
         try {
           await headless({
+            childConcurrency: opts.childConcurrency,
             currentEngine: {
               nodeVersion: opts.nodeVersion,
               pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',


### PR DESCRIPTION
close #3399