### PR TITLE
fix(npm-resolver): unhandled rejection in fetch

### DIFF
--- a/.changeset/little-dragons-wave.md
+++ b/.changeset/little-dragons-wave.md
@@ -1,5 +1,4 @@
 ---
-"@pnpm/error": patch
 "@pnpm/npm-resolver": patch
 ---
 

--- a/.changeset/little-dragons-wave.md
+++ b/.changeset/little-dragons-wave.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/error": patch
+"@pnpm/npm-resolver": patch
+---
+
+Fix: unhandled rejection in npm resolver when fetch fails

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -18,7 +18,7 @@ export default class PnpmError extends Error {
   }
 }
 
-export interface FetchErrorResponse { status: number | string, statusText: string }
+export interface FetchErrorResponse { status: number, statusText: string }
 
 export interface FetchErrorRequest { url: string, authHeaderValue?: string }
 

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -18,7 +18,7 @@ export default class PnpmError extends Error {
   }
 }
 
-export interface FetchErrorResponse { status: number, statusText: string }
+export interface FetchErrorResponse { status: number | string, statusText: string }
 
 export interface FetchErrorRequest { url: string, authHeaderValue?: string }
 

--- a/packages/npm-resolver/src/fetch.ts
+++ b/packages/npm-resolver/src/fetch.ts
@@ -50,11 +50,21 @@ export default async function fromRegistry (
   const op = retry.operation(fetchOpts.retry)
   return new Promise((resolve, reject) =>
     op.attempt(async (attempt) => {
-      const response = await fetch(uri, {
-        authHeaderValue,
-        retry: fetchOpts.retry,
-        timeout: fetchOpts.timeout,
-      }) as RegistryResponse
+      let response: RegistryResponse
+      try {
+        response = await fetch(uri, {
+          authHeaderValue,
+          retry: fetchOpts.retry,
+          timeout: fetchOpts.timeout,
+        }) as RegistryResponse
+      } catch (error) {
+        console.log(error)
+        reject(new FetchError({
+          url: uri,
+          authHeaderValue: authHeaderValue,
+        }, { status: error.code, statusText: error.message }))
+        return
+      }
       if (response.status > 400) {
         const request = {
           authHeaderValue,

--- a/packages/npm-resolver/src/fetch.ts
+++ b/packages/npm-resolver/src/fetch.ts
@@ -58,11 +58,7 @@ export default async function fromRegistry (
           timeout: fetchOpts.timeout,
         }) as RegistryResponse
       } catch (error) {
-        console.log(error)
-        reject(new FetchError({
-          url: uri,
-          authHeaderValue: authHeaderValue,
-        }, { status: error.code, statusText: error.message }))
+        reject(new PnpmError('META_FETCH_FAIL', `GET ${uri}: ${error.message as string}`, { attempts: attempt }))
         return
       }
       if (response.status > 400) {

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -673,7 +673,7 @@ test('error is thrown when registry not responding', async () => {
     retry: { retries: 1 },
   })
   await expect(resolveFromNpm({ alias: notExistingPackage, pref: '1.0.0' }, { registry: notExistingRegistry })).rejects
-    .toThrow(new PnpmError('META_FETCH_FAIL', `GET ${notExistingRegistry}/${notExistingPackage}: request to ${notExistingRegistry}/${notExistingPackage} failed, reason: connect ECONNREFUSED 127.0.0.1:4873 - ECONNREFUSED`, { attempts: 1 }))
+    .toThrow(new PnpmError('META_FETCH_FAIL', `GET ${notExistingRegistry}/${notExistingPackage}: request to ${notExistingRegistry}/${notExistingPackage} failed, reason: connect ECONNREFUSED 127.0.0.1:4873`, { attempts: 1 }))
 })
 
 test('extra info is shown if package has valid semver appended', async () => {

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../typings/index.d.ts"/>
 import path from 'path'
-import PnpmError, { FetchError } from '@pnpm/error'
+import PnpmError from '@pnpm/error'
 import { createFetchFromRegistry } from '@pnpm/fetch'
 import _createResolveFromNpm, {
   RegistryResponseError,
@@ -666,24 +666,14 @@ test('error is thrown when package is not found in the registry', async () => {
 
 test('error is thrown when registry not responding', async () => {
   const notExistingPackage = 'foo'
-  const notExistingRegistry = 'http://localhost:4873/'
+  const notExistingRegistry = 'http://localhost:4873'
 
   const resolveFromNpm = createResolveFromNpm({
     storeDir: tempy.directory(),
     retry: { retries: 1 },
   })
   await expect(resolveFromNpm({ alias: notExistingPackage, pref: '1.0.0' }, { registry: notExistingRegistry })).rejects
-    .toThrow(
-      new FetchError(
-        {
-          url: `${notExistingRegistry}${notExistingPackage}`,
-        },
-        {
-          status: 'ECONNREFUSED',
-          statusText: 'request to http://localhost:4873/foo failed, reason: connect ECONNREFUSED 127.0.0.1:4873',
-        }
-      )
-    )
+    .toThrow(new PnpmError('META_FETCH_FAIL', `GET ${notExistingRegistry}/${notExistingPackage}: request to ${notExistingRegistry}/${notExistingPackage} failed, reason: connect ECONNREFUSED 127.0.0.1:4873 - ECONNREFUSED`, { attempts: 1 }))
 })
 
 test('extra info is shown if package has valid semver appended', async () => {


### PR DESCRIPTION
When fetch command fails for any reason catch it and return FetchError to avoid Unhandled rejection

ref #3261 