### PR TITLE
fix: prefer headless install when lockfile is up-to-date

### DIFF
--- a/.changeset/smooth-bags-shave.md
+++ b/.changeset/smooth-bags-shave.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Prefer headless install, when the lockfile is up-to-date and some packages are linked using relative path via `workspace:<path>`.

--- a/packages/supi/src/install/allProjectsAreUpToDate.ts
+++ b/packages/supi/src/install/allProjectsAreUpToDate.ts
@@ -83,7 +83,8 @@ async function linkedPackagesAreUpToDate (
         isLinked &&
         (
           currentSpec.startsWith('link:') ||
-          currentSpec.startsWith('file:')
+          currentSpec.startsWith('file:') ||
+          currentSpec.startsWith('workspace:.')
         )
       ) {
         continue

--- a/packages/supi/test/allProjectsAreUpToDate.test.ts
+++ b/packages/supi/test/allProjectsAreUpToDate.test.ts
@@ -13,6 +13,44 @@ const workspacePackages = {
   },
 }
 
+test('allProjectsAreUpToDate(): works with packages linked through the workspace protocol using relative path', async () => {
+  expect(await allProjectsAreUpToDate([
+    {
+      id: 'bar',
+      manifest: {
+        dependencies: {
+          foo: 'workspace:../foo',
+        },
+      },
+      rootDir: 'bar',
+    },
+    {
+      id: 'foo',
+      manifest: fooManifest,
+      rootDir: 'foo',
+    },
+  ], {
+    linkWorkspacePackages: true,
+    wantedLockfile: {
+      importers: {
+        bar: {
+          dependencies: {
+            foo: 'link:../foo',
+          },
+          specifiers: {
+            foo: 'workspace:../foo',
+          },
+        },
+        foo: {
+          specifiers: {},
+        },
+      },
+      lockfileVersion: 5,
+    },
+    workspacePackages,
+  })).toBeTruthy()
+})
+
 test('allProjectsAreUpToDate(): works with aliased local dependencies', async () => {
   expect(await allProjectsAreUpToDate([
     {


### PR DESCRIPTION
Prefer headless install, when the lockfile is up-to-date
and some packages are linked using relative path via `workspace:<path>`.