### PR TITLE
feat(list): add workspace to list command when setting output to json

### DIFF
--- a/.changeset/strange-camels-kiss.md
+++ b/.changeset/strange-camels-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/list": patch
+"@pnpm/list": minor
 ---
 
 Feat - add path as part of list command json output

--- a/.changeset/strange-camels-kiss.md
+++ b/.changeset/strange-camels-kiss.md
@@ -2,4 +2,4 @@
 "@pnpm/list": patch
 ---
 
-Feat - add workspace as part of list command json output
+Feat - add path as part of list command json output

--- a/.changeset/strange-camels-kiss.md
+++ b/.changeset/strange-camels-kiss.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/list": patch
+---
+
+Feat - add workspace as part of list command json output

--- a/packages/list/src/renderJson.ts
+++ b/packages/list/src/renderJson.ts
@@ -17,8 +17,8 @@ export default async function (
   const jsonArr = await Promise.all(pkgs.map(async (pkg) => {
     const jsonObj = {
       name: pkg.name,
-
       version: pkg.version,
+      workspace: pkg.path,
     }
     for (const dependenciesField of [...DEPENDENCIES_FIELDS.sort(), 'unsavedDependencies']) {
       if (pkg[dependenciesField]?.length) {

--- a/packages/list/src/renderJson.ts
+++ b/packages/list/src/renderJson.ts
@@ -18,7 +18,7 @@ export default async function (
     const jsonObj = {
       name: pkg.name,
       version: pkg.version,
-      workspace: pkg.path,
+      path: pkg.path,
     }
     for (const dependenciesField of [...DEPENDENCIES_FIELDS.sort(), 'unsavedDependencies']) {
       if (pkg[dependenciesField]?.length) {

--- a/packages/list/test/index.ts
+++ b/packages/list/test/index.ts
@@ -245,7 +245,7 @@ test('JSON list with depth 1', async () => {
   expect(await list([fixture], { reportAs: 'json', depth: 1, lockfileDir: fixture })).toBe(JSON.stringify([{
     name: 'fixture',
     version: '1.0.0',
-
+    workspace: fixture,
     dependencies: {
       'write-json-file': {
         from: 'write-json-file',
@@ -320,12 +320,11 @@ test('JSON list with aliased dep', async () => {
       {
         name: 'with-aliased-dep',
         version: '1.0.0',
-
+        workspace: fixtureWithAliasedDep,
         dependencies: {
           positive: {
             from: 'is-positive',
             version: '1.0.0',
-
             resolved: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
           },
         },
@@ -338,7 +337,7 @@ test('JSON list with aliased dep', async () => {
     JSON.stringify([{
       name: 'with-aliased-dep',
       version: '1.0.0',
-
+      workspace: fixtureWithAliasedDep,
       dependencies: {
         positive: {
           from: 'is-positive',

--- a/packages/list/test/index.ts
+++ b/packages/list/test/index.ts
@@ -245,7 +245,7 @@ test('JSON list with depth 1', async () => {
   expect(await list([fixture], { reportAs: 'json', depth: 1, lockfileDir: fixture })).toBe(JSON.stringify([{
     name: 'fixture',
     version: '1.0.0',
-    workspace: fixture,
+    path: fixture,
     dependencies: {
       'write-json-file': {
         from: 'write-json-file',
@@ -320,7 +320,7 @@ test('JSON list with aliased dep', async () => {
       {
         name: 'with-aliased-dep',
         version: '1.0.0',
-        workspace: fixtureWithAliasedDep,
+        path: fixtureWithAliasedDep,
         dependencies: {
           positive: {
             from: 'is-positive',
@@ -337,7 +337,7 @@ test('JSON list with aliased dep', async () => {
     JSON.stringify([{
       name: 'with-aliased-dep',
       version: '1.0.0',
-      workspace: fixtureWithAliasedDep,
+      path: fixtureWithAliasedDep,
       dependencies: {
         positive: {
           from: 'is-positive',


### PR DESCRIPTION
when running pnpm list  with --json flag for each workspace print the path in the json output

closes #3418