### PR TITLE
feat(publish): --report-summary

### DIFF
--- a/.changeset/chatty-dolphins-destroy.md
+++ b/.changeset/chatty-dolphins-destroy.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": minor
+---
+
+New option: reportSummary. When it is set to `true`, recursive publish will save the summary of published packages to `pnpm-publish-summary.json`.

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -39,6 +39,7 @@ export function cliOptionsTypes () {
     force: Boolean,
     json: Boolean,
     recursive: Boolean,
+    'report-summary': Boolean,
   }
 }
 
@@ -79,6 +80,10 @@ export function help () {
           {
             description: 'Packages are proceeded to be published even if their current version is already in the registry. This is useful when a "prepublishOnly" script bumps the version of the package before it is published',
             name: '--force',
+          },
+          {
+            description: 'Save the list of the newly published packages to "pnpm-publish-summary.json". Usefull when some other tooling is used to report the list of published packages.',
+            name: '--report-summary',
           },
         ],
       },
@@ -195,6 +200,7 @@ Do you want to continue?`,
       'postpublish',
     ], manifest)
   }
+  return { manifest }
 }
 
 async function runScriptsIfPresent (

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -82,7 +82,7 @@ export function help () {
             name: '--force',
           },
           {
-            description: 'Save the list of the newly published packages to "pnpm-publish-summary.json". Usefull when some other tooling is used to report the list of published packages.',
+            description: 'Save the list of the newly published packages to "pnpm-publish-summary.json". Useful when some other tooling is used to report the list of published packages.',
             name: '--report-summary',
           },
         ],

--- a/packages/plugin-commands-publishing/test/__snapshots__/recursivePublish.ts.snap
+++ b/packages/plugin-commands-publishing/test/__snapshots__/recursivePublish.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`recursive publish writes publish summary 1`] = `
+Object {
+  "publishedPackages": Array [
+    Object {
+      "name": "@pnpmtest/test-recursive-publish-project-4",
+      "version": "1.0.0",
+    },
+    Object {
+      "name": "@pnpmtest/test-recursive-publish-project-3",
+      "version": "1.0.0",
+    },
+  ],
+}
+`;

--- a/packages/plugin-commands-publishing/test/recursivePublish.ts
+++ b/packages/plugin-commands-publishing/test/recursivePublish.ts
@@ -260,7 +260,24 @@ test('recursive publish writes publish summary', async () => {
     reportSummary: true,
   }, [])
 
-  const publishSummary = await loadJsonFile('pnpm-publish-summary.json')
+  {
+    const publishSummary = await loadJsonFile('pnpm-publish-summary.json')
+    expect(publishSummary).toMatchSnapshot()
+    await fs.unlink('pnpm-publish-summary.json')
+  }
 
-  expect(publishSummary).toMatchSnapshot()
+  await publish.handler({
+    ...DEFAULT_OPTS,
+    ...await readProjects(process.cwd(), []),
+    dir: process.cwd(),
+    recursive: true,
+    reportSummary: true,
+  }, [])
+
+  {
+    const publishSummary = await loadJsonFile('pnpm-publish-summary.json')
+    expect(publishSummary).toStrictEqual({
+      publishedPackages: [],
+    })
+  }
 })

--- a/packages/plugin-commands-publishing/test/recursivePublish.ts
+++ b/packages/plugin-commands-publishing/test/recursivePublish.ts
@@ -200,3 +200,67 @@ test('packages are released even if their current version is published, when for
   const manifest = await loadJsonFile<ProjectManifest>('is-positive/package.json')
   expect(manifest.version).toBe('4.0.0')
 })
+
+test('recursive publish writes publish summary', async () => {
+  preparePackages([
+    {
+      name: '@pnpmtest/test-recursive-publish-project-3',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    },
+    {
+      name: '@pnpmtest/test-recursive-publish-project-4',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    // This will not be published because is-positive@1.0.0 is in the registry
+    {
+      name: 'is-positive',
+      version: '1.0.0',
+
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+    // This will not be published because it is a private package
+    {
+      name: 'i-am-private',
+      version: '1.0.0',
+
+      private: true,
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+    // Package with no name is skipped
+    {
+      location: 'no-name',
+      package: {
+        scripts: {
+          prepublishOnly: 'exit 1',
+        },
+      },
+    },
+  ])
+
+  await fs.writeFile('.npmrc', CREDENTIALS, 'utf8')
+
+  process.env.npm_config_userconfig = path.join('.npmrc')
+  await publish.handler({
+    ...DEFAULT_OPTS,
+    ...await readProjects(process.cwd(), []),
+    dir: process.cwd(),
+    recursive: true,
+    reportSummary: true,
+  }, [])
+
+  const publishSummary = await loadJsonFile('pnpm-publish-summary.json')
+
+  expect(publishSummary).toMatchSnapshot()
+})


### PR DESCRIPTION
`pnpm publish -r --report-summary` will save the summary of published packages to `pnpm-publish-summary.json`. Useful when some other tooling is used to report the list of published packages.