### PR TITLE
feat(find-workspace-dir): add env var support for setting the workspace dir

### DIFF
--- a/.changeset/six-files-drive.md
+++ b/.changeset/six-files-drive.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/find-workspace-dir": patch
+---
+
+Add support for NPM_CONFIG_WORKSPACE_DIR override environment variable when finding the workspace directory

--- a/packages/find-workspace-dir/jest.config.js
+++ b/packages/find-workspace-dir/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/packages/find-workspace-dir/package.json
+++ b/packages/find-workspace-dir/package.json
@@ -12,8 +12,9 @@
     "node": ">=12.17"
   },
   "scripts": {
-    "lint": "eslint -c ../../eslint.json src/**/*.ts",
-    "test": "pnpm run compile",
+    "lint": "eslint -c ../../eslint.json src/**/*.ts test/**/*.ts",
+    "_test": "jest",
+    "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
   },

--- a/packages/find-workspace-dir/src/index.ts
+++ b/packages/find-workspace-dir/src/index.ts
@@ -2,10 +2,16 @@ import path from 'path'
 import PnpmError from '@pnpm/error'
 import findUp from 'find-up'
 
+const WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR'
 const WORKSPACE_MANIFEST_FILENAME = 'pnpm-workspace.yaml'
 
 export default async function findWorkspaceDir (cwd: string) {
-  const workspaceManifestLocation = await findUp([WORKSPACE_MANIFEST_FILENAME, 'pnpm-workspace.yml'], { cwd })
+  const workspaceManifestDirEnvVar = process.env[WORKSPACE_DIR_ENV_VAR] ??
+    process.env[WORKSPACE_DIR_ENV_VAR.toUpperCase()] ??
+    process.env[WORKSPACE_DIR_ENV_VAR.toLowerCase()]
+  const workspaceManifestLocation = workspaceManifestDirEnvVar
+    ? path.join(workspaceManifestDirEnvVar, 'pnpm-workspace.yaml')
+    : await findUp([WORKSPACE_MANIFEST_FILENAME, 'pnpm-workspace.yml'], { cwd })
   if (workspaceManifestLocation?.endsWith('.yml')) {
     throw new PnpmError('BAD_WORKSPACE_MANIFEST_NAME', `The workspace manifest file should be named "pnpm-workspace.yaml". File found: ${workspaceManifestLocation}`)
   }

--- a/packages/find-workspace-dir/test/index.ts
+++ b/packages/find-workspace-dir/test/index.ts
@@ -1,0 +1,21 @@
+/// <reference path="../../../typings/index.d.ts"/>
+import path from 'path'
+import findWorkspaceDir from '@pnpm/find-workspace-dir'
+
+const NPM_CONFIG_WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR'
+const FAKE_PATH = 'FAKE_PATH'
+
+test('finds actual workspace dir', async () => {
+  const workspaceDir = await findWorkspaceDir(process.cwd())
+
+  expect(workspaceDir).toBe(path.resolve(__dirname, '..', '..', '..'))
+})
+
+test('finds overriden workspace dir', async () => {
+  const oldValue = process.env[NPM_CONFIG_WORKSPACE_DIR_ENV_VAR]
+  process.env[NPM_CONFIG_WORKSPACE_DIR_ENV_VAR] = FAKE_PATH
+  const workspaceDir = await findWorkspaceDir(process.cwd())
+  process.env[NPM_CONFIG_WORKSPACE_DIR_ENV_VAR] = oldValue
+
+  expect(workspaceDir).toBe(FAKE_PATH)
+})


### PR DESCRIPTION
PNPM has support for passing in the lockfile dir override via `NPM_CONFIG_LOCKFILE_DIR`, however the workspace dir is only calculated by traversing up the folder structure from the working dir in search of a `pnpm-workspace.yaml` file. This change lets `NPM_CONFIG_WORKSPACE_DIR` work in a similar manner by overriding (and avoiding the traversal if possible).