### PR TITLE
feat(publish): support "publishConfig.directory" field

### DIFF
--- a/.changeset/pretty-moose-speak.md
+++ b/.changeset/pretty-moose-speak.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-publishing": minor
+"@pnpm/run-npm": minor
+"@pnpm/types": minor
+---
+
+support "publishConfig.directory" field

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -188,7 +188,12 @@ Do you want to continue?`,
         }
       }
 
-      const { status } = runNpm(opts.npmPath, ['publish', '--ignore-scripts', ...args])
+      const cwd = manifest.publishConfig?.directory ? path.join(dir, manifest.publishConfig.directory) : undefined
+
+      const { status } = runNpm(opts.npmPath, ['publish', '--ignore-scripts', ...args], {
+        cwd,
+      })
+
       _status = status!
     }
   )

--- a/packages/run-npm/src/index.ts
+++ b/packages/run-npm/src/index.ts
@@ -3,10 +3,14 @@ import path from 'path'
 import spawn from 'cross-spawn'
 import PATH from 'path-name'
 
-export default function runNpm (npmPath: string | undefined, args: string[]) {
+export interface RunNPMOptions {
+  cwd?: string
+}
+
+export default function runNpm (npmPath: string | undefined, args: string[], options?: RunNPMOptions) {
   const npm = npmPath ?? 'npm'
   return runScriptSync(npm, args, {
-    cwd: process.cwd(),
+    cwd: options?.cwd ?? process.cwd(),
     stdio: 'inherit',
     userAgent: undefined,
   })

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -46,6 +46,10 @@ export interface PeerDependenciesMeta {
   }
 }
 
+export interface PublishConfig extends Record<string, unknown> {
+  directory?: string
+}
+
 interface BaseManifest {
   name?: string
   version?: string
@@ -76,7 +80,7 @@ interface BaseManifest {
   module?: string
   typings?: string
   types?: string
-  publishConfig?: Record<string, unknown>
+  publishConfig?: PublishConfig
 }
 
 export type DependencyManifest = BaseManifest & Required<Pick<BaseManifest, 'name' | 'version'>>


### PR DESCRIPTION
Adding support for "publishConfig.directory" field, feature present in changesets https://github.com/atlassian/changesets/pull/428, and lerna: https://github.com/lerna/lerna/tree/main/commands/publish#publishconfigdirectory