### PR TITLE
fix(install): fix calculate repository root when the installed project is one or more level above the workspace project

### DIFF
--- a/.changeset/angry-falcons-obey.md
+++ b/.changeset/angry-falcons-obey.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+fix calculate repository root when the installed project is a parent of the workspace folder

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -438,7 +438,7 @@ function calculateRepositoryRoot (
   // assume repo root is workspace dir
   let relativeRepoRoot = '.'
   for (const rootDir of projectDirs) {
-    const relativePartRegExp = new RegExp(`^(\\.\\.\\${path.sep})+`)
+    const relativePartRegExp = new RegExp(`^(\\.\\.\\${path.sep})*(\\.\\.)?`)
     const relativePartMatch = relativePartRegExp.exec(path.relative(workspaceDir, rootDir))
     if (relativePartMatch != null) {
       const relativePart = relativePartMatch[0]

--- a/packages/pnpm/test/monorepo/index.ts
+++ b/packages/pnpm/test/monorepo/index.ts
@@ -941,6 +941,86 @@ test('shared-workspace-lockfile: install dependencies in projects that are relat
   })
 })
 
+test('shared-workspace-lockfile: install dependencies in projects that are in one more level up from the workspace directory', async () => {
+  preparePackages([
+    {
+      location: 'monorepo/workspace',
+      package: {
+        name: 'root-package',
+        version: '1.0.0',
+
+        dependencies: {
+          'package-1': '1.0.0',
+          'is-negative': '1.0.0',
+        },
+      },
+    },
+    {
+      location: 'monorepo',
+      package: {
+        name: 'package-1',
+        version: '1.0.0',
+
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+      },
+    },
+  ])
+
+  await writeYamlFile('monorepo/workspace/pnpm-workspace.yaml', { packages: ['../**', '!store/**'] })
+
+  process.chdir('monorepo/workspace')
+
+  await execPnpm(['recursive', 'install', '--store-dir', 'store', '--shared-workspace-lockfile', '--link-workspace-packages'])
+
+  const lockfile = await readYamlFile<Lockfile>(WANTED_LOCKFILE)
+
+  expect(lockfile).toStrictEqual({
+    importers: {
+      '.': {
+        dependencies: {
+          'is-negative': '1.0.0',
+          'package-1': 'link:..',
+        },
+        specifiers: {
+          'is-negative': '1.0.0',
+          'package-1': '1.0.0',
+        },
+      },
+      '..': {
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+        specifiers: {
+          'is-positive': '1.0.0',
+        },
+      },
+    },
+    lockfileVersion: 5.3,
+    packages: {
+      '/is-negative/1.0.0': {
+        dev: false,
+        engines: {
+          node: '>=0.10.0',
+        },
+        resolution: {
+          integrity: 'sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=',
+        },
+      },
+      '/is-positive/1.0.0': {
+        dev: false,
+        engines: {
+          node: '>=0.10.0',
+        },
+        resolution: {
+          integrity: 'sha1-iACYVrZKLx632LsBeUGEJK4EUss=',
+        },
+      },
+    },
+  })
+})
+
 test('shared-workspace-lockfile: entries of removed projects should be removed from shared lockfile', async () => {
   preparePackages([
     {


### PR DESCRIPTION
pnpm does nothing when installing a project in the parent folder of the workspace location.

Use case:
Rush workspace is in `project/common/temp/pnpm-workspace.yaml`
Root repository is `project`

`pnpm install --filter '<root package name>'` does nothing