### PR TITLE
fix: ensure command output ends with newline

### DIFF
--- a/.changeset/shy-days-whisper.md
+++ b/.changeset/shy-days-whisper.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+A trailing newline should always be added to the output.

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -200,60 +200,53 @@ export default async function run (inputArgv: string[]) {
     config.workspaceDir = wsDir
   }
 
-  // NOTE: we defer the next stage, otherwise reporter might not catch all the logs
-  let { output, exitCode }: { output: string | null, exitCode: number } = await new Promise((resolve, reject) => {
-    setTimeout(async () => {
-      if (!isCI && !selfUpdate && !config.offline && !config.preferOffline && !config.fallbackCommandUsed) {
-        checkForUpdates(config).catch(() => { /* Ignore */ })
-      }
+  let { output, exitCode }: { output: string | null, exitCode: number } = await (async () => {
+    // NOTE: we defer the next stage, otherwise reporter might not catch all the logs
+    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+    if (!isCI && !selfUpdate && !config.offline && !config.preferOffline && !config.fallbackCommandUsed) {
+      checkForUpdates(config).catch(() => { /* Ignore */ })
+    }
 
-      if (config.force === true && !config.fallbackCommandUsed) {
-        logger.warn({
-          message: 'using --force I sure hope you know what you are doing',
-          prefix: config.dir,
-        })
-      }
-
-      scopeLogger.debug({
-        ...(
-          !cliOptions['recursive']
-            ? { selected: 1 }
-            : {
-              selected: Object.keys(config.selectedProjectsGraph!).length,
-              total: config.allProjects!.length,
-            }
-        ),
-        ...(workspaceDir ? { workspacePrefix: workspaceDir } : {}),
+    if (config.force === true && !config.fallbackCommandUsed) {
+      logger.warn({
+        message: 'using --force I sure hope you know what you are doing',
+        prefix: config.dir,
       })
+    }
 
-      try {
-        if (config.useNodeVersion != null) {
-          const nodePath = await node.getNodeDir(config)
-          config.extraBinPaths.push(nodePath)
-        }
-        let result = pnpmCmds[cmd ?? 'help'](
-          // TypeScript doesn't currently infer that the type of config
-          // is `Omit<typeof config, 'reporter'>` after the `delete config.reporter` statement
-          config as Omit<typeof config, 'reporter'>,
-          cliParams
-        )
-        if (result instanceof Promise) {
-          result = await result
-        }
-        if (!result) {
-          resolve({ output: null, exitCode: 0 })
-          return
-        }
-        if (typeof result === 'string') {
-          resolve({ output: result, exitCode: 0 })
-          return
-        }
-        resolve({ output: result['output'], exitCode: result['exitCode'] })
-      } catch (err) {
-        reject(err)
-      }
-    }, 0)
-  })
+    scopeLogger.debug({
+      ...(
+        !cliOptions['recursive']
+          ? { selected: 1 }
+          : {
+            selected: Object.keys(config.selectedProjectsGraph!).length,
+            total: config.allProjects!.length,
+          }
+      ),
+      ...(workspaceDir ? { workspacePrefix: workspaceDir } : {}),
+    })
+
+    if (config.useNodeVersion != null) {
+      const nodePath = await node.getNodeDir(config)
+      config.extraBinPaths.push(nodePath)
+    }
+    let result = pnpmCmds[cmd ?? 'help'](
+      // TypeScript doesn't currently infer that the type of config
+      // is `Omit<typeof config, 'reporter'>` after the `delete config.reporter` statement
+      config as Omit<typeof config, 'reporter'>,
+      cliParams
+    )
+    if (result instanceof Promise) {
+      result = await result
+    }
+    if (!result) {
+      return { output: null, exitCode: 0 }
+    }
+    if (typeof result === 'string') {
+      return { output: result, exitCode: 0 }
+    }
+    return result
+  })()
   if (output) {
     if (!output.endsWith('\n')) {
       output = `${output}\n`

--- a/packages/pnpm/test/bin.ts
+++ b/packages/pnpm/test/bin.ts
@@ -11,7 +11,7 @@ test('pnpm bin', async () => {
   const result = execPnpmSync(['bin'])
 
   expect(result.status).toStrictEqual(0)
-  expect(result.stdout.toString()).toBe(path.resolve('node_modules/.bin'))
+  expect(result.stdout.toString().trim()).toBe(path.resolve('node_modules/.bin'))
 })
 
 test('pnpm bin -g', async () => {
@@ -20,5 +20,5 @@ test('pnpm bin -g', async () => {
   const result = execPnpmSync(['bin', '-g'])
 
   expect(result.status).toStrictEqual(0)
-  expect(process.env[PATH]!).toContain(result.stdout.toString())
+  expect(process.env[PATH]!).toContain(result.stdout.toString().trim())
 })


### PR DESCRIPTION
I found some missing newlines at the end of the output of `pnpm audit` and `pnpm list`.
When looking at `plugin-command-listing` I found that adding newlines there might be cumbersome, so I added it just before writing to stdout.

I also added some types, because the template literal I added complained about `any`.