### PR TITLE
feat(plugin-commands-store): add `store path` command

### DIFF
--- a/.changeset/empty-pugs-kick.md
+++ b/.changeset/empty-pugs-kick.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-store": minor
+---
+
+Add `pnpm store path` command that prints the path to the current store directory.

--- a/packages/plugin-commands-store/src/store.ts
+++ b/packages/plugin-commands-store/src/store.ts
@@ -72,6 +72,8 @@ export async function handler (opts: StoreCommandOptions, params: string[]) {
   switch (params[0]) {
   case 'status':
     return statusCmd(opts)
+  case 'path':
+    return storePath(opts.dir, opts.storeDir)
   case 'prune': {
     store = await createOrConnectStoreController(opts)
     const storePruneOptions = Object.assign(opts, {

--- a/packages/plugin-commands-store/test/storePath.ts
+++ b/packages/plugin-commands-store/test/storePath.ts
@@ -1,0 +1,25 @@
+import os from 'os'
+import { store } from '@pnpm/plugin-commands-store'
+import prepare from '@pnpm/prepare'
+import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
+
+const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}/`
+
+test('CLI prints the current store path', async () => {
+  prepare()
+
+  const candidateStorePath = await store.handler({
+    dir: process.cwd(),
+    rawConfig: {
+      registry: REGISTRY,
+    },
+    registries: { default: REGISTRY },
+    storeDir: '/home/example/.pnpm-store',
+  }, ['path'])
+
+  const expectedStorePath = os.platform() === 'win32'
+    ? '\\home\\example\\.pnpm-store\\v3'
+    : '/home/example/.pnpm-store/v3'
+
+  expect(candidateStorePath).toBe(expectedStorePath)
+})


### PR DESCRIPTION
Add a `pnpm store path` command to print the location of the pnpm store
as the CLI would resolve it. This allows the user to inspect the current
store location, as well as allows external tooling (like shell scripts)
to locate the pnpm store without needing to make assumptions about its
location or needing to load the `@pnpm/store-path` module.

This command differs from running `pnpm get store`, as `pnpm get store`
prints "undefined" in the case that no custom store path has been set,
which requires external tooling to have knowledge about where pnpm
locates its store in the default case.

---

Please let me know if you would like anything changed or improved. The test I added simply tests that `pnpm store path` doesn't throw an error, but if you have any pointers on how to test the logger output, I'm happy to add a test that validates the printed output. I didn't see any other examples of testing the logger output from a quick glance, though I'm not very familiar with the codebase here and could have missed something obvious.

Fixes #2575