### PR TITLE
fix(supi): never do full resolution when package manifest is ignored

### DIFF
--- a/.changeset/six-weeks-perform.md
+++ b/.changeset/six-weeks-perform.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Never do full resolution when package manifest is ignored

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -190,12 +190,15 @@ export async function mutateModules (
 
   async function _install (): Promise<Array<{ rootDir: string, manifest: ProjectManifest }>> {
     const packageExtensionsChecksum = isEmpty(packageExtensions ?? {}) ? undefined : createObjectChecksum(packageExtensions!)
-    let needsFullResolution = !equals(ctx.wantedLockfile.overrides ?? {}, overrides ?? {}) ||
+    let needsFullResolution = !maybeOpts.ignorePackageManifest && (
+      !equals(ctx.wantedLockfile.overrides ?? {}, overrides ?? {}) ||
       !equals((ctx.wantedLockfile.neverBuiltDependencies ?? []).sort(), (neverBuiltDependencies ?? []).sort()) ||
-      ctx.wantedLockfile.packageExtensionsChecksum !== packageExtensionsChecksum
-    ctx.wantedLockfile.overrides = overrides
-    ctx.wantedLockfile.neverBuiltDependencies = neverBuiltDependencies
-    ctx.wantedLockfile.packageExtensionsChecksum = packageExtensionsChecksum
+      ctx.wantedLockfile.packageExtensionsChecksum !== packageExtensionsChecksum)
+    if (needsFullResolution) {
+      ctx.wantedLockfile.overrides = overrides
+      ctx.wantedLockfile.neverBuiltDependencies = neverBuiltDependencies
+      ctx.wantedLockfile.packageExtensionsChecksum = packageExtensionsChecksum
+    }
     const frozenLockfile = opts.frozenLockfile ||
       opts.frozenLockfileIfExists && ctx.existsWantedLockfile
     if (

--- a/packages/supi/test/install/overrides.ts
+++ b/packages/supi/test/install/overrides.ts
@@ -36,6 +36,15 @@ test('versions are replaced with versions specified through pnpm.overrides field
     const currentLockfile = await project.readCurrentLockfile()
     expect(lockfile.overrides).toStrictEqual(currentLockfile.overrides)
   }
+  // shall be able to install when package manifest is ignored
+  await mutateModules([
+    {
+      buildIndex: 0,
+      manifest,
+      mutation: 'install',
+      rootDir: process.cwd(),
+    },
+  ], { ...await testDefaults(), ignorePackageManifest: true })
 
   // The lockfile is updated if the overrides are changed
   manifest.pnpm!.overrides!['bar@^100.0.0'] = '100.0.0'


### PR DESCRIPTION

Close #3576