### PR TITLE
feat: publishConfig.executableFiles

### DIFF
--- a/.changeset/neat-needles-retire.md
+++ b/.changeset/neat-needles-retire.md
@@ -1,0 +1,13 @@
+---
+"@pnpm/plugin-commands-publishing": minor
+---
+
+By default, for portability reasons, no files except those listed in the bin field will be marked as executable in the resulting package archive. The executableFiles field lets you declare additional fields that must have the executable flag (+x) set even if they aren't directly accessible through the bin field.
+
+```json
+"publishConfig": {
+  "executableFiles": [
+    "./dist/shim.js",
+  ]
+}
+```

--- a/.changeset/sharp-buttons-sell.md
+++ b/.changeset/sharp-buttons-sell.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/types": minor
+---
+
+Add `publishConfig.executableFiles`.

--- a/packages/plugin-commands-publishing/fixtures/has-bin/package.json
+++ b/packages/plugin-commands-publishing/fixtures/has-bin/package.json
@@ -1,5 +1,8 @@
 {
   "name": "has-bin",
   "version": "0.0.0",
-  "bin": "exec"
+  "bin": "exec",
+  "publishConfig": {
+    "executableFiles": ["./other-exec"]
+  }
 }

--- a/packages/plugin-commands-publishing/test/pack.ts
+++ b/packages/plugin-commands-publishing/test/pack.ts
@@ -119,6 +119,10 @@ const modeIsExecutable = (mode: number) => (mode & 0o111) === 0o111
     expect(modeIsExecutable(stat.mode)).toBeTruthy()
   }
   {
+    const stat = fs.statSync(path.resolve('package/other-exec'))
+    expect(modeIsExecutable(stat.mode)).toBeTruthy()
+  }
+  {
     const stat = fs.statSync(path.resolve('package/index.js'))
     expect(modeIsExecutable(stat.mode)).toBeFalsy()
   }

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -164,7 +164,11 @@
     "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix && rimraf dist bin/nodes && pnpm run bundle && shx cp -r node-gyp-bin dist/node-gyp-bin && shx cp -r node_modules/@pnpm/tabtab/lib/scripts dist/scripts && shx cp -r node_modules/ps-list/vendor dist/vendor && pkg ./dist/pnpm.cjs --out-path=../artifacts/win-x64 --targets=node14-win-x64 && pkg ./dist/pnpm.cjs --out-path=../artifacts/linux-x64 --targets=node14-linux-x64 && pkg ./dist/pnpm.cjs --out-path=../artifacts/macos-x64 --targets=node14-macos-x64"
   },
   "publishconfig": {
-    "tag": "next"
+    "tag": "next",
+    "executableFiles": [
+      "./dist/node-gyp-bin/node-gyp",
+      "./dist/node-gyp-bin/node-gyp.cmd"
+    ]
   },
   "funding": "https://opencollective.com/pnpm"
 }

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -48,6 +48,7 @@ export interface PeerDependenciesMeta {
 
 export interface PublishConfig extends Record<string, unknown> {
   directory?: string
+  executableFiles?: string[]
 }
 
 interface BaseManifest {


### PR DESCRIPTION
By default, for portability reasons, no files except those listed in the bin field will be marked as executable in the resulting package archive. The executableFiles field lets you declare additional fields that must have the executable flag (+x) set even if they aren't directly accessible through the bin field.

```json
"publishConfig": {
  "executableFiles": [
    "./dist/shim.js",
  ]
}
```