### PR TITLE
feat: dlx

### DIFF
--- a/.changeset/polite-dolls-wink.md
+++ b/.changeset/polite-dolls-wink.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"pnpm": minor
+---
+
+New command added for running packages in a tempory environment: `pnpm dlx <command> ...`

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -50,6 +50,7 @@
     "@pnpm/lifecycle": "workspace:11.0.4",
     "@pnpm/read-project-manifest": "workspace:2.0.5",
     "@pnpm/sort-packages": "workspace:2.1.1",
+    "@pnpm/store-path": "^5.0.0",
     "@pnpm/types": "workspace:7.4.0",
     "p-limit": "^3.1.0",
     "path-exists": "^4.0.0",

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -16,7 +16,9 @@ export function rcOptionsTypes () {
   return {}
 }
 
-export const cliOptionsTypes = () => ({})
+export const cliOptionsTypes = () => ({
+  package: String,
+})
 
 export function help () {
   return renderHelp({
@@ -39,7 +41,9 @@ export function help () {
 }
 
 export async function handler (
-  opts: {},
+  opts: {
+    package?: string
+  },
   params: string[]
 ) {
   const cache = path.join(await storePath(process.cwd(), '~/.pnpm-store'), 'tmp')
@@ -57,7 +61,8 @@ export async function handler (
     } catch (err) { }
   })
   await rimraf(bins)
-  await execa('pnpm', ['add', params[0], '--global', '--global-dir', prefix, '--dir', prefix], {
+  const pkg = opts.package ?? params[0]
+  await execa('pnpm', ['add', pkg, '--global', '--global-dir', prefix, '--dir', prefix], {
     stdio: 'inherit',
   })
   await execa(params[0], params.slice(1), {

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -1,0 +1,74 @@
+import fs from 'fs'
+import path from 'path'
+import storePath from '@pnpm/store-path'
+import rimraf from '@zkochan/rimraf'
+import execa from 'execa'
+import PATH from 'path-name'
+import renderHelp from 'render-help'
+
+export const shorthands = {
+  p: '--package',
+}
+
+export const commandNames = ['dlx']
+
+export function rcOptionsTypes () {
+  return {}
+}
+
+export const cliOptionsTypes = () => ({})
+
+export function help () {
+  return renderHelp({
+    description: 'Run a package in a temporary environment.',
+    descriptionLists: [
+      {
+        title: 'Options',
+
+        list: [
+          {
+            description: 'The package to install before running the command',
+            name: '--package',
+            shortAlias: '-p',
+          },
+        ],
+      },
+    ],
+    usages: ['pnpm dlx <command> [args...]'],
+  })
+}
+
+export async function handler (
+  opts: {},
+  params: string[]
+) {
+  const cache = path.join(await storePath(process.cwd(), '~/.pnpm-store'), 'tmp')
+  const prefix = path.join(cache, `dlx-${process.pid.toString()}`)
+  const bins = process.platform === 'win32'
+    ? prefix
+    : path.join(prefix, 'bin')
+  fs.mkdirSync(prefix, { recursive: true })
+  process.on('exit', () => {
+    try {
+      fs.rmdirSync(prefix, {
+        recursive: true,
+        maxRetries: 3,
+      })
+    } catch (err) { }
+  })
+  await rimraf(bins)
+  await execa('pnpm', ['add', params[0], '--global', '--global-dir', prefix, '--dir', prefix], {
+    stdio: 'inherit',
+  })
+  await execa(params[0], params.slice(1), {
+    cwd: prefix,
+    env: {
+      ...process.env,
+      [PATH]: [
+        bins,
+        process.env[PATH],
+      ].join(path.delimiter),
+    },
+    stdio: 'inherit',
+  })
+}

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -6,10 +6,6 @@ import execa from 'execa'
 import PATH from 'path-name'
 import renderHelp from 'render-help'
 
-export const shorthands = {
-  p: '--package',
-}
-
 export const commandNames = ['dlx']
 
 export function rcOptionsTypes () {
@@ -31,7 +27,6 @@ export function help () {
           {
             description: 'The package to install before running the command',
             name: '--package',
-            shortAlias: '-p',
           },
         ],
       },

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -61,7 +61,6 @@ export async function handler (
     stdio: 'inherit',
   })
   await execa(params[0], params.slice(1), {
-    cwd: prefix,
     env: {
       ...process.env,
       [PATH]: [

--- a/packages/plugin-commands-script-runners/src/index.ts
+++ b/packages/plugin-commands-script-runners/src/index.ts
@@ -1,3 +1,4 @@
+import * as dlx from './dlx'
 import * as exec from './exec'
 import * as restart from './restart'
 import * as run from './run'
@@ -8,4 +9,4 @@ const test = {
   ..._test,
 }
 
-export { exec, restart, run, test }
+export { dlx, exec, restart, run, test }

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -1,0 +1,11 @@
+import fs from 'fs'
+import { dlx } from '@pnpm/plugin-commands-script-runners'
+import { prepareEmpty } from '@pnpm/prepare'
+
+test('dlx', async () => {
+  prepareEmpty()
+
+  await dlx.handler({}, ['touch', 'foo'])
+
+  expect(fs.existsSync('foo')).toBeTruthy()
+})

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -9,3 +9,13 @@ test('dlx', async () => {
 
   expect(fs.existsSync('foo')).toBeTruthy()
 })
+
+test('dlx --package <pkg>', async () => {
+  prepareEmpty()
+
+  await dlx.handler({
+    package: 'zkochan/for-testing-pnpm-dlx',
+  }, ['foo'])
+
+  expect(fs.existsSync('foo')).toBeTruthy()
+})

--- a/packages/pnpm/src/cmd/index.ts
+++ b/packages/pnpm/src/cmd/index.ts
@@ -9,6 +9,7 @@ import { outdated } from '@pnpm/plugin-commands-outdated'
 import { pack, publish } from '@pnpm/plugin-commands-publishing'
 import { rebuild } from '@pnpm/plugin-commands-rebuild'
 import {
+  dlx,
   exec,
   restart,
   run,
@@ -62,6 +63,7 @@ const commands: Array<{
   add,
   audit,
   bin,
+  dlx,
   env,
   exec,
   fetch,

--- a/packages/pnpm/src/parseCliArgs.ts
+++ b/packages/pnpm/src/parseCliArgs.ts
@@ -17,7 +17,7 @@ const RENAMED_OPTIONS = {
 export default async function parseCliArgs (inputArgv: string[]) {
   return parseCliArgsLib({
     fallbackCommand: 'run',
-    escapeArgs: ['exec'],
+    escapeArgs: ['dlx', 'exec'],
     getCommandLongName: getCommandFullName,
     getTypesByCommandName: getCliOptionsTypes,
     renamedOptions: RENAMED_OPTIONS,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2258,6 +2258,7 @@ importers:
       '@pnpm/prepare': workspace:0.0.26
       '@pnpm/read-project-manifest': workspace:2.0.5
       '@pnpm/sort-packages': workspace:2.1.1
+      '@pnpm/store-path': ^5.0.0
       '@pnpm/types': workspace:7.4.0
       '@types/ramda': 0.27.39
       '@zkochan/rimraf': ^2.1.1
@@ -2279,6 +2280,7 @@ importers:
       '@pnpm/lifecycle': link:../lifecycle
       '@pnpm/read-project-manifest': link:../read-project-manifest
       '@pnpm/sort-packages': link:../sort-packages
+      '@pnpm/store-path': 5.0.0
       '@pnpm/types': link:../types
       p-limit: 3.1.0
       path-exists: 4.0.0


### PR DESCRIPTION
pnpx will be removed in pnpm v7 and replaced by `pnpm exec` (which is already implemented) and `pnpm dlx`, which is this PR.

`pnpm dlx` works the same as `yarn dlx`.

FYI: npx is also kind of deprecated and replaced by `npm exec`.