### PR TITLE
chore(release): update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install ldid
+        run: |
+          sudo apt-get update
+          sudo apt-get install git build-essential libplist-dev libssl-dev openssl qemu-user-binfmt
+          cd /tmp
+          git clone git://git.saurik.com/ldid.git
+          cd ldid
+          git submodule update --init
+          gcc -I. -c -o lookup2.o lookup2.c
+          g++ -std=c++11 -o ldid lookup2.o ldid.cpp -I. -lcrypto -lplist -lxml2
+          sudo mv ldid /usr/local/bin
       - name: install pnpm and npm
         run: |
           curl -L https://get.pnpm.io/v6.js | node - add --global pnpm@next npm@7


### PR DESCRIPTION
Fixes #3702

There is a warning on release workflow.
Installing ldid would fix the not working on M1 Mac problem by codesigning.

https://github.com/pnpm/pnpm/runs/3403887763

```
> Warning Unable to sign the macOS executable
  Due to the mandatory code signing requirement, before the
  executable is distributed to end users, it must be signed.
  Otherwise, it will be immediately killed by kernel on launch.
  An ad-hoc signature is sufficient.
  To do that, run pkg on a Mac, or transfer the executable to a Mac
  and run "codesign --sign - <executable>", or (if you use Linux)
  install "ldid" utility to PATH and then run pkg again
```