### PR TITLE
feat: allow installing mutiple packages using dlx command

### DIFF
--- a/.changeset/seven-birds-flash.md
+++ b/.changeset/seven-birds-flash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+---
+
+Support for multiple `--package` parameters added for `pnpm dlx` command

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -13,7 +13,7 @@ export function rcOptionsTypes () {
 }
 
 export const cliOptionsTypes = () => ({
-  package: String,
+  package: [String, Array],
 })
 
 export function help () {
@@ -37,7 +37,7 @@ export function help () {
 
 export async function handler (
   opts: {
-    package?: string
+    package?: string[]
   },
   params: string[]
 ) {
@@ -55,8 +55,8 @@ export async function handler (
     } catch (err) { }
   })
   await rimraf(bins)
-  const pkg = opts.package ?? params[0]
-  await execa('pnpm', ['add', pkg, '--global', '--global-dir', prefix, '--dir', prefix], {
+  const pkgs = opts.package ?? params.slice(0, 1)
+  await execa('pnpm', ['add', ...pkgs, '--global', '--global-dir', prefix, '--dir', prefix], {
     stdio: 'inherit',
   })
   await execa(params[0], params.slice(1), {

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -16,7 +16,7 @@ test('dlx --package <pkg1> [--package <pkg2>]', async () => {
   await dlx.handler({
     package: [
       'zkochan/for-testing-pnpm-dlx',
-      'zkochan/install-scripts-example',
+      'is-positive',
     ],
   }, ['foo'])
 

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -10,11 +10,14 @@ test('dlx', async () => {
   expect(fs.existsSync('foo')).toBeTruthy()
 })
 
-test('dlx --package <pkg>', async () => {
+test('dlx --package <pkg1> [--package <pkg2>]', async () => {
   prepareEmpty()
 
   await dlx.handler({
-    package: 'zkochan/for-testing-pnpm-dlx',
+    package: [
+      'zkochan/for-testing-pnpm-dlx',
+      'zkochan/install-scripts-example',
+    ],
   }, ['foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()


### PR DESCRIPTION
Allow use of mutiple ```--package``` parameters with ```pnpm dlx``` command. For use with CLI tools which may require some additional optional packages