### PR TITLE
chore(setup): do not remove executable in setup

### DIFF
--- a/.changeset/poor-lobsters-turn.md
+++ b/.changeset/poor-lobsters-turn.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-setup": minor
+---
+
+The original binary will not be removed after pnpm setup.

--- a/packages/plugin-commands-setup/src/setup.ts
+++ b/packages/plugin-commands-setup/src/setup.ts
@@ -33,11 +33,11 @@ function getExecPath () {
   return (require.main != null) ? require.main.filename : process.cwd()
 }
 
-function moveCli (currentLocation: string, targetDir: string) {
+function copyCli (currentLocation: string, targetDir: string) {
   const newExecPath = path.join(targetDir, path.basename(currentLocation))
   if (path.relative(newExecPath, currentLocation) === '') return
   logger.info({
-    message: `Moving pnpm CLI from ${currentLocation} to ${newExecPath}`,
+    message: `Copying pnpm CLI from ${currentLocation} to ${newExecPath}`,
     prefix: process.cwd(),
   })
   fs.mkdirSync(targetDir, { recursive: true })
@@ -52,7 +52,7 @@ export async function handler (
   const currentShell = process.env.SHELL ? path.basename(process.env.SHELL) : null
   const execPath = getExecPath()
   if (execPath.match(/\.[cm]?js$/) == null) {
-    moveCli(execPath, opts.pnpmHomeDir)
+    copyCli(execPath, opts.pnpmHomeDir)
   }
   const updateOutput = await updateShell(currentShell, opts.pnpmHomeDir)
   if (updateOutput === false) {

--- a/packages/plugin-commands-setup/src/setup.ts
+++ b/packages/plugin-commands-setup/src/setup.ts
@@ -41,11 +41,7 @@ function moveCli (currentLocation: string, targetDir: string) {
     prefix: process.cwd(),
   })
   fs.mkdirSync(targetDir, { recursive: true })
-  try {
-    fs.renameSync(currentLocation, newExecPath)
-  } catch (err) {
-    fs.copyFileSync(currentLocation, newExecPath)
-  }
+  fs.copyFileSync(currentLocation, newExecPath)
 }
 
 export async function handler (

--- a/packages/plugin-commands-setup/src/setup.ts
+++ b/packages/plugin-commands-setup/src/setup.ts
@@ -45,9 +45,6 @@ function moveCli (currentLocation: string, targetDir: string) {
     fs.renameSync(currentLocation, newExecPath)
   } catch (err) {
     fs.copyFileSync(currentLocation, newExecPath)
-    try {
-      fs.unlinkSync(currentLocation)
-    } catch (err) {}
   }
 }
 


### PR DESCRIPTION
The executable installed by the package manager (e.g. Homebrew) should
not be removed after the setup command is run.
The installation script should remove that and install.sh do so.