### PR TITLE
chore: add macos-latest to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
 
     name: '${{matrix.platform}} / Node.js ${{ matrix.node }}'
     runs-on: ${{matrix.platform}}


### PR DESCRIPTION
Please add macOS runs to required status checks if you want.