### PR TITLE
fix: respect cache-dir/state-dir from config files

### DIFF
--- a/.changeset/thirty-stringrays-type.md
+++ b/.changeset/thirty-stringrays-type.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+Fix a bug that doesn't respect `cache-dir`/`state-dir` paths from configuration files

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -35,6 +35,7 @@ async function which (cmd: string) {
 
 export const types = Object.assign({
   bail: Boolean,
+  'cache-dir': String,
   'child-concurrency': Number,
   color: ['always', 'auto', 'never'],
   dev: [null, true],
@@ -93,6 +94,7 @@ export const types = Object.assign({
   'side-effects-cache-readonly': Boolean,
   symlink: Boolean,
   sort: Boolean,
+  'state-dir': String,
   store: String, // TODO: deprecate
   'store-dir': String,
   stream: Boolean,


### PR DESCRIPTION
Currently I can't customize `cache-dir` / `state-dir` path from `.npmrc` file.