### PR TITLE
feat: improve error and warning reporting

### DIFF
--- a/.changeset/red-hairs-relate.md
+++ b/.changeset/red-hairs-relate.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": minor
+---
+
+Improve error and warning reporting.

--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -234,7 +234,7 @@ function formatGenericError (errorMessage: string, stack: object) {
 }
 
 function formatErrorSummary (message: string, code?: string) {
-  return `${chalk.bgRed.black(`\u2009${code ?? 'ERROR'}\u2009`)} ${chalk.red(message)}`
+  return chalk.red.bold(`${chalk.bgRed.black(`(!!) ${code ?? 'ERROR'} `)} ${message}`)
 }
 
 function reportModifiedDependency (msg: { modified: string[] }) {

--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -19,7 +19,7 @@ export default function reportError (logObj: Log, config?: Config) {
   const errorInfo = getErrorInfo(logObj, config)
   let output = formatErrorSummary(errorInfo.title, logObj['err']['code'])
   if (errorInfo.body) {
-    output += `\n\n${errorInfo.body}`
+    output += `\n\n${errorInfo.body}`.split('\n').join(`\n${chalk.red.bold('(!)')} `)
   }
   return output
 }
@@ -234,7 +234,7 @@ function formatGenericError (errorMessage: string, stack: object) {
 }
 
 function formatErrorSummary (message: string, code?: string) {
-  return chalk.red.bold(`${chalk.bgRed.black(`(!!) ${code ?? 'ERROR'} `)} ${message}`)
+  return chalk.red.bold(`${chalk.bgRed.black(`(!) ${code ?? 'ERROR'} `)} ${message}`)
 }
 
 function reportModifiedDependency (msg: { modified: string[] }) {

--- a/packages/default-reporter/src/reporterForClient/utils/formatWarn.ts
+++ b/packages/default-reporter/src/reporterForClient/utils/formatWarn.ts
@@ -1,8 +1,5 @@
 import chalk from 'chalk'
 
 export default function formatWarn (message: string) {
-  // The \u2009 is the "thin space" unicode character
-  // It is used instead of ' ' because chalk (as of version 2.1.0)
-  // trims whitespace at the beginning
-  return `${chalk.bgYellow.black('\u2009WARN\u2009')} ${message}`
+  return chalk.bold.yellow(`(!) ${message}`)
 }

--- a/packages/default-reporter/test/index.ts
+++ b/packages/default-reporter/test/index.ts
@@ -21,9 +21,9 @@ import normalizeNewline from 'normalize-newline'
 import repeat from 'ramda/src/repeat'
 import formatWarn from '../src/reporterForClient/utils/formatWarn'
 
-const formatErrorCode = (code: string) => chalk.bgRed.black(`\u2009${code}\u2009`)
+const formatErrorCode = (code: string) => chalk.bgRed.black(`(!) ${code} `)
 const formatError = (code: string, message: string) => {
-  return `${formatErrorCode(code)} ${chalk.red(message)}`
+  return `${chalk.red.bold(`${formatErrorCode(code)} ${message}`)}`
 }
 const DEPRECATED = chalk.red('deprecated')
 const versionColor = chalk.grey

--- a/packages/default-reporter/test/reportingErrors.ts
+++ b/packages/default-reporter/test/reportingErrors.ts
@@ -10,11 +10,11 @@ import loadJsonFile from 'load-json-file'
 import normalizeNewline from 'normalize-newline'
 import StackTracey from 'stacktracey'
 
-const formatErrorCode = (code: string) => chalk.bgRed.black(`\u2009${code}\u2009`)
+const formatErrorCode = (code: string) => chalk.bgRed.black(`(!) ${code} `)
 const formatError = (code: string, message: string) => {
-  return `${formatErrorCode(code)} ${chalk.red(message)}`
+  return `${chalk.red.bold(`${formatErrorCode(code)} ${message}`)}`
 }
-const ERROR_PAD = ''
+const ERROR_PAD = `${chalk.red.bold('(!)')} `
 
 test('prints generic error', (done) => {
   const output$ = toOutput$({


### PR DESCRIPTION
This is how warnings are printed:
![image](https://user-images.githubusercontent.com/1927579/133001019-87de553e-284b-4b5d-89c4-0958b32d1a66.png)

This is how errors are printed:
![image](https://user-images.githubusercontent.com/1927579/133001053-14275ecd-8739-4236-9506-77e96f82d188.png)
