### PR TITLE
fix(supi): preinstall should run before the installation

### DIFF
--- a/.changeset/strange-goats-push.md
+++ b/.changeset/strange-goats-push.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+Fix that preinstall hook should run before the installation

--- a/packages/plugin-commands-setup/src/setupOnWindows.ts
+++ b/packages/plugin-commands-setup/src/setupOnWindows.ts
@@ -29,6 +29,7 @@ export async function setupWindowsEnvironmentPath (pnpmHomeDir: string): Promise
     logger.push(`Setting 'PNPM_HOME' to value '${homeDir}'`)
     const addResult = await execa('reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', homeDir, '/f'])
     if (addResult.failed) {
+      /* eslint-disable @typescript-eslint/restrict-template-expressions */
       logger.push(`\t${addResult.stderr}`)
     } else {
       commitNeeded = true

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -463,6 +463,18 @@ export async function mutateModules (
       ctx.existsWantedLockfile && !ctx.existsCurrentLockfile ||
       !ctx.currentLockfileIsUpToDate
     )
+
+    if (!opts.ignoreScripts) {
+      if (opts.enablePnp) {
+        scriptsOpts.extraEnv = makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs'))
+      }
+      await runLifecycleHooksConcurrently(['preinstall'],
+        projectsToBeInstalled,
+        opts.childConcurrency,
+        scriptsOpts
+      )
+    }
+
     const result = await installInContext(projectsToInstall, ctx, {
       ...opts,
       currentLockfileIsUpToDate: !ctx.existsWantedLockfile || ctx.currentLockfileIsUpToDate,
@@ -475,10 +487,7 @@ export async function mutateModules (
     })
 
     if (!opts.ignoreScripts) {
-      if (opts.enablePnp) {
-        scriptsOpts.extraEnv = makeNodeRequireOption(path.join(opts.lockfileDir, '.pnp.cjs'))
-      }
-      await runLifecycleHooksConcurrently(['preinstall', 'install', 'postinstall', 'prepare'],
+      await runLifecycleHooksConcurrently(['install', 'postinstall', 'prepare'],
         projectsToBeInstalled,
         opts.childConcurrency,
         scriptsOpts


### PR DESCRIPTION
solve #3760 

The preinstall hook should run before install like npm and yarn