### PR TITLE
fix(supi): --fix-lockfile should preserve dependencies in the existing lockfile

### DIFF
--- a/.changeset/fifty-snakes-refuse.md
+++ b/.changeset/fifty-snakes-refuse.md
@@ -1,0 +1,5 @@
+---
+"supi": patch
+---
+
+--fix-lockdile should preserve existing lockfile's dependencies and optionalDependencies

--- a/.changeset/fifty-snakes-refuse.md
+++ b/.changeset/fifty-snakes-refuse.md
@@ -2,4 +2,4 @@
 "supi": patch
 ---
 
---fix-lockdile should preserve existing lockfile's dependencies and optionalDependencies
+`--fix-lockfile` should preserve existing lockfile's `dependencies` and `optionalDependencies`.

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -738,8 +738,11 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     ctx.wantedLockfile.packages = Object.entries(ctx.wantedLockfile.packages).reduce((pre, [depPath, snapshot]) => ({
       ...pre,
       [depPath]: {
+        // These fields are needed to avoid losing information of the locked dependencies if these fields are not broken
+        // If these fields are broken, they will also be regenerated
         dependencies: snapshot.dependencies,
         optionalDependencies: snapshot.optionalDependencies,
+        resolution: snapshot.resolution,
       },
     }), {})
   }

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -728,7 +728,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
   })
   const projectsToResolve = await Promise.all(projects.map(async (project) => _toResolveImporter(project)))
 
-  // Ignore some fields when fixing lockfile, so these fileds can be regenereated
+  // Ignore some fields when fixing lockfile, so these fields can be regenerated
   // and make sure it's up-to-date
   if (
     opts.fixLockfile &&

--- a/packages/supi/src/install/index.ts
+++ b/packages/supi/src/install/index.ts
@@ -728,7 +728,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
   })
   const projectsToResolve = await Promise.all(projects.map(async (project) => _toResolveImporter(project)))
 
-  // Ignore some field when fixing lockfile, so this filed can be regenereated
+  // Ignore some fields when fixing lockfile, so these fileds can be regenereated
   // and make sure it's up-to-date
   if (
     opts.fixLockfile &&
@@ -738,8 +738,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     ctx.wantedLockfile.packages = Object.entries(ctx.wantedLockfile.packages).reduce((pre, [depPath, snapshot]) => ({
       ...pre,
       [depPath]: {
-        name: snapshot.name,
-        version: snapshot.version,
+        dependencies: snapshot.dependencies,
+        optionalDependencies: snapshot.optionalDependencies,
       },
     }), {})
   }

--- a/packages/supi/test/install/fixLockfile.ts
+++ b/packages/supi/test/install/fixLockfile.ts
@@ -1,6 +1,7 @@
+import path from 'path'
 import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
-import { prepareEmpty } from '@pnpm/prepare'
-import { install } from 'supi'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
+import { install, MutatedProject, mutateModules } from 'supi'
 import writeYamlFile from 'write-yaml-file'
 import readYamlFile from 'read-yaml-file'
 import { Lockfile, PackageSnapshots } from '@pnpm/lockfile-file'
@@ -58,4 +59,163 @@ test('fix broken lockfile with --fix-lockfile', async () => {
   })
   expect(lockfile.packages?.['/core-js-pure/3.16.2']?.requiresBuild).toBeTruthy()
   expect(lockfile.packages?.['/core-js-pure/3.16.2']?.dev).toBeTruthy()
+})
+
+test('--fix-lockfile should preserve all locked dependencies version', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: { name: 'root' },
+    },
+    {
+      location: 'project-1',
+      package: { name: 'project-1', dependencies: { '@babel/runtime-corejs3': '7.15.3' } },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2', dependencies: { '@babel/runtime-corejs3': '7.15.4' } },
+    },
+  ])
+
+  const importers: MutatedProject[] = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'root',
+        version: '1.0.0',
+      },
+      mutation: 'install',
+      rootDir: path.resolve('.'),
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: {
+          '@babel/runtime-corejs3': '7.15.3',
+        },
+      },
+      mutation: 'install',
+      rootDir: path.resolve('project-1'),
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-3',
+        version: '1.0.0',
+        dependencies: {
+          '@babel/runtime-corejs3': '7.15.4',
+        },
+      },
+      mutation: 'install',
+      rootDir: path.resolve('project-2'),
+    },
+  ]
+
+  /**
+   * project-1 depends on @babel/runtime-corejs3@7.15.3 while project-2 depends on @babel/runtime-corejs3@7.15.4,
+   * and @babel/runtime-corejs3@7.15.3 depends on core-js-pure@3.17.2 while @babel/runtime-corejs3@7.15.4 depends on core-js-pure@3.17.3
+   * --fix-lockfile should not change the locked dependency version and only adding missing fields in this scene
+   */
+  await writeYamlFile(WANTED_LOCKFILE, {
+    lockfileVersion: 5.3,
+    importers: {
+      '.': {
+        specifiers: {},
+      },
+      'project-1': {
+        specifiers: {
+          '@babel/runtime-corejs3': '7.15.3',
+        },
+        dependencies: {
+          '@babel/runtime-corejs3': '7.15.3',
+        },
+      },
+      'project-2': {
+        specifiers: {
+          '@babel/runtime-corejs3': '7.15.4',
+        },
+        dependencies: {
+          '@babel/runtime-corejs3': '7.15.4',
+        },
+      },
+    },
+    packages: {
+      '/@babel/runtime-corejs3/7.15.3': {
+        resolution: { integrity: 'sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==' },
+        // engines: { node: '>=6.9.0' },
+        dependencies: {
+          'core-js-pure': '3.17.2',
+          'regenerator-runtime': '0.13.9',
+        },
+        dev: false,
+      },
+      '/@babel/runtime-corejs3/7.15.4': {
+        resolution: { integrity: 'sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==' },
+        engines: { node: '>=6.9.0' },
+        dependencies: {
+          'core-js-pure': '3.17.3',
+          'regenerator-runtime': '0.13.9',
+        },
+        dev: false,
+      },
+      '/core-js-pure/3.17.2': {
+        resolution: { integrity: 'sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==' },
+        // requiresBuild: true,
+        dev: false,
+      },
+      '/core-js-pure/3.17.3': {
+      // resolution: { integrity: 'sha512-YusrqwiOTTn8058JDa0cv9unbXdIiIgcgI9gXso0ey4WgkFLd3lYlV9rp9n7nDCsYxXsMDTjA4m1h3T348mdlQ==' },
+      // requiresBuild: true,
+      // dev: false
+      },
+      '/regenerator-runtime/0.13.9': {
+        resolution: { integrity: 'sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==' },
+      // dev: false
+      },
+    },
+  }, { lineWidth: 1000 })
+
+  await mutateModules(importers, await testDefaults({ fixLockfile: true, lockfileOnly: true }))
+
+  const lockfile: Lockfile = await readYamlFile(WANTED_LOCKFILE)
+
+  expect(Object.keys(lockfile.packages as PackageSnapshots).length).toBe(5)
+
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.3']).toBeTruthy()
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.3']?.resolution).toEqual({
+    integrity: 'sha512-30A3lP+sRL6ml8uhoJSs+8jwpKzbw8CqBvDc1laeptxPm5FahumJxirigcbD2qTs71Sonvj1cyZB0OKGAmxQ+A==',
+  })
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.3']?.engines).toEqual({
+    node: '>=6.9.0',
+  })
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.3']?.dev).toBeFalsy()
+
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.4']).toBeTruthy()
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.4']?.resolution).toEqual({
+    integrity: 'sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==',
+  })
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.4']?.engines).toEqual({
+    node: '>=6.9.0',
+  })
+  expect(lockfile.packages?.['/@babel/runtime-corejs3/7.15.4']?.dev).toBeFalsy()
+
+  expect(lockfile.packages?.['/core-js-pure/3.17.2']).toBeTruthy()
+  expect(lockfile.packages?.['/core-js-pure/3.17.2']?.resolution).toHaveProperty('integrity', 'sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==')
+  expect(lockfile.packages?.['/core-js-pure/3.17.2']?.requiresBuild).toBeTruthy()
+  expect(lockfile.packages?.['/core-js-pure/3.17.2']?.dev).toBeFalsy()
+
+  expect(lockfile.packages?.['/core-js-pure/3.17.3']).toBeTruthy()
+  expect(lockfile.packages?.['/core-js-pure/3.17.3']?.resolution).toEqual({
+    integrity: 'sha512-YusrqwiOTTn8058JDa0cv9unbXdIiIgcgI9gXso0ey4WgkFLd3lYlV9rp9n7nDCsYxXsMDTjA4m1h3T348mdlQ==',
+  })
+  expect(lockfile.packages?.['/core-js-pure/3.17.3']?.requiresBuild).toBeTruthy()
+  expect(lockfile.packages?.['/core-js-pure/3.17.3']?.dev).toBeFalsy()
+
+  expect(lockfile.packages?.['/regenerator-runtime/0.13.9']).toBeTruthy()
+  expect(lockfile.packages?.['/regenerator-runtime/0.13.9']?.resolution).toEqual({
+    integrity: 'sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==',
+  })
+  expect(lockfile.packages?.['/regenerator-runtime/0.13.9']?.dev).toBeFalsy()
 })


### PR DESCRIPTION
Currently all fields in the lockfile entries will be regenerated when fixing the lockfile, including the dependencies field. This behavior  will lead to lose locked dependencies version of an existing lockfile entry, which is not work as intended.

Currently preferedVersion are used to lock the existing version and works well in most case, but in some edge cases, the lockfile structure may change due to the lose of locked dependency version info