### PR TITLE
fix: only hoist packages in the dependencies tree when partial install

### DIFF
--- a/.changeset/tiny-buttons-call.md
+++ b/.changeset/tiny-buttons-call.md
@@ -2,4 +2,4 @@
 "@pnpm/hoist": minor
 ---
 
-allow to hoist packages based on importerIds, only hoist packages that is subdependencies of the specified importerIds
+allow to hoist packages based on importerIds, only hoist packages that are subdependencies of the specified importerIds

--- a/.changeset/tiny-buttons-call.md
+++ b/.changeset/tiny-buttons-call.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/hoist": minor
+---
+
+allow to hoist packages based on importerIds, only hoist packages that is subdependencies of the specified importerIds

--- a/.changeset/unlucky-eggs-whisper.md
+++ b/.changeset/unlucky-eggs-whisper.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/headless": patch
+"@pnpm/hoist": patch
+"supi": patch
+---
+
+fix that only hoist packages in the dependencies tree when partial install

--- a/.changeset/unlucky-eggs-whisper.md
+++ b/.changeset/unlucky-eggs-whisper.md
@@ -1,7 +1,6 @@
 ---
 "@pnpm/headless": patch
-"@pnpm/hoist": patch
 "supi": patch
 ---
 
-fix that only hoist packages in the dependencies tree when partial install
+fix that hoisting all packages in the dependencies tree when using filtering

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -288,6 +288,7 @@ export default async (opts: HeadlessOptions) => {
       newHoistedDependencies = await hoist({
         extendNodePath: opts.extendNodePath,
         lockfile: hoistLockfile,
+        importerIds,
         lockfileDir,
         privateHoistedModulesDir: hoistedModulesDir,
         privateHoistPattern: opts.hoistPattern ?? [],

--- a/packages/hoist/src/index.ts
+++ b/packages/hoist/src/index.ts
@@ -19,7 +19,7 @@ export default async function hoistByLockfile (
     extendNodePath?: boolean
     lockfile: Lockfile
     lockfileDir: string
-    importerIds: string[]
+    importerIds?: string[]
     privateHoistPattern: string[]
     privateHoistedModulesDir: string
     publicHoistPattern: string[]
@@ -31,7 +31,7 @@ export default async function hoistByLockfile (
 
   const { directDeps, step } = lockfileWalker(
     opts.lockfile,
-    opts.importerIds
+    opts.importerIds ?? Object.keys(opts.lockfile.importers)
   )
   const deps = [
     {

--- a/packages/hoist/src/index.ts
+++ b/packages/hoist/src/index.ts
@@ -19,6 +19,7 @@ export default async function hoistByLockfile (
     extendNodePath?: boolean
     lockfile: Lockfile
     lockfileDir: string
+    importerIds: string[]
     privateHoistPattern: string[]
     privateHoistedModulesDir: string
     publicHoistPattern: string[]
@@ -30,7 +31,7 @@ export default async function hoistByLockfile (
 
   const { directDeps, step } = lockfileWalker(
     opts.lockfile,
-    Object.keys(opts.lockfile.importers)
+    opts.importerIds
   )
   const deps = [
     {

--- a/packages/supi/src/install/link.ts
+++ b/packages/supi/src/install/link.ts
@@ -249,6 +249,7 @@ export default async function linkPackages (
     newHoistedDependencies = await hoist({
       extendNodePath: opts.extendNodePath,
       lockfile: hoistLockfile,
+      importerIds: projectIds,
       lockfileDir: opts.lockfileDir,
       privateHoistedModulesDir: opts.hoistedModulesDir,
       privateHoistPattern: opts.hoistPattern ?? [],


### PR DESCRIPTION
close #3808 

## summary
When partial install in monorepo, the hoist packages under .pnpm/node_modules may be wrong as we use the whole importIds in the lockfile to collect deps instead of the selected projects.

This causes problems, for example, project-A depends on is-positive@2.0.0 and project-B depends on is-positive@3.0.0, and is-positive@2.0.0 presents first in the lockfile, then is-positive@2.0.0 will be picked wrongly to hoist when we partial install project-B. we expect to hoist is-positive@3.0.0 but is-positive@2.0.0 is picked.

and  the packages which is not in the filtered lockfile graph will be ignored here: https://github.com/pnpm/pnpm/blob/b14c9a0f1e8082a72672f0892c631d51e6430675/packages/hoist/src/index.ts#L194-L202, the filter lockfile graph doesn't includes is-positive@2.0.0 actually, so is-positive is skiped and will not be hoisted at all.

This pr tries  to fix this issue, a test is added for this case.