### PR TITLE
Add the `pnpm init` command

### DIFF
--- a/packages/plugin-commands-init/test/init.test.ts
+++ b/packages/plugin-commands-init/test/init.test.ts
@@ -1,0 +1,98 @@
+import PnpmError from '@pnpm/error'
+import { init } from '../src'
+
+// mock the file detection and writing functions
+
+describe('non-interactive mode', () => {
+  it('generates a valid package.json in the current directory', async () => {
+    await init.handler({}, [])
+
+    // check that the file was created
+  })
+
+  it('throws an error if a package.json exists in the current directory', async () => {
+    // mock the existence of ./package.json
+
+    await expect(
+      init.handler({}, [])
+    ).rejects.toThrow(PnpmError)
+
+    // check that the file wasn't created
+  })
+
+  it('throws an error on excess arguments', async () => {
+    await expect(
+      init.handler({}, ['directory', 'something-else'])
+    ).rejects.toThrow(PnpmError)
+
+    // check that the file wasn't created
+  })
+
+  it('overwrites the existing package.json in the current directory with `--force`', async () => {
+    // mock the existence of ./package.json
+
+    await init.handler({ force: true }, [])
+
+    // check that the file was overwritten
+  })
+
+  it('creates and respects the specified directory', async () => {
+    await init.handler({}, ['directory'])
+
+    // check that the directory and file were created
+  })
+})
+
+describe('interactive mode', () => {
+  it('generates a valid package.json in the current directory', async () => {
+    // mock the prompt
+
+    await init.handler({ interactive: true }, [])
+
+    // check that the file was created
+  })
+
+  it('respects the user\'s edits', async () => {
+    // mock the prompt
+
+    await init.handler({ interactive: true }, [])
+
+    // check that the file was created
+  })
+
+  it('screens quotes in user input', async () => {
+    // mock the prompt
+
+    await init.handler({ interactive: true }, [])
+
+    // check that the file was created
+  })
+
+  it('throws an error if a package.json exists in the current directory', async () => {
+    // mock the existence of ./package.json
+
+    await init.handler({ interactive: true }, [])
+
+    // check that the prompt wasn't called
+
+    // check that the file wasn't created
+  })
+
+  it('overwrites the existing package.json in the current directory with `--force`', async () => {
+    // mock the existence of ./package.json
+
+    // mock the prompt
+
+    await init.handler({ interactive: true, force: true }, [])
+
+    // check that the file was created
+  })
+
+  it('creates and respects the specified directory', async () => {
+    // mock the prompt
+
+    await init.handler({ interactive: true }, ['directory'])
+
+    // check that the directory and file were created
+  })
+})


### PR DESCRIPTION
That's where this commit should have gone.

I propose the following interface for `pnpm init`:

It would accept two options, `--interactive` and `--force`, and an optional parameter – the name of the directory to start a project in.

1. If you execute `pnpm init`, you will get a `package.json` generated in your current working directory with no questions asked. It will be a static template with placeholder values to fill out. I propose the following values:
   ```json
   {
     "name": "<here will be the name of the current working directory>",
     "description": "TODO: Project description.",
     "version": "0.1.0",
     "author": "TODO: Full Name (e-mail@address.com)",
     "license": "ISC"
   }
   ```
    1.1. If you have a `package.json` in your current working directory already, the command will not overwrite it and instead fail with a non-zero exit code.
    1.2. If you want to overwrite the existing `package.json`, use `pnpm init --force`
2. If you execute `pnpm init -i`, you will be asked a couple of questions:
   ```
   Do you intend to publish your package to npm? Yes / No
   Which Git hosting service will be used to store this project?
   ❭ None / Other
     GitHub
     GitLab
     Bitbucket
   ```
   Upon answering these questions, you will get a snippet prompt suggesting to fill in the placeholder values interactively. Depending on the choices in the questions above, the snippet will contain the fields:
   * `name`, `description`, `version`, `author`
   * `private`, if the package will not be published
   * `license`, if the package will be published
   * `repository`, if the package will be hosted on a Git hosting
   * `homepage`, `bugs`, if the package will be hosted on GitHub
3. If you execute `pnpm init some/directory`, then the `package.json` file will be generated in `./some/directory/`, these directories will be created if they do not exist previously. Same rules apply for `-f` and `-i` 
   
After the successful generation, perhaps we can suggest to run `git init` as well. Just as a message, not as something integrated into `pnpm`. 

What do you think?