### PR TITLE
fix(npm-resolver): scoped workspace alias (#3883)

### DIFF
--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -197,7 +197,7 @@ async function resolveNpm (
 }
 
 function workspacePrefToNpm (workspacePref: string): string {
-  const prefParts = /^workspace:([^@]+@)?(.*)$/.exec(workspacePref)
+  const prefParts = /^workspace:([^._/][^@]*@)?(.*)$/.exec(workspacePref)
   if (prefParts == null) {
     throw new Error(`Invalid workspace spec: ${workspacePref}`)
   }

--- a/packages/npm-resolver/test/index.ts
+++ b/packages/npm-resolver/test/index.ts
@@ -1653,6 +1653,105 @@ test('resolve workspace:~', async () => {
   expect(resolveResult!.manifest!.version).toBe('1.0.0')
 })
 
+test('resolve workspace:is-positive@^3.0.0', async () => {
+  const cacheDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    cacheDir,
+  })
+  const resolveResult = await resolve({ alias: 'is-my-positive-alias', pref: 'workspace:is-positive@^3.0.0' }, {
+    projectDir: '/home/istvan/src',
+    registry,
+    workspacePackages: {
+      'is-positive': {
+        '3.0.0': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '3.0.0',
+          },
+        },
+      },
+    },
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('local-filesystem')
+  expect(resolveResult!.id).toBe('link:is-positive')
+  expect(resolveResult!.latest).toBeFalsy()
+  expect(resolveResult!.resolution).toStrictEqual({
+    directory: '/home/istvan/src/is-positive',
+    type: 'directory',
+  })
+  expect(resolveResult!.manifest).toBeTruthy()
+  expect(resolveResult!.manifest!.name).toBe('is-positive')
+  expect(resolveResult!.manifest!.version).toBe('3.0.0')
+})
+
+test('resolve workspace:@scope/is-positive@^3.0.0', async () => {
+  const cacheDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    cacheDir,
+  })
+  const resolveResult = await resolve({ alias: '@scope2/is-my-positive-alias', pref: 'workspace:@scope/is-positive@^3.0.0' }, {
+    projectDir: '/home/istvan/src',
+    registry,
+    workspacePackages: {
+      '@scope/is-positive': {
+        '3.0.0': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '3.0.0',
+          },
+        },
+      },
+    },
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('local-filesystem')
+  expect(resolveResult!.id).toBe('link:is-positive')
+  expect(resolveResult!.latest).toBeFalsy()
+  expect(resolveResult!.resolution).toStrictEqual({
+    directory: '/home/istvan/src/is-positive',
+    type: 'directory',
+  })
+  expect(resolveResult!.manifest).toBeTruthy()
+  expect(resolveResult!.manifest!.name).toBe('is-positive')
+  expect(resolveResult!.manifest!.version).toBe('3.0.0')
+})
+
+test('resolve workspace:@scope/is-positive@~', async () => {
+  const cacheDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    cacheDir,
+  })
+  const resolveResult = await resolve({ alias: '@scope2/is-my-positive-alias', pref: 'workspace:@scope/is-positive@~' }, {
+    projectDir: '/home/istvan/src',
+    registry,
+    workspacePackages: {
+      '@scope/is-positive': {
+        '3.0.0': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '3.0.0',
+          },
+        },
+      },
+    },
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('local-filesystem')
+  expect(resolveResult!.id).toBe('link:is-positive')
+  expect(resolveResult!.latest).toBeFalsy()
+  expect(resolveResult!.resolution).toStrictEqual({
+    directory: '/home/istvan/src/is-positive',
+    type: 'directory',
+  })
+  expect(resolveResult!.manifest).toBeTruthy()
+  expect(resolveResult!.manifest!.name).toBe('is-positive')
+  expect(resolveResult!.manifest!.version).toBe('3.0.0')
+})
+
 test('resolveFromNpm() does not fail if the meta file contains no integrity information', async () => {
   nock(registry)
     .get('/is-positive')


### PR DESCRIPTION
Fix npm-resolver to resolve workspace aliases that contain scoped package names, e.g. `workspace:@scope/is-positive@^3.0.0`