### PR TITLE
fix: don't link to Node.js executables that are not managed by pnpm

### DIFF
--- a/.changeset/quiet-teachers-dance.md
+++ b/.changeset/quiet-teachers-dance.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Do not explicitly link to Node.js executables that are not in the pnpm home directory.

--- a/packages/plugin-commands-installation/src/install.ts
+++ b/packages/plugin-commands-installation/src/install.ts
@@ -279,7 +279,7 @@ export type InstallCommandOptions = Pick<Config,
   useBetaCli?: boolean
   recursive?: boolean
   workspace?: boolean
-} & Partial<Pick<Config, 'preferWorkspacePackages'>>
+} & Partial<Pick<Config, 'pnpmHomeDir' | 'preferWorkspacePackages'>>
 
 export async function handler (
   opts: InstallCommandOptions


### PR DESCRIPTION
close #3905