### PR TITLE
fix: do not print an info message about conflicting command names

### DIFF
--- a/.changeset/warm-crabs-sparkle.md
+++ b/.changeset/warm-crabs-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/link-bins": patch
+---
+
+Do not warn about bin conflicts, just log a debug message.

--- a/packages/link-bins/package.json
+++ b/packages/link-bins/package.json
@@ -49,6 +49,7 @@
     "ramda": "^0.27.1"
   },
   "devDependencies": {
+    "@pnpm/logger": "^4.0.0",
     "@types/is-windows": "^1.0.0",
     "@types/ncp": "^2.0.4",
     "@types/node": "^14.14.33",
@@ -59,5 +60,8 @@
     "path-exists": "^4.0.0",
     "tempy": "^1.0.0"
   },
-  "funding": "https://opencollective.com/pnpm"
+  "funding": "https://opencollective.com/pnpm",
+  "peerDependencies": {
+    "@pnpm/logger": "^4.0.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1164,6 +1164,7 @@ importers:
     specifiers:
       '@pnpm/error': workspace:2.0.0
       '@pnpm/link-bins': 'link:'
+      '@pnpm/logger': ^4.0.0
       '@pnpm/manifest-utils': workspace:2.1.0
       '@pnpm/package-bins': workspace:5.0.5
       '@pnpm/read-modules-dir': workspace:3.0.1
@@ -1203,6 +1204,7 @@ importers:
       ramda: 0.27.1
     devDependencies:
       '@pnpm/link-bins': 'link:'
+      '@pnpm/logger': 4.0.0
       '@types/is-windows': 1.0.0
       '@types/ncp': 2.0.5
       '@types/node': 14.17.27


### PR DESCRIPTION
close #3575