### PR TITLE
refactor: add pnpm execution from the source code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,9 @@
 ## Setting Up the Environment
 
 1. Run `pnpm install` in the root of the repository to install all dependencies.
-2. For compiling all projects, run `pnpm run compile` in the root of the repository. To run a task that will recompile the projects on change, run `pnpm run watch`.
-3. In order to run all the tests in the repository, run `pnpm run test-main`. You may also run tests of specific projects by running `pnpm test` inside a project's directory or using `pnpm --filter <project name> test`.
+2. Change any source code file and run `node <repo_directory>/packages/pnpm/spnpm [command] [flags]` to run `pnpm` directly from the source code by compiling all the files without typechecking in memory.
+3. Alternatively, for compiling all the projects with typechecking, run `pnpm run compile` in the root of the repository. To run a task that will recompile the projects on change, run `pnpm run watch`.
+4. In order to run all the tests in the repository, run `pnpm run test-main`. You may also run tests of specific projects by running `pnpm test` inside a project's directory or using `pnpm --filter <project name> test`.
 
 ## Submitting a Pull Request (PR)
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
+    "@babel/plugin-transform-modules-commonjs": "^7.15.4",
+    "@babel/plugin-proposal-dynamic-import": "^7.14.5",
+    "@babel/preset-typescript": "^7.10.1",
     "@changesets/cli": "^2.17.0",
     "@commitlint/cli": "^13.2.1",
     "@commitlint/config-conventional": "^13.2.0",

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -54,6 +54,7 @@
     "@pnpm/prepare": "workspace:0.0.26",
     "@pnpm/read-package-json": "workspace:5.0.4",
     "@pnpm/read-project-manifest": "workspace:2.0.5",
+    "@pnpm/ts-execution-runtime": "workspace:1.0.0",
     "@pnpm/run-npm": "workspace:3.1.0",
     "@pnpm/store-path": "^5.0.0",
     "@pnpm/tabtab": "^0.1.2",

--- a/packages/pnpm/spnpm.js
+++ b/packages/pnpm/spnpm.js
@@ -1,0 +1,3 @@
+require('@pnpm/ts-execution-runtime')
+
+require('./src/pnpm.ts')

--- a/packages/pnpm/spnpx.js
+++ b/packages/pnpm/spnpx.js
@@ -1,0 +1,3 @@
+require('@pnpm/ts-execution-runtime')
+
+require('./src/pnpx.ts')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
   .:
     specifiers:
       '@babel/core': ^7.15.8
+      '@babel/plugin-proposal-dynamic-import': ^7.14.5
+      '@babel/plugin-transform-modules-commonjs': ^7.15.4
+      '@babel/preset-typescript': ^7.10.1
       '@changesets/cli': ^2.17.0
       '@commitlint/cli': ^13.2.1
       '@commitlint/config-conventional': ^13.2.0
@@ -57,6 +60,9 @@ importers:
       yarn: ^1.22.17
     devDependencies:
       '@babel/core': 7.15.8
+      '@babel/plugin-proposal-dynamic-import': 7.14.5_@babel+core@7.15.8
+      '@babel/plugin-transform-modules-commonjs': 7.15.4_@babel+core@7.15.8
+      '@babel/preset-typescript': 7.15.0_@babel+core@7.15.8
       '@changesets/cli': 2.17.0
       '@commitlint/cli': 13.2.1
       '@commitlint/config-conventional': 13.2.0
@@ -2707,6 +2713,7 @@ importers:
       '@pnpm/run-npm': workspace:3.1.0
       '@pnpm/store-path': ^5.0.0
       '@pnpm/tabtab': ^0.1.2
+      '@pnpm/ts-execution-runtime': workspace:1.0.0
       '@pnpm/types': workspace:7.4.0
       '@pnpm/write-project-manifest': workspace:2.0.4
       '@types/byline': ^4.2.32
@@ -2799,6 +2806,7 @@ importers:
       '@pnpm/run-npm': link:../run-npm
       '@pnpm/store-path': 5.0.0
       '@pnpm/tabtab': 0.1.2
+      '@pnpm/ts-execution-runtime': link:../../utils/ts-execution-runtime
       '@pnpm/types': link:../types
       '@pnpm/write-project-manifest': link:../write-project-manifest
       '@types/byline': 4.2.33
@@ -3416,6 +3424,12 @@ importers:
       execa: /safe-execa/0.1.1
       make-empty-dir: 2.0.0
 
+  utils/ts-execution-runtime:
+    specifiers:
+      '@babel/register': ^7.13.16
+    devDependencies:
+      '@babel/register': 7.15.3_@babel+core@7.15.8
+
   utils/tsconfig:
     specifiers:
       '@pnpm/tsconfig': 'link:'
@@ -3473,6 +3487,13 @@ packages:
       source-map: 0.5.7
     dev: true
 
+  /@babel/helper-annotate-as-pure/7.15.4:
+    resolution: {integrity: sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.15.6
+    dev: true
+
   /@babel/helper-compilation-targets/7.15.4_@babel+core@7.15.8:
     resolution: {integrity: sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==}
     engines: {node: '>=6.9.0'}
@@ -3484,6 +3505,23 @@ packages:
       '@babel/helper-validator-option': 7.14.5
       browserslist: 4.17.5
       semver: 6.3.0
+    dev: true
+
+  /@babel/helper-create-class-features-plugin/7.15.4_@babel+core@7.15.8:
+    resolution: {integrity: sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-annotate-as-pure': 7.15.4
+      '@babel/helper-function-name': 7.15.4
+      '@babel/helper-member-expression-to-functions': 7.15.4
+      '@babel/helper-optimise-call-expression': 7.15.4
+      '@babel/helper-replace-supers': 7.15.4
+      '@babel/helper-split-export-declaration': 7.15.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/helper-function-name/7.15.4:
@@ -3633,6 +3671,17 @@ packages:
       '@babel/types': 7.15.6
     dev: true
 
+  /@babel/plugin-proposal-dynamic-import/7.14.5_@babel+core@7.15.8:
+    resolution: {integrity: sha512-ExjiNYc3HDN5PXJx+bwC50GIx/KKanX2HiggnIUAYedbARdImiCU4RhhHfdf0Kd7JNXGpsBBBCOm+bBVy3Gb0g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.15.8
+    dev: true
+
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.15.8:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
@@ -3653,6 +3702,15 @@ packages:
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.15.8:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.15.8:
+    resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
@@ -3750,6 +3808,63 @@ packages:
     dependencies:
       '@babel/core': 7.15.8
       '@babel/helper-plugin-utils': 7.14.5
+    dev: true
+
+  /@babel/plugin-transform-modules-commonjs/7.15.4_@babel+core@7.15.8:
+    resolution: {integrity: sha512-qg4DPhwG8hKp4BbVDvX1s8cohM8a6Bvptu4l6Iingq5rW+yRUAhe/YRup/YcW2zCOlrysEWVhftIcKzrEZv3sA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-module-transforms': 7.15.8
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-simple-access': 7.15.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/plugin-transform-typescript/7.15.8_@babel+core@7.15.8:
+    resolution: {integrity: sha512-ZXIkJpbaf6/EsmjeTbiJN/yMxWPFWvlr7sEG1P95Xb4S4IBcrf2n7s/fItIhsAmOf8oSh3VJPDppO6ExfAfKRQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-create-class-features-plugin': 7.15.4_@babel+core@7.15.8
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/plugin-syntax-typescript': 7.14.5_@babel+core@7.15.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-typescript/7.15.0_@babel+core@7.15.8:
+    resolution: {integrity: sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      '@babel/helper-plugin-utils': 7.14.5
+      '@babel/helper-validator-option': 7.14.5
+      '@babel/plugin-transform-typescript': 7.15.8_@babel+core@7.15.8
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/register/7.15.3_@babel+core@7.15.8:
+    resolution: {integrity: sha512-mj4IY1ZJkorClxKTImccn4T81+UKTo4Ux0+OFSV9hME1ooqS9UV+pJ6BjD0qXPK4T3XW/KNa79XByjeEMZz+fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.15.8
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.1
+      source-map-support: 0.5.20
     dev: true
 
   /@babel/runtime/7.15.4:
@@ -6249,6 +6364,12 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-dynamic-import-node/2.3.3:
+    resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
+    dependencies:
+      object.assign: 4.1.2
+    dev: true
+
   /babel-plugin-istanbul/6.1.1:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
@@ -6985,6 +7106,10 @@ packages:
   /commander/8.1.0:
     resolution: {integrity: sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==}
     engines: {node: '>= 12'}
+    dev: true
+
+  /commondir/1.0.1:
+    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
     dev: true
 
   /compare-func/2.0.0:
@@ -8618,6 +8743,15 @@ packages:
       unpipe: 1.0.0
     dev: true
 
+  /find-cache-dir/2.1.0:
+    resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 2.1.0
+      pkg-dir: 3.0.0
+    dev: true
+
   /find-packages/8.0.5:
     resolution: {integrity: sha512-uOWyMebURrYdumRBylY1fLNUZG8Wjzuyv+UkD0MX1H+aQNcDhtINSw5oM5HKCBpBGHQO3PlhyVxmfKrPM840sw==}
     engines: {node: '>=12.17'}
@@ -8646,6 +8780,13 @@ packages:
     dependencies:
       locate-path: 2.0.0
     dev: false
+
+  /find-up/3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
+    dependencies:
+      locate-path: 3.0.0
+    dev: true
 
   /find-up/4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -10872,6 +11013,14 @@ packages:
       path-exists: 3.0.0
     dev: false
 
+  /locate-path/3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+    dev: true
+
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -12086,6 +12235,13 @@ packages:
       p-limit: 1.3.0
     dev: false
 
+  /p-locate/3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: true
+
   /p-locate/4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -12420,6 +12576,13 @@ packages:
     dependencies:
       find-up: 2.1.0
     dev: false
+
+  /pkg-dir/3.0.0:
+    resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
+    engines: {node: '>=6'}
+    dependencies:
+      find-up: 3.0.0
+    dev: true
 
   /pkg-dir/4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}

--- a/utils/ts-execution-runtime/README.md
+++ b/utils/ts-execution-runtime/README.md
@@ -1,0 +1,25 @@
+# @pnpm/ts-execution-runtime
+
+> pnpm's TypeScript execution runtime
+
+## Usage
+
+Create the `js` file in the TypeScript package you want to execute directly from source with the following contents:
+
+```js
+require('@pnpm/ts-execution-runtime')
+
+require('./src/index.ts')
+```
+
+## Rationale
+
+There are cases when the contributor wants to check changes to `pnpm` codebase as quick as possible. The TypeScript compiler does not currently let the user compile the code without typechecking, thus this process is pretty slow. The typechecking step can also be skipped for quick changes, because editors typically have `eslint` integration and do typechecking inside
+modified files.
+
+Tnis module allows to use `@babel/register` to transpile `pnpm` TypeScript source code on the fly
+without typechecking. In order to use this module on `pnpm` source code, one needs to execute: `node <repo_directory>/packages/pnpm/spnpm [command] [flags]`
+
+## License
+
+MIT

--- a/utils/ts-execution-runtime/index.js
+++ b/utils/ts-execution-runtime/index.js
@@ -1,0 +1,18 @@
+const babelRegister = require('@babel/register')
+const path = require('path')
+
+const root = path.dirname(path.dirname(__dirname))
+
+babelRegister({
+  root,
+  cwd: root,
+  extensions: ['.ts'],
+  presets: [
+    '@babel/preset-typescript',
+  ],
+  plugins: [
+    '@babel/plugin-transform-modules-commonjs',
+    '@babel/plugin-proposal-dynamic-import',
+    require.resolve('./rewrite-imports.js')
+  ]
+})

--- a/utils/ts-execution-runtime/package.json
+++ b/utils/ts-execution-runtime/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@pnpm/ts-execution-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "main": "index.js",
+  "devDependencies": {
+    "@babel/register": "^7.13.16"
+  }
+}

--- a/utils/ts-execution-runtime/rewrite-imports.js
+++ b/utils/ts-execution-runtime/rewrite-imports.js
@@ -1,0 +1,90 @@
+// This plugin transforms module imports inside `pnpm` codebase, so that they point to
+// TypeScript sources `src/index.ts` and not to declared entrypoints `lib/index.js`.
+// Also, sometimes the code uses deep imports from `@pnpm/.../lib/...` packages,
+// the plugin rewrites `lib` to `src` for such deep imports to point back to TypeScript code
+
+const path = require('path')
+
+const NATIVE_MODULES = new Set(Object.keys(process.binding('natives')))
+
+module.exports = ({ types: t }, opts) => {
+  function rewriteModulePath(source, file, state) {
+    const opts = state.opts
+    let result = source
+    const sourceParts = source.split('/')
+    const isQualifiedModulePath = sourceParts.length > 2 || (sourceParts.length == 2 && sourceParts[0][0] !== '@')
+    if (!isQualifiedModulePath && !path.isAbsolute(source) && !source.startsWith('.') && !NATIVE_MODULES.has(source)) {
+      try {
+        const packageRootDir = path.dirname(require.resolve(source + '/package.json', {paths: [file]}))
+        if (packageRootDir.split(path.sep).indexOf('node_modules') < 0) {
+          result = path.join(packageRootDir, 'src/index.ts')
+        }
+      } catch (e) {
+        // If we have hit ESM module, we just ignore this case for now and do not rewrite imports
+        if (e.code !== 'ERR_PACKAGE_PATH_NOT_EXPORTED')
+          throw e;
+      }
+    }
+    if (isQualifiedModulePath && source.startsWith('@pnpm/') && source.indexOf('/lib/') >= 0) {
+      result = source.replace('/lib/', '/src/')
+    }
+
+    if (result !== source) {
+      return result
+    } else {
+      return
+    }
+  }
+
+  function replaceRequire(nodePath, state) {
+    if (
+      !t.isIdentifier(nodePath.node.callee, { name: 'require' }) &&
+        !(
+            t.isMemberExpression(nodePath.node.callee) &&
+            t.isIdentifier(nodePath.node.callee.object, { name: 'require' })
+        )
+    ) {
+      return
+    }
+
+    const moduleArg = nodePath.node.arguments[0]
+    if (moduleArg && moduleArg.type === 'StringLiteral') {
+      const modulePath = rewriteModulePath(moduleArg.value, state.file.opts.filename, state)
+      if (modulePath) {
+        nodePath.replaceWith(t.callExpression(
+          nodePath.node.callee, [t.stringLiteral(modulePath)]
+        ))
+      }
+    }
+  }
+
+  function replaceImportExport(nodePath, state) {
+    const moduleArg = nodePath.node.source
+    if (moduleArg && moduleArg.type === 'StringLiteral') {
+      const modulePath = rewriteModulePath(moduleArg.value, state.file.opts.filename, state)
+      if (modulePath) {
+        nodePath.node.source = t.stringLiteral(modulePath)
+      }
+    }
+  }
+
+  return {
+    visitor: {
+      CallExpression: {
+        exit(nodePath, state) {
+          return replaceRequire(nodePath, state)
+        }
+      },
+      ImportDeclaration: {
+        exit(nodePath, state) {
+          return replaceImportExport(nodePath, state)
+        }
+      },
+      ExportDeclaration: {
+        exit(nodePath, state) {
+          return replaceImportExport(nodePath, state)
+        }
+      },
+    }
+  }
+}


### PR DESCRIPTION
Implements execution of `pnpm` from the source code in development mode. This is a replacement for PR #3921, but this time the implementation is done with minimal changes to `pnpm` codebase.

At the moment when one wants to quickly check their changes to pnpm by running a binary have to compile binary first via pnpm run compile. This process is relatively slow.

pnpm run compile in the best case takes 46 seconds on my laptop. This process is slow in part because ALL of the TypeScript files are typechecked. But one usually changes only a few source code files and most of the time they are typechcked by the eslint integration in the editor.

I have added an option to use babel to transpile pnpm source code on the fly. In order to use it one needs to execute command: node <repo_directory>/packages/pnpm/pnpm [command] [flags].

On my laptop node <repo_directory>/packages/pnpm/pnpm help takes 1.5 secs. Running the pnpm help take 0.5 secs. After changing some source code files and running node <repo_directory>/packages/pnpm/pnpm help takes 2.5 secs.

Running pnpm directly from source code is orders of magnitude faster than compiling binary with type-checking, however bootstrap time is worse, of course. Another bonus is that running directly from source code is easier for new contributors and for quickly checking small changes.