### PR TITLE
chore: public-hoist-pattern prettier config

### DIFF
--- a/.changeset/new-insects-invent.md
+++ b/.changeset/new-insects-invent.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+Any package with "prettier" in its name is hoisted.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -190,8 +190,7 @@ export default async (
     'prefer-workspace-packages': false,
     'public-hoist-pattern': [
       '*eslint*',
-      '@prettier/plugin-*',
-      '*prettier-plugin-*',
+      '*prettier*',
     ],
     'recursive-install': true,
     registry: npmDefaults.registry,


### PR DESCRIPTION
`prettier` need hoist