### PR TITLE
fix: use the system default Node.js to check package compatibility

### DIFF
--- a/.changeset/stale-mayflies-hear.md
+++ b/.changeset/stale-mayflies-hear.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/package-is-installable": patch
+"pnpm": patch
+---
+
+Use the system default Node.js version to check package compatibility [#3785](https://github.com/pnpm/pnpm/issues/3785).

--- a/packages/cli-utils/src/packageIsInstallable.ts
+++ b/packages/cli-utils/src/packageIsInstallable.ts
@@ -11,12 +11,16 @@ export function packageIsInstallable (
   },
   opts: {
     engineStrict?: boolean
+    nodeVersion?: string
   }
 ) {
   const pnpmVersion = packageManager.name === 'pnpm'
     ? packageManager.stableVersion
     : undefined
-  const err = checkPackage(pkgPath, pkg, { pnpmVersion })
+  const err = checkPackage(pkgPath, pkg, {
+    nodeVersion: opts.nodeVersion,
+    pnpmVersion,
+  })
   if (err === null) return
   if (
     (err instanceof UnsupportedEngineError && err.wanted.pnpm) ??

--- a/packages/cli-utils/src/readProjectManifest.ts
+++ b/packages/cli-utils/src/readProjectManifest.ts
@@ -4,7 +4,10 @@ import { packageIsInstallable } from './packageIsInstallable'
 
 export async function readProjectManifest (
   projectDir: string,
-  opts: { engineStrict?: boolean }
+  opts: {
+    engineStrict?: boolean
+    nodeVersion?: string
+  }
 ): Promise<{
     fileName: string
     manifest: ProjectManifest
@@ -17,7 +20,10 @@ export async function readProjectManifest (
 
 export async function readProjectManifestOnly (
   projectDir: string,
-  opts: { engineStrict?: boolean }
+  opts: {
+    engineStrict?: boolean
+    nodeVersion?: string
+  }
 ): Promise<ProjectManifest> {
   const manifest = await utils.readProjectManifestOnly(projectDir)
   packageIsInstallable(projectDir, manifest as any, opts) // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -26,7 +32,10 @@ export async function readProjectManifestOnly (
 
 export async function tryReadProjectManifest (
   projectDir: string,
-  opts: { engineStrict?: boolean }
+  opts: {
+    engineStrict?: boolean
+    nodeVersion?: string
+  }
 ): Promise<{
     fileName: string
     manifest: ProjectManifest | null

--- a/packages/find-workspace-packages/src/index.ts
+++ b/packages/find-workspace-packages/src/index.ts
@@ -11,6 +11,7 @@ export default async (
   workspaceRoot: string,
   opts?: {
     engineStrict?: boolean
+    nodeVersion?: string
     patterns?: string[]
   }
 ) => {

--- a/packages/package-is-installable/package.json
+++ b/packages/package-is-installable/package.json
@@ -32,6 +32,8 @@
     "@pnpm/core-loggers": "workspace:6.0.6",
     "@pnpm/error": "workspace:2.0.0",
     "@pnpm/types": "workspace:7.6.0",
+    "execa": "npm:safe-execa@^0.1.1",
+    "mem": "^8.0.0",
     "semver": "^7.3.4"
   },
   "devDependencies": {

--- a/packages/package-is-installable/src/getSystemNodeVersion.ts
+++ b/packages/package-is-installable/src/getSystemNodeVersion.ts
@@ -1,0 +1,11 @@
+import mem from 'mem'
+import * as execa from 'execa'
+
+export function getSystemNodeVersionNonCached () {
+  if (process['pkg'] != null) {
+    return execa.sync('node', ['--version']).stdout.toString()
+  }
+  return process.version
+}
+
+export const getSystemNodeVersion = mem(getSystemNodeVersionNonCached)

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -2,20 +2,12 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
-import mem from 'mem'
-import * as execa from 'execa'
 import checkEngine, { UnsupportedEngineError, WantedEngine } from './checkEngine'
 import checkPlatform, { UnsupportedPlatformError } from './checkPlatform'
+import { getSystemNodeVersion } from './getSystemNodeVersion'
 
 export { Engine } from './checkEngine'
 export { Platform, WantedPlatform } from './checkPlatform'
-
-const systemNodeVersion = mem(function systemNodeVersion () {
-  if (process['pkg'] != null) {
-    return execa.sync('node', ['-v']).stdout.toString()
-  }
-  return process.version
-})
 
 export {
   UnsupportedEngineError,
@@ -88,7 +80,7 @@ export function checkPackage (
     (manifest.engines == null)
       ? null
       : checkEngine(pkgId, manifest.engines, {
-        node: options.nodeVersion ?? systemNodeVersion(),
+        node: options.nodeVersion ?? getSystemNodeVersion(),
         pnpm: options.pnpmVersion,
       })
   )

--- a/packages/package-is-installable/src/index.ts
+++ b/packages/package-is-installable/src/index.ts
@@ -2,11 +2,20 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
+import mem from 'mem'
+import * as execa from 'execa'
 import checkEngine, { UnsupportedEngineError, WantedEngine } from './checkEngine'
 import checkPlatform, { UnsupportedPlatformError } from './checkPlatform'
 
 export { Engine } from './checkEngine'
 export { Platform, WantedPlatform } from './checkPlatform'
+
+const systemNodeVersion = mem(function systemNodeVersion () {
+  if (process['pkg'] != null) {
+    return execa.sync('node', ['-v']).stdout.toString()
+  }
+  return process.version
+})
 
 export {
   UnsupportedEngineError,
@@ -79,7 +88,7 @@ export function checkPackage (
     (manifest.engines == null)
       ? null
       : checkEngine(pkgId, manifest.engines, {
-        node: options.nodeVersion ?? process.version,
+        node: options.nodeVersion ?? systemNodeVersion(),
         pnpm: options.pnpmVersion,
       })
   )

--- a/packages/package-is-installable/test/getSystemNodeVersion.test.ts
+++ b/packages/package-is-installable/test/getSystemNodeVersion.test.ts
@@ -1,0 +1,19 @@
+import { getSystemNodeVersionNonCached } from '@pnpm/package-is-installable/lib/getSystemNodeVersion'
+import * as execa from 'execa'
+
+jest.mock('execa', () => ({
+  sync: jest.fn(() => ({
+    stdout: 'v10.0.0',
+  })),
+}))
+
+test('getSystemNodeVersion() executed from an executable pnpm CLI', () => {
+  process['pkg'] = {}
+  expect(getSystemNodeVersionNonCached()).toBe('v10.0.0')
+  expect(execa.sync).toHaveBeenCalledWith('node', ['--version'])
+})
+
+test('getSystemNodeVersion() from a non-executable pnpm CLI', () => {
+  delete process['pkg']
+  expect(getSystemNodeVersionNonCached()).toBe(process.version)
+})

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -253,6 +253,7 @@ export default async function run (inputArgv: string[]) {
     if (config.useNodeVersion != null) {
       const nodePath = await node.getNodeBinDir(config)
       config.extraBinPaths.push(nodePath)
+      config.nodeVersion = config.useNodeVersion
     }
     let result = pnpmCmds[cmd ?? 'help'](
       // TypeScript doesn't currently infer that the type of config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,11 +1773,15 @@ importers:
       '@pnpm/package-is-installable': 'link:'
       '@pnpm/types': workspace:7.6.0
       '@types/semver': ^7.3.4
+      execa: npm:safe-execa@^0.1.1
+      mem: ^8.0.0
       semver: ^7.3.4
     dependencies:
       '@pnpm/core-loggers': link:../core-loggers
       '@pnpm/error': link:../error
       '@pnpm/types': link:../types
+      execa: /safe-execa/0.1.1
+      mem: 8.1.1
       semver: 7.3.5
     devDependencies:
       '@pnpm/logger': 4.0.0


### PR DESCRIPTION
close #3785
close #3673

TODO:
* [x] it should work when the Node.js version is set via the `use-node-version` setting in `.npmrc`.