### PR TITLE
ci: workaround for PowerShell 7.2.0 issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
     - name: install pnpm and npm
       run: |
         curl -L https://get.pnpm.io/v6.16.js | node - add --global pnpm@next npm@7
+      shell: bash # workaround for PowerShell 7.2.0 \x1b piping issue
     - name: pnpm install
       run: pnpm install
     - name: Audit


### PR DESCRIPTION
PowerShell 7.2.0 has an issue piping (maybe downloading) `\x1b` character (#3770).