### PR TITLE
feat(dlx): handle version specifiers in command names

### DIFF
--- a/.changeset/rich-horses-know.md
+++ b/.changeset/rich-horses-know.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+`pnpm dlx` will now support version specifiers for packages.

--- a/packages/plugin-commands-script-runners/src/dlx.ts
+++ b/packages/plugin-commands-script-runners/src/dlx.ts
@@ -68,7 +68,7 @@ export async function handler (
   await execa('pnpm', pnpmArgs, {
     stdio: 'inherit',
   })
-  await execa(scopeless(params[0]), params.slice(1), {
+  await execa(versionless(scopeless(params[0])), params.slice(1), {
     env: {
       ...process.env,
       [PATH]: [
@@ -85,4 +85,8 @@ function scopeless (pkgName: string) {
     return pkgName.split('/')[1]
   }
   return pkgName
+}
+
+function versionless (scopelessPkgName: string) {
+  return scopelessPkgName.split('@')[0]
 }

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -11,3 +11,11 @@ test('dlx should work with scoped packages', async () => {
 
   expect(execa).toBeCalledWith('bar', [], expect.anything())
 })
+
+test('dlx should work with versioned packages', async () => {
+  prepareEmpty()
+
+  await dlx.handler({}, ['@foo/bar@next'])
+
+  expect(execa).toBeCalledWith('bar', [], expect.anything())
+})

--- a/packages/plugin-commands-script-runners/test/dlx.ts
+++ b/packages/plugin-commands-script-runners/test/dlx.ts
@@ -4,6 +4,8 @@ import { prepareEmpty } from '@pnpm/prepare'
 
 jest.mock('execa')
 
+beforeEach((execa as jest.Mock).mockClear)
+
 test('dlx should work with scoped packages', async () => {
   prepareEmpty()
 
@@ -17,5 +19,10 @@ test('dlx should work with versioned packages', async () => {
 
   await dlx.handler({}, ['@foo/bar@next'])
 
+  expect(execa).toBeCalledWith(
+    'pnpm',
+    expect.arrayContaining(['add', '@foo/bar@next']),
+    expect.anything()
+  )
   expect(execa).toBeCalledWith('bar', [], expect.anything())
 })


### PR DESCRIPTION
Closes #4023 

Now you can run commands like `pnpm dlx some-package@1.0.0` and `pnpm create svelte@next` without getting errors due to version specifiers present in the package.