### PR TITLE
ci: add pnpm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: ${{ matrix.node }}
         cache: 'pnpm'
     - name: Install npm@7
-      run: node - add --global npm@7
+      run: pnpm add --global npm@7
     - name: pnpm install
       run: pnpm install
     - name: Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         git config --global user.email "x@y.z"
     - name: Checkout Commit
       uses: actions/checkout@v1
-    - name: checkout main
-      run: git branch -f main origin/main
     - name: Install pnpm
       uses: pnpm/action-setup@v2.0.1
       with: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}
+        cache: 'pnpm'
     - name: checkout main
       run: git branch -f main origin/main
     - name: install pnpm and npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,17 @@ jobs:
         git config --global user.email "x@y.z"
     - name: Checkout Commit
       uses: actions/checkout@v1
+    - name: checkout main
+      run: git branch -f main origin/main
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2.0.1
+      with: 
+        version: next
     - name: Setup Node
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}
         cache: 'pnpm'
-    - name: checkout main
-      run: git branch -f main origin/main
-    - name: install pnpm and npm
-      run: |
-        ${{ runner.os == 'Windows' && '$PSStyle.OutputRendering = "Ansi"' || '' }}
-        curl -L https://get.pnpm.io/v6.16.js | node - add --global pnpm@next npm@7
     - name: pnpm install
       run: pnpm install
     - name: Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
         cache: 'pnpm'
+    - name: Install npm@7
+      run: node - add --global npm@7
     - name: pnpm install
       run: pnpm install
     - name: Audit


### PR DESCRIPTION
As the `actions/setup-node@v2`'s new feature, it now support cache the pnpm install: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
