### PR TITLE
CI: setup cache for TS and Jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
           packages/*/tsconfig.tsbuildinfo
           privatePackages/*/lib
           privatePackages/*/tsconfig.tsbuildinfo
-        key: ${{ runner.os }}-${{ matrix.node }}-test
+          .jest-cache
+        key: ${{ runner.os }}-${{ matrix.node }}-test1
     - name: run tests (main)
       if: github.ref == 'refs/heads/main'
       run: pnpm run test-main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: pnpm install
     # - name: Audit
       # run: pnpm audit
-    - name: Cache TypeScript
+    - name: Cache TypeScript and Jest
       uses: actions/cache@v2
       with:
         path: |
@@ -50,7 +50,8 @@ jobs:
           privatePackages/*/lib
           privatePackages/*/tsconfig.tsbuildinfo
           .jest-cache
-        key: ${{ runner.os }}-${{ matrix.node }}-test1
+        key: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-${{ github.run_id }}
+        restore-keys: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-
     - name: run tests (main)
       if: github.ref == 'refs/heads/main'
       run: pnpm run test-main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Install pnpm
       uses: pnpm/action-setup@v2.0.1
-      with: 
+      with:
         version: next
     - name: Setup Node
       uses: actions/setup-node@v2
@@ -41,6 +41,15 @@ jobs:
       run: pnpm install
     # - name: Audit
       # run: pnpm audit
+    - name: Cache TypeScript
+      uses: actions/cache@v2
+      with:
+        path: |
+          packages/*/lib
+          packages/*/tsconfig.tsbuildinfo
+          privatePackages/*/lib
+          privatePackages/*/tsconfig.tsbuildinfo
+        key: ${{ runner.os }}-${{ matrix.node }}-test
     - name: run tests (main)
       if: github.ref == 'refs/heads/main'
       run: pnpm run test-main

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ storage
 yarn.lock
 
 RELEASE.md
+
+.jest-cache

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -168,7 +168,7 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
       scripts._test = `${scripts._test} && pnpm posttest`
     }
   }
-  scripts.compile = 'rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix'
+  scripts.compile = 'tsc --build && pnpm run lint -- --fix'
   delete scripts.tsc
   let homepage: string
   let repository: string | { type: 'git', url: string }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 const path = require("path");
 
+const pathAsArr = process.env.PNPM_SCRIPT_SRC_DIR.split(path.sep);
+const packageName = pathAsArr[pathAsArr.length - 1];
+
 module.exports = {
   preset: "ts-jest",
   testMatch: ["**/test/**/*.[jt]s?(x)", "**/src/**/*.test.ts"],
@@ -9,4 +12,5 @@ module.exports = {
   testPathIgnorePatterns: ["/fixtures/", "<rootDir>/test/utils/.+"],
   testTimeout: 4 * 60 * 1000, // 4 minutes
   setupFilesAfterEnv: [path.join(__dirname, "jest.setup.js")],
+  cacheDirectory: path.join(__dirname, ".jest-cache", packageName),
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,12 @@
-const path = require('path')
+const path = require("path");
 
 module.exports = {
-  preset: 'ts-jest',
+  preset: "ts-jest",
   testMatch: ["**/test/**/*.[jt]s?(x)", "**/src/**/*.test.ts"],
-  testEnvironment: 'node',
+  testEnvironment: "node",
   collectCoverage: true,
-  coveragePathIgnorePatterns: ['/node_modules/'],
-  testPathIgnorePatterns: [
-    '/fixtures/',
-    '<rootDir>/test/utils/.+',
-  ],
+  coveragePathIgnorePatterns: ["/node_modules/"],
+  testPathIgnorePatterns: ["/fixtures/", "<rootDir>/test/utils/.+"],
   testTimeout: 4 * 60 * 1000, // 4 minutes
-  setupFilesAfterEnv: [path.join(__dirname, 'jest.setup.js')],
+  setupFilesAfterEnv: [path.join(__dirname, "jest.setup.js")],
 };

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/audit",
   "keywords": [

--- a/packages/build-modules/package.json
+++ b/packages/build-modules/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/build-modules",
   "keywords": [

--- a/packages/cafs/package.json
+++ b/packages/cafs/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "prepublishOnly": "pnpm run compile"
   },
   "keywords": [

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/calc-dep-state",
   "keywords": [

--- a/packages/cli-meta/package.json
+++ b/packages/cli-meta/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/cli-meta",
   "keywords": [

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "test": "pnpm run compile"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/cli-utils",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/client",
   "keywords": [

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/command",
   "keywords": [

--- a/packages/common-cli-options-help/package.json
+++ b/packages/common-cli-options-help/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/common-cli-options-help",
   "keywords": [

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -15,7 +15,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "start": "tsc --watch",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/config",
   "keywords": [

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/constants",
   "keywords": [

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -34,7 +34,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/types": "workspace:7.9.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -143,7 +143,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=4873 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "funding": "https://opencollective.com/pnpm"
 }

--- a/packages/default-reporter/package.json
+++ b/packages/default-reporter/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/default-reporter",
   "keywords": [

--- a/packages/default-resolver/package.json
+++ b/packages/default-resolver/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/default-resolver",
   "keywords": [

--- a/packages/dependencies-hierarchy/package.json
+++ b/packages/dependencies-hierarchy/package.json
@@ -13,7 +13,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "engines": {
     "node": ">=12.17"

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -13,7 +13,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/dependency-path",
   "keywords": [

--- a/packages/directory-fetcher/package.json
+++ b/packages/directory-fetcher/package.json
@@ -14,7 +14,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/directory-fetcher",
   "engines": {

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/error",
   "keywords": [

--- a/packages/exportable-manifest/package.json
+++ b/packages/exportable-manifest/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "_test": "jest"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/exportable-manifest",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/fetch",
   "keywords": [

--- a/packages/fetcher-base/package.json
+++ b/packages/fetcher-base/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/fetcher-base",
   "keywords": [

--- a/packages/fetching-types/package.json
+++ b/packages/fetching-types/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/fetching-types#readme",
   "scripts": {
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile"

--- a/packages/file-reporter/package.json
+++ b/packages/file-reporter/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/file-reporter",
   "keywords": [

--- a/packages/filter-lockfile/package.json
+++ b/packages/filter-lockfile/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/filter-lockfile",
   "keywords": [

--- a/packages/filter-workspace-packages/package.json
+++ b/packages/filter-workspace-packages/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/filter-workspace-packages",
   "keywords": [

--- a/packages/find-packages/package.json
+++ b/packages/find-packages/package.json
@@ -13,7 +13,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/find-packages",
   "keywords": [

--- a/packages/find-workspace-dir/package.json
+++ b/packages/find-workspace-dir/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/find-workspace-dir",
   "keywords": [

--- a/packages/find-workspace-packages/package.json
+++ b/packages/find-workspace-packages/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/find-workspace-packages",
   "keywords": [

--- a/packages/get-context/package.json
+++ b/packages/get-context/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/get-context",
   "keywords": [

--- a/packages/git-fetcher/package.json
+++ b/packages/git-fetcher/package.json
@@ -13,7 +13,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/git-fetcher",
   "engines": {

--- a/packages/git-resolver/package.json
+++ b/packages/git-resolver/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/git-resolver",
   "keywords": [

--- a/packages/global-bin-dir/package.json
+++ b/packages/global-bin-dir/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "_test": "jest"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/global-bin-dir",

--- a/packages/graceful-fs/package.json
+++ b/packages/graceful-fs/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/graceful-fs",
   "keywords": [

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -64,7 +64,7 @@
     "prepublishOnly": "pnpm run compile",
     "runPrepareFixtures": "node ../pnpm/bin/pnpm.cjs i -r -C test/fixtures --no-shared-workspace-lockfile --no-link-workspace-packages --lockfile-only --registry http://localhost:4873/ --ignore-scripts --force --no-strict-peer-dependencies",
     "prepareFixtures": "registry-mock prepare && run-p -r registry-mock runPrepareFixtures",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/build-modules": "workspace:8.0.0",

--- a/packages/hoist/package.json
+++ b/packages/hoist/package.json
@@ -37,7 +37,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/constants": "workspace:5.0.0",

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lifecycle",
   "keywords": [

--- a/packages/link-bins/package.json
+++ b/packages/link-bins/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json --project . --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/link-bins",
   "keywords": [

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -16,7 +16,7 @@
     "pretest": "pnpm run pretest --filter dependencies-hierarchy",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/list",
   "keywords": [

--- a/packages/local-resolver/package.json
+++ b/packages/local-resolver/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/local-resolver",
   "keywords": [

--- a/packages/lockfile-file/package.json
+++ b/packages/lockfile-file/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-file",
   "keywords": [

--- a/packages/lockfile-to-pnp/package.json
+++ b/packages/lockfile-to-pnp/package.json
@@ -16,7 +16,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-to-pnp",
   "keywords": [

--- a/packages/lockfile-types/package.json
+++ b/packages/lockfile-types/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-types#readme",
   "scripts": {
     "lint": "eslint src/**/*.ts",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "prepublishOnly": "pnpm run compile"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/packages/lockfile-utils/package.json
+++ b/packages/lockfile-utils/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-utils",
   "keywords": [

--- a/packages/lockfile-walker/package.json
+++ b/packages/lockfile-walker/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/lockfile-walker",
   "keywords": [

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -18,7 +18,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/make-dedicated-lockfile",
   "keywords": [

--- a/packages/manifest-utils/package.json
+++ b/packages/manifest-utils/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:6.1.3",

--- a/packages/matcher/package.json
+++ b/packages/matcher/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/matcher",
   "keywords": [

--- a/packages/merge-lockfile-changes/package.json
+++ b/packages/merge-lockfile-changes/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/merge-lockfile-changes",
   "keywords": [

--- a/packages/modules-cleaner/package.json
+++ b/packages/modules-cleaner/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:6.1.3",

--- a/packages/modules-yaml/package.json
+++ b/packages/modules-yaml/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/modules-yaml",
   "keywords": [

--- a/packages/mount-modules/package.json
+++ b/packages/mount-modules/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install --dir=test/__fixtures__/simple",
     "_test": "pnpm pretest && jest",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/mount-modules",
   "keywords": [

--- a/packages/normalize-registries/package.json
+++ b/packages/normalize-registries/package.json
@@ -23,7 +23,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/types": "workspace:7.9.0",

--- a/packages/npm-registry-agent/package.json
+++ b/packages/npm-registry-agent/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "devDependencies": {
     "@pnpm/npm-registry-agent": "workspace:5.0.2",

--- a/packages/npm-resolver/package.json
+++ b/packages/npm-resolver/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/npm-resolver",
   "keywords": [

--- a/packages/outdated/package.json
+++ b/packages/outdated/package.json
@@ -19,7 +19,7 @@
     "test:jest": "jest",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7771 pnpm run test:e2e",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/outdated",
   "keywords": [

--- a/packages/package-bins/package.json
+++ b/packages/package-bins/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json --project . --fix",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/package-bins",
   "keywords": [

--- a/packages/package-is-installable/package.json
+++ b/packages/package-is-installable/package.json
@@ -26,7 +26,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:6.1.3",

--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -17,7 +17,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7772 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest"

--- a/packages/package-store/package.json
+++ b/packages/package-store/package.json
@@ -71,7 +71,7 @@
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "funding": "https://opencollective.com/pnpm"
 }

--- a/packages/parse-cli-args/package.json
+++ b/packages/parse-cli-args/package.json
@@ -17,7 +17,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "start": "tsc --watch",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/parse-cli-args",
   "keywords": [

--- a/packages/parse-overrides/package.json
+++ b/packages/parse-overrides/package.json
@@ -24,7 +24,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/parse-overrides#readme",
   "funding": "https://opencollective.com/pnpm",

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "validate-npm-package-name": "3.0.0"

--- a/packages/pick-registry-for-package/package.json
+++ b/packages/pick-registry-for-package/package.json
@@ -24,7 +24,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/types": "workspace:7.9.0"

--- a/packages/pkgs-graph/package.json
+++ b/packages/pkgs-graph/package.json
@@ -13,7 +13,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/pkgs-graph",
   "license": "MIT",

--- a/packages/plugin-commands-audit/package.json
+++ b/packages/plugin-commands-audit/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-audit",
   "keywords": [

--- a/packages/plugin-commands-env/package.json
+++ b/packages/plugin-commands-env/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-env",
   "keywords": [

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -20,7 +20,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7773 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-installation",
   "keywords": [

--- a/packages/plugin-commands-listing/package.json
+++ b/packages/plugin-commands-listing/package.json
@@ -19,7 +19,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-listing",
   "keywords": [

--- a/packages/plugin-commands-outdated/package.json
+++ b/packages/plugin-commands-outdated/package.json
@@ -19,7 +19,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7775 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-outdated",
   "keywords": [

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -20,7 +20,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7776 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-publishing",
   "keywords": [

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -19,7 +19,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7777 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-rebuild",
   "keywords": [

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -20,7 +20,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "start": "tsc --watch",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-script-runners",
   "keywords": [

--- a/packages/plugin-commands-server/package.json
+++ b/packages/plugin-commands-server/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-server",
   "keywords": [

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-setup",
   "keywords": [

--- a/packages/plugin-commands-store/package.json
+++ b/packages/plugin-commands-store/package.json
@@ -19,7 +19,7 @@
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/plugin-commands-store",
   "keywords": [

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -159,7 +159,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm compile && npm cache clear --force && publish-packed --prune --npm-client=pnpm --dest=dist",
     "postpublish": "publish-packed",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix && rimraf dist bin/nodes && pnpm run bundle && shx cp -r node-gyp-bin dist/node-gyp-bin && shx cp -r node_modules/@pnpm/tabtab/lib/scripts dist/scripts && shx cp -r node_modules/ps-list/vendor dist/vendor && shx cp pnpmrc dist/pnpmrc"
+    "compile": "tsc --build && pnpm run lint -- --fix && rimraf dist bin/nodes && pnpm run bundle && shx cp -r node-gyp-bin dist/node-gyp-bin && shx cp -r node_modules/@pnpm/tabtab/lib/scripts dist/scripts && shx cp -r node_modules/ps-list/vendor dist/vendor && shx cp pnpmrc dist/pnpmrc"
   },
   "publishConfig": {
     "tag": "next",

--- a/packages/pnpmfile/package.json
+++ b/packages/pnpmfile/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/pnpmfile",
   "keywords": [

--- a/packages/prepare-package/package.json
+++ b/packages/prepare-package/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/prepare-package",
   "keywords": [

--- a/packages/prune-lockfile/package.json
+++ b/packages/prune-lockfile/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/prune-lockfile",
   "keywords": [

--- a/packages/read-modules-dir/package.json
+++ b/packages/read-modules-dir/package.json
@@ -22,7 +22,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"

--- a/packages/read-package-json/package.json
+++ b/packages/read-package-json/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/read-package-json",
   "keywords": [

--- a/packages/read-project-manifest/package.json
+++ b/packages/read-project-manifest/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/read-project-manifest",
   "keywords": [

--- a/packages/read-projects-context/package.json
+++ b/packages/read-projects-context/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/lockfile-file": "workspace:4.2.6",

--- a/packages/real-hoist/package.json
+++ b/packages/real-hoist/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/lockfile-utils": "workspace:3.1.6",

--- a/packages/remove-bins/package.json
+++ b/packages/remove-bins/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:6.1.3",

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -24,7 +24,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/render-peer-issues#readme",
   "funding": "https://opencollective.com/pnpm",

--- a/packages/resolve-dependencies/package.json
+++ b/packages/resolve-dependencies/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "_test": "jest"
   },
   "dependencies": {

--- a/packages/resolve-workspace-range/package.json
+++ b/packages/resolve-workspace-range/package.json
@@ -22,7 +22,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "semver": "^7.3.4"

--- a/packages/resolver-base/package.json
+++ b/packages/resolver-base/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/resolver-base",
   "keywords": [

--- a/packages/run-npm/package.json
+++ b/packages/run-npm/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/run-npm",
   "keywords": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/server",
   "keywords": [

--- a/packages/sort-packages/package.json
+++ b/packages/sort-packages/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/sort-packages",
   "keywords": [

--- a/packages/store-connection-manager/package.json
+++ b/packages/store-connection-manager/package.json
@@ -16,7 +16,7 @@
     "pretest": "rimraf node_modules/.bin/pnpm",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/store-connection-manager",
   "keywords": [

--- a/packages/store-controller-types/package.json
+++ b/packages/store-controller-types/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "lint": "eslint src/**/*.ts"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/store-controller-types",

--- a/packages/symlink-dependency/package.json
+++ b/packages/symlink-dependency/package.json
@@ -36,7 +36,7 @@
     "test": "pnpm run compile",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:6.1.3",

--- a/packages/tarball-fetcher/package.json
+++ b/packages/tarball-fetcher/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/tarball-fetcher",
   "keywords": [

--- a/packages/tarball-resolver/package.json
+++ b/packages/tarball-resolver/package.json
@@ -17,7 +17,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/tarball-resolver",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix",
+    "compile": "tsc --build && pnpm run lint -- --fix",
     "lint": "eslint src/**/*.ts"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/types",

--- a/packages/which-version-is-pinned/package.json
+++ b/packages/which-version-is-pinned/package.json
@@ -24,7 +24,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/which-version-is-pinned#readme",
   "funding": "https://opencollective.com/pnpm",

--- a/packages/write-project-manifest/package.json
+++ b/packages/write-project-manifest/package.json
@@ -16,7 +16,7 @@
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build && pnpm run lint -- --fix"
+    "compile": "tsc --build && pnpm run lint -- --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/packages/write-project-manifest",
   "keywords": [

--- a/privatePackages/assert-store/package.json
+++ b/privatePackages/assert-store/package.json
@@ -34,7 +34,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/assert-store",
   "scripts": {
-    "compile": "rimraf lib tsconfig.tsbuildinfo && tsc --build",
+    "compile": "tsc --build",
     "lint": "tslint -c ../../tslint.json src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install -C test/fixture/project --force --no-shared-workspace-lockfile",


### PR DESCRIPTION
Closes https://twitter.com/ZoltanKochan/status/1459137137517936688 😄 I noticed your pain on Twitter and decided to try some solutions. 

without cache: https://github.com/7rulnik/pnpm/runs/4858665185?check_suite_focus=true ~27min
with cache: https://github.com/7rulnik/pnpm/runs/4859302337?check_suite_focus=true ~15 min

Things to do:
- [x] cache for TS
- [x] cache for jest
- [x] enable cache via GitHub actions

----------

# What I did

## TypeScript

TS has [incremental](https://www.typescriptlang.org/tsconfig#incremental) option. It turns on automatically when using [composite](https://www.typescriptlang.org/tsconfig#composite) which is already was set. Within this mode, TS emits `.tsbuildinfo` files which contain cache info for the next compilations. But it doesn't recreate JS files so we need to cache TS ouput (`lib`'s directories). See https://github.com/microsoft/TypeScript/issues/30602 for more info. 

## Jest

Jest has [cacheDirectory](https://jestjs.io/docs/configuration#cachedirectory-string) option. It's enabled by default but stores cache in `/tmp/*`. We need a stable name for the directory cache so we can cache it. And since we're running a lot of jokes, we want to avoid concurrent cache writes. So we use package directory name via `PNPM_SCRIPT_SRC_DIR`. So we store cache in `.jest-cache/{packageName}`.

## Cache via Github Actions

We need to pass TS and Jest caches between builds. We use this cache key`ts-jest-${{ matrix.platform }}-${{ matrix.node }}-${{ github.run_id }}` and `restore key` `ts-jest-${{ matrix.platform }}-${{ matrix.node }}-`. So on each build, we will have a completely new key and we could expect cache miss. But thanks to `restore key`, we will fallback to the most recently created cache. We need this hack because we what to update the cache on every run. When we create a branch we will reuse cache from the default branch (see [cache scopes](https://github.com/actions/cache#cache-scopes))
