### PR TITLE
fix(npm-resolver): always add trailing slash to registry URL

### DIFF
--- a/.changeset/sixty-houses-clap.md
+++ b/.changeset/sixty-houses-clap.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": patch
+---
+
+Always add a trailing slash to the registry URL [#4052](https://github.com/pnpm/pnpm/issues/4052).

--- a/packages/npm-resolver/src/fetch.ts
+++ b/packages/npm-resolver/src/fetch.ts
@@ -105,5 +105,5 @@ function toUri (pkgName: string, registry: string) {
     encodedName = encodeURIComponent(pkgName)
   }
 
-  return new url.URL(encodedName, registry).toString()
+  return new url.URL(encodedName, registry.endsWith('/') ? registry : `${registry}/`).toString()
 }


### PR DESCRIPTION
ref #4052