### PR TITLE
feat: aggregate-output

### DIFF
--- a/.changeset/hip-gorillas-happen.md
+++ b/.changeset/hip-gorillas-happen.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/config": minor
+"@pnpm/default-reporter": minor
+"pnpm": minor
+---
+
+A new option `--aggregate-output` for `append-only` reporter is added. It aggregates lifecycle logs output for each command that is run in parallel, and only prints command logs when command is finished.
+
+Related discussion: [#4070](https://github.com/pnpm/pnpm/discussions/4070).

--- a/.changeset/hip-gorillas-happen.md
+++ b/.changeset/hip-gorillas-happen.md
@@ -1,4 +1,5 @@
 ---
+"@pnpm/common-cli-options-help": minor
 "@pnpm/config": minor
 "@pnpm/default-reporter": minor
 "pnpm": minor

--- a/packages/common-cli-options-help/src/index.ts
+++ b/packages/common-cli-options-help/src/index.ts
@@ -54,6 +54,10 @@ export const UNIVERSAL_OPTIONS = [
     name: '--stream',
   },
   {
+    description: 'Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.',
+    name: '--aggregate-output',
+  },
+  {
     description: 'Divert all output to stderr',
     name: '--use-stderr',
   },

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -115,6 +115,7 @@ export interface Config {
   workspaceConcurrency: number
   workspaceDir?: string
   reporter?: string
+  aggregateOutput: boolean
   linkWorkspacePackages: boolean | 'deep'
   preferWorkspacePackages: boolean
   reverse: boolean

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -87,6 +87,7 @@ export const types = Object.assign({
   'publish-branch': String,
   'recursive-install': Boolean,
   reporter: String,
+  'aggregate-output': Boolean,
   'save-peer': Boolean,
   'save-workspace-protocol': Boolean,
   'script-shell': String,

--- a/packages/default-reporter/src/index.ts
+++ b/packages/default-reporter/src/index.ts
@@ -20,6 +20,7 @@ export default function (
       appendOnly?: boolean
       logLevel?: LogLevel
       streamLifecycleOutput?: boolean
+      aggregateOutput?: boolean
       throttleProgress?: number
       outputMaxWidth?: number
     }
@@ -80,6 +81,7 @@ export function toOutput$ (
       logLevel?: LogLevel
       outputMaxWidth?: number
       streamLifecycleOutput?: boolean
+      aggregateOutput?: boolean
       throttleProgress?: number
     }
     context: {
@@ -219,6 +221,7 @@ export function toOutput$ (
       logLevel: opts.reportingOptions?.logLevel,
       pnpmConfig: opts.context.config,
       streamLifecycleOutput: opts.reportingOptions?.streamLifecycleOutput,
+      aggregateOutput: opts.reportingOptions?.aggregateOutput,
       throttleProgress: opts.reportingOptions?.throttleProgress,
       width: opts.reportingOptions?.outputMaxWidth,
     }

--- a/packages/default-reporter/src/reporterForClient/index.ts
+++ b/packages/default-reporter/src/reporterForClient/index.ts
@@ -51,6 +51,7 @@ export default function (
     logLevel?: LogLevel
     pnpmConfig?: Config
     streamLifecycleOutput?: boolean
+    aggregateOutput?: boolean
     throttleProgress?: number
     width?: number
   }
@@ -69,6 +70,7 @@ export default function (
     reportPeerDependencyIssues(log$),
     reportLifecycleScripts(log$, {
       appendOnly: opts.appendOnly === true || opts.streamLifecycleOutput,
+      aggregateOutput: opts.aggregateOutput,
       cwd,
       width,
     }),

--- a/packages/default-reporter/test/reportingLifecycleScripts.ts
+++ b/packages/default-reporter/test/reportingLifecycleScripts.ts
@@ -367,12 +367,8 @@ test('groups lifecycle output when append-only and aggregate-output are used', a
     `${chalk.cyan('packages/foo')} ${PREINSTALL}: Failed`,
     `${chalk.magenta('packages/qar')} ${INSTALL}$ node qar`,
     `${chalk.magenta('packages/qar')} ${INSTALL}: Done`,
-    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}$ node foo`,
-    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo I`,
     `${chalk.blue('packages/bar')} ${POSTINSTALL}$ node bar`,
     `${chalk.blue('packages/bar')} ${POSTINSTALL}: bar I`,
-    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo II`,
-    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo III`,
     `${chalk.blue('packages/bar')} ${POSTINSTALL}: Done`,
   ])
 })

--- a/packages/default-reporter/test/reportingLifecycleScripts.ts
+++ b/packages/default-reporter/test/reportingLifecycleScripts.ts
@@ -2,9 +2,10 @@ import path from 'path'
 import { lifecycleLogger } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
-import { map, skip, take } from 'rxjs/operators'
+import { map, skip, take, toArray } from 'rxjs/operators'
 import chalk from 'chalk'
 import normalizeNewline from 'normalize-newline'
+import { firstValueFrom } from 'rxjs'
 
 const hlValue = chalk.cyanBright
 const hlPkgId = chalk['whiteBright']
@@ -256,6 +257,124 @@ ${chalk.blue('packages/qar')} ${INSTALL}: Done`)
       allOutputs.push(output)
     },
   })
+})
+
+test('groups lifecycle output when append-only and aggregate-output are used', async () => {
+  const output$ = toOutput$({
+    context: { argv: ['install'] },
+    reportingOptions: {
+      appendOnly: true,
+      aggregateOutput: true,
+      outputMaxWidth: 79,
+    },
+    streamParser: createStreamParser(),
+  })
+
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    optional: false,
+    script: 'node foo',
+    stage: 'preinstall',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    line: 'foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30',
+    stage: 'preinstall',
+    stdio: 'stdout',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    exitCode: 1,
+    optional: true,
+    stage: 'preinstall',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    optional: false,
+    script: 'node foo',
+    stage: 'postinstall',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    line: 'foo I',
+    stage: 'postinstall',
+    stdio: 'stdout',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/bar',
+    optional: false,
+    script: 'node bar',
+    stage: 'postinstall',
+    wd: 'packages/bar',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/bar',
+    line: 'bar I',
+    stage: 'postinstall',
+    stdio: 'stdout',
+    wd: 'packages/bar',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    line: 'foo II',
+    stage: 'postinstall',
+    stdio: 'stdout',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/foo',
+    line: 'foo III',
+    stage: 'postinstall',
+    stdio: 'stdout',
+    wd: 'packages/foo',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/qar',
+    optional: false,
+    script: 'node qar',
+    stage: 'install',
+    wd: 'packages/qar',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/qar',
+    exitCode: 0,
+    optional: false,
+    stage: 'install',
+    wd: 'packages/qar',
+  })
+  lifecycleLogger.debug({
+    depPath: 'packages/bar',
+    exitCode: 0,
+    optional: false,
+    stage: 'postinstall',
+    wd: 'packages/bar',
+  })
+
+  await expect(
+    firstValueFrom(
+      output$.pipe(map<string, string>(normalizeNewline), take(8), toArray())
+    )
+  ).resolves.toEqual([
+    `${chalk.cyan('packages/foo')} ${PREINSTALL}$ node foo`,
+    `${chalk.cyan(
+      'packages/foo'
+    )} ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30`,
+    `${chalk.cyan('packages/foo')} ${PREINSTALL}: Failed`,
+    `${chalk.magenta('packages/qar')} ${INSTALL}$ node qar`,
+    `${chalk.magenta('packages/qar')} ${INSTALL}: Done`,
+    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}$ node foo`,
+    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo I`,
+    `${chalk.blue('packages/bar')} ${POSTINSTALL}$ node bar`,
+    `${chalk.blue('packages/bar')} ${POSTINSTALL}: bar I`,
+    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo II`,
+    // `${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo III`,
+    `${chalk.blue('packages/bar')} ${POSTINSTALL}: Done`,
+  ])
 })
 
 test('groups lifecycle output when streamLifecycleOutput is used', (done) => {

--- a/packages/pnpm/src/cmd/index.ts
+++ b/packages/pnpm/src/cmd/index.ts
@@ -38,6 +38,7 @@ export const GLOBAL_OPTIONS = pick([
   'prefix',
   'reporter',
   'stream',
+  'aggregate-output',
   'test-pattern',
   'changed-files-ignore-pattern',
   'use-stderr',

--- a/packages/pnpm/src/reporter/index.ts
+++ b/packages/pnpm/src/reporter/index.ts
@@ -38,6 +38,7 @@ export default (
       },
       reportingOptions: {
         appendOnly: true,
+        aggregateOutput: opts.config.aggregateOutput,
         logLevel: opts.config.loglevel as LogLevel,
         throttleProgress: 1000,
       },


### PR DESCRIPTION
Implements proposal [#4070](https://github.com/pnpm/pnpm/discussions/4070)

Implementation details:
- enabled only for lifecycle logs and only when `--reporter=append-only`
- `--aggregate-output` is optional, and is disabled by default
- `.npmrc / cli` option supported

p.s. today is my first day of using Rxjs, I'm more than open to suggestions what to improve/change