### PR TITLE
chore: upgrade verdaccio 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ts-jest": "27.1.1",
     "ts-node": "^10.4.0",
     "typescript": "4.5.3",
-    "verdaccio": "5.2.2",
+    "verdaccio": "5.3.1",
     "yarn": "^1.22.17"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
       ts-jest: 27.1.1
       ts-node: ^10.4.0
       typescript: 4.5.3
-      verdaccio: 5.2.2
+      verdaccio: 5.3.1
       yarn: ^1.22.17
     devDependencies:
       '@babel/core': 7.16.0
@@ -91,7 +91,7 @@ importers:
       ts-jest: 27.1.1_b1e62d4ec9144088555daf61e2739fdf
       ts-node: 10.4.0_efbd19efcdff5017ea393128a26f794c
       typescript: 4.5.3
-      verdaccio: 5.2.2
+      verdaccio: 5.3.1
       yarn: 1.22.17
 
   .meta-updater:
@@ -3461,9 +3461,9 @@ importers:
       eslint-plugin-node: ^11.1.0
       eslint-plugin-promise: ^5.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.6.0_16d83f5c41c3abb1061a82b07c18e4f3
-      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.2
-      eslint-config-standard-with-typescript: 21.0.1_0df57457d31906dbf937b1ec93a5d21c
+      '@typescript-eslint/eslint-plugin': 5.6.0_0d0cecf582ba45923647a091322795b0
+      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.3
+      eslint-config-standard-with-typescript: 21.0.1_801f35a17d1ce9bca28655caf321ce63
       eslint-plugin-import: 2.25.3_eslint@8.4.1
       eslint-plugin-node: 11.1.0_eslint@8.4.1
       eslint-plugin-promise: 5.2.0_eslint@8.4.1
@@ -4930,7 +4930,7 @@ packages:
       read-yaml-file: 2.1.0
       rimraf: 3.0.2
       tempy: 1.0.1
-      verdaccio: 5.2.2
+      verdaccio: 5.3.1
       write-yaml-file: 4.2.0
     transitivePeerDependencies:
       - bufferutil
@@ -5426,7 +5426,7 @@ packages:
     resolution: {integrity: sha512-8NYnGOctzsI4W0ApsP/BIHD/LnxpJ6XaGf2AZmz4EyDYJMxtprN4279dLNI1CPZcwC9H18qYcaFv4bXi0wmokg==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.6.0_16d83f5c41c3abb1061a82b07c18e4f3:
+  /@typescript-eslint/eslint-plugin/5.6.0_0d0cecf582ba45923647a091322795b0:
     resolution: {integrity: sha512-MIbeMy5qfLqtgs1hWd088k1hOuRsN9JrHUPwVVKCD99EOUqScd7SrwoZl4Gso05EAP9w1kvLWUVGJOVpRPkDPA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5437,8 +5437,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.2
-      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.2
+      '@typescript-eslint/experimental-utils': 5.6.0_eslint@8.4.1+typescript@4.5.3
+      '@typescript-eslint/parser': 5.6.0_eslint@8.4.1+typescript@4.5.3
       '@typescript-eslint/scope-manager': 5.6.0
       debug: 4.3.3
       eslint: 8.4.1
@@ -5446,13 +5446,13 @@ packages:
       ignore: 5.1.9
       regexpp: 3.2.0
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.2
-      typescript: 4.5.2
+      tsutils: 3.21.0_typescript@4.5.3
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.4.1+typescript@4.5.2:
+  /@typescript-eslint/experimental-utils/5.6.0_eslint@8.4.1+typescript@4.5.3:
     resolution: {integrity: sha512-VDoRf3Qj7+W3sS/ZBXZh3LBzp0snDLEgvp6qj0vOAIiAPM07bd5ojQ3CTzF/QFl5AKh7Bh1ycgj6lFBJHUt/DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5461,7 +5461,7 @@ packages:
       '@types/json-schema': 7.0.9
       '@typescript-eslint/scope-manager': 5.6.0
       '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.3
       eslint: 8.4.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.4.1
@@ -5470,7 +5470,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/4.33.0_eslint@8.4.1+typescript@4.5.2:
+  /@typescript-eslint/parser/4.33.0_eslint@8.4.1+typescript@4.5.3:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5482,15 +5482,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.2
+      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.3
       debug: 4.3.3
       eslint: 8.4.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.6.0_eslint@8.4.1+typescript@4.5.2:
+  /@typescript-eslint/parser/5.6.0_eslint@8.4.1+typescript@4.5.3:
     resolution: {integrity: sha512-YVK49NgdUPQ8SpCZaOpiq1kLkYRPMv9U5gcMrywzI8brtwZjr/tG3sZpuHyODt76W/A0SufNjYt9ZOgrC4tLIQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5502,10 +5502,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.6.0
       '@typescript-eslint/types': 5.6.0
-      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.2
+      '@typescript-eslint/typescript-estree': 5.6.0_typescript@4.5.3
       debug: 4.3.3
       eslint: 8.4.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5536,7 +5536,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.2:
+  /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.3:
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5551,13 +5551,13 @@ packages:
       globby: 11.0.4
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.2
-      typescript: 4.5.2
+      tsutils: 3.21.0_typescript@4.5.3
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.2:
+  /@typescript-eslint/typescript-estree/5.6.0_typescript@4.5.3:
     resolution: {integrity: sha512-92vK5tQaE81rK7fOmuWMrSQtK1IMonESR+RJR2Tlc7w4o0MeEdjgidY/uO2Gobh7z4Q1hhS94Cr7r021fMVEeA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5572,8 +5572,8 @@ packages:
       globby: 11.0.4
       is-glob: 4.0.3
       semver: 7.3.5
-      tsutils: 3.21.0_typescript@4.5.2
-      typescript: 4.5.2
+      tsutils: 3.21.0_typescript@4.5.3
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5594,37 +5594,38 @@ packages:
       eslint-visitor-keys: 3.1.0
     dev: false
 
-  /@verdaccio/commons-api/10.0.1:
-    resolution: {integrity: sha512-dO/3ocK2Cpx5GZ/HST7YWRMVXAZu5zkDglfcoxEnUh2V9D4detGn0sIDV9nCJJJiO70ZmhuOoA5oeUmrA1lELA==}
+  /@verdaccio/commons-api/10.0.2:
+    resolution: {integrity: sha512-bJdarFsuaAOMyk1qAFEsCqcl5Ol0LCRqlwPgi1aFBAgsPNuebLEnCrdT6B6FMnFdPSYVyP1byTLN+0W1t9Iqsg==}
     engines: {node: '>=8'}
     dependencies:
       http-errors: 1.8.1
       http-status-codes: 1.4.0
     dev: true
 
-  /@verdaccio/file-locking/10.0.0:
-    resolution: {integrity: sha512-2tQUbJF3tQ3CY9grAlpovaF/zu8G56CBYMaeHwMBHo9rAmsJI9i7LfliHGS6Jygbs8vd0cOCPT7vl2CL9T8upw==}
+  /@verdaccio/commons-api/10.1.0:
+    resolution: {integrity: sha512-7xidrFzpyS4QVqVSFK+2lJn3mefpAPvk2pPe4SbiCibjRBFTXdj2KaeaqMEh2ROGzag4+tbx7l4hZ1qkB/1mkA==}
+    engines: {node: '>=8'}
+    dependencies:
+      http-errors: 1.8.1
+      http-status-codes: 1.4.0
+    dev: true
+
+  /@verdaccio/file-locking/10.1.0:
+    resolution: {integrity: sha512-PULcFqfj8S8shY/Ry+v+q6aYhhJBG517Pfzf9DYgJW5AcAHk6SpLB+0XyjfBtJ66ic0jlVnx/Y0FanQXrJDkig==}
     engines: {node: '>=8'}
     dependencies:
       lockfile: 1.0.4
     dev: true
 
-  /@verdaccio/file-locking/10.0.1:
-    resolution: {integrity: sha512-yUi3wo17jhY2LZMNAv8/+oVfHJfqx0MdpKgUeQjoXHFfrEmpMck23ZfBQmXSM8xiC7RmdmOqlyGkJMbAkMb6nQ==}
+  /@verdaccio/local-storage/10.1.0:
+    resolution: {integrity: sha512-NSW7uLOCLaqTpvPsHkMyir0G0EgaywsUyLHpEs4CeEVR5QIKBklQPx1zATL+KqsPH8yQSlMQFbDYkNylxSCB3A==}
     engines: {node: '>=8'}
     dependencies:
-      lockfile: 1.0.4
-    dev: true
-
-  /@verdaccio/local-storage/10.0.7:
-    resolution: {integrity: sha512-DpR4RFDQXVFI9ILEU0xXIqGP7m59u4n5RJ9AYEbc6i/6Iv0Ba2K2Q4l/J22ZLURjqCKZY4ZPUJkhUwXSmzRFMQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@verdaccio/commons-api': 10.0.1
-      '@verdaccio/file-locking': 10.0.0
-      '@verdaccio/streams': 10.0.0
-      async: 3.2.0
-      debug: 4.3.1
+      '@verdaccio/commons-api': 10.1.0
+      '@verdaccio/file-locking': 10.1.0
+      '@verdaccio/streams': 10.1.0
+      async: 3.2.2
+      debug: 4.3.3
       lodash: 4.17.21
       lowdb: 1.0.0
       mkdirp: 1.0.4
@@ -5632,8 +5633,8 @@ packages:
       - supports-color
     dev: true
 
-  /@verdaccio/readme/10.0.0:
-    resolution: {integrity: sha512-OD3dMnRC8SvhgytEzczMBleN+K/3lMqyWw/epeXvolCpCd7mW/Dl5zSR25GiHh/2h3eTKP/HMs4km8gS1MMLgA==}
+  /@verdaccio/readme/10.2.0:
+    resolution: {integrity: sha512-M+yXLGSazt9lPJKhZwCL/UsY0+/wGjyYsYZBmAPTbxuBtcjjcRHpGxkN/eRtr6HMIgBiuP/V7+8OInAtgb+ZiA==}
     dependencies:
       dompurify: 2.3.4
       jsdom: 15.2.1
@@ -5644,8 +5645,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@verdaccio/streams/10.0.0:
-    resolution: {integrity: sha512-PqxxY11HhweN6z1lwfn9ydLCdnOkCPpthMZs+SGCDz8Rt6gOyrjJVslV7o4uobDipjD9+hUPpJHDeO33Qt24uw==}
+  /@verdaccio/streams/10.1.0:
+    resolution: {integrity: sha512-19FebNvwNiJkk68fFEq/kNOcPNKYX/NoPFqOlZH6mGUGUo3htHh4tD5k2WepAZpBeK9SC868UiPbMizdIXquSg==}
     engines: {node: '>=8', npm: '>=5'}
     dev: true
 
@@ -6349,9 +6350,9 @@ packages:
       picomatch: 2.3.0
     dev: true
 
-  /apache-md5/1.1.2:
-    resolution: {integrity: sha1-7klza2ObTxCLbp5ibG2pkwa0FpI=}
-    engines: {node: '>=4.6.1'}
+  /apache-md5/1.1.7:
+    resolution: {integrity: sha512-JtHjzZmJxtzfTSjsCyHgPR155HBe5WGyUyHTaEkfy46qhwCFKx1Epm6nAxgUG3WfUZP1dWhGqj9Z2NOBeZ+uBw==}
+    engines: {node: '>=8'}
     dev: true
 
   /append-buffer/1.0.2:
@@ -6522,10 +6523,6 @@ packages:
   /astral-regex/2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
-
-  /async/3.2.0:
-    resolution: {integrity: sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==}
-    dev: true
 
   /async/3.2.2:
     resolution: {integrity: sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==}
@@ -7718,18 +7715,6 @@ packages:
     dependencies:
       ms: 2.1.3
 
-  /debug/4.3.1:
-    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.2
-    dev: true
-
   /debug/4.3.3:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
     engines: {node: '>=6.0'}
@@ -8392,7 +8377,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-standard-with-typescript/21.0.1_0df57457d31906dbf937b1ec93a5d21c:
+  /eslint-config-standard-with-typescript/21.0.1_801f35a17d1ce9bca28655caf321ce63:
     resolution: {integrity: sha512-FeiMHljEJ346Y0I/HpAymNKdrgKEpHpcg/D93FvPHWfCzbT4QyUJba/0FwntZeGLXfUiWDSeKmdJD597d9wwiw==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.6.0
@@ -8402,14 +8387,14 @@ packages:
       eslint-plugin-promise: ^4.2.1 || ^5.0.0
       typescript: ^3.9 || ^4.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.6.0_16d83f5c41c3abb1061a82b07c18e4f3
-      '@typescript-eslint/parser': 4.33.0_eslint@8.4.1+typescript@4.5.2
+      '@typescript-eslint/eslint-plugin': 5.6.0_0d0cecf582ba45923647a091322795b0
+      '@typescript-eslint/parser': 4.33.0_eslint@8.4.1+typescript@4.5.3
       eslint: 8.4.1
       eslint-config-standard: 16.0.3_79a23b4ffc45aed4cdeb891cd82eaee3
       eslint-plugin-import: 2.25.3_eslint@8.4.1
       eslint-plugin-node: 11.1.0_eslint@8.4.1
       eslint-plugin-promise: 5.2.0_eslint@8.4.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -10907,8 +10892,8 @@ packages:
       nwsapi: 2.2.0
       parse5: 5.1.0
       pn: 1.1.0
-      request: 2.88.0
-      request-promise-native: 1.0.9_request@2.88.0
+      request: 2.88.2
+      request-promise-native: 1.0.9_request@2.88.2
       saxes: 3.1.11
       symbol-tree: 3.2.4
       tough-cookie: 3.0.1
@@ -12055,11 +12040,6 @@ packages:
     resolution: {integrity: sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==}
     dependencies:
       semver: 5.7.1
-    dev: true
-
-  /node-fetch/2.6.1:
-    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
-    engines: {node: 4.x || >=6.0.0}
     dev: true
 
   /node-fetch/2.6.6:
@@ -13583,25 +13563,25 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /request-promise-core/1.1.4_request@2.88.0:
+  /request-promise-core/1.1.4_request@2.88.2:
     resolution: {integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       request: ^2.34
     dependencies:
       lodash: 4.17.21
-      request: 2.88.0
+      request: 2.88.2
     dev: true
 
-  /request-promise-native/1.0.9_request@2.88.0:
+  /request-promise-native/1.0.9_request@2.88.2:
     resolution: {integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==}
     engines: {node: '>=0.12.0'}
     deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     peerDependencies:
       request: ^2.34
     dependencies:
-      request: 2.88.0
-      request-promise-core: 1.1.4_request@2.88.0
+      request: 2.88.2
+      request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
     dev: true
@@ -14996,14 +14976,14 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.5.2:
+  /tsutils/3.21.0_typescript@4.5.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.5.2
+      typescript: 4.5.3
     dev: false
 
   /tty-table/2.8.13:
@@ -15349,38 +15329,38 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /verdaccio-audit/10.0.2:
-    resolution: {integrity: sha512-pcud2xwztYETO15r+a11cFkpvweLmnsuJJ0FLCifL3+z4IzYFgD5KgPwUD9sdMPHFz5efOrHeO71cu8hb8oEWg==}
+  /verdaccio-audit/10.1.0:
+    resolution: {integrity: sha512-lu2rpicM7PeVQ+7dlupP92Ddp7v+Rqae4gFfzd9GTxgzS7wWm7USM88GalEPTJtcn4zDh4nC3nbjE7eEQTVFKg==}
     engines: {node: '>=8'}
     dependencies:
       body-parser: 1.19.0
       express: 4.17.1
       https-proxy-agent: 5.0.0
-      node-fetch: 2.6.1
+      node-fetch: 2.6.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /verdaccio-htpasswd/10.0.0:
-    resolution: {integrity: sha512-3TKwiLwl8/fbaTDawHvjSYcsyMmdARg58keP/1plv74x+Jw0sC66HbbRwQ/tPO5mqoG0UwoWW+lkO8h/OiWi9w==}
+  /verdaccio-htpasswd/10.1.0:
+    resolution: {integrity: sha512-HPpAJ62Y3FRA19Vp47VSeeeur5mqPUU4E/W4N914vUFw63iZqDBqhMQI5g99SqnlB97HplYsS5CpXj6cRv4hmw==}
     engines: {node: '>=8'}
     dependencies:
-      '@verdaccio/file-locking': 10.0.1
-      apache-md5: 1.1.2
+      '@verdaccio/file-locking': 10.1.0
+      apache-md5: 1.1.7
       bcryptjs: 2.4.3
       http-errors: 1.8.1
       unix-crypt-td-js: 1.1.4
     dev: true
 
-  /verdaccio/5.2.2:
-    resolution: {integrity: sha512-7TbQ2QWDIQBabYMUAJQtJl9qbxpBKl8tndNYtMl9gVUgWN67gr+kPeMoqY0m4whg/+OdWrMyBj3NQy5VoTQiIw==}
+  /verdaccio/5.3.1:
+    resolution: {integrity: sha512-IA+UxL6/73G5SgQ01ZZPPOFCpRge0DdXLrgaRpzi5SdGQDQkKsWnk90SI8q1qH1VuvgzVn0UEeq3SQTvx6ZXDg==}
     engines: {node: '>=12', npm: '>=6'}
     hasBin: true
     dependencies:
-      '@verdaccio/commons-api': 10.0.1
-      '@verdaccio/local-storage': 10.0.7
-      '@verdaccio/readme': 10.0.0
-      '@verdaccio/streams': 10.0.0
+      '@verdaccio/commons-api': 10.0.2
+      '@verdaccio/local-storage': 10.1.0
+      '@verdaccio/readme': 10.2.0
+      '@verdaccio/streams': 10.1.0
       '@verdaccio/ui-theme': 3.2.1
       async: 3.2.2
       body-parser: 1.19.0
@@ -15416,8 +15396,8 @@ packages:
       request: 2.88.0
       semver: 7.3.5
       validator: 13.7.0
-      verdaccio-audit: 10.0.2
-      verdaccio-htpasswd: 10.0.0
+      verdaccio-audit: 10.1.0
+      verdaccio-htpasswd: 10.1.0
     transitivePeerDependencies:
       - bufferutil
       - canvas


### PR DESCRIPTION
I've noticed this downgrade https://github.com/pnpm/pnpm/commit/0726f3b913185803250c1d36d4841422e292a3f6 with a good reason, I've patched the stable version, let's try this again.

The issue was some core dependencies had `core-js` babel/env config enabled that was injecting some `requires(..` into the transpiled code and since pnpm is strict, failed.