### PR TITLE
fix: use-node-version isn't respected if the first download fails

### DIFF
--- a/.changeset/khaki-cars-return.md
+++ b/.changeset/khaki-cars-return.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-env": minor
+"pnpm": minor
+---
+
+If pnpm previously failed to install node when the `use-node-version` option is set, that download and install will now be re-attempted when pnpm is ran again.

--- a/packages/plugin-commands-env/src/node.ts
+++ b/packages/plugin-commands-env/src/node.ts
@@ -67,7 +67,6 @@ export async function getNodeDir (fetch: FetchFromRegistry, opts: NvmNodeCommand
 }
 
 async function installNode (fetch: FetchFromRegistry, wantedNodeVersion: string, versionDir: string, opts: NvmNodeCommandOptions & { releaseDir?: string }) {
-  await fs.promises.mkdir(versionDir, { recursive: true })
   const nodeMirror = getNodeMirror(opts.rawConfig, opts.releaseDir ?? 'release')
   const { tarball, pkgName } = getNodeJSTarball(wantedNodeVersion, nodeMirror)
   if (tarball.endsWith('.zip')) {

--- a/packages/plugin-commands-env/test/fixtures/node-16.4.0-release-info.json
+++ b/packages/plugin-commands-env/test/fixtures/node-16.4.0-release-info.json
@@ -1,0 +1,35 @@
+[
+  {
+    "version": "v16.4.0",
+    "date": "2021-06-23",
+    "files": [
+      "aix-ppc64",
+      "headers",
+      "linux-arm64",
+      "linux-armv7l",
+      "linux-ppc64le",
+      "linux-s390x",
+      "linux-x64",
+      "osx-arm64-tar",
+      "osx-x64-pkg",
+      "osx-x64-tar",
+      "src",
+      "win-x64-7z",
+      "win-x64-exe",
+      "win-x64-msi",
+      "win-x64-zip",
+      "win-x86-7z",
+      "win-x86-exe",
+      "win-x86-msi",
+      "win-x86-zip"
+    ],
+    "npm": "7.18.1",
+    "v8": "9.1.269.36",
+    "uv": "1.41.0",
+    "zlib": "1.2.11",
+    "openssl": "1.1.1k+quic",
+    "modules": "93",
+    "lts": false,
+    "security": false
+  }
+]


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/4104. Opening as a draft until CI checks pass.

## Context

The suggested fix was to make `<pnpm-home-dir>/nodejs/X.X.X` dir creation more atomic by using [`path-temp`](https://www.npmjs.com/package/path-temp): https://github.com/pnpm/pnpm/issues/4104#issuecomment-990246287

It looks like this is already the case in all the code paths I looked at. Because of this, I believe we can just remove the premature `mkdir` that runs before the node archive gets downloaded. (Line 70.)

https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/plugin-commands-env/src/node.ts#L69-L70

This premature `mkdir` was causing pnpm to think Node.js was already installed on reruns.

https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/plugin-commands-env/src/node.ts#L63-L65

I've checked all code paths following this initial `mkdir` to make sure they create the dir later if it's non-existent, and that they do so with a rename so it's atomically populated.

## Investigation

### Zips

On Windows, a `.zip` archive is downloaded and handled by the `downloadAndUnpackZip` function, which passes a temp dir to `renameOverwrite`

https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/plugin-commands-env/src/node.ts#L109

https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/plugin-commands-env/src/node.ts#L117

The `renameOverwrite` function looks like it'll guarantee that the version directory exists in a complete state, or not at all on failures:

https://github.com/zkochan/packages/blob/6da32f07fb3592675505b77724e8e4fd17afaa34/rename-overwrite/index.js#L27-L29

```ts
      case 'ENOENT':
        await mkdir(path.dirname(newPath), { recursive: true })
        await rename(oldPath, newPath)
```

### Tarballs

The non-Windows branch (e.g. macOS, Linux) is a bit more complicated since it uses the CAFS. There's several import methods that could get used: `hardlink`, `copy`, or `clone`.

https://github.com/pnpm/pnpm/blob/e2b42b57c365f7580db8d6b1a9b537183be93015/packages/package-store/src/storeController/createImportPackage.ts#L26

Every CAFS import method calls `importIndexedDir`

 - `clone`
   https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/package-store/src/storeController/createImportPackage.ts#L95-L96
- `hardlink`
   https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/package-store/src/storeController/createImportPackage.ts#L113-L114
-  `copyPkg`
   https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/package-store/src/storeController/createImportPackage.ts#L155-L156

The `importIndexedDir` function in turn calls uses `path-temp` and `renameOverwrite`.

https://github.com/pnpm/pnpm/blob/89dcc1115abda5a3cb2f9b9f960e34007171c19d/packages/package-store/src/fs/importIndexedDir.ts#L19-L22

## Questions

- Did I miss any code paths above? It's possible I overlooked another way the node archive could be extracted.

- Is it safe to rely on `importIndexedDir` for this behavior? I don't see a test to make sure it works on non-existent directories or that it creates directories atomically with a move.

   https://github.com/pnpm/pnpm/blob/d6d091f249b66871744d15d489d51a40a4501cf6/packages/package-store/test/createImportPackage.spec.ts

   My gut instinct is that we should write a test for that before this merges, but wanted to verify that makes sense with reviewers before editing `createImportPackage.spec.ts`.