### PR TITLE
fix(plugin-commands-publishing): add readme file to published package.json

### DIFF
--- a/.changeset/flat-dogs-admire.md
+++ b/.changeset/flat-dogs-admire.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/exportable-manifest": patch
+"@pnpm/plugin-commands-publishing": patch
+"@pnpm/types": patch
+---
+
+add readme file to published package.json file

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -36,7 +36,7 @@ const PREPUBLISH_SCRIPTS = [
   'postpublish',
 ]
 
-export default async function makePublishManifest (dir: string, originalManifest: ProjectManifest) {
+export default async function makePublishManifest (dir: string, originalManifest: ProjectManifest, readmeFile?: string) {
   const publishManifest: ProjectManifest = omit(['pnpm', 'scripts'], originalManifest)
   if (originalManifest.scripts != null) {
     publishManifest.scripts = omit(PREPUBLISH_SCRIPTS, originalManifest.scripts)
@@ -55,6 +55,10 @@ export default async function makePublishManifest (dir: string, originalManifest
       .forEach(key => {
         publishManifest[key] = publishConfig[key]
       })
+  }
+
+  if (readmeFile) {
+    publishManifest.readme = readmeFile
   }
 
   return publishManifest

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -36,7 +36,7 @@ const PREPUBLISH_SCRIPTS = [
   'postpublish',
 ]
 
-export default async function makePublishManifest (dir: string, originalManifest: ProjectManifest, readmeFile?: string) {
+export default async function makePublishManifest (dir: string, originalManifest: ProjectManifest, opts?: { readmeFile?: string }) {
   const publishManifest: ProjectManifest = omit(['pnpm', 'scripts'], originalManifest)
   if (originalManifest.scripts != null) {
     publishManifest.scripts = omit(PREPUBLISH_SCRIPTS, originalManifest.scripts)
@@ -57,8 +57,8 @@ export default async function makePublishManifest (dir: string, originalManifest
       })
   }
 
-  if (readmeFile) {
-    publishManifest.readme ??= readmeFile
+  if (opts?.readmeFile) {
+    publishManifest.readme ??= opts.readmeFile
   }
 
   return publishManifest

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -58,7 +58,7 @@ export default async function makePublishManifest (dir: string, originalManifest
   }
 
   if (readmeFile) {
-    publishManifest.readme = readmeFile
+    publishManifest.readme ??= readmeFile
   }
 
   return publishManifest

--- a/packages/exportable-manifest/test/index.test.ts
+++ b/packages/exportable-manifest/test/index.test.ts
@@ -50,7 +50,7 @@ test('readme added to published manifest', async () => {
   expect(await exportableManifest(process.cwd(), {
     name: 'foo',
     version: '1.0.0',
-  }, 'readme content')).toStrictEqual({
+  }, { readmeFile: 'readme content' })).toStrictEqual({
     name: 'foo',
     version: '1.0.0',
     readme: 'readme content',

--- a/packages/exportable-manifest/test/index.test.ts
+++ b/packages/exportable-manifest/test/index.test.ts
@@ -45,3 +45,14 @@ test('publish lifecycle scripts are removed', async () => {
     },
   })
 })
+
+test('readme added to published manifest', async () => {
+  expect(await exportableManifest(process.cwd(), {
+    name: 'foo',
+    version: '1.0.0',
+  }, 'readme content')).toStrictEqual({
+    name: 'foo',
+    version: '1.0.0',
+    readme: 'readme content',
+  })
+})

--- a/packages/plugin-commands-publishing/src/pack.ts
+++ b/packages/plugin-commands-publishing/src/pack.ts
@@ -124,7 +124,9 @@ async function packPkg (destFile: string, filesMap: Record<string, string>, proj
     }
     const mode = isExecutable ? 0o755 : 0o644
     if (/^package\/package\.(json|json5|yaml)/.test(name)) {
-      const publishManifest = await exportableManifest(projectDir, manifest)
+      const readmePath = Object.values(filesMap).find(name => name.toLowerCase().includes('readme.md'))
+      const readmeFile = readmePath ? fs.readFileSync(readmePath, 'utf8') : undefined
+      const publishManifest = await exportableManifest(projectDir, manifest, readmeFile)
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(publishManifest, null, 2))
       continue
     }

--- a/packages/plugin-commands-publishing/src/pack.ts
+++ b/packages/plugin-commands-publishing/src/pack.ts
@@ -124,8 +124,8 @@ async function packPkg (destFile: string, filesMap: Record<string, string>, proj
     }
     const mode = isExecutable ? 0o755 : 0o644
     if (/^package\/package\.(json|json5|yaml)/.test(name)) {
-      const readmePath = Object.values(filesMap).find(name => name.toLowerCase().includes('readme.md'))
-      const readmeFile = readmePath ? fs.readFileSync(readmePath, 'utf8') : undefined
+      const readmePath = Object.keys(filesMap).find(name => /^package\/readme.md$/i.test(name))
+      const readmeFile = readmePath ? await fs.promises.readFile(filesMap[readmePath], 'utf8') : undefined
       const publishManifest = await exportableManifest(projectDir, manifest, readmeFile)
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(publishManifest, null, 2))
       continue

--- a/packages/plugin-commands-publishing/src/pack.ts
+++ b/packages/plugin-commands-publishing/src/pack.ts
@@ -126,7 +126,7 @@ async function packPkg (destFile: string, filesMap: Record<string, string>, proj
     if (/^package\/package\.(json|json5|yaml)/.test(name)) {
       const readmePath = Object.keys(filesMap).find(name => /^package\/readme.md$/i.test(name))
       const readmeFile = readmePath ? await fs.promises.readFile(filesMap[readmePath], 'utf8') : undefined
-      const publishManifest = await exportableManifest(projectDir, manifest, readmeFile)
+      const publishManifest = await exportableManifest(projectDir, manifest, { readmeFile })
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(publishManifest, null, 2))
       continue
     }

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -90,6 +90,7 @@ export interface BaseManifest {
   typings?: string
   types?: string
   publishConfig?: PublishConfig
+  readme?: string
 }
 
 export type DependencyManifest = BaseManifest & Required<Pick<BaseManifest, 'name' | 'version'>>


### PR DESCRIPTION
fix(plugin-commands-publishing): add readme file to published package.json

add readme file to published package.json to prevent missing in the verdaccio registry

https://github.com/pnpm/pnpm/issues/4091