### PR TITLE
fix: don't crash when peer ranges cannot be merged

### DIFF
--- a/.changeset/spotty-singers-behave.md
+++ b/.changeset/spotty-singers-behave.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+If making an intersection of peer dependency ranges does not succeed, install should not crash [#4134](https://github.com/pnpm/pnpm/issues/4134).

--- a/packages/resolve-dependencies/src/mergePeers.ts
+++ b/packages/resolve-dependencies/src/mergePeers.ts
@@ -10,7 +10,7 @@ export function mergePeers (missingPeers: MissingPeerIssuesByPeerName) {
       intersections[peerName] = ranges[0].wantedRange
       continue
     }
-    const intersection = intersect(...ranges.map(({ wantedRange }) => wantedRange))
+    const intersection = safeIntersect(ranges.map(({ wantedRange }) => wantedRange))
     if (intersection === null) {
       conflicts.push(peerName)
     } else {
@@ -18,4 +18,12 @@ export function mergePeers (missingPeers: MissingPeerIssuesByPeerName) {
     }
   }
   return { conflicts, intersections }
+}
+
+function safeIntersect (ranges: string[]): null | string {
+  try {
+    return intersect(...ranges)
+  } catch {
+    return null
+  }
 }


### PR DESCRIPTION
close #4134