### PR TITLE
feat: pnpm add support `--types` option

### DIFF
--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -161,8 +161,10 @@ export async function mutateModules (
     streamParser.on('data', reporter)
   }
 
+  // 一些配置项的 opts
   const opts = await extendOptions(maybeOpts)
 
+  // optionalDep 不能单独安装如果没有 dep
   if (!opts.include.dependencies && opts.include.optionalDependencies) {
     throw new PnpmError('OPTIONAL_DEPS_REQUIRE_PROD_DEPS', 'Optional dependencies cannot be installed without production dependencies')
   }
@@ -170,6 +172,7 @@ export async function mutateModules (
   const installsOnly = projects.every((project) => project.mutation === 'install')
   if (!installsOnly) opts.strictPeerDependencies = false
   opts['forceNewModules'] = installsOnly
+  // 读一波 pkg.json
   const rootProjectManifest = projects.find(({ rootDir }) => rootDir === opts.lockfileDir)?.manifest ??
     // When running install/update on a subset of projects, the root project might not be included,
     // so reading its manifest explicitly here.
@@ -181,7 +184,11 @@ export async function mutateModules (
     packageExtensions: opts.packageExtensions,
     peerDependencyRules: opts.peerDependencyRules,
   })
+  // console.log('opts: ', opts);
+  // console.log('projects', projects);
+  // ctx 是个比较关键的上下文信息,存储一些新装依赖的信息
   const ctx = await getContext(projects, opts)
+  // console.log('ctx: ', ctx);
   const pruneVirtualStore = ctx.modulesFile?.prunedAt && opts.modulesCacheMaxAge > 0
     ? cacheExpired(ctx.modulesFile.prunedAt, opts.modulesCacheMaxAge)
     : true
@@ -194,6 +201,7 @@ export async function mutateModules (
     }
   }
 
+  // 安装依赖在 _install 这个方法里面
   const result = await _install()
 
   if (global['verifiedFileIntegrity'] > 1000) {
@@ -233,6 +241,7 @@ export async function mutateModules (
         }
       )
     }
+    // undefined
     const packageExtensionsChecksum = isEmpty(opts.packageExtensions ?? {}) ? undefined : createObjectChecksum(opts.packageExtensions!)
     let needsFullResolution = !maybeOpts.ignorePackageManifest &&
       lockfileIsUpToDate(ctx.wantedLockfile, {
@@ -242,6 +251,7 @@ export async function mutateModules (
         packageExtensionsChecksum,
       }) ||
       opts.fixLockfile
+    // 不存在
     if (needsFullResolution) {
       ctx.wantedLockfile.overrides = opts.overrides
       ctx.wantedLockfile.neverBuiltDependencies = opts.neverBuiltDependencies
@@ -327,6 +337,7 @@ export async function mutateModules (
 
     // TODO: make it concurrent
     for (const project of ctx.projects) {
+      // 通过 project 的 mutation 来推断 add -> installSome
       switch (project.mutation) {
       case 'uninstallSome':
         projectsToInstall.push({

--- a/packages/get-context/package.json
+++ b/packages/get-context/package.json
@@ -12,6 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
+    "start": "pnpm tsc --watch",
     "lint": "eslint src/**/*.ts",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",

--- a/packages/get-context/src/index.ts
+++ b/packages/get-context/src/index.ts
@@ -99,6 +99,7 @@ export default async function getContext<T> (
 ): Promise<PnpmContext<T>> {
   const modulesDir = opts.modulesDir ?? 'node_modules'
   let importersContext = await readProjectsContext(projects, { lockfileDir: opts.lockfileDir, modulesDir })
+  console.log('importersContext: ', importersContext);
   const virtualStoreDir = pathAbsolute(opts.virtualStoreDir ?? path.join(modulesDir, '.pnpm'), opts.lockfileDir)
 
   if (importersContext.modules != null) {

--- a/packages/plugin-commands-installation/src/add.ts
+++ b/packages/plugin-commands-installation/src/add.ts
@@ -78,6 +78,7 @@ export function cliOptionsTypes () {
     recursive: Boolean,
     save: Boolean,
     workspace: Boolean,
+    types: Boolean,
   }
 }
 
@@ -135,6 +136,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
             description: 'Only adds the new dependency if it is found in the workspace',
             name: '--workspace',
           },
+          {
+            description: 'Install both package and it\'s type package',
+            name: '--types'
+          },
           OPTIONS.ignoreScripts,
           OPTIONS.offline,
           OPTIONS.preferOffline,
@@ -174,6 +179,7 @@ export async function handler (
   opts: AddCommandOptions,
   params: string[]
 ) {
+  // console.log('opts', opts);
   if (opts.cliOptions['save'] === false) {
     throw new PnpmError('OPTION_NOT_SUPPORTED', 'The "add" command currently does not support the no-save option')
   }

--- a/packages/plugin-commands-installation/src/getTypeDependecies.ts
+++ b/packages/plugin-commands-installation/src/getTypeDependecies.ts
@@ -1,0 +1,2 @@
+export async function hasDefinitelyTyped (pkgName: string) {
+}

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -95,6 +95,8 @@ export default async function handler (
   opts: InstallDepsOptions,
   params: string[]
 ) {
+  // npmrc 的值从 otps.rawLocalConfig 里面读
+  // cliOptions 里面的值，可以从 opts.xxx 里面直接读
   if (opts.workspace) {
     if (opts.latest) {
       throw new PnpmError('BAD_OPTIONS', 'Cannot use --latest with --workspace simultaneously')
@@ -114,6 +116,7 @@ when running add/update with the --workspace option')
     }
     opts['preserveWorkspaceProtocol'] = !opts.linkWorkspacePackages
   }
+  // includeDirect 会当参数传进来
   const includeDirect = opts.includeDirect ?? {
     dependencies: true,
     devDependencies: true,
@@ -126,11 +129,13 @@ when running add/update with the --workspace option')
   const allProjects = opts.allProjects ?? (
     opts.workspaceDir ? await findWorkspacePackages(opts.workspaceDir, opts) : []
   )
+  // 判断是在 workspaceDir 的情况下
   if (opts.workspaceDir) {
     const selectedProjectsGraph = opts.selectedProjectsGraph ?? selectProjectByDir(allProjects, opts.dir)
     if (selectedProjectsGraph != null) {
       const sequencedGraph = sequenceGraph(selectedProjectsGraph)
       // Check and warn if there are cyclic dependencies
+      // 检查循环依赖
       if (!sequencedGraph.safe) {
         const cyclicDependenciesInfo = sequencedGraph.cycles.length > 0
           ? `: ${sequencedGraph.cycles.map(deps => deps.join(', ')).join('; ')}` // eslint-disable-line
@@ -141,6 +146,7 @@ when running add/update with the --workspace option')
         })
       }
 
+      // 如果实在 workspace 下，递归执行一次
       await recursive(allProjects,
         params,
         {
@@ -150,6 +156,7 @@ when running add/update with the --workspace option')
           selectedProjectsGraph,
           workspaceDir: opts.workspaceDir,
         },
+        // 如果没 params 的话就走 add 的逻辑 否则走 install 
         opts.update ? 'update' : (params.length === 0 ? 'install' : 'add')
       )
       return
@@ -161,10 +168,12 @@ when running add/update with the --workspace option')
   const dir = opts.dir || process.cwd()
   let workspacePackages!: WorkspacePackages
 
+  // 判断是不是 pnpm workspace 项目
   if (opts.workspaceDir) {
     workspacePackages = arrayOfWorkspacePackagesToMap(allProjects)
   }
 
+  // mainfest 是项目的 pkg.json
   let { manifest, writeProjectManifest } = await tryReadProjectManifest(opts.dir, opts)
   if (manifest === null) {
     if (opts.update === true || params.length === 0) {
@@ -173,6 +182,7 @@ when running add/update with the --workspace option')
     manifest = {}
   }
 
+  // store 的相关信息 store.dir 以及 store.ctrl
   const store = await createOrConnectStoreController(opts)
   const installOpts: MutateModulesOptions = {
     ...opts,
@@ -220,7 +230,10 @@ when running add/update with the --workspace option')
       params = createWorkspaceSpecs(params, workspacePackages)
     }
   }
+  // 如果是 pnpm add 的话ex: pnpm add lodash --types (loadash) 就是 params
   if (params?.length) {
+    console.log('params: ', params);
+    // pnpm 的依赖安装过程在 mutateModules 中
     const mutatedProject: MutatedProject = {
       allowNew: opts.allowNew,
       binsDir: opts.bin,
@@ -238,6 +251,7 @@ when running add/update with the --workspace option')
     }
     return
   }
+  // 上面逻辑中杀死 pnpm add xxx 逻辑, 下面我不必关注
 
   const updatedManifest = await install(manifest, installOpts)
   if (opts.update === true && opts.save !== false) {


### PR DESCRIPTION
I am now focus on the issue: https://github.com/pnpm/pnpm/issues/3868

And i will update the develop process and the question which i will face here:

## Problem

The command `pnpm add` add a new option which discussed in the issue named `--types`

## Examples

When we execute the command below:

```bash
pnpm add jest --types
```

Both `jest` and its types dependencies `@types/jest` will be installed in the `package.json`

And the package which has its own types declarations(https://github.blog/changelog/2020-12-16-npm-displays-packages-with-bundled-typescript-declarations/) will not install the dependencies `@types/xxx`.(Such as many libraries which was written in TypeScript.)

## Implemention

The `add` command which was in `plugin-commands-installation/src/insallDeps.ts`: 
```ts
  if (params?.length) {
    const [updatedImporter] = await mutateModules([
      {
        allowNew: opts.allowNew,
        binsDir: installOpts.bin,
        dependencySelectors: params,
        manifest,
        mutation: 'installSome',
        peer: opts.savePeer,
        pinnedVersion: getPinnedVersion(opts),
        rootDir: installOpts.dir,
        targetDependenciesField: getSaveType(installOpts),
      },
    ], installOpts)
    if (opts.save !== false) {
      await writeProjectManifest(updatedImporter.manifest)
    }
    return
  }
```

And the install process was happend in the function `mutateModules`.

The param `dependencySelectors` which included the dependencies was installed such as if we execute `pnpm add lodash` then the  `dependencySelectors` was `['lodash']`.

So I just need to add the types dependencies to the `dependencySelectors` array when the user executed the command  like `pnpm add lodash --types`(then the dependencies `@types/lodash` will be added). 

Maybe some pkgs not have a `DT` dependencies, i will print the info.

And as the `Examples` describe, I also need to implement two function.

- [ ] `hasTypeDependencies(pkg)` which was used for judge the dependencies has types dependencies or not.
- [ ] `getTypeDependencies(pkg)` which was used to get the types dependencies for the dependencies don't its own type declarations.(In many case the name was just added `@types/xxx` prefix and i am not sure there are some edge case or not).

cc when you are free~ @zkochan 
