### PR TITLE
fix(link-bins): don't throw error during install when bin points to path that doesn't exist

### DIFF
--- a/.changeset/odd-garlics-crash.md
+++ b/.changeset/odd-garlics-crash.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/link-bins": patch
+"pnpm": patch
 ---
 
-don't throw error during install when bin points to path that doesn't exist
+Don't throw an error during install when the bin of a dependency points to a path that doesn't exist [#3763](https://github.com/pnpm/pnpm/issues/3763).

--- a/.changeset/odd-garlics-crash.md
+++ b/.changeset/odd-garlics-crash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/link-bins": patch
+---
+
+don't throw error during install when bin points to path that doesn't exist

--- a/packages/link-bins/src/index.ts
+++ b/packages/link-bins/src/index.ts
@@ -203,15 +203,15 @@ async function getPackageBinsFromManifest (manifest: DependencyManifest, pkgDir:
 async function linkBin (cmd: CommandInfo, binsDir: string, opts?: { extendNodePath?: boolean }) {
   const externalBinPath = path.join(binsDir, cmd.name)
 
-  let nodePath: string[] | undefined
-  if (opts?.extendNodePath !== false) {
-    nodePath = await getBinNodePaths(cmd.path)
-    const binsParentDir = path.dirname(binsDir)
-    if (path.relative(cmd.path, binsParentDir) !== '') {
-      nodePath = union(nodePath, await getBinNodePaths(binsParentDir))
-    }
-  }
   try {
+    let nodePath: string[] | undefined
+    if (opts?.extendNodePath !== false) {
+      nodePath = await getBinNodePaths(cmd.path)
+      const binsParentDir = path.dirname(binsDir)
+      if (path.relative(cmd.path, binsParentDir) !== '') {
+        nodePath = union(nodePath, await getBinNodePaths(binsParentDir))
+      }
+    }
     await cmdShim(cmd.path, externalBinPath, {
       createPwshFile: cmd.makePowerShellShim,
       nodePath,

--- a/packages/link-bins/test/fixtures/bin-not-exist/node_modules/foo/package.json
+++ b/packages/link-bins/test/fixtures/bin-not-exist/node_modules/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "meow",
+  "version": "1.0.0",
+  "bin": "dist/not-exist.js"
+}


### PR DESCRIPTION
Attempt to fix #3763 

- Basically moves the codes that may throw `ENOENT` into `try-catch`.
- Added test too. Without this patch, the test will fail to run because an `ENOENT` error will be thrown from `getBinNodePaths`

Let me know if there's a better approach. Thanks

