### PR TITLE
feat: add option to not set npm_config_argv in process.env

### DIFF
--- a/.changeset/itchy-mugs-occur.md
+++ b/.changeset/itchy-mugs-occur.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+feat: if useBetaCli, then don't set npm_config_argv in process.env

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -81,7 +81,6 @@ export default async function run (inputArgv: string[]) {
       return
     }
   }
-  process.env['npm_config_argv'] = JSON.stringify(argv)
 
   let config: Config & {
     forceSharedLockfile: boolean
@@ -108,6 +107,10 @@ export default async function run (inputArgv: string[]) {
     printError(err.message, hint)
     process.exitCode = 1
     return
+  }
+  if (!config.useBetaCli) {
+    process.env['npm_config_argv'] = JSON.stringify(argv)
+    config.rawConfig.argv = process.env['npm_config_argv']
   }
 
   let write: (text: string) => void = process.stdout.write.bind(process.stdout)


### PR DESCRIPTION
Based on https://github.com/pnpm/pnpm/discussions/4153 I'd like to see if it's possible to provide option to not set npm_config_argv in process.env

~~This PR adds that option by setting in `.npmrc`:~~

```
set-npm-config-argv-as-environment-variable=false
```

~~(naming is hard, if there's better name, please do suggest 😆)~~

As suggested, used "`useBetaCli`". If flag is true, then don't set npm_config_argv in process.env

----

I also moved down this block

```
process.env['npm_config_argv'] = JSON.stringify(argv)
```

because at the original location, it haven't parsed configs from `.npmrc` yet


-----

Please let me know if there's any concern. Thanks


---

~~Edit: oh wow the test are failing, but I couldn't figure out how lifecycle events are run before config are read ? 😅😅😅😅~~
