### PR TITLE
refactor: rename the values of the node-linker setting

### DIFF
--- a/.changeset/lemon-clocks-brake.md
+++ b/.changeset/lemon-clocks-brake.md
@@ -4,4 +4,8 @@
 "@pnpm/headless": minor
 ---
 
-nodeLinker may accept two new values: `isolated-node-modules` and `hoisted-node-modules`. `hoisted-node-modules` will create a "classic" `node_modules` folder without using symlinks.
+nodeLinker may accept two new values: `isolated` and `hoisted`.
+
+`hoisted` will create a "classic" `node_modules` folder without using symlinks.
+
+`isolated` will be the default value that creates a symlinked `node_modules`.

--- a/.changeset/lemon-clocks-brake.md
+++ b/.changeset/lemon-clocks-brake.md
@@ -4,4 +4,4 @@
 "@pnpm/headless": minor
 ---
 
-nodeLinker may accept a new value: node-modules. node-modules will create a "classic" node_modules folder without using symlinks.
+nodeLinker may accept two new values: `isolated-node-modules` and `hoisted-node-modules`. `hoisted-node-modules` will create a "classic" `node_modules` folder without using symlinks.

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -73,7 +73,7 @@ export interface Config {
   enablePrePostScripts?: boolean
   useNodeVersion?: string
   useStderr?: boolean
-  nodeLinker?: 'hoisted-node-modules' | 'isolated-node-modules' | 'pnp'
+  nodeLinker?: 'hoisted' | 'isolated' | 'pnp'
 
   // proxy
   httpProxy?: string

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -73,7 +73,7 @@ export interface Config {
   enablePrePostScripts?: boolean
   useNodeVersion?: string
   useStderr?: boolean
-  nodeLinker?: 'node-modules' | 'pnpm' | 'pnp'
+  nodeLinker?: 'hoisted-node-modules' | 'isolated-node-modules' | 'pnp'
 
   // proxy
   httpProxy?: string

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -72,7 +72,7 @@ export const types = Object.assign({
   'modules-cache-max-age': Number,
   'modules-dir': String,
   'network-concurrency': Number,
-  'node-linker': ['pnp'],
+  'node-linker': ['pnp', 'isolated-node-modules', 'hoisted-node-modules'],
   noproxy: String,
   'npm-path': String,
   offline: Boolean,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -72,7 +72,7 @@ export const types = Object.assign({
   'modules-cache-max-age': Number,
   'modules-dir': String,
   'network-concurrency': Number,
-  'node-linker': ['pnp', 'isolated-node-modules', 'hoisted-node-modules'],
+  'node-linker': ['pnp', 'isolated', 'hoisted'],
   noproxy: String,
   'npm-path': String,
   offline: Boolean,

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -47,7 +47,7 @@ export interface StrictInstallOptions {
   engineStrict: boolean
   neverBuiltDependencies: string[]
   nodeExecPath?: string
-  nodeLinker?: 'isolated-node-modules' | 'hoisted-node-modules' | 'pnp'
+  nodeLinker?: 'isolated' | 'hoisted' | 'pnp'
   nodeVersion: string
   packageExtensions: Record<string, PackageExtension>
   packageManager: {
@@ -127,7 +127,7 @@ const defaults = async (opts: InstallOptions) => {
     lockfileOnly: false,
     neverBuiltDependencies: [] as string[],
     nodeVersion: process.version,
-    nodeLinker: 'isolated-node-modules',
+    nodeLinker: 'isolated',
     overrides: {},
     ownLifecycleHooksStdio: 'inherit',
     ignorePackageManifest: false,

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -47,7 +47,7 @@ export interface StrictInstallOptions {
   engineStrict: boolean
   neverBuiltDependencies: string[]
   nodeExecPath?: string
-  nodeLinker?: 'node-modules' | 'pnpm' | 'pnp'
+  nodeLinker?: 'isolated-node-modules' | 'hoisted-node-modules' | 'pnp'
   nodeVersion: string
   packageExtensions: Record<string, PackageExtension>
   packageManager: {
@@ -127,7 +127,7 @@ const defaults = async (opts: InstallOptions) => {
     lockfileOnly: false,
     neverBuiltDependencies: [] as string[],
     nodeVersion: process.version,
-    nodeLinker: 'pnpm',
+    nodeLinker: 'isolated-node-modules',
     overrides: {},
     ownLifecycleHooksStdio: 'inherit',
     ignorePackageManifest: false,

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -914,7 +914,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     await finishLockfileUpdates()
     await writeWantedLockfile(ctx.lockfileDir, newLockfile, lockfileOpts)
 
-    if (opts.nodeLinker !== 'node-modules') {
+    if (opts.nodeLinker !== 'hoisted-node-modules') {
       // This is only needed because otherwise the reporter will hang
       stageLogger.debug({
         prefix: opts.lockfileDir,
@@ -942,7 +942,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
 const installInContext: InstallFunction = async (projects, ctx, opts) => {
   try {
-    if (opts.nodeLinker === 'node-modules' && !opts.lockfileOnly) {
+    if (opts.nodeLinker === 'hoisted-node-modules' && !opts.lockfileOnly) {
       const result = await _installInContext(projects, ctx, {
         ...opts,
         lockfileOnly: true,

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -914,7 +914,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     await finishLockfileUpdates()
     await writeWantedLockfile(ctx.lockfileDir, newLockfile, lockfileOpts)
 
-    if (opts.nodeLinker !== 'hoisted-node-modules') {
+    if (opts.nodeLinker !== 'hoisted') {
       // This is only needed because otherwise the reporter will hang
       stageLogger.debug({
         prefix: opts.lockfileDir,
@@ -942,7 +942,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
 const installInContext: InstallFunction = async (projects, ctx, opts) => {
   try {
-    if (opts.nodeLinker === 'hoisted-node-modules' && !opts.lockfileOnly) {
+    if (opts.nodeLinker === 'hoisted' && !opts.lockfileOnly) {
       const result = await _installInContext(projects, ctx, {
         ...opts,
         lockfileOnly: true,

--- a/packages/core/test/hoistedNodeLinker/install.ts
+++ b/packages/core/test/hoistedNodeLinker/install.ts
@@ -4,7 +4,7 @@ import { install } from '@pnpm/core'
 import { prepareEmpty } from '@pnpm/prepare'
 import { testDefaults } from '../utils'
 
-test('installing with hoisted-node-modules node-linker', async () => {
+test('installing with hoisted node-linker', async () => {
   prepareEmpty()
 
   await install({
@@ -14,7 +14,7 @@ test('installing with hoisted-node-modules node-linker', async () => {
       ms: '1.0.0',
     },
   }, await testDefaults({
-    nodeLinker: 'hoisted-node-modules',
+    nodeLinker: 'hoisted',
   }))
 
   expect(fs.realpathSync('node_modules/send')).toEqual(path.resolve('node_modules/send'))

--- a/packages/core/test/install/nodeLinkerHoistedNodeModules.ts
+++ b/packages/core/test/install/nodeLinkerHoistedNodeModules.ts
@@ -4,7 +4,7 @@ import { install } from '@pnpm/core'
 import { prepareEmpty } from '@pnpm/prepare'
 import { testDefaults } from '../utils'
 
-test('installing with node-modules node-linker', async () => {
+test('installing with hoisted-node-modules node-linker', async () => {
   prepareEmpty()
 
   await install({
@@ -14,7 +14,7 @@ test('installing with node-modules node-linker', async () => {
       ms: '1.0.0',
     },
   }, await testDefaults({
-    nodeLinker: 'node-modules',
+    nodeLinker: 'hoisted-node-modules',
   }))
 
   expect(fs.realpathSync('node_modules/send')).toEqual(path.resolve('node_modules/send'))

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -130,7 +130,7 @@ export interface HeadlessOptions {
   pendingBuilds: string[]
   skipped: Set<string>
   enableModulesDir?: boolean
-  nodeLinker?: 'pnpm' | 'node-modules' | 'pnp'
+  nodeLinker?: 'isolated-node-modules' | 'hoisted-node-modules' | 'pnp'
 }
 
 export default async (opts: HeadlessOptions) => {
@@ -236,7 +236,7 @@ export default async (opts: HeadlessOptions) => {
     pnpmVersion: opts.currentEngine.pnpmVersion,
   } as LockfileToDepGraphOptions
   const { hierarchy, directDependenciesByImporterId, graph, symlinkedDirectDependenciesByImporterId } = await (
-    opts.nodeLinker === 'node-modules'
+    opts.nodeLinker === 'hoisted-node-modules'
       ? lockfileToHoistedDepGraph(
         filteredLockfile,
         lockfileToDepGraphOpts
@@ -273,7 +273,7 @@ export default async (opts: HeadlessOptions) => {
   }
 
   let newHoistedDependencies!: HoistedDependencies
-  if (opts.nodeLinker === 'node-modules' && hierarchy) {
+  if (opts.nodeLinker === 'hoisted-node-modules' && hierarchy) {
     await linkAllPkgsInOrder(opts.storeController, graph, hierarchy, {
       force: opts.force,
       lockfileDir: opts.lockfileDir,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -130,7 +130,7 @@ export interface HeadlessOptions {
   pendingBuilds: string[]
   skipped: Set<string>
   enableModulesDir?: boolean
-  nodeLinker?: 'isolated-node-modules' | 'hoisted-node-modules' | 'pnp'
+  nodeLinker?: 'isolated' | 'hoisted' | 'pnp'
 }
 
 export default async (opts: HeadlessOptions) => {
@@ -236,7 +236,7 @@ export default async (opts: HeadlessOptions) => {
     pnpmVersion: opts.currentEngine.pnpmVersion,
   } as LockfileToDepGraphOptions
   const { hierarchy, directDependenciesByImporterId, graph, symlinkedDirectDependenciesByImporterId } = await (
-    opts.nodeLinker === 'hoisted-node-modules'
+    opts.nodeLinker === 'hoisted'
       ? lockfileToHoistedDepGraph(
         filteredLockfile,
         lockfileToDepGraphOpts
@@ -273,7 +273,7 @@ export default async (opts: HeadlessOptions) => {
   }
 
   let newHoistedDependencies!: HoistedDependencies
-  if (opts.nodeLinker === 'hoisted-node-modules' && hierarchy) {
+  if (opts.nodeLinker === 'hoisted' && hierarchy) {
     await linkAllPkgsInOrder(opts.storeController, graph, hierarchy, {
       force: opts.force,
       lockfileDir: opts.lockfileDir,

--- a/packages/headless/test/index.ts
+++ b/packages/headless/test/index.ts
@@ -819,13 +819,13 @@ test('installing with no modules directory', async () => {
   expect(await exists(path.join(prefix, 'node_modules'))).toBeFalsy()
 })
 
-test('installing with node-linker=node-modules', async () => {
+test('installing with node-linker=hoisted-node-modules', async () => {
   const prefix = f.prepare('has-several-versions-of-same-pkg')
 
   await headless(await testDefaults({
     enableModulesDir: false,
     lockfileDir: prefix,
-    nodeLinker: 'node-modules',
+    nodeLinker: 'hoisted-node-modules',
   }))
 
   expect(realpathSync('node_modules/ms')).toBe(path.resolve('node_modules/ms'))
@@ -833,7 +833,7 @@ test('installing with node-linker=node-modules', async () => {
   expect(existsSync('node_modules/send/node_modules/ms')).toBeTruthy()
 })
 
-test('installing in a workspace with node-linker=node-modules', async () => {
+test('installing in a workspace with node-linker=hoisted-node-modules', async () => {
   const prefix = f.prepare('workspace2')
 
   let { projects } = await readprojectsContext(
@@ -853,7 +853,7 @@ test('installing in a workspace with node-linker=node-modules', async () => {
   )
   await headless(await testDefaults({
     lockfileDir: prefix,
-    nodeLinker: 'node-modules',
+    nodeLinker: 'hoisted-node-modules',
     projects,
   }))
 

--- a/packages/headless/test/index.ts
+++ b/packages/headless/test/index.ts
@@ -819,13 +819,13 @@ test('installing with no modules directory', async () => {
   expect(await exists(path.join(prefix, 'node_modules'))).toBeFalsy()
 })
 
-test('installing with node-linker=hoisted-node-modules', async () => {
+test('installing with node-linker=hoisted', async () => {
   const prefix = f.prepare('has-several-versions-of-same-pkg')
 
   await headless(await testDefaults({
     enableModulesDir: false,
     lockfileDir: prefix,
-    nodeLinker: 'hoisted-node-modules',
+    nodeLinker: 'hoisted',
   }))
 
   expect(realpathSync('node_modules/ms')).toBe(path.resolve('node_modules/ms'))
@@ -833,7 +833,7 @@ test('installing with node-linker=hoisted-node-modules', async () => {
   expect(existsSync('node_modules/send/node_modules/ms')).toBeTruthy()
 })
 
-test('installing in a workspace with node-linker=hoisted-node-modules', async () => {
+test('installing in a workspace with node-linker=hoisted', async () => {
   const prefix = f.prepare('workspace2')
 
   let { projects } = await readprojectsContext(
@@ -853,7 +853,7 @@ test('installing in a workspace with node-linker=hoisted-node-modules', async ()
   )
   await headless(await testDefaults({
     lockfileDir: prefix,
-    nodeLinker: 'hoisted-node-modules',
+    nodeLinker: 'hoisted',
     projects,
   }))
 


### PR DESCRIPTION
ref #4073

In their [RFC](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md#naming), npm decided to use this terminology: 

> This mode is called isolated-mode because it makes the boundaries between packages and workspaces stronger, making them more isolated.
>
> To make the discussions more efficient, we could also name the current default installation mode of npm. We will call this mode hoisted-mode as packages are shared across workspaces by hoisting them to the root of the project. This term is already known by developers familiar with yarn or pnpm.

In Yarn, the node linker setting may have these values: pnp, node-modules, and pnpm.

Probably it is better to use isolated/hoisted instead of pnpm/node-modules because pnpm also creates a node-modules folder.

So I suggest us to use this values: `isolated-node-modules`, `hoisted-node-modules`, and `pnp`.