### PR TITLE
feat: support peerDependencyRules for muting peer dep issues

### DIFF
--- a/.changeset/famous-toys-provide.md
+++ b/.changeset/famous-toys-provide.md
@@ -1,0 +1,21 @@
+---
+"pnpm": minor
+"@pnpm/plugin-commands-installation": minor
+---
+
+In order to mute some types of peer dependency warnings, a new section in `package.json` may be used for declaring peer dependency warning rules. For example, the next configuration will turn off any warnings about missing `babel-loader` peer dependency and about `@angular/common`, when the wanted version of `@angular/common` is not v13.
+
+```json
+{
+  "name": "foo",
+  "version": "0.0.0",
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["babel-loader"],
+      "allowedVersions": {
+        "@angular/common": "13"
+      }
+    }
+  }
+}
+```

--- a/.changeset/itchy-berries-wink.md
+++ b/.changeset/itchy-berries-wink.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/core": minor
+---
+
+New optional option supported: `peerDependencyRules`. This setting allows to mute specific peer dependency warnings.

--- a/.changeset/plenty-mayflies-hug.md
+++ b/.changeset/plenty-mayflies-hug.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/types": minor
+---
+
+New field added to package.json.pnpm section: peerDependencyRules.

--- a/packages/core/src/install/createPeerDependencyPatcher.ts
+++ b/packages/core/src/install/createPeerDependencyPatcher.ts
@@ -1,0 +1,23 @@
+import { PeerDependencyRules, ReadPackageHook } from '@pnpm/types'
+import isEmpty from 'ramda/src/isEmpty'
+
+export default function (
+  peerDependencyRules: PeerDependencyRules
+): ReadPackageHook {
+  const ignoreMissing = new Set(peerDependencyRules.ignoreMissing ?? [])
+  return ((pkg) => {
+    if (isEmpty(pkg.peerDependencies)) return pkg
+    for (const peerName of Object.keys(pkg.peerDependencies ?? {})) {
+      if (ignoreMissing.has(peerName) && !pkg.peerDependenciesMeta?.[peerName]?.optional) {
+        pkg.peerDependenciesMeta = pkg.peerDependenciesMeta ?? {}
+        pkg.peerDependenciesMeta[peerName] = {
+          optional: true,
+        }
+      }
+      if (peerDependencyRules.allowedVersions?.[peerName]) {
+        pkg.peerDependencies![peerName] += ` || ${peerDependencyRules.allowedVersions[peerName]}`
+      }
+    }
+    return pkg
+  }) as ReadPackageHook
+}

--- a/packages/core/src/install/createPeerDependencyPatcher.ts
+++ b/packages/core/src/install/createPeerDependencyPatcher.ts
@@ -7,14 +7,17 @@ export default function (
   const ignoreMissing = new Set(peerDependencyRules.ignoreMissing ?? [])
   return ((pkg) => {
     if (isEmpty(pkg.peerDependencies)) return pkg
-    for (const peerName of Object.keys(pkg.peerDependencies ?? {})) {
+    for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
       if (ignoreMissing.has(peerName) && !pkg.peerDependenciesMeta?.[peerName]?.optional) {
         pkg.peerDependenciesMeta = pkg.peerDependenciesMeta ?? {}
         pkg.peerDependenciesMeta[peerName] = {
           optional: true,
         }
       }
-      if (peerDependencyRules.allowedVersions?.[peerName]) {
+      if (
+        peerDependencyRules.allowedVersions?.[peerName] &&
+        peerVersion !== '*'
+      ) {
         pkg.peerDependencies![peerName] += ` || ${peerDependencyRules.allowedVersions[peerName]}`
       }
     }

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -7,6 +7,7 @@ import { WorkspacePackages } from '@pnpm/resolver-base'
 import { StoreController } from '@pnpm/store-controller-types'
 import {
   PackageExtension,
+  PeerDependencyRules,
   ReadPackageHook,
   Registries,
 } from '@pnpm/types'
@@ -80,6 +81,7 @@ export interface StrictInstallOptions {
   symlink: boolean
   enableModulesDir: boolean
   modulesCacheMaxAge: number
+  peerDependencyRules: PeerDependencyRules
 
   hoistPattern: string[] | undefined
   forceHoistPattern: boolean

--- a/packages/core/test/install/createPeerDependencyPatcher.test.ts
+++ b/packages/core/test/install/createPeerDependencyPatcher.test.ts
@@ -1,0 +1,39 @@
+import createPeerDependencyPatcher from '@pnpm/core/lib/install/createPeerDependencyPatcher'
+
+test('createPeerDependencyPatcher() ignores missing', () => {
+  const patcher = createPeerDependencyPatcher({
+    ignoreMissing: ['foo'],
+  })
+  const patchedPkg = patcher({
+    peerDependencies: {
+      foo: '*',
+      bar: '*',
+    },
+  })
+  expect(patchedPkg['peerDependenciesMeta']).toStrictEqual({
+    foo: {
+      optional: true,
+    },
+  })
+})
+
+test('createPeerDependencyPatcher() extends peer ranges', () => {
+  const patcher = createPeerDependencyPatcher({
+    allowedVersions: {
+      foo: '1',
+      qar: '1',
+    },
+  })
+  const patchedPkg = patcher({
+    peerDependencies: {
+      foo: '0',
+      bar: '0',
+      qar: '*',
+    },
+  })
+  expect(patchedPkg['peerDependencies']).toStrictEqual({
+    foo: '0 || 1',
+    bar: '0',
+    qar: '*',
+  })
+})

--- a/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
+++ b/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
@@ -1,15 +1,26 @@
-import { ProjectManifest } from '@pnpm/types'
+import {
+  PackageExtension,
+  PeerDependencyRules,
+  ProjectManifest,
+} from '@pnpm/types'
 
-export default function getOptionsFromRootManifest (manifest: ProjectManifest) {
+export default function getOptionsFromRootManifest (manifest: ProjectManifest): {
+  overrides?: Record<string, string>
+  neverBuiltDependencies?: string[]
+  packageExtensions?: Record<string, PackageExtension>
+  peerDependencyRules?: PeerDependencyRules
+} {
   // We read Yarn's resolutions field for compatibility
   // but we really replace the version specs to any other version spec, not only to exact versions,
   // so we cannot call it resolutions
   const overrides = manifest.pnpm?.overrides ?? manifest.resolutions
   const neverBuiltDependencies = manifest.pnpm?.neverBuiltDependencies ?? []
   const packageExtensions = manifest.pnpm?.packageExtensions
+  const peerDependencyRules = manifest.pnpm?.peerDependencyRules
   return {
     overrides,
     neverBuiltDependencies,
     packageExtensions,
+    peerDependencyRules,
   }
 }

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -97,11 +97,17 @@ export type DependencyManifest = BaseManifest & Required<Pick<BaseManifest, 'nam
 
 export type PackageExtension = Pick<BaseManifest, 'dependencies' | 'optionalDependencies' | 'peerDependencies' | 'peerDependenciesMeta'>
 
+export interface PeerDependencyRules {
+  ignoreMissing?: string[]
+  allowedVersions?: Record<string, string>
+}
+
 export type ProjectManifest = BaseManifest & {
   pnpm?: {
     neverBuiltDependencies?: string[]
     overrides?: Record<string, string>
     packageExtensions?: Record<string, PackageExtension>
+    peerDependencyRules?: PeerDependencyRules
   }
   private?: boolean
   resolutions?: Record<string, string>


### PR DESCRIPTION
close #4183

example

```json
{
  "pnpm": {
    "peerDependencyRules": {
      "ignoreMissing": ["babel-loader"],
      "allowedVersions": {
        "@angular/common": "13"
      }
    }
  }
}
```