### PR TITLE
fix: print warnings about deprecated subdependencies

### DIFF
--- a/.changeset/eleven-sheep-wash.md
+++ b/.changeset/eleven-sheep-wash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": patch
+---
+
+Print warnings about deprecated subdependencies [#4227](https://github.com/pnpm/pnpm/issues/4227).

--- a/packages/default-reporter/src/reporterForClient/reportDeprecations.ts
+++ b/packages/default-reporter/src/reporterForClient/reportDeprecations.ts
@@ -1,6 +1,6 @@
 import { DeprecationLog } from '@pnpm/core-loggers'
 import * as Rx from 'rxjs'
-import { filter, map } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 import chalk from 'chalk'
 import formatWarn from './utils/formatWarn'
 import { zoomOut } from './utils/zooming'
@@ -13,8 +13,6 @@ export default (
   }
 ) => {
   return deprecation$.pipe(
-    // print warnings only about deprecated packages from the root
-    filter((log) => log.depth === 0),
     map((log) => {
       if (!opts.isRecursive && log.prefix === opts.cwd) {
         return Rx.of({


### PR DESCRIPTION
close #4227

This might cause a lot of additional warnings on big projects but both npm and Yarn print these warnings.