### PR TITLE
feat: add support of the update-notifier configuration option

### DIFF
--- a/.changeset/forty-pens-stare.md
+++ b/.changeset/forty-pens-stare.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+add support of the update-notifier configuration option

--- a/.changeset/forty-pens-stare.md
+++ b/.changeset/forty-pens-stare.md
@@ -3,4 +3,4 @@
 "pnpm": minor
 ---
 
-add support of the update-notifier configuration option
+Add support of the `update-notifier` configuration option [#4158](https://github.com/pnpm/pnpm/issues/4158).

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -92,6 +92,7 @@ export interface Config {
 
   userAgent?: string
   tag?: string
+  updateNotifier?: boolean
 
   alwaysAuth?: boolean
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -223,7 +223,6 @@ export default async (
      * @todo Make `false` by default in v7.
      */
     'embed-readme': true,
-    'update-notifier': true,
   })
 
   npmConfig.addFile(path.resolve(path.join(__dirname, 'pnpmrc')), 'pnpm-builtin')

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -121,6 +121,7 @@ export const types = Object.assign({
   'test-pattern': [String, Array],
   'changed-files-ignore-pattern': [String, Array],
   'embed-readme': Boolean,
+  'update-notifier': Boolean,
 }, npmTypes.types)
 
 export type CliOptions = Record<string, unknown> & { dir?: string }
@@ -222,6 +223,7 @@ export default async (
      * @todo Make `false` by default in v7.
      */
     'embed-readme': true,
+    'update-notifier': true,
   })
 
   npmConfig.addFile(path.resolve(path.join(__dirname, 'pnpmrc')), 'pnpm-builtin')

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -231,6 +231,7 @@ export default async function run (inputArgv: string[]) {
       !config.offline &&
       !config.preferOffline &&
       !config.fallbackCommandUsed &&
+      !config.updateNotifier &&
       (cmd === 'install' || cmd === 'add')
     ) {
       checkForUpdates(config).catch(() => { /* Ignore */ })

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -226,12 +226,12 @@ export default async function run (inputArgv: string[]) {
     await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
 
     if (
+      config.updateNotifier !== false &&
       !isCI &&
       !selfUpdate &&
       !config.offline &&
       !config.preferOffline &&
       !config.fallbackCommandUsed &&
-      !config.updateNotifier &&
       (cmd === 'install' || cmd === 'add')
     ) {
       checkForUpdates(config).catch(() => { /* Ignore */ })


### PR DESCRIPTION
The configuration option `update-notifier` allows users to disable the update verification. This is interesting when pnpm is installed from another package manager because the given instructions will not be accurate. The[ `update-notifier` option exists in NPM](https://docs.npmjs.com/cli/v8/using-npm/config#update-notifier) so it can also ease the migration to pnpm.

Closes #4158.