### PR TITLE
feat: run scripts without --

### DIFF
--- a/.changeset/odd-kangaroos-care.md
+++ b/.changeset/odd-kangaroos-care.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/parse-cli-args": major
+"@pnpm/plugin-commands-script-runners": major
+"pnpm": major
+---
+
+When using `pnpm run <script>`, all command line arguments after the script name are now passed to the script's argv. Previously flagged arguments (e.g. `--silent`) were intepreted as pnpm arguments unless `--` came before it.

--- a/packages/plugin-commands-script-runners/src/run.ts
+++ b/packages/plugin-commands-script-runners/src/run.ts
@@ -107,7 +107,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
       FILTERING,
     ],
     url: docsUrl('run'),
-    usages: ['pnpm run <command> [-- <args>...]'],
+    usages: ['pnpm run <command> [<args>...]'],
   })
 }
 
@@ -134,6 +134,11 @@ export async function handler (
 ) {
   let dir: string
   const [scriptName, ...passedThruArgs] = params
+  // For backward compatibility
+  const firstDoubleDash = passedThruArgs.findIndex((arg) => arg === '--')
+  if (firstDoubleDash !== -1) {
+    passedThruArgs.splice(firstDoubleDash, 1)
+  }
   if (opts.recursive) {
     if (scriptName || Object.keys(opts.selectedProjectsGraph).length > 1) {
       return runRecursive(params, opts)

--- a/packages/pnpm/test/run.ts
+++ b/packages/pnpm/test/run.ts
@@ -17,13 +17,54 @@ test('run -r: pass the args to the command that is specfied in the build script'
   await fs.writeFile('project/args.json', '[]', 'utf8')
   await fs.writeFile('project/recordArgs.js', RECORD_ARGS_FILE, 'utf8')
 
-  await execPnpm(['run', '-r', '--config.enable-pre-post-scripts', 'foo', 'arg', '--', '--flag=true'])
+  await execPnpm(['run', '-r', '--config.enable-pre-post-scripts', 'foo', 'arg', '--flag=true'])
 
   const { default: args } = await import(path.resolve('project/args.json'))
   expect(args).toStrictEqual([
     [],
     ['arg', '--flag=true'],
     [],
+  ])
+})
+
+// Before pnpm v7, `--` was required to pass flags to a build script.
+test('run: handle -- in a backwards compatible manner', async () => {
+  prepare({
+    name: 'project',
+    scripts: {
+      foo: 'node recordArgs',
+      postfoo: 'node recordArgs',
+      prefoo: 'node recordArgs',
+    },
+  })
+  await fs.writeFile('args.json', '[]', 'utf8')
+  await fs.writeFile('recordArgs.js', RECORD_ARGS_FILE, 'utf8')
+
+  await execPnpm(['run', 'foo', 'arg', '--', '--flag=true'])
+
+  const { default: args } = await import(path.resolve('args.json'))
+  expect(args).toStrictEqual([
+    ['arg', '--flag=true'],
+  ])
+})
+
+test('run: pass -- to the build script if specified twice', async () => {
+  prepare({
+    name: 'project',
+    scripts: {
+      foo: 'node recordArgs',
+      postfoo: 'node recordArgs',
+      prefoo: 'node recordArgs',
+    },
+  })
+  await fs.writeFile('args.json', '[]', 'utf8')
+  await fs.writeFile('recordArgs.js', RECORD_ARGS_FILE, 'utf8')
+
+  await execPnpm(['run', 'foo', '--', 'arg', '--', '--flag=true'])
+
+  const { default: args } = await import(path.resolve('args.json'))
+  expect(args).toStrictEqual([
+    ['arg', '--', '--flag=true'],
   ])
 })
 

--- a/packages/pnpm/test/run.ts
+++ b/packages/pnpm/test/run.ts
@@ -27,6 +27,26 @@ test('run -r: pass the args to the command that is specfied in the build script'
   ])
 })
 
+test('run: pass the args to the command that is specfied in the build script', async () => {
+  prepare({
+    name: 'project',
+    scripts: {
+      foo: 'node recordArgs',
+      postfoo: 'node recordArgs',
+      prefoo: 'node recordArgs',
+    },
+  })
+  await fs.writeFile('args.json', '[]', 'utf8')
+  await fs.writeFile('recordArgs.js', RECORD_ARGS_FILE, 'utf8')
+
+  await execPnpm(['run', 'foo', 'arg', '--flag=true'])
+
+  const { default: args } = await import(path.resolve('args.json'))
+  expect(args).toStrictEqual([
+    ['arg', '--flag=true'],
+  ])
+})
+
 // Before pnpm v7, `--` was required to pass flags to a build script.
 test('run: handle -- in a backwards compatible manner', async () => {
   prepare({


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/3778.

## Behavior Change

There's a lot of scenarios mentioned in the original issue that make all solutions ambiguous/non-ideal. While still not perfect, I think the behavior below will cause the least amount of confusion:

- Anything after the `<command>` portion of `pnpm run <command>` is passed directly to `<command>` itself.
- Any command line flags before the `<command>` portion is treated as an option to `pnpm run`.
- For backwards compatibility, the first occurrence of `--` anywhere after `<command>` is swallowed.

For example:
- This allows `pnpm run --help` to still show the help text for `pnpm run`.
- While `pnpm run changeset --help` will show the help text of whatever command drives the `changeset` script.

## Notes

- See https://github.com/pnpm/pnpm/pull/3492 for a related change.
- I did not address https://github.com/pnpm/pnpm/issues/4094 in this issue. I'd like to handle that in a separate PR.
- I noticed that @zkochan started work on this 4 months ago and cherry-picked the new test from the `feat/3778` branch: https://github.com/pnpm/pnpm/commit/624b8a7a405910c1173fcdd9cf456e60517662cb Hope that was okay @zkochan.
- For reference on the `escapeArgs` option in `nopt`: https://github.com/pnpm/nopt/commit/446cfbe622ee8bc5597c513aa51d86c65e606aa8