### PR TITLE
fix: revert backwards compatible handling of -- for run

### DIFF
--- a/.changeset/odd-kangaroos-care.md
+++ b/.changeset/odd-kangaroos-care.md
@@ -4,4 +4,4 @@
 "pnpm": major
 ---
 
-When using `pnpm run <script>`, all command line arguments after the script name are now passed to the script's argv. Previously flagged arguments (e.g. `--silent`) were intepreted as pnpm arguments unless `--` came before it.
+When using `pnpm run <script>`, all command line arguments after the script name are now passed to the script's argv, even `--`. For example, `pnpm run echo --hello -- world` will now pass `--hello -- world` to the `echo` script's argv. Previously flagged arguments (e.g. `--silent`) were intepreted as pnpm arguments unless `--` came before it.

--- a/packages/plugin-commands-script-runners/src/run.ts
+++ b/packages/plugin-commands-script-runners/src/run.ts
@@ -134,11 +134,6 @@ export async function handler (
 ) {
   let dir: string
   const [scriptName, ...passedThruArgs] = params
-  // For backward compatibility
-  const firstDoubleDash = passedThruArgs.findIndex((arg) => arg === '--')
-  if (firstDoubleDash !== -1) {
-    passedThruArgs.splice(firstDoubleDash, 1)
-  }
   if (opts.recursive) {
     if (scriptName || Object.keys(opts.selectedProjectsGraph).length > 1) {
       return runRecursive(params, opts)

--- a/packages/pnpm/test/run.ts
+++ b/packages/pnpm/test/run.ts
@@ -47,8 +47,10 @@ test('run: pass the args to the command that is specfied in the build script', a
   ])
 })
 
-// Before pnpm v7, `--` was required to pass flags to a build script.
-test('run: handle -- in a backwards compatible manner', async () => {
+// Before pnpm v7, `--` was required to pass flags to a build script. Now all
+// arguments after the script name should be passed to the build script, even
+// `--`.
+test('run: pass all arguments after script name to the build script, even --', async () => {
   prepare({
     name: 'project',
     scripts: {
@@ -61,26 +63,6 @@ test('run: handle -- in a backwards compatible manner', async () => {
   await fs.writeFile('recordArgs.js', RECORD_ARGS_FILE, 'utf8')
 
   await execPnpm(['run', 'foo', 'arg', '--', '--flag=true'])
-
-  const { default: args } = await import(path.resolve('args.json'))
-  expect(args).toStrictEqual([
-    ['arg', '--flag=true'],
-  ])
-})
-
-test('run: pass -- to the build script if specified twice', async () => {
-  prepare({
-    name: 'project',
-    scripts: {
-      foo: 'node recordArgs',
-      postfoo: 'node recordArgs',
-      prefoo: 'node recordArgs',
-    },
-  })
-  await fs.writeFile('args.json', '[]', 'utf8')
-  await fs.writeFile('recordArgs.js', RECORD_ARGS_FILE, 'utf8')
-
-  await execPnpm(['run', 'foo', '--', 'arg', '--', '--flag=true'])
 
   const { default: args } = await import(path.resolve('args.json'))
   expect(args).toStrictEqual([


### PR DESCRIPTION
This is a followup to the discussion here: https://github.com/pnpm/pnpm/pull/4290#discussion_r795245493

Updating `pnpm run <script>` to not handle `--` in a backwards compatible manner since it's confusing.

Before this change:

```
❯ pnpm run --silent echo a -- b
a b
```

After this change:

```
❯ pnpm run --silent echo a -- b
a -- b
```

Opening as a draft PR until tests pass. I'll mark it "*Ready for review*" once this can be looked at.