### PR TITLE
feat(exec): support shell interpreter

### DIFF
--- a/.changeset/slow-shrimps-laugh.md
+++ b/.changeset/slow-shrimps-laugh.md
@@ -1,0 +1,21 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+Added --shell-mode option support to pnpm exec [#4328](https://github.com/pnpm/pnpm/pull/4328)
+
+* `--shell-mode`: shell interpreter. see: https://github.com/sindresorhus/execa/tree/484f28de7c35da5150155e7a523cbb20de161a4f#shell
+
+Usage example:
+
+```shell
+pnpm --recursive --shell-mode exec -- echo \"\$PNPM_PACKAGE_NAME\"
+```
+
+```json
+{
+    "scripts": {
+        "check": " pnpm --recursive --shell-mode exec -- echo \"\\$PNPM_PACKAGE_NAME\""
+    }
+}
+```

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -19,6 +19,7 @@ import {
 
 export const shorthands = {
   parallel: runShorthands.parallel,
+  c: '--shell-mode',
 }
 
 export const commandNames = ['exec']
@@ -63,6 +64,7 @@ Uses /bin/sh on UNIX and \\cmd.exe on Windows. \
 A different shell can be specified as a string. \
 The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
             name: '--shell-mode',
+            shortAlias: '-c',
           },
         ],
       },

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -70,7 +70,7 @@ The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
       },
     ],
     url: docsUrl('exec'),
-    usages: ['pnpm [-r] [--shell-mode] exec <command> [args...]'],
+    usages: ['pnpm [-r] [-c] exec <command> [args...]'],
   })
 }
 

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -24,12 +24,15 @@ export const shorthands = {
 export const commandNames = ['exec']
 
 export function rcOptionsTypes () {
-  return pick([
-    'bail',
-    'sort',
-    'unsafe-perm',
-    'workspace-concurrency',
-  ], types)
+  return {
+    ...pick([
+      'bail',
+      'sort',
+      'unsafe-perm',
+      'workspace-concurrency',
+    ], types),
+    'shell-mode': Boolean,
+  }
 }
 
 export const cliOptionsTypes = () => ({
@@ -54,11 +57,18 @@ For options that may be used with `-r`, see "pnpm help recursive"',
             name: '--recursive',
             shortAlias: '-r',
           },
+          {
+            description: 'If exist, runs file inside of a shell. \
+Uses /bin/sh on UNIX and \\cmd.exe on Windows. \
+A different shell can be specified as a string. \
+The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
+            name: '--shell-mode',
+          },
         ],
       },
     ],
     url: docsUrl('exec'),
-    usages: ['pnpm [-r] exec <command> [args...]'],
+    usages: ['pnpm [-r] [--shell-mode] exec <command> [args...]'],
   })
 }
 
@@ -70,6 +80,7 @@ export async function handler (
     reverse?: boolean
     sort?: boolean
     workspaceConcurrency?: number
+    shellMode?: boolean
   } & Pick<Config, 'extraBinPaths' | 'lockfileDir' | 'dir' | 'userAgent' | 'recursive' | 'workspaceDir'>,
   params: string[]
 ) {
@@ -134,6 +145,7 @@ export async function handler (
             cwd: prefix,
             env,
             stdio: 'inherit',
+            shell: opts.shellMode ?? false,
           })
           result.passes++
         } catch (err: any) { // eslint-disable-line

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -61,7 +61,6 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           {
             description: 'If exist, runs file inside of a shell. \
 Uses /bin/sh on UNIX and \\cmd.exe on Windows. \
-A different shell can be specified as a string. \
 The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
             name: '--shell-mode',
             shortAlias: '-c',

--- a/packages/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/packages/plugin-commands-script-runners/test/exec.e2e.ts
@@ -417,6 +417,8 @@ test('pnpm exec outside of projects', async () => {
 test('pnpm exec shell mode', async () => {
   prepareEmpty()
 
+  const echoArgs = process.platform === 'win32' ? '%PNPM_PACKAGE_NAME% > name.txt' : '$PNPM_PACKAGE_NAME > name.txt'
+
   await exec.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
@@ -434,7 +436,7 @@ test('pnpm exec shell mode', async () => {
       },
     },
     shellMode: true,
-  }, ['echo', '$PNPM_PACKAGE_NAME > name.txt'])
+  }, ['echo', echoArgs])
 
   const result = (await fs.readFile(path.resolve('name.txt'), 'utf8')).trim()
 

--- a/packages/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/packages/plugin-commands-script-runners/test/exec.e2e.ts
@@ -414,6 +414,33 @@ test('pnpm exec outside of projects', async () => {
   expect(outputs).toStrictEqual([])
 })
 
+test('pnpm exec shell mode', async () => {
+  prepareEmpty()
+
+  await exec.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    recursive: false,
+    selectedProjectsGraph: {
+      [process.cwd()]: {
+        dependencies: [],
+        package: {
+          dir: process.cwd(),
+          writeProjectManifest: async () => {},
+          manifest: {
+            name: 'test_shell_mode',
+          },
+        },
+      },
+    },
+    shellMode: true,
+  }, ['echo', '$PNPM_PACKAGE_NAME > name.txt'])
+
+  const result = (await fs.readFile(path.resolve('name.txt'), 'utf8')).trim()
+
+  expect(result).toBe('test_shell_mode')
+})
+
 test('pnpm recursive exec works with PnP', async () => {
   preparePackages([
     {


### PR DESCRIPTION
Fixed: https://github.com/pnpm/pnpm/issues/4320

Once this PR has been merged, the following commands will be supported:

```shell
pnpm --recursive --shell-mode exec -- echo \"\$PNPM_PACKAGE_NAME\"
```

```json
{
    "scripts": {
        "check": " pnpm --recursive --shell-mode exec -- echo \"\\$PNPM_PACKAGE_NAME\""
    }
}
```