### PR TITLE
fix: make unrecognized CLI flags show error when using fallback command

### DIFF
--- a/.changeset/little-keys-fix.md
+++ b/.changeset/little-keys-fix.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+When using `pnpm <script>` as a shorthand for `pnpm run <script>`, unknown command line flags now throw an error. For example, `pnpm --unknown compile` now prints `Unknown option: 'unknown'` and exits the command. Previously these flags would not be passed to the underlying script, and pnpm would ignore the flag.

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -65,7 +65,7 @@ export default async function run (inputArgv: string[]) {
     return
   }
 
-  if (unknownOptions.size > 0 && !fallbackCommandUsed) {
+  if (unknownOptions.size > 0) {
     const unknownOptionsArray = Array.from(unknownOptions.keys())
     if (unknownOptionsArray.every((option) => DEPRECATED_OPTIONS.has(option))) {
       let deprecationMsg = `${chalk.bgYellow.black('\u2009WARN\u2009')}`

--- a/packages/pnpm/test/run.ts
+++ b/packages/pnpm/test/run.ts
@@ -71,6 +71,18 @@ test('run: pass all arguments after script name to the build script, even --', a
   ])
 })
 
+test('run: unknown flags to pnpm and show an error', () => {
+  preparePackages([{
+    name: 'project',
+    scripts: {
+      hello: 'node -e "process.stdout.write(\'hello\')"',
+    },
+  }])
+
+  const result = execPnpmSync(['--unknown', 'hello'])
+  expect((result.stdout as Buffer).toString('utf8')).toMatch(/Unknown option: 'unknown'/)
+})
+
 test('test -r: pass the args to the command that is specfied in the build script of a package.json manifest', async () => {
   preparePackages([{
     name: 'project',


### PR DESCRIPTION
Fixes #4094. I think this is safe to do now that #4290 has merged, but could use help verifying.

Before:

```
❯ pnpm --unknown echo --test

> @ echo /Users/gluxon/Developer/pnpm
> echo "--test"

--test
```

After:

```
❯ pnpm --unknown echo --test
 ERROR   ERROR  Unknown option: 'unknown'
For help, run: pnpm help run
```

---

Note that explicitly typing `run` always showed an error before and after this change.

```
❯ pnpm run --unknown echo --test
 ERROR   ERROR  Unknown option: 'unknown'
For help, run: pnpm help run
```

```
❯ pnpm --unknown run echo --test
 ERROR   ERROR  Unknown option: 'unknown'
For help, run: pnpm help run
```