### PR TITLE
fix(make-dedicated-lockfile): don't re-resolve dependency versions in dedicated lockfile

### DIFF
--- a/.changeset/perfect-eyes-study.md
+++ b/.changeset/perfect-eyes-study.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/make-dedicated-lockfile": patch
+---
+
+Do not re-resolve dependency versions

--- a/packages/make-dedicated-lockfile/src/index.ts
+++ b/packages/make-dedicated-lockfile/src/index.ts
@@ -53,6 +53,7 @@ export default async function (lockfileDir: string, projectDir: string) {
   try {
     await pnpmExec([
       'install',
+      '--frozen-lockfile',
       '--lockfile-dir=.',
       '--lockfile-only',
       '--filter=.',

--- a/packages/make-dedicated-lockfile/test/fixtures/fixture/packages/is-negative/package.json
+++ b/packages/make-dedicated-lockfile/test/fixtures/fixture/packages/is-negative/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "ramda": "0.26.0",
+    "request": "^2.0.0",
     "is-positive": "workspace:1.0.0"
   }
 }

--- a/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
+++ b/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
@@ -1,65 +1,72 @@
+lockfileVersion: 5.3
+
 importers:
+
   packages/is-negative:
-    dependencies:
-      is-positive: 'link:../is-positive'
-      ramda: 0.26.0
     specifiers:
-      is-positive: 'workspace:1.0.0'
+      is-positive: workspace:1.0.0
       ramda: 0.26.0
+      request: 2.0.0
+    dependencies:
+      is-positive: link:../is-positive
+      ramda: 0.26.0
+      request: 2.0.0
+
   packages/is-negative/example:
-    dependencies:
-      lodash: 1.0.0
     specifiers:
       lodash: 1.0.0
+    dependencies:
+      lodash: 1.0.0
+
   packages/is-positive:
-    dependencies:
-      express: 1.0.0
     specifiers:
       express: 1.0.0
-lockfileVersion: 5.1
+    dependencies:
+      express: 1.0.0
+
 packages:
+
   /connect/3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
     dependencies:
       debug: 2.6.9
       finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
     dev: false
-    engines:
-      node: '>= 0.10.0'
-    resolution:
-      integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
+
   /debug/2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     dependencies:
       ms: 2.0.0
     dev: false
-    resolution:
-      integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+
   /ee-first/1.1.1:
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
-    resolution:
-      integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
   /encodeurl/1.0.2:
+    resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
+    engines: {node: '>= 0.8'}
     dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
   /escape-html/1.0.3:
+    resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
     dev: false
-    resolution:
-      integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
   /express/1.0.0:
+    resolution: {integrity: sha1-SKQ9eKluuSMvYx0jzI3o+FTY4Ok=}
+    engines: {node: '>= 0.2.0'}
+    deprecated: express 1.x series is deprecated
+    hasBin: true
     dependencies:
       connect: 3.7.0
-    deprecated: express 1.x series is deprecated
     dev: false
-    engines:
-      node: '>= 0.2.0'
-    hasBin: true
-    resolution:
-      integrity: sha1-SKQ9eKluuSMvYx0jzI3o+FTY4Ok=
+
   /finalhandler/1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
     dependencies:
       debug: 2.6.9
       encodeurl: 1.0.2
@@ -69,54 +76,49 @@ packages:
       statuses: 1.5.0
       unpipe: 1.0.0
     dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+
   /lodash/1.0.0:
+    resolution: {integrity: sha1-JTXC99y2k3zujSZyxfcTju4N9qk=}
+    engines: {'0': node, '1': rhino}
     dev: false
-    engines:
-      '0': node
-      '1': rhino
-    resolution:
-      integrity: sha1-JTXC99y2k3zujSZyxfcTju4N9qk=
+
   /ms/2.0.0:
+    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
     dev: false
-    resolution:
-      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
   /on-finished/2.3.0:
+    resolution: {integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=}
+    engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
     dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+
   /parseurl/1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
     dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
   /ramda/0.26.0:
+    resolution: {integrity: sha512-maK1XqpgsOo5DwjhROjqDvpm1vkphLQbpleVv+b3t5Y9uOQ0t8hTHT582+mDs7RLrex1kd4lWYizNXWLVjsq9w==}
     dev: false
-    resolution:
-      integrity: sha512-maK1XqpgsOo5DwjhROjqDvpm1vkphLQbpleVv+b3t5Y9uOQ0t8hTHT582+mDs7RLrex1kd4lWYizNXWLVjsq9w==
+
+  /request/2.0.0:
+    resolution: {integrity: sha1-6OzcsS3tA7eVqh3g9Er926uY89s=}
+    engines: {'0': node >= 0.3.6}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+    dev: false
+
   /statuses/1.5.0:
+    resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
+    engines: {node: '>= 0.6'}
     dev: false
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
   /unpipe/1.0.0:
+    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    engines: {node: '>= 0.8'}
     dev: false
-    engines:
-      node: '>= 0.8'
-    resolution:
-      integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
   /utils-merge/1.0.1:
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    engines: {node: '>= 0.4.0'}
     dev: false
-    engines:
-      node: '>= 0.4.0'
-    resolution:
-      integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=

--- a/packages/make-dedicated-lockfile/test/index.ts
+++ b/packages/make-dedicated-lockfile/test/index.ts
@@ -16,5 +16,6 @@ test('makeDedicatedLockfile()', async () => {
     '/is-positive/1.0.0',
     '/lodash/1.0.0',
     '/ramda/0.26.0',
+    '/request/2.0.0',
   ])
 })


### PR DESCRIPTION
Closes issue in #3864 

I chose to add `--frozen-lockfile` flag instead of removing the install command altogether as in my testing, the `makeDedicatedLockfile` function in some cases will overwrite the package's `node_modules` directory, and the install command will rebuild the `node_modules`. Furthermore, in certain use cases, such as the one outline in the issue above, the `package.json` used to build the dedicated lockfile may a different set of dependencies than the original one, and so the `node_modules` should fit the new set of dependencies. 