### PR TITLE
feat: use the versions from overrides when adding deps without specs

### DIFF
--- a/.changeset/wicked-sheep-tell.md
+++ b/.changeset/wicked-sheep-tell.md
@@ -10,7 +10,9 @@ Normally, if the latest version of `foo` is `2.0.0`, then `pnpm add foo` install
 ```json
 {
   "pnpm": {
-    "foo": "1.0.0"
+    "overrides": {
+      "foo": "1.0.0"
+    }
   }
 }
 ```

--- a/.changeset/wicked-sheep-tell.md
+++ b/.changeset/wicked-sheep-tell.md
@@ -1,0 +1,19 @@
+---
+"@pnpm/core": minor
+"pnpm": minor
+---
+
+When adding a new dependency, use the version specifier from the overrides, when present [#4313](https://github.com/pnpm/pnpm/issues/4313).
+
+Normally, if the latest version of `foo` is `2.0.0`, then `pnpm add foo` installs `foo@^2.0.0`. This behavior changes if `foo` is specified in an override:
+
+```json
+{
+  "pnpm": {
+    "foo": "1.0.0"
+  }
+}
+```
+
+In this case, `pnpm add foo` will add `foo@1.0.0` to the dependency. However, if a version is explicitly specifying, then the specified version will be used and the override will be ignored. So `pnpm add foo@0` will install v0 and it doesn't matter what is in the overrides.
+

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -443,6 +443,7 @@ export async function mutateModules (
         optionalDependencies,
         updateWorkspaceDependencies: opts.update,
         preferredSpecs,
+        overrides: opts.overrides,
       })
       projectsToInstall.push({
         pruneDirectDependencies: false,

--- a/packages/core/src/parseWantedDependencies.ts
+++ b/packages/core/src/parseWantedDependencies.ts
@@ -13,6 +13,7 @@ export default function parseWantedDependencies (
     devDependencies: Dependencies
     optional: boolean
     optionalDependencies: Dependencies
+    overrides?: Record<string, string>
     updateWorkspaceDependencies?: boolean
     preferredSpecs?: Record<string, string>
   }
@@ -54,6 +55,13 @@ export default function parseWantedDependencies (
           ...result,
           pref: opts.preferredSpecs[alias],
           raw: `${rawWantedDependency}@${opts.preferredSpecs[alias]}`,
+        }
+      }
+      if (alias && opts.overrides?.[alias]) {
+        return {
+          ...result,
+          pref: opts.overrides[alias],
+          raw: `${alias}@${opts.overrides[alias]}`,
         }
       }
       return {

--- a/packages/core/test/install/overrides.ts
+++ b/packages/core/test/install/overrides.ts
@@ -111,3 +111,19 @@ test('versions are replaced with versions specified through overrides option', a
     )
   )
 })
+
+test('when adding a new dependency that is present in the overrides, use the spec from the override', async () => {
+  prepareEmpty()
+
+  await addDistTag({ package: 'bar', version: '100.0.0', distTag: 'latest' })
+
+  const overrides = {
+    bar: '100.1.0',
+  }
+  const manifest = await addDependenciesToPackage({},
+    ['bar'],
+    await testDefaults({ overrides })
+  )
+
+  expect(manifest.dependencies?.bar).toBe(overrides.bar)
+})


### PR DESCRIPTION
close #4313