### PR TITLE
test: ignore override if a version is specified at install

### DIFF
--- a/packages/core/test/install/overrides.ts
+++ b/packages/core/test/install/overrides.ts
@@ -127,3 +127,20 @@ test('when adding a new dependency that is present in the overrides, use the spe
 
   expect(manifest.dependencies?.bar).toBe(overrides.bar)
 })
+
+test('explicitly specifying a version at install will ignore overrides', async () => {
+  prepareEmpty()
+
+  await addDistTag({ package: 'bar', version: '100.0.0', distTag: 'latest' })
+
+  const overrides = {
+    bar: '100.1.0',
+  }
+  const EXACT_VERSION = '100.0.0'
+  const manifest = await addDependenciesToPackage({},
+    [`bar@${EXACT_VERSION}`],
+    await testDefaults({ overrides })
+  )
+
+  expect(manifest.dependencies?.bar).toBe(EXACT_VERSION)
+})


### PR DESCRIPTION
Ref #4355

Added a missing test for:

> However, if a version is explicitly specifying, then the specified version will be used and the override will be ignored. So pnpm add foo@0 will install v0 and it doesn't matter what is in the overrides.

There is 1 failing tests but it doesn't seem to be related ("fail on non-compatible pnpm-lock.yaml")