### PR TITLE
fix: ignore case, when verifying package name in the store

### DIFF
--- a/.changeset/brave-ties-begin.md
+++ b/.changeset/brave-ties-begin.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/package-requester": patch
+"pnpm": patch
+---
+
+Ignore case, when verifying package name in the store [#4367](https://github.com/pnpm/pnpm/issues/4367).

--- a/packages/package-requester/src/packageRequester.ts
+++ b/packages/package-requester/src/packageRequester.ts
@@ -446,7 +446,7 @@ function fetchToStore (
             (
               pkgFilesIndex.name != null &&
               opts.pkg.name != null &&
-              pkgFilesIndex.name !== opts.pkg.name
+              pkgFilesIndex.name.toLowerCase() !== opts.pkg.name.toLowerCase()
             ) ||
             (
               pkgFilesIndex.version != null &&

--- a/packages/package-requester/test/index.ts
+++ b/packages/package-requester/test/index.ts
@@ -943,6 +943,28 @@ test('throw exception if the package data in the store differs from the expected
     })
     await expect(files()).resolves.toStrictEqual(expect.anything())
   }
+
+  {
+    const requestPackage = createPackageRequester({
+      resolve,
+      fetchers,
+      cafs,
+      networkConcurrency: 1,
+      storeDir,
+      verifyStoreIntegrity: true,
+    })
+    const { files } = requestPackage.fetchPackageToStore({
+      force: false,
+      lockfileDir: tempy.directory(),
+      pkg: {
+        name: 'IS-positive',
+        version: 'v1.0.0',
+        id: pkgResponse.body.id,
+        resolution: pkgResponse.body.resolution,
+      },
+    })
+    await expect(files()).resolves.toStrictEqual(expect.anything())
+  }
 })
 
 test('the version in the bundled manifest should be normalized', async () => {


### PR DESCRIPTION
close #4367