### PR TITLE
fix: pnpm i should work on virtual drives

### DIFF
--- a/.changeset/itchy-pigs-deny.md
+++ b/.changeset/itchy-pigs-deny.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+pnpm i should work correctly on virtual drives instead of silently shutting down

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -54,7 +54,8 @@
     "tempy": "^1.0.0",
     "write-json-file": "^4.3.0",
     "write-pkg": "4.0.0",
-    "write-yaml-file": "^4.2.0"
+    "write-yaml-file": "^4.2.0",
+    "symlink-dir": "^5.0.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:0.6.48",

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -176,7 +176,7 @@ export default async function recursive (
   // For a workspace with shared lockfile
   if (opts.lockfileDir && ['add', 'install', 'remove', 'update', 'import'].includes(cmdFullName)) {
     let importers = await getImporters()
-    const calculatedRepositoryRoot = calculateRepositoryRoot(opts.workspaceDir, importers.map(x => x.rootDir))
+    const calculatedRepositoryRoot = await fs.realpath(calculateRepositoryRoot(opts.workspaceDir, importers.map(x => x.rootDir)))
     const isFromWorkspace = isSubdir.bind(null, calculatedRepositoryRoot)
     importers = await pFilter(importers, async ({ rootDir }: { rootDir: string }) => isFromWorkspace(await fs.realpath(rootDir)))
     if (importers.length === 0) return true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2155,6 +2155,7 @@ importers:
       read-yaml-file: ^2.1.0
       render-help: ^1.0.1
       sinon: ^11.1.1
+      symlink-dir: ^5.0.0
       tempy: ^1.0.0
       version-selector-type: ^3.0.0
       write-json-file: ^4.3.0
@@ -2226,6 +2227,7 @@ importers:
       proxyquire: 2.1.3
       read-yaml-file: 2.1.0
       sinon: 11.1.2
+      symlink-dir: 5.0.1
       tempy: 1.0.1
       write-json-file: 4.3.0
       write-pkg: 4.0.0


### PR DESCRIPTION
This is reproducible on Windows with virtual drives created by subst command

**Background:**
You are on windows, and you have drive C:.
You have created virtual drive X: using https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/subst somewhere on C:
You cloned a pnpm-managed monorepo with a common lockfile to drive X: and did 'pnpm i'

**Expected:**
X:\pnpm>pnpm i
Scope: all 119 workspace projects
 WARN  There are cyclic workspace dependencies: X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\package-requester; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\package-requester, X:\pnpm\packages\package-store
Lockfile is up-to-date, resolution step is skipped
Already up-to-date
packages/exe preinstall$ node setup.js
└─ Done in 75ms
. prepare$ pnpm --dir=verdaccio install && husky install
│ husky - Git hooks installed
└─ Done in 639ms
packages/exe prepare$ node prepare.js
└─ Done in 59ms

\-\-\-
**i.e. install is done**

**Actual:**

X:\pnpm>pnpm i
Scope: all 119 workspace projects
 WARN  There are cyclic workspace dependencies: X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\package-requester; X:\pnpm\packages\client, X:\pnpm\packages\git-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\client, X:\pnpm\packages\tarball-fetcher, X:\pnpm\packages\package-store, X:\pnpm\packages\package-requester, X:\pnpm\packages\package-store

\-\-\-
**i.e. install just shuts down silently.**

**Why this happens?**
There is a bug in: packages/plugin-commands-installation/src/recursive.ts
calculatedRepositoryRoot  is calculated as X:/......, while all paths to packages are calculated as C:/....... , because paths to packages are being mapped by fs.realpath, and repo root is not. 
isFromWorkspace check fails, since root and packages are from 'different' drives, so importers array is empty, pnpm assumes that there is no work to be done and exits.