### PR TITLE
fix: types should not be hoisted to the root of node_modules

### DIFF
--- a/.changeset/rude-rats-smell.md
+++ b/.changeset/rude-rats-smell.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+"pnpm": major
+---
+
+Don't hoist types by default to the root of node_modules.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -188,9 +188,6 @@ export default async (
     pending: false,
     'prefer-workspace-packages': false,
     'public-hoist-pattern': [
-      // Packages like @types/node, @babel/types
-      // should be publicly hoisted because TypeScript only searches in the root of node_modules
-      '*types*',
       '*eslint*',
       '@prettier/plugin-*',
       '*prettier-plugin-*',


### PR DESCRIPTION
close #4457