### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -83,7 +83,7 @@ async function updateTSConfig (
   const references = [] as Array<{ path: string }>
   for (const [depName, spec] of Object.entries(deps)) {
     if (!spec.startsWith('link:') || spec.length === 5) continue
-    const relativePath = spec.substr(5)
+    const relativePath = spec.slice(5)
     if (!await exists(path.join(dir, relativePath, 'tsconfig.json'))) continue
     if (
       depName === '@pnpm/package-store' && (

--- a/packages/cafs/src/addFilesFromTarball.ts
+++ b/packages/cafs/src/addFilesFromTarball.ts
@@ -20,7 +20,7 @@ export default async function (
       // which are the same file.
       // Hence, we are normalizing the file name, replacing // with / and checking for duplicates.
       // Example of such package: @pnpm/colorize-semver-diff@1.0.1
-      const filename = header.name.substr(header.name.indexOf('/') + 1).replace(/\/\//g, '/')
+      const filename = header.name.slice(header.name.indexOf('/') + 1).replace(/\/\//g, '/')
       if (header.type !== 'file' || ignore(filename) || filesIndex[filename]) {
         fileStream.resume()
         next()

--- a/packages/cli-meta/src/index.ts
+++ b/packages/cli-meta/src/index.ts
@@ -30,7 +30,7 @@ const packageManager = {
   name: pkgJson.name,
   // Never a prerelease version
   stableVersion: pkgJson.version.includes('-')
-    ? pkgJson.version.substr(0, pkgJson.version.indexOf('-'))
+    ? pkgJson.version.slice(0, pkgJson.version.indexOf('-'))
     : pkgJson.version,
   // This may be a 3.0.0-beta.2
   version: pkgJson.version,

--- a/packages/config/src/getScopeRegistries.ts
+++ b/packages/config/src/getScopeRegistries.ts
@@ -4,7 +4,7 @@ export default function getScopeRegistries (rawConfig: Object) {
   const registries = {}
   for (const configKey of Object.keys(rawConfig)) {
     if (configKey[0] === '@' && configKey.endsWith(':registry')) {
-      registries[configKey.substr(0, configKey.indexOf(':'))] = normalizeRegistryUrl(rawConfig[configKey])
+      registries[configKey.slice(0, configKey.indexOf(':'))] = normalizeRegistryUrl(rawConfig[configKey])
     }
   }
   return registries

--- a/packages/core/src/install/allProjectsAreUpToDate.ts
+++ b/packages/core/src/install/allProjectsAreUpToDate.ts
@@ -90,7 +90,7 @@ async function linkedPackagesAreUpToDate (
         continue
       }
       const linkedDir = isLinked
-        ? path.join(project.dir, lockfileRef.substr(5))
+        ? path.join(project.dir, lockfileRef.slice(5))
         : workspacePackages?.[depName]?.[lockfileRef]?.dir
       if (!linkedDir) continue
       if (!linkWorkspacePackages && !currentSpec.startsWith('workspace:')) {
@@ -110,12 +110,12 @@ async function linkedPackagesAreUpToDate (
 }
 
 function getVersionRange (spec: string) {
-  if (spec.startsWith('workspace:')) return spec.substr(10)
+  if (spec.startsWith('workspace:')) return spec.slice(10)
   if (spec.startsWith('npm:')) {
-    spec = spec.substr(4)
+    spec = spec.slice(4)
     const index = spec.indexOf('@', 1)
     if (index === -1) return '*'
-    return spec.substr(index + 1) || '*'
+    return spec.slice(index + 1) || '*'
   }
   return spec
 }

--- a/packages/core/src/install/link.ts
+++ b/packages/core/src/install/link.ts
@@ -457,7 +457,7 @@ async function linkAllModules (
           Object.entries(childrenToLink)
             .map(async ([childAlias, childDepPath]) => {
               if (childDepPath.startsWith('link:')) {
-                await limitLinking(async () => symlinkDependency(path.resolve(opts.lockfileDir, childDepPath.substr(5)), modules, childAlias))
+                await limitLinking(async () => symlinkDependency(path.resolve(opts.lockfileDir, childDepPath.slice(5)), modules, childAlias))
                 return
               }
               const pkg = depGraph[childDepPath]

--- a/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
+++ b/packages/default-reporter/src/reporterForClient/reportLifecycleScripts.ts
@@ -206,7 +206,7 @@ function formatIndentedStatus (status: string) {
 
 function highlightLastFolder (p: string) {
   const lastSlash = p.lastIndexOf('/') + 1
-  return `${chalk.gray(p.substr(0, lastSlash))}${p.substr(lastSlash)}`
+  return `${chalk.gray(p.slice(0, lastSlash))}${p.slice(lastSlash)}`
 }
 
 const ANSI_ESCAPES_LENGTH_OF_PREFIX = hlValue(' ').length - 1
@@ -268,7 +268,7 @@ function formatLine (maxWidth: number, logObj: LifecycleLog) {
 }
 
 function cutLine (line: string, maxLength: number) {
-  return stripAnsi(line).substr(0, maxLength)
+  return stripAnsi(line).slice(0, maxLength)
 }
 
 function aggregateOutput (source: Rx.Observable<LifecycleLog>) {

--- a/packages/default-reporter/src/reporterForClient/utils/formatPrefix.ts
+++ b/packages/default-reporter/src/reporterForClient/utils/formatPrefix.ts
@@ -9,7 +9,7 @@ export default function formatPrefix (cwd: string, prefix: string) {
     return prefix
   }
 
-  const shortPrefix = prefix.substr(-PREFIX_MAX_LENGTH + 3)
+  const shortPrefix = prefix.slice(-PREFIX_MAX_LENGTH + 3)
 
   const separatorLocation = shortPrefix.indexOf('/')
 
@@ -17,7 +17,7 @@ export default function formatPrefix (cwd: string, prefix: string) {
     return `...${shortPrefix}`
   }
 
-  return `...${shortPrefix.substr(separatorLocation)}`
+  return `...${shortPrefix.slice(separatorLocation)}`
 }
 
 export function formatPrefixNoTrim (cwd: string, prefix: string) {

--- a/packages/dependencies-hierarchy/src/index.ts
+++ b/packages/dependencies-hierarchy/src/index.ts
@@ -395,7 +395,7 @@ function getPkgInfo (
     isPeer: Boolean(opts.peers?.has(opts.alias)),
     isSkipped,
     name,
-    path: depPath ? path.join(opts.modulesDir, '.pnpm', depPathToFilename(depPath)) : path.join(opts.modulesDir, '..', opts.ref.substr(5)),
+    path: depPath ? path.join(opts.modulesDir, '.pnpm', depPathToFilename(depPath)) : path.join(opts.modulesDir, '..', opts.ref.slice(5)),
     version,
   }
   if (resolved) {

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -14,7 +14,8 @@ export function resolve (
   if (!isAbsolute(resolutionLocation)) {
     let registryUrl!: string
     if (resolutionLocation[1] === '@') {
-      const scope = resolutionLocation.substr(1, resolutionLocation.indexOf('/', 1) - 1)
+      const slashIndex = resolutionLocation.indexOf('/', 1)
+      const scope = resolutionLocation.slice(1, slashIndex !== -1 ? slashIndex : 0)
       registryUrl = registries[scope] || registries.default
     } else {
       registryUrl = registries.default
@@ -31,7 +32,7 @@ export function tryGetPackageId (registries: Registries, relDepPath: string) {
   }
   const underscoreIndex = relDepPath.indexOf('_', relDepPath.lastIndexOf('/'))
   if (underscoreIndex !== -1) {
-    return resolve(registries, relDepPath.substr(0, underscoreIndex))
+    return resolve(registries, relDepPath.slice(0, underscoreIndex))
   }
   return resolve(registries, relDepPath)
 }
@@ -55,7 +56,7 @@ export function refToAbsolute (
 
 export function getRegistryByPackageName (registries: Registries, packageName: string) {
   if (packageName[0] !== '@') return registries.default
-  const scope = packageName.substr(0, packageName.indexOf('/'))
+  const scope = packageName.substring(0, packageName.indexOf('/'))
   return registries[scope] || registries.default
 }
 
@@ -67,7 +68,7 @@ export function relative (
   const registryName = encodeRegistry(getRegistryByPackageName(registries, packageName))
 
   if (absoluteResolutionLoc.startsWith(`${registryName}/`)) {
-    return absoluteResolutionLoc.substr(absoluteResolutionLoc.indexOf('/'))
+    return absoluteResolutionLoc.slice(absoluteResolutionLoc.indexOf('/'))
   }
   return absoluteResolutionLoc
 }
@@ -142,7 +143,7 @@ function depPathToFilenameUnescaped (depPath: string) {
       depPath = depPath.substring(1)
     }
     const index = depPath.lastIndexOf('/')
-    return `${depPath.substring(0, index)}@${depPath.substr(index + 1)}`
+    return `${depPath.substring(0, index)}@${depPath.slice(index + 1)}`
   }
   return depPath.replace(':', '+')
 }

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -108,7 +108,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
     return `${semverRangeToken}${manifest.version}`
   }
   if (depSpec.startsWith('workspace:./') || depSpec.startsWith('workspace:../')) {
-    const { manifest } = await tryReadProjectManifest(path.join(dir, depSpec.substr(10)))
+    const { manifest } = await tryReadProjectManifest(path.join(dir, depSpec.slice(10)))
     if ((manifest == null) || !manifest.name || !manifest.version) {
       throw new PnpmError(
         'CANNOT_RESOLVE_WORKSPACE_PROTOCOL',
@@ -119,7 +119,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
     if (manifest.name === depName) return `${manifest.version}`
     return `npm:${manifest.name}@${manifest.version}`
   }
-  depSpec = depSpec.substr(10)
+  depSpec = depSpec.slice(10)
   if (depSpec.includes('@')) {
     return `npm:${depSpec}`
   }

--- a/packages/filter-workspace-packages/src/parsePackageSelector.ts
+++ b/packages/filter-workspace-packages/src/parsePackageSelector.ts
@@ -20,10 +20,10 @@ export default (rawSelector: string, prefix: string): PackageSelector => {
   let excludeSelf = false
   const includeDependencies = rawSelector.endsWith('...')
   if (includeDependencies) {
-    rawSelector = rawSelector.substring(0, rawSelector.length - 3)
+    rawSelector = rawSelector.slice(0, -3)
     if (rawSelector.endsWith('^')) {
       excludeSelf = true
-      rawSelector = rawSelector.substr(0, rawSelector.length - 1)
+      rawSelector = rawSelector.slice(0, -1)
     }
   }
   const includeDependents = rawSelector.startsWith('...')
@@ -31,7 +31,7 @@ export default (rawSelector: string, prefix: string): PackageSelector => {
     rawSelector = rawSelector.substring(3)
     if (rawSelector.startsWith('^')) {
       excludeSelf = true
-      rawSelector = rawSelector.substr(1)
+      rawSelector = rawSelector.slice(1)
     }
   }
   const matches = rawSelector.match(/^([^.][^{}[\]]*)?(\{[^}]+\})?(\[[^\]]+\])?$/)
@@ -50,13 +50,13 @@ export default (rawSelector: string, prefix: string): PackageSelector => {
   }
 
   return {
-    diff: matches[3]?.substr(1, matches[3].length - 2),
+    diff: matches[3]?.slice(1, -1),
     exclude,
     excludeSelf,
     includeDependencies,
     includeDependents,
     namePattern: matches[1],
-    parentDir: matches[2] && path.join(prefix, matches[2].substr(1, matches[2].length - 2)),
+    parentDir: matches[2] && path.join(prefix, matches[2].slice(1, -1)),
   }
 }
 

--- a/packages/git-resolver/src/index.ts
+++ b/packages/git-resolver/src/index.ts
@@ -121,6 +121,6 @@ function resolveRefFromRefs (refs: {[ref: string]: string}, repo: string, ref: s
 }
 
 function isSsh (gitSpec: string): boolean {
-  return gitSpec.substr(0, 10) === 'git+ssh://' ||
-    gitSpec.substr(0, 4) === 'git@'
+  return gitSpec.slice(0, 10) === 'git+ssh://' ||
+    gitSpec.slice(0, 4) === 'git@'
 }

--- a/packages/git-resolver/src/parsePref.ts
+++ b/packages/git-resolver/src/parsePref.ts
@@ -36,7 +36,7 @@ export default async function parsePref (pref: string): Promise<HostedPackageSpe
   }
   const colonsPos = pref.indexOf(':')
   if (colonsPos === -1) return null
-  const protocol = pref.substr(0, colonsPos)
+  const protocol = pref.slice(0, colonsPos)
   if (protocol && gitProtocols.has(protocol.toLocaleLowerCase())) {
     const urlparse = new URL(escapeColon(pref))
     if (!urlparse || !urlparse.protocol) return null
@@ -69,7 +69,7 @@ function urlToFetchSpec (urlparse: URL) {
   urlparse.hash = ''
   const fetchSpec = url.format(urlparse)
   if (fetchSpec.startsWith('git+')) {
-    return fetchSpec.substr(4)
+    return fetchSpec.slice(4)
   }
   return fetchSpec
 }
@@ -107,7 +107,7 @@ async function fromHostedGit (hosted: any): Promise<HostedPackageSpec> { // esli
           // npm instead tries git ls-remote directly which prompts user for login credentials.
 
           // HTTP HEAD on https://domain/user/repo, strip out ".git"
-          const response = await fetch(httpsUrl.substr(0, httpsUrl.length - 4), { method: 'HEAD', follow: 0, retry: { retries: 0 } })
+          const response = await fetch(httpsUrl.slice(0, -4), { method: 'HEAD', follow: 0, retry: { retries: 0 } })
           if (response.ok) {
             fetchSpec = httpsUrl
           }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -584,7 +584,7 @@ async function linkRootPackages (
         if (allDeps[alias].startsWith('link:')) {
           const isDev = Boolean(projectSnapshot.devDependencies?.[alias])
           const isOptional = Boolean(projectSnapshot.optionalDependencies?.[alias])
-          const packageDir = path.join(opts.projectDir, allDeps[alias].substr(5))
+          const packageDir = path.join(opts.projectDir, allDeps[alias].slice(5))
           const linkedPackage = await (async () => {
             const importerId = getLockfileImporterId(opts.lockfileDir, packageDir)
             if (importerManifestsByImporterId[importerId]) {

--- a/packages/headless/src/lockfileToDepGraph.ts
+++ b/packages/headless/src/lockfileToDepGraph.ts
@@ -234,7 +234,7 @@ async function getChildrenPaths (
   for (const alias of Object.keys(allDeps)) {
     const childDepPath = dp.refToAbsolute(allDeps[alias], alias, ctx.registries)
     if (childDepPath === null) {
-      children[alias] = path.resolve(ctx.lockfileDir, importerId, allDeps[alias].substr(5))
+      children[alias] = path.resolve(ctx.lockfileDir, importerId, allDeps[alias].slice(5))
       continue
     }
     const childRelDepPath = dp.refToRelative(allDeps[alias], alias) as string
@@ -246,7 +246,7 @@ async function getChildrenPaths (
       const pkgName = nameVerFromPkgSnapshot(childRelDepPath, childPkgSnapshot).name
       children[alias] = path.join(ctx.virtualStoreDir, dp.depPathToFilename(childRelDepPath), 'node_modules', pkgName)
     } else if (allDeps[alias].indexOf('file:') === 0) {
-      children[alias] = path.resolve(ctx.lockfileDir, allDeps[alias].substr(5))
+      children[alias] = path.resolve(ctx.lockfileDir, allDeps[alias].slice(5))
     } else if (!ctx.skipped.has(childRelDepPath) && ((peerDeps == null) || !peerDeps.has(alias))) {
       throw new Error(`${childRelDepPath} not found in ${WANTED_LOCKFILE}`)
     }

--- a/packages/headless/src/lockfileToHoistedDepGraph.ts
+++ b/packages/headless/src/lockfileToHoistedDepGraph.ts
@@ -124,7 +124,7 @@ function pickLinkedDirectDeps (
   const directDeps = {}
   for (const [alias, ref] of Object.entries(rootDeps)) {
     if (ref.startsWith('link:')) {
-      directDeps[alias] = path.resolve(importerDir, ref.substr(5))
+      directDeps[alias] = path.resolve(importerDir, ref.slice(5))
     }
   }
   return directDeps

--- a/packages/lockfile-to-pnp/src/index.ts
+++ b/packages/lockfile-to-pnp/src/index.ts
@@ -143,7 +143,7 @@ function toPackageDependenciesMap (
 ): Array<[string, string | [string, string]]> {
   return Object.entries(deps).map(([depAlias, ref]) => {
     if (importerId && ref.startsWith('link:')) {
-      return [depAlias, path.join(importerId, ref.substr(5))]
+      return [depAlias, path.join(importerId, ref.slice(5))]
     }
     const relDepPath = refToRelative(ref, depAlias)
     if (!relDepPath) return [depAlias, ref]

--- a/packages/make-dedicated-lockfile/src/index.ts
+++ b/packages/make-dedicated-lockfile/src/index.ts
@@ -23,7 +23,7 @@ export default async function (lockfileDir: string, projectDir: string) {
   const baseImporterId = getLockfileImporterId(lockfileDir, projectDir)
   for (const [importerId, importer] of Object.entries(allImporters)) {
     if (importerId.startsWith(`${baseImporterId}/`)) {
-      const newImporterId = importerId.substr(baseImporterId.length + 1)
+      const newImporterId = importerId.slice(baseImporterId.length + 1)
       lockfile.importers[newImporterId] = projectSnapshotWithoutLinkedDeps(importer)
       continue
     }

--- a/packages/npm-resolver/src/fetch.ts
+++ b/packages/npm-resolver/src/fetch.ts
@@ -100,7 +100,7 @@ function toUri (pkgName: string, registry: string) {
   let encodedName: string
 
   if (pkgName[0] === '@') {
-    encodedName = `@${encodeURIComponent(pkgName.substr(1))}`
+    encodedName = `@${encodeURIComponent(pkgName.slice(1))}`
   } else {
     encodedName = encodeURIComponent(pkgName)
   }

--- a/packages/npm-resolver/src/parsePref.ts
+++ b/packages/npm-resolver/src/parsePref.ts
@@ -16,14 +16,14 @@ export default function parsePref (
 ): RegistryPackageSpec | null {
   let name = alias
   if (pref.startsWith('npm:')) {
-    pref = pref.substr(4)
+    pref = pref.slice(4)
     const index = pref.lastIndexOf('@')
     if (index < 1) {
       name = pref
       pref = defaultTag
     } else {
-      name = pref.substr(0, index)
-      pref = pref.substr(index + 1)
+      name = pref.slice(0, index)
+      pref = pref.slice(index + 1)
     }
   }
   if (name) {

--- a/packages/package-bins/src/index.ts
+++ b/packages/package-bins/src/index.ts
@@ -42,7 +42,7 @@ function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string) {
   if (typeof bin === 'string') {
     return [
       {
-        name: pkgName.startsWith('@') ? pkgName.substr(pkgName.indexOf('/') + 1) : pkgName,
+        name: pkgName.startsWith('@') ? pkgName.slice(pkgName.indexOf('/') + 1) : pkgName,
         path: path.join(pkgPath, bin),
       },
     ]

--- a/packages/parse-wanted-dependency/src/index.ts
+++ b/packages/parse-wanted-dependency/src/index.ts
@@ -10,11 +10,11 @@ export default function parseWantedDependency (
 ): Partial<ParsedWantedDependency> & (Omit<ParsedWantedDependency, 'pref'> | Omit<ParsedWantedDependency, 'alias'> | ParsedWantedDependency) {
   const versionDelimiter = rawWantedDependency.indexOf('@', 1) // starting from 1 to skip the @ that marks scope
   if (versionDelimiter !== -1) {
-    const alias = rawWantedDependency.substr(0, versionDelimiter)
+    const alias = rawWantedDependency.slice(0, versionDelimiter)
     if (validateNpmPackageName(alias).validForOldPackages) {
       return {
         alias,
-        pref: rawWantedDependency.substr(versionDelimiter + 1),
+        pref: rawWantedDependency.slice(versionDelimiter + 1),
       }
     }
     return {

--- a/packages/pick-registry-for-package/src/index.ts
+++ b/packages/pick-registry-for-package/src/index.ts
@@ -7,13 +7,13 @@ export default (registries: Registries, packageName: string, pref?: string) => {
 
 function getScope (pkgName: string, pref?: string): string | null {
   if (pref?.startsWith('npm:')) {
-    pref = pref.substr(4)
+    pref = pref.slice(4)
     if (pref[0] === '@') {
-      return pref.substr(0, pref.indexOf('/'))
+      return pref.substring(0, pref.indexOf('/'))
     }
   }
   if (pkgName[0] === '@') {
-    return pkgName.substr(0, pkgName.indexOf('/'))
+    return pkgName.substring(0, pkgName.indexOf('/'))
   }
   return null
 }

--- a/packages/pkgs-graph/src/index.ts
+++ b/packages/pkgs-graph/src/index.ts
@@ -60,7 +60,7 @@ export default function <T> (pkgs: Array<Package & T>, opts?: {
         const isWorkspaceSpec = rawSpec.startsWith('workspace:')
         try {
           if (isWorkspaceSpec) {
-            rawSpec = rawSpec.substr(10)
+            rawSpec = rawSpec.slice(10)
             if (rawSpec === '^' || rawSpec === '~') {
               rawSpec = '*'
             };

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -508,8 +508,8 @@ export function createMatcher (params: string[]) {
       pattern = param
       spec = ''
     } else {
-      pattern = param.substr(0, atIndex)
-      spec = param.substr(atIndex + 1)
+      pattern = param.slice(0, atIndex)
+      spec = param.slice(atIndex + 1)
     }
     return {
       match: matcher(pattern),

--- a/packages/plugin-commands-installation/src/updateToLatestSpecsFromManifest.ts
+++ b/packages/plugin-commands-installation/src/updateToLatestSpecsFromManifest.ts
@@ -21,7 +21,7 @@ export function createLatestSpecs (specs: string[], manifest: ProjectManifest) {
   const allDeps = getAllDependenciesFromManifest(manifest)
   return specs
     .filter((selector) => selector.includes('@', 1)
-      ? allDeps[selector.substr(0, selector.indexOf('@', 1))]
+      ? allDeps[selector.slice(0, selector.indexOf('@', 1))]
       : allDeps[selector]
     )
     .map((selector) => {
@@ -39,5 +39,5 @@ export function createLatestSpecs (specs: string[], manifest: ProjectManifest) {
 }
 
 function removeVersionFromSpec (spec: string) {
-  return spec.substr(0, spec.lastIndexOf('@'))
+  return spec.substring(0, spec.lastIndexOf('@'))
 }

--- a/packages/pnpm/bin/pnpm.cjs
+++ b/packages/pnpm/bin/pnpm.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const [major, minor] = process.version.substr(1).split('.')
+const [major, minor] = process.version.slice(1).split('.')
 const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.`
 
 if (major < 14 || major == 14 && minor < 19) {

--- a/packages/pnpm/bin/pnpx.cjs
+++ b/packages/pnpm/bin/pnpx.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const [major, minor] = process.version.substr(1).split('.')
+const [major, minor] = process.version.slice(1).split('.')
 const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.`
 
 if (major < 12 || major == 12 && minor < 17) {

--- a/packages/pnpm/src/cmd/completion.ts
+++ b/packages/pnpm/src/cmd/completion.ts
@@ -23,7 +23,7 @@ export default function (
 
     // Parse only words that are before the pointer and finished.
     // Finished means that there's at least one space between the word and pointer
-    const finishedArgv = env.partial.substr(0, env.partial.length - env.lastPartial.length)
+    const finishedArgv = env.partial.slice(0, -env.lastPartial.length)
     const inputArgv = splitCmd(finishedArgv).slice(1)
     // We cannot autocomplete what a user types after "pnpm test --"
     if (inputArgv.includes('--')) return

--- a/packages/resolve-dependencies/src/nodeIdUtils.ts
+++ b/packages/resolve-dependencies/src/nodeIdUtils.ts
@@ -13,5 +13,5 @@ export function createNodeId (parentNodeId: string, pkgId: string) {
 }
 
 export function splitNodeId (nodeId: string) {
-  return nodeId.substr(1, nodeId.length - 2).split('>')
+  return nodeId.slice(1, -1).split('>')
 }

--- a/packages/resolve-dependencies/src/toResolveImporter.ts
+++ b/packages/resolve-dependencies/src/toResolveImporter.ts
@@ -120,12 +120,12 @@ function getVersionSpecsByRealNames (deps: Dependencies) {
   return Object.keys(deps)
     .reduce((acc, depName) => {
       if (deps[depName].startsWith('npm:')) {
-        const pref = deps[depName].substr(4)
+        const pref = deps[depName].slice(4)
         const index = pref.lastIndexOf('@')
-        const spec = pref.substr(index + 1)
+        const spec = pref.slice(index + 1)
         const selector = getVerSelType(spec)
         if (selector != null) {
-          const pkgName = pref.substr(0, index)
+          const pkgName = pref.substring(0, index)
           acc[pkgName] = acc[pkgName] || {}
           acc[pkgName][selector.normalized] = selector.type
         }

--- a/packages/resolve-dependencies/src/updateLockfile.ts
+++ b/packages/resolve-dependencies/src/updateLockfile.ts
@@ -255,10 +255,10 @@ export function relativeTarball (tarball: string, registry: string) {
   // So we add @mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz
   // not /@mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz
   // Related issue: https://github.com/pnpm/pnpm/issues/1827
-  if (tarball.substr(0, registry.length) !== registry) {
+  if (tarball.slice(0, registry.length) !== registry) {
     return tarball
   }
-  const relative = tarball.substr(registry.length)
+  const relative = tarball.slice(registry.length)
   if (relative[0] === '/') return relative.substring(1)
   return relative
 }

--- a/packages/resolve-dependencies/src/updateProjectManifest.ts
+++ b/packages/resolve-dependencies/src/updateProjectManifest.ts
@@ -127,11 +127,11 @@ function getPrefPreferSpecifiedSpec (
 ) {
   const prefix = getPrefix(opts.alias, opts.name)
   if (opts.specRaw?.startsWith(`${opts.alias}@${prefix}`)) {
-    const range = opts.specRaw.substr(`${opts.alias}@${prefix}`.length)
+    const range = opts.specRaw.slice(`${opts.alias}@${prefix}`.length)
     if (range) {
       const selector = versionSelectorType(range)
       if ((selector != null) && (selector.type === 'version' || selector.type === 'range')) {
-        return opts.specRaw.substr(opts.alias.length + 1)
+        return opts.specRaw.slice(opts.alias.length + 1)
       }
     }
   }
@@ -153,10 +153,10 @@ function getPrefPreferSpecifiedExoticSpec (
 ) {
   const prefix = getPrefix(opts.alias, opts.name)
   if (opts.specRaw?.startsWith(`${opts.alias}@${prefix}`) && opts.specRaw !== `${opts.alias}@workspace:*`) {
-    const specWithoutName = opts.specRaw.substr(`${opts.alias}@${prefix}`.length)
+    const specWithoutName = opts.specRaw.slice(`${opts.alias}@${prefix}`.length)
     const selector = versionSelectorType(specWithoutName)
     if (!((selector != null) && (selector.type === 'version' || selector.type === 'range'))) {
-      return opts.specRaw.substr(opts.alias.length + 1)
+      return opts.specRaw.slice(opts.alias.length + 1)
     }
   }
   return `${prefix}${createVersionSpec(opts.version, opts.pinnedVersion)}`

--- a/packages/tarball-resolver/src/index.ts
+++ b/packages/tarball-resolver/src/index.ts
@@ -27,7 +27,7 @@ const GIT_HOSTERS = new Set([
 
 function isRepository (pref: string) {
   if (pref.endsWith('/')) {
-    pref = pref.substr(0, pref.length - 1)
+    pref = pref.slice(0, -1)
   }
   const parts = pref.split('/')
   return (parts.length === 5 && GIT_HOSTERS.has(parts[2]))

--- a/packages/which-version-is-pinned/src/index.ts
+++ b/packages/which-version-is-pinned/src/index.ts
@@ -1,7 +1,7 @@
 import { parseRange } from 'semver-utils'
 
 export default function whichVersionIsPinned (spec: string) {
-  if (spec.startsWith('workspace:')) spec = spec.substr('workspace:'.length)
+  if (spec.startsWith('workspace:')) spec = spec.slice('workspace:'.length)
   if (spec === '*') return 'none'
   const parsedRange = parseRange(spec)
   if (parsedRange.length !== 1) return undefined

--- a/packages/write-project-manifest/src/index.ts
+++ b/packages/write-project-manifest/src/index.ts
@@ -18,7 +18,7 @@ export default async function writeProjectManifest (
     insertFinalNewline?: boolean
   }
 ): Promise<void> {
-  const fileType = filePath.substr(filePath.lastIndexOf('.') + 1).toLowerCase()
+  const fileType = filePath.slice(filePath.lastIndexOf('.') + 1).toLowerCase()
   if (fileType === 'yaml') {
     return writeYamlFile(filePath, manifest, YAML_FORMAT)
   }

--- a/utils/eslint-config/eslint.json
+++ b/utils/eslint-config/eslint.json
@@ -76,6 +76,13 @@
     "max-len": "off",
     "no-multiple-empty-lines": "error",
     "no-redeclare": "error",
+    "no-restricted-properties": [
+      "error",
+      {
+        "property": "substr",
+        "message": "Use .slice instead of .substr."
+      }
+    ],
     "no-trailing-spaces": "error",
     "no-var": "error",
     "space-before-function-paren": [


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.