### PR TITLE
Chore/friendly git error

### DIFF
--- a/.changeset/mean-zoos-move.md
+++ b/.changeset/mean-zoos-move.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+Show friendly error message when get current git branch name error.

--- a/packages/plugin-commands-publishing/src/gitChecks.ts
+++ b/packages/plugin-commands-publishing/src/gitChecks.ts
@@ -12,8 +12,13 @@ export async function isGitRepo () {
 }
 
 export async function getCurrentBranch () {
-  const { stdout } = await execa('git', ['symbolic-ref', '--short', 'HEAD'])
-  return stdout
+  try {
+    const { stdout } = await execa('git', ['symbolic-ref', '--short', 'HEAD'])
+    return stdout
+  } catch (_: any) {  // eslint-disable-line
+    // Command will fail with code 1 if the HEAD is detached.
+    return null
+  }
 }
 
 export async function isWorkingTreeClean () {

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -116,6 +116,15 @@ export async function handler (
     }
     const branches = opts.publishBranch ? [opts.publishBranch] : ['master', 'main']
     const currentBranch = await getCurrentBranch()
+    if (currentBranch === null) {
+      throw new PnpmError(
+        'GIT_UNKNOWN_BRANCH',
+        `The Git HEAD may not attached to any branch, but your "publish-branch" is set to "${branches.join('|')}".`,
+        {
+          hint: GIT_CHECKS_HINT,
+        }
+      )
+    }
     if (!branches.includes(currentBranch)) {
       const { confirm } = await prompt({
         message: `You're on branch "${currentBranch}" but your "publish-branch" is set to "${branches.join('|')}". \


### PR DESCRIPTION
More friendly git error messages.

related #3136

---

Before ⬇️
![image](https://user-images.githubusercontent.com/18554747/160277164-05b715af-b7ad-4ba7-abd0-76507309dc59.png)

Now (may need adjustment)⬇️
> The Git HEAD may not attached to any branch, but your "publish-branch" is set to \'master|main\'
>
> If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".

---

## References

> **git symbolic-ref** will exit with status 0 if the contents of the symbolic ref were printed correctly, with status 1 if the requested name is not a symbolic ref, or 128 if another error occurs.

- https://git-scm.com/docs/git-symbolic-ref