### PR TITLE
lockfile-file: export function read

### DIFF
--- a/packages/lockfile-file/src/read.ts
+++ b/packages/lockfile-file/src/read.ts
@@ -24,7 +24,7 @@ export async function readCurrentLockfile (
   }
 ): Promise<Lockfile | null> {
   const lockfilePath = path.join(virtualStoreDir, 'lock.yaml')
-  return (await _read(lockfilePath, virtualStoreDir, opts)).lockfile
+  return (await read(lockfilePath, virtualStoreDir, opts)).lockfile
 }
 
 export async function readWantedLockfileAndAutofixConflicts (
@@ -38,7 +38,7 @@ export async function readWantedLockfileAndAutofixConflicts (
     hadConflicts: boolean
   }> {
   const lockfilePath = path.join(pkgPath, WANTED_LOCKFILE)
-  return _read(lockfilePath, pkgPath, { ...opts, autofixMergeConflicts: true })
+  return read(lockfilePath, pkgPath, { ...opts, autofixMergeConflicts: true })
 }
 
 export async function readWantedLockfile (
@@ -49,10 +49,10 @@ export async function readWantedLockfile (
   }
 ): Promise<Lockfile | null> {
   const lockfilePath = path.join(pkgPath, WANTED_LOCKFILE)
-  return (await _read(lockfilePath, pkgPath, opts)).lockfile
+  return (await read(lockfilePath, pkgPath, opts)).lockfile
 }
 
-async function _read (
+export async function read (
   lockfilePath: string,
   prefix: string,
   opts: {


### PR DESCRIPTION
useful for workspaces = `package.json` and `pnpm-lock.yaml` are in different folders

example use in [parselock](https://github.com/milahu/parselock/blob/main/patches/%40pnpm%2Blockfile-file%2B5.0.0.patch)

```js
  var lockfilePath = ".../pnpm-lock.yaml";
  var lockData = await pnpm.readWantedLockfile(pkgPath, {
    wantedVersion: pnpm_version,
    lockfilePath,
  });
```
