### PR TITLE
Improve spnpm to use esbuild

### DIFF
--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -2,6 +2,8 @@ import { requestRetryLogger } from '@pnpm/core-loggers'
 import { operation, RetryTimeoutOptions } from '@zkochan/retry'
 import fetch, { Request, RequestInit as NodeRequestInit, Response } from 'node-fetch'
 
+export { isRedirect } from 'node-fetch'
+
 export { Response, RetryTimeoutOptions }
 
 interface URLLike {
@@ -14,8 +16,6 @@ export interface RequestInit extends NodeRequestInit {
   retry?: RetryTimeoutOptions
   timeout?: number
 }
-
-export const isRedirect = fetch.isRedirect
 
 export default async function fetchRetry (url: RequestInfo, opts: RequestInit = {}): Promise<Response> {
   const retryOpts = opts.retry ?? {}

--- a/packages/pnpm/.gitignore
+++ b/packages/pnpm/.gitignore
@@ -1,1 +1,2 @@
 bin/nodes
+dist-spnpm

--- a/packages/pnpm/spnpm.js
+++ b/packages/pnpm/spnpm.js
@@ -1,3 +1,60 @@
-require('@pnpm/ts-execution-runtime')
+const fs = require('fs')
+const esbuild = require('esbuild')
+const pathLib = require('path')
+const packagesDir = pathLib.resolve(__dirname, '..')
 
-require('./src/pnpm.ts')
+const localPackages = fs.readdirSync(packagesDir)
+
+const pnpmPackageJson = JSON.parse(fs.readFileSync(pathLib.join(__dirname, 'package.json'), 'utf8'))
+
+// This plugin rewrites imports to reference the `src` dir instead of `lib` so
+// esbuild can compile the original TypeScript
+const spnpmImportsPlugin = {
+  name: 'spnpmImports',
+  setup: (build) => {
+    // This is an exception to the rule that all local packages start with `@pnpm`
+    build.onResolve({ filter: /^dependency-path$/ }, ({path, resolveDir}) => ({
+      path: pathLib.resolve(packagesDir, 'dependency-path', 'src', 'index.ts')
+    }))
+
+    // E.g. @pnpm/config -> /<some_dir>/pnpm/packages/config/src/index.ts
+    build.onResolve({ filter: /@pnpm\// }, ({path, resolveDir}) => {
+      const pathParts = path.split('/')
+      const packageName = pathParts[1]
+
+      // Bail if the package isn't present locally
+      if (!localPackages.includes(packageName)) {
+        return
+      }
+
+      const newPath = pathLib.resolve(packagesDir, packageName, 'src', 'index.ts')
+
+      return {
+        path: newPath
+      }
+    })
+  }
+}
+
+;(async () => {
+  await esbuild.build({
+    bundle: true,
+    platform: 'node',
+    entryPoints: [pathLib.resolve(__dirname, 'lib/pnpm.js')],
+    outfile: pathLib.resolve(__dirname, 'dist-spnpm/spnpm.cjs'),
+    external: [
+      'node-gyp',
+      './get-uid-gid.js', // traces back to: https://github.com/npm/uid-number/blob/6e9bdb302ae4799d05abf12e922ccdb4bd9ea023/uid-number.js#L31
+    ],
+    define: {
+      'process.env.npm_package_name': JSON.stringify(pnpmPackageJson.name),
+      'process.env.npm_package_version': JSON.stringify(pnpmPackageJson.version),
+    },
+    sourcemap: true, // nice for local debugging
+    logLevel: 'warning', // keeps esbuild quiet unless there's a problem
+    plugins: [spnpmImportsPlugin],
+  })
+
+  // Require the file just built by esbuild
+  require('./dist-spnpm/spnpm.cjs')
+})()

--- a/packages/pnpm/spnpm.js
+++ b/packages/pnpm/spnpm.js
@@ -40,6 +40,7 @@ const spnpmImportsPlugin = {
   await esbuild.build({
     bundle: true,
     platform: 'node',
+    target: 'node14',
     entryPoints: [pathLib.resolve(__dirname, 'lib/pnpm.js')],
     outfile: pathLib.resolve(__dirname, 'dist-spnpm/spnpm.cjs'),
     external: [

--- a/packages/resolve-dependencies/src/resolvePeers.ts
+++ b/packages/resolve-dependencies/src/resolvePeers.ts
@@ -263,6 +263,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
           return { name, version }
         })
     )
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     depPath = `${resolvedPackage.depPath}${peersFolderSuffix}`
   }
   const localLocation = path.join(ctx.virtualStoreDir, depPathToFilename(depPath))


### PR DESCRIPTION
I've been doing a lot of local debugging with `spnpm` lately and it's challenging to work with. The ts-execution-engine has been oddly flaky and resulting in cases where TS files weren't getting resolved correctly. Also babel register adds some friction when I want to use `--inspect-brk` and set breakpoints before the execution begins; the sourcemaps aren't present until the files are resolved and read in.

This PR rewrites `spnpm` to use esbuild to bundle (with sourcemaps) a file which is then `require`ed in.

Esbuild is fast enough (~500ms on my machine) to just bundle on every invocation.

Let me know what you think. It's been much more stable for my local development and solves all the problems I've run into.