### PR TITLE
Fix `add` bug with overlapping workspace packages

### DIFF
--- a/.changeset/strange-parents-drum.md
+++ b/.changeset/strange-parents-drum.md
@@ -1,5 +1,7 @@
 ---
 "@pnpm/resolve-dependencies": patch
+"pnpm": patch
 ---
 
-fix #4565 which was incorrectly marking some packages for npm resolution with `link-workspace-packages=false`
+Don't update a direct dependency that has the same name as a dependency in the workspace, when adding a new dependency to a workspace project [#4575](https://github.com/pnpm/pnpm/pull/4575).
+

--- a/.changeset/strange-parents-drum.md
+++ b/.changeset/strange-parents-drum.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+fix #4565 which was incorrectly marking some packages for npm resolution with `link-workspace-packages=false`

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -287,7 +287,8 @@ async function resolveDependenciesOfDependency (
       options.workspacePackages,
       extendedWantedDep.wantedDependency,
       { defaultTag: ctx.defaultTag, registry: ctx.registries.default }
-    )
+    ) &&
+    ctx.linkWorkspacePackagesDepth !== -1 // fix for #4565
   ) || ctx.updatedSet.has(extendedWantedDep.infoFromLockfile.name!)
 
   const resolveDependencyOpts: ResolveDependencyOptions = {

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -283,12 +283,12 @@ async function resolveDependenciesOfDependency (
     )
   ) || Boolean(
     (options.workspacePackages != null) &&
+    ctx.linkWorkspacePackagesDepth !== -1 &&
     wantedDepIsLocallyAvailable(
       options.workspacePackages,
       extendedWantedDep.wantedDependency,
       { defaultTag: ctx.defaultTag, registry: ctx.registries.default }
-    ) &&
-    ctx.linkWorkspacePackagesDepth !== -1 // fix for #4565
+    )
   ) || ctx.updatedSet.has(extendedWantedDep.infoFromLockfile.name!)
 
   const resolveDependencyOpts: ResolveDependencyOptions = {

--- a/utils/eslint-config/package.json
+++ b/utils/eslint-config/package.json
@@ -10,8 +10,7 @@
   "bugs": {
     "url": "https://github.com/pnpm/eslint-config/issues"
   },
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
+  "main": "index.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Fix for #4565. I couldn't find any relevant tests to work with.

I also tossed in a fix to `@pnpm/eslint-config` which was throwing this error for me locally:
```
(node:93074) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/jdlm/stripe/contrib/pnpm/node_modules/@pnpm/eslint-config/package.json' of 'lib/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```