### PR TITLE
fix(filter-workspace-packages): filter not working if the path contains Korean characters

### DIFF
--- a/.changeset/funny-mirrors-act.md
+++ b/.changeset/funny-mirrors-act.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/filter-workspace-packages": patch
+---
+
+'filter-workspace-packages' will filter the package well even if Korean is included in the path. fix #4594

--- a/packages/filter-workspace-packages/src/getChangedPackages.ts
+++ b/packages/filter-workspace-packages/src/getChangedPackages.ts
@@ -64,6 +64,8 @@ async function getChangedDirsSinceCommit (commit: string, workingDir: string, te
   }
 
   const allChangedFiles = diff.split('\n')
+    // The prefix and suffix '"' are appended to the Korean path
+    .map(line => line.replace(/^"/, '').replace(/"$/, ''))
   const patterns = changedFilesIgnorePattern.filter(
     (pattern) => pattern.length
   )

--- a/packages/filter-workspace-packages/test/index.ts
+++ b/packages/filter-workspace-packages/test/index.ts
@@ -366,6 +366,11 @@ test('select changed packages', async () => {
 
   await mkdir(pkg3Dir)
 
+  const pkgKorDir = path.join(workspaceDir, 'package-kor')
+
+  await mkdir(pkgKorDir)
+  await touch(path.join(pkgKorDir, 'fileKor한글.js'))
+
   await execa('git', ['add', '.'], { cwd: workspaceDir })
   await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: workspaceDir })
 
@@ -412,6 +417,16 @@ test('select changed packages', async () => {
         },
       },
     },
+    [pkgKorDir]: {
+      dependencies: [],
+      package: {
+        dir: pkgKorDir,
+        manifest: {
+          name: 'package-kor',
+          version: '0.0.0',
+        },
+      },
+    },
     [pkg20Dir]: {
       dependencies: [],
       package: {
@@ -429,7 +444,7 @@ test('select changed packages', async () => {
       diff: 'HEAD~1',
     }], { workspaceDir })
 
-    expect(Object.keys(selectedProjectsGraph)).toStrictEqual([pkg1Dir, pkg2Dir])
+    expect(Object.keys(selectedProjectsGraph)).toStrictEqual([pkg1Dir, pkg2Dir, pkgKorDir])
   }
   {
     const { selectedProjectsGraph } = await filterWorkspacePackages(pkgsGraph, [{
@@ -453,7 +468,7 @@ test('select changed packages', async () => {
       includeDependents: true,
     }], { workspaceDir, testPattern: ['*/file2.js'] })
 
-    expect(Object.keys(selectedProjectsGraph)).toStrictEqual([pkg1Dir, pkg2Dir])
+    expect(Object.keys(selectedProjectsGraph)).toStrictEqual([pkg1Dir, pkgKorDir, pkg2Dir])
   }
 })
 


### PR DESCRIPTION
fix #4594 🙇 

Package filtering is not working, if changed file include korean char.
Because `gif diff` result starts and end with `"`.
