### PR TITLE
fix(exportable-manifest, types): add typesVersions field to PUBLISH_CONFIG_WHITELIST

### DIFF
--- a/.changeset/yellow-wolves-swim.md
+++ b/.changeset/yellow-wolves-swim.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exportable-manifest": patch
+"@pnpm/types": patch
+---
+
+Add typesVersions to PUBLISH_CONFIG_WHITELIST

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -26,6 +26,8 @@ const PUBLISH_CONFIG_WHITELIST = new Set([
   // These are useful to hide in order to avoid warnings during local development
   'os',
   'cpu',
+  // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
+  'typesVersions',
 ])
 
 const PREPUBLISH_SCRIPTS = [
@@ -49,19 +51,7 @@ export default async function makePublishManifest (dir: string, originalManifest
     }
   }
 
-  const { publishConfig } = publishManifest
-  if (publishConfig != null) {
-    Object.keys(publishConfig)
-      .filter(key => PUBLISH_CONFIG_WHITELIST.has(key))
-      .forEach(key => {
-        publishManifest[key] = publishConfig[key]
-        delete publishConfig[key]
-      })
-
-    if (isEmpty(publishConfig)) {
-      delete publishManifest.publishConfig
-    }
-  }
+  overridePublishConfig(publishManifest)
 
   if (opts?.readmeFile) {
     publishManifest.readme ??= opts.readmeFile
@@ -124,4 +114,22 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
     return `npm:${depSpec}`
   }
   return depSpec
+}
+
+export function overridePublishConfig (publishManifest: ProjectManifest): void {
+  const { publishConfig } = publishManifest
+  if (!publishConfig) {
+    return
+  }
+
+  Object.keys(publishConfig)
+    .filter(key => PUBLISH_CONFIG_WHITELIST.has(key))
+    .forEach(key => {
+      publishManifest[key] = publishConfig[key]
+      delete publishConfig[key]
+    })
+
+  if (isEmpty(publishConfig)) {
+    delete publishManifest.publishConfig
+  }
 }

--- a/packages/exportable-manifest/src/index.ts
+++ b/packages/exportable-manifest/src/index.ts
@@ -3,32 +3,8 @@ import PnpmError from '@pnpm/error'
 import { tryReadProjectManifest } from '@pnpm/read-project-manifest'
 import { Dependencies, ProjectManifest } from '@pnpm/types'
 import fromPairs from 'ramda/src/fromPairs'
-import isEmpty from 'ramda/src/isEmpty'
 import omit from 'ramda/src/omit'
-
-// property keys that are copied from publishConfig into the manifest
-const PUBLISH_CONFIG_WHITELIST = new Set([
-  // manifest fields that may make sense to overwrite
-  'bin',
-  'type',
-  'imports',
-  // https://github.com/stereobooster/package.json#package-bundlers
-  'main',
-  'module',
-  'typings',
-  'types',
-  'exports',
-  'browser',
-  'esnext',
-  'es2015',
-  'unpkg',
-  'umd:main',
-  // These are useful to hide in order to avoid warnings during local development
-  'os',
-  'cpu',
-  // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
-  'typesVersions',
-])
+import { overridePublishConfig } from './overridePublishConfig'
 
 const PREPUBLISH_SCRIPTS = [
   'prepublishOnly',
@@ -114,22 +90,4 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
     return `npm:${depSpec}`
   }
   return depSpec
-}
-
-export function overridePublishConfig (publishManifest: ProjectManifest): void {
-  const { publishConfig } = publishManifest
-  if (!publishConfig) {
-    return
-  }
-
-  Object.keys(publishConfig)
-    .filter(key => PUBLISH_CONFIG_WHITELIST.has(key))
-    .forEach(key => {
-      publishManifest[key] = publishConfig[key]
-      delete publishConfig[key]
-    })
-
-  if (isEmpty(publishConfig)) {
-    delete publishManifest.publishConfig
-  }
 }

--- a/packages/exportable-manifest/src/overridePublishConfig.ts
+++ b/packages/exportable-manifest/src/overridePublishConfig.ts
@@ -1,0 +1,44 @@
+import { ProjectManifest } from '@pnpm/types'
+import isEmpty from 'ramda/src/isEmpty'
+
+// property keys that are copied from publishConfig into the manifest
+const PUBLISH_CONFIG_WHITELIST = new Set([
+  // manifest fields that may make sense to overwrite
+  'bin',
+  'type',
+  'imports',
+  // https://github.com/stereobooster/package.json#package-bundlers
+  'main',
+  'module',
+  'typings',
+  'types',
+  'exports',
+  'browser',
+  'esnext',
+  'es2015',
+  'unpkg',
+  'umd:main',
+  // These are useful to hide in order to avoid warnings during local development
+  'os',
+  'cpu',
+  // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
+  'typesVersions',
+])
+
+export function overridePublishConfig (publishManifest: ProjectManifest): void {
+  const { publishConfig } = publishManifest
+  if (!publishConfig) {
+    return
+  }
+
+  Object.keys(publishConfig)
+    .filter(key => PUBLISH_CONFIG_WHITELIST.has(key))
+    .forEach(key => {
+      publishManifest[key] = publishConfig[key]
+      delete publishConfig[key]
+    })
+
+  if (isEmpty(publishConfig)) {
+    delete publishManifest.publishConfig
+  }
+}

--- a/packages/exportable-manifest/src/overridePublishConfig.ts
+++ b/packages/exportable-manifest/src/overridePublishConfig.ts
@@ -27,14 +27,12 @@ const PUBLISH_CONFIG_WHITELIST = new Set([
 
 export function overridePublishConfig (publishManifest: ProjectManifest): void {
   const { publishConfig } = publishManifest
-  if (!publishConfig) {
-    return
-  }
+  if (!publishConfig) return
 
-  Object.keys(publishConfig)
-    .filter(key => PUBLISH_CONFIG_WHITELIST.has(key))
-    .forEach(key => {
-      publishManifest[key] = publishConfig[key]
+  Object.entries(publishConfig)
+    .filter(([key]) => PUBLISH_CONFIG_WHITELIST.has(key))
+    .forEach(([key, value]) => {
+      publishManifest[key] = value
       delete publishConfig[key]
     })
 

--- a/packages/exportable-manifest/test/index.test.ts
+++ b/packages/exportable-manifest/test/index.test.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../typings/index.d.ts"/>
-import exportableManifest from '@pnpm/exportable-manifest'
+import exportableManifest, { overridePublishConfig } from '@pnpm/exportable-manifest'
+import { PackageManifest, PublishConfig } from '@pnpm/types'
 
 test('the pnpm options are removed', async () => {
   expect(await exportableManifest(process.cwd(), {
@@ -54,5 +55,34 @@ test('readme added to published manifest', async () => {
     name: 'foo',
     version: '1.0.0',
     readme: 'readme content',
+  })
+})
+
+test('publish config to be overridden', async () => {
+  const publishConfig: PublishConfig = {
+    main: 'overridden',
+    types: 'overridden',
+    typesVersions: {
+      '*': {
+        '*': ['overridden'],
+      },
+    },
+  }
+  const publishManifest: PackageManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    main: 'origin',
+    types: 'origin',
+    typesVersions: {
+      '*': {
+        '*': ['origin'],
+      },
+    },
+    publishConfig,
+  }
+  overridePublishConfig(publishManifest)
+
+  Object.keys(publishConfig).forEach((publishConfigKey) => {
+    expect(publishManifest[publishConfigKey]).toEqual(publishConfig[publishConfigKey])
   })
 })

--- a/packages/exportable-manifest/test/index.test.ts
+++ b/packages/exportable-manifest/test/index.test.ts
@@ -1,6 +1,5 @@
 /// <reference path="../../../typings/index.d.ts"/>
-import exportableManifest, { overridePublishConfig } from '@pnpm/exportable-manifest'
-import { PackageManifest, PublishConfig } from '@pnpm/types'
+import exportableManifest from '@pnpm/exportable-manifest'
 
 test('the pnpm options are removed', async () => {
   expect(await exportableManifest(process.cwd(), {
@@ -55,34 +54,5 @@ test('readme added to published manifest', async () => {
     name: 'foo',
     version: '1.0.0',
     readme: 'readme content',
-  })
-})
-
-test('publish config to be overridden', async () => {
-  const publishConfig: PublishConfig = {
-    main: 'overridden',
-    types: 'overridden',
-    typesVersions: {
-      '*': {
-        '*': ['overridden'],
-      },
-    },
-  }
-  const publishManifest: PackageManifest = {
-    name: 'foo',
-    version: '1.0.0',
-    main: 'origin',
-    types: 'origin',
-    typesVersions: {
-      '*': {
-        '*': ['origin'],
-      },
-    },
-    publishConfig,
-  }
-  overridePublishConfig(publishManifest)
-
-  Object.keys(publishConfig).forEach((publishConfigKey) => {
-    expect(publishManifest[publishConfigKey]).toEqual(publishConfig[publishConfigKey])
   })
 })

--- a/packages/exportable-manifest/test/overridePublishConfig.test.ts
+++ b/packages/exportable-manifest/test/overridePublishConfig.test.ts
@@ -1,0 +1,31 @@
+import { PackageManifest, PublishConfig } from '@pnpm/types'
+import { overridePublishConfig } from '../lib/overridePublishConfig'
+
+test('publish config to be overridden', async () => {
+  const publishConfig: PublishConfig = {
+    main: 'overridden',
+    types: 'overridden',
+    typesVersions: {
+      '*': {
+        '*': ['overridden'],
+      },
+    },
+  }
+  const publishManifest: PackageManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    main: 'origin',
+    types: 'origin',
+    typesVersions: {
+      '*': {
+        '*': ['origin'],
+      },
+    },
+    publishConfig,
+  }
+  overridePublishConfig(publishManifest)
+
+  Object.keys(publishConfig).forEach((publishConfigKey) => {
+    expect(publishManifest[publishConfigKey]).toEqual(publishConfig[publishConfigKey])
+  })
+})

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -58,6 +58,14 @@ export interface PublishConfig extends Record<string, unknown> {
   executableFiles?: string[]
 }
 
+type Version = string
+type Pattern = string
+export interface TypesVersions {
+  [version: Version]: {
+    [pattern: Pattern]: string[]
+  }
+}
+
 export interface BaseManifest {
   name?: string
   version?: string
@@ -90,6 +98,7 @@ export interface BaseManifest {
   typings?: string
   types?: string
   publishConfig?: PublishConfig
+  typesVersions?: TypesVersions
   readme?: string
   keywords?: string[]
   author?: string


### PR DESCRIPTION
fix #4636 🙇

Add typesVersions field to PUBLISH_CONFIG_WHITELIST
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions

related pr: https://github.com/pnpm/pnpm.github.io/pull/255