### PR TITLE
Use local version when prefer-workspace-packages: true despite versions match

### DIFF
--- a/packages/npm-resolver/src/index.ts
+++ b/packages/npm-resolver/src/index.ts
@@ -198,6 +198,23 @@ async function resolveNpm (
         }),
         latest: meta['dist-tags'].latest,
       }
+    } else if (opts.preferWorkspacePackages) {
+      const localPackages = Object.values(workspacePackages[pickedPackage.name])
+
+      if (localPackages.length === 1) {
+        const localPackage = localPackages.pop()
+
+        if (localPackage) {
+          return {
+            ...resolveFromLocalPackage(localPackage, spec.normalizedPref, {
+              projectDir: opts.projectDir,
+              lockfileDir: opts.lockfileDir,
+              hardLinkLocalPackages: wantedDependency.injected,
+            }),
+            latest: meta['dist-tags'].latest,
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/4656

Current logic uses versions match to detect local versions. If there was no such local version was skipped even when `prefer-workspace-packages: true`. Here if `prefer-workspace-packages: true` and we have only one local package we use it.