### PR TITLE
fix: `pnpm setup` breaks PATH with non-ascii characters

### DIFF
--- a/.changeset/neat-islands-think.md
+++ b/.changeset/neat-islands-think.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-setup": patch
+---
+
+fix `pnpm setup` breaks %PATH% with non-ascii characters [#4698](https://github.com/pnpm/pnpm/issues/4698)

--- a/packages/plugin-commands-setup/src/setupOnWindows.ts
+++ b/packages/plugin-commands-setup/src/setupOnWindows.ts
@@ -8,7 +8,9 @@ export async function setupWindowsEnvironmentPath (pnpmHomeDir: string): Promise
   const pnpmHomeRegex = /^ {4}(?<name>PNPM_HOME) {4}(?<type>\w+) {4}(?<data>.*)$/gim
   const regKey = 'HKEY_CURRENT_USER\\Environment'
 
-  const queryResult = await execa('reg', ['query', regKey])
+  // Use `chcp` to make `reg` use utf8 encoding for output.
+  // Otherwise, the non-ascii characters in the environment variables will become garbled characters.
+  const queryResult = await execa(`chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
 
   if (queryResult.failed) {
     return 'Win32 registry environment values could not be retrieved'

--- a/packages/plugin-commands-setup/test/setupOnWindows/01.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/01.test.ts
@@ -34,6 +34,6 @@ test('Win32 registry environment values could not be retrieved', async () => {
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(output).toContain('Win32 registry environment values could not be retrieved')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/02.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/02.test.ts
@@ -37,6 +37,6 @@ test('Environment PATH is not configured correctly', async () => {
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(output).toContain('Current PATH is not set. No changes to this environment variable are applied')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/03.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/03.test.ts
@@ -40,6 +40,6 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(output).toContain('Current PATH is empty. No changes to this environment variable are applied')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/04.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/04.test.ts
@@ -49,7 +49,7 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'])
   expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'])
   expect(execa).toHaveBeenNthCalledWith(4, 'setx', ['PNPM_HOME', __dirname])

--- a/packages/plugin-commands-setup/test/setupOnWindows/05.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/05.test.ts
@@ -46,7 +46,7 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${'.pnpm\\home'};${currentPathInRegistry}`, '/f'])
   expect(execa).toHaveBeenNthCalledWith(3, 'setx', ['PNPM_HOME', '.pnpm\\home'])
   expect(output).toContain(`Currently 'PNPM_HOME' is set to '${'.pnpm\\home'}'`)

--- a/packages/plugin-commands-setup/test/setupOnWindows/06.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/06.test.ts
@@ -42,7 +42,7 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(output).toContain(`Currently 'PNPM_HOME' is set to '${'.pnpm\\home'}'`)
   expect(output).toContain('PATH already contains PNPM_HOME')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/07.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/07.test.ts
@@ -49,7 +49,7 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, 'reg', ['query', regKey])
+  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
   expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'])
   expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'])
   expect(output).toContain(`Setting 'PNPM_HOME' to value '${__dirname}`)


### PR DESCRIPTION
Previous `pnpm setup` would break %PATH% containing non-ascii characters.
Now it works fine.

Closes https://github.com/pnpm/pnpm/issues/4698