### PR TITLE
fix: make `pnpm setup` free of garbled characters

### DIFF
--- a/.changeset/dirty-dryers-lie.md
+++ b/.changeset/dirty-dryers-lie.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-setup": patch
+---
+
+fix: make `pnpm setup` free of garbled characters.

--- a/packages/plugin-commands-setup/test/setupOnWindows/01.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/01.test.ts
@@ -26,7 +26,13 @@ afterAll(() => {
 const regKey = 'HKEY_CURRENT_USER\\Environment'
 
 test('Win32 registry environment values could not be retrieved', async () => {
-  execa['mockResolvedValue']({
+  execa['mockResolvedValueOnce']({
+    failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValue({
     failed: true,
   })
 
@@ -34,6 +40,6 @@ test('Win32 registry environment values could not be retrieved', async () => {
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
   expect(output).toContain('Win32 registry environment values could not be retrieved')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/02.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/02.test.ts
@@ -28,6 +28,12 @@ const regKey = 'HKEY_CURRENT_USER\\Environment'
 test('Environment PATH is not configured correctly', async () => {
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: 'SOME KIND OF ERROR OR UNSUPPORTED RESPONSE FORMAT',
   }).mockResolvedValue({
     failed: true,
@@ -37,6 +43,6 @@ test('Environment PATH is not configured correctly', async () => {
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
   expect(output).toContain('Current PATH is not set. No changes to this environment variable are applied')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/03.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/03.test.ts
@@ -28,10 +28,16 @@ const regKey = 'HKEY_CURRENT_USER\\Environment'
 test('Environment PATH is empty', async () => {
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     Path    REG_EXPAND_SZ    
-`,
+    `,
   }).mockResolvedValue({
     failed: false,
   })
@@ -40,6 +46,6 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
   expect(output).toContain('Current PATH is empty. No changes to this environment variable are applied')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/04.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/04.test.ts
@@ -30,6 +30,12 @@ test('Successful first time installation', async () => {
 
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     Path    REG_EXPAND_SZ    ${currentPathInRegistry}
@@ -49,10 +55,10 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
-  expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'])
-  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'])
-  expect(execa).toHaveBeenNthCalledWith(4, 'setx', ['PNPM_HOME', __dirname])
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(4, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(5, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(6, 'setx', ['PNPM_HOME', __dirname])
   expect(output).toContain(`Setting 'PNPM_HOME' to value '${__dirname}`)
   expect(output).toContain('Updating PATH')
   expect(output).toContain('PNPM_HOME ENV VAR SET')

--- a/packages/plugin-commands-setup/test/setupOnWindows/05.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/05.test.ts
@@ -30,6 +30,12 @@ test('PNPM_HOME is already set, but path is updated', async () => {
   const pnpmHomeDir = '.pnpm\\home'
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     PNPM_HOME    REG_EXPAND_SZ    ${pnpmHomeDir}
@@ -45,9 +51,9 @@ HKEY_CURRENT_USER\\Environment
 
   const output = await setup.handler({ pnpmHomeDir })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
-  expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${'.pnpm\\home'};${currentPathInRegistry}`, '/f'])
-  expect(execa).toHaveBeenNthCalledWith(3, 'setx', ['PNPM_HOME', '.pnpm\\home'])
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(4, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${'.pnpm\\home'};${currentPathInRegistry}`, '/f'], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(5, 'setx', ['PNPM_HOME', '.pnpm\\home'])
   expect(output).toContain('Updating PATH')
   expect(output).toContain('PATH UPDATED')
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/06.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/06.test.ts
@@ -28,6 +28,12 @@ const regKey = 'HKEY_CURRENT_USER\\Environment'
 test('setup throws an error if PNPM_HOME is already set to a different directory', async () => {
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     PNPM_HOME    REG_EXPAND_SZ    .pnpm\\home
@@ -48,6 +54,12 @@ HKEY_CURRENT_USER\\Environment
 test('setup overrides PNPM_HOME, when setup is forced', async () => {
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     PNPM_HOME    REG_EXPAND_SZ    .pnpm\\home
@@ -64,6 +76,6 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
   expect(output).toContain(`Setting 'PNPM_HOME' to value '${pnpmHomeDir}'`)
 })

--- a/packages/plugin-commands-setup/test/setupOnWindows/07.test.ts
+++ b/packages/plugin-commands-setup/test/setupOnWindows/07.test.ts
@@ -30,6 +30,12 @@ test('Failure to install', async () => {
 
   execa['mockResolvedValueOnce']({
     failed: false,
+    stdout: '活动代码页: 936',
+  }).mockResolvedValueOnce({
+    failed: false,
+    stdout: '',
+  }).mockResolvedValueOnce({
+    failed: false,
     stdout: `
 HKEY_CURRENT_USER\\Environment
     Path    REG_EXPAND_SZ    ${currentPathInRegistry}
@@ -49,9 +55,9 @@ HKEY_CURRENT_USER\\Environment
     pnpmHomeDir: __dirname,
   })
 
-  expect(execa).toHaveBeenNthCalledWith(1, `chcp 65001>nul && reg query ${regKey}`, undefined, { shell: true })
-  expect(execa).toHaveBeenNthCalledWith(2, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'])
-  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'])
+  expect(execa).toHaveBeenNthCalledWith(3, 'reg', ['query', regKey], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(4, 'reg', ['add', regKey, '/v', 'PNPM_HOME', '/t', 'REG_EXPAND_SZ', '/d', __dirname, '/f'], { windowsHide: false })
+  expect(execa).toHaveBeenNthCalledWith(5, 'reg', ['add', regKey, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', `${__dirname};${currentPathInRegistry}`, '/f'], { windowsHide: false })
   expect(output).toContain(`Setting 'PNPM_HOME' to value '${__dirname}`)
   expect(output).toContain('FAILED TO SET PNPM_HOME')
   expect(output).toContain('Updating PATH')


### PR DESCRIPTION
The output used to be garbled on non-English systems, but not anymore.