### PR TITLE
fix(create): pass all args to the executed create-app pkg

### DIFF
--- a/.changeset/seven-lies-wonder.md
+++ b/.changeset/seven-lies-wonder.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+All arguments after `pnpm create <pkg>` should be passed to the executed create app package. So `pnpm create next-app --typescript` should work`.

--- a/packages/pnpm/src/parseCliArgs.ts
+++ b/packages/pnpm/src/parseCliArgs.ts
@@ -17,7 +17,7 @@ const RENAMED_OPTIONS = {
 export default async function parseCliArgs (inputArgv: string[]) {
   return parseCliArgsLib({
     fallbackCommand: 'run',
-    escapeArgs: ['dlx', 'exec'],
+    escapeArgs: ['create', 'dlx', 'exec'],
     getCommandLongName: getCommandFullName,
     getTypesByCommandName: getCliOptionsTypes,
     renamedOptions: RENAMED_OPTIONS,


### PR DESCRIPTION
ref https://github.com/vercel/next.js/issues/36360