### PR TITLE
feat: auto install peer dependencies

### DIFF
--- a/.changeset/chilly-seahorses-visit.md
+++ b/.changeset/chilly-seahorses-visit.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": minor
+"@pnpm/resolve-dependencies": minor
+---
+
+New option added for automatically installing missing peer dependencies: `autoInstallPeers`.

--- a/.changeset/forty-fireants-fail.md
+++ b/.changeset/forty-fireants-fail.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/prune-lockfile": patch
+---
+
+Don't prune peer deps.

--- a/.changeset/giant-mice-bathe.md
+++ b/.changeset/giant-mice-bathe.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+When `auto-install-peers` is set to `true`, automatically install missing peer dependencies without writing them to `package.json` as dependencies. This makes pnpm handle peer dependencies the same way as npm v7 [#4776](https://github.com/pnpm/pnpm/pull/4776).

--- a/.changeset/quick-suits-yell.md
+++ b/.changeset/quick-suits-yell.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": patch
+---
+
+Add hints to the peer dependencies error.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@commitlint/prompt-cli": "^16.0.0",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "0.0.6",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^27.4.0",
     "@types/node": "^14.17.32",
@@ -120,7 +120,9 @@
         "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@yarnpkg/core": "*"
       },
-      "ignoreMissing": ["@yarnpkg/plugin-patch"]
+      "ignoreMissing": [
+        "@yarnpkg/plugin-patch"
+      ]
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/package-store": "workspace:13.0.5",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/store-path": "workspace:6.0.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.5",

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -16,6 +16,7 @@ import pnpmPkgJson from '../pnpmPkgJson'
 import { ReporterFunction } from '../types'
 
 export interface StrictInstallOptions {
+  autoInstallPeers: boolean
   forceSharedLockfile: boolean
   frozenLockfile: boolean
   frozenLockfileIfExists: boolean
@@ -107,6 +108,7 @@ const defaults = async (opts: InstallOptions) => {
     version: pnpmPkgJson.version,
   }
   return {
+    autoInstallPeers: false,
     childConcurrency: 5,
     depth: 0,
     enablePnp: false,

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -740,6 +740,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     projects,
     {
       allowBuild: createAllowBuildFunction(opts),
+      autoInstallPeers: opts.autoInstallPeers,
       currentLockfile: ctx.currentLockfile,
       defaultUpdateDepth: (opts.update || (opts.updateMatching != null)) ? opts.depth : -1,
       dryRun: opts.lockfileOnly,

--- a/packages/core/test/install/autoInstallPeers.ts
+++ b/packages/core/test/install/autoInstallPeers.ts
@@ -3,18 +3,35 @@ import { prepareEmpty } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/registry-mock'
 import { testDefaults } from '../utils'
 
-test('auto install peer dependencies', async () => {
+test('auto install non-optional peer dependencies', async () => {
   await addDistTag({ package: 'peer-a', version: '1.0.0', distTag: 'latest' })
-  await addDistTag({ package: 'peer-b', version: '1.0.0', distTag: 'latest' })
-  await addDistTag({ package: 'peer-c', version: '1.0.0', distTag: 'latest' })
   const project = prepareEmpty()
-  await addDependenciesToPackage({}, ['abc'], await testDefaults({ autoInstallPeers: true }))
+  await addDependenciesToPackage({}, ['abc-optional-peers@1.0.0'], await testDefaults({ autoInstallPeers: true }))
   const lockfile = await project.readLockfile()
   expect(Object.keys(lockfile.packages)).toStrictEqual([
-    '/abc/1.0.0_czpb4cfd67t7o7o3k4vnbzkwma',
-    '/dep-of-pkg-with-1-dep/100.0.0',
+    '/abc-optional-peers/1.0.0_peer-a@1.0.0',
     '/peer-a/1.0.0',
-    '/peer-b/1.0.0',
+  ])
+})
+
+test('auto install the common peer dependency', async () => {
+  await addDistTag({ package: 'peer-c', version: '1.0.1', distTag: 'latest' })
+  const project = prepareEmpty()
+  await addDependenciesToPackage({}, ['wants-peer-c-1', 'wants-peer-c-1.0.0'], await testDefaults({ autoInstallPeers: true }))
+  const lockfile = await project.readLockfile()
+  expect(Object.keys(lockfile.packages)).toStrictEqual([
     '/peer-c/1.0.0',
+    '/wants-peer-c-1.0.0/1.0.0_peer-c@1.0.0',
+    '/wants-peer-c-1/1.0.0_peer-c@1.0.0',
+  ])
+})
+
+test('do not auto install when there is no common peer dependency range intersection', async () => {
+  const project = prepareEmpty()
+  await addDependenciesToPackage({}, ['wants-peer-c-1', 'wants-peer-c-2'], await testDefaults({ autoInstallPeers: true }))
+  const lockfile = await project.readLockfile()
+  expect(Object.keys(lockfile.packages)).toStrictEqual([
+    '/wants-peer-c-1/1.0.0',
+    '/wants-peer-c-2/1.0.0',
   ])
 })

--- a/packages/core/test/install/autoInstallPeers.ts
+++ b/packages/core/test/install/autoInstallPeers.ts
@@ -1,8 +1,20 @@
 import { addDependenciesToPackage } from '@pnpm/core'
 import { prepareEmpty } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/registry-mock'
 import { testDefaults } from '../utils'
 
 test('auto install peer dependencies', async () => {
-  prepareEmpty()
-  await addDependenciesToPackage({}, ['abc'], await testDefaults())
+  await addDistTag({ package: 'peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: 'peer-b', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: 'peer-c', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  await addDependenciesToPackage({}, ['abc'], await testDefaults({ autoInstallPeers: true }))
+  const lockfile = await project.readLockfile()
+  expect(Object.keys(lockfile.packages)).toStrictEqual([
+    '/abc/1.0.0_czpb4cfd67t7o7o3k4vnbzkwma',
+    '/dep-of-pkg-with-1-dep/100.0.0',
+    '/peer-a/1.0.0',
+    '/peer-b/1.0.0',
+    '/peer-c/1.0.0',
+  ])
 })

--- a/packages/core/test/install/autoInstallPeers.ts
+++ b/packages/core/test/install/autoInstallPeers.ts
@@ -1,0 +1,8 @@
+import { addDependenciesToPackage } from '@pnpm/core'
+import { prepareEmpty } from '@pnpm/prepare'
+import { testDefaults } from '../utils'
+
+test('auto install peer dependencies', async () => {
+  prepareEmpty()
+  await addDependenciesToPackage({}, ['abc'], await testDefaults())
+})

--- a/packages/core/test/install/peerDependencies.ts
+++ b/packages/core/test/install/peerDependencies.ts
@@ -1116,7 +1116,7 @@ test('peer dependency that is resolved by a dev dependency', async () => {
   ], await testDefaults({ fastUnpack: false, lockfileOnly: true, strictPeerDependencies: false }))
 
   const lockfile = await project.readLockfile()
-  expect(lockfile.packages['/@types/mongoose/5.7.32'].dev).toBeTruthy()
+  expect(lockfile.packages['/@types/mongoose/5.7.32'].dev).toBeUndefined()
 
   await mutateModules([
     {

--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -412,5 +412,6 @@ ${hints.map((hint) => `hint: ${hint}`).join('\n')}
 }
 
 function getHasMissingPeers (issuesByProjects: PeerDependencyIssuesByProjects) {
-  return Object.values(issuesByProjects).some((issues) => Object.keys(issues.missing).length > 0)
+  return Object.values(issuesByProjects)
+    .some((issues) => Object.values(issues.missing).flat().some(({ optional }) => !optional))
 }

--- a/packages/default-reporter/src/reportError.ts
+++ b/packages/default-reporter/src/reportError.ts
@@ -397,8 +397,20 @@ function reportPeerDependencyIssuesError (
   err: Error,
   msg: { issuesByProjects: PeerDependencyIssuesByProjects }
 ) {
+  const hasMissingPeers = getHasMissingPeers(msg.issuesByProjects)
+  const hints: string[] = []
+  if (hasMissingPeers) {
+    hints.push('If you want peer dependencies to be automatically installed, set the "auto-install-peers" setting to "true".')
+  }
+  hints.push('If you don\'t want pnpm to fail on peer dependency issues, set the "strict-peer-dependencies" setting to "false".')
   return {
     title: err.message,
-    body: renderPeerIssues(msg.issuesByProjects),
+    body: `${renderPeerIssues(msg.issuesByProjects)}
+${hints.map((hint) => `hint: ${hint}`).join('\n')}
+`,
   }
+}
+
+function getHasMissingPeers (issuesByProjects: PeerDependencyIssuesByProjects) {
+  return Object.values(issuesByProjects).some((issues) => Object.keys(issues.missing).length > 0)
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -22,7 +22,7 @@
     "@pnpm/package-store": "workspace:13.0.5",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-projects-context": "workspace:6.0.3",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/store-path": "workspace:6.0.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.5",

--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -65,7 +65,7 @@
     "@pnpm/create-cafs-store": "workspace:1.0.1",
     "@pnpm/logger": "^4.0.0",
     "@pnpm/package-requester": "workspace:18.0.5",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.27.39",

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -39,7 +39,7 @@
     "@pnpm/modules-yaml": "workspace:10.0.1",
     "@pnpm/plugin-commands-installation": "workspace:10.0.6",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/is-ci": "^3.0.0",
     "@types/proxyquire": "^1.3.28",

--- a/packages/plugin-commands-installation/test/add.ts
+++ b/packages/plugin-commands-installation/test/add.ts
@@ -291,7 +291,7 @@ test('pnpm add - should add prefix when set in .npmrc when a range is not specif
 })
 
 test('pnpm add automatically installs missing peer dependencies', async () => {
-  prepare()
+  const project = prepare()
   await add.handler({
     ...DEFAULT_OPTIONS,
     autoInstallPeers: true,
@@ -299,10 +299,6 @@ test('pnpm add automatically installs missing peer dependencies', async () => {
     linkWorkspacePackages: false,
   }, ['abc@1.0.0'])
 
-  const manifest = (await import(path.resolve('package.json')))
-
-  expect(manifest.dependencies['abc']).toBe('1.0.0')
-  expect(manifest.devDependencies['peer-a']).toBe('^1.0.0')
-  expect(manifest.devDependencies['peer-b']).toBe('^1.0.0')
-  expect(manifest.devDependencies['peer-c']).toBe('^1.0.0')
+  const lockfile = await project.readLockfile()
+  expect(Object.keys(lockfile.packages).length).toBe(5)
 })

--- a/packages/plugin-commands-listing/package.json
+++ b/packages/plugin-commands-listing/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:10.0.6",
     "@pnpm/plugin-commands-listing": "workspace:5.0.6",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@types/ramda": "0.27.39",
     "execa": "npm:safe-execa@^0.1.1",
     "strip-ansi": "^6.0.0",

--- a/packages/plugin-commands-outdated/package.json
+++ b/packages/plugin-commands-outdated/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:10.0.6",
     "@pnpm/plugin-commands-outdated": "workspace:6.0.6",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@types/lru-cache": "^5.1.0",
     "@types/ramda": "0.27.39",
     "@types/wrap-ansi": "^3.0.0",

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -39,7 +39,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/plugin-commands-publishing": "workspace:5.0.7",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/is-ci": "^3.0.0",
     "@types/is-windows": "^1.0.0",

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -37,7 +37,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/plugin-commands-rebuild": "workspace:6.1.5",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.27.39",
     "@types/semver": "^7.3.4",

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -38,7 +38,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/plugin-commands-script-runners": "workspace:5.0.7",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.27.39",
     "is-windows": "^1.0.2",

--- a/packages/plugin-commands-store/package.json
+++ b/packages/plugin-commands-store/package.json
@@ -38,7 +38,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/plugin-commands-store": "workspace:5.1.5",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@types/archy": "0.0.31",
     "@types/ramda": "0.27.39",
     "@types/ssri": "^7.1.0",

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -55,7 +55,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-package-json": "workspace:6.0.2",
     "@pnpm/read-project-manifest": "workspace:3.0.2",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/run-npm": "workspace:4.0.1",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/types": "workspace:8.0.1",

--- a/packages/prune-lockfile/src/index.ts
+++ b/packages/prune-lockfile/src/index.ts
@@ -9,7 +9,6 @@ import { PackageManifest } from '@pnpm/types'
 import { refToRelative } from 'dependency-path'
 import difference from 'ramda/src/difference'
 import isEmpty from 'ramda/src/isEmpty'
-import omit from 'ramda/src/omit'
 import unnest from 'ramda/src/unnest'
 
 export * from '@pnpm/lockfile-types'
@@ -197,7 +196,7 @@ function copyDependencySubGraph (
     } else if (depLockfile.dev === undefined && !ctx.notProdOnly.has(depPath)) {
       depLockfile.dev = false
     }
-    const newDependencies = resolvedDepsToDepPaths(omit(Object.keys(depLockfile.peerDependencies ?? {}) ?? [], depLockfile.dependencies ?? {}))
+    const newDependencies = resolvedDepsToDepPaths(depLockfile.dependencies ?? {})
     copyDependencySubGraph(ctx, newDependencies, opts)
     const newOptionalDependencies = resolvedDepsToDepPaths(depLockfile.optionalDependencies ?? {})
     copyDependencySubGraph(ctx, newOptionalDependencies, { dev: opts.dev, optional: true })

--- a/packages/resolve-dependencies/src/getNonDevWantedDependencies.ts
+++ b/packages/resolve-dependencies/src/getNonDevWantedDependencies.ts
@@ -8,7 +8,7 @@ export interface WantedDependency {
   injected?: boolean
 }
 
-export default function getNonDevWantedDependencies (pkg: DependencyManifest) {
+export default function getNonDevWantedDependencies (pkg: Pick<DependencyManifest, 'bundleDependencies' | 'optionalDependencies' | 'dependencies' | 'dependenciesMeta'>) {
   const bd = pkg.bundleDependencies ?? pkg.bundleDependencies
   const bundledDeps = new Set(Array.isArray(bd) ? bd : [])
   const filterDeps = getNotBundledDeps.bind(null, bundledDeps)

--- a/packages/resolve-dependencies/src/index.ts
+++ b/packages/resolve-dependencies/src/index.ts
@@ -136,7 +136,7 @@ export default async function (
         difference(
           Object.keys(getAllDependenciesFromManifest(project.manifest)),
           resolvedImporter.directDependencies
-            .filter((dep, index) => project.wantedDependencies[index].isNew === true)
+            .filter((dep, index) => project.wantedDependencies[index]?.isNew === true)
             .map(({ alias }) => alias) || []
         ),
         project.modulesDir

--- a/packages/resolve-dependencies/src/mergePeers.ts
+++ b/packages/resolve-dependencies/src/mergePeers.ts
@@ -20,7 +20,7 @@ export function mergePeers (missingPeers: MissingPeerIssuesByPeerName) {
   return { conflicts, intersections }
 }
 
-function safeIntersect (ranges: string[]): null | string {
+export function safeIntersect (ranges: string[]): null | string {
   try {
     return intersect(...ranges)
   } catch {

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -40,9 +40,9 @@ import * as dp from 'dependency-path'
 import exists from 'path-exists'
 import isEmpty from 'ramda/src/isEmpty'
 import semver from 'semver'
-import { intersect } from 'semver-range-intersect'
 import encodePkgId from './encodePkgId'
 import getNonDevWantedDependencies, { WantedDependency } from './getNonDevWantedDependencies'
+import { safeIntersect } from './mergePeers'
 import {
   createNodeId,
   nodeIdContainsSequence,
@@ -290,7 +290,7 @@ function mergePkgsDeps (pkgsDeps: Array<Record<string, string>>): Record<string,
   }
   const mergedPkgDeps = {} as Record<string, string>
   for (const [name, ranges] of Object.entries(groupedRanges)) {
-    const intersection = intersect(...ranges)
+    const intersection = safeIntersect(ranges)
     if (intersection) {
       mergedPkgDeps[name] = intersection
     }

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -116,6 +116,7 @@ export interface ChildrenByParentDepPath {
 }
 
 export interface ResolutionContext {
+  autoInstallPeers: boolean
   allowBuild?: (pkgName: string) => boolean
   updatedSet: Set<string>
   defaultTag: string
@@ -251,6 +252,7 @@ export default async function resolveDependencies (
       ...pkgAddresses,
       ...newPkgAddresses,
     ]
+    if (!ctx.autoInstallPeers) break
     // TODO: make an overlap for the version ranges
     const allMissingPeers = newPkgAddresses.reduce((acc, { missingPeers }) => ({ ...acc, ...missingPeers }), {})
     if (!Object.keys(allMissingPeers).length) break

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -230,9 +230,9 @@ export default async function resolveDependencies (
   wantedDependencies: Array<WantedDependency & { updateDepth?: number }>,
   options: ResolvedDependenciesOptions
 ): Promise<Array<PkgAddress | LinkedDependency>> {
-  let extendedWantedDeps = [] as ExtendedWantedDependency[]
+  let extendedWantedDeps: ExtendedWantedDependency[] = []
   const postponedResolutionsQueue: PostponedResolutionFunction[] = []
-  const pkgAddresses = [] as PkgAddress[]
+  const pkgAddresses: PkgAddress[] = []
   while (true) {
     extendedWantedDeps = getDepsToResolve(wantedDependencies, ctx.wantedLockfile, {
       preferredDependencies: options.preferredDependencies,
@@ -251,8 +251,7 @@ export default async function resolveDependencies (
           extendedWantedDep
         ))
       )
-    )
-      .filter(Boolean) as PkgAddress[]
+    ).filter(Boolean) as PkgAddress[]
     pkgAddresses.push(...newPkgAddresses)
     if (!ctx.autoInstallPeers) break
     const allMissingPeers = mergePkgsDeps(newPkgAddresses.map(({ missingPeers }) => missingPeers))

--- a/packages/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/packages/resolve-dependencies/src/resolveDependencyTree.ts
@@ -137,7 +137,7 @@ export default async function<T> (
         depPath: importer.id,
         rootDir: importer.rootDir,
       },
-      parentPkgAliases: [],
+      parentPkgAliases: {},
       proceed,
       resolvedDependencies: {
         ...projectSnapshot.dependencies,

--- a/packages/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/packages/resolve-dependencies/src/resolveDependencyTree.ts
@@ -52,6 +52,7 @@ export interface ImporterToResolveGeneric<T> extends Importer<T> {
 }
 
 export interface ResolveDependenciesOptions {
+  autoInstallPeers?: boolean
   allowBuild?: (pkgName: string) => boolean
   currentLockfile: Lockfile
   dryRun: boolean
@@ -84,6 +85,7 @@ export default async function<T> (
 
   const wantedToBeSkippedPackageIds = new Set<string>()
   const ctx = {
+    autoInstallPeers: opts.autoInstallPeers === true,
     allowBuild: opts.allowBuild,
     childrenByParentDepPath: {} as ChildrenByParentDepPath,
     currentLockfile: opts.currentLockfile,

--- a/packages/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/packages/resolve-dependencies/src/resolveDependencyTree.ts
@@ -135,6 +135,7 @@ export default async function<T> (
         depPath: importer.id,
         rootDir: importer.rootDir,
       },
+      parentPkgAliases: [],
       proceed,
       resolvedDependencies: {
         ...projectSnapshot.dependencies,

--- a/packages/resolve-dependencies/src/updateProjectManifest.ts
+++ b/packages/resolve-dependencies/src/updateProjectManifest.ts
@@ -22,7 +22,7 @@ export default async function updateProjectManifest (
     throw new Error('Cannot save because no package.json found')
   }
   const specsToUpsert = opts.directDependencies
-    .filter((rdd, index) => importer.wantedDependencies[index]!.updateSpec)
+    .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
     .map((rdd, index) => {
       const wantedDep = importer.wantedDependencies[index]!
       return resolvedDirectDepToSpecObject({ ...rdd, isNew: wantedDep.isNew, specRaw: wantedDep.raw }, importer, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
       '@commitlint/prompt-cli': ^16.0.0
       '@pnpm/eslint-config': workspace:*
       '@pnpm/meta-updater': 0.0.6
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/tsconfig': workspace:*
       '@types/jest': ^27.4.0
       '@types/node': ^14.17.32
@@ -72,7 +72,7 @@ importers:
       '@commitlint/prompt-cli': 16.2.4
       '@pnpm/eslint-config': link:utils/eslint-config
       '@pnpm/meta-updater': 0.0.6
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/tsconfig': link:utils/tsconfig
       '@types/jest': 27.5.0
       '@types/node': 14.18.16
@@ -422,7 +422,7 @@ importers:
       '@pnpm/read-modules-dir': workspace:4.0.0
       '@pnpm/read-package-json': workspace:6.0.2
       '@pnpm/read-project-manifest': workspace:3.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/remove-bins': workspace:3.0.2
       '@pnpm/resolve-dependencies': workspace:27.0.4
       '@pnpm/resolver-base': workspace:9.0.1
@@ -527,7 +527,7 @@ importers:
       '@pnpm/logger': 4.0.0
       '@pnpm/package-store': link:../package-store
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/store-path': link:../store-path
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
       '@types/fs-extra': 9.0.13
@@ -1113,7 +1113,7 @@ importers:
       '@pnpm/read-project-manifest': workspace:3.0.2
       '@pnpm/read-projects-context': workspace:6.0.3
       '@pnpm/real-hoist': workspace:0.2.3
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/store-controller-types': workspace:13.0.1
       '@pnpm/store-path': workspace:6.0.0
       '@pnpm/symlink-dependency': workspace:5.0.1
@@ -1174,7 +1174,7 @@ importers:
       '@pnpm/package-store': link:../package-store
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@pnpm/read-projects-context': link:../read-projects-context
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/store-path': link:../store-path
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
       '@types/fs-extra': 9.0.13
@@ -1867,7 +1867,7 @@ importers:
       '@pnpm/package-is-installable': workspace:6.0.3
       '@pnpm/package-requester': workspace:18.0.5
       '@pnpm/read-package-json': workspace:6.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/resolver-base': workspace:9.0.1
       '@pnpm/store-controller-types': workspace:13.0.1
       '@pnpm/test-fixtures': workspace:*
@@ -1918,7 +1918,7 @@ importers:
       '@pnpm/create-cafs-store': link:../create-cafs-store
       '@pnpm/logger': 4.0.0
       '@pnpm/package-requester': 'link:'
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
       '@types/normalize-path': 3.0.0
       '@types/ramda': 0.27.39
@@ -2190,7 +2190,7 @@ importers:
       '@pnpm/pnpmfile': workspace:2.0.2
       '@pnpm/prepare': workspace:*
       '@pnpm/read-project-manifest': workspace:3.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/resolver-base': workspace:9.0.1
       '@pnpm/semver-diff': ^1.0.2
       '@pnpm/sort-packages': workspace:3.0.2
@@ -2287,7 +2287,7 @@ importers:
       '@pnpm/modules-yaml': link:../modules-yaml
       '@pnpm/plugin-commands-installation': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
       '@types/is-ci': 3.0.0
       '@types/proxyquire': 1.3.28
@@ -2318,7 +2318,7 @@ importers:
       '@pnpm/plugin-commands-installation': workspace:10.0.6
       '@pnpm/plugin-commands-listing': workspace:5.0.6
       '@pnpm/prepare': workspace:*
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/types': workspace:8.0.1
       '@types/ramda': 0.27.39
       execa: npm:safe-execa@^0.1.1
@@ -2342,7 +2342,7 @@ importers:
       '@pnpm/plugin-commands-installation': link:../plugin-commands-installation
       '@pnpm/plugin-commands-listing': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@types/ramda': 0.27.39
       execa: /safe-execa/0.1.1
       strip-ansi: 6.0.1
@@ -2366,7 +2366,7 @@ importers:
       '@pnpm/plugin-commands-installation': workspace:10.0.6
       '@pnpm/plugin-commands-outdated': workspace:6.0.6
       '@pnpm/prepare': workspace:*
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/semver-diff': ^1.0.2
       '@pnpm/store-path': workspace:6.0.0
       '@pnpm/types': workspace:8.0.1
@@ -2409,7 +2409,7 @@ importers:
       '@pnpm/plugin-commands-installation': link:../plugin-commands-installation
       '@pnpm/plugin-commands-outdated': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@types/lru-cache': 5.1.1
       '@types/ramda': 0.27.39
       '@types/wrap-ansi': 3.0.0
@@ -2429,7 +2429,7 @@ importers:
       '@pnpm/pick-registry-for-package': workspace:3.0.1
       '@pnpm/plugin-commands-publishing': workspace:5.0.7
       '@pnpm/prepare': workspace:*
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/resolver-base': workspace:9.0.1
       '@pnpm/run-npm': workspace:4.0.1
       '@pnpm/sort-packages': workspace:3.0.2
@@ -2492,7 +2492,7 @@ importers:
       '@pnpm/logger': 4.0.0
       '@pnpm/plugin-commands-publishing': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@types/cross-spawn': 6.0.2
       '@types/is-ci': 3.0.0
       '@types/is-windows': 1.0.0
@@ -2530,7 +2530,7 @@ importers:
       '@pnpm/normalize-registries': workspace:3.0.1
       '@pnpm/plugin-commands-rebuild': workspace:6.1.5
       '@pnpm/prepare': workspace:*
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/sort-packages': workspace:3.0.2
       '@pnpm/store-connection-manager': workspace:4.1.5
       '@pnpm/store-controller-types': workspace:13.0.1
@@ -2589,7 +2589,7 @@ importers:
       '@pnpm/logger': 4.0.0
       '@pnpm/plugin-commands-rebuild': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/test-fixtures': link:../../privatePackages/test-fixtures
       '@types/ramda': 0.27.39
       '@types/semver': 7.3.9
@@ -2615,7 +2615,7 @@ importers:
       '@pnpm/prepare': workspace:*
       '@pnpm/read-package-json': workspace:6.0.2
       '@pnpm/read-project-manifest': workspace:3.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/sort-packages': workspace:3.0.2
       '@pnpm/store-path': workspace:6.0.0
       '@pnpm/types': workspace:8.0.1
@@ -2658,7 +2658,7 @@ importers:
       '@pnpm/logger': 4.0.0
       '@pnpm/plugin-commands-script-runners': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@types/is-windows': 1.0.0
       '@types/ramda': 0.27.39
       is-windows: 1.0.2
@@ -2748,7 +2748,7 @@ importers:
       '@pnpm/pick-registry-for-package': workspace:3.0.1
       '@pnpm/plugin-commands-store': workspace:5.1.5
       '@pnpm/prepare': workspace:*
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/store-connection-manager': workspace:4.1.5
       '@pnpm/store-controller-types': workspace:13.0.1
       '@pnpm/store-path': workspace:6.0.0
@@ -2795,7 +2795,7 @@ importers:
       '@pnpm/logger': 4.0.0
       '@pnpm/plugin-commands-store': 'link:'
       '@pnpm/prepare': link:../../privatePackages/prepare
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@types/archy': 0.0.31
       '@types/ramda': 0.27.39
       '@types/ssri': 7.1.1
@@ -2843,7 +2843,7 @@ importers:
       '@pnpm/prepare': workspace:*
       '@pnpm/read-package-json': workspace:6.0.2
       '@pnpm/read-project-manifest': workspace:3.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/run-npm': workspace:4.0.1
       '@pnpm/tabtab': ^0.1.2
       '@pnpm/types': workspace:8.0.1
@@ -2931,7 +2931,7 @@ importers:
       '@pnpm/prepare': link:../../privatePackages/prepare
       '@pnpm/read-package-json': link:../read-package-json
       '@pnpm/read-project-manifest': link:../read-project-manifest
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/run-npm': link:../run-npm
       '@pnpm/tabtab': 0.1.2
       '@pnpm/types': link:../types
@@ -3529,7 +3529,7 @@ importers:
       '@pnpm/constants': workspace:6.1.0
       '@pnpm/lockfile-types': workspace:4.0.1
       '@pnpm/modules-yaml': workspace:10.0.1
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/types': workspace:8.0.1
       '@types/is-windows': ^1.0.0
       '@types/isexe': 2.0.0
@@ -3544,7 +3544,7 @@ importers:
       '@pnpm/constants': link:../../packages/constants
       '@pnpm/lockfile-types': link:../../packages/lockfile-types
       '@pnpm/modules-yaml': link:../../packages/modules-yaml
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       '@pnpm/types': link:../../packages/types
       is-windows: 1.0.2
       isexe: 2.0.0
@@ -3561,11 +3561,11 @@ importers:
     specifiers:
       '@pnpm/assert-store': workspace:*
       '@pnpm/cafs': workspace:4.0.2
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       path-exists: ^4.0.0
     dependencies:
       '@pnpm/cafs': link:../../packages/cafs
-      '@pnpm/registry-mock': 2.16.0
+      '@pnpm/registry-mock': 2.17.0
       path-exists: 4.0.0
     devDependencies:
       '@pnpm/assert-store': 'link:'
@@ -5134,8 +5134,8 @@ packages:
       strip-bom: 4.0.0
     dev: true
 
-  /@pnpm/registry-mock/2.16.0:
-    resolution: {integrity: sha512-Ro5tsRBR+qTnYne6B9aQJIzsyIJWhSBfARZMpEBmVVUysivYPWjoIRBNZ3EVbtt67oF6tMXTBGViPvYkwQYeyQ==}
+  /@pnpm/registry-mock/2.17.0:
+    resolution: {integrity: sha512-vZuWSJaixugxz0Y39VIEKeyYm69TG3/8qXkgMXjLjRWtE/4EezKKGfiAEhuJasSdvVoYUQWY2Ng0nEkWihTN9w==}
     engines: {node: '>=10.13'}
     hasBin: true
     dependencies:
@@ -5312,7 +5312,7 @@ packages:
   /@types/byline/4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 17.0.31
+      '@types/node': 17.0.35
     dev: true
 
   /@types/cacheable-request/6.0.2:
@@ -5485,6 +5485,10 @@ packages:
 
   /@types/node/17.0.31:
     resolution: {integrity: sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==}
+
+  /@types/node/17.0.35:
+    resolution: {integrity: sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -9438,7 +9442,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.15.4
+      uglify-js: 3.15.5
 
   /har-schema/2.0.0:
     resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
@@ -14584,8 +14588,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /uglify-js/3.15.4:
-    resolution: {integrity: sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==}
+  /uglify-js/3.15.5:
+    resolution: {integrity: sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true

--- a/privatePackages/assert-project/package.json
+++ b/privatePackages/assert-project/package.json
@@ -45,7 +45,7 @@
     "@pnpm/constants": "workspace:6.1.0",
     "@pnpm/lockfile-types": "workspace:4.0.1",
     "@pnpm/modules-yaml": "workspace:10.0.1",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "@pnpm/types": "workspace:8.0.1",
     "is-windows": "^1.0.2",
     "isexe": "2.0.0",

--- a/privatePackages/assert-store/package.json
+++ b/privatePackages/assert-store/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:4.0.2",
-    "@pnpm/registry-mock": "2.16.0",
+    "@pnpm/registry-mock": "2.17.0",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] the package entries that were added with peer dependencies autoinstalled should have the same location format as those that have peers resolved from parent deps (`<pkg_id>_<peer_deps_hash>`)
- [x] when the same package has appeared twice in the dep tree. Once it doesn't have its peer resolved but once it has. In this case, when the peer may be resolved from the parent packages, do resolve it from there.

related discussion: https://github.com/pnpm/pnpm/discussions/3995
close #4684