### PR TITLE
test(core): update integrity resolutions from sha1 to sha512

### DIFF
--- a/packages/core/test/lockfile.ts
+++ b/packages/core/test/lockfile.ts
@@ -482,7 +482,7 @@ test('scoped module from different registry', async () => {
           node: '>=0.10.0',
         },
         resolution: {
-          integrity: 'sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=',
+          integrity: 'sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==',
         },
       },
       '/is-positive/3.1.0': {
@@ -491,7 +491,7 @@ test('scoped module from different registry', async () => {
           node: '>=0.10.0',
         },
         resolution: {
-          integrity: 'sha1-hX21hKG6XRyymAUn/DtsQ103sP0=',
+          integrity: 'sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==',
         },
       },
     },


### PR DESCRIPTION
## Problem

Running tests in `packages/core` seems to fail due to npmjs.com switching integrity resolution fields from sha1 to sha512. This error should be reproducible from the current `main` branch commit on CI for any pull request triggering tests in `packages/core` to rerun.

Example:

```
FAIL test/lockfile.ts (14.657 s)
  ● scoped module from different registry
    expect(received).toStrictEqual(expected) // deep equality
    - Expected  - 2
    + Received  + 2
    @@ -32,20 +32,20 @@
            "dev": false,
            "engines": Object {
              "node": ">=0.10.0",
            },
            "resolution": Object {
    -         "integrity": "sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=",
    +         "integrity": "sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==",
            },
          },
          "/is-positive/3.1.0": Object {
            "dev": false,
            "engines": Object {
              "node": ">=0.10.0",
            },
            "resolution": Object {
    -         "integrity": "sha1-hX21hKG6XRyymAUn/DtsQ103sP0=",
    +         "integrity": "sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==",
            },
          },
        },
        "specifiers": Object {
          "@foo/has-dep-from-same-scope": "^1.0.0",
      447 |   const lockfile = await project.readLockfile()
      448 |
    > 449 |   expect(lockfile).toStrictEqual({
          |                    ^
      450 |     dependencies: {
      451 |       '@foo/has-dep-from-same-scope': '1.0.0',
      452 |       '@zkochan/foo': '1.0.0',
      at Object.<anonymous> (test/lockfile.ts:449:20)
```

## Verdaccio Caches

Even after the fix in this commit, I'm seeing different test results locally and on CI due to a verdaccio storage cache only being restored on CI.

https://github.com/pnpm/pnpm/blob/797334ef0ba876a035a7b884153e44f6fb45e3e5/package.json#L8

An earlier version of this PR attempted to switch more instances of `is-positive`'s SHA1 resolution, but those other instances are going through Verdaccio and would need an update to the [`verdaccio/storage-1.0.0.tgz` file](https://github.com/pnpm/pnpm/blob/f0007b077cc801e1a07b05485da8b5a1a5536252/verdaccio/storage-1.0.0.tgz)