### PR TITLE
fix: pnpm install fail when using URLs as Dependencies with registry path. fix #4828

### DIFF
--- a/packages/npm-resolver/src/parsePref.ts
+++ b/packages/npm-resolver/src/parsePref.ts
@@ -37,7 +37,7 @@ export default function parsePref (
     }
   }
   if (pref.startsWith(registry)) {
-    const pkg = parseNpmTarballUrl(pref)
+    const pkg = parseNpmTarballUrl(pref.replace(registry, ''))
     if (pkg != null) {
       return {
         fetchSpec: pkg.version,


### PR DESCRIPTION
fix #4828