### PR TITLE
feat: allowed deprecated versions

### DIFF
--- a/.changeset/fast-bears-care.md
+++ b/.changeset/fast-bears-care.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/types": minor
+---
+
+Add new setting to pnpm field of the manifest: allowedDeprecatedVersions.

--- a/.changeset/sharp-pugs-join.md
+++ b/.changeset/sharp-pugs-join.md
@@ -1,0 +1,22 @@
+---
+"@pnpm/core": minor
+"@pnpm/plugin-commands-installation": minor
+"@pnpm/resolve-dependencies": minor
+"pnpm": minor
+---
+
+A new setting is supported for ignoring specific deprecation messages: `pnpm.allowedDeprecatedVersions`. The setting should be provided in the `pnpm` section of the root `package.json` file. The below example will mute any deprecation warnings about the `request` package and warnings about `express` v1:
+
+```json
+{
+  "pnpm": {
+    "allowedDeprecatedVersions": {
+      "request": "*",
+      "express": "1"
+    }
+  }
+}
+```
+
+Related issue: [#4306](https://github.com/pnpm/pnpm/issues/4306)
+Related PR: [#4864](https://github.com/pnpm/pnpm/pull/4864)

--- a/packages/core/src/getPeerDependencyIssues.ts
+++ b/packages/core/src/getPeerDependencyIssues.ts
@@ -48,6 +48,7 @@ export async function getPeerDependencyIssues (
     projectsToResolve,
     {
       currentLockfile: ctx.currentLockfile,
+      allowedDeprecatedVersions: {},
       defaultUpdateDepth: -1,
       dryRun: true,
       engineStrict: false,

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -7,6 +7,7 @@ import normalizeRegistries, { DEFAULT_REGISTRIES } from '@pnpm/normalize-registr
 import { WorkspacePackages } from '@pnpm/resolver-base'
 import { StoreController } from '@pnpm/store-controller-types'
 import {
+  AllowedDeprecatedVersions,
   PackageExtension,
   PeerDependencyRules,
   ReadPackageHook,
@@ -86,6 +87,7 @@ export interface StrictInstallOptions {
   enableModulesDir: boolean
   modulesCacheMaxAge: number
   peerDependencyRules: PeerDependencyRules
+  allowedDeprecatedVersions: AllowedDeprecatedVersions
 
   publicHoistPattern: string[] | undefined
   hoistPattern: string[] | undefined
@@ -108,6 +110,7 @@ const defaults = async (opts: InstallOptions) => {
     version: pnpmPkgJson.version,
   }
   return {
+    allowedDeprecatedVersions: {},
     autoInstallPeers: false,
     childConcurrency: 5,
     depth: 0,

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -740,6 +740,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     projects,
     {
       allowBuild: createAllowBuildFunction(opts),
+      allowedDeprecatedVersions: opts.allowedDeprecatedVersions,
       autoInstallPeers: opts.autoInstallPeers,
       currentLockfile: ctx.currentLockfile,
       defaultUpdateDepth: (opts.update || (opts.updateMatching != null)) ? opts.depth : -1,

--- a/packages/core/test/install/reporting.ts
+++ b/packages/core/test/install/reporting.ts
@@ -4,39 +4,48 @@ import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import {
   addDependenciesToPackage,
 } from '@pnpm/core'
-import * as sinon from 'sinon'
 import { testDefaults } from '../utils'
 
 // TODO: use a smaller package for testing deprecation
 test('reports warning when installing deprecated packages', async () => {
   const project = prepareEmpty()
+  const reporter = jest.fn()
 
-  let manifest
-  {
-    const reporter = sinon.spy()
+  const manifest = await addDependenciesToPackage({}, ['express@0.14.1'], await testDefaults({ fastUnpack: false, reporter }))
 
-    manifest = await addDependenciesToPackage({}, ['express@0.14.1'], await testDefaults({ fastUnpack: false, reporter }))
-
-    expect(reporter.calledWithMatch({
-      deprecated: 'express 0.x series is deprecated',
-      level: 'debug',
-      name: 'pnpm:deprecation',
-      pkgId: `localhost+${REGISTRY_MOCK_PORT}/express/0.14.1`,
-    } as DeprecationLog)).toBeTruthy()
-  }
+  expect(reporter).toBeCalledWith(expect.objectContaining({
+    deprecated: 'express 0.x series is deprecated',
+    level: 'debug',
+    name: 'pnpm:deprecation',
+    pkgId: `localhost+${REGISTRY_MOCK_PORT}/express/0.14.1`,
+  } as DeprecationLog))
 
   const lockfile = await project.readLockfile()
   expect(lockfile.packages['/express/0.14.1'].deprecated).toBe('express 0.x series is deprecated')
 
-  {
-    const reporter = sinon.spy()
+  reporter.mockReset()
 
-    await addDependenciesToPackage(manifest, ['express@4.16.3'], await testDefaults({ fastUnpack: false, reporter }))
+  await addDependenciesToPackage(manifest, ['express@4.16.3'], await testDefaults({ fastUnpack: false, reporter }))
 
-    expect(reporter.calledWithMatch({
-      level: 'debug',
-      name: 'pnpm:deprecation',
-      pkgId: `localhost+${REGISTRY_MOCK_PORT}/express/4.16.3`,
-    } as DeprecationLog)).toBeFalsy()
-  }
+  expect(reporter).not.toBeCalledWith(expect.objectContaining({
+    level: 'debug',
+    name: 'pnpm:deprecation',
+  } as DeprecationLog))
+})
+
+test('doesn\'t report a warning when the deprecated package is allowed', async () => {
+  prepareEmpty()
+  const reporter = jest.fn()
+
+  await addDependenciesToPackage({}, ['express@0.14.1'], await testDefaults({
+    allowedDeprecatedVersions: {
+      express: '0.14.1',
+    },
+    reporter,
+  }))
+
+  expect(reporter).not.toBeCalledWith(expect.objectContaining({
+    level: 'debug',
+    name: 'pnpm:deprecation',
+  } as DeprecationLog))
 })

--- a/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
+++ b/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
@@ -1,10 +1,12 @@
 import {
+  AllowedDeprecatedVersions,
   PackageExtension,
   PeerDependencyRules,
   ProjectManifest,
 } from '@pnpm/types'
 
 export default function getOptionsFromRootManifest (manifest: ProjectManifest): {
+  allowedDeprecatedVersions?: AllowedDeprecatedVersions
   overrides?: Record<string, string>
   neverBuiltDependencies?: string[]
   onlyBuiltDependencies?: string[]
@@ -19,7 +21,9 @@ export default function getOptionsFromRootManifest (manifest: ProjectManifest): 
   const onlyBuiltDependencies = manifest.pnpm?.onlyBuiltDependencies
   const packageExtensions = manifest.pnpm?.packageExtensions
   const peerDependencyRules = manifest.pnpm?.peerDependencyRules
+  const allowedDeprecatedVersions = manifest.pnpm?.allowedDeprecatedVersions
   return {
+    allowedDeprecatedVersions,
     overrides,
     neverBuiltDependencies,
     onlyBuiltDependencies,

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -29,6 +29,7 @@ import {
   StoreController,
 } from '@pnpm/store-controller-types'
 import {
+  AllowedDeprecatedVersions,
   Dependencies,
   DependencyManifest,
   PackageManifest,
@@ -119,6 +120,7 @@ export interface ChildrenByParentDepPath {
 export interface ResolutionContext {
   autoInstallPeers: boolean
   allowBuild?: (pkgName: string) => boolean
+  allowedDeprecatedVersions: AllowedDeprecatedVersions
   updatedSet: Set<string>
   defaultTag: string
   dryRun: boolean
@@ -889,7 +891,10 @@ async function resolveDependency (
   const isNew = !ctx.resolvedPackagesByDepPath[depPath]
 
   if (isNew) {
-    if (pkg.deprecated) {
+    if (
+      pkg.deprecated &&
+      (!ctx.allowedDeprecatedVersions[pkg.name] || !semver.satisfies(pkg.version, ctx.allowedDeprecatedVersions[pkg.name]))
+    ) {
       // Report deprecated packages only on first occurrence.
       deprecationLogger.debug({
         deprecated: pkg.deprecated,

--- a/packages/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/packages/resolve-dependencies/src/resolveDependencyTree.ts
@@ -2,6 +2,7 @@ import { Lockfile } from '@pnpm/lockfile-types'
 import { PreferredVersions, Resolution, WorkspacePackages } from '@pnpm/resolver-base'
 import { StoreController } from '@pnpm/store-controller-types'
 import {
+  AllowedDeprecatedVersions,
   ProjectManifest,
   ReadPackageHook,
   Registries,
@@ -55,6 +56,7 @@ export interface ImporterToResolveGeneric<T> extends Importer<T> {
 export interface ResolveDependenciesOptions {
   autoInstallPeers?: boolean
   allowBuild?: (pkgName: string) => boolean
+  allowedDeprecatedVersions: AllowedDeprecatedVersions
   currentLockfile: Lockfile
   dryRun: boolean
   engineStrict: boolean
@@ -88,6 +90,7 @@ export default async function<T> (
   const ctx = {
     autoInstallPeers: opts.autoInstallPeers === true,
     allowBuild: opts.allowBuild,
+    allowedDeprecatedVersions: opts.allowedDeprecatedVersions,
     childrenByParentDepPath: {} as ChildrenByParentDepPath,
     currentLockfile: opts.currentLockfile,
     defaultTag: opts.tag,

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -115,6 +115,8 @@ export interface PeerDependencyRules {
   allowedVersions?: Record<string, string>
 }
 
+export type AllowedDeprecatedVersions = Record<string, string>
+
 export type ProjectManifest = BaseManifest & {
   pnpm?: {
     neverBuiltDependencies?: string[]
@@ -122,6 +124,7 @@ export type ProjectManifest = BaseManifest & {
     overrides?: Record<string, string>
     packageExtensions?: Record<string, PackageExtension>
     peerDependencyRules?: PeerDependencyRules
+    allowedDeprecatedVersions?: AllowedDeprecatedVersions
   }
   private?: boolean
   resolutions?: Record<string, string>


### PR DESCRIPTION
close #4306

A new setting is supported for ignoring specific deprecation messages: `pnpm.allowedDeprecatedVersions`. The setting should be provided in the `pnpm` section of the root `package.json` file. The below example will mute any deprecation warnings about the `request` package and warnings about `express` v1:

```json
{
  "pnpm": {
    "allowedDeprecatedVersions": {
      "request": "*",
      "express": "1"
    }
  }
}
```