### PR TITLE
feat: patch package

### DIFF
--- a/.changeset/bright-lemons-arrive.md
+++ b/.changeset/bright-lemons-arrive.md
@@ -1,0 +1,23 @@
+---
+"@pnpm/core": minor
+"@pnpm/headless": minor
+"@pnpm/types": minor
+"pnpm": minor
+"@pnpm/resolve-dependencies": minor
+"@pnpm/lockfile-types": minor
+"@pnpm/lifecycle": minor
+"@pnpm/plugin-commands-installation": minor
+---
+
+Dependencies patching is possible via the `pnpm.patchedDependencies` field of the `package.json`.
+To patch a package, the package name, exact version, and the relative path to the patch file should be specified. For instance:
+
+```json
+{
+  "pnpm": {
+    "patchedDependencies": {
+      "eslint@1.0.0": "./patches/eslint@1.0.0.patch"
+    }
+  }
+}
+```

--- a/.changeset/four-poems-leave.md
+++ b/.changeset/four-poems-leave.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/calc-dep-state": major
+---
+
+Changed the order of arguments in calcDepState and added an optional last argument for patchFileHash.

--- a/.changeset/shiny-countries-behave.md
+++ b/.changeset/shiny-countries-behave.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/create-cafs-store": major
+"@pnpm/fetcher-base": major
+"@pnpm/package-store": major
+"@pnpm/server": major
+"@pnpm/store-controller-types": major
+---
+
+Rename engine and targetEngine fields to sideEffectsCacheKey.

--- a/.changeset/tasty-cobras-reflect.md
+++ b/.changeset/tasty-cobras-reflect.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/build-modules": minor
+---
+
+Support packages patching.

--- a/packages/build-modules/src/buildSequence.ts
+++ b/packages/build-modules/src/buildSequence.ts
@@ -16,6 +16,10 @@ export interface DependenciesGraphNode {
   optionalDependencies: Set<string>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   requiresBuild?: boolean | any // this is a durty workaround added in https://github.com/pnpm/pnpm/pull/4898
+  patchFile?: {
+    hash: string
+    path: string
+  }
 }
 
 export interface DependenciesGraph {

--- a/packages/build-modules/src/index.ts
+++ b/packages/build-modules/src/index.ts
@@ -94,9 +94,9 @@ async function buildDependency (
     })
     if (hasSideEffects && opts.sideEffectsCacheWrite) {
       try {
-        const engine = calcDepState(depGraph, opts.depsStateCache, depPath, depNode.patchFile?.hash)
+        const sideEffectsCacheKey = calcDepState(depGraph, opts.depsStateCache, depPath, depNode.patchFile?.hash)
         await opts.storeController.upload(depNode.dir, {
-          engine,
+          sideEffectsCacheKey,
           filesIndexFile: depNode.filesIndexFile,
         })
       } catch (err: any) { // eslint-disable-line

--- a/packages/build-modules/src/index.ts
+++ b/packages/build-modules/src/index.ts
@@ -83,6 +83,7 @@ async function buildDependency (
       extraEnv: opts.extraEnv,
       initCwd: opts.lockfileDir,
       optional: depNode.optional,
+      patchPath: depNode.patchFile?.path,
       pkgRoot: depNode.dir,
       rawConfig: opts.rawConfig,
       rootModulesDir: opts.rootModulesDir,
@@ -93,8 +94,9 @@ async function buildDependency (
     })
     if (hasSideEffects && opts.sideEffectsCacheWrite) {
       try {
+        const engine = calcDepState(depGraph, opts.depsStateCache, depPath, depNode.patchFile?.hash)
         await opts.storeController.upload(depNode.dir, {
-          engine: calcDepState(depPath, depGraph, opts.depsStateCache),
+          engine,
           filesIndexFile: depNode.filesIndexFile,
         })
       } catch (err: any) { // eslint-disable-line

--- a/packages/calc-dep-state/src/index.ts
+++ b/packages/calc-dep-state/src/index.ts
@@ -11,7 +11,7 @@ export interface DepsGraphNode {
 }
 
 export interface DepsStateCache {
-  [nodeId: string]: DepStateObj
+  [depPath: string]: DepStateObj
 }
 
 export interface DepStateObj {
@@ -19,22 +19,27 @@ export interface DepStateObj {
 }
 
 export function calcDepState (
-  nodeId: string,
   depsGraph: DepsGraph,
-  cache: DepsStateCache
+  cache: DepsStateCache,
+  depPath: string,
+  patchFileHash?: string
 ): string {
-  const depStateObj = calcDepStateObj(nodeId, depsGraph, cache, new Set())
-  return `${ENGINE_NAME}-${JSON.stringify(depStateObj)}`
+  const depStateObj = calcDepStateObj(depPath, depsGraph, cache, new Set())
+  let result = `${ENGINE_NAME}-${JSON.stringify(depStateObj)}`
+  if (patchFileHash) {
+    result += `-${patchFileHash}`
+  }
+  return result
 }
 
 function calcDepStateObj (
-  nodeId: string,
+  depPath: string,
   depsGraph: DepsGraph,
   cache: DepsStateCache,
   parents: Set<string>
 ): DepStateObj {
-  if (cache[nodeId]) return cache[nodeId]
-  const node = depsGraph[nodeId]
+  if (cache[depPath]) return cache[depPath]
+  const node = depsGraph[depPath]
   if (!node) return {}
   const nextParents = new Set([...Array.from(parents), node.depPath])
   const state: DepStateObj = {}
@@ -47,6 +52,6 @@ function calcDepStateObj (
     }
     state[child.depPath] = calcDepStateObj(childId, depsGraph, cache, nextParents)
   }
-  cache[nodeId] = sortKeys(state)
-  return cache[nodeId]
+  cache[depPath] = sortKeys(state)
+  return cache[depPath]
 }

--- a/packages/calc-dep-state/test/index.ts
+++ b/packages/calc-dep-state/test/index.ts
@@ -2,7 +2,7 @@ import { calcDepState } from '@pnpm/calc-dep-state'
 import { ENGINE_NAME } from '@pnpm/constants'
 
 test('calcDepState()', () => {
-  expect(calcDepState('/registry/foo/1.0.0', {
+  expect(calcDepState({
     'registry/foo/1.0.0': {
       depPath: '/foo/1.0.0',
       children: {
@@ -15,5 +15,5 @@ test('calcDepState()', () => {
         foo: 'registry/foo/1.0.0',
       },
     },
-  }, {})).toBe(`${ENGINE_NAME}-{}`)
+  }, {}, '/registry/foo/1.0.0')).toBe(`${ENGINE_NAME}-{}`)
 })

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -100,6 +100,7 @@ export interface StrictInstallOptions {
 
   global: boolean
   globalBin?: string
+  patchedDependencies?: Record<string, string>
 }
 
 export type InstallOptions =

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -240,6 +240,7 @@ export async function mutateModules (
         neverBuiltDependencies: opts.neverBuiltDependencies,
         onlyBuiltDependencies: opts.onlyBuiltDependencies,
         packageExtensionsChecksum,
+        patchedDependencies: opts.patchedDependencies,
       }) ||
       opts.fixLockfile
     if (needsFullResolution) {
@@ -247,6 +248,7 @@ export async function mutateModules (
       ctx.wantedLockfile.neverBuiltDependencies = opts.neverBuiltDependencies
       ctx.wantedLockfile.onlyBuiltDependencies = opts.onlyBuiltDependencies
       ctx.wantedLockfile.packageExtensionsChecksum = packageExtensionsChecksum
+      ctx.wantedLockfile.patchedDependencies = opts.patchedDependencies
     }
     const frozenLockfile = opts.frozenLockfile ||
       opts.frozenLockfileIfExists && ctx.existsWantedLockfile
@@ -490,16 +492,19 @@ function lockfileIsUpToDate (
     onlyBuiltDependencies,
     overrides,
     packageExtensionsChecksum,
+    patchedDependencies,
   }: {
     neverBuiltDependencies?: string[]
     onlyBuiltDependencies?: string[]
     overrides?: Record<string, string>
     packageExtensionsChecksum?: string
+    patchedDependencies?: Record<string, string>
   }) {
   return !equals(lockfile.overrides ?? {}, overrides ?? {}) ||
     !equals((lockfile.neverBuiltDependencies ?? []).sort(), (neverBuiltDependencies ?? []).sort()) ||
     !equals(onlyBuiltDependencies?.sort(), lockfile.onlyBuiltDependencies) ||
-    lockfile.packageExtensionsChecksum !== packageExtensionsChecksum
+    lockfile.packageExtensionsChecksum !== packageExtensionsChecksum ||
+    !equals(lockfile.patchedDependencies ?? {}, patchedDependencies ?? {})
 }
 
 export function createObjectChecksum (obj: Object) {
@@ -773,6 +778,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       virtualStoreDir: ctx.virtualStoreDir,
       wantedLockfile: ctx.wantedLockfile,
       workspacePackages: opts.workspacePackages,
+      patchedDependencies: opts.patchedDependencies,
     }
   )
 

--- a/packages/core/src/install/link.ts
+++ b/packages/core/src/install/link.ts
@@ -406,7 +406,7 @@ async function linkAllPkgs (
 
       let targetEngine: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = calcDepState(depNode.depPath, opts.depGraph, opts.depsStateCache)
+        targetEngine = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, depNode.patchFile?.hash)
       }
       if (typeof depNode.requiresBuild === 'function') {
         depNode.requiresBuild = await depNode.requiresBuild()

--- a/packages/core/src/install/link.ts
+++ b/packages/core/src/install/link.ts
@@ -404,9 +404,9 @@ async function linkAllPkgs (
     depNodes.map(async (depNode) => {
       const filesResponse = await depNode.fetchingFiles()
 
-      let targetEngine: string | undefined
+      let sideEffectsCacheKey: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, depNode.patchFile?.hash)
+        sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, depNode.patchFile?.hash)
       }
       if (typeof depNode.requiresBuild === 'function') {
         depNode.requiresBuild = await depNode.requiresBuild()
@@ -414,7 +414,7 @@ async function linkAllPkgs (
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,
         force: opts.force,
-        targetEngine,
+        sideEffectsCacheKey,
         requiresBuild: depNode.requiresBuild,
       })
       if (importMethod) {

--- a/packages/core/test/fixtures/patch-pkg/is-positive@1.0.0.patch
+++ b/packages/core/test/fixtures/patch-pkg/is-positive@1.0.0.patch
@@ -1,0 +1,12 @@
+diff --git a/index.js b/index.js
+index 8e020ca..ff3aee4 100644
+--- a/index.js
++++ b/index.js
+@@ -5,5 +5,6 @@ module.exports = function (n) {
+ 		throw new TypeError('Expected a number');
+ 	}
+ 
++  // patched
+ 	return n >= 0;
+ };
+

--- a/packages/core/test/install/patch.ts
+++ b/packages/core/test/install/patch.ts
@@ -1,0 +1,90 @@
+import fs from 'fs'
+import path from 'path'
+import { PackageFilesIndex } from '@pnpm/cafs'
+import { ENGINE_NAME } from '@pnpm/constants'
+import { install } from '@pnpm/core'
+import { prepareEmpty } from '@pnpm/prepare'
+import fixtures from '@pnpm/test-fixtures'
+import rimraf from '@zkochan/rimraf'
+import loadJsonFile from 'load-json-file'
+import { testDefaults } from '../utils'
+
+const f = fixtures(__dirname)
+
+test('patch package', async () => {
+  const project = prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')
+
+  const patchedDependencies = {
+    'is-positive@1.0.0': path.relative(process.cwd(), patchPath),
+  }
+  const opts = await testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies,
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, opts)
+
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+
+  const lockfile = await project.readLockfile()
+  expect(lockfile.patchedDependencies).toStrictEqual(patchedDependencies)
+
+  const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812c5d8da8a735e94c2a1ccb77b4583808ee8405313951e7146ac83ede3671dc292-index.json')
+  const filesIndex = await loadJsonFile<PackageFilesIndex>(filesIndexFile)
+  const sideEffectsKey = `${ENGINE_NAME}-{}-meyqmf5tej4bwn3gxydpfig6pe`
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey]['index.js']?.integrity
+  expect(patchedFileIntegrity).toBeTruthy()
+  const originalFileIntegrity = filesIndex.files['index.js'].integrity
+  expect(originalFileIntegrity).toBeTruthy()
+  // The integrity of the original file differs from the integrity of the patched file
+  expect(originalFileIntegrity).not.toEqual(patchedFileIntegrity)
+
+  // The same with frozen lockfile
+  await rimraf('node_modules')
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, {
+    ...opts,
+    frozenLockfile: true,
+  })
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+
+  // The same with frozen lockfile and hoisted node_modules
+  await rimraf('node_modules')
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, {
+    ...opts,
+    frozenLockfile: true,
+    nodeLinker: 'hoisted',
+  })
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// patched')
+
+  process.chdir('..')
+  fs.mkdirSync('project2')
+  process.chdir('project2')
+
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, await testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    offline: true,
+  }, {}, {}, { packageImportMethod: 'hardlink' }))
+
+  // The original file did not break, when a patched version was created
+  expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).not.toContain('// patched')
+})

--- a/packages/create-cafs-store/src/index.ts
+++ b/packages/create-cafs-store/src/index.ts
@@ -22,7 +22,7 @@ function createPackageImporter (
   const packageImportMethod = opts.packageImportMethod
   const gfm = getFlatMap.bind(null, opts.cafsDir)
   return async (to, opts) => {
-    const { filesMap, isBuilt } = gfm(opts.filesResponse, opts.targetEngine)
+    const { filesMap, isBuilt } = gfm(opts.filesResponse, opts.sideEffectsCacheKey)
     const pkgImportMethod = (opts.requiresBuild && !isBuilt)
       ? 'clone-or-copy'
       : (opts.filesResponse.packageImportMethod ?? packageImportMethod)

--- a/packages/fetcher-base/src/index.ts
+++ b/packages/fetcher-base/src/index.ts
@@ -23,7 +23,7 @@ export type PackageFilesResponse = {
 
 export interface ImportPackageOpts {
   requiresBuild?: boolean
-  targetEngine?: string
+  sideEffectsCacheKey?: string
   filesResponse: PackageFilesResponse
   force: boolean
 }

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -71,6 +71,7 @@
     "@pnpm/calc-dep-state": "workspace:2.0.1",
     "@pnpm/constants": "workspace:6.1.0",
     "@pnpm/core-loggers": "workspace:7.0.3",
+    "@pnpm/crypto.base32-hash": "workspace:1.0.0",
     "@pnpm/error": "workspace:3.0.1",
     "@pnpm/filter-lockfile": "workspace:6.0.6",
     "@pnpm/hoist": "workspace:6.1.4",

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -679,15 +679,15 @@ async function linkAllPkgs (
         throw err
       }
 
-      let targetEngine: string | undefined
+      let sideEffectsCacheKey: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, depNode.patchFile?.hash)
+        sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, depNode.patchFile?.hash)
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,
         force: opts.force,
         requiresBuild: depNode.requiresBuild,
-        targetEngine,
+        sideEffectsCacheKey,
       })
       if (importMethod) {
         progressLogger.debug({

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -681,7 +681,7 @@ async function linkAllPkgs (
 
       let targetEngine: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = calcDepState(depNode.dir, opts.depGraph, opts.depsStateCache)
+        targetEngine = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, depNode.patchFile?.hash)
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,

--- a/packages/headless/src/linkHoistedModules.ts
+++ b/packages/headless/src/linkHoistedModules.ts
@@ -99,15 +99,15 @@ async function linkAllPkgsInOrder (
         throw err
       }
 
-      let targetEngine: string | undefined
+      let sideEffectsCacheKey: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = _calcDepState(dir, depNode.patchFile?.hash)
+        sideEffectsCacheKey = _calcDepState(dir, depNode.patchFile?.hash)
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,
         force: opts.force || depNode.depPath !== prevGraph[dir]?.depPath,
         requiresBuild: depNode.requiresBuild,
-        targetEngine,
+        sideEffectsCacheKey,
       })
       if (importMethod) {
         progressLogger.debug({

--- a/packages/headless/src/linkHoistedModules.ts
+++ b/packages/headless/src/linkHoistedModules.ts
@@ -87,6 +87,7 @@ async function linkAllPkgsInOrder (
     warn: (message: string) => void
   }
 ) {
+  const _calcDepState = calcDepState.bind(null, graph, opts.depsStateCache)
   await Promise.all(
     Object.entries(hierarchy).map(async ([dir, deps]) => {
       const depNode = graph[dir]
@@ -100,7 +101,7 @@ async function linkAllPkgsInOrder (
 
       let targetEngine: string | undefined
       if (opts.sideEffectsCacheRead && filesResponse.sideEffects && !isEmpty(filesResponse.sideEffects)) {
-        targetEngine = calcDepState(dir, graph, opts.depsStateCache)
+        targetEngine = _calcDepState(dir, depNode.patchFile?.hash)
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,

--- a/packages/headless/src/lockfileToHoistedDepGraph.ts
+++ b/packages/headless/src/lockfileToHoistedDepGraph.ts
@@ -23,6 +23,7 @@ import {
   DepHierarchy,
   DirectDependenciesByImporterId,
   LockfileToDepGraphResult,
+  tryReadPatchFile,
 } from './lockfileToDepGraph'
 
 export interface LockfileToHoistedDepGraphOptions {
@@ -208,6 +209,7 @@ async function fetchDeps (
       optionalDependencies: new Set(Object.keys(pkgSnapshot.optionalDependencies ?? {})),
       prepare: pkgSnapshot.prepare === true,
       requiresBuild: pkgSnapshot.requiresBuild === true,
+      patchFile: await tryReadPatchFile(opts.lockfileDir, opts.lockfile, pkgName, pkgVersion),
     }
     opts.pkgLocationByDepPath[depPath] = dir
     depHierarchy[dir] = await fetchDeps(opts, path.join(dir, 'node_modules'), dep.dependencies)

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../core-loggers"
     },
     {
+      "path": "../crypto.base32-hash"
+    },
+    {
       "path": "../dependency-path"
     },
     {

--- a/packages/lifecycle/src/index.ts
+++ b/packages/lifecycle/src/index.ts
@@ -25,6 +25,10 @@ export async function runPostinstallHooks (
   if (pkg.scripts == null) {
     pkg.scripts = {}
   }
+  if (opts.patchPath) {
+    pkg.scripts['pnpm:patch'] = `git apply ${opts.patchPath}`
+    await runLifecycleHook('pnpm:patch', pkg, opts)
+  }
 
   if (!pkg.scripts.install) {
     await checkBindingGyp(opts.pkgRoot, pkg.scripts)
@@ -42,7 +46,8 @@ export async function runPostinstallHooks (
 
   return pkg.scripts.preinstall != null ||
     pkg.scripts.install != null ||
-    pkg.scripts.postinstall != null
+    pkg.scripts.postinstall != null ||
+    Boolean(opts.patchPath)
 }
 
 /**

--- a/packages/lifecycle/src/runLifecycleHook.ts
+++ b/packages/lifecycle/src/runLifecycleHook.ts
@@ -12,6 +12,7 @@ export interface RunLifecycleHookOptions {
   extraEnv?: Record<string, string>
   initCwd?: string
   optional?: boolean
+  patchPath?: string
   pkgRoot: string
   rawConfig: object
   rootModulesDir: string

--- a/packages/lockfile-types/src/index.ts
+++ b/packages/lockfile-types/src/index.ts
@@ -8,6 +8,7 @@ export interface Lockfile {
   onlyBuiltDependencies?: string[]
   overrides?: Record<string, string>
   packageExtensionsChecksum?: string
+  patchedDependencies?: Record<string, string>
 }
 
 export interface ProjectSnapshot {

--- a/packages/package-store/src/storeController/index.ts
+++ b/packages/package-store/src/storeController/index.ts
@@ -53,7 +53,7 @@ export default async function (
     upload,
   }
 
-  async function upload (builtPkgLocation: string, opts: {filesIndexFile: string, engine: string}) {
+  async function upload (builtPkgLocation: string, opts: {filesIndexFile: string, sideEffectsCacheKey: string}) {
     const sideEffectsIndex = await cafs.addFilesFromDir(builtPkgLocation)
     // TODO: move this to a function
     // This is duplicated in @pnpm/package-requester
@@ -80,7 +80,7 @@ export default async function (
       filesIndex = { files: integrity }
     }
     filesIndex.sideEffects = filesIndex.sideEffects ?? {}
-    filesIndex.sideEffects[opts.engine] = integrity
+    filesIndex.sideEffects[opts.sideEffectsCacheKey] = integrity
     await writeJsonFile(opts.filesIndexFile, filesIndex, { indent: undefined })
   }
 }

--- a/packages/package-store/src/storeController/index.ts
+++ b/packages/package-store/src/storeController/index.ts
@@ -59,17 +59,17 @@ export default async function (
     // This is duplicated in @pnpm/package-requester
     const integrity: Record<string, PackageFileInfo> = {}
     await Promise.all(
-      Object.keys(sideEffectsIndex)
-        .map(async (filename) => {
+      Object.entries(sideEffectsIndex)
+        .map(async ([filename, { writeResult, mode, size }]) => {
           const {
             checkedAt,
             integrity: fileIntegrity,
-          } = await sideEffectsIndex[filename].writeResult
+          } = await writeResult
           integrity[filename] = {
             checkedAt,
             integrity: fileIntegrity.toString(), // TODO: use the raw Integrity object
-            mode: sideEffectsIndex[filename].mode,
-            size: sideEffectsIndex[filename].size,
+            mode,
+            size,
           }
         })
     )

--- a/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
+++ b/packages/plugin-commands-installation/src/getOptionsFromRootManifest.ts
@@ -11,6 +11,7 @@ export default function getOptionsFromRootManifest (manifest: ProjectManifest): 
   neverBuiltDependencies?: string[]
   onlyBuiltDependencies?: string[]
   packageExtensions?: Record<string, PackageExtension>
+  patchedDependencies?: Record<string, string>
   peerDependencyRules?: PeerDependencyRules
 } {
   // We read Yarn's resolutions field for compatibility
@@ -22,6 +23,7 @@ export default function getOptionsFromRootManifest (manifest: ProjectManifest): 
   const packageExtensions = manifest.pnpm?.packageExtensions
   const peerDependencyRules = manifest.pnpm?.peerDependencyRules
   const allowedDeprecatedVersions = manifest.pnpm?.allowedDeprecatedVersions
+  const patchedDependencies = manifest.pnpm?.patchedDependencies
   return {
     allowedDeprecatedVersions,
     overrides,
@@ -29,5 +31,6 @@ export default function getOptionsFromRootManifest (manifest: ProjectManifest): 
     onlyBuiltDependencies,
     packageExtensions,
     peerDependencyRules,
+    patchedDependencies,
   }
 }

--- a/packages/resolve-dependencies/package.json
+++ b/packages/resolve-dependencies/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@pnpm/constants": "workspace:6.1.0",
     "@pnpm/core-loggers": "workspace:7.0.3",
+    "@pnpm/crypto.base32-hash": "workspace:1.0.0",
     "@pnpm/error": "workspace:3.0.1",
     "@pnpm/lockfile-types": "workspace:4.0.3",
     "@pnpm/lockfile-utils": "workspace:4.0.5",

--- a/packages/resolve-dependencies/src/index.ts
+++ b/packages/resolve-dependencies/src/index.ts
@@ -256,7 +256,8 @@ async function finishLockfileUpdates (
           Boolean(pkgJson.scripts.postinstall)
         ) ||
         filesResponse.filesIndex['binding.gyp'] ||
-          Object.keys(filesResponse.filesIndex).some((filename) => !(filename.match(/^[.]hooks[\\/]/) == null)) // TODO: optimize this
+          Object.keys(filesResponse.filesIndex).some((filename) => !(filename.match(/^[.]hooks[\\/]/) == null)) || // TODO: optimize this
+        depNode.patchFile != null
       )
     } else {
       // This should never ever happen

--- a/packages/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/packages/resolve-dependencies/src/resolveDependencyTree.ts
@@ -67,6 +67,7 @@ export interface ResolveDependenciesOptions {
   }
   nodeVersion: string
   registries: Registries
+  patchedDependencies?: Record<string, string>
   pnpmVersion: string
   preferredVersions?: PreferredVersions
   preferWorkspacePackages?: boolean
@@ -103,6 +104,7 @@ export default async function<T> (
     lockfileDir: opts.lockfileDir,
     nodeVersion: opts.nodeVersion,
     outdatedDependencies: {} as {[pkgId: string]: string},
+    patchedDependencies: opts.patchedDependencies,
     pendingNodes: [] as PendingNode[],
     pnpmVersion: opts.pnpmVersion,
     preferWorkspacePackages: opts.preferWorkspacePackages,

--- a/packages/resolve-dependencies/tsconfig.json
+++ b/packages/resolve-dependencies/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../core-loggers"
     },
     {
+      "path": "../crypto.base32-hash"
+    },
+    {
       "path": "../dependency-path"
     },
     {

--- a/packages/server/src/connectStoreController.ts
+++ b/packages/server/src/connectStoreController.ts
@@ -46,7 +46,7 @@ export default async function (
       stop: async () => {
         await limitedFetch(`${remotePrefix}/stop`, {})
       },
-      upload: async (builtPkgLocation: string, opts: {filesIndexFile: string, engine: string}) => {
+      upload: async (builtPkgLocation: string, opts: {filesIndexFile: string, sideEffectsCacheKey: string}) => {
         await limitedFetch(`${remotePrefix}/upload`, {
           builtPkgLocation,
           opts,

--- a/packages/server/test/index.ts
+++ b/packages/server/test/index.ts
@@ -167,7 +167,7 @@ test('server upload', async () => {
   const filesIndexFile = path.join(storeDir, 'test.example.com/fake-pkg/1.0.0.json')
 
   await storeCtrl.upload(path.join(__dirname, 'side-effect-fake-dir'), {
-    engine: fakeEngine,
+    sideEffectsCacheKey: fakeEngine,
     filesIndexFile,
   })
 
@@ -199,7 +199,7 @@ test('disable server upload', async () => {
   let thrown = false
   try {
     await storeCtrl.upload(path.join(__dirname, 'side-effect-fake-dir'), {
-      engine: fakeEngine,
+      sideEffectsCacheKey: fakeEngine,
       filesIndexFile,
     })
   } catch (e) {

--- a/packages/store-controller-types/src/index.ts
+++ b/packages/store-controller-types/src/index.ts
@@ -35,13 +35,20 @@ DependencyManifest,
 | 'version'
 >
 
+export interface UpdloadPkgToStoreOpts {
+  filesIndexFile: string
+  engine: string
+}
+
+export type UpdloadPkgToStore = (builtPkgLocation: string, opts: UpdloadPkgToStoreOpts) => Promise<void>
+
 export interface StoreController {
   requestPackage: RequestPackageFunction
   fetchPackage: FetchPackageToStoreFunction
   importPackage: ImportPackageFunction
   close: () => Promise<void>
   prune: () => Promise<void>
-  upload: (builtPkgLocation: string, opts: {filesIndexFile: string, engine: string}) => Promise<void>
+  upload: UpdloadPkgToStore
 }
 
 export type FetchPackageToStoreFunction = (

--- a/packages/store-controller-types/src/index.ts
+++ b/packages/store-controller-types/src/index.ts
@@ -35,12 +35,12 @@ DependencyManifest,
 | 'version'
 >
 
-export interface UpdloadPkgToStoreOpts {
+export interface UploadPkgToStoreOpts {
   filesIndexFile: string
-  engine: string
+  sideEffectsCacheKey: string
 }
 
-export type UpdloadPkgToStore = (builtPkgLocation: string, opts: UpdloadPkgToStoreOpts) => Promise<void>
+export type UploadPkgToStore = (builtPkgLocation: string, opts: UploadPkgToStoreOpts) => Promise<void>
 
 export interface StoreController {
   requestPackage: RequestPackageFunction
@@ -48,7 +48,7 @@ export interface StoreController {
   importPackage: ImportPackageFunction
   close: () => Promise<void>
   prune: () => Promise<void>
-  upload: UpdloadPkgToStore
+  upload: UploadPkgToStore
 }
 
 export type FetchPackageToStoreFunction = (

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -50,6 +50,7 @@ export interface DependenciesMeta {
   [dependencyName: string]: {
     injected?: boolean
     node?: string
+    patch?: string
   }
 }
 
@@ -126,6 +127,7 @@ export type ProjectManifest = BaseManifest & {
     packageExtensions?: Record<string, PackageExtension>
     peerDependencyRules?: PeerDependencyRules
     allowedDeprecatedVersions?: AllowedDeprecatedVersions
+    patchedDependencies?: Record<string, string>
   }
   private?: boolean
   resolutions?: Record<string, string>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,7 @@ importers:
       '@pnpm/client': workspace:7.1.5
       '@pnpm/constants': workspace:6.1.0
       '@pnpm/core-loggers': workspace:7.0.3
+      '@pnpm/crypto.base32-hash': workspace:1.0.0
       '@pnpm/error': workspace:3.0.1
       '@pnpm/filter-lockfile': workspace:6.0.6
       '@pnpm/headless': workspace:18.2.0
@@ -1173,6 +1174,7 @@ importers:
       '@pnpm/calc-dep-state': link:../calc-dep-state
       '@pnpm/constants': link:../constants
       '@pnpm/core-loggers': link:../core-loggers
+      '@pnpm/crypto.base32-hash': link:../crypto.base32-hash
       '@pnpm/error': link:../error
       '@pnpm/filter-lockfile': link:../filter-lockfile
       '@pnpm/hoist': link:../hoist
@@ -3211,6 +3213,7 @@ importers:
     specifiers:
       '@pnpm/constants': workspace:6.1.0
       '@pnpm/core-loggers': workspace:7.0.3
+      '@pnpm/crypto.base32-hash': workspace:1.0.0
       '@pnpm/error': workspace:3.0.1
       '@pnpm/lockfile-types': workspace:4.0.3
       '@pnpm/lockfile-utils': workspace:4.0.5
@@ -3246,6 +3249,7 @@ importers:
     dependencies:
       '@pnpm/constants': link:../constants
       '@pnpm/core-loggers': link:../core-loggers
+      '@pnpm/crypto.base32-hash': link:../crypto.base32-hash
       '@pnpm/error': link:../error
       '@pnpm/lockfile-types': link:../lockfile-types
       '@pnpm/lockfile-utils': link:../lockfile-utils


### PR DESCRIPTION
TODO:
- [x] when a package is patched, the side-effects cache key of that package should contain the patch file hash.
- [x] patching should not affect files in the CAFS (so maybe it should not work when hard links are used?)

For creating the patch, we may probably use this library of Yarn: https://github.com/yarnpkg/berry/blob/82376c1b7b96ea894ca92a9c8b777bbc17535ea3/packages/plugin-patch/sources/patchUtils.ts#L279