### PR TITLE
fix: resolve real path for case insensitive systems

### DIFF
--- a/.changeset/quiet-icons-wait.md
+++ b/.changeset/quiet-icons-wait.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/find-workspace-dir": patch
+"pnpm": patch
 ---
 
-Resolve native workspace path for case-insensitive file systems
+Resolve native workspace path for case-insensitive file systems [#4904](https://github.com/pnpm/pnpm/issues/4904).

--- a/.changeset/quiet-icons-wait.md
+++ b/.changeset/quiet-icons-wait.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/find-workspace-dir": patch
+---
+
+Resolve native workspace path for case-insensitive file systems

--- a/packages/find-workspace-dir/src/index.ts
+++ b/packages/find-workspace-dir/src/index.ts
@@ -19,6 +19,10 @@ export default async function findWorkspaceDir (cwd: string) {
 
 async function getRealPath (path: string) {
   return new Promise<string>((resolve) => {
+    // We need to resolve the real native path for case-insensitive file systems.
+    // For example, we can access file as C:\Code\Project as well as c:\code\projects
+    // Without this we can face a problem when try to install packages with -w flag,
+    // when root dir is using c:\code\projects but packages were found by C:\Code\Project
     fs.realpath.native(path, function (err, resolvedPath) {
       resolve(err !== null ? path : resolvedPath)
     })

--- a/packages/find-workspace-dir/src/index.ts
+++ b/packages/find-workspace-dir/src/index.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import PnpmError from '@pnpm/error'
 import findUp from 'find-up'
@@ -9,9 +10,17 @@ export default async function findWorkspaceDir (cwd: string) {
   const workspaceManifestDirEnvVar = process.env[WORKSPACE_DIR_ENV_VAR] ?? process.env[WORKSPACE_DIR_ENV_VAR.toLowerCase()]
   const workspaceManifestLocation = workspaceManifestDirEnvVar
     ? path.join(workspaceManifestDirEnvVar, 'pnpm-workspace.yaml')
-    : await findUp([WORKSPACE_MANIFEST_FILENAME, 'pnpm-workspace.yml'], { cwd })
+    : await findUp([WORKSPACE_MANIFEST_FILENAME, 'pnpm-workspace.yml'], { cwd: await getRealPath(cwd) })
   if (workspaceManifestLocation?.endsWith('.yml')) {
     throw new PnpmError('BAD_WORKSPACE_MANIFEST_NAME', `The workspace manifest file should be named "pnpm-workspace.yaml". File found: ${workspaceManifestLocation}`)
   }
   return workspaceManifestLocation && path.dirname(workspaceManifestLocation)
+}
+
+async function getRealPath (path: string) {
+  return new Promise<string>((resolve) => {
+    fs.realpath.native(path, function (err, resolvedPath) {
+      resolve(err !== null ? path : resolvedPath)
+    })
+  })
 }

--- a/packages/find-workspace-dir/test/index.ts
+++ b/packages/find-workspace-dir/test/index.ts
@@ -1,9 +1,23 @@
 /// <reference path="../../../typings/index.d.ts"/>
 import path from 'path'
+import fs from 'fs'
 import findWorkspaceDir from '@pnpm/find-workspace-dir'
 
 const NPM_CONFIG_WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR'
 const FAKE_PATH = 'FAKE_PATH'
+
+function isFileSystemCaseSensitive () {
+  try {
+    fs.realpathSync.native(process.cwd().toUpperCase())
+    return false
+  } catch (_) {
+    return true
+  }
+}
+
+// We don't need to validate case-sensitive systems
+// because it is not possible to reach process.cwd() with wrong case there.
+const testOnCaseInSensitiveSystems = isFileSystemCaseSensitive() ? test.skip : test
 
 test('finds actual workspace dir', async () => {
   const workspaceDir = await findWorkspaceDir(process.cwd())
@@ -11,7 +25,7 @@ test('finds actual workspace dir', async () => {
   expect(workspaceDir).toBe(path.resolve(__dirname, '..', '..', '..'))
 })
 
-test('finds workspace dir with wrong case from cwd', async () => {
+testOnCaseInSensitiveSystems('finds workspace dir with wrong case from cwd', async () => {
   const workspaceDir = await findWorkspaceDir(process.cwd().toUpperCase())
 
   expect(workspaceDir).toBe(path.resolve(__dirname, '..', '..', '..'))

--- a/packages/find-workspace-dir/test/index.ts
+++ b/packages/find-workspace-dir/test/index.ts
@@ -11,6 +11,12 @@ test('finds actual workspace dir', async () => {
   expect(workspaceDir).toBe(path.resolve(__dirname, '..', '..', '..'))
 })
 
+test('finds workspace dir with wrong case from cwd', async () => {
+  const workspaceDir = await findWorkspaceDir(process.cwd().toUpperCase())
+
+  expect(workspaceDir).toBe(path.resolve(__dirname, '..', '..', '..'))
+})
+
 test('finds overriden workspace dir', async () => {
   const oldValue = process.env[NPM_CONFIG_WORKSPACE_DIR_ENV_VAR]
   process.env[NPM_CONFIG_WORKSPACE_DIR_ENV_VAR] = FAKE_PATH


### PR DESCRIPTION
For case insensitive systems (Windows) `findWorkspaceDir` will return the path to the module as it was called (because of `cwd`) not the real path.

It leads to an issue when `getImporters` can't find the the manifest (#4904).

Can be reproduces if `pnpm` was called from "c:\code\project" but the real path is "C:\Code\Project".
`getImporters` will find all `manifestsByPath` as "C:\Code\Project\...", but `prefixes` will use workspace root "c:\code\project\...", and it can't match them.

It is possible to try [true-case-path](https://github.com/Profiscience/true-case-path/pulls) but has some vulnerable deps. 