### PR TITLE
fix: use recursive for deploy command directory creation

### DIFF
--- a/.changeset/odd-masks-type.md
+++ b/.changeset/odd-masks-type.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-deploy": minor
+---
+
+Changes deployment directories to be created recursivly

--- a/.changeset/odd-masks-type.md
+++ b/.changeset/odd-masks-type.md
@@ -2,4 +2,4 @@
 "@pnpm/plugin-commands-deploy": minor
 ---
 
-Changes deployment directories to be created recursivly
+Changes deployment directories to be created recursively

--- a/packages/plugin-commands-deploy/src/deploy.ts
+++ b/packages/plugin-commands-deploy/src/deploy.ts
@@ -47,7 +47,7 @@ export async function handler (
   const deployedDir = selectedDirs[0]
   const deployDir = path.join(opts.workspaceDir, params[0])
   await rimraf(deployDir)
-  await fs.promises.mkdir(deployDir)
+  await fs.promises.mkdir(deployDir, { recursive: true })
   await copyProject(deployedDir, deployDir)
   const readPackageHook = opts.hooks?.readPackage
   // eslint-disable-next-line


### PR DESCRIPTION
Currently the deploy command will throw when the deploy directory is nested.

Example running: 
```console
pnpm --filter=pkg deploy deploy/pkg
```
will throw with 
```console
 ENOENT  ENOENT: no such file or directory, mkdir '/home/project/deploy/pkg'
```

This happens when the parent folder (deploy in this case) has not been already created.

This PR adds { recursive: true } to allow creating the deploy directory recursivly.