### PR TITLE
Add "refs/"+refname to resolution options

### DIFF
--- a/.changeset/hip-sheep-smoke.md
+++ b/.changeset/hip-sheep-smoke.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/git-resolver": minor
+---
+
+Add `refs/` to git resolution prefixes

--- a/packages/git-resolver/src/index.ts
+++ b/packages/git-resolver/src/index.ts
@@ -87,6 +87,7 @@ function resolveRefFromRefs (refs: {[ref: string]: string}, repo: string, ref: s
   if (!range) {
     const commitId =
       refs[ref] ||
+      refs[`refs/${ref}`] ||
       refs[`refs/tags/${ref}^{}`] || // prefer annotated tags
       refs[`refs/tags/${ref}`] ||
       refs[`refs/heads/${ref}`]

--- a/packages/git-resolver/test/index.ts
+++ b/packages/git-resolver/test/index.ts
@@ -72,6 +72,18 @@ test('resolveFromGit() with branch', async () => {
   })
 })
 
+test('resolveFromGit() with branch relative to refs', async () => {
+  const resolveResult = await resolveFromGit({ pref: 'zkochan/is-negative#heads/canary' })
+  expect(resolveResult).toStrictEqual({
+    id: 'github.com/zkochan/is-negative/4c39fbc124cd4944ee51cb082ad49320fab58121',
+    normalizedPref: 'github:zkochan/is-negative#heads/canary',
+    resolution: {
+      tarball: 'https://codeload.github.com/zkochan/is-negative/tar.gz/4c39fbc124cd4944ee51cb082ad49320fab58121',
+    },
+    resolvedVia: 'git-repository',
+  })
+})
+
 test('resolveFromGit() with tag', async () => {
   const resolveResult = await resolveFromGit({ pref: 'zkochan/is-negative#2.0.1' })
   expect(resolveResult).toStrictEqual({


### PR DESCRIPTION
Fix #2045

Previously, if you wanted to check out a git PR branch, you needed to specify the url as, e.g. `github:pnpm/pnpm#refs/pull/4953/merge`. Now this will resolve without the leading "refs", i.e. `github:pnpm/pnpm#pull/4953/merge`