### PR TITLE
fix filter-prod flag including all workspace pkgs

### DIFF
--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -196,9 +196,9 @@ export default async function run (inputArgv: string[]) {
     ]
     const relativeWSDirPath = () => path.relative(process.cwd(), wsDir) || '.'
     if (config.workspaceRoot) {
-      filters.push({ filter: `{${relativeWSDirPath()}}`, followProdDepsOnly: false })
+      filters.push({ filter: `{${relativeWSDirPath()}}`, followProdDepsOnly: Boolean(config.filterProd.length) })
     } else if (!config.includeWorkspaceRoot && (cmd === 'run' || cmd === 'exec' || cmd === 'add' || cmd === 'test')) {
-      filters.push({ filter: `!{${relativeWSDirPath()}}`, followProdDepsOnly: false })
+      filters.push({ filter: `!{${relativeWSDirPath()}}`, followProdDepsOnly: Boolean(config.filterProd.length) })
     }
 
     const filterResults = await filterPackages(allProjects, filters, {


### PR DESCRIPTION
https://github.com/pnpm/pnpm/commit/f48d46ef6fc0b9922403b9c1d85854d7062a52c3 appears to have surfaced a regression where the exclusion filter for workspace root broke was inserted without followProdDepsOnly. i guess we didn't notice earlier because filterProd together with workspaceRoot is an edge-case ;)