### PR TITLE
fix: don't symlink the autoinstalled peers to the root of node_modules

### DIFF
--- a/.changeset/early-bats-sell.md
+++ b/.changeset/early-bats-sell.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Don't symlink the autoinstalled peer dependencies to the root of `node_modules` [#4988](https://github.com/pnpm/pnpm/issues/4988).

--- a/packages/core/src/install/link.ts
+++ b/packages/core/src/install/link.ts
@@ -160,8 +160,10 @@ export default async function linkPackages (
   if (opts.symlink) {
     await Promise.all(projects.map(async ({ id, manifest, modulesDir, rootDir }) => {
       const deps = opts.dependenciesByProjectId[id]
+      const importerFromLockfile = newCurrentLockfile.importers[id]
       await Promise.all([
         ...Object.entries(deps)
+          .filter(([rootAlias]) => importerFromLockfile.specifiers[rootAlias])
           .map(([rootAlias, depPath]) => ({ rootAlias, depGraphNode: depGraph[depPath] }))
           .filter(({ depGraphNode }) => depGraphNode)
           .map(async ({ rootAlias, depGraphNode }) => {

--- a/packages/core/test/install/autoInstallPeers.ts
+++ b/packages/core/test/install/autoInstallPeers.ts
@@ -12,6 +12,7 @@ test('auto install non-optional peer dependencies', async () => {
     '/abc-optional-peers/1.0.0_peer-a@1.0.0',
     '/peer-a/1.0.0',
   ])
+  await project.hasNot('peer-a')
 })
 
 test('auto install the common peer dependency', async () => {


### PR DESCRIPTION
close #4988