### PR TITLE
feat: use irreversible-delete in pnpm patch-commit

### DIFF
--- a/.changeset/fresh-singers-sparkle.md
+++ b/.changeset/fresh-singers-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": minor
+---
+
+Avoid retaining a copy of the contents of files deleted during patching

--- a/packages/plugin-commands-patching/src/patchCommit.ts
+++ b/packages/plugin-commands-patching/src/patchCommit.ts
@@ -61,7 +61,7 @@ async function diffFolders (folderA: string, folderB: string) {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--full-index', '--no-index', '--text', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/packages/plugin-commands-patching/test/patch.test.ts
+++ b/packages/plugin-commands-patching/test/patch.test.ts
@@ -28,7 +28,12 @@ test('patch and commit', async () => {
   }, ['is-positive@1.0.0'])
 
   const userPatchDir = output.substring(output.indexOf(':') + 1).trim()
+
+  // sanity check to ensure that the license file contains the expected string
+  expect(fs.readFileSync(path.join(userPatchDir, 'license'), 'utf8')).toContain('The MIT License (MIT)')
+
   fs.appendFileSync(path.join(userPatchDir, 'index.js'), '// test patching', 'utf8')
+  fs.unlinkSync(path.join(userPatchDir, 'license'))
 
   await patchCommit.handler({
     ...DEFAULT_OPTS,
@@ -43,4 +48,7 @@ test('patch and commit', async () => {
   expect(patchContent).toContain('diff --git')
   expect(patchContent).toContain('// test patching')
   expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+
+  expect(patchContent).not.toContain('The MIT License (MIT)')
+  expect(fs.existsSync('node_modules/is-positive/license')).toBe(false)
 })


### PR DESCRIPTION
Avoid retaining a copy of the contents of files deleted during patching

fixes #5003