### PR TITLE
fix(file-reporter): output logs incrementally

### DIFF
--- a/.changeset/wise-cameras-yawn.md
+++ b/.changeset/wise-cameras-yawn.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/file-reporter": minor
+---
+
+Logs will be added as they are created instead of all at once at the end. Prevents memory exceeded errors if there are too many logs.

--- a/packages/file-reporter/src/index.ts
+++ b/packages/file-reporter/src/index.ts
@@ -24,10 +24,8 @@ export default function (streamParser: Object) {
   process.on('exit', (code: number) => {
     if (code === 0 || global['writeDebugLogFile'] === false) {
       // it might not exist, so it is OK if it fails
-      try {
-        if (fs.existsSync(LOG_FILENAME)) fs.unlinkSync(LOG_FILENAME)
-        if (fs.existsSync(path.basename(LOG_FILENAME))) fs.unlinkSync(path.basename(LOG_FILENAME))
-      } catch (err) {}
+      if (fs.existsSync(LOG_FILENAME)) fs.unlinkSync(LOG_FILENAME)
+      if (fs.existsSync(path.basename(LOG_FILENAME))) fs.unlinkSync(path.basename(LOG_FILENAME))
     }
   })
 

--- a/packages/file-reporter/src/index.ts
+++ b/packages/file-reporter/src/index.ts
@@ -7,10 +7,8 @@ export default function (streamParser: Object) {
   let logNum = 0
 
   // Clean up previous log files
-  if (global['writeDebugLogFile'] !== false) {
-    if (fs.existsSync(LOG_FILENAME)) fs.unlinkSync(LOG_FILENAME)
-    if (fs.existsSync(path.basename(LOG_FILENAME))) fs.unlinkSync(path.basename(LOG_FILENAME))
-  }
+  if (fs.existsSync(LOG_FILENAME)) fs.unlinkSync(LOG_FILENAME)
+  if (fs.existsSync(path.basename(LOG_FILENAME))) fs.unlinkSync(path.basename(LOG_FILENAME))
 
   streamParser['on']('data', function (logObj: Object) {
     if (isUsefulLog(logObj) && global['writeDebugLogFile'] !== false) {
@@ -20,6 +18,16 @@ export default function (streamParser: Object) {
       const dest = fs.existsSync(path.dirname(LOG_FILENAME)) ? LOG_FILENAME : path.basename(LOG_FILENAME)
       fs.appendFileSync(dest, jsonLogs)
       logNum++
+    }
+  })
+
+  process.on('exit', (code: number) => {
+    if (code === 0 || global['writeDebugLogFile'] === false) {
+      // it might not exist, so it is OK if it fails
+      try {
+        if (fs.existsSync(LOG_FILENAME)) fs.unlinkSync(LOG_FILENAME)
+        if (fs.existsSync(path.basename(LOG_FILENAME))) fs.unlinkSync(path.basename(LOG_FILENAME))
+      } catch (err) {}
     }
   })
 

--- a/packages/file-reporter/test/fixture/1/stdout
+++ b/packages/file-reporter/test/fixture/1/stdout
@@ -1,7 +1,9 @@
 {
-  "0 info pnpm": "foo",
-  "1 warn pnpm": {
-    "foo": 1,
-    "bar": 2
-  }
+  "message": "foo",
+  "key": "0 info pnpm"
+}
+{
+  "foo": 1,
+  "bar": 2,
+  "key": "1 warn pnpm"
 }


### PR DESCRIPTION
Resolves issue #4949 where pnpm install will crash in a very large repository as the `logs` object in memory becomes too large for JSON.stringify to handle. Performance has been tested on a large monorepo and this change does not seem to hinder installation time in any measurable way as compared to not logging at all.

The output log format has been changed from:
```
{
  "0 info pnpm": "foo",
  "1 warn pnpm": {
    "foo": 1,
    "bar": 2
  }
}
```
to:
```
{
  "message": "foo",
  "key": "0 info pnpm"
}
{
  "foo": 1,
  "bar": 2,
  "key": "1 warn pnpm"
}
```
Where each object is written to the file incrementally, instead of storing all logs and writing all at once.

Note: because we are using `fs.appendFileSync` which does not overwrite previous files, the log file must be cleaned up before any logging.