### PR TITLE
fix: plugin-commands-deploy use path resolve on deploy target dir

### DIFF
--- a/.changeset/fair-foxes-know.md
+++ b/.changeset/fair-foxes-know.md
@@ -3,4 +3,4 @@
 "@pnpm/plugin-commands-deploy": patch
 ---
 
-**pnpm deploy**: accept absolute paths and use cwd instead of workspaceDir for deploy target directory.
+**pnpm deploy**: accept absolute paths and use cwd instead of workspaceDir for deploy target directory [#4980](https://github.com/pnpm/pnpm/issues/4980).

--- a/.changeset/fair-foxes-know.md
+++ b/.changeset/fair-foxes-know.md
@@ -1,5 +1,6 @@
 ---
-"@pnpm/plugin-commands-deploy": major
+"pnpm": "patch"
+"@pnpm/plugin-commands-deploy": patch
 ---
 
-Accept absolute paths and use cwd instead of workspaceDir for deploy target directory.
+**pnpm deploy**: accept absolute paths and use cwd instead of workspaceDir for deploy target directory.

--- a/.changeset/fair-foxes-know.md
+++ b/.changeset/fair-foxes-know.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-deploy": major
+---
+
+Accept absolute paths and use cwd instead of workspaceDir for deploy target directory.

--- a/packages/plugin-commands-deploy/src/deploy.ts
+++ b/packages/plugin-commands-deploy/src/deploy.ts
@@ -45,7 +45,8 @@ export async function handler (
     throw new PnpmError('INVALID_DEPLOY_TARGET', 'This command requires one parameter')
   }
   const deployedDir = selectedDirs[0]
-  const deployDir = path.resolve(params[0])
+  const deployDirParam = params[0]
+  const deployDir = path.isAbsolute(deployDirParam) ? deployDirParam : path.join(opts.dir, deployDirParam)
   await rimraf(deployDir)
   await fs.promises.mkdir(deployDir, { recursive: true })
   await copyProject(deployedDir, deployDir)

--- a/packages/plugin-commands-deploy/src/deploy.ts
+++ b/packages/plugin-commands-deploy/src/deploy.ts
@@ -45,7 +45,7 @@ export async function handler (
     throw new PnpmError('INVALID_DEPLOY_TARGET', 'This command requires one parameter')
   }
   const deployedDir = selectedDirs[0]
-  const deployDir = path.join(opts.workspaceDir, params[0])
+  const deployDir = path.resolve(params[0])
   await rimraf(deployDir)
   await fs.promises.mkdir(deployDir, { recursive: true })
   await copyProject(deployedDir, deployDir)


### PR DESCRIPTION
This changes the behaviour of the deploy command as discussed in https://github.com/pnpm/pnpm/issues/4980 to use the working directory and to accept absolute paths.

close  #4980