### PR TITLE
fix: summary reporting

### DIFF
--- a/.changeset/lemon-numbers-hug.md
+++ b/.changeset/lemon-numbers-hug.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+Do not print a package with unchanged version in the installation summary.

--- a/packages/default-reporter/package.json
+++ b/packages/default-reporter/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "start": "tsc --watch",
     "lint": "eslint src/**/*.ts test/**/*.ts",
-    "pretty-test": "ts-node test | tap-diff",
     "just-test-preview": "ts-node test --type-check",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/packages/default-reporter/src/reporterForClient/pkgsDiff.ts
+++ b/packages/default-reporter/src/reporterForClient/pkgsDiff.ts
@@ -56,39 +56,32 @@ export default function (
     scan((pkgsDiff, args) => {
       const rootLog = args[0]
       const deprecationSet = args[1] as Set<string>
+      let action: '-' | '+' | undefined
+      let log!: any // eslint-disable-line
       if (rootLog['added']) {
-        const depType = rootLog['added'].dependencyType || 'nodeModulesOnly'
-        const removeKey = `-${rootLog['added'].name as string}`
-        const previous = pkgsDiff[depType][removeKey]
-        if (previous && previous.version === rootLog['added'].version) {
-          delete pkgsDiff[depType][removeKey]
-          return pkgsDiff
-        }
-        pkgsDiff[depType][`+${rootLog['added'].name as string}`] = {
-          added: true,
-          deprecated: deprecationSet.has(rootLog['added'].id),
-          from: rootLog['added'].linkedFrom,
-          latest: rootLog['added'].latest,
-          name: rootLog['added'].name,
-          realName: rootLog['added'].realName,
-          version: rootLog['added'].version,
-        }
+        action = '+'
+        log = rootLog['added']
+      } else if (rootLog['removed']) {
+        action = '-'
+        log = rootLog['removed']
+      } else {
         return pkgsDiff
       }
-      if (rootLog['removed']) {
-        const depType = rootLog['removed'].dependencyType || 'nodeModulesOnly'
-        const addKey = `+${rootLog['removed'].name as string}`
-        const previous = pkgsDiff[depType][addKey]
-        if (previous && previous.version === rootLog['removed'].version) {
-          delete pkgsDiff[depType][addKey]
-          return pkgsDiff
-        }
-        pkgsDiff[depType][`-${rootLog['removed'].name as string}`] = {
-          added: false,
-          name: rootLog['removed'].name,
-          version: rootLog['removed'].version,
-        }
+      const depType = log.dependencyType || 'nodeModulesOnly'
+      const oppositeKey = `${action === '-' ? '+' : '-'}${log.name as string}`
+      const previous = pkgsDiff[depType][oppositeKey]
+      if (previous && previous.version === log.version) {
+        delete pkgsDiff[depType][oppositeKey]
         return pkgsDiff
+      }
+      pkgsDiff[depType][`${action}${log.name as string}`] = {
+        added: action === '+',
+        deprecated: deprecationSet.has(log.id),
+        from: log.linkedFrom,
+        latest: log.latest,
+        name: log.name,
+        realName: log.realName,
+        version: log.version,
       }
       return pkgsDiff
     }, {

--- a/packages/default-reporter/src/reporterForClient/pkgsDiff.ts
+++ b/packages/default-reporter/src/reporterForClient/pkgsDiff.ts
@@ -57,7 +57,14 @@ export default function (
       const rootLog = args[0]
       const deprecationSet = args[1] as Set<string>
       if (rootLog['added']) {
-        pkgsDiff[rootLog['added'].dependencyType || 'nodeModulesOnly'][`+${rootLog['added'].name as string}`] = {
+        const depType = rootLog['added'].dependencyType || 'nodeModulesOnly'
+        const removeKey = `-${rootLog['added'].name as string}`
+        const previous = pkgsDiff[depType][removeKey]
+        if (previous && previous.version === rootLog['added'].version) {
+          delete pkgsDiff[depType][removeKey]
+          return pkgsDiff
+        }
+        pkgsDiff[depType][`+${rootLog['added'].name as string}`] = {
           added: true,
           deprecated: deprecationSet.has(rootLog['added'].id),
           from: rootLog['added'].linkedFrom,
@@ -69,7 +76,14 @@ export default function (
         return pkgsDiff
       }
       if (rootLog['removed']) {
-        pkgsDiff[rootLog['removed'].dependencyType || 'nodeModulesOnly'][`-${rootLog['removed'].name as string}`] = {
+        const depType = rootLog['removed'].dependencyType || 'nodeModulesOnly'
+        const addKey = `+${rootLog['removed'].name as string}`
+        const previous = pkgsDiff[depType][addKey]
+        if (previous && previous.version === rootLog['removed'].version) {
+          delete pkgsDiff[depType][addKey]
+          return pkgsDiff
+        }
+        pkgsDiff[depType][`-${rootLog['removed'].name as string}`] = {
           added: false,
           name: rootLog['removed'].name,
           version: rootLog['removed'].version,

--- a/packages/default-reporter/test/index.ts
+++ b/packages/default-reporter/test/index.ts
@@ -34,7 +34,7 @@ const h1 = chalk.cyanBright
 
 const EOL = '\n'
 
-test('prints summary (of current package only)', (done) => {
+test.only('prints summary (of current package only)', (done) => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -97,6 +97,24 @@ test('prints summary (of current package only)', (done) => {
       name: 'foo',
       version: '0.1.0',
     },
+  })
+  rootLogger.debug({
+    prefix,
+    removed: {
+      dependencyType: 'prod',
+      name: 'no-changes',
+      version: '1.0.0',
+    },
+  })
+  rootLogger.debug({
+    added: {
+      dependencyType: 'prod',
+      id: 'registry.npmjs.org/no-changes/2.0.0',
+      name: 'no-changes',
+      realName: 'no-changes',
+      version: '1.0.0',
+    },
+    prefix,
   })
   rootLogger.debug({
     added: {


### PR DESCRIPTION
before the fix, the summary was printing dependencies that did not change (but their dependencies changed):

![image](https://user-images.githubusercontent.com/1927579/178847418-564ab666-1e5a-4ed2-9fd4-7c43265e78f4.png)

after the fix:

![image](https://user-images.githubusercontent.com/1927579/178847460-440ec2b9-bf11-4a12-984d-b6d022fb23e4.png)
