### PR TITLE
pnpm rebuild accepts --store-dir

### DIFF
--- a/.changeset/rich-plums-mate.md
+++ b/.changeset/rich-plums-mate.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-rebuild": patch
+---
+
+pnpm rebuild accepts --store-dir

--- a/packages/plugin-commands-rebuild/src/rebuild.ts
+++ b/packages/plugin-commands-rebuild/src/rebuild.ts
@@ -21,6 +21,7 @@ export function rcOptionsTypes () {
       'reporter',
       'scripts-prepend-node-path',
       'unsafe-perm',
+      'store-dir',
     ], allTypes),
   }
 }
@@ -54,6 +55,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           {
             description: 'Rebuild packages that were not build during installation. Packages are not build when installing with the --ignore-scripts flag',
             name: '--pending',
+          },
+          {
+            description: 'The directory in which all the packages are saved on the disk',
+            name: '--store-dir <dir>',
           },
           ...UNIVERSAL_OPTIONS,
         ],


### PR DESCRIPTION
### Summary

Make `pnpm rebuild` accepts `--store-dir`

### Detail

#### Before:

```
pnpm install --store-dir <some_dir> --ignore-scripts
pnpm rebuild --store-dir <some_dir> --pending
```

pnpm complains

```
 ERROR   ERROR  Unknown option: 'store-dir'
Did you mean 'stream'? Use "--config.unknown=value" to force an unknown option.
```

#### After:

```
pnpm rebuild --store-dir <some_dir> --pending works
```

#### workaround now

```
pnpm rebuild --config.storeDir=<some_dir> --pending
```
