### PR TITLE
chore(deps): upgrade sinon to v14

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
     "path-name": "^1.0.0",
     "read-yaml-file": "^2.1.0",
     "resolve-link-target": "^2.0.0",
-    "sinon": "^11.1.2",
+    "sinon": "^14.0.0",
     "symlink-dir": "^5.0.1",
     "write-json-file": "^4.3.0",
     "write-yaml-file": "^4.2.0"

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -32,7 +32,7 @@
     "isexe": "2.0.0",
     "load-json-file": "^6.2.0",
     "npm-run-all": "^4.1.5",
-    "sinon": "^11.1.2",
+    "sinon": "^14.0.0",
     "tempy": "^1.0.1",
     "write-json-file": "^4.3.0"
   },

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -50,7 +50,7 @@
     "path-name": "^1.0.0",
     "proxyquire": "^2.1.3",
     "read-yaml-file": "^2.1.0",
-    "sinon": "^11.1.2",
+    "sinon": "^14.0.0",
     "symlink-dir": "^5.0.1",
     "tempy": "^1.0.1",
     "write-json-file": "^4.3.0",

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -44,7 +44,7 @@
     "@types/sinon": "^10.0.12",
     "execa": "npm:safe-execa@^0.1.1",
     "path-exists": "^4.0.0",
-    "sinon": "^11.1.2",
+    "sinon": "^14.0.0",
     "write-yaml-file": "^4.2.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -484,7 +484,7 @@ importers:
       resolve-link-target: ^2.0.0
       run-groups: ^3.0.1
       semver: ^7.3.7
-      sinon: ^11.1.2
+      sinon: ^14.0.0
       symlink-dir: ^5.0.1
       version-selector-type: ^3.0.0
       write-json-file: ^4.3.0
@@ -571,7 +571,7 @@ importers:
       path-name: 1.0.0
       read-yaml-file: 2.1.0
       resolve-link-target: 2.0.0
-      sinon: 11.1.2
+      sinon: 14.0.0
       symlink-dir: 5.0.1
       write-json-file: 4.3.0
       write-yaml-file: 4.2.0
@@ -1175,7 +1175,7 @@ importers:
       path-exists: ^4.0.0
       ramda: ^0.28.0
       realpath-missing: ^1.1.0
-      sinon: ^11.1.2
+      sinon: ^14.0.0
       tempy: ^1.0.1
       write-json-file: ^4.3.0
     dependencies:
@@ -1226,7 +1226,7 @@ importers:
       isexe: 2.0.0
       load-json-file: 6.2.0
       npm-run-all: 4.1.5
-      sinon: 11.1.2
+      sinon: 14.0.0
       tempy: 1.0.1
       write-json-file: 4.3.0
 
@@ -2322,7 +2322,7 @@ importers:
       read-ini-file: ^3.1.0
       read-yaml-file: ^2.1.0
       render-help: ^1.0.2
-      sinon: ^11.1.2
+      sinon: ^14.0.0
       symlink-dir: ^5.0.1
       tempy: ^1.0.1
       version-selector-type: ^3.0.0
@@ -2394,7 +2394,7 @@ importers:
       path-name: 1.0.0
       proxyquire: 2.1.3
       read-yaml-file: 2.1.0
-      sinon: 11.1.2
+      sinon: 14.0.0
       symlink-dir: 5.0.1
       tempy: 1.0.1
       write-json-file: 4.3.0
@@ -2691,7 +2691,7 @@ importers:
       render-help: ^1.0.2
       run-groups: ^3.0.1
       semver: ^7.3.7
-      sinon: ^11.1.2
+      sinon: ^14.0.0
       write-yaml-file: ^4.2.0
     dependencies:
       '@pnpm/cli-utils': link:../cli-utils
@@ -2735,7 +2735,7 @@ importers:
       '@types/sinon': 10.0.12
       execa: /safe-execa/0.1.1
       path-exists: 4.0.0
-      sinon: 11.1.2
+      sinon: 14.0.0
       write-yaml-file: 4.2.0
 
   packages/plugin-commands-script-runners:
@@ -5449,12 +5449,6 @@ packages:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
     dependencies:
       type-detect: 4.0.8
-    dev: true
-
-  /@sinonjs/fake-timers/7.1.2:
-    resolution: {integrity: sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==}
-    dependencies:
-      '@sinonjs/commons': 1.8.3
     dev: true
 
   /@sinonjs/fake-timers/9.1.2:
@@ -11258,7 +11252,7 @@ packages:
     resolution: {integrity: sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==}
     dependencies:
       '@sinonjs/commons': 1.8.3
-      '@sinonjs/fake-timers': 7.1.2
+      '@sinonjs/fake-timers': 9.1.2
       '@sinonjs/text-encoding': 0.7.1
       just-extend: 4.2.1
       path-to-regexp: 1.8.0
@@ -12968,11 +12962,11 @@ packages:
       simple-concat: 1.0.1
     dev: true
 
-  /sinon/11.1.2:
-    resolution: {integrity: sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==}
+  /sinon/14.0.0:
+    resolution: {integrity: sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==}
     dependencies:
       '@sinonjs/commons': 1.8.3
-      '@sinonjs/fake-timers': 7.1.2
+      '@sinonjs/fake-timers': 9.1.2
       '@sinonjs/samsam': 6.1.1
       diff: 5.1.0
       nise: 5.1.1


### PR DESCRIPTION
## Description

v14 drops Node 12 support which doesn't impact us, other changes also don't require code updates, see: https://github.com/sinonjs/sinon/blob/v14.0.0/CHANGES.md

## Changes

- upgrade `sinon` throughout packages to 14.0.0