### PR TITLE
feat: print package name when printing installed dependencies summary

### DIFF
--- a/.changeset/tasty-falcons-serve.md
+++ b/.changeset/tasty-falcons-serve.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": minor
+---
+
+Print package name when printing installed dependencies summary [#1084](https://github.com/pnpm/pnpm/issues/1084).

--- a/packages/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/packages/default-reporter/src/reporterForClient/reportSummary.ts
@@ -42,18 +42,24 @@ export default (
   const pkgsDiff$ = getPkgsDiff(log$, { prefix: opts.cwd })
 
   const summaryLog$ = log$.summary.pipe(take(1))
+  const packageManifest$ = log$.packageManifest.pipe(take(1))
 
-  return Rx.combineLatest(
+  return Rx.combineLatest([
     pkgsDiff$,
-    summaryLog$
-  )
+    packageManifest$,
+    summaryLog$,
+  ])
     .pipe(
       take(1),
-      map(([pkgsDiff]) => {
+      map(([pkgsDiff, packageManifest]) => {
         let msg = ''
         for (const depType of ['prod', 'optional', 'peer', 'dev', 'nodeModulesOnly']) {
           const diffs: PackageDiff[] = Object.values(pkgsDiff[depType])
           if (diffs.length > 0) {
+            if ('initial' in packageManifest && packageManifest.initial.name) {
+              msg += EOL
+              msg += packageManifest.initial.name as string
+            }
             msg += EOL
             if (opts.pnpmConfig?.global) {
               msg += chalk.cyanBright(`${opts.cwd}:`)


### PR DESCRIPTION
## Description

With this PR, each package install/removal diff shows the name based on `package.json` name.

I am open to suggestions for a different color, underlining it, hiding it behind a feature flag, etc.

## Changes
- output package name per package on install diff

Closes https://github.com/pnpm/pnpm/issues/1084

## Screenshot
![Screenshot from 2022-07-17 18-20-14](https://user-images.githubusercontent.com/16797721/179411199-4f0b1467-2058-4acf-a057-483c53460477.png)