### PR TITLE
fix: symlink a workspace pkg correctly, when it has a custom publish dir

### DIFF
--- a/.changeset/chilled-penguins-hang.md
+++ b/.changeset/chilled-penguins-hang.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/exportable-manifest": minor
+---
+
+Accept the module directory path where the dependency's manifest should be read.

--- a/.changeset/fifty-otters-perform.md
+++ b/.changeset/fifty-otters-perform.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"pnpm": patch
+---
+
+It should be possible to publish a package with local dependencies from a custom publish directory (set via `publishConfig.directory`) [#3901](https://github.com/pnpm/pnpm/issues/3901#issuecomment-1194156886).

--- a/.changeset/tasty-elephants-battle.md
+++ b/.changeset/tasty-elephants-battle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/npm-resolver": patch
+"pnpm": patch
+---
+
+When a project in a workspace has a `publishConfig.directory` set, dependent projects should install the project from that directory [#3901](https://github.com/pnpm/pnpm/issues/3901)

--- a/packages/core/test/install/multipleImporters.ts
+++ b/packages/core/test/install/multipleImporters.ts
@@ -11,6 +11,7 @@ import {
   mutateModules,
 } from '@pnpm/core'
 import rimraf from '@zkochan/rimraf'
+import loadJsonFile from 'load-json-file'
 import exists from 'path-exists'
 import pick from 'ramda/src/pick.js'
 import sinon from 'sinon'
@@ -1529,4 +1530,69 @@ test('do not update dependency that has the same name as a dependency in the wor
     '/dep-of-pkg-with-1-dep/100.0.0',
     '/is-negative/2.1.0',
   ])
+})
+
+test('symlink local package from the location described in its publishConfig.directory', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+    {
+      location: 'project-1/dist',
+      package: { name: 'project-1-dist' },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2' },
+    },
+  ])
+
+  const project1Manifest = {
+    name: 'project-1',
+    version: '1.0.0',
+    publishConfig: {
+      directory: 'dist',
+    },
+  }
+  const project2Manifest = {
+    name: 'project-2',
+    version: '1.0.0',
+
+    dependencies: {
+      'project-1': 'workspace:*',
+    },
+  }
+  const importers: MutatedProject[] = [
+    {
+      buildIndex: 0,
+      manifest: project1Manifest,
+      mutation: 'install',
+      rootDir: path.resolve('project-1'),
+    },
+    {
+      buildIndex: 0,
+      manifest: project2Manifest,
+      mutation: 'install',
+      rootDir: path.resolve('project-2'),
+    },
+  ]
+  const workspacePackages = {
+    'project-1': {
+      '1.0.0': {
+        dir: path.resolve('project-1'),
+        manifest: project1Manifest,
+      },
+    },
+    'project-2': {
+      '1.0.0': {
+        dir: path.resolve('project-2'),
+        manifest: project2Manifest,
+      },
+    },
+  }
+  await mutateModules(importers, await testDefaults({ workspacePackages }))
+
+  const linkedManifest = await loadJsonFile<{ name: string }>('project-2/node_modules/project-1/package.json')
+  expect(linkedManifest.name).toBe('project-1-dist')
 })

--- a/packages/plugin-commands-publishing/src/pack.ts
+++ b/packages/plugin-commands-publishing/src/pack.ts
@@ -110,6 +110,7 @@ export async function handler (
     filesMap,
     projectDir: dir,
     embedReadme: opts.embedReadme,
+    modulesDir: path.join(opts.dir, 'node_modules'),
   })
   if (!opts.ignoreScripts) {
     await _runScriptsIfPresent(['postpack'], entryManifest)
@@ -132,6 +133,7 @@ async function packPkg (opts: {
   filesMap: Record<string, string>
   projectDir: string
   embedReadme?: boolean
+  modulesDir: string
 }): Promise<void> {
   const {
     destFile,
@@ -152,7 +154,7 @@ async function packPkg (opts: {
     const mode = isExecutable ? 0o755 : 0o644
     if (/^package\/package\.(json|json5|yaml)/.test(name)) {
       const readmeFile = embedReadme ? await readReadmeFile(filesMap) : undefined
-      const publishManifest = await exportableManifest(projectDir, manifest, { readmeFile })
+      const publishManifest = await exportableManifest(projectDir, manifest, { readmeFile, modulesDir: opts.modulesDir })
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(publishManifest, null, 2))
       continue
     }


### PR DESCRIPTION
- [x] add tests
- ~when the directory setting changes, `pnpm install` should update the symlink~ will be done in a separate PR

close #3901