### PR TITLE
fix: don't incorrectly identify a lockfile out-of-date

### DIFF
--- a/.changeset/eighty-cheetahs-shout.md
+++ b/.changeset/eighty-cheetahs-shout.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile-file": patch
+"pnpm": patch
+---
+
+Don't incorrectly identify a lockfile out-of-date when the package has a publishConfig.directory field [#5124](https://github.com/pnpm/pnpm/issues/5124).

--- a/packages/lockfile-file/src/read.ts
+++ b/packages/lockfile-file/src/read.ts
@@ -231,6 +231,7 @@ function convertFromLockfileFileMutable (lockfileFile: LockfileFile): Lockfile {
       '.': {
         specifiers: lockfileFile['specifiers'] ?? {},
         dependenciesMeta: lockfileFile['dependenciesMeta'],
+        publishDirectory: lockfileFile['publishDirectory'],
       },
     }
     delete lockfileFile.specifiers

--- a/packages/lockfile-file/test/read.test.ts
+++ b/packages/lockfile-file/test/read.test.ts
@@ -27,6 +27,7 @@ test('readWantedLockfile()', async () => {
         dependenciesMeta: {
           foo: { injected: true },
         },
+        publishDirectory: undefined,
       },
     })
   }


### PR DESCRIPTION
when the package has a publishConfig.directory field

close #5124