### PR TITLE
fix: don't crash on a .npmrc with missing env var

### DIFF
--- a/.changeset/three-mugs-hide.md
+++ b/.changeset/three-mugs-hide.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": patch
+"pnpm": patch
+---
+
+Don't crash when a config file contains a setting with an env variable that doesn't exist [#5093](https://github.com/pnpm/pnpm/issues/5093).

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -36,7 +36,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/git-utils": "workspace:*",
     "@pnpm/matcher": "workspace:*",
-    "@pnpm/npm-conf": "1.0.5",
+    "@pnpm/npm-conf": "2.0.0",
     "@pnpm/pnpmfile": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -144,7 +144,6 @@ export default async (
   const env = opts.env ?? process.env
   const packageManager = opts.packageManager ?? { name: 'pnpm', version: 'undefined' }
   const cliOptions = opts.cliOptions ?? {}
-  const warnings = new Array<string>()
 
   if (cliOptions['hoist'] === false) {
     if (cliOptions['shamefully-hoist'] === true) {
@@ -176,7 +175,7 @@ export default async (
     cliOptions['prefix'] = cliOptions.dir // the npm config system still expects `prefix`
   }
   const rcOptionsTypes = { ...types, ...opts.rcOptionsTypes }
-  const npmConfig = loadNpmConf(cliOptions, rcOptionsTypes, {
+  const { config: npmConfig, warnings } = loadNpmConf(cliOptions, rcOptionsTypes, {
     'auto-install-peers': false,
     bail: true,
     color: 'auto',

--- a/packages/config/test/index.ts
+++ b/packages/config/test/index.ts
@@ -912,3 +912,16 @@ test('preferSymlinkedExecutables should be true when nodeLinker is hoisted', asy
   })
   expect(config.preferSymlinkedExecutables).toBeTruthy()
 })
+
+test('return a warning when the .npmrc has an env variable that does not exist', async () => {
+  await fs.writeFile('.npmrc', 'foo=${ENV_VAR_123}', 'utf8') // eslint-disable-line
+  const { warnings } = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+
+  expect(warnings[0]).toContain('Failed to replace env in config: ${ENV_VAR_123}') // eslint-disable-line
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,8 +475,8 @@ importers:
         specifier: workspace:*
         version: link:../matcher
       '@pnpm/npm-conf':
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 2.0.0
+        version: 2.0.0
       '@pnpm/pnpmfile':
         specifier: workspace:*
         version: link:../pnpmfile
@@ -5519,7 +5519,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.17.10
+      '@babel/types': 7.18.9
     dev: true
 
   /@babel/parser/7.18.9:
@@ -6752,8 +6752,8 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@pnpm/npm-conf/1.0.5:
-    resolution: {integrity: sha512-hD8ml183638O3R6/Txrh0L8VzGOrFXgRtRDG4qQC4tONdZ5Z1M+tlUUDUvrjYdmK6G+JTBTeaCLMna11cXzi8A==}
+  /@pnpm/npm-conf/2.0.0:
+    resolution: {integrity: sha512-Ot3xJvdbRQ3fwtDeRYMik/97BbCKij9ZupSgY1tJLCzPPgYRTIIjwdOBHQX2qGbwqNeKd6EneMyKAAsUMO09Bw==}
     engines: {node: '>=12'}
     dependencies:
       '@pnpm/network.ca-file': 1.0.1


### PR DESCRIPTION
close #5093