### PR TITLE
Change "up-to-date" to "up to date" where necessary

### DIFF
--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -301,7 +301,7 @@ export async function mutateModules (
         if (maybeOpts.ignorePackageManifest) {
           logger.info({ message: 'Importing packages to virtual store', prefix: opts.lockfileDir })
         } else {
-          logger.info({ message: 'Lockfile is up-to-date, resolution step is skipped', prefix: opts.lockfileDir })
+          logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
         }
         try {
           await headless({
@@ -760,7 +760,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     ctx.lockfileHadConflicts
 
   // Ignore some fields when fixing lockfile, so these fields can be regenerated
-  // and make sure it's up-to-date
+  // and make sure it's up to date
   if (
     opts.fixLockfile &&
     (ctx.wantedLockfile.packages != null) &&

--- a/packages/core/test/install/autoInstallPeers.ts
+++ b/packages/core/test/install/autoInstallPeers.ts
@@ -168,7 +168,7 @@ test('automatically install root peer dependencies', async () => {
     })
   }
 
-  // Automatically install the peer dependency when the lockfile is up-to-date
+  // Automatically install the peer dependency when the lockfile is up to date
   await rimraf('node_modules')
 
   await install(manifest, await testDefaults({ autoInstallPeers: true, frozenLockfile: true }))

--- a/packages/core/test/install/frozenLockfile.ts
+++ b/packages/core/test/install/frozenLockfile.ts
@@ -27,7 +27,7 @@ test(`frozen-lockfile: installation fails if specs in package.json don't match t
         'is-positive': '^3.1.0',
       },
     }, await testDefaults({ frozenLockfile: true }))
-  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up-to-date with package.json`)
+  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with package.json`)
 })
 
 test(`frozen-lockfile+hoistPattern: installation fails if specs in package.json don't match the ones in ${WANTED_LOCKFILE}`, async () => {
@@ -45,7 +45,7 @@ test(`frozen-lockfile+hoistPattern: installation fails if specs in package.json 
         'is-positive': '^3.1.0',
       },
     }, await testDefaults({ frozenLockfile: true, hoistPattern: '*' }))
-  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up-to-date with package.json`)
+  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with package.json`)
 })
 
 test(`frozen-lockfile: fail on a shared ${WANTED_LOCKFILE} that does not satisfy one of the package.json files`, async () => {
@@ -87,7 +87,7 @@ test(`frozen-lockfile: fail on a shared ${WANTED_LOCKFILE} that does not satisfy
 
   await expect(
     mutateModules(projects, await testDefaults({ frozenLockfile: true }))
-  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up-to-date with p1${path.sep}package.json`)
+  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with p1${path.sep}package.json`)
 })
 
 test(`frozen-lockfile: should successfully install when ${WANTED_LOCKFILE} is available`, async () => {
@@ -134,7 +134,7 @@ test(`prefer-frozen-lockfile: should prefer headless installation when ${WANTED_
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 
@@ -161,7 +161,7 @@ test(`prefer-frozen-lockfile: should not prefer headless installation when ${WAN
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeFalsy()
 
@@ -200,7 +200,7 @@ test(`prefer-frozen-lockfile+hoistPattern: should prefer headless installation w
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 
@@ -262,7 +262,7 @@ test('prefer-frozen-lockfile: should prefer frozen-lockfile when package has lin
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 

--- a/packages/core/test/install/misc.ts
+++ b/packages/core/test/install/misc.ts
@@ -926,7 +926,7 @@ test('do not update deps when lockfile is present', async () => {
   expect(initialLockfile).toStrictEqual(latestLockfile)
 })
 
-test('all the subdeps of dependencies are linked when a node_modules is partially up-to-date', async () => {
+test('all the subdeps of dependencies are linked when a node_modules is partially up to date', async () => {
   prepareEmpty()
 
   await mutateModules([

--- a/packages/core/test/install/multipleImporters.ts
+++ b/packages/core/test/install/multipleImporters.ts
@@ -398,7 +398,7 @@ test('headless install is used when package linked to another package in the wor
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 
@@ -462,7 +462,7 @@ test('headless install is used with an up-to-date lockfile when package referenc
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 
@@ -537,7 +537,7 @@ test('headless install is used when packages are not linked from the workspace (
 
   expect(reporter.calledWithMatch({
     level: 'info',
-    message: 'Lockfile is up-to-date, resolution step is skipped',
+    message: 'Lockfile is up to date, resolution step is skipped',
     name: 'pnpm',
   })).toBeTruthy()
 })

--- a/packages/core/test/lockfile.ts
+++ b/packages/core/test/lockfile.ts
@@ -1033,7 +1033,7 @@ test('lockfile is not getting broken if the used registry changes', async () => 
   ])
 })
 
-test('broken lockfile is fixed even if it seems like up-to-date at first. Unless frozenLockfile option is set to true', async () => {
+test('broken lockfile is fixed even if it seems like up to date at first. Unless frozenLockfile option is set to true', async () => {
   const project = prepareEmpty()
   await addDistTag({ package: 'dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
 

--- a/packages/default-reporter/src/reporterForClient/reportStats.ts
+++ b/packages/default-reporter/src/reporterForClient/reportStats.ts
@@ -69,7 +69,7 @@ function statsForCurrentPackage (
         if (opts.cmd === 'link') {
           return Rx.NEVER
         }
-        return Rx.of({ msg: 'Already up-to-date' })
+        return Rx.of({ msg: 'Already up to date' })
       }
 
       let msg = 'Packages:'

--- a/packages/default-reporter/test/reportingProgress.ts
+++ b/packages/default-reporter/test/reportingProgress.ts
@@ -280,7 +280,7 @@ test('moves fixed line to the end', (done) => {
   })
 })
 
-test('prints "Already up-to-date"', (done) => {
+test('prints "Already up to date"', (done) => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -297,7 +297,7 @@ test('prints "Already up-to-date"', (done) => {
     complete: () => done(),
     error: done,
     next: output => {
-      expect(output).toBe('Already up-to-date')
+      expect(output).toBe('Already up to date')
     },
   })
 })

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -175,7 +175,7 @@ export default async (opts: HeadlessOptions) => {
     for (const { id, manifest, rootDir } of opts.projects) {
       if (!satisfiesPackageManifest(wantedLockfile, manifest, id, { autoInstallPeers: opts.autoInstallPeers })) {
         throw new PnpmError('OUTDATED_LOCKFILE',
-          `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up-to-date with ` +
+          `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with ` +
           path.relative(lockfileDir, path.join(rootDir, 'package.json')), {
             hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
           })

--- a/packages/headless/test/index.ts
+++ b/packages/headless/test/index.ts
@@ -458,7 +458,7 @@ test('available packages are relinked during forced install', async () => {
   })).toBeTruthy()
 })
 
-test(`fail when ${WANTED_LOCKFILE} is not up-to-date with package.json`, async () => {
+test(`fail when ${WANTED_LOCKFILE} is not up to date with package.json`, async () => {
   const projectDir = tempDir()
 
   const simpleDir = f.find('simple')
@@ -471,7 +471,7 @@ test(`fail when ${WANTED_LOCKFILE} is not up-to-date with package.json`, async (
     await headless(await testDefaults({ lockfileDir: projectDir }))
     throw new Error()
   } catch (err: any) { // eslint-disable-line
-    expect(err.message).toBe(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up-to-date with package.json`)
+    expect(err.message).toBe(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with package.json`)
   }
 })
 

--- a/packages/plugin-commands-installation/src/update/index.ts
+++ b/packages/plugin-commands-installation/src/update/index.ts
@@ -202,9 +202,9 @@ async function interactiveUpdate (
   const choices = getUpdateChoices(unnest(outdatedPkgsOfProjects))
   if (choices.length === 0) {
     if (opts.latest) {
-      return 'All of your dependencies are already up-to-date'
+      return 'All of your dependencies are already up to date'
     }
-    return 'All of your dependencies are already up-to-date inside the specified ranges. Use the --latest option to update the ranges in package.json'
+    return 'All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json'
   }
   const { updateDependencies } = await prompt({
     choices,

--- a/packages/plugin-commands-publishing/src/publish.ts
+++ b/packages/plugin-commands-publishing/src/publish.ts
@@ -54,7 +54,7 @@ export function help () {
 
         list: [
           {
-            description: "Don't check if current branch is your publish branch, clean, and up-to-date",
+            description: "Don't check if current branch is your publish branch, clean, and up to date",
             name: '--no-git-checks',
           },
           {

--- a/packages/plugin-commands-publishing/test/gitChecks.ts
+++ b/packages/plugin-commands-publishing/test/gitChecks.ts
@@ -105,7 +105,7 @@ test('publish: fails git check if branch is not clean', async () => {
   )
 })
 
-test('publish: fails git check if branch is not up-to-date', async () => {
+test('publish: fails git check if branch is not up to date', async () => {
   const remote = tempy.directory()
 
   prepare({

--- a/packages/plugin-commands-setup/src/setup.ts
+++ b/packages/plugin-commands-setup/src/setup.ts
@@ -94,7 +94,7 @@ export async function handler (
 
 function renderSetupOutput (report: PathExtenderReport) {
   if (report.oldSettings === report.newSettings) {
-    return 'No changes to the environment were made. Everything is already up-to-date.'
+    return 'No changes to the environment were made. Everything is already up to date.'
   }
   const output = []
   if (report.configFile) {
@@ -111,6 +111,6 @@ function reportConfigChange (configReport: ConfigReport): string {
   case 'created': return `Created ${configReport.path}`
   case 'appended': return `Appended new lines to ${configReport.path}`
   case 'modified': return `Replaced configuration in ${configReport.path}`
-  case 'skipped': return `Configuration already up-to-date in ${configReport.path}`
+  case 'skipped': return `Configuration already up to date in ${configReport.path}`
   }
 }

--- a/packages/plugin-commands-setup/test/setup.test.ts
+++ b/packages/plugin-commands-setup/test/setup.test.ts
@@ -14,7 +14,7 @@ test('setup makes no changes', async () => {
     newSettings: 'PNPM_HOME=dir',
   }))
   const output = await setup.handler({ pnpmHomeDir: '' })
-  expect(output).toBe('No changes to the environment were made. Everything is already up-to-date.')
+  expect(output).toBe('No changes to the environment were made. Everything is already up to date.')
 })
 
 test('setup makes changes on POSIX', async () => {


### PR DESCRIPTION
The correct usage is _[noun] is up to date_ and _an up-to-date [noun]_. That is, hyphens are only used when _up-to-date_ is used as an adjective preceding a noun. Two examples from the New Oxford American Dictionary for reference:

> a modern, up-to-date hospital

> the book will keep you up to date