### PR TITLE
fix: read package manifest when verifyStoreIntegrity is false

### DIFF
--- a/.changeset/silent-turtles-suffer.md
+++ b/.changeset/silent-turtles-suffer.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/cafs": minor
+"@pnpm/package-requester": patch
+"pnpm": patch
+---
+
+Fix bug where the package manifest was not resolved if `verifyStoreIntegrity` is set to `false`.

--- a/packages/cafs/src/index.ts
+++ b/packages/cafs/src/index.ts
@@ -11,6 +11,7 @@ import checkFilesIntegrity, {
   PackageFilesIndex,
   verifyFileIntegrity,
 } from './checkFilesIntegrity'
+import readManifestFromStore from './readManifestFromStore'
 import getFilePathInCafs, {
   contentPathFromHex,
   FileType,
@@ -19,10 +20,9 @@ import getFilePathInCafs, {
 } from './getFilePathInCafs'
 import writeFile from './writeFile'
 
-export { parseJsonBuffer } from './parseJson'
-
 export {
   checkFilesIntegrity,
+  readManifestFromStore,
   FileType,
   getFilePathByModeInCafs,
   getFilePathInCafs,

--- a/packages/cafs/src/index.ts
+++ b/packages/cafs/src/index.ts
@@ -19,6 +19,8 @@ import getFilePathInCafs, {
 } from './getFilePathInCafs'
 import writeFile from './writeFile'
 
+export { parseJsonBuffer } from './parseJson'
+
 export {
   checkFilesIntegrity,
   FileType,

--- a/packages/cafs/src/readManifestFromStore.ts
+++ b/packages/cafs/src/readManifestFromStore.ts
@@ -1,0 +1,23 @@
+import { DeferredManifestPromise, PackageFileInfo } from '@pnpm/fetcher-base'
+import gfs from '@pnpm/graceful-fs'
+import { getFilePathByModeInCafs } from './getFilePathInCafs'
+import { parseJsonBuffer } from './parseJson'
+
+export default async function readManifestFromStore (
+  cafsDir: string,
+  pkgIndex: Record<string, PackageFileInfo>,
+  deferredManifest?: DeferredManifestPromise
+) {
+  const pkg = pkgIndex['package.json']
+
+  if (deferredManifest) {
+    if (pkg) {
+      const fileName = getFilePathByModeInCafs(cafsDir, pkg.integrity, pkg.mode)
+      parseJsonBuffer(await gfs.readFile(fileName), deferredManifest)
+    } else {
+      deferredManifest.resolve(undefined)
+    }
+  }
+
+  return true
+}

--- a/packages/package-requester/src/packageRequester.ts
+++ b/packages/package-requester/src/packageRequester.ts
@@ -119,10 +119,13 @@ export default function (
 
         const pkg = pkgIndex['package.json']
 
-        if (pkg && deferredManifest) {
-          const fileName = _getFilePathByModeInCafs(cafsDir, pkg.integrity, pkg.mode)
-
-          _parseJsonBuffer(await gfs.readFile(fileName), deferredManifest)
+        if (deferredManifest) {
+          if (pkg) {
+            const fileName = _getFilePathByModeInCafs(cafsDir, pkg.integrity, pkg.mode)
+            _parseJsonBuffer(await gfs.readFile(fileName), deferredManifest)
+          } else {
+            deferredManifest.resolve(undefined)
+          }
         }
 
         return true


### PR DESCRIPTION
This PR fixes an issue where `verifyStoreIntegrity` is set to `false`. The problem was that `checkFilesIntegrity` is called with a deferred promise which is expected to be resolved, however, it was not. This PR makes sure that if integrity checks are disabled that it will still read the package manifest and resolve the promise properly.