### PR TITLE
build: update used versions in github workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
         git config --global user.name "xyz"
         git config --global user.email "x@y.z"
     - name: Checkout Commit
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Install pnpm
       uses: pnpm/action-setup@v2.2.2
       with:
         version: next-7
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
         cache: 'pnpm'
@@ -42,7 +42,7 @@ jobs:
     - name: Audit
       run: pnpm audit
     - name: Cache TypeScript and Jest
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           packages/*/lib

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,11 +42,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install ldid
         run: |
           sudo apt-get update

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
     - name: Update tag
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

I noticed that some GitHub actions are outdated, so upgraded them to latest which might lead to faster CI runs.

## Changes

- update all `actions/*` to v3
- update all `github/codeql-action/*` to v2