### PR TITLE
refactor: autoremove redundant disabled lint occurrences

### DIFF
--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -49,7 +49,7 @@ function getAuthHeaders (
 ) {
   const headers: { authorization?: string } = {}
   if (credentials.alwaysAuth && credentials.authHeaderValue) {
-    headers['authorization'] = credentials.authHeaderValue // eslint-disable-line
+    headers['authorization'] = credentials.authHeaderValue
   }
   return headers
 }

--- a/packages/core-loggers/src/deprecationLogger.ts
+++ b/packages/core-loggers/src/deprecationLogger.ts
@@ -3,7 +3,7 @@ import baseLogger, {
   Logger,
 } from '@pnpm/logger'
 
-export const deprecationLogger = baseLogger('deprecation') as Logger<DeprecationMessage> // eslint-disable-line
+export const deprecationLogger = baseLogger('deprecation') as Logger<DeprecationMessage>
 
 export interface DeprecationMessage {
   pkgName: string

--- a/packages/core-loggers/src/fetchingProgressLogger.ts
+++ b/packages/core-loggers/src/fetchingProgressLogger.ts
@@ -3,7 +3,7 @@ import baseLogger, {
   Logger,
 } from '@pnpm/logger'
 
-export const fetchingProgressLogger = baseLogger('fetching-progress') as Logger<FetchingProgressMessage> // eslint-disable-line
+export const fetchingProgressLogger = baseLogger('fetching-progress') as Logger<FetchingProgressMessage>
 
 export type FetchingProgressMessage = {
   attempt: number

--- a/packages/core-loggers/src/progressLogger.ts
+++ b/packages/core-loggers/src/progressLogger.ts
@@ -3,7 +3,7 @@ import baseLogger, {
   Logger,
 } from '@pnpm/logger'
 
-export const progressLogger = baseLogger('progress') as Logger<ProgressMessage> // eslint-disable-line
+export const progressLogger = baseLogger('progress') as Logger<ProgressMessage>
 
 export type ProgressMessage = {
   packageId: string

--- a/packages/core/src/install/extendInstallOptions.ts
+++ b/packages/core/src/install/extendInstallOptions.ts
@@ -221,6 +221,6 @@ export default async (
     extendedOpts.userAgent = `${extendedOpts.packageManager.name}/${extendedOpts.packageManager.version} ${extendedOpts.userAgent}`
   }
   extendedOpts.registries = normalizeRegistries(extendedOpts.registries)
-  extendedOpts.rawConfig['registry'] = extendedOpts.registries.default // eslint-disable-line @typescript-eslint/dot-notation
+  extendedOpts.rawConfig['registry'] = extendedOpts.registries.default
   return extendedOpts
 }

--- a/packages/core/src/install/index.ts
+++ b/packages/core/src/install/index.ts
@@ -406,7 +406,7 @@ export async function mutateModules (
               continue
             }
           } catch (err: any) { // eslint-disable-line
-            if (err['code'] !== 'ENOENT') throw err // eslint-disable-line @typescript-eslint/dot-notation
+            if (err['code'] !== 'ENOENT') throw err
           }
           await rimraf(path.join(project.modulesDir, depName))
           if (allDeps[depName]) {

--- a/packages/core/src/parseWantedDependencies.ts
+++ b/packages/core/src/parseWantedDependencies.ts
@@ -21,7 +21,6 @@ export default function parseWantedDependencies (
   return rawWantedDependencies
     .map((rawWantedDependency) => {
       const parsed = parseWantedDependency(rawWantedDependency)
-      /* eslint-disable @typescript-eslint/dot-notation */
       const alias = parsed['alias']
       let pref = parsed['pref']
       let pinnedVersion!: PinnedVersion | undefined

--- a/packages/core/test/api.ts
+++ b/packages/core/test/api.ts
@@ -10,7 +10,6 @@ test('API', () => {
 // maybe a new property should be introduced
 // this seems illogical as even though all save types are false,
 // the dependency will be saved
-// eslint-disable-next-line @typescript-eslint/dot-notation
 test.skip('install fails when all saving types are false', async () => {
   try {
     await pnpm.install({}, await testDefaults({ save: false, saveDev: false, saveOptional: false }))

--- a/packages/core/test/breakingChanges.ts
+++ b/packages/core/test/breakingChanges.ts
@@ -46,7 +46,6 @@ test("don't fail on non-compatible node_modules when forced in a workspace", asy
 
   process.chdir('..')
 
-  // eslint-disable-next-line
   await fs.writeFile('node_modules/.modules.yaml', `packageManager: pnpm@${3}\nstore: ${opts.storeDir}\nlayoutVersion: 1`)
 
   await install(manifest, { ...opts, dir: path.resolve('pkg'), lockfileDir: process.cwd() })

--- a/packages/core/test/install/fromRepo.ts
+++ b/packages/core/test/install/fromRepo.ts
@@ -142,7 +142,6 @@ test('from a git repo', async () => {
 })
 
 // This test is unstable due to dependency on third party registry
-// eslint-disable-next-line @typescript-eslint/dot-notation
 test.skip('from a non-github git repo', async () => {
   const project = prepareEmpty()
 

--- a/packages/core/test/install/hooks.ts
+++ b/packages/core/test/install/hooks.ts
@@ -27,7 +27,7 @@ test('readPackage, afterAllResolved hooks', async () => {
   }
 
   const afterAllResolved = jest.fn((lockfile: Lockfile) => {
-    lockfile['foo'] = 'foo' // eslint-disable-line
+    lockfile['foo'] = 'foo'
     return lockfile
   })
 
@@ -43,7 +43,7 @@ test('readPackage, afterAllResolved hooks', async () => {
   expect(afterAllResolved.mock.calls[0][0].lockfileVersion).toEqual(LOCKFILE_VERSION)
 
   const wantedLockfile = await project.readLockfile()
-  expect(wantedLockfile['foo']).toEqual('foo') // eslint-disable-line @typescript-eslint/dot-notation
+  expect(wantedLockfile['foo']).toEqual('foo')
 })
 
 test('readPackage, afterAllResolved async hooks', async () => {
@@ -65,7 +65,7 @@ test('readPackage, afterAllResolved async hooks', async () => {
   }
 
   const afterAllResolved = jest.fn(async (lockfile: Lockfile) => {
-    lockfile['foo'] = 'foo' // eslint-disable-line
+    lockfile['foo'] = 'foo'
     return lockfile
   })
 
@@ -81,5 +81,5 @@ test('readPackage, afterAllResolved async hooks', async () => {
   expect(afterAllResolved.mock.calls[0][0].lockfileVersion).toEqual(LOCKFILE_VERSION)
 
   const wantedLockfile = await project.readLockfile()
-  expect(wantedLockfile['foo']).toEqual('foo') // eslint-disable-line @typescript-eslint/dot-notation
+  expect(wantedLockfile['foo']).toEqual('foo')
 })

--- a/packages/core/test/install/lockfileDir.ts
+++ b/packages/core/test/install/lockfileDir.ts
@@ -19,7 +19,7 @@ test.skip('subsequent installation uses same lockfile directory by default', asy
 
   const lockfile = await readYamlFile<Lockfile>(path.resolve('..', WANTED_LOCKFILE))
 
-  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['/is-negative/1.0.0', '/is-positive/1.0.0']) // eslint-disable-line @typescript-eslint/dot-notation
+  expect(Object.keys(lockfile.packages ?? {})).toStrictEqual(['/is-negative/1.0.0', '/is-positive/1.0.0'])
 })
 
 test.skip('subsequent installation fails if a different lockfile directory is specified', async () => {

--- a/packages/core/test/install/misc.ts
+++ b/packages/core/test/install/misc.ts
@@ -425,7 +425,6 @@ test('refetch package to store if it has been modified', async () => {
 })
 
 // TODO: decide what to do with this case
-// eslint-disable-next-line @typescript-eslint/dot-notation
 test.skip('relink package to project if the dependency is not linked from store', async () => {
   prepareEmpty()
   const manifest = await addDependenciesToPackage({}, ['magic-hook@2.0.0'], await testDefaults({ save: true, pinnedVersion: 'patch' }))

--- a/packages/core/test/install/peerDependencies.ts
+++ b/packages/core/test/install/peerDependencies.ts
@@ -497,7 +497,6 @@ test('peer dependencies are linked when running two separate named installations
   expect(deepRequireCwd(['abc-grand-parent-with-c', 'abc-parent-with-ab', 'abc', 'peer-c', './package.json']).version).toBe('1.0.0')
 })
 
-// eslint-disable-next-line @typescript-eslint/dot-notation
 test.skip('peer dependencies are linked', async () => {
   const project = prepareEmpty()
   await install({
@@ -620,7 +619,7 @@ test('peer dependency is grouped with dependent when the peer is a top dependenc
 
   const lockfile = await readYamlFile<Lockfile>(path.join('..', WANTED_LOCKFILE))
 
-  expect(lockfile.importers.project).toStrictEqual({ // eslint-disable-line
+  expect(lockfile.importers.project).toStrictEqual({
     dependencies: {
       ajv: '4.10.4',
       'ajv-keywords': '1.5.0_ajv@4.10.4',

--- a/packages/core/test/link.ts
+++ b/packages/core/test/link.ts
@@ -84,7 +84,7 @@ test('relative link is not rewritten by argumentless install', async () => {
       dir: process.cwd(),
       manifest: {},
       reporter,
-    }) // eslint-disable-line @typescript-eslint/no-explicit-any
+    })
 
   expect(reporter.calledWithMatch({
     added: {

--- a/packages/core/test/lockfile.ts
+++ b/packages/core/test/lockfile.ts
@@ -437,9 +437,9 @@ test('scoped module from different registry', async () => {
   const project = prepareEmpty()
 
   const opts = await testDefaults()
-  opts.registries!.default = 'https://registry.npmjs.org/' // eslint-disable-line
-  opts.registries!['@zkochan'] = `http://localhost:${REGISTRY_MOCK_PORT}` // eslint-disable-line
-  opts.registries!['@foo'] = `http://localhost:${REGISTRY_MOCK_PORT}` // eslint-disable-line
+  opts.registries!.default = 'https://registry.npmjs.org/'
+  opts.registries!['@zkochan'] = `http://localhost:${REGISTRY_MOCK_PORT}`
+  opts.registries!['@foo'] = `http://localhost:${REGISTRY_MOCK_PORT}`
   await addDependenciesToPackage({}, ['@zkochan/foo', '@foo/has-dep-from-same-scope', 'is-positive'], opts)
 
   await project.has('@zkochan/foo')
@@ -810,7 +810,7 @@ test('lockfile file has correct format when lockfile directory does not equal th
 
   const modules = await readYamlFile<object>(path.resolve('node_modules', '.modules.yaml'))
   expect(modules).toBeTruthy()
-  expect(modules['pendingBuilds'].length).toBe(0) // eslint-disable-line @typescript-eslint/dot-notation
+  expect(modules['pendingBuilds'].length).toBe(0)
 
   {
     const lockfile: Lockfile = await readYamlFile(WANTED_LOCKFILE)
@@ -862,8 +862,8 @@ test('lockfile file has correct format when lockfile directory does not equal th
     expect(lockfile.packages).toHaveProperty([id])
     expect(lockfile.packages![id].dependencies).toBeTruthy()
     expect(lockfile.packages![id].dependencies).toHaveProperty(['dep-of-pkg-with-1-dep'])
-    expect(lockfile.packages![id].resolution).toHaveProperty(['integrity']) // eslint-disable-line
-    expect(lockfile.packages![id].resolution).not.toHaveProperty(['tarball']) // eslint-disable-line
+    expect(lockfile.packages![id].resolution).toHaveProperty(['integrity'])
+    expect(lockfile.packages![id].resolution).not.toHaveProperty(['tarball'])
 
     const absDepPath = 'github.com/kevva/is-negative/1d7e288222b53a0cab90a331f1865220ec29560c'
     expect(lockfile.packages).toHaveProperty([absDepPath])

--- a/packages/core/test/utils/testDefaults.ts
+++ b/packages/core/test/utils/testDefaults.ts
@@ -21,7 +21,7 @@ export default async function testDefaults<T> (
     fastUnpack?: boolean
     storeDir?: string
     prefix?: string
-  }, // eslint-disable-line
+  },
   resolveOpts?: any, // eslint-disable-line
   fetchOpts?: any, // eslint-disable-line
   storeOpts?: any // eslint-disable-line

--- a/packages/fetch/src/fetchFromRegistry.ts
+++ b/packages/fetch/src/fetchFromRegistry.ts
@@ -90,7 +90,7 @@ function getHeaders (
     accept: opts.fullMetadata === true ? JSON_DOC : CORGI_DOC,
   }
   if (opts.auth) {
-    headers['authorization'] = opts.auth // eslint-disable-line
+    headers['authorization'] = opts.auth
   }
   if (opts.userAgent) {
     headers['user-agent'] = opts.userAgent

--- a/packages/find-workspace-packages/src/index.ts
+++ b/packages/find-workspace-packages/src/index.ts
@@ -45,7 +45,7 @@ async function requirePackagesManifest (dir: string): Promise<{packages?: string
   try {
     return await readYamlFile<{ packages?: string[] }>(path.join(dir, WORKSPACE_MANIFEST_FILENAME))
   } catch (err: any) { // eslint-disable-line
-    if (err['code'] === 'ENOENT') { // eslint-disable-line
+    if (err['code'] === 'ENOENT') {
       return null
     }
     throw err

--- a/packages/get-context/src/readLockfiles.ts
+++ b/packages/get-context/src/readLockfiles.ts
@@ -98,7 +98,6 @@ export default async function (
       }
     })()
   )
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   const files = await Promise.all<Lockfile | null | undefined>(fileReads)
   const sopts = { lockfileVersion: LOCKFILE_VERSION }
   const importerIds = opts.projects.map((importer) => importer.id)

--- a/packages/lifecycle/src/index.ts
+++ b/packages/lifecycle/src/index.ts
@@ -54,6 +54,6 @@ async function checkBindingGyp (
   scripts: {}
 ) {
   if (await exists(path.join(root, 'binding.gyp'))) {
-    scripts['install'] = 'node-gyp rebuild' // eslint-disable-line @typescript-eslint/dot-notation
+    scripts['install'] = 'node-gyp rebuild'
   }
 }

--- a/packages/local-resolver/src/parsePref.ts
+++ b/packages/local-resolver/src/parsePref.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import PnpmError from '@pnpm/error'
 import normalize from 'normalize-path'
 
-// eslint-disable-next-line
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
 const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
 const isFilename = /[.](?:tgz|tar.gz|tar)$/i
@@ -43,7 +42,6 @@ export default function parsePref (
   if (wd.pref.startsWith('path:')) {
     const err = new PnpmError('PATH_IS_UNSUPPORTED_PROTOCOL', 'Local dependencies via `path:` protocol are not supported. ' +
       'Use the `link:` protocol for folder dependencies and `file:` for local tarballs')
-    /* eslint-disable @typescript-eslint/dot-notation */
     err['pref'] = wd.pref
     err['protocol'] = 'path:'
     /* eslint-enable @typescript-eslint/dot-notation */

--- a/packages/lockfile-utils/src/pkgSnapshotToResolution.ts
+++ b/packages/lockfile-utils/src/pkgSnapshotToResolution.ts
@@ -11,7 +11,6 @@ export default (
   pkgSnapshot: PackageSnapshot,
   registries: Registries
 ): Resolution => {
-  /* eslint-disable @typescript-eslint/dot-notation */
   if (pkgSnapshot.resolution['type'] || pkgSnapshot.resolution['tarball']?.startsWith('file:')) {
     return pkgSnapshot.resolution as Resolution
   }

--- a/packages/modules-cleaner/src/prune.ts
+++ b/packages/modules-cleaner/src/prune.ts
@@ -242,7 +242,6 @@ function getPkgsDepPathsOwnedOnlyByImporters (
       include,
       skipped,
     })
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const packagesOfSelectedOnly = pickAll(difference(Object.keys(selected.packages!), Object.keys(other.packages!)), selected.packages!) as PackageSnapshots
   return getPkgsDepPaths(registries, packagesOfSelectedOnly, skipped)
 }

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -93,7 +93,7 @@ export default async function outdated (
 
           // It might be not the best solution to check for pkgSnapshot.name
           // TODO: add some other field to distinct packages not from the registry
-          if (pkgSnapshot.resolution && (pkgSnapshot.resolution['type'] || pkgSnapshot.name)) { // eslint-disable-line @typescript-eslint/dot-notation
+          if (pkgSnapshot.resolution && (pkgSnapshot.resolution['type'] || pkgSnapshot.name)) {
             if (current !== wanted) {
               outdated.push({
                 alias,

--- a/packages/package-requester/src/packageRequester.ts
+++ b/packages/package-requester/src/packageRequester.ts
@@ -104,8 +104,8 @@ export default function (
   const requestsQueue = new PQueue({
     concurrency: networkConcurrency,
   })
-  requestsQueue['counter'] = 0 // eslint-disable-line
-  requestsQueue['concurrency'] = networkConcurrency // eslint-disable-line
+  requestsQueue['counter'] = 0
+  requestsQueue['concurrency'] = networkConcurrency
 
   const cafsDir = path.join(opts.storeDir, 'files')
   const getFilePathInCafs = _getFilePathInCafs.bind(null, cafsDir)
@@ -188,7 +188,7 @@ async function resolveAndFetch (
     forceFetch = Boolean(
       ((options.currentPkg?.resolution) != null) &&
       pkgId?.startsWith('file:') &&
-      options.currentPkg?.resolution['integrity'] !== resolveResult.resolution['integrity'] // eslint-disable-line @typescript-eslint/dot-notation
+      options.currentPkg?.resolution['integrity'] !== resolveResult.resolution['integrity']
     )
 
     updated = pkgId !== resolveResult.id || !resolution || forceFetch
@@ -350,7 +350,7 @@ function fetchToStore (
     // Changing the value of fromStore is needed for correct reporting of `pnpm server`.
     // Otherwise, if a package was not in store when the server started, it will always be
     // reported as "downloaded" instead of "reused".
-    files.promise.then((cache) => { // eslint-disable-line
+    files.promise.then((cache) => {
       progressLogger.debug({
         packageId: opts.pkg.id,
         requester: opts.lockfileDir,
@@ -497,7 +497,7 @@ Actual package in the store by the given integrity: ${pkgFilesIndex.name}@${pkgF
       // However, when one line is left available, allow it to be picked up by a metadata request.
       // This is done in order to avoid situations when tarballs are downloaded in chunks
       // As many tarballs should be downloaded simultaneously as possible.
-      const priority = (++ctx.requestsQueue['counter'] % ctx.requestsQueue['concurrency'] === 0 ? -1 : 1) * 1000 // eslint-disable-line
+      const priority = (++ctx.requestsQueue['counter'] % ctx.requestsQueue['concurrency'] === 0 ? -1 : 1) * 1000
 
       const fetchManifest = opts.fetchRawManifest
         ? safePromiseDefer<DependencyManifest | undefined>()
@@ -584,9 +584,9 @@ Actual package in the store by the given integrity: ${pkgFilesIndex.name}@${pkgF
         }
       }
 
-      if (isLocalTarballDep && opts.pkg.resolution['integrity']) { // eslint-disable-line @typescript-eslint/dot-notation
+      if (isLocalTarballDep && opts.pkg.resolution['integrity']) {
         await fs.mkdir(target, { recursive: true })
-        await gfs.writeFile(path.join(target, TARBALL_INTEGRITY_FILENAME), opts.pkg.resolution['integrity'], 'utf8') // eslint-disable-line @typescript-eslint/dot-notation
+        await gfs.writeFile(path.join(target, TARBALL_INTEGRITY_FILENAME), opts.pkg.resolution['integrity'], 'utf8')
       }
 
       files.resolve(filesResult)

--- a/packages/parse-cli-args/src/index.ts
+++ b/packages/parse-cli-args/src/index.ts
@@ -152,7 +152,7 @@ export default async function parseCliArgs (
     }
   }
   const dir = options['dir'] ?? process.cwd()
-  const workspaceDir = options['global'] || options['ignore-workspace'] // eslint-disable-line
+  const workspaceDir = options['global'] || options['ignore-workspace']
     ? undefined
     : await findWorkspaceDir(dir)
   if (options['workspace-root']) {

--- a/packages/plugin-commands-installation/src/import/index.ts
+++ b/packages/plugin-commands-installation/src/import/index.ts
@@ -120,7 +120,7 @@ export async function handler (
       // Check and warn if there are cyclic dependencies
       if (!sequencedGraph.safe) {
         const cyclicDependenciesInfo = sequencedGraph.cycles.length > 0
-          ? `: ${sequencedGraph.cycles.map(deps => deps.join(', ')).join('; ')}` // eslint-disable-line
+          ? `: ${sequencedGraph.cycles.map(deps => deps.join(', ')).join('; ')}`
           : ''
         logger.warn({
           message: `There are cyclic workspace dependencies${cyclicDependenciesInfo}`,
@@ -175,7 +175,7 @@ async function readYarnLockFile (dir: string) {
       }
     }
   } catch (err: any) { // eslint-disable-line
-    if (err['code'] !== 'ENOENT') throw err // eslint-disable-line @typescript-eslint/dot-notation
+    if (err['code'] !== 'ENOENT') throw err
   }
   throw new PnpmError('YARN_LOCKFILE_NOT_FOUND', 'No yarn.lock found')
 }
@@ -212,12 +212,12 @@ async function readNpmLockfile (dir: string) {
   try {
     return await loadJsonFile<LockedPackage>(path.join(dir, 'package-lock.json'))
   } catch (err: any) { // eslint-disable-line
-    if (err['code'] !== 'ENOENT') throw err // eslint-disable-line @typescript-eslint/dot-notation
+    if (err['code'] !== 'ENOENT') throw err
   }
   try {
     return await loadJsonFile<LockedPackage>(path.join(dir, 'npm-shrinkwrap.json'))
   } catch (err: any) { // eslint-disable-line
-    if (err['code'] !== 'ENOENT') throw err // eslint-disable-line @typescript-eslint/dot-notation
+    if (err['code'] !== 'ENOENT') throw err
   }
   throw new PnpmError('NPM_LOCKFILE_NOT_FOUND', 'No package-lock.json or npm-shrinkwrap.json found')
 }

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -134,7 +134,7 @@ when running add/update with the --workspace option')
       // Check and warn if there are cyclic dependencies
       if (!sequencedGraph.safe) {
         const cyclicDependenciesInfo = sequencedGraph.cycles.length > 0
-          ? `: ${sequencedGraph.cycles.map(deps => deps.join(', ')).join('; ')}` // eslint-disable-line
+          ? `: ${sequencedGraph.cycles.map(deps => deps.join(', ')).join('; ')}`
           : ''
         logger.warn({
           message: `There are cyclic workspace dependencies${cyclicDependenciesInfo}`,

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -380,7 +380,7 @@ export default async function recursive (
           return
         }
 
-        err['prefix'] = rootDir // eslint-disable-line @typescript-eslint/dot-notation
+        err['prefix'] = rootDir
         throw err
       }
     })

--- a/packages/plugin-commands-listing/src/list.ts
+++ b/packages/plugin-commands-listing/src/list.ts
@@ -165,7 +165,6 @@ export async function render (
     include: opts.include,
     lockfileDir: opts.lockfileDir,
     long: opts.long,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     reportAs: (opts.parseable ? 'parseable' : (opts.json ? 'json' : 'tree')) as ('parseable' | 'json' | 'tree'),
     showExtraneous: false,
   }

--- a/packages/plugin-commands-listing/src/recursive.ts
+++ b/packages/plugin-commands-listing/src/recursive.ts
@@ -34,7 +34,7 @@ export default async (
       outputs.push(output)
     } catch (err: any) { // eslint-disable-line
       logger.info(err)
-      err['prefix'] = dir // eslint-disable-line @typescript-eslint/dot-notation
+      err['prefix'] = dir
       throw err
     }
   }

--- a/packages/plugin-commands-publishing/test/gitChecks.ts
+++ b/packages/plugin-commands-publishing/test/gitChecks.ts
@@ -5,10 +5,8 @@ import PnpmError from '@pnpm/error'
 import execa from 'execa'
 import tempy from 'tempy'
 
-// eslint-disable-next-line
 import * as enquirer from 'enquirer'
 
-// eslint-disable-next-line
 import { publish } from '@pnpm/plugin-commands-publishing'
 import { DEFAULT_OPTS } from './utils'
 

--- a/packages/plugin-commands-rebuild/src/recursive.ts
+++ b/packages/plugin-commands-rebuild/src/recursive.ts
@@ -154,7 +154,7 @@ export default async function recursive (
             return
           }
 
-          err['prefix'] = rootDir // eslint-disable-line @typescript-eslint/dot-notation
+          err['prefix'] = rootDir
           throw err
         }
       })

--- a/packages/plugin-commands-script-runners/src/exec.ts
+++ b/packages/plugin-commands-script-runners/src/exec.ts
@@ -166,7 +166,6 @@ export async function handler (
             return
           }
 
-          /* eslint-disable @typescript-eslint/dot-notation */
           err['code'] = 'ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL'
           err['prefix'] = prefix
           /* eslint-enable @typescript-eslint/dot-notation */

--- a/packages/plugin-commands-script-runners/src/runRecursive.ts
+++ b/packages/plugin-commands-script-runners/src/runRecursive.ts
@@ -113,7 +113,6 @@ export default async (
             return
           }
 
-          /* eslint-disable @typescript-eslint/dot-notation */
           err['code'] = 'ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL'
           err['prefix'] = prefix
           /* eslint-enable @typescript-eslint/dot-notation */

--- a/packages/pnpm/src/reporter/silentReporter.ts
+++ b/packages/pnpm/src/reporter/silentReporter.ts
@@ -11,8 +11,8 @@ export default (
     // Known errors are not printed
     if (obj['err'].code?.startsWith('ERR_PNPM_')) return
 
-    console.log(obj['err']?.message ?? obj['message']) // eslint-disable-line
-    if (obj['err']?.stack) { // eslint-disable-line
+    console.log(obj['err']?.message ?? obj['message'])
+    if (obj['err']?.stack) {
       console.log(`\n${obj['err'].stack}`) // eslint-disable-line
     }
   })

--- a/packages/pnpm/test/install/global.ts
+++ b/packages/pnpm/test/install/global.ts
@@ -62,7 +62,6 @@ test('always install latest when doing global installation without spec', async 
 
   process.chdir(globalPrefix)
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   expect((await import(path.resolve('node_modules', 'peer-c', 'package.json'))).default.version).toBe('2.0.0')
 })
 

--- a/packages/pnpm/test/install/hooks.ts
+++ b/packages/pnpm/test/install/hooks.ts
@@ -247,7 +247,6 @@ test('readPackage hook from pnpmfile at root of workspace', async () => {
   process.chdir('..')
 
   const lockfile = await readYamlFile<Lockfile>('pnpm-lock.yaml')
-  /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
   expect(lockfile.packages!['/is-positive/1.0.0'].dependencies).toStrictEqual({
     'dep-of-pkg-with-1-dep': '100.1.0',
   })

--- a/packages/pnpm/test/recursive/misc.ts
+++ b/packages/pnpm/test/recursive/misc.ts
@@ -233,7 +233,6 @@ test('recursive installation of packages in workspace ignores hooks in packages'
   await execPnpm(['recursive', 'install'])
 
   const lockfile = await readYamlFile<Lockfile>('pnpm-lock.yaml')
-  /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
   expect(lockfile.packages).not.toHaveProperty(['/dep-of-pkg-with-1-dep/100.1.0'])
   expect(lockfile.packages).toHaveProperty(['/is-number/1.0.0'])
   /* eslint-enable @typescript-eslint/no-unnecessary-type-assertion */

--- a/packages/pnpm/test/utils/retryLoadJsonFile.ts
+++ b/packages/pnpm/test/utils/retryLoadJsonFile.ts
@@ -5,7 +5,6 @@ export default async <T>(filePath: string): Promise<T> => {
   const operation = retry.operation({})
 
   return new Promise<T>((resolve, reject) => {
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     operation.attempt(async (currentAttempt) => {
       try {
         resolve(await loadJsonFile<T>(filePath))

--- a/packages/read-project-manifest/src/index.ts
+++ b/packages/read-project-manifest/src/index.ts
@@ -105,7 +105,7 @@ export async function tryReadProjectManifest (projectDir: string): Promise<{
     }
     if ((s != null) && !s.isDirectory()) {
       const err = new Error(`"${projectDir}" is not a directory`)
-      err['code'] = 'ENOTDIR' // eslint-disable-line
+      err['code'] = 'ENOTDIR'
       throw err
     }
   }

--- a/packages/resolve-dependencies/src/index.ts
+++ b/packages/resolve-dependencies/src/index.ts
@@ -224,9 +224,7 @@ export default async function (
 
   if (opts.forceFullResolution && opts.wantedLockfile != null) {
     for (const [depPath, pkg] of Object.entries(dependenciesGraph)) {
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (opts.allowBuild != null && !opts.allowBuild(pkg.name)) ||
         (opts.wantedLockfile.packages?.[depPath] == null) ||
         pkg.requiresBuild === true

--- a/packages/resolve-dependencies/src/resolveDependencies.ts
+++ b/packages/resolve-dependencies/src/resolveDependencies.ts
@@ -547,7 +547,7 @@ function getDepsToResolve (
         // So for example, if foo@1.0.0 had bar@1.0.0 as a dependency
         // and foo was updated to 1.1.0 which depends on bar ^1.0.0
         // then bar@1.0.0 can be reused for foo@1.1.0
-        semver.validRange(wantedDependency.pref) !== null && // eslint-disable-line
+        semver.validRange(wantedDependency.pref) !== null &&
         preferredDependencies[wantedDependency.alias] &&
         satisfiesWanted(preferredDependencies[wantedDependency.alias])
       ) {
@@ -794,7 +794,7 @@ async function resolveDependency (
   }
 
   if (pkgResponse.body.isLocal) {
-    const manifest = pkgResponse.body.manifest ?? await pkgResponse.bundledManifest!() // eslint-disable-line @typescript-eslint/dot-notation
+    const manifest = pkgResponse.body.manifest ?? await pkgResponse.bundledManifest!()
     if (!manifest) {
       // This should actually never happen because the local-resolver returns a manifest
       // even if no real manifest exists in the filesystem.
@@ -872,7 +872,6 @@ async function resolveDependency (
       ...pkg,
     }
   } else {
-    /* eslint-disable @typescript-eslint/dot-notation */
     prepare = Boolean(
       pkgResponse.body.resolvedVia === 'git-repository' &&
       typeof pkg.scripts?.prepare === 'string'

--- a/packages/resolve-dependencies/src/resolvePeers.ts
+++ b/packages/resolve-dependencies/src/resolvePeers.ts
@@ -263,7 +263,6 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
           return { name, version }
         })
     )
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     depPath = `${resolvedPackage.depPath}${peersFolderSuffix}`
   }
   const localLocation = path.join(ctx.virtualStoreDir, depPathToFilename(depPath))

--- a/packages/resolve-dependencies/src/updateLockfile.ts
+++ b/packages/resolve-dependencies/src/updateLockfile.ts
@@ -92,7 +92,6 @@ function toLockfileDependency (
   const result = {
     resolution: lockfileResolution,
   }
-  /* eslint-disable @typescript-eslint/dot-notation */
   if (dp.isAbsolute(opts.depPath)) {
     result['name'] = pkg.name
 
@@ -235,7 +234,6 @@ function toLockfileResolution (
   registry: string,
   lockfileIncludeTarballUrl?: boolean
 ): LockfileResolution {
-  /* eslint-disable @typescript-eslint/dot-notation */
   if (dp.isAbsolute(depPath) || resolution.type !== undefined || !resolution['integrity']) {
     return resolution as LockfileResolution
   }

--- a/packages/store-connection-manager/src/index.ts
+++ b/packages/store-connection-manager/src/index.ts
@@ -64,7 +64,7 @@ export async function createOrConnectStoreController (
       prefix: opts.dir,
     })
     return {
-      ctrl: await connectStoreController(serverJson.connectionOptions), // eslint-disable-line
+      ctrl: await connectStoreController(serverJson.connectionOptions),
       dir: storeDir,
     }
   }
@@ -79,7 +79,7 @@ export async function createOrConnectStoreController (
       prefix: opts.dir,
     })
     return {
-      ctrl: await connectStoreController(serverJson!.connectionOptions), // eslint-disable-line
+      ctrl: await connectStoreController(serverJson!.connectionOptions),
       dir: storeDir,
     }
   }

--- a/privatePackages/assert-project/src/index.ts
+++ b/privatePackages/assert-project/src/index.ts
@@ -136,7 +136,7 @@ export default (projectPath: string, encodedRegistryName?: string): Project => {
     },
     async readCurrentLockfile () {
       try {
-        return await readYamlFile(path.join(await getVirtualStoreDir(), 'lock.yaml')) // eslint-disable-line
+        return await readYamlFile(path.join(await getVirtualStoreDir(), 'lock.yaml'))
       } catch (err: any) { // eslint-disable-line
         if (err.code === 'ENOENT') return null!
         throw err
@@ -145,7 +145,7 @@ export default (projectPath: string, encodedRegistryName?: string): Project => {
     readModulesManifest: async () => readModules(modules),
     async readLockfile (lockfileName: string = WANTED_LOCKFILE) {
       try {
-        return await readYamlFile(path.join(projectPath, lockfileName)) // eslint-disable-line
+        return await readYamlFile(path.join(projectPath, lockfileName))
       } catch (err: any) { // eslint-disable-line
         if (err.code === 'ENOENT') return null!
         throw err

--- a/utils/eslint-config/eslint.json
+++ b/utils/eslint-config/eslint.json
@@ -4,6 +4,7 @@
     "project": "./tsconfig.lint.json",
     "sourceType": "module"
   },
+  "reportUnusedDisableDirectives": true,
   "rules": {
     "import/no-extraneous-dependencies": [
       "error",


### PR DESCRIPTION
## Description

`reportUnusedDisableDirectives` is a really convenient eslint flag that removes outdated `eslint-disable` statements.

As a side note, `eslint-disable-line` should never be used since it disables ALL rules for a certain line. Rather use e.g. `eslint-disable-line @typescript-eslint/dot-notation` as it only disables that single rule for the line.

## Changes

- add `reportUnusedDisableDirectives: true` to `eslint-config`
- run `lint:ts --fix` which autoremoves all redundant disabled lint occurrences