### PR TITLE
docs: fix typos much -> match

### DIFF
--- a/packages/core/src/install/link.ts
+++ b/packages/core/src/install/link.ts
@@ -241,7 +241,7 @@ export default async function linkPackages (
   let newHoistedDependencies!: HoistedDependencies
   if ((opts.hoistPattern != null || opts.publicHoistPattern != null) && (newDepPaths.length > 0 || removedDepPaths.size > 0)) {
     // It is important to keep the skipped packages in the lockfile which will be saved as the "current lockfile".
-    // pnpm is comparing the current lockfile to the wanted one and they should much.
+    // pnpm is comparing the current lockfile to the wanted one and they should match.
     // But for hoisting, we need a version of the lockfile w/o the skipped packages, so we're making a copy.
     const hoistLockfile = {
       ...currentLockfile,

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -349,7 +349,7 @@ export default async (opts: HeadlessOptions) => {
 
     if (opts.ignorePackageManifest !== true && (opts.hoistPattern != null || opts.publicHoistPattern != null)) {
       // It is important to keep the skipped packages in the lockfile which will be saved as the "current lockfile".
-      // pnpm is comparing the current lockfile to the wanted one and they should much.
+      // pnpm is comparing the current lockfile to the wanted one and they should match.
       // But for hoisting, we need a version of the lockfile w/o the skipped packages, so we're making a copy.
       const hoistLockfile = {
         ...filteredLockfile,

--- a/packages/resolve-dependencies/src/index.ts
+++ b/packages/resolve-dependencies/src/index.ts
@@ -253,7 +253,7 @@ function verifyPatches (patchedDependencies: string[], appliedPatches: Set<strin
   const nonAppliedPatches: string[] = patchedDependencies.filter((patchKey) => !appliedPatches.has(patchKey))
   if (nonAppliedPatches.length) {
     throw new PnpmError('PATCH_NOT_APPLIED', `The following patches were not applied: ${nonAppliedPatches.join(', ')}`, {
-      hint: 'Either remove them from "patchedDependencies" or update them to much packages in your dependencies.',
+      hint: 'Either remove them from "patchedDependencies" or update them to match packages in your dependencies.',
     })
   }
 }


### PR DESCRIPTION
Small typo fixes (_much_ to _match_). The only place this is visible to the user is when `PATCH_NOT_APPLIED` error is thrown.