### PR TITLE
fix(read-project-manifest/test): remove unnecessary escape characters in regular expressions

### DIFF
--- a/packages/read-project-manifest/test/index.ts
+++ b/packages/read-project-manifest/test/index.ts
@@ -119,7 +119,7 @@ test('fail on invalid JSON', async () => {
   expect(err).toBeTruthy()
   expect(err['code']).toBe('ERR_PNPM_JSON_PARSE')
   // eslint-disable-next-line
-  expect(err.message).toMatch(/^Unexpected string in JSON at position 20 while parsing \'{  "name": "foo"  "version": "1.0.0"}\' in /)
+  expect(err.message).toMatch(/^Unexpected string in JSON at position 20 while parsing '{  "name": "foo"  "version": "1.0.0"}' in /)
 })
 
 test('fail on invalid JSON5', async () => {


### PR DESCRIPTION
In regular expressions, a single quote has no special meaning, so it doesn't need to be escaped.

So I remove them.