### PR TITLE
fix(pnpm/test): add escape characters

### DIFF
--- a/packages/pnpm/test/cli.ts
+++ b/packages/pnpm/test/cli.ts
@@ -18,7 +18,7 @@ test('some commands pass through to npm', () => {
   const result = execPnpmSync(['dist-tag', 'ls', 'is-positive'])
 
   expect(result.status).toBe(0)
-  expect(result.stdout.toString()).not.toMatch(/Usage: pnpm \[command\] \[flags\]/)
+  expect(result.stdout.toString()).not.toContain('Usage: pnpm [command] [flags]')
 })
 
 test('installs in the folder where the package.json file is', async () => {

--- a/packages/pnpm/test/cli.ts
+++ b/packages/pnpm/test/cli.ts
@@ -18,7 +18,7 @@ test('some commands pass through to npm', () => {
   const result = execPnpmSync(['dist-tag', 'ls', 'is-positive'])
 
   expect(result.status).toBe(0)
-  expect(result.stdout.toString()).not.toMatch(/Usage: pnpm [command] [flags]/)
+  expect(result.stdout.toString()).not.toMatch(/Usage: pnpm \[command\] \[flags\]/)
 })
 
 test('installs in the folder where the package.json file is', async () => {

--- a/packages/read-project-manifest/test/index.ts
+++ b/packages/read-project-manifest/test/index.ts
@@ -118,8 +118,8 @@ test('fail on invalid JSON', async () => {
 
   expect(err).toBeTruthy()
   expect(err['code']).toBe('ERR_PNPM_JSON_PARSE')
-  // eslint-disable-next-line
-  expect(err.message).toMatch(/^Unexpected string in JSON at position 20 while parsing \'{  "name": "foo"  "version": "1.0.0"}\' in /)
+
+  expect(err.message).toContain('Unexpected string in JSON at position 20 while parsing \'{  "name": "foo"  "version": "1.0.0"}\' in ')
 })
 
 test('fail on invalid JSON5', async () => {


### PR DESCRIPTION
In regular expressions, `[` and `]` have special meanings, and only one of the characters enclosed by them can be matched to the target string, and this test is actually to match `[command]` and `[flags]` itself, so these two special characters need to be escaped.

Also, Jest's `toMatch` method supports both strings and regular expressions, so I can pass in a string to avoid escaping:

```javascript
expect(result.stdout.toString()).not.toMatch('Usage: pnpm [command] [flags]')
```

But I observed other files of the project, most of them use regular expressions, and this file does. So I still choose to modify the regular expression (add escape characters) to achieve the purpose.