### PR TITLE
refactor(pnpm/bin): use `semver` to make the code to determine Node.js version more semantic

### DIFF
--- a/packages/pnpm/bin/pnpm.cjs
+++ b/packages/pnpm/bin/pnpm.cjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-const [major, minor] = process.version.slice(1).split('.')
+const semver = require('semver')
+
 const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.`
 
-if (major < 14 || major == 14 && minor < 6) {
+if (!semver.satisfies(process.version, '>=14.6.0')) {
   console.log(`ERROR: This version of pnpm requires at least Node.js v14.6
 The current version of Node.js is ${process.version}
 ${COMPATIBILITY_PAGE}`)

--- a/packages/pnpm/bin/pnpx.cjs
+++ b/packages/pnpm/bin/pnpx.cjs
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
-const [major, minor] = process.version.slice(1).split('.')
+const semver = require('semver')
+
 const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.`
 
-if (major < 12 || major == 12 && minor < 17) {
-  console.log(`ERROR: This version of pnpm requires at least Node.js v12.17
-The current version of Node.js is ${process.version}
-${COMPATIBILITY_PAGE}`)
-  process.exit(1)
-} else if (major == 13 && minor < 7) {
-  console.log(`ERROR: This version of pnpm requires at least Node.js v13.7
+if (!semver.satisfies(process.version, '^12.17.0 || >=13.7.0')) {
+  console.log(`ERROR: This version of pnpm requires at least Node.js v12.17 or v13.7
 The current version of Node.js is ${process.version}
 ${COMPATIBILITY_PAGE}`)
   process.exit(1)


### PR DESCRIPTION
As the title and code show.

---

I haven't modified the behavior of the code, but have a few questions to ask:

1. Why do the `pnpm` and `pnpx` commands require different versions of Node.js? Can it be unified?
2. If it can be unified, can this logic be split into another file?
3. I noticed a comment about debugging in `pnpm.cjs` but not in `pnpx.cjs`, is it necessary to unify?