### PR TITLE
In a workspace, also include missing deeply linked workspace packages at headless installation

### DIFF
--- a/.changeset/new-vans-guess.md
+++ b/.changeset/new-vans-guess.md
@@ -1,7 +1,6 @@
 ---
-"@pnpm/core": patch
-"@pnpm/filter-lockfile": patch
 "@pnpm/headless": patch
+"pnpm": patch
 ---
 
-fix: also include missing deeply linked workspace packages at headless installation
+Also include missing deeply linked workspace packages at headless installation [#5034](https://github.com/pnpm/pnpm/issues/5034).

--- a/.changeset/new-vans-guess.md
+++ b/.changeset/new-vans-guess.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/core": patch
+"@pnpm/filter-lockfile": patch
+"@pnpm/headless": patch
+---
+
+fix: also include missing deeply linked workspace packages at headless installation

--- a/.changeset/silly-walls-shave.md
+++ b/.changeset/silly-walls-shave.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/filter-lockfile": major
+---
+
+Breaking change to the API. Also include missing deeply linked workspace packages at headless installation.

--- a/fixtures/workspace-external-depends-deep/.npmrc
+++ b/fixtures/workspace-external-depends-deep/.npmrc
@@ -2,3 +2,4 @@ link-workspace-packages = deep
 prefer-workspace-packages = true
 shared-workspace-lockfile = true
 save-workspace-protocol = rolling
+registry=http://localhost:4873

--- a/fixtures/workspace-external-depends-deep/.npmrc
+++ b/fixtures/workspace-external-depends-deep/.npmrc
@@ -1,0 +1,4 @@
+link-workspace-packages = deep
+prefer-workspace-packages = true
+shared-workspace-lockfile = true
+save-workspace-protocol = rolling

--- a/fixtures/workspace-external-depends-deep/package.json
+++ b/fixtures/workspace-external-depends-deep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "1.0.0"
+  }
+}

--- a/fixtures/workspace-external-depends-deep/packages/f/package.json
+++ b/fixtures/workspace-external-depends-deep/packages/f/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@kenrick95/internal-f",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "1.0.0",
+    "is-negative": "1.0.0"
+  }
+}
+

--- a/fixtures/workspace-external-depends-deep/packages/g/package.json
+++ b/fixtures/workspace-external-depends-deep/packages/g/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@kenrick95/internal-g",
+  "version": "1.0.0",
+  "dependencies": {
+    "@kenrick95/external-depend-on-internal-dep": "1.0.0",
+    "is-positive": "1.0.0"
+  }
+}

--- a/fixtures/workspace-external-depends-deep/packages/g/package.json
+++ b/fixtures/workspace-external-depends-deep/packages/g/package.json
@@ -2,7 +2,7 @@
   "name": "@kenrick95/internal-g",
   "version": "1.0.0",
   "dependencies": {
-    "@kenrick95/external-depend-on-internal-dep": "1.0.0",
+    "@pnpm.e2e/external-depend-on-internal-dep": "1.0.0",
     "is-positive": "1.0.0"
   }
 }

--- a/fixtures/workspace-external-depends-deep/pnpm-lock.yaml
+++ b/fixtures/workspace-external-depends-deep/pnpm-lock.yaml
@@ -18,18 +18,18 @@ importers:
 
   packages/g:
     specifiers:
-      '@kenrick95/external-depend-on-internal-dep': 1.0.0
+      '@pnpm.e2e/external-depend-on-internal-dep': 1.0.0
       is-positive: 1.0.0
     dependencies:
-      '@kenrick95/external-depend-on-internal-dep': 1.0.0
+      '@pnpm.e2e/external-depend-on-internal-dep': 1.0.0
       is-positive: 1.0.0
 
 packages:
 
-  /@kenrick95/external-depend-on-internal-dep/1.0.0:
-    resolution: {integrity: sha512-r7XGZxVJ+Ixq1m5aljeyXtvBK94k9mXw0R9mxHhtmEznVCOiu/vAwO5csUvr8FKtIJrm3r+9PHnIgaDJt8YQOA==}
+  /@pnpm.e2e/external-depend-on-internal-dep/1.0.0:
+    resolution: {integrity: sha512-UPhSnFgg3p1acuOcuWgunypA7tTqhVCBUUC4laNotJw1RUbTldprdLJmrhOvGylvw4VBipHnXPm/y9wTIAf53A==}
     dependencies:
-      '@kenrick95/internal-f': link:packages/f
+      '@pnpm.e2e/internal-f': link:packages/f
     dev: false
 
   /is-negative/1.0.0:
@@ -38,6 +38,6 @@ packages:
     dev: false
 
   /is-positive/1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/fixtures/workspace-external-depends-deep/pnpm-lock.yaml
+++ b/fixtures/workspace-external-depends-deep/pnpm-lock.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      is-positive: 1.0.0
+    dependencies:
+      is-positive: 1.0.0
+
+  packages/f:
+    specifiers:
+      is-negative: 1.0.0
+      is-positive: 1.0.0
+    dependencies:
+      is-negative: 1.0.0
+      is-positive: 1.0.0
+
+  packages/g:
+    specifiers:
+      '@kenrick95/external-depend-on-internal-dep': 1.0.0
+      is-positive: 1.0.0
+    dependencies:
+      '@kenrick95/external-depend-on-internal-dep': 1.0.0
+      is-positive: 1.0.0
+
+packages:
+
+  /@kenrick95/external-depend-on-internal-dep/1.0.0:
+    resolution: {integrity: sha512-r7XGZxVJ+Ixq1m5aljeyXtvBK94k9mXw0R9mxHhtmEznVCOiu/vAwO5csUvr8FKtIJrm3r+9PHnIgaDJt8YQOA==}
+    dependencies:
+      '@kenrick95/internal-f': link:packages/f
+    dev: false
+
+  /is-negative/1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-positive/1.0.0:
+    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/fixtures/workspace-external-depends-deep/pnpm-workspace.yaml
+++ b/fixtures/workspace-external-depends-deep/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/**'

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt-cli": "^17.1.2",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "0.2.0",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^29.1.2",
     "@types/node": "^14.18.29",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "@pnpm/git-utils": "workspace:*",
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,6 @@
     "@pnpm/read-modules-dir": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
-    "@pnpm/read-projects-context": "workspace:*",
     "@pnpm/remove-bins": "workspace:*",
     "@pnpm/resolve-dependencies": "workspace:*",
     "@pnpm/resolver-base": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "@pnpm/read-modules-dir": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
+    "@pnpm/read-projects-context": "workspace:*",
     "@pnpm/remove-bins": "workspace:*",
     "@pnpm/resolve-dependencies": "workspace:*",
     "@pnpm/resolver-base": "workspace:*",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -121,6 +121,9 @@
       "path": "../read-project-manifest"
     },
     {
+      "path": "../read-projects-context"
+    },
+    {
       "path": "../remove-bins"
     },
     {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -121,9 +121,6 @@
       "path": "../read-project-manifest"
     },
     {
-      "path": "../read-projects-context"
-    },
-    {
       "path": "../remove-bins"
     },
     {

--- a/packages/filter-lockfile/src/filterLockfileByImportersAndEngine.ts
+++ b/packages/filter-lockfile/src/filterLockfileByImportersAndEngine.ts
@@ -19,6 +19,7 @@ function toImporterDepPaths (
   importerIds: string[],
   opts: {
     include: { [dependenciesField in DependenciesField]: boolean }
+    importerIdSet: Set<string>
   }
 ): string[] {
   const importerDeps = importerIds
@@ -37,6 +38,9 @@ function toImporterDepPaths (
   if (!nextImporterIds.length) {
     return depPaths
   }
+  nextImporterIds.forEach((importerId) => {
+    opts.importerIdSet.add(importerId)
+  })
   return [
     ...depPaths,
     ...toImporterDepPaths(lockfile, nextImporterIds, opts),
@@ -80,6 +84,7 @@ export default function filterByImportersAndEngine (
 
   const directDepPaths = toImporterDepPaths(lockfile, importerIds, {
     include: opts.include,
+    importerIdSet,
   })
 
   const packages =
@@ -215,6 +220,7 @@ function pkgAllDeps (
     nextRelDepPaths.push(
       ...toImporterDepPaths(ctx.lockfile, additionalImporterIds, {
         include: opts.include,
+        importerIdSet: ctx.importerIdSet,
       })
     )
     pkgAllDeps(ctx, nextRelDepPaths, installable, opts)

--- a/packages/filter-lockfile/src/filterLockfileByImportersAndEngine.ts
+++ b/packages/filter-lockfile/src/filterLockfileByImportersAndEngine.ts
@@ -14,56 +14,6 @@ import filterImporter from './filterImporter'
 
 const logger = pnpmLogger('lockfile')
 
-function toImporterDepPaths (
-  lockfile: Lockfile,
-  importerIds: string[],
-  opts: {
-    include: { [dependenciesField in DependenciesField]: boolean }
-    importerIdSet: Set<string>
-  }
-): string[] {
-  const importerDeps = importerIds
-    .map(importerId => lockfile.importers[importerId])
-    .map(importer => ({
-      ...(opts.include.dependencies ? importer.dependencies : {}),
-      ...(opts.include.devDependencies ? importer.devDependencies : {}),
-      ...(opts.include.optionalDependencies
-        ? importer.optionalDependencies
-        : {}),
-    }))
-    .map(Object.entries)
-
-  const { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
-
-  if (!nextImporterIds.length) {
-    return depPaths
-  }
-  nextImporterIds.forEach((importerId) => {
-    opts.importerIdSet.add(importerId)
-  })
-  return [
-    ...depPaths,
-    ...toImporterDepPaths(lockfile, nextImporterIds, opts),
-  ]
-}
-
-function parseDepRefs (refsByPkgNames: Array<[string, string]>, lockfile: Lockfile) {
-  return refsByPkgNames
-    .reduce((acc, [pkgName, ref]) => {
-      if (ref.startsWith('link:')) {
-        const importerId = ref.substring(5)
-        if (lockfile.importers[importerId]) {
-          acc.importerIds.push(importerId)
-        }
-        return acc
-      }
-      const depPath = dp.refToRelative(ref, pkgName)
-      if (depPath == null) return acc
-      acc.depPaths.push(depPath)
-      return acc
-    }, { depPaths: [] as string[], importerIds: [] as string[] })
-}
-
 export default function filterByImportersAndEngine (
   lockfile: Lockfile,
   importerIds: string[],
@@ -79,7 +29,7 @@ export default function filterByImportersAndEngine (
     lockfileDir: string
     skipped: Set<string>
   }
-): { lockfile: Lockfile, importerIds: string[] } {
+): { lockfile: Lockfile, selectedImporterIds: string[] } {
   const importerIdSet = new Set(importerIds) as Set<string>
 
   const directDepPaths = toImporterDepPaths(lockfile, importerIds, {
@@ -120,7 +70,7 @@ export default function filterByImportersAndEngine (
       importers,
       packages,
     },
-    importerIds: Array.from(importerIdSet),
+    selectedImporterIds: Array.from(importerIdSet),
   }
 }
 
@@ -225,4 +175,54 @@ function pkgAllDeps (
     )
     pkgAllDeps(ctx, nextRelDepPaths, installable, opts)
   }
+}
+
+function toImporterDepPaths (
+  lockfile: Lockfile,
+  importerIds: string[],
+  opts: {
+    include: { [dependenciesField in DependenciesField]: boolean }
+    importerIdSet: Set<string>
+  }
+): string[] {
+  const importerDeps = importerIds
+    .map(importerId => lockfile.importers[importerId])
+    .map(importer => ({
+      ...(opts.include.dependencies ? importer.dependencies : {}),
+      ...(opts.include.devDependencies ? importer.devDependencies : {}),
+      ...(opts.include.optionalDependencies
+        ? importer.optionalDependencies
+        : {}),
+    }))
+    .map(Object.entries)
+
+  const { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
+
+  if (!nextImporterIds.length) {
+    return depPaths
+  }
+  nextImporterIds.forEach((importerId) => {
+    opts.importerIdSet.add(importerId)
+  })
+  return [
+    ...depPaths,
+    ...toImporterDepPaths(lockfile, nextImporterIds, opts),
+  ]
+}
+
+function parseDepRefs (refsByPkgNames: Array<[string, string]>, lockfile: Lockfile) {
+  return refsByPkgNames
+    .reduce((acc, [pkgName, ref]) => {
+      if (ref.startsWith('link:')) {
+        const importerId = ref.substring(5)
+        if (lockfile.importers[importerId]) {
+          acc.importerIds.push(importerId)
+        }
+        return acc
+      }
+      const depPath = dp.refToRelative(ref, pkgName)
+      if (depPath == null) return acc
+      acc.depPaths.push(depPath)
+      return acc
+    }, { depPaths: [] as string[], importerIds: [] as string[] })
 }

--- a/packages/filter-lockfile/test/filterByImportersAndEngine.ts
+++ b/packages/filter-lockfile/test/filterByImportersAndEngine.ts
@@ -643,4 +643,9 @@ test('filterByImportersAndEngine(): includes linked packages', () => {
       },
     },
   })
+  expect(filteredLockfile.importerIds).toStrictEqual([
+    'project-1',
+    'project-2',
+    'project-3',
+  ])
 })

--- a/packages/filter-lockfile/test/filterByImportersAndEngine.ts
+++ b/packages/filter-lockfile/test/filterByImportersAndEngine.ts
@@ -643,7 +643,7 @@ test('filterByImportersAndEngine(): includes linked packages', () => {
       },
     },
   })
-  expect(filteredLockfile.importerIds).toStrictEqual([
+  expect(filteredLockfile.selectedImporterIds).toStrictEqual([
     'project-1',
     'project-2',
     'project-3',

--- a/packages/filter-lockfile/test/filterByImportersAndEngine.ts
+++ b/packages/filter-lockfile/test/filterByImportersAndEngine.ts
@@ -119,7 +119,7 @@ test('filterByImportersAndEngine(): skip packages that are not installable', () 
     }
   )
 
-  expect(filteredLockfile).toStrictEqual({
+  expect(filteredLockfile.lockfile).toStrictEqual({
     importers: {
       'project-1': {
         dependencies: {
@@ -298,7 +298,7 @@ test('filterByImportersAndEngine(): filter the packages that set os and cpu', ()
     }
   )
 
-  expect(filteredLockfile).toStrictEqual({
+  expect(filteredLockfile.lockfile).toStrictEqual({
     importers: {
       'project-1': {
         dependencies: {
@@ -466,7 +466,7 @@ test('filterByImportersAndEngine(): filter the packages that set libc', () => {
     }
   )
 
-  expect(filteredLockfile).toStrictEqual({
+  expect(filteredLockfile.lockfile).toStrictEqual({
     importers: {
       'project-1': {
         dependencies: {

--- a/packages/filter-lockfile/test/filterByImportersAndEngine.ts
+++ b/packages/filter-lockfile/test/filterByImportersAndEngine.ts
@@ -538,3 +538,109 @@ test('filterByImportersAndEngine(): filter the packages that set libc', () => {
   })
   expect(Array.from(skippedPackages)).toStrictEqual(['/preserve-existing-skipped/1.0.0', '/optional-dep/1.0.0', '/foo/1.0.0'])
 })
+
+test('filterByImportersAndEngine(): includes linked packages', () => {
+  const filteredLockfile = filterLockfileByImportersAndEngine(
+    {
+      importers: {
+        'project-1': {
+          dependencies: {
+            'project-2': 'link:project-2',
+          },
+          devDependencies: {
+          },
+          optionalDependencies: {
+          },
+          specifiers: {
+            'project-2': '^1.0.0',
+          },
+        },
+        'project-2': {
+          dependencies: {
+            'project-3': 'link:project-3',
+            foo: '1.0.0',
+          },
+          specifiers: {
+            foo: '^1.0.0',
+          },
+        },
+        'project-3': {
+          dependencies: {
+            bar: '1.0.0',
+          },
+          specifiers: {
+            bar: '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        '/bar/1.0.0': {
+          resolution: { integrity: '' },
+        },
+        '/foo/1.0.0': {
+          resolution: { integrity: '' },
+        },
+      },
+    },
+    ['project-1'],
+    {
+      currentEngine: {
+        nodeVersion: '10.0.0',
+        pnpmVersion: '2.0.0',
+      },
+      engineStrict: true,
+      failOnMissingDependencies: true,
+      include: {
+        dependencies: true,
+        devDependencies: true,
+        optionalDependencies: true,
+      },
+      lockfileDir: process.cwd(),
+      skipped: new Set(),
+    }
+  )
+
+  expect(filteredLockfile.lockfile).toStrictEqual({
+    importers: {
+      'project-1': {
+        dependencies: {
+          'project-2': 'link:project-2',
+        },
+        devDependencies: {
+        },
+        optionalDependencies: {
+        },
+        specifiers: {
+          'project-2': '^1.0.0',
+        },
+      },
+      'project-2': {
+        dependencies: {
+          'project-3': 'link:project-3',
+          foo: '1.0.0',
+        },
+        specifiers: {
+          foo: '^1.0.0',
+        },
+      },
+      'project-3': {
+        dependencies: {
+          bar: '1.0.0',
+        },
+        specifiers: {
+          bar: '^1.0.0',
+        },
+      },
+    },
+    lockfileVersion: LOCKFILE_VERSION,
+    packages: {
+      '/bar/1.0.0': {
+        resolution: { integrity: '' },
+      },
+      '/foo/1.0.0': {
+        resolution: { integrity: '' },
+      },
+    },
+  })
+})

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -22,7 +22,7 @@
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -243,7 +243,7 @@ export async function headlessInstall (opts: HeadlessOptions) {
   const initialImporterIds = (opts.ignorePackageManifest === true || opts.nodeLinker === 'hoisted')
     ? Object.keys(wantedLockfile.importers)
     : selectedProjects.map(({ id }) => id)
-  const { lockfile: filteredLockfile, importerIds } = filterLockfileByImportersAndEngine(wantedLockfile, initialImporterIds, {
+  const { lockfile: filteredLockfile, selectedImporterIds: importerIds } = filterLockfileByImportersAndEngine(wantedLockfile, initialImporterIds, {
     ...filterOpts,
     currentEngine: opts.currentEngine,
     engineStrict: opts.engineStrict,
@@ -253,17 +253,13 @@ export async function headlessInstall (opts: HeadlessOptions) {
   })
 
   // Update selectedProjects to add missing projects. importerIds will have the updated ids, found from deeply linked workspace projects
-  const missingIds = [] as string[]
   const initialImporterIdSet = new Set(initialImporterIds)
-  for (const id of importerIds) {
-    if (!initialImporterIdSet.has(id)) {
-      missingIds.push(id)
-    }
-  }
-  for (const id of missingIds) {
-    const additionalProject = Object.values(opts.allProjects).find((project) => project.id === id)
-    if (additionalProject) {
-      selectedProjects.push(additionalProject)
+  const missingIds = importerIds.filter((importerId) => !initialImporterIdSet.has(importerId))
+  if (missingIds.length > 0) {
+    for (const project of Object.values(opts.allProjects)) {
+      if (missingIds.includes(project.id)) {
+        selectedProjects.push(project)
+      }
     }
   }
 

--- a/packages/headless/test/utils/testDefaults.ts
+++ b/packages/headless/test/utils/testDefaults.ts
@@ -75,7 +75,7 @@ export default async function testDefaults (
       version: '1.0.0',
     },
     pendingBuilds,
-    selectedProjectDirs: projects.map((project) => project.rootDir),
+    selectedProjectDirs: opts.selectedProjectDirs ?? projects.map((project) => project.rootDir),
     allProjects: fromPairs(
       await Promise.all(projects.map(async (project) => [project.rootDir, { ...project, manifest: await safeReadPackageFromDir(project.rootDir) }]))
     ),

--- a/packages/headless/test/utils/testDefaults.ts
+++ b/packages/headless/test/utils/testDefaults.ts
@@ -28,7 +28,7 @@ export default async function testDefaults (
   let storeDir = opts?.storeDir ?? path.join(tmp, 'store')
   const cacheDir = path.join(tmp, 'cache')
   const lockfileDir = opts?.lockfileDir ?? process.cwd()
-  const { include, pendingBuilds, projects, registries } = await readProjectsContext(
+  const { include, pendingBuilds, projects } = await readProjectsContext(
     opts.projects
       ? opts.projects.map((rootDir: string) => ({ rootDir }))
       : [
@@ -80,7 +80,7 @@ export default async function testDefaults (
       await Promise.all(projects.map(async (project) => [project.rootDir, { ...project, manifest: await safeReadPackageFromDir(project.rootDir) }]))
     ),
     rawConfig: {},
-    registries: registries ?? {
+    registries: {
       default: registry,
     },
     sideEffectsCache: true,

--- a/packages/package-requester/package.json
+++ b/packages/package-requester/package.json
@@ -67,7 +67,7 @@
     "@pnpm/client": "workspace:*",
     "@pnpm/create-cafs-store": "workspace:*",
     "@pnpm/package-requester": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.15",

--- a/packages/plugin-commands-deploy/package.json
+++ b/packages/plugin-commands-deploy/package.json
@@ -42,7 +42,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/plugin-commands-deploy": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0"
+    "@pnpm/registry-mock": "3.1.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",

--- a/packages/plugin-commands-installation/package.json
+++ b/packages/plugin-commands-installation/package.json
@@ -38,7 +38,7 @@
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/is-ci": "^3.0.0",
     "@types/proxyquire": "^1.3.28",

--- a/packages/plugin-commands-listing/package.json
+++ b/packages/plugin-commands-listing/package.json
@@ -37,7 +37,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-listing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/ramda": "0.28.15",
     "execa": "npm:safe-execa@^0.1.2",
     "strip-ansi": "^6.0.1",

--- a/packages/plugin-commands-outdated/package.json
+++ b/packages/plugin-commands-outdated/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-outdated": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/ramda": "0.28.15",
     "@types/wrap-ansi": "^3.0.0",
     "@types/zkochan__table": "npm:@types/table@6.0.0"

--- a/packages/plugin-commands-patching/package.json
+++ b/packages/plugin-commands-patching/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/ramda": "0.28.15"
   },
   "dependencies": {

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/is-ci": "^3.0.0",
     "@types/is-windows": "^1.0.0",

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -36,7 +36,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-rebuild": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.15",
     "@types/semver": "7.3.12",

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -37,7 +37,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.28.15",
     "is-windows": "^1.0.2",

--- a/packages/plugin-commands-store/package.json
+++ b/packages/plugin-commands-store/package.json
@@ -37,7 +37,7 @@
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@types/archy": "0.0.32",
     "@types/ramda": "0.28.15",
     "@types/ssri": "^7.1.1",

--- a/packages/pnpm/package.json
+++ b/packages/pnpm/package.json
@@ -56,7 +56,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/run-npm": "workspace:*",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/types": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0_typanion@3.12.0
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/tsconfig':
         specifier: workspace:*
         version: link:utils/tsconfig
@@ -726,8 +726,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../store-path
@@ -1655,8 +1655,8 @@ importers:
         specifier: workspace:*
         version: link:../read-projects-context
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../store-path
@@ -2795,8 +2795,8 @@ importers:
         specifier: workspace:*
         version: 'link:'
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../privatePackages/test-fixtures
@@ -3094,8 +3094,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
 
   packages/plugin-commands-env:
     dependencies:
@@ -3361,8 +3361,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../privatePackages/test-fixtures
@@ -3461,8 +3461,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/ramda':
         specifier: 0.28.15
         version: 0.28.15
@@ -3558,8 +3558,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/ramda':
         specifier: 0.28.15
         version: 0.28.15
@@ -3625,8 +3625,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/ramda':
         specifier: 0.28.15
         version: 0.28.15
@@ -3725,8 +3725,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2
@@ -3879,8 +3879,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../privatePackages/test-fixtures
@@ -3985,8 +3985,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/is-windows':
         specifier: ^1.0.0
         version: 1.0.0
@@ -4174,8 +4174,8 @@ importers:
         specifier: workspace:*
         version: link:../../privatePackages/prepare
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@types/archy':
         specifier: 0.0.32
         version: 0.0.32
@@ -4205,7 +4205,7 @@ importers:
     optionalDependencies:
       node-gyp:
         specifier: ^9.2.0
-        version: 9.2.0
+        version: 9.3.0
     devDependencies:
       '@pnpm/assert-project':
         specifier: workspace:*
@@ -4319,8 +4319,8 @@ importers:
         specifier: workspace:*
         version: link:../read-project-manifest
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../run-npm
@@ -5225,8 +5225,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/modules-yaml
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -5265,8 +5265,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/cafs
       '@pnpm/registry-mock':
-        specifier: 3.0.0
-        version: 3.0.0_typanion@3.12.0
+        specifier: 3.1.0
+        version: 3.1.0_typanion@3.12.0
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -7698,8 +7698,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/registry-mock/3.0.0_typanion@3.12.0:
-    resolution: {integrity: sha512-/e6P2sVX+1frYDl7z4qAnRHEU2VG4RUu4vcsoSZdc9LFi93ZxQ9gbuF066aR+T3S+JcFFjHNZXfJUj8ZaTfssg==}
+  /@pnpm/registry-mock/3.1.0_typanion@3.12.0:
+    resolution: {integrity: sha512-uOWJxzqNOutPbeH+yQW+cYwg0yM1eCdaMWstlIVjBCCoJ2IEpwsi3KhQnCDmMKZbqqUdPDcHTQaYzMKVG0WAFQ==}
     engines: {node: '>=10.13'}
     hasBin: true
     dependencies:
@@ -7977,7 +7977,7 @@ packages:
   /@types/byline/4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.8.4
+      '@types/node': 18.8.5
     dev: true
 
   /@types/cacheable-request/6.0.2:
@@ -8131,6 +8131,10 @@ packages:
 
   /@types/node/18.8.4:
     resolution: {integrity: sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow==}
+
+  /@types/node/18.8.5:
+    resolution: {integrity: sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -9889,7 +9893,7 @@ packages:
     hasBin: true
     dependencies:
       graceful-fs: 4.2.10
-      minimist: 1.2.6
+      minimist: 1.2.7
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
@@ -10076,8 +10080,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /decimal.js/10.4.1:
-    resolution: {integrity: sha512-F29o+vci4DodHYT9UrR5IEbfBw9pE5eSapIJdTqXK5+6hq+t8VRxwQyKlW2i+KDKFkkJQRvFyI/QXD83h8LyQw==}
+  /decimal.js/10.4.2:
+    resolution: {integrity: sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==}
 
   /decompress-maybe/1.0.0:
     resolution: {integrity: sha512-av8/KhXWRUYQ7lGTl/9Gtizz3nQ+7NqDFm/I4Lx+JvTbzHiD4WqfqxMO4YYi91FTqffoBDCYPfIvofwQZwZ3ZQ==}
@@ -11728,7 +11732,7 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.7
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
@@ -12857,7 +12861,7 @@ packages:
       cssom: 0.4.4
       cssstyle: 2.3.0
       data-urls: 2.0.0
-      decimal.js: 10.4.1
+      decimal.js: 10.4.2
       domexception: 2.0.1
       escodegen: 2.0.0
       form-data: 3.0.1
@@ -13612,6 +13616,9 @@ packages:
   /minimist/1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
 
+  /minimist/1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+
   /minipass-collect/1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
     engines: {node: '>= 8'}
@@ -13699,7 +13706,7 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.7
 
   /mkdirp/1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -13880,8 +13887,8 @@ packages:
       - bluebird
       - supports-color
 
-  /node-gyp/9.2.0:
-    resolution: {integrity: sha512-/+/YxGfIJOh/fnMsr4Ep0v6oOIjnO1BgLd2dcDspBX1spTkQU7xSIox5RdRE/2/Uq3ZwK8Z5swRIbMUmPlslmg==}
+  /node-gyp/9.3.0:
+    resolution: {integrity: sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==}
     engines: {node: ^12.22 || ^14.13 || >=16}
     hasBin: true
     requiresBuild: true
@@ -14034,6 +14041,7 @@ packages:
 
   /npmlog/4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
+    requiresBuild: true
     dependencies:
       are-we-there-yet: 1.1.7
       console-control-strings: 1.1.0
@@ -14370,7 +14378,7 @@ packages:
       fs-extra: 7.0.1
       is-ci: 2.0.0
       klaw-sync: 6.0.0
-      minimist: 1.2.6
+      minimist: 1.2.7
       open: 7.4.2
       rimraf: 2.7.1
       semver: 5.7.1
@@ -17132,7 +17140,7 @@ time:
   /@pnpm/npm-package-arg/1.0.0: '2022-06-28T12:48:31.287Z'
   /@pnpm/os.env.path-extender/0.2.6: '2022-08-08T10:36:30.986Z'
   /@pnpm/ramda/0.28.1: '2022-08-03T13:56:59.597Z'
-  /@pnpm/registry-mock/3.0.0: '2022-09-04T20:12:48.942Z'
+  /@pnpm/registry-mock/3.1.0: '2022-10-13T19:59:17.408Z'
   /@pnpm/semver-diff/1.1.0: '2021-11-16T12:40:59.941Z'
   /@pnpm/tabtab/0.1.2: '2021-03-05T17:31:19.932Z'
   /@types/adm-zip/0.4.34: '2021-04-04T18:01:23.318Z'
@@ -17261,7 +17269,7 @@ time:
   /micromatch/4.0.5: '2022-03-24T19:31:47.722Z'
   /nock/13.2.9: '2022-07-19T18:34:55.582Z'
   /node-fetch/3.0.0-beta.9: '2020-09-05T12:52:27.791Z'
-  /node-gyp/9.2.0: '2022-10-04T10:40:24.552Z'
+  /node-gyp/9.3.0: '2022-10-11T04:54:21.968Z'
   /normalize-newline/3.0.0: '2016-09-06T12:35:43.571Z'
   /normalize-package-data/4.0.1: '2022-08-15T21:03:50.558Z'
   /normalize-path/3.0.0: '2018-04-19T14:54:47.609Z'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
       '@pnpm/read-project-manifest':
         specifier: workspace:*
         version: link:../read-project-manifest
+      '@pnpm/read-projects-context':
+        specifier: workspace:*
+        version: link:../read-projects-context
       '@pnpm/remove-bins':
         specifier: workspace:*
         version: link:../remove-bins

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,9 +640,6 @@ importers:
       '@pnpm/read-project-manifest':
         specifier: workspace:*
         version: link:../read-project-manifest
-      '@pnpm/read-projects-context':
-        specifier: workspace:*
-        version: link:../read-projects-context
       '@pnpm/remove-bins':
         specifier: workspace:*
         version: link:../remove-bins

--- a/privatePackages/assert-project/package.json
+++ b/privatePackages/assert-project/package.json
@@ -44,7 +44,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "@pnpm/types": "workspace:*",
     "is-windows": "^1.0.2",
     "isexe": "2.0.0",

--- a/privatePackages/assert-store/package.json
+++ b/privatePackages/assert-store/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
-    "@pnpm/registry-mock": "3.0.0",
+    "@pnpm/registry-mock": "3.1.0",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Attempt to fix #5034 

Problem:

When using link-workspace-packages = deep + filter, there could be case where it depends on a project inside the workspace that is not selected by the filter. We only know what are the projects after we resolve the dependencies.

Idea for solution:

~~"resolve-dependencies", after the first "resolveDependencyTree", when we encounter projects in "dependenciesTree" that are not yet part of the "projectsToResolve", we add it into "importers" & "projectsToResolve" and run "resolveDependencyTree" again and again till all projects in "dependenciesTree" are part of "projectsToResolve"~~

~~I wonder if the solution sounds ok?~~

~~Not fully working yet, have some questions (inline in codes)~~

~~plus there are some failing tests (`test/linkRecursive.ts` & `test/miscRecursive.ts`) due to this change~~

Updated solution:

- core passes allProjects to headless
- filterByImportersAndEngine finds out the missing deeply linked projects while traversing the lockfile
- headless updates "opts.options" with missing projects