### PR TITLE
fix: remove legacy signal handlers

### DIFF
--- a/.changeset/chilly-poets-care.md
+++ b/.changeset/chilly-poets-care.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Remove legacy signal handlers

--- a/packages/pnpm/src/main.ts
+++ b/packages/pnpm/src/main.ts
@@ -1,5 +1,3 @@
-// Map SIGINT & SIGTERM to process exit
-// so that lockfiles are removed automatically
 import loudRejection from 'loud-rejection'
 import packageManager from '@pnpm/cli-meta'
 import { getConfig } from '@pnpm/cli-utils'
@@ -23,10 +21,6 @@ import path from 'path'
 import isEmpty from 'ramda/src/isEmpty'
 import stripAnsi from 'strip-ansi'
 import which from 'which'
-
-process
-  .once('SIGINT', () => process.exit(0))
-  .once('SIGTERM', () => process.exit(0))
 
 loudRejection()
 


### PR DESCRIPTION
This PR removes legacy signal handlers which are no longer necessary. This also means that when someone runs a script that gets interrupted, the process now properly terminates with the correct status code, e.g. 130 for `SIGINT` and not always `0`.