### PR TITLE
feat(cafs): extend cafs with getFilePathByModeInCafs

### DIFF
--- a/.changeset/polite-kings-travel.md
+++ b/.changeset/polite-kings-travel.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cafs": minor
+"@pnpm/cafs-types": minor
+---
+
+Extend cafs with `getFilePathByModeInCafs`.

--- a/packages/cafs-types/src/index.ts
+++ b/packages/cafs-types/src/index.ts
@@ -57,6 +57,7 @@ export interface Cafs {
   addFilesFromDir: (dir: string, manifest?: DeferredManifestPromise) => Promise<FilesIndex>
   addFilesFromTarball: (stream: NodeJS.ReadableStream, manifest?: DeferredManifestPromise) => Promise<FilesIndex>
   getFilePathInCafs: (integrity: string | IntegrityLike, fileType: FileType) => string
+  getFilePathByModeInCafs: (integrity: string | IntegrityLike, mode: number) => string
   importPackage: ImportPackageFunction
   tempDir: () => Promise<string>
 }

--- a/packages/cafs/src/index.ts
+++ b/packages/cafs/src/index.ts
@@ -41,6 +41,7 @@ export default function createCafs (cafsDir: string, ignore?: ((filename: string
     addFilesFromDir: addFilesFromDir.bind(null, { addBuffer, addStream }),
     addFilesFromTarball: addFilesFromTarball.bind(null, addStream, ignore ?? null),
     getFilePathInCafs: getFilePathInCafs.bind(null, cafsDir),
+    getFilePathByModeInCafs: getFilePathByModeInCafs.bind(null, cafsDir),
   }
 }
 


### PR DESCRIPTION
This PR exetnds the `cafs` object with `getFilePathByModeInCafs` which is useful for custom fetchers.