### PR TITLE
fix: node<16 download fail on arm chips on macos

### DIFF
--- a/.changeset/five-ties-add.md
+++ b/.changeset/five-ties-add.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/node.fetcher": patch
+---
+
+For node version < 16, install x64 build on darwin arm as arm build is not available.

--- a/packages/node.fetcher/src/getNodeTarball.ts
+++ b/packages/node.fetcher/src/getNodeTarball.ts
@@ -7,11 +7,9 @@ export function getNodeTarball (
   processArch: string
 ) {
   const platform = processPlatform === 'win32' ? 'win' : processPlatform
-  const arch = normalizeArch(processPlatform, processArch)
-  const nodeMajorVersion = +nodeVersion.split('.')[0]
-  const nodeBinaryArch = (platform === 'darwin' && arch === 'arm64' && (nodeMajorVersion < 16)) ? 'x64' : arch
+  const arch = normalizeArch(processPlatform, processArch, nodeVersion)
   const extension = platform === 'win' ? 'zip' : 'tar.gz'
-  const pkgName = `node-v${nodeVersion}-${platform}-${nodeBinaryArch}`
+  const pkgName = `node-v${nodeVersion}-${platform}-${arch}`
   return {
     pkgName,
     tarball: `${nodeMirror}v${nodeVersion}/${pkgName}.${extension}`,

--- a/packages/node.fetcher/src/getNodeTarball.ts
+++ b/packages/node.fetcher/src/getNodeTarball.ts
@@ -8,8 +8,10 @@ export function getNodeTarball (
 ) {
   const platform = processPlatform === 'win32' ? 'win' : processPlatform
   const arch = normalizeArch(processPlatform, processArch)
+  const nodeMajorVersion = +nodeVersion.split('.')[0]
+  const nodeBinaryArch = (platform === 'darwin' && arch === 'arm64' && (nodeMajorVersion < 16)) ? 'x64' : arch
   const extension = platform === 'win' ? 'zip' : 'tar.gz'
-  const pkgName = `node-v${nodeVersion}-${platform}-${arch}`
+  const pkgName = `node-v${nodeVersion}-${platform}-${nodeBinaryArch}`
   return {
     pkgName,
     tarball: `${nodeMirror}v${nodeVersion}/${pkgName}.${extension}`,

--- a/packages/node.fetcher/src/normalizeArch.ts
+++ b/packages/node.fetcher/src/normalizeArch.ts
@@ -1,4 +1,10 @@
-export default function getNormalizedArch (platform: string, arch: string) {
+export default function getNormalizedArch (platform: string, arch: string, nodeVersion?: string) {
+  if (nodeVersion) {
+    const nodeMajorVersion = +nodeVersion.split('.')[0]
+    if ((platform === 'darwin' && arch === 'arm64' && (nodeMajorVersion < 16))) {
+      return 'x64'
+    }
+  }
   if (platform === 'win32' && arch === 'ia32') {
     return 'x86'
   }

--- a/packages/node.fetcher/test/getNodeTarball.test.ts
+++ b/packages/node.fetcher/test/getNodeTarball.test.ts
@@ -31,6 +31,26 @@ test.each([
       tarball: 'https://nodejs.org/download/release/v16.0.0/node-v16.0.0-linux-x64.tar.gz',
     },
   ],
+  [
+    '15.14.0',
+    'https://nodejs.org/download/release/',
+    'darwin',
+    'arm64',
+    {
+      pkgName: 'node-v15.14.0-darwin-x64',
+      tarball: 'https://nodejs.org/download/release/v15.14.0/node-v15.14.0-darwin-x64.tar.gz',
+    },
+  ],
+  [
+    '16.0.0',
+    'https://nodejs.org/download/release/',
+    'darwin',
+    'arm64',
+    {
+      pkgName: 'node-v16.0.0-darwin-arm64',
+      tarball: 'https://nodejs.org/download/release/v16.0.0/node-v16.0.0-darwin-arm64.tar.gz',
+    },
+  ],
 ])('getNodeTarball', (version, nodeMirrorBaseUrl, platform, arch, tarball) => {
   expect(getNodeTarball(version, nodeMirrorBaseUrl, platform, arch)).toStrictEqual(tarball)
 })

--- a/packages/node.fetcher/test/normalizeArch.test.ts
+++ b/packages/node.fetcher/test/normalizeArch.test.ts
@@ -7,3 +7,11 @@ test.each([
 ])('normalizedArch(%s, %s)', (platform, arch, normalizedArch) => {
   expect(normalizeArch(platform, arch)).toBe(normalizedArch)
 })
+
+// macos apple silicon
+test.each([
+  ['darwin', 'arm64', '14.20.0', 'x64'],
+  ['darwin', 'arm64', '16.17.0', 'arm64'],
+])('normalizedArch(%s, %s)', (platform, arch, nodeVersion, normalizedArch) => {
+  expect(normalizeArch(platform, arch, nodeVersion)).toBe(normalizedArch)
+})


### PR DESCRIPTION
Add a check for macos apple silicon and required node version < 16.
In such case, download x64 binary.
Because arm build does not exist.
Macos automatically detects x64 instructions and converts them so downloaded node works as expected.
Previous behaviour:
Try to download non existing arm build and fail with 404.

NO breaking change
fixes #4489