### PR TITLE
feat(env): show state on fetching node

### DIFF
--- a/.changeset/purple-tools-leave.md
+++ b/.changeset/purple-tools-leave.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-env": minor
+---
+
+Add an immediate response when fetching Node.js on version switching, preventing pnpm looks like just hanging there.

--- a/packages/plugin-commands-env/package.json
+++ b/packages/plugin-commands-env/package.json
@@ -34,6 +34,7 @@
     "@pnpm/config": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/fetch": "workspace:*",
+    "@pnpm/logger": "^4.0.0",
     "@pnpm/node.fetcher": "workspace:*",
     "@pnpm/node.resolver": "workspace:*",
     "@pnpm/store-path": "workspace:*",

--- a/packages/plugin-commands-env/src/node.ts
+++ b/packages/plugin-commands-env/src/node.ts
@@ -71,6 +71,7 @@ export async function getNodeDir (fetch: FetchFromRegistry, opts: NvmNodeCommand
       pnpmHomeDir: opts.pnpmHomeDir,
     })
     const cafsDir = path.join(storeDir, 'files')
+    console.log(`Fetching Node.js ${opts.useNodeVersion} ...`)
     await fetchNode(fetch, opts.useNodeVersion, versionDir, {
       ...opts,
       cafsDir,

--- a/packages/plugin-commands-env/src/node.ts
+++ b/packages/plugin-commands-env/src/node.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { Config } from '@pnpm/config'
 import { createFetchFromRegistry, FetchFromRegistry } from '@pnpm/fetch'
+import { globalInfo } from '@pnpm/logger'
 import { fetchNode } from '@pnpm/node.fetcher'
 import storePath from '@pnpm/store-path'
 import loadJsonFile from 'load-json-file'
@@ -71,7 +72,7 @@ export async function getNodeDir (fetch: FetchFromRegistry, opts: NvmNodeCommand
       pnpmHomeDir: opts.pnpmHomeDir,
     })
     const cafsDir = path.join(storeDir, 'files')
-    console.log(`Fetching Node.js ${opts.useNodeVersion} ...`)
+    globalInfo(`Fetching Node.js ${opts.useNodeVersion} ...`)
     await fetchNode(fetch, opts.useNodeVersion, versionDir, {
       ...opts,
       cafsDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3060,6 +3060,9 @@ importers:
       '@pnpm/fetch':
         specifier: workspace:*
         version: link:../fetch
+      '@pnpm/logger':
+        specifier: ^4.0.0
+        version: 4.0.0
       '@pnpm/node.fetcher':
         specifier: workspace:*
         version: link:../node.fetcher


### PR DESCRIPTION
Add an immediate response when fetching Node.js on version switching, preventing pnpm looks like just hanging there.

I noticed that `@pnpm/logger` and `@pnpm/core-loggers` are being used in many packages. 
But it doesn't work when I try to use it like `logger.info({ message: "...", prefix: "dir" })`, I think I have missed something.