### PR TITLE
feat(env): add remove command to pnpm env

### DIFF
--- a/.changeset/long-trainers-share.md
+++ b/.changeset/long-trainers-share.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-env": minor
+---
+
+Enhance `pnpm env` with the `uninstall` command.

--- a/.changeset/long-trainers-share.md
+++ b/.changeset/long-trainers-share.md
@@ -2,4 +2,4 @@
 "@pnpm/plugin-commands-env": minor
 ---
 
-Enhance `pnpm env` with the `uninstall` command.
+Enhance `pnpm env` with the `remove` command.

--- a/.changeset/long-trainers-share.md
+++ b/.changeset/long-trainers-share.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-env": minor
+"pnpm": minor
 ---
 
 Enhance `pnpm env` with the `remove` command.

--- a/packages/plugin-commands-env/package.json
+++ b/packages/plugin-commands-env/package.json
@@ -37,6 +37,7 @@
     "@pnpm/logger": "^4.0.0",
     "@pnpm/node.fetcher": "workspace:*",
     "@pnpm/node.resolver": "workspace:*",
+    "@pnpm/remove-bins": "workspace:*",
     "@pnpm/store-path": "workspace:*",
     "@zkochan/cmd-shim": "^5.3.1",
     "@zkochan/rimraf": "^2.1.2",

--- a/packages/plugin-commands-env/package.json
+++ b/packages/plugin-commands-env/package.json
@@ -39,6 +39,7 @@
     "@pnpm/node.resolver": "workspace:*",
     "@pnpm/store-path": "workspace:*",
     "@zkochan/cmd-shim": "^5.3.1",
+    "@zkochan/rimraf": "^2.1.2",
     "load-json-file": "^6.2.0",
     "render-help": "^1.0.2",
     "write-json-file": "^4.3.0"

--- a/packages/plugin-commands-env/src/env.ts
+++ b/packages/plugin-commands-env/src/env.ts
@@ -25,13 +25,27 @@ export const commandNames = ['env']
 
 export function help () {
   return renderHelp({
-    description: 'Install and use the specified version of Node.js. The npm CLI bundled with the given Node.js version gets installed as well.',
+    description: 'Manage Node.js versions.',
     descriptionLists: [
+      {
+        title: 'Commands',
+        list: [
+          {
+            description: 'Installs the specified version of Node.JS. The npm CLI bundled with the given Node.js version gets installed as well.',
+            name: 'use',
+          },
+          {
+            description: 'Uninstalls the specified version of Node.JS.',
+            name: 'remove\nuninstall',
+            shortAlias: 'rm,\nun',
+          },
+        ],
+      },
       {
         title: 'Options',
         list: [
           {
-            description: 'Installs and uninstalls Node.js globally',
+            description: 'Manages Node.js versions globally',
             name: '--global',
             shortAlias: '-g',
           },
@@ -46,11 +60,11 @@ export function help () {
       'pnpm env use --global argon',
       'pnpm env use --global latest',
       'pnpm env use --global rc/16',
-      'pnpm env uninstall --global 16',
-      'pnpm env uninstall --global lts',
-      'pnpm env uninstall --global argon',
-      'pnpm env uninstall --global latest',
-      'pnpm env uninstall --global rc/16',
+      'pnpm env remove --global 16',
+      'pnpm env remove --global lts',
+      'pnpm env remove --global argon',
+      'pnpm env remove --global latest',
+      'pnpm env remove --global rc/16',
     ],
   })
 }
@@ -103,7 +117,10 @@ export async function handler (opts: NvmNodeCommandOptions, params: string[]) {
     return `Node.js ${nodeVersion as string} is activated
   ${dest} -> ${src}`
   }
-  case 'uninstall': {
+  case 'remove':
+  case 'rm':
+  case 'uninstall':
+  case 'un': {
     if (!opts.global) {
       throw new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env use <version>" can only be used with the "--global" option currently')
     }
@@ -137,7 +154,13 @@ export async function handler (opts: NvmNodeCommandOptions, params: string[]) {
         fs.unlink(nodePath),
         fs.unlink(npmPath),
         fs.unlink(npxPath),
-      ])
+      ]).catch(err => {
+        const { code = '' } = err
+
+        if (code.toLowerCase() !== 'enoent') {
+          throw err
+        }
+      })
     }
 
     const [processMajorVersion, processMinorVersion] = process.versions.node.split('.')

--- a/packages/plugin-commands-env/src/env.ts
+++ b/packages/plugin-commands-env/src/env.ts
@@ -155,12 +155,8 @@ export async function handler (opts: NvmNodeCommandOptions, params: string[]) {
           fs.unlink(npmPath),
           fs.unlink(npxPath),
         ])
-      } catch (err) {
-        const { code = '' } = err as NodeJS.ErrnoException
-
-        if (code !== 'ENOENT') {
-          throw err
-        }
+      } catch (err: any) { // eslint-disable-line
+        if (err.code !== 'ENOENT') throw err
       }
     }
 

--- a/packages/plugin-commands-env/src/node.ts
+++ b/packages/plugin-commands-env/src/node.ts
@@ -57,7 +57,7 @@ export async function getNodeBinDir (opts: NvmNodeCommandOptions) {
   return process.platform === 'win32' ? nodeDir : path.join(nodeDir, 'bin')
 }
 
-function getNodeVersionsBaseDir (pnpmHomeDir: string) {
+export function getNodeVersionsBaseDir (pnpmHomeDir: string) {
   return path.join(pnpmHomeDir, 'nodejs')
 }
 

--- a/packages/plugin-commands-env/test/env.test.ts
+++ b/packages/plugin-commands-env/test/env.test.ts
@@ -134,7 +134,7 @@ test('it re-attempts failed downloads', async () => {
   }
 })
 
-describe('env uninstall', () => {
+describe('env remove', () => {
   test('fail if --global is missing', async () => {
     tempDir()
 
@@ -144,7 +144,7 @@ describe('env uninstall', () => {
         global: false,
         pnpmHomeDir: process.cwd(),
         rawConfig: {},
-      }, ['uninstall', 'lts'])
+      }, ['remove', 'lts'])
     ).rejects.toEqual(new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env use <version>" can only be used with the "--global" option currently'))
   })
 
@@ -157,11 +157,11 @@ describe('env uninstall', () => {
         global: true,
         pnpmHomeDir: process.cwd(),
         rawConfig: {},
-      }, ['uninstall', 'non-existing-version'])
+      }, ['rm', 'non-existing-version'])
     ).rejects.toEqual(new PnpmError('COULD_NOT_RESOLVE_NODEJS', 'Couldn\'t find Node.js version matching non-existing-version'))
   })
 
-  test('fail if trying to uninstall version that is not installed', async () => {
+  test('fail if trying to remove version that is not installed', async () => {
     tempDir()
 
     const nodeDir = node.getNodeVersionsBaseDir(process.cwd())
@@ -172,11 +172,11 @@ describe('env uninstall', () => {
         global: true,
         pnpmHomeDir: process.cwd(),
         rawConfig: {},
-      }, ['uninstall', '16.4.0'])
+      }, ['remove', '16.4.0'])
     ).rejects.toEqual(new PnpmError('ENV_NO_NODE_DIRECTORY', `Couldn't find Node.js directory in ${path.resolve(nodeDir, '16.4.0')}`))
   })
 
-  test('install and uninstall Node.js by exact version', async () => {
+  test('install and remove Node.js by exact version', async () => {
     tempDir()
 
     const configDir = path.resolve('config')
@@ -206,7 +206,7 @@ describe('env uninstall', () => {
       global: true,
       pnpmHomeDir: process.cwd(),
       rawConfig: {},
-    }, ['uninstall', '16.4.0'])
+    }, ['rm', '16.4.0'])
 
     expect(() => execa.sync('node', ['-v'], opts)).toThrowError()
   })

--- a/packages/plugin-commands-env/test/env.test.ts
+++ b/packages/plugin-commands-env/test/env.test.ts
@@ -173,7 +173,7 @@ describe('env uninstall', () => {
         pnpmHomeDir: process.cwd(),
         rawConfig: {},
       }, ['uninstall', '16.4.0'])
-    ).rejects.toEqual(new PnpmError('ENV_NO_NODE_DIRECTORY', `Couldn't find Node.js directory in ${nodeDir as string}/16.4.0`))
+    ).rejects.toEqual(new PnpmError('ENV_NO_NODE_DIRECTORY', `Couldn't find Node.js directory in ${path.resolve(nodeDir, '16.4.0')}`))
   })
 
   test('install and uninstall Node.js by exact version', async () => {

--- a/packages/plugin-commands-env/test/env.test.ts
+++ b/packages/plugin-commands-env/test/env.test.ts
@@ -191,7 +191,7 @@ describe('env remove', () => {
 
     const opts = {
       env: {
-        [PATH]: `${process.cwd()}${path.delimiter}${process.env[PATH] as string}`,
+        [PATH]: process.cwd(),
       },
       extendEnv: false,
     }

--- a/packages/plugin-commands-env/test/node.test.ts
+++ b/packages/plugin-commands-env/test/node.test.ts
@@ -73,3 +73,9 @@ test('install and rc version of Node.js', async () => {
   const extension = process.platform === 'win32' ? 'zip' : 'tar.gz'
   expect(fetchMock.mock.calls[0][0]).toBe(`https://nodejs.org/download/rc/v18.0.0-rc.3/node-v18.0.0-rc.3-${platform}-x64.${extension}`)
 })
+
+test('get node version base dir', async () => {
+  expect(typeof node.getNodeVersionsBaseDir).toBe('function')
+  const versionDir = node.getNodeVersionsBaseDir(process.cwd())
+  expect(versionDir).toBe(`${process.cwd()}/nodejs`)
+})

--- a/packages/plugin-commands-env/test/node.test.ts
+++ b/packages/plugin-commands-env/test/node.test.ts
@@ -77,5 +77,5 @@ test('install and rc version of Node.js', async () => {
 test('get node version base dir', async () => {
   expect(typeof node.getNodeVersionsBaseDir).toBe('function')
   const versionDir = node.getNodeVersionsBaseDir(process.cwd())
-  expect(versionDir).toBe(`${process.cwd()}/nodejs`)
+  expect(versionDir).toBe(path.resolve(process.cwd(), 'nodejs'))
 })

--- a/packages/plugin-commands-env/tsconfig.json
+++ b/packages/plugin-commands-env/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../node.resolver"
     },
     {
+      "path": "../remove-bins"
+    },
+    {
       "path": "../store-path"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3078,6 +3078,9 @@ importers:
       '@pnpm/node.resolver':
         specifier: workspace:*
         version: link:../node.resolver
+      '@pnpm/remove-bins':
+        specifier: workspace:*
+        version: link:../remove-bins
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../store-path

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3084,6 +3084,9 @@ importers:
       '@zkochan/cmd-shim':
         specifier: ^5.3.1
         version: 5.3.1
+      '@zkochan/rimraf':
+        specifier: ^2.1.2
+        version: 2.1.2
       load-json-file:
         specifier: ^6.2.0
         version: 6.2.0


### PR DESCRIPTION
#### Summary
This PR enhances the `pnpm env` functionality with the `uninstall` command, allowing to uninstall Node.JS globally, that was previously installed with `pnpm env use <version>`.

Partially closes #5155 

Listing installed Node.JS will be done in a separate PR, I'm trying to keep this one short.

#### Note to reviewers
I think there's room for refactoring, but for now, I just tried to follow what's already in place. If refactoring is an option, I could work on it furthermore.