### PR TITLE
fix: supply patch-package with package details

### DIFF
--- a/packages/build-modules/src/index.ts
+++ b/packages/build-modules/src/index.ts
@@ -9,6 +9,7 @@ import { fromDir as readPackageFromDir, safeReadPackageFromDir } from '@pnpm/rea
 import { StoreController } from '@pnpm/store-controller-types'
 import { DependencyManifest } from '@pnpm/types'
 import { applyPatch } from 'patch-package/dist/applyPatches'
+import { getPackageDetailsFromPatchFilename } from 'patch-package/dist/PackageDetails'
 import runGroups from 'run-groups'
 import buildSequence, { DependenciesGraph, DependenciesGraphNode } from './buildSequence'
 
@@ -156,7 +157,9 @@ function applyPatchToDep (patchDir: string, patchFilePath: string) {
   process.chdir(patchDir)
   const success = applyPatch({
     patchFilePath,
+    packageDetails: getPackageDetailsFromPatchFilename(path.basename(patchFilePath)),
     patchDir,
+    reverse: false,
   })
   process.chdir(cwd)
   if (!success) {

--- a/typings/local.d.ts
+++ b/typings/local.d.ts
@@ -145,3 +145,7 @@ declare module 'string.prototype.replaceall' {
   const anything: any
   export = anything
 }
+
+declare module 'patch-package/dist/PackageDetails' {
+  export function getPackageDetailsFromPatchFilename (patchFileName: string): any
+}


### PR DESCRIPTION
ref #5278 

Without supplying the appropriate `packageDetails` to [`patch-package`'s `applyPatch`](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts#L232), when failures arise the user is presented with a vague error 

```
#0 117.4  ERROR  Cannot read properties of undefined (reading 'pathSpecifier')
#0 117.4 
#0 117.4 pnpm: Cannot read properties of undefined (reading 'pathSpecifier')
#0 117.4     at Object.readPatch (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:122192:61)
#0 117.4     at applyPatch (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:122387:28)
#0 117.4     at applyPatchToDep (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:122671:53)
#0 117.4     at buildDependency (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:122609:11)
```

This PR aims to address the issue with the failure in order to allow patch-package to surface its own error message. I've intentionally not included a `try/catch` block in this function, however I can add it if we'd like to show a different error