### PR TITLE
fix: don't extend NODE_PATH in command shims

### DIFF
--- a/.changeset/seven-humans-cover.md
+++ b/.changeset/seven-humans-cover.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+"pnpm": patch
+---
+
+Don't extend NODE_PATH in command shims [#5176](https://github.com/pnpm/pnpm/issues/5176).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -186,7 +186,7 @@ export async function getConfig (
     color: 'auto',
     'dedupe-peer-dependents': false,
     'enable-modules-dir': true,
-    'extend-node-path': true,
+    'extend-node-path': false,
     'fetch-retries': 2,
     'fetch-retry-factor': 10,
     'fetch-retry-maxtimeout': 60000,


### PR DESCRIPTION
close #5285