### PR TITLE
fix: implement merging hooks provided in opts

### DIFF
--- a/.changeset/cyan-walls-remember.md
+++ b/.changeset/cyan-walls-remember.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpmfile": patch
+---
+
+Implement merging hooks provided in opts

--- a/packages/pnpmfile/test/index.ts
+++ b/packages/pnpmfile/test/index.ts
@@ -23,6 +23,29 @@ test('readPackage hook run fails when returned dependencies is not an object ', 
   ).rejects.toEqual(new BadReadPackageHookError(pnpmfilePath, 'readPackage hook returned package manifest object\'s property \'dependencies\' must be an object.'))
 })
 
+test('filterLog hook works from single source', () => {
+  const pnpmfile = path.join(__dirname, 'pnpmfiles/filterLog.js')
+  const hooks = requireHooks(__dirname, { pnpmfile })
+
+  expect(hooks.filterLog).toBeDefined()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'error',
+    prefix: 'test',
+  })).toBeTruthy()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'warn',
+    prefix: 'test',
+    message: 'message',
+  })).toBeTruthy()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'debug',
+    prefix: 'test',
+  })).toBeTruthy()
+})
+
 test('filterLog hook combines with the global hook', () => {
   const globalPnpmfile = path.join(__dirname, 'pnpmfiles/globalFilterLog.js')
   const pnpmfile = path.join(__dirname, 'pnpmfiles/filterLog.js')
@@ -36,7 +59,87 @@ test('filterLog hook combines with the global hook', () => {
   })).toBeTruthy()
   expect(hooks.filterLog!({
     name: 'pnpm:summary',
+    level: 'warn',
+    prefix: 'test',
+    message: 'message',
+  })).toBeTruthy()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
     level: 'debug',
     prefix: 'test',
   })).toBeFalsy()
+})
+
+test('filterLog hook combines with the global hook and the options hook', () => {
+  const globalPnpmfile = path.join(__dirname, 'pnpmfiles/globalFilterLog.js')
+  const pnpmfile = path.join(__dirname, 'pnpmfiles/filterLog.js')
+  const hooks = requireHooks(__dirname, {
+    globalPnpmfile,
+    pnpmfile,
+    hooks: {
+      filterLog (log) {
+        return log.level === 'error'
+      },
+    },
+  })
+
+  expect(hooks.filterLog).toBeDefined()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'error',
+    prefix: 'test',
+  })).toBeTruthy()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'warn',
+    prefix: 'test',
+    message: 'message',
+  })).toBeFalsy()
+  expect(hooks.filterLog!({
+    name: 'pnpm:summary',
+    level: 'debug',
+    prefix: 'test',
+  })).toBeFalsy()
+})
+
+test('readPackage hook works from single source', async () => {
+  const pnpmfile = path.join(__dirname, 'pnpmfiles/readPackage.js')
+  const hooks = requireHooks(__dirname, { pnpmfile })
+
+  expect(hooks.readPackage).toBeDefined()
+  console.log(hooks.readPackage!({}))
+  expect(await hooks.readPackage!({})).toHaveProperty('local', true)
+  expect(await hooks.readPackage!({})).not.toHaveProperty('global', true)
+  expect(await hooks.readPackage!({})).not.toHaveProperty('opts', true)
+})
+
+test('readPackage hook combines with the global hook', async () => {
+  const pnpmfile = path.join(__dirname, 'pnpmfiles/readPackage.js')
+  const globalPnpmfile = path.join(__dirname, 'pnpmfiles/globalReadPackage.js')
+  const hooks = requireHooks(__dirname, { pnpmfile, globalPnpmfile })
+
+  expect(hooks.readPackage).toBeDefined()
+  expect(await hooks.readPackage!({})).toHaveProperty('local', true)
+  expect(await hooks.readPackage!({})).toHaveProperty('global', true)
+  expect(await hooks.readPackage!({})).not.toHaveProperty('opts', true)
+})
+
+test('readPackage hook combines with the global hook and the options hook', async () => {
+  const pnpmfile = path.join(__dirname, 'pnpmfiles/readPackage.js')
+  const globalPnpmfile = path.join(__dirname, 'pnpmfiles/globalReadPackage.js')
+  const hooks = requireHooks(__dirname, {
+    pnpmfile,
+    globalPnpmfile,
+    hooks: {
+      readPackage (pkg) {
+        pkg.opts = true
+        return pkg
+      },
+    },
+  })
+
+  expect(hooks.readPackage).toBeDefined()
+  expect(await hooks.readPackage!({})).toHaveProperty('local', true)
+  expect(await hooks.readPackage!({})).toHaveProperty('global', true)
+  expect(await hooks.readPackage!({})).toHaveProperty('opts', true)
 })

--- a/packages/pnpmfile/test/pnpmfiles/filterLog.js
+++ b/packages/pnpmfile/test/pnpmfiles/filterLog.js
@@ -3,5 +3,5 @@ module.exports = {
 }
 
 function filterLog(log) {
-  return log.level === 'debug' || log.level === 'error'
+  return log.level === 'debug' || log.level === 'error' || log.level === 'warn'
 }

--- a/packages/pnpmfile/test/pnpmfiles/globalFilterLog.js
+++ b/packages/pnpmfile/test/pnpmfiles/globalFilterLog.js
@@ -3,5 +3,5 @@ module.exports = {
 }
 
 function filterLog(log) {
-  return log.level === 'error'
+  return log.level === 'error' || log.level === 'warn'
 }

--- a/packages/pnpmfile/test/pnpmfiles/globalReadPackage.js
+++ b/packages/pnpmfile/test/pnpmfiles/globalReadPackage.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: { readPackage }
+}
+
+function readPackage (pkg) {
+  pkg.global = true
+  return pkg
+}

--- a/packages/pnpmfile/test/pnpmfiles/readPackage.js
+++ b/packages/pnpmfile/test/pnpmfiles/readPackage.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: { readPackage }
+}
+
+function readPackage (pkg) {
+  pkg.local = true
+  return pkg
+}


### PR DESCRIPTION
Pnpm deploy command is providing readPackage in opts and it is being discarded by requireHooks.
This change ensures, that hooks provided in opts are merged with those from local and global
pnpmfiles.

Closes #5306