### PR TITLE
feat: publicly hoist any dependency that is related to tools for chec…

### DIFF
--- a/.changeset/wild-grapes-train.md
+++ b/.changeset/wild-grapes-train.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+Publicly hoist any dependency that is related to tools for checking code.

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -214,6 +214,9 @@ export default async (
     'public-hoist-pattern': [
       '*eslint*',
       '*prettier*',
+      'husky',
+      'lint-staged',
+      '@commitlint/*',
     ],
     'recursive-install': true,
     registry: npmDefaults.registry,


### PR DESCRIPTION
Let's say I have a convenient tool named `my-checking-code-tool`. After I run `pnpm add my-checking-code-tool -D` to devDependencies, this tool will install all the sub-packages, like `husky`, `eslint`, `lint-staged` and `@commitlint/cli`, and then setup all the config. So that I don't need to setup `.husky` file (directory), `.eslintrc`, `.lintstagedrc`, `. commitlintrc`. Just install such all-in-one tool, I can easily setup all the thing for checking code and commit-message.

This tool works well with `npm`, but cannot works well with`pnpm`. The mainly reason is that `pnpm` not publicly hoist the sub-dependencies like `husky`, `lint-staged` and `@commitlint/cli`. Tools like these are commonly used by many projects for checking code.