### PR TITLE
fix: error in pnpm --dir <path> link --global

### DIFF
--- a/.changeset/orange-apes-scream.md
+++ b/.changeset/orange-apes-scream.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+add path join and add test case for pnpm --dir <path> link global

--- a/.changeset/stale-rice-nail.md
+++ b/.changeset/stale-rice-nail.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+fix error in pnpm --dir <path> link --global

--- a/packages/plugin-commands-installation/src/link.ts
+++ b/packages/plugin-commands-installation/src/link.ts
@@ -7,7 +7,7 @@ import {
   tryReadProjectManifest,
 } from '@pnpm/cli-utils'
 import { UNIVERSAL_OPTIONS } from '@pnpm/common-cli-options-help'
-import { CliOptions, Config, types as allTypes } from '@pnpm/config'
+import { Config, types as allTypes } from '@pnpm/config'
 import PnpmError from '@pnpm/error'
 import findWorkspaceDir from '@pnpm/find-workspace-dir'
 import findWorkspacePackages, { arrayOfWorkspacePackagesToMap } from '@pnpm/find-workspace-packages'
@@ -116,7 +116,7 @@ export async function handler (
     const { manifest, writeProjectManifest } = await tryReadProjectManifest(opts.dir, opts)
     const newManifest = await addDependenciesToPackage(
       manifest ?? {},
-      [`link:${(opts.cliOptions as CliOptions)?.dir ?? cwd}`],
+      [`link:${opts.cliOptions?.dir ? path.join(cwd, opts.cliOptions.dir) : cwd}`],
       linkOpts
     )
     await writeProjectManifest(newManifest)

--- a/packages/plugin-commands-installation/src/link.ts
+++ b/packages/plugin-commands-installation/src/link.ts
@@ -7,7 +7,7 @@ import {
   tryReadProjectManifest,
 } from '@pnpm/cli-utils'
 import { UNIVERSAL_OPTIONS } from '@pnpm/common-cli-options-help'
-import { Config, types as allTypes } from '@pnpm/config'
+import { CliOptions, Config, types as allTypes } from '@pnpm/config'
 import PnpmError from '@pnpm/error'
 import findWorkspaceDir from '@pnpm/find-workspace-dir'
 import findWorkspacePackages, { arrayOfWorkspacePackagesToMap } from '@pnpm/find-workspace-packages'
@@ -116,7 +116,7 @@ export async function handler (
     const { manifest, writeProjectManifest } = await tryReadProjectManifest(opts.dir, opts)
     const newManifest = await addDependenciesToPackage(
       manifest ?? {},
-      [`link:${cwd}`],
+      [`link:${(opts.cliOptions as CliOptions)?.dir ?? cwd}`],
       linkOpts
     )
     await writeProjectManifest(newManifest)

--- a/packages/plugin-commands-installation/test/link.ts
+++ b/packages/plugin-commands-installation/test/link.ts
@@ -72,6 +72,32 @@ test('link global bin', async function () {
   await isExecutable((value) => expect(value).toBeTruthy(), path.join(globalBin, 'package-with-bin'))
 })
 
+test('link --dir global bin', async function () {
+  prepare()
+  process.chdir('..')
+
+  const globalDir = path.resolve('global')
+  const globalBin = path.join(globalDir, 'bin')
+  const oldPath = process.env[PATH]
+  process.env[PATH] = `${globalBin}${path.delimiter}${oldPath ?? ''}`
+  await fs.mkdir(globalBin, { recursive: true })
+
+  await writePkg('./dir/package-with-bin-in-dir', { name: 'package-with-bin-in-dir', version: '1.0.0', bin: 'bin.js' })
+  await fs.writeFile('./dir/package-with-bin-in-dir/bin.js', '#!/usr/bin/env node\nconsole.log(/hi/)\n', 'utf8')
+
+  await link.handler({
+    ...DEFAULT_OPTS,
+    cliOptions: {
+      dir: './dir/package-with-bin-in-dir',
+    },
+    bin: globalBin,
+    dir: globalDir,
+  })
+  process.env[PATH] = oldPath
+
+  await isExecutable((value) => expect(value).toBeTruthy(), path.join(globalBin, 'package-with-bin-in-dir'))
+})
+
 test('relative link', async () => {
   const project = prepare({
     dependencies: {


### PR DESCRIPTION
close https://github.com/pnpm/pnpm/issues/5368

pnpm link always use `cwd` and don't read the `--dir` option, I try to fix it but I am not sure if it's the best way