### PR TITLE
Feature: ignore packages listed in `package.json > pnpm.updateConfig.ignoreDependencies` on update/outdated commands

### DIFF
--- a/.changeset/rude-vans-build.md
+++ b/.changeset/rude-vans-build.md
@@ -5,4 +5,4 @@
 "@pnpm/types": minor
 ---
 
-Ignore packages listed in package.json > pnpm.update.ignoreDependencies fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)
+Ignore packages listed in package.json > pnpm.updateConfig.ignoreDependencies fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)

--- a/.changeset/rude-vans-build.md
+++ b/.changeset/rude-vans-build.md
@@ -1,8 +1,8 @@
 ---
-"@pnpm/outdated": major
-"@pnpm/plugin-commands-installation": major
-"@pnpm/plugin-commands-outdated": major
-"@pnpm/types": major
+"@pnpm/outdated": minor
+"@pnpm/plugin-commands-installation": minor
+"@pnpm/plugin-commands-outdated": minor
+"@pnpm/types": minor
 ---
 
 Ignore packages listed in package.json > pnpm.update.ignoreDependencies fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)

--- a/.changeset/rude-vans-build.md
+++ b/.changeset/rude-vans-build.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/outdated": major
+"@pnpm/plugin-commands-installation": major
+"@pnpm/plugin-commands-outdated": major
+"@pnpm/types": major
+---
+
+Ignore packages listed in package.json > pnpm.update.ignore fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)

--- a/.changeset/rude-vans-build.md
+++ b/.changeset/rude-vans-build.md
@@ -5,4 +5,4 @@
 "@pnpm/types": major
 ---
 
-Ignore packages listed in package.json > pnpm.update.ignore fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)
+Ignore packages listed in package.json > pnpm.update.ignoreDependencies fields on update/outdated command [#5358](https://github.com/pnpm/pnpm/issues/5358)

--- a/fixtures/with-pnpm-update-ignore/package.json
+++ b/fixtures/with-pnpm-update-ignore/package.json
@@ -7,7 +7,7 @@
   },
   "pnpm": {
     "update": {
-      "ignore": [
+      "ignoreDependencies": [
         "is-positive"
       ]
     }

--- a/fixtures/with-pnpm-update-ignore/package.json
+++ b/fixtures/with-pnpm-update-ignore/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "with-pnpm-update-ignore",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "1.0.0",
+    "is-negative": "1.0.0"
+  },
+  "pnpm": {
+    "update": {
+      "ignore": [
+        "is-positive"
+      ]
+    }
+  }
+}

--- a/fixtures/with-pnpm-update-ignore/package.json
+++ b/fixtures/with-pnpm-update-ignore/package.json
@@ -6,7 +6,7 @@
     "is-negative": "1.0.0"
   },
   "pnpm": {
-    "update": {
+    "updateConfig": {
       "ignoreDependencies": [
         "is-positive"
       ]

--- a/fixtures/with-pnpm-update-ignore/pnpm-lock.yaml
+++ b/fixtures/with-pnpm-update-ignore/pnpm-lock.yaml
@@ -1,0 +1,21 @@
+lockfileVersion: 5.4
+
+specifiers:
+  is-negative: 1.0.0
+  is-positive: 1.0.0
+
+dependencies:
+  is-negative: 1.0.0
+  is-positive: 1.0.0
+
+packages:
+
+  /is-negative/1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-positive/1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -74,7 +74,7 @@ export default async function outdated (
             return
           }
 
-          if ((opts.manifest.pnpm?.update?.ignoreDependencies ?? []).includes(alias)) {
+          if ((opts.manifest.pnpm?.updateConfig?.ignoreDependencies ?? []).includes(alias)) {
             return
           }
 

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -34,6 +34,7 @@ export default async function outdated (
     compatible?: boolean
     currentLockfile: Lockfile | null
     getLatestManifest: GetLatestManifestFunction
+    ignoreDependencies?: Set<string>
     include?: IncludedDependencies
     lockfileDir: string
     manifest: ProjectManifest
@@ -74,7 +75,7 @@ export default async function outdated (
             return
           }
 
-          if ((opts.manifest.pnpm?.updateConfig?.ignoreDependencies ?? []).includes(alias)) {
+          if (opts.ignoreDependencies?.has(alias)) {
             return
           }
 

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -70,12 +70,10 @@ export default async function outdated (
         pkgs.map(async (alias) => {
           const ref = opts.wantedLockfile!.importers[importerId][depType]![alias]
 
-          // ignoring linked packages. (For backward compatibility)
-          if (ref.startsWith('file:')) {
-            return
-          }
-
-          if (opts.ignoreDependencies?.has(alias)) {
+          if (
+            ref.startsWith('file:') || // ignoring linked packages. (For backward compatibility)
+            opts.ignoreDependencies?.has(alias)
+          ) {
             return
           }
 

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -74,6 +74,10 @@ export default async function outdated (
             return
           }
 
+          if ((opts.manifest.pnpm?.update?.ignore ?? []).includes(alias)) {
+            return
+          }
+
           const relativeDepPath = dp.refToRelative(ref, alias)
 
           // ignoring linked packages

--- a/packages/outdated/src/outdated.ts
+++ b/packages/outdated/src/outdated.ts
@@ -74,7 +74,7 @@ export default async function outdated (
             return
           }
 
-          if ((opts.manifest.pnpm?.update?.ignore ?? []).includes(alias)) {
+          if ((opts.manifest.pnpm?.update?.ignoreDependencies ?? []).includes(alias)) {
             return
           }
 

--- a/packages/outdated/src/outdatedDepsOfProjects.ts
+++ b/packages/outdated/src/outdatedDepsOfProjects.ts
@@ -18,6 +18,7 @@ export default async function outdatedDepsOfProjects (
   args: string[],
   opts: Omit<ManifestGetterOptions, 'fullMetadata' | 'lockfileDir'> & {
     compatible?: boolean
+    ignoreDependencies?: Set<string>
     include: IncludedDependencies
   } & Partial<Pick<ManifestGetterOptions, 'fullMetadata' | 'lockfileDir'>>
 ): Promise<OutdatedPackage[][]> {
@@ -44,6 +45,7 @@ export default async function outdatedDepsOfProjects (
       compatible: opts.compatible,
       currentLockfile,
       getLatestManifest,
+      ignoreDependencies: opts.ignoreDependencies,
       include: opts.include,
       lockfileDir,
       manifest,

--- a/packages/plugin-commands-installation/jest.config.js
+++ b/packages/plugin-commands-installation/jest.config.js
@@ -1,1 +1,7 @@
-module.exports = require('../../jest.config.js')
+module.exports = {
+  ...require('../../jest.config.js'),
+  // This is a temporary workaround.
+  // Currently, multiple tests use the @pnpm.e2e/foo package and they change it's dist-tags.
+  // These tests are in separate files, so sometimes they will simultaneously set the dist tag and fail because they expect different versions to be tagged.
+  maxWorkers: 1,
+}

--- a/packages/plugin-commands-installation/src/ignoreDependenciesWithSelectorPattern.ts
+++ b/packages/plugin-commands-installation/src/ignoreDependenciesWithSelectorPattern.ts
@@ -1,3 +1,0 @@
-export function ignoreDependenciesWithSelectorPattern (selectorPattern: string[], ignoredDependencies: string[]): string[] {
-  return [...ignoredDependencies.map(depName => `!${depName}`), ...selectorPattern]
-}

--- a/packages/plugin-commands-installation/src/ignoreDependenciesWithSelectorPattern.ts
+++ b/packages/plugin-commands-installation/src/ignoreDependenciesWithSelectorPattern.ts
@@ -1,0 +1,3 @@
+export function ignoreDependenciesWithSelectorPattern (selectorPattern: string[], ignoredDependencies: string[]): string[] {
+  return [...ignoredDependencies.map(depName => `!${depName}`), ...selectorPattern]
+}

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -226,7 +226,7 @@ when running add/update with the --workspace option')
   if (opts.update) {
     params = params.filter((param) => {
       const packageName = param.slice(0, param.lastIndexOf('@'))
-      return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+      return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
     })
   }
 

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -201,7 +201,7 @@ when running add/update with the --workspace option')
 
   let currentInput = [...params]
 
-  if (opts.update) {
+  if (opts.update && params.length === 0) {
     const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
     currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
   }

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -199,46 +199,44 @@ when running add/update with the --workspace option')
     }
   }
 
-  let currentInput = [...params]
-
   let updateMatch: UpdateDepsMatcher | null
   if (opts.update) {
     const ignoreDeps = manifest.pnpm?.updateConfig?.ignoreDependencies
     if (params.length === 0 && ignoreDeps?.length) {
-      currentInput = makeIgnorePatterns(ignoreDeps)
+      params = makeIgnorePatterns(ignoreDeps)
     }
-    updateMatch = currentInput.length ? createMatcher(currentInput) : null
+    updateMatch = params.length ? createMatcher(params) : null
   } else {
     updateMatch = null
   }
   if (updateMatch != null) {
-    currentInput = matchDependencies(updateMatch, manifest, includeDirect)
-    if (currentInput.length === 0 && opts.depth === 0) {
+    params = matchDependencies(updateMatch, manifest, includeDirect)
+    if (params.length === 0 && opts.depth === 0) {
       throw new PnpmError('NO_PACKAGE_IN_DEPENDENCIES',
         'None of the specified packages were found in the dependencies.')
     }
   }
 
   if (opts.update && opts.latest) {
-    if (!currentInput || (currentInput.length === 0)) {
-      currentInput = updateToLatestSpecsFromManifest(manifest, includeDirect)
+    if (!params || (params.length === 0)) {
+      params = updateToLatestSpecsFromManifest(manifest, includeDirect)
     } else {
-      currentInput = createLatestSpecs(currentInput, manifest)
+      params = createLatestSpecs(params, manifest)
     }
   }
   if (opts.workspace) {
-    if (!currentInput || (currentInput.length === 0)) {
-      currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+    if (!params || (params.length === 0)) {
+      params = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
     } else {
-      currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
+      params = createWorkspaceSpecs(params, workspacePackages)
     }
   }
 
-  if (currentInput?.length) {
+  if (params?.length) {
     const mutatedProject: MutatedProject = {
       allowNew: opts.allowNew,
       binsDir: opts.bin,
-      dependencySelectors: currentInput,
+      dependencySelectors: params,
       manifest,
       mutation: 'installSome',
       peer: opts.savePeer,

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -222,6 +222,14 @@ when running add/update with the --workspace option')
       params = createWorkspaceSpecs(params, workspacePackages)
     }
   }
+
+  if (opts.update) {
+    params = params.filter((param) => {
+      const packageName = param.slice(0, param.lastIndexOf('@'))
+      return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+    })
+  }
+
   if (params?.length) {
     const mutatedProject: MutatedProject = {
       allowNew: opts.allowNew,

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -201,9 +201,11 @@ when running add/update with the --workspace option')
 
   let updateMatch: UpdateDepsMatcher | null
   if (opts.update) {
-    const ignoreDeps = manifest.pnpm?.updateConfig?.ignoreDependencies
-    if (params.length === 0 && ignoreDeps?.length) {
-      params = makeIgnorePatterns(ignoreDeps)
+    if (params.length === 0) {
+      const ignoreDeps = manifest.pnpm?.updateConfig?.ignoreDependencies
+      if (ignoreDeps?.length) {
+        params = makeIgnorePatterns(ignoreDeps)
+      }
     }
     updateMatch = params.length ? createMatcher(params) : null
   } else {
@@ -231,7 +233,6 @@ when running add/update with the --workspace option')
       params = createWorkspaceSpecs(params, workspacePackages)
     }
   }
-
   if (params?.length) {
     const mutatedProject: MutatedProject = {
       allowNew: opts.allowNew,

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -199,42 +199,37 @@ when running add/update with the --workspace option')
     }
   }
 
-  const updateMatch = opts.update && (params.length > 0) ? createMatcher(params) : null
+  let currentInput = [...params]
+
+  const updateMatch = opts.update && (currentInput.length > 0) ? createMatcher(currentInput) : null
   if (updateMatch != null) {
-    params = matchDependencies(updateMatch, manifest, includeDirect)
-    if (params.length === 0 && opts.depth === 0) {
+    currentInput = matchDependencies(updateMatch, manifest, includeDirect)
+    if (currentInput.length === 0 && opts.depth === 0) {
       throw new PnpmError('NO_PACKAGE_IN_DEPENDENCIES',
         'None of the specified packages were found in the dependencies.')
     }
   }
 
   if (opts.update && opts.latest) {
-    if (!params || (params.length === 0)) {
-      params = updateToLatestSpecsFromManifest(manifest, includeDirect)
+    if (!currentInput || (currentInput.length === 0)) {
+      currentInput = updateToLatestSpecsFromManifest(manifest, includeDirect)
     } else {
-      params = createLatestSpecs(params, manifest)
+      currentInput = createLatestSpecs(currentInput, manifest)
     }
   }
   if (opts.workspace) {
-    if (!params || (params.length === 0)) {
-      params = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+    if (!currentInput || (currentInput.length === 0)) {
+      currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
     } else {
-      params = createWorkspaceSpecs(params, workspacePackages)
+      currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
     }
   }
 
-  if (opts.update) {
-    params = params.filter((param) => {
-      const packageName = param.slice(0, param.lastIndexOf('@'))
-      return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
-    })
-  }
-
-  if (params?.length) {
+  if (currentInput?.length) {
     const mutatedProject: MutatedProject = {
       allowNew: opts.allowNew,
       binsDir: opts.bin,
-      dependencySelectors: params,
+      dependencySelectors: currentInput,
       manifest,
       mutation: 'installSome',
       peer: opts.savePeer,

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -24,10 +24,9 @@ import getOptionsFromRootManifest from './getOptionsFromRootManifest'
 import getPinnedVersion from './getPinnedVersion'
 import getSaveType from './getSaveType'
 import getNodeExecPath from './nodeExecPath'
-import recursive, { createMatcher, matchDependencies } from './recursive'
+import recursive, { createMatcher, matchDependencies, makeIgnorePatterns } from './recursive'
 import updateToLatestSpecsFromManifest, { createLatestSpecs } from './updateToLatestSpecsFromManifest'
 import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies'
-import { ignoreDependenciesWithSelectorPattern } from './ignoreDependenciesWithSelectorPattern'
 
 const OVERWRITE_UPDATE_OPTIONS = {
   allowNew: true,
@@ -205,7 +204,7 @@ when running add/update with the --workspace option')
   const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
   const shouldIgnorePackages = opts.update && params.length === 0 && ignoredPackages.length > 0
   if (shouldIgnorePackages) {
-    currentInput = ignoreDependenciesWithSelectorPattern(currentInput, ignoredPackages)
+    currentInput = makeIgnorePatterns(ignoredPackages)
   }
 
   const updateMatch = opts.update && (currentInput.length > 0) ? createMatcher(currentInput) : null

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -209,7 +209,7 @@ when running add/update with the --workspace option')
 
   const updateMatch = opts.update && (currentInput.length > 0) ? createMatcher(currentInput) : null
   if (updateMatch != null) {
-    const currentInput = matchDependencies(updateMatch, manifest, includeDirect)
+    currentInput = matchDependencies(updateMatch, manifest, includeDirect)
     if (currentInput.length === 0 && opts.depth === 0 && ignoredPackages.length === 0) {
       throw new PnpmError('NO_PACKAGE_IN_DEPENDENCIES',
         'None of the specified packages were found in the dependencies.')

--- a/packages/plugin-commands-installation/src/installDeps.ts
+++ b/packages/plugin-commands-installation/src/installDeps.ts
@@ -201,6 +201,11 @@ when running add/update with the --workspace option')
 
   let currentInput = [...params]
 
+  if (opts.update) {
+    const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
+    currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
+  }
+
   const updateMatch = opts.update && (currentInput.length > 0) ? createMatcher(currentInput) : null
   if (updateMatch != null) {
     currentInput = matchDependencies(updateMatch, manifest, includeDirect)

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -226,6 +226,14 @@ export default async function recursive (
           currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
         }
       }
+
+      if (opts.update) {
+        currentInput = currentInput.filter((param) => {
+          const packageName = param.slice(0, param.lastIndexOf('@'))
+          return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+        })
+      }
+
       writeProjectManifests.push(writeProjectManifest)
       switch (mutation) {
       case 'uninstallSome':
@@ -325,6 +333,13 @@ export default async function recursive (
           } else {
             currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
           }
+        }
+
+        if (opts.update) {
+          currentInput = currentInput.filter((param) => {
+            const packageName = param.slice(0, param.lastIndexOf('@'))
+            return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+          })
         }
 
         let action!: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -173,13 +173,12 @@ export default async function recursive (
     optionalDependencies: true,
   }
 
-  let currentInput = [...params]
   const ignoredPackages = (manifestsByPath[opts.workspaceDir]?.manifest?.pnpm?.updateConfig?.ignoreDependencies ?? [])
   const shouldIgnorePackages = opts.update && params.length === 0 && ignoredPackages.length > 0
   if (shouldIgnorePackages) {
-    currentInput = makeIgnorePatterns(ignoredPackages)
+    params = makeIgnorePatterns(ignoredPackages)
   }
-  const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
+  const updateMatch = cmdFullName === 'update' && (params.length > 0) ? createMatcher(params) : null
   // For a workspace with shared lockfile
   if (opts.lockfileDir && ['add', 'install', 'remove', 'update', 'import'].includes(cmdFullName)) {
     let importers = await getImporters()
@@ -205,6 +204,7 @@ export default async function recursive (
       const localConfig = await memReadLocalConfig(rootDir)
       const modulesDir = localConfig.modulesDir ?? opts.modulesDir
       const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
+      let currentInput = [...params]
       if (updateMatch != null) {
         currentInput = matchDependencies(updateMatch, manifest, includeDirect)
         if ((currentInput.length === 0) && (typeof opts.depth === 'undefined' || opts.depth <= 0)) {

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -199,11 +199,12 @@ export default async function recursive (
       const modulesDir = localConfig.modulesDir ?? opts.modulesDir
       const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
       let currentInput = [...params]
+      const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
       if (opts.update && params.length === 0) {
-        const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
         currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
       }
       const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
+      const hasIgnored = ignoredPackages.length > 0
       if (updateMatch != null) {
         currentInput = matchDependencies(updateMatch, manifest, includeDirect)
         if ((currentInput.length === 0) && (typeof opts.depth === 'undefined' || opts.depth <= 0)) {
@@ -212,7 +213,7 @@ export default async function recursive (
         }
       }
       if (updateToLatest) {
-        if (!params || (params.length === 0)) {
+        if ((!params || (params.length === 0)) && !hasIgnored) {
           currentInput = updateToLatestSpecsFromManifest(manifest, includeDirect)
         } else {
           currentInput = createLatestSpecs(currentInput, manifest)
@@ -311,17 +312,18 @@ export default async function recursive (
 
         const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
         let currentInput = [...params]
+        const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
         if (opts.update && params.length === 0) {
-          const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
           currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
         }
         const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
+        const hasIgnored = ignoredPackages.length > 0
         if (updateMatch != null) {
           currentInput = matchDependencies(updateMatch, manifest, includeDirect)
           if (currentInput.length === 0) return
         }
         if (updateToLatest) {
-          if (!params || (params.length === 0)) {
+          if ((!params || (params.length === 0)) && !hasIgnored) {
             currentInput = updateToLatestSpecsFromManifest(manifest, includeDirect)
           } else {
             currentInput = createLatestSpecs(currentInput, manifest)

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -40,7 +40,6 @@ import updateToLatestSpecsFromManifest, { createLatestSpecs } from './updateToLa
 import getSaveType from './getSaveType'
 import getPinnedVersion from './getPinnedVersion'
 import { PreferredVersions } from '@pnpm/resolver-base'
-import { ignoreDependenciesWithSelectorPattern } from './ignoreDependenciesWithSelectorPattern'
 
 type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'bail'
@@ -203,7 +202,7 @@ export default async function recursive (
       const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
       const shouldIgnorePackages = opts.update && params.length === 0 && ignoredPackages.length > 0
       if (shouldIgnorePackages) {
-        currentInput = ignoreDependenciesWithSelectorPattern(currentInput, ignoredPackages)
+        currentInput = makeIgnorePatterns(ignoredPackages)
       }
       const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
       if (updateMatch != null) {
@@ -231,7 +230,6 @@ export default async function recursive (
           currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
         }
       }
-
       writeProjectManifests.push(writeProjectManifest)
       switch (mutation) {
       case 'uninstallSome':
@@ -316,7 +314,7 @@ export default async function recursive (
         const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
         const shouldIgnorePackages = opts.update && params.length === 0 && ignoredPackages.length > 0
         if (shouldIgnorePackages) {
-          currentInput = ignoreDependenciesWithSelectorPattern(currentInput, ignoredPackages)
+          currentInput = makeIgnorePatterns(ignoredPackages)
         }
         const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
         if (updateMatch != null) {
@@ -530,4 +528,8 @@ export function createMatcher (params: string[]) {
     if (index === -1) return null
     return specs[index]
   }
+}
+
+export function makeIgnorePatterns (ignoredDependencies: string[]): string[] {
+  return ignoredDependencies.map(depName => `!${depName}`)
 }

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -175,9 +175,11 @@ export default async function recursive (
 
   let updateMatch: UpdateDepsMatcher | null
   if (cmdFullName === 'update') {
-    const ignoreDeps = manifestsByPath[opts.workspaceDir]?.manifest?.pnpm?.updateConfig?.ignoreDependencies
-    if (params.length === 0 && ignoreDeps?.length) {
-      params = makeIgnorePatterns(ignoreDeps)
+    if (params.length === 0) {
+      const ignoreDeps = manifestsByPath[opts.workspaceDir]?.manifest?.pnpm?.updateConfig?.ignoreDependencies
+      if (ignoreDeps?.length) {
+        params = makeIgnorePatterns(ignoreDeps)
+      }
     }
     updateMatch = params.length ? createMatcher(params) : null
   } else {

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -173,8 +173,6 @@ export default async function recursive (
     optionalDependencies: true,
   }
 
-  const updateMatch = cmdFullName === 'update' && (params.length > 0) ? createMatcher(params) : null
-
   // For a workspace with shared lockfile
   if (opts.lockfileDir && ['add', 'install', 'remove', 'update', 'import'].includes(cmdFullName)) {
     let importers = await getImporters()
@@ -201,6 +199,11 @@ export default async function recursive (
       const modulesDir = localConfig.modulesDir ?? opts.modulesDir
       const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
       let currentInput = [...params]
+      if (opts.update) {
+        const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
+        currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
+      }
+      const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
       if (updateMatch != null) {
         currentInput = matchDependencies(updateMatch, manifest, includeDirect)
         if ((currentInput.length === 0) && (typeof opts.depth === 'undefined' || opts.depth <= 0)) {
@@ -308,6 +311,11 @@ export default async function recursive (
 
         const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
         let currentInput = [...params]
+        if (opts.update) {
+          const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
+          currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
+        }
+        const updateMatch = cmdFullName === 'update' && (currentInput.length > 0) ? createMatcher(currentInput) : null
         if (updateMatch != null) {
           currentInput = matchDependencies(updateMatch, manifest, includeDirect)
           if (currentInput.length === 0) return

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -230,7 +230,7 @@ export default async function recursive (
       if (opts.update) {
         currentInput = currentInput.filter((param) => {
           const packageName = param.slice(0, param.lastIndexOf('@'))
-          return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+          return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
         })
       }
 
@@ -338,7 +338,7 @@ export default async function recursive (
         if (opts.update) {
           currentInput = currentInput.filter((param) => {
             const packageName = param.slice(0, param.lastIndexOf('@'))
-            return !(manifest?.pnpm?.update?.ignore ?? []).includes(packageName)
+            return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
           })
         }
 

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -199,7 +199,7 @@ export default async function recursive (
       const modulesDir = localConfig.modulesDir ?? opts.modulesDir
       const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
       let currentInput = [...params]
-      if (opts.update) {
+      if (opts.update && params.length === 0) {
         const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
         currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
       }
@@ -311,7 +311,7 @@ export default async function recursive (
 
         const { manifest, writeProjectManifest } = manifestsByPath[rootDir]
         let currentInput = [...params]
-        if (opts.update) {
+        if (opts.update && params.length === 0) {
           const ignoredPackages = (manifest.pnpm?.updateConfig?.ignoreDependencies ?? [])
           currentInput = [...ignoredPackages.map(pkg => `!${pkg}`), ...currentInput]
         }

--- a/packages/plugin-commands-installation/src/recursive.ts
+++ b/packages/plugin-commands-installation/src/recursive.ts
@@ -227,13 +227,6 @@ export default async function recursive (
         }
       }
 
-      if (opts.update) {
-        currentInput = currentInput.filter((param) => {
-          const packageName = param.slice(0, param.lastIndexOf('@'))
-          return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
-        })
-      }
-
       writeProjectManifests.push(writeProjectManifest)
       switch (mutation) {
       case 'uninstallSome':
@@ -333,13 +326,6 @@ export default async function recursive (
           } else {
             currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
           }
-        }
-
-        if (opts.update) {
-          currentInput = currentInput.filter((param) => {
-            const packageName = param.slice(0, param.lastIndexOf('@'))
-            return !(manifest?.pnpm?.update?.ignoreDependencies ?? []).includes(packageName)
-          })
         }
 
         let action!: any // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -225,7 +225,7 @@ test('update should work normal when set empty string version', async () => {
   expect(lockfile.devDependencies['@pnpm.e2e/peer-c']).toEqual('2.0.0')
 })
 
-test('ignore packages in package.json > pnpm.update.ignore fields in update command', async () => {
+test('ignore packages in package.json > pnpm.update.ignoreDependencies fields in update command', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 
@@ -236,7 +236,7 @@ test('ignore packages in package.json > pnpm.update.ignore fields in update comm
     },
     pnpm: {
       update: {
-        ignore: [
+        ignoreDependencies: [
           '@pnpm.e2e/foo',
         ],
       },

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -261,6 +261,7 @@ test('ignore packages in package.json > Config.ignoreDependencies fields in upda
     ...DEFAULT_OPTS,
     dir: process.cwd(),
     workspaceDir: process.cwd(),
+    latest: true,
   })
 
   const lockfileUpdated = await project.readLockfile()

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -268,3 +268,47 @@ test('ignore packages in package.json > pnpm.update.ignoreDependencies fields in
   expect(lockfileUpdated.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
   expect(lockfileUpdated.packages['/@pnpm.e2e/bar/100.1.0']).toBeTruthy()
 })
+
+test('not ignore packages if these are specified in parameter even if these are listed in package.json > pnpm.update.ignoreDependencies fields in update command', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '2.0.0',
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+    pnpm: {
+      update: {
+        ignoreDependencies: [
+          '@pnpm.e2e/foo',
+        ],
+      },
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+
+  const lockfile = await project.readLockfile()
+
+  expect(lockfile.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfile.packages['/@pnpm.e2e/bar/100.0.0']).toBeTruthy()
+
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }, ['@pnpm.e2e/foo@latest', '@pnpm.e2e/bar@latest'])
+
+  const lockfileUpdated = await project.readLockfile()
+
+  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
+  expect(lockfileUpdated.packages['/@pnpm.e2e/bar/100.1.0']).toBeTruthy()
+})

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -225,7 +225,7 @@ test('update should work normal when set empty string version', async () => {
   expect(lockfile.devDependencies['@pnpm.e2e/peer-c']).toEqual('2.0.0')
 })
 
-test('ignore packages in package.json > Config.ignoreDependencies fields in update command', async () => {
+test('ignore packages in package.json > updateConfig.ignoreDependencies fields in update command', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -225,7 +225,7 @@ test('update should work normal when set empty string version', async () => {
   expect(lockfile.devDependencies['@pnpm.e2e/peer-c']).toEqual('2.0.0')
 })
 
-test('ignore packages in package.json > pnpm.update.ignoreDependencies fields in update command', async () => {
+test('ignore packages in package.json > Config.ignoreDependencies fields in update command', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 
@@ -235,7 +235,7 @@ test('ignore packages in package.json > pnpm.update.ignoreDependencies fields in
       '@pnpm.e2e/bar': '100.0.0',
     },
     pnpm: {
-      update: {
+      updateConfig: {
         ignoreDependencies: [
           '@pnpm.e2e/foo',
         ],
@@ -279,7 +279,7 @@ test('not ignore packages if these are specified in parameter even if these are 
       '@pnpm.e2e/bar': '100.0.0',
     },
     pnpm: {
-      update: {
+      updateConfig: {
         ignoreDependencies: [
           '@pnpm.e2e/foo',
         ],

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -224,3 +224,47 @@ test('update should work normal when set empty string version', async () => {
   expect(lockfile.devDependencies['@pnpm.e2e/foo']).toEqual('2.0.0')
   expect(lockfile.devDependencies['@pnpm.e2e/peer-c']).toEqual('2.0.0')
 })
+
+test('ignore packages in package.json > pnpm.update.ignore fields in update command', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
+
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '2.0.0',
+      '@pnpm.e2e/bar': '100.0.0',
+    },
+    pnpm: {
+      update: {
+        ignore: [
+          '@pnpm.e2e/foo',
+        ],
+      },
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+
+  const lockfile = await project.readLockfile()
+
+  expect(lockfile.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfile.packages['/@pnpm.e2e/bar/100.0.0']).toBeTruthy()
+
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
+
+  const lockfileUpdated = await project.readLockfile()
+
+  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfileUpdated.packages['/@pnpm.e2e/bar/100.1.0']).toBeTruthy()
+})

--- a/packages/plugin-commands-installation/test/update/update.ts
+++ b/packages/plugin-commands-installation/test/update/update.ts
@@ -226,12 +226,12 @@ test('update should work normal when set empty string version', async () => {
 })
 
 test('ignore packages in package.json > updateConfig.ignoreDependencies fields in update command', async () => {
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 
   const project = prepare({
     dependencies: {
-      '@pnpm.e2e/foo': '2.0.0',
+      '@pnpm.e2e/foo': '100.0.0',
       '@pnpm.e2e/bar': '100.0.0',
     },
     pnpm: {
@@ -251,10 +251,10 @@ test('ignore packages in package.json > updateConfig.ignoreDependencies fields i
 
   const lockfile = await project.readLockfile()
 
-  expect(lockfile.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfile.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
   expect(lockfile.packages['/@pnpm.e2e/bar/100.0.0']).toBeTruthy()
 
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
 
   await update.handler({
@@ -266,17 +266,17 @@ test('ignore packages in package.json > updateConfig.ignoreDependencies fields i
 
   const lockfileUpdated = await project.readLockfile()
 
-  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
   expect(lockfileUpdated.packages['/@pnpm.e2e/bar/100.1.0']).toBeTruthy()
 })
 
 test('not ignore packages if these are specified in parameter even if these are listed in package.json > pnpm.update.ignoreDependencies fields in update command', async () => {
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 
   const project = prepare({
     dependencies: {
-      '@pnpm.e2e/foo': '2.0.0',
+      '@pnpm.e2e/foo': '100.0.0',
       '@pnpm.e2e/bar': '100.0.0',
     },
     pnpm: {
@@ -296,10 +296,10 @@ test('not ignore packages if these are specified in parameter even if these are 
 
   const lockfile = await project.readLockfile()
 
-  expect(lockfile.packages['/@pnpm.e2e/foo/2.0.0']).toBeTruthy()
+  expect(lockfile.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
   expect(lockfile.packages['/@pnpm.e2e/bar/100.0.0']).toBeTruthy()
 
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
 
   await update.handler({
@@ -310,6 +310,6 @@ test('not ignore packages if these are specified in parameter even if these are 
 
   const lockfileUpdated = await project.readLockfile()
 
-  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
+  expect(lockfileUpdated.packages['/@pnpm.e2e/foo/100.1.0']).toBeTruthy()
   expect(lockfileUpdated.packages['/@pnpm.e2e/bar/100.1.0']).toBeTruthy()
 })

--- a/packages/plugin-commands-outdated/src/outdated.ts
+++ b/packages/plugin-commands-outdated/src/outdated.ts
@@ -167,15 +167,17 @@ export async function handler (
     const pkgs = Object.values(opts.selectedProjectsGraph).map((wsPkg) => wsPkg.package)
     return outdatedRecursive(pkgs, params, { ...opts, include })
   }
+  const manifest = await readProjectManifestOnly(opts.dir, opts)
   const packages = [
     {
       dir: opts.dir,
-      manifest: await readProjectManifestOnly(opts.dir, opts),
+      manifest,
     },
   ]
   const [outdatedPackages] = await outdatedDepsOfProjects(packages, params, {
     ...opts,
     fullMetadata: opts.long,
+    ignoreDependencies: new Set(manifest?.pnpm?.updateConfig?.ignoreDependencies ?? []),
     include,
     retry: {
       factor: opts.fetchRetryFactor,

--- a/packages/plugin-commands-outdated/src/recursive.ts
+++ b/packages/plugin-commands-outdated/src/recursive.ts
@@ -50,9 +50,11 @@ export default async (
   opts: OutdatedCommandOptions & { include: IncludedDependencies }
 ) => {
   const outdatedMap = {} as Record<string, OutdatedInWorkspace>
+  const rootManifest = pkgs.find(({ dir }) => dir === opts.lockfileDir ?? opts.dir)
   const outdatedPackagesByProject = await outdatedDepsOfProjects(pkgs, params, {
     ...opts,
     fullMetadata: opts.long,
+    ignoreDependencies: new Set(rootManifest?.manifest?.pnpm?.updateConfig?.ignoreDependencies ?? []),
     retry: {
       factor: opts.fetchRetryFactor,
       maxTimeout: opts.fetchRetryMaxtimeout,

--- a/packages/plugin-commands-outdated/test/index.ts
+++ b/packages/plugin-commands-outdated/test/index.ts
@@ -15,6 +15,7 @@ const hasOutdatedDepsFixtureAndExternalLockfile = path.join(fixtures, 'has-outda
 const hasNotOutdatedDepsFixture = path.join(fixtures, 'has-not-outdated-deps')
 const hasMajorOutdatedDepsFixture = path.join(fixtures, 'has-major-outdated-deps')
 const hasNoLockfileFixture = path.join(fixtures, 'has-no-lockfile')
+const withPnpmUpdateIgnore = path.join(fixtures, 'with-pnpm-update-ignore')
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
 
@@ -314,6 +315,22 @@ test('pnpm outdated: print only compatible versions', async () => {
 │ Package     │ Current │ Latest │
 ├─────────────┼─────────┼────────┤
 │ is-negative │ 1.0.0   │ 1.0.1  │
+└─────────────┴─────────┴────────┘
+`)
+})
+
+test('ignore packages in package.json > pnpm.update.ignore in outdated command', async () => {
+  const { output, exitCode } = await outdated.handler({
+    ...OUTDATED_OPTIONS,
+    dir: withPnpmUpdateIgnore,
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stripAnsi(output)).toBe(`\
+┌─────────────┬─────────┬────────┐
+│ Package     │ Current │ Latest │
+├─────────────┼─────────┼────────┤
+│ is-negative │ 1.0.0   │ 2.1.0  │
 └─────────────┴─────────┴────────┘
 `)
 })

--- a/packages/plugin-commands-outdated/test/index.ts
+++ b/packages/plugin-commands-outdated/test/index.ts
@@ -319,7 +319,7 @@ test('pnpm outdated: print only compatible versions', async () => {
 `)
 })
 
-test('ignore packages in package.json > pnpm.update.ignoreDependencies in outdated command', async () => {
+test('ignore packages in package.json > pnpm.updateConfig.ignoreDependencies in outdated command', async () => {
   const { output, exitCode } = await outdated.handler({
     ...OUTDATED_OPTIONS,
     dir: withPnpmUpdateIgnore,

--- a/packages/plugin-commands-outdated/test/index.ts
+++ b/packages/plugin-commands-outdated/test/index.ts
@@ -319,7 +319,7 @@ test('pnpm outdated: print only compatible versions', async () => {
 `)
 })
 
-test('ignore packages in package.json > pnpm.update.ignore in outdated command', async () => {
+test('ignore packages in package.json > pnpm.update.ignoreDependencies in outdated command', async () => {
   const { output, exitCode } = await outdated.handler({
     ...OUTDATED_OPTIONS,
     dir: withPnpmUpdateIgnore,

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -131,6 +131,9 @@ export type ProjectManifest = BaseManifest & {
     allowedDeprecatedVersions?: AllowedDeprecatedVersions
     allowNonAppliedPatches?: boolean
     patchedDependencies?: Record<string, string>
+    update?: {
+      ignore?: string[]
+    }
   }
   private?: boolean
   resolutions?: Record<string, string>

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -132,7 +132,7 @@ export type ProjectManifest = BaseManifest & {
     allowNonAppliedPatches?: boolean
     patchedDependencies?: Record<string, string>
     update?: {
-      ignore?: string[]
+      ignoreDependencies?: string[]
     }
   }
   private?: boolean

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -131,7 +131,7 @@ export type ProjectManifest = BaseManifest & {
     allowedDeprecatedVersions?: AllowedDeprecatedVersions
     allowNonAppliedPatches?: boolean
     patchedDependencies?: Record<string, string>
-    update?: {
+    updateConfig?: {
       ignoreDependencies?: string[]
     }
   }


### PR DESCRIPTION
Closes: #5358 

## Motivation 🔥 

supports a function to ignore packages listed in `package.json > pnpm.update.ignore` on update/outdated commands like `npm-check-updates` to cover some usecase.

## Goal 🚗 

when we run `update/outdated` commands with the package.json with the fields like below:

```json
{
  ...
  "pnpm": {
    "updates": {
      "ignore": [
          ...packages
      ]
    }
  }
}
```

pnpm will ignore packages listed in `package.json > pnpm.update.ignore` on update/outdated commands like `npm-check-updates`

## Tasks

- [x] define `update.ignore` fields in "pnpm"
- [x] ignore packages listed in `package.json > pnpm.update.ignore` on update
- [x] ignore packages listed in `package.json > pnpm.update.ignore` on outdated
- [x] write tests
- [x] add changeset