### PR TITLE
feat: add warning if package.json specifies workspaces

### DIFF
--- a/packages/find-workspace-dir/package.json
+++ b/packages/find-workspace-dir/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/packages/find-workspace-dir#readme",
   "dependencies": {
     "@pnpm/error": "workspace:*",
+    "@pnpm/graceful-fs": "workspace:*",
     "find-up": "^5.0.0"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/packages/find-workspace-dir/tsconfig.json
+++ b/packages/find-workspace-dir/tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "../error"
+    },
+    {
+      "path": "../graceful-fs"
     }
   ]
 }

--- a/packages/plugin-commands-publishing/package.json
+++ b/packages/plugin-commands-publishing/package.json
@@ -17,7 +17,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7778 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -16,7 +16,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -16,7 +16,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/plugin-commands-rebuild/package.json
+++ b/packages/plugin-commands-rebuild/package.json
@@ -16,7 +16,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7778 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -16,7 +16,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "start": "tsc --watch",

--- a/packages/plugin-commands-script-runners/package.json
+++ b/packages/plugin-commands-script-runners/package.json
@@ -16,7 +16,7 @@
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
-    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 pnpm run test:e2e",
+    "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "start": "tsc --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1325,6 +1325,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../error
+      '@pnpm/graceful-fs':
+        specifier: workspace:*
+        version: link:../graceful-fs
       find-up:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
This PR attempts to add a suggestion to use pnpm-workspace.yaml > package.json in cases where a user still has workspaces specified in their package.json file, per #5363 .