### PR TITLE
fix: dir path repeated join in link global

### DIFF
--- a/.changeset/rotten-moose-search.md
+++ b/.changeset/rotten-moose-search.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+fix dir path repeated join in link global

--- a/packages/plugin-commands-installation/src/link.ts
+++ b/packages/plugin-commands-installation/src/link.ts
@@ -116,7 +116,7 @@ export async function handler (
     const { manifest, writeProjectManifest } = await tryReadProjectManifest(opts.dir, opts)
     const newManifest = await addDependenciesToPackage(
       manifest ?? {},
-      [`link:${opts.cliOptions?.dir ? path.join(cwd, opts.cliOptions.dir) : cwd}`],
+      [`link:${opts.cliOptions?.dir ? path.resolve(cwd, opts.cliOptions.dir) : cwd}`],
       linkOpts
     )
     await writeProjectManifest(newManifest)

--- a/packages/plugin-commands-installation/src/link.ts
+++ b/packages/plugin-commands-installation/src/link.ts
@@ -116,7 +116,7 @@ export async function handler (
     const { manifest, writeProjectManifest } = await tryReadProjectManifest(opts.dir, opts)
     const newManifest = await addDependenciesToPackage(
       manifest ?? {},
-      [`link:${opts.cliOptions?.dir ? path.resolve(cwd, opts.cliOptions.dir) : cwd}`],
+      [`link:${opts.cliOptions?.dir ? path.resolve(opts.cliOptions.dir) : cwd}`],
       linkOpts
     )
     await writeProjectManifest(newManifest)

--- a/packages/plugin-commands-installation/test/link.ts
+++ b/packages/plugin-commands-installation/test/link.ts
@@ -88,7 +88,7 @@ test('link --dir global bin', async function () {
   await link.handler({
     ...DEFAULT_OPTS,
     cliOptions: {
-      dir: './dir/package-with-bin-in-dir',
+      dir: path.resolve(process.cwd(), './dir/package-with-bin-in-dir'),
     },
     bin: globalBin,
     dir: globalDir,

--- a/packages/plugin-commands-installation/test/link.ts
+++ b/packages/plugin-commands-installation/test/link.ts
@@ -88,7 +88,7 @@ test('link --dir global bin', async function () {
   await link.handler({
     ...DEFAULT_OPTS,
     cliOptions: {
-      dir: path.resolve(process.cwd(), './dir/package-with-bin-in-dir'),
+      dir: path.resolve('./dir/package-with-bin-in-dir'),
     },
     bin: globalBin,
     dir: globalDir,


### PR DESCRIPTION
To fix repeated join in global link and use absolute path in test case

From discussion: https://github.com/pnpm/pnpm/discussions/5421