### PR TITLE
fix: pnpm patch-commit with a trailing slash on Windows does not work

### DIFF
--- a/.changeset/wicked-zebras-deliver.md
+++ b/.changeset/wicked-zebras-deliver.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-patching": patch
+"pnpm": patch
 ---
 
-pnpm patch-commit should work on a directory with a trailing slash
+`pnpm patch-commit` should work when the patch directory is specified with a trailing slash [#5449](https://github.com/pnpm/pnpm/issues/5449).

--- a/.changeset/wicked-zebras-deliver.md
+++ b/.changeset/wicked-zebras-deliver.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+pnpm patch-commit should work on a directory with a trailing slash

--- a/packages/plugin-commands-patching/src/patchCommit.ts
+++ b/packages/plugin-commands-patching/src/patchCommit.ts
@@ -89,15 +89,17 @@ async function diffFolders (folderA: string, folderB: string) {
   if (stderr.length > 0)
     throw new Error(`Unable to diff directories. Make sure you have a recent version of 'git' available in PATH.\nThe following error was reported by 'git':\n${stderr}`)
 
-  const normalizePath = (p: string) =>
-    (p.startsWith('/') || p.endsWith('/'))
-      ? p.replace(/^\/|\/$/g, '')
-      : p
-
   return stdout
-    .replace(new RegExp(`(a|b)(${escapeStringRegexp(`/${normalizePath(folderAN)}/`)})`, 'g'), '$1/')
-    .replace(new RegExp(`(a|b)${escapeStringRegexp(`/${normalizePath(folderBN)}/`)}`, 'g'), '$1/')
+    .replace(new RegExp(`(a|b)(${escapeStringRegexp(`/${removeTrailingAndLeadingSlash(folderAN)}/`)})`, 'g'), '$1/')
+    .replace(new RegExp(`(a|b)${escapeStringRegexp(`/${removeTrailingAndLeadingSlash(folderBN)}/`)}`, 'g'), '$1/')
     .replace(new RegExp(escapeStringRegexp(`${folderAN}/`), 'g'), '')
     .replace(new RegExp(escapeStringRegexp(`${folderBN}/`), 'g'), '')
     .replace(/\n\\ No newline at end of file$/, '')
+}
+
+function removeTrailingAndLeadingSlash (p: string) {
+  if (p.startsWith('/') || p.endsWith('/')) {
+    return p.replace(/^\/|\/$/g, '')
+  }
+  return p
 }

--- a/packages/plugin-commands-patching/src/patchCommit.ts
+++ b/packages/plugin-commands-patching/src/patchCommit.ts
@@ -89,9 +89,10 @@ async function diffFolders (folderA: string, folderB: string) {
   if (stderr.length > 0)
     throw new Error(`Unable to diff directories. Make sure you have a recent version of 'git' available in PATH.\nThe following error was reported by 'git':\n${stderr}`)
 
-  const normalizePath = folderAN.startsWith('/')
-    ? (p: string) => p.slice(1)
-    : (p: string) => p
+  const normalizePath = (p: string) =>
+    (p.startsWith('/') || p.endsWith('/'))
+      ? p.replace(/^\/|\/$/g, '')
+      : p
 
   return stdout
     .replace(new RegExp(`(a|b)(${escapeStringRegexp(`/${normalizePath(folderAN)}/`)})`, 'g'), '$1/')

--- a/packages/plugin-commands-patching/test/patch.test.ts
+++ b/packages/plugin-commands-patching/test/patch.test.ts
@@ -95,7 +95,7 @@ describe('patch and commit', () => {
   })
 
   test('patch and commit with a trailing slash', async () => {
-    const editDir = path.join(tempy.directory()) + '\\'
+    const editDir = path.join(tempy.directory()) + (os.platform() === 'win32' ? '\\' : '/')
 
     const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
     const patchDir = output.substring(output.indexOf(':') + 1).trim()

--- a/packages/plugin-commands-patching/test/patch.test.ts
+++ b/packages/plugin-commands-patching/test/patch.test.ts
@@ -93,6 +93,25 @@ describe('patch and commit', () => {
     await expect(() => patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0']))
       .rejects.toThrow(`The target directory already exists: '${editDir}'`)
   })
+
+  test('patch and commit with a trailing slash', async () => {
+    const editDir = path.join(tempy.directory()) + '\\'
+
+    const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])
+    const patchDir = output.substring(output.indexOf(':') + 1).trim()
+
+    expect(patchDir).toBe(editDir)
+    expect(fs.existsSync(patchDir)).toBe(true)
+
+    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
+
+    await patchCommit.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+    }, [patchDir])
+
+    expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+  })
 })
 
 describe('patching should work when there is a no EOL in the patched file', () => {

--- a/packages/plugin-commands-patching/test/patch.test.ts
+++ b/packages/plugin-commands-patching/test/patch.test.ts
@@ -94,7 +94,7 @@ describe('patch and commit', () => {
       .rejects.toThrow(`The target directory already exists: '${editDir}'`)
   })
 
-  test('patch and commit with a trailing slash', async () => {
+  test('patch and commit should work when the patch directory is specified with a trailing slash', async () => {
     const editDir = path.join(tempy.directory()) + (os.platform() === 'win32' ? '\\' : '/')
 
     const output = await patch.handler({ ...defaultPatchOption, editDir }, ['is-positive@1.0.0'])


### PR DESCRIPTION
pnpm patch-commit did not apply patch if the absolute path to a directory passed to it contained a trailing slash on Windows, now the trailing slash is removed

closes https://github.com/pnpm/pnpm/issues/5449