### PR TITLE
docs: support light and dark versions of sponsor logos on release file

### DIFF
--- a/utils/get-release-text/src/main.ts
+++ b/utils/get-release-text/src/main.ts
@@ -79,20 +79,40 @@ function getChangelogEntry (changelog: string, version: string) {
         <a href="https://bit.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/nhost.svg" width="180">
-        </a>
-        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/nhost_light.svg" width="180">
-        </a>
+        <picture>
+          <source
+            media="(prefers-color-scheme: light)"
+            srcset="https://pnpm.io/img/users/nhost.svg"
+          />
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://pnpm.io/img/users/nhost_light.svg"
+          />
+          <a
+            href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes"
+            target="_blank"
+          >
+            <img src="https://pnpm.io/img/users/nhost.svg" width="180" />
+          </a>
+        </picture>
       </td>
       <td align="center" valign="middle">
-        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/novu.svg" width="180">
-        </a>
-        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/novu_light.svg" width="180">
-        </a>
+        <picture>
+          <source
+            media="(prefers-color-scheme: light)"
+            srcset="https://pnpm.io/img/users/novu.svg"
+          />
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://pnpm.io/img/users/novu_light.svg"
+          />
+          <a
+            href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes"
+            target="_blank"
+          >
+            <img src="https://pnpm.io/img/users/novu.svg" width="180" />
+          </a>
+        </picture>
       </td>
     </tr>
   </tbody>
@@ -104,12 +124,22 @@ function getChangelogEntry (changelog: string, version: string) {
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/prisma.svg" width="180">
-        </a>
-        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/prisma_light.svg" width="180">
-        </a>
+        <picture>
+          <source
+            media="(prefers-color-scheme: light)"
+            srcset="https://pnpm.io/img/users/prisma.svg"
+          />
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://pnpm.io/img/users/prisma_light.svg"
+          />
+          <a
+            href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes"
+            target="_blank"
+          >
+            <img src="https://pnpm.io/img/users/prisma.svg" width="180" />
+          </a>
+        </picture>
       </td>
       <td align="center" valign="middle">
         <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
@@ -117,12 +147,22 @@ function getChangelogEntry (changelog: string, version: string) {
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/vercel.svg" width="180">
-        </a>
-        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/vercel_light.svg" width="180">
-        </a>
+        <picture>
+          <source
+          media="(prefers-color-scheme: light)"
+          srcset="https://pnpm.io/img/users/vercel.svg"
+          />
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://pnpm.io/img/users/vercel_light.svg"
+          />
+          <a
+            href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes"
+            target="_blank"
+          >
+            <img src="https://pnpm.io/img/users/vercel.svg" width="180" />
+          </a>
+        </picture>
       </td>
     </tr>
     <tr>
@@ -132,12 +172,22 @@ function getChangelogEntry (changelog: string, version: string) {
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/doppler.svg" width="280">
-        </a>
-        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
-          <img src="https://pnpm.io/img/users/doppler_light.svg" width="280">
-        </a>
+        <picture>
+          <source
+          media="(prefers-color-scheme: light)"
+          srcset="https://pnpm.io/img/users/doppler.svg"
+          />
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://pnpm.io/img/users/doppler_light.svg"
+          />
+          <a
+            href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes"
+            target="_blank"
+          >
+            <img src="https://pnpm.io/img/users/doppler.svg" width="280" />
+          </a>
+        </picture>
       </td>
     </tr>
   </tbody>

--- a/utils/get-release-text/src/main.ts
+++ b/utils/get-release-text/src/main.ts
@@ -79,40 +79,22 @@ function getChangelogEntry (changelog: string, version: string) {
         <a href="https://bit.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
       </td>
       <td align="center" valign="middle">
-        <picture>
-          <source
-            media="(prefers-color-scheme: light)"
-            srcset="https://pnpm.io/img/users/nhost.svg"
-          />
-          <source
-            media="(prefers-color-scheme: dark)"
-            srcset="https://pnpm.io/img/users/nhost_light.svg"
-          />
-          <a
-            href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes"
-            target="_blank"
-          >
+        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nhost.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nhost_light.svg" />
             <img src="https://pnpm.io/img/users/nhost.svg" width="180" />
-          </a>
-        </picture>
+          </picture>
+        </a>
       </td>
       <td align="center" valign="middle">
-        <picture>
-          <source
-            media="(prefers-color-scheme: light)"
-            srcset="https://pnpm.io/img/users/novu.svg"
-          />
-          <source
-            media="(prefers-color-scheme: dark)"
-            srcset="https://pnpm.io/img/users/novu_light.svg"
-          />
-          <a
-            href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes"
-            target="_blank"
-          >
+        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/novu.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/novu_light.svg" />
             <img src="https://pnpm.io/img/users/novu.svg" width="180" />
-          </a>
-        </picture>
+          </picture>
+        </a>
       </td>
     </tr>
   </tbody>
@@ -124,22 +106,13 @@ function getChangelogEntry (changelog: string, version: string) {
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <picture>
-          <source
-            media="(prefers-color-scheme: light)"
-            srcset="https://pnpm.io/img/users/prisma.svg"
-          />
-          <source
-            media="(prefers-color-scheme: dark)"
-            srcset="https://pnpm.io/img/users/prisma_light.svg"
-          />
-          <a
-            href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes"
-            target="_blank"
-          >
+        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/prisma.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/prisma_light.svg" />
             <img src="https://pnpm.io/img/users/prisma.svg" width="180" />
-          </a>
-        </picture>
+          </picture>
+        </a>
       </td>
       <td align="center" valign="middle">
         <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
@@ -147,22 +120,13 @@ function getChangelogEntry (changelog: string, version: string) {
         </a>
       </td>
       <td align="center" valign="middle">
-        <picture>
-          <source
-          media="(prefers-color-scheme: light)"
-          srcset="https://pnpm.io/img/users/vercel.svg"
-          />
-          <source
-            media="(prefers-color-scheme: dark)"
-            srcset="https://pnpm.io/img/users/vercel_light.svg"
-          />
-          <a
-            href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes"
-            target="_blank"
-          >
+        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vercel.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vercel_light.svg" />
             <img src="https://pnpm.io/img/users/vercel.svg" width="180" />
-          </a>
-        </picture>
+          </picture>
+        </a>
       </td>
     </tr>
     <tr>
@@ -172,22 +136,13 @@ function getChangelogEntry (changelog: string, version: string) {
         </a>
       </td>
       <td align="center" valign="middle">
-        <picture>
-          <source
-          media="(prefers-color-scheme: light)"
-          srcset="https://pnpm.io/img/users/doppler.svg"
-          />
-          <source
-            media="(prefers-color-scheme: dark)"
-            srcset="https://pnpm.io/img/users/doppler_light.svg"
-          />
-          <a
-            href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes"
-            target="_blank"
-          >
+        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
+          <picture>
+            <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/doppler.svg" />
+            <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/doppler_light.svg" />
             <img src="https://pnpm.io/img/users/doppler.svg" width="280" />
-          </a>
-        </picture>
+          </picture>
+        </a>
       </td>
     </tr>
   </tbody>

--- a/utils/get-release-text/src/main.ts
+++ b/utils/get-release-text/src/main.ts
@@ -79,10 +79,20 @@ function getChangelogEntry (changelog: string, version: string) {
         <a href="https://bit.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/nhost.svg" width="180"></a>
+        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/nhost.svg" width="180">
+        </a>
+        <a href="https://nhost.io/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/nhost_light.svg" width="180">
+        </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/novu.svg" width="180"></a>
+        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/novu.svg" width="180">
+        </a>
+        <a href="https://novu.co/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/novu_light.svg" width="180">
+        </a>
       </td>
     </tr>
   </tbody>
@@ -94,30 +104,39 @@ function getChangelogEntry (changelog: string, version: string) {
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=readme" target="_blank">
+        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
           <img src="https://pnpm.io/img/users/prisma.svg" width="180">
+        </a>
+        <a href="https://prisma.io/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/prisma_light.svg" width="180">
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
+        <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
           <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80">
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
+        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
           <img src="https://pnpm.io/img/users/vercel.svg" width="180">
+        </a>
+        <a href="https://vercel.com/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/vercel_light.svg" width="180">
         </a>
       </td>
     </tr>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://www.takeshape.io/?utm_source=pnpm&utm_medium=readme" target="_blank">
+        <a href="https://www.takeshape.io/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
           <img src="https://pnpm.io/img/users/takeshape.svg" width="280">
         </a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=readme#gh-light-mode-only" target="_blank">
+        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes#gh-light-mode-only" target="_blank">
           <img src="https://pnpm.io/img/users/doppler.svg" width="280">
+        </a>
+        <a href="https://doppler.com/?utm_source=pnpm&utm_medium=release_notes#gh-dark-mode-only" target="_blank">
+          <img src="https://pnpm.io/img/users/doppler_light.svg" width="280">
         </a>
       </td>
     </tr>


### PR DESCRIPTION
## Description
I noticed that the sponsor logos were fixed on `README.md` to work for light and dark mode in https://github.com/pnpm/pnpm/commit/a0b855fbce10a912460af6b14fd6ff0bbdf986ac, but not on `RELEASE.md`

Some `utm_medium` parameters were also wrongly pointing to `README.md`, updated that too.

## Changes

- update `getChangelogEntry()` method to render sponsor logos for light and dark mode correctly

## How it looked before
Sponsor logos like the one from Prisma are barely readable:

![Screenshot from 2022-10-21 07-40-16](https://user-images.githubusercontent.com/16797721/197123587-5b7c139e-fe3f-49c2-9c44-22495b69a709.png)
