### PR TITLE
fix: pnpmHomeDir should read PNPM_HOME defined in environment variables

### DIFF
--- a/.changeset/wise-pugs-wave.md
+++ b/.changeset/wise-pugs-wave.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/config": patch
+"pnpm": patch
 ---
 
-Fix pnpmHomeDir should read PNPM_HOME defined in environment variables
+It should be possible to set a custom home directory for pnpm by changing the PNPM_HOME environment variable.

--- a/.changeset/wise-pugs-wave.md
+++ b/.changeset/wise-pugs-wave.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+Fix pnpmHomeDir should read PNPM_HOME defined in environment variables

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -297,7 +297,7 @@ export async function getConfig (
     }
     return undefined
   })()
-  pnpmConfig.pnpmHomeDir = getDataDir(process)
+  pnpmConfig.pnpmHomeDir = process.env.PNPM_HOME ?? getDataDir(process)
 
   if (cliOptions['global']) {
     let globalDirRoot

--- a/packages/config/test/index.ts
+++ b/packages/config/test/index.ts
@@ -971,3 +971,23 @@ test('do not return a warning if a package.json has workspaces field and there i
   })
   expect(warnings).toStrictEqual([])
 })
+
+test('Read PNPM_HOME defined in environment variables', async () => {
+  const oldEnv = process.env
+  const homeDir = './specified-dir'
+  process.env = {
+    ...oldEnv,
+    PNPM_HOME: homeDir,
+  }
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.pnpmHomeDir).toBe(homeDir)
+
+  process.env = oldEnv
+})

--- a/packages/config/test/index.ts
+++ b/packages/config/test/index.ts
@@ -972,7 +972,7 @@ test('do not return a warning if a package.json has workspaces field and there i
   expect(warnings).toStrictEqual([])
 })
 
-test('Read PNPM_HOME defined in environment variables', async () => {
+test('read PNPM_HOME defined in environment variables', async () => {
   const oldEnv = process.env
   const homeDir = './specified-dir'
   process.env = {


### PR DESCRIPTION
When the environment variable `PNPM_HOME` is updated by user, the config `pnpmHomeDir` is still the default directory.