### PR TITLE
fix: use lexigraphical sorting in places where it matters

### DIFF
--- a/.changeset/smart-coats-jam.md
+++ b/.changeset/smart-coats-jam.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/find-workspace-packages": patch
+"find-packages": patch
+"@pnpm/hoist": patch
+---
+
+Use deterministic sorting.

--- a/packages/find-packages/package.json
+++ b/packages/find-packages/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/util.lex-comparator": "1.0.0",
     "fast-glob": "^3.2.12",
     "p-filter": "^2.1.0"
   },

--- a/packages/find-packages/src/index.ts
+++ b/packages/find-packages/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { readExactProjectManifest } from '@pnpm/read-project-manifest'
 import { ProjectManifest } from '@pnpm/types'
+import { lexCompare } from '@pnpm/util.lex-comparator'
 import fastGlob from 'fast-glob'
 import pFilter from 'p-filter'
 
@@ -48,7 +49,7 @@ export async function findPackages (root: string, opts?: Options): Promise<Proje
         paths
           .map(manifestPath => path.join(root, manifestPath))
           .sort((path1, path2) =>
-            path.dirname(path1).localeCompare(path.dirname(path2))
+            lexCompare(path.dirname(path1), path.dirname(path2))
           )
       ),
       async manifestPath => {

--- a/packages/find-workspace-packages/package.json
+++ b/packages/find-workspace-packages/package.json
@@ -32,6 +32,7 @@
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/util.lex-comparator": "1.0.0",
     "find-packages": "workspace:*",
     "read-yaml-file": "^2.1.0"
   },

--- a/packages/find-workspace-packages/src/index.ts
+++ b/packages/find-workspace-packages/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { packageIsInstallable } from '@pnpm/cli-utils'
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import { Project } from '@pnpm/types'
+import { lexCompare } from '@pnpm/util.lex-comparator'
 import { findPackages } from 'find-packages'
 import readYamlFile from 'read-yaml-file'
 
@@ -37,7 +38,7 @@ export async function findWorkspacePackagesNoCheck (workspaceRoot: string, opts?
     includeRoot: true,
     patterns,
   })
-  pkgs.sort((pkg1: { dir: string }, pkg2: { dir: string }) => pkg1.dir.localeCompare(pkg2.dir))
+  pkgs.sort((pkg1: { dir: string }, pkg2: { dir: string }) => lexCompare(pkg1.dir, pkg2.dir))
   return pkgs
 }
 

--- a/packages/hoist/package.json
+++ b/packages/hoist/package.json
@@ -47,6 +47,7 @@
     "@pnpm/matcher": "workspace:*",
     "@pnpm/symlink-dependency": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/util.lex-comparator": "1.0.0",
     "dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },

--- a/packages/hoist/src/index.ts
+++ b/packages/hoist/src/index.ts
@@ -10,6 +10,7 @@ import { logger } from '@pnpm/logger'
 import { createMatcher } from '@pnpm/matcher'
 import { symlinkDependency } from '@pnpm/symlink-dependency'
 import { HoistedDependencies } from '@pnpm/types'
+import { lexCompare } from '@pnpm/util.lex-comparator'
 import * as dp from 'dependency-path'
 
 const hoistLogger = logger('hoist')
@@ -171,7 +172,7 @@ async function hoistGraph (
     // sort by depth and then alphabetically
     .sort((a, b) => {
       const depthDiff = a.depth - b.depth
-      return depthDiff === 0 ? a.depPath.localeCompare(b.depPath) : depthDiff
+      return depthDiff === 0 ? lexCompare(a.depPath, b.depPath) : depthDiff
     })
     // build the alias map and the id map
     .forEach((depNode) => {

--- a/packages/lockfile-file/package.json
+++ b/packages/lockfile-file/package.json
@@ -52,6 +52,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/merge-lockfile-changes": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/util.lex-comparator": "1.0.0",
     "@zkochan/rimraf": "^2.1.2",
     "comver-to-semver": "^1.0.0",
     "dependency-path": "workspace:*",

--- a/packages/lockfile-file/src/sortLockfileKeys.ts
+++ b/packages/lockfile-file/src/sortLockfileKeys.ts
@@ -1,3 +1,4 @@
+import { lexCompare } from '@pnpm/util.lex-comparator'
 import sortKeys from 'sort-keys'
 import { LockfileFile } from './write'
 
@@ -53,10 +54,7 @@ function compareWithPriority (priority: Record<string, number>, left: string, ri
   if (leftPriority && rightPriority) return leftPriority - rightPriority
   if (leftPriority) return -1
   if (rightPriority) return 1
-  // We want deterministic sorting, so we can't use .localCompare here.
-  // comparing strings with < and > will produce the same result on each machine.
-  // An alternative solution could be to use a specific culture for compare, using Intl.Collator
-  return left < right ? -1 : (left > right ? 1 : 0)
+  return lexCompare(left, right)
 }
 
 export function sortLockfileKeys (lockfile: LockfileFile) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1314,6 +1314,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../types
+      '@pnpm/util.lex-comparator':
+        specifier: 1.0.0
+        version: 1.0.0
       fast-glob:
         specifier: ^3.2.12
         version: 3.2.12
@@ -1349,6 +1352,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../types
+      '@pnpm/util.lex-comparator':
+        specifier: 1.0.0
+        version: 1.0.0
       find-packages:
         specifier: workspace:*
         version: link:../find-packages
@@ -1726,6 +1732,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../types
+      '@pnpm/util.lex-comparator':
+        specifier: 1.0.0
+        version: 1.0.0
       dependency-path:
         specifier: workspace:*
         version: link:../dependency-path
@@ -2020,6 +2029,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../types
+      '@pnpm/util.lex-comparator':
+        specifier: 1.0.0
+        version: 1.0.0
       '@zkochan/rimraf':
         specifier: ^2.1.2
         version: 2.1.2
@@ -7835,6 +7847,11 @@ packages:
     resolution: {integrity: sha512-IKUpbWRHDB9C4Yy4UeBpeYhU7eIsLj50jF5HNRUkbJnM0CWHPLxX9TGCI+ov8pgGeTP1t1g0GPDHD6en9D8LxQ==}
     engines: {node: '>=14.6'}
     dev: true
+
+  /@pnpm/util.lex-comparator/1.0.0:
+    resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}
+    engines: {node: '>=12.22.0'}
+    dev: false
 
   /@pnpm/which-version-is-pinned/4.0.0:
     resolution: {integrity: sha512-XqZqdxgX7vqxiMX+REsN6lfZ9TR2FQhhaaClA6ymFAVjhuMzJidDDVibqAx5nlfoSqeBklJEZxYXYnU7LjghlA==}
@@ -16967,6 +16984,7 @@ time:
   /@pnpm/registry-mock/3.1.0: '2022-10-13T19:59:17.408Z'
   /@pnpm/semver-diff/1.1.0: '2021-11-16T12:40:59.941Z'
   /@pnpm/tabtab/0.1.2: '2021-03-05T17:31:19.932Z'
+  /@pnpm/util.lex-comparator/1.0.0: '2022-11-04T01:03:46.134Z'
   /@types/adm-zip/0.4.34: '2021-04-04T18:01:23.318Z'
   /@types/archy/0.0.32: '2021-07-06T18:11:33.301Z'
   /@types/byline/4.2.33: '2021-07-06T18:22:06.440Z'


### PR DESCRIPTION
I feel kind of weird for creating a separate package for such a simple and straightforward function. But the only reason I have created it is to document why it is needed: https://github.com/pnpm/components/blob/main/util/lex-comparator/lex-comparator.docs.mdx