### PR TITLE
fix(resolve-dependencies): don't fail when dependency tree doesn't contain parent package

### DIFF
--- a/packages/resolve-dependencies/src/resolvePeers.ts
+++ b/packages/resolve-dependencies/src/resolvePeers.ts
@@ -208,6 +208,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
           ctx.pathsByNodeId[cachedNodeId] &&
           ctx.pathsByNodeId[cachedNodeId] === ctx.pathsByNodeId[parentPkgs[name].nodeId!]
         ) return true
+        if (!ctx.dependenciesTree[parentPkgNodeId]) return false
         const parentDepPath = (ctx.dependenciesTree[parentPkgNodeId].resolvedPackage as T).depPath
         if (!ctx.purePkgs.has(parentDepPath)) return false
         const cachedDepPath = (ctx.dependenciesTree[cachedNodeId].resolvedPackage as T).depPath


### PR DESCRIPTION
This PR fixes the problem mentioned in https://github.com/pnpm/pnpm/issues/5327.

We started experiencing problems with `pnpm install` when migrating [our dashboard to our monorepo](https://github.com/nhost/nhost/pull/1104). Although the dashboard project was using yarn originally, I decided to migrate to pnpm in the standalone repository first. Everything was working fine there. It only started breaking when the project was moved to the monorepo.

_P.S: The problem can be reproduced in [our repository](https://github.com/nhost/nhost) by removing pnpm-lock.yaml and running `pnpm install`._