### PR TITLE
test(plugin-commands-env): fix a test that falling in arm64

### DIFF
--- a/env/plugin-commands-env/test/node.test.ts
+++ b/env/plugin-commands-env/test/node.test.ts
@@ -70,8 +70,11 @@ test('install and rc version of Node.js', async () => {
   await node.getNodeBinDir(opts)
 
   const platform = process.platform === 'win32' ? 'win' : process.platform
+  const arch = process.arch
   const extension = process.platform === 'win32' ? 'zip' : 'tar.gz'
-  expect(fetchMock.mock.calls[0][0]).toBe(`https://nodejs.org/download/rc/v18.0.0-rc.3/node-v18.0.0-rc.3-${platform}-x64.${extension}`)
+  expect(fetchMock.mock.calls[0][0]).toBe(
+    `https://nodejs.org/download/rc/v18.0.0-rc.3/node-v18.0.0-rc.3-${platform}-${arch}.${extension}`
+  )
 })
 
 test('get node version base dir', async () => {


### PR DESCRIPTION
When I tried to run the full test suite in Apple Sillicon, the test about installation of Node.js failed.

I fixed this by getting arch from `process.arch`.
This value is strictly not equal to the value Node.js uses, for example, `process.arch` returns `ppc64` but Node.js provides only `ppc64le`, but I think it is a trivial matter.