### PR TITLE
fix: `--lockfile-only` and `readPackage` hook modifying workspace packages

### DIFF
--- a/.changeset/proud-schools-jump.md
+++ b/.changeset/proud-schools-jump.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/core": patch
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+readPackage hooks should not modify the `package.json` files in a workspace [#5670](https://github.com/pnpm/pnpm/issues/5670).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -690,6 +690,7 @@ export type ImporterToUpdate = {
 } & DependenciesMutation
 
 export interface UpdatedProject {
+  originalManifest?: ProjectManifest
   manifest: ProjectManifest
   peerDependencyIssues?: PeerDependencyIssues
   rootDir: string

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -257,7 +257,7 @@ export async function recursive (
     if (opts.save !== false) {
       await Promise.all(
         mutatedPkgs
-          .map(async ({ manifest }, index) => writeProjectManifests[index](manifest))
+          .map(async ({ originalManifest, manifest }, index) => writeProjectManifests[index](originalManifest ?? manifest))
       )
     }
     return true

--- a/pnpm/test/hooks.ts
+++ b/pnpm/test/hooks.ts
@@ -39,7 +39,7 @@ test('readPackage hook in single project doesn\'t modify manifest', async () => 
   await project.hasNot('is-positive')
 
   // Reset for --lockfile-only checks
-  await fs.rm('pnpm-lock.yaml');
+  await fs.unlink('pnpm-lock.yaml');
 
   await execPnpm(['install', '--lockfile-only'])
   pkg = await loadJsonFile(path.resolve('package.json'))
@@ -93,7 +93,7 @@ test('readPackage hook in monorepo doesn\'t modify manifest', async () => {
   expect(pkg.dependencies).toBeFalsy() // remove & readPackage hook work
 
   // Reset for --lockfile-only checks
-  await fs.rm('pnpm-lock.yaml');
+  await fs.unlink('pnpm-lock.yaml');
 
   await execPnpm(['install', '--lockfile-only'])
   pkg = await loadJsonFile(path.resolve('project-a/package.json'))

--- a/pnpm/test/hooks.ts
+++ b/pnpm/test/hooks.ts
@@ -37,6 +37,18 @@ test('readPackage hook in single project doesn\'t modify manifest', async () => 
   pkg = await loadJsonFile(path.resolve('package.json'))
   expect(pkg.dependencies).toBeFalsy() // remove & readPackage hook work
   await project.hasNot('is-positive')
+
+  // Reset for --lockfile-only checks
+  await fs.rm('pnpm-lock.yaml');
+
+  await execPnpm(['install', '--lockfile-only'])
+  pkg = await loadJsonFile(path.resolve('package.json'))
+  expect(pkg.dependencies).toBeFalsy() // install --lockfile-only & readPackage hook work, without pnpm-lock.yaml
+
+  // runs with pnpm-lock.yaml should not mutate local projects
+  await execPnpm(['install', '--lockfile-only'])
+  pkg = await loadJsonFile(path.resolve('package.json'))
+  expect(pkg.dependencies).toBeFalsy() // install --lockfile-only & readPackage hook work, with pnpm-lock.yaml
 })
 
 test('readPackage hook in monorepo doesn\'t modify manifest', async () => {
@@ -79,6 +91,19 @@ test('readPackage hook in monorepo doesn\'t modify manifest', async () => {
   await execPnpm(['remove', 'is-positive', '--filter', 'project-a'])
   pkg = await loadJsonFile(path.resolve('project-a/package.json'))
   expect(pkg.dependencies).toBeFalsy() // remove & readPackage hook work
+
+  // Reset for --lockfile-only checks
+  await fs.rm('pnpm-lock.yaml');
+
+  await execPnpm(['install', '--lockfile-only'])
+  pkg = await loadJsonFile(path.resolve('project-a/package.json'))
+  expect(pkg.dependencies).toBeFalsy() // install --lockfile-only & readPackage hook work, without pnpm-lock.yaml
+
+  // runs with pnpm-lock.yaml should not mutate local projects
+  await execPnpm(['install', '--lockfile-only'])
+  pkg = await loadJsonFile(path.resolve('project-a/package.json'))
+  expect(pkg.dependencies).toBeFalsy() // install --lockfile-only & readPackage hook work, with pnpm-lock.yaml
+
 })
 
 test('filterLog hook filters peer dependency warning', async () => {


### PR DESCRIPTION
Resolves #5670

Recursive installation will now defer to `originalManifest` when checking if workspace `package.json` need to be updated, if available.

Note that this fix applies to the scenario where `pnpm-lock.yaml` exists, odds are that when generating from scratch, one of the following codepaths are used instead.
* https://github.com/pnpm/pnpm/blob/d5496cc3f8fb5696fb4236fb27a956ec93c50eda/pkg-manager/resolve-dependencies/src/index.ts#L187
* https://github.com/pnpm/pnpm/blob/d5496cc3f8fb5696fb4236fb27a956ec93c50eda/pkg-manager/core/src/install/index.ts#L750-L752
* https://github.com/pnpm/pnpm/blob/d5496cc3f8fb5696fb4236fb27a956ec93c50eda/pkg-manager/core/src/install/index.ts#L370