### PR TITLE
fix(read-package-hook): resolve file overrides should relative to root directory

### DIFF
--- a/.changeset/old-otters-sleep.md
+++ b/.changeset/old-otters-sleep.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
+---
+
+It should be possible to override a dependency with a local package using relative path from the workspace root directory [#5493](https://github.com/pnpm/pnpm/issues/5493).

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -13,7 +13,7 @@ export function createVersionsOverrider (
     parseOverrides(overrides)
       .map((override) => {
         let linkTarget: string | undefined
-        if (override.newPref.startsWith('link:')) {
+        if (override.newPref.startsWith('link:') || override.newPref.startsWith('file:')) {
           linkTarget = path.join(rootDir, override.newPref.substring(5))
         }
         return {
@@ -69,7 +69,7 @@ function overrideDeps (versionOverrides: VersionOverride[], deps: Dependencies, 
     if (actual == null) continue
     if (!isSubRange(versionOverride.targetPkg.pref, actual)) continue
     if (versionOverride.linkTarget && dir) {
-      deps[versionOverride.targetPkg.name] = `link:${normalizePath(path.relative(dir, versionOverride.linkTarget))}`
+      deps[versionOverride.targetPkg.name] = `${versionOverride.newPref.startsWith('link:') ? 'link:' : 'file:'}${normalizePath(path.relative(dir, versionOverride.linkTarget))}`
       continue
     }
     deps[versionOverride.targetPkg.name] = versionOverride.newPref

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -68,9 +68,15 @@ function overrideDeps (versionOverrides: VersionOverride[], deps: Dependencies, 
     const actual = deps[versionOverride.targetPkg.name]
     if (actual == null) continue
     if (!isSubRange(versionOverride.targetPkg.pref, actual)) continue
-    if (versionOverride.linkTarget && dir) {
-      deps[versionOverride.targetPkg.name] = `${versionOverride.newPref.startsWith('link:') ? 'link:' : 'file:'}${normalizePath(path.relative(dir, versionOverride.linkTarget))}`
-      continue
+    if (versionOverride.linkTarget) {
+      if (versionOverride.newPref.startsWith('file:')) {
+        deps[versionOverride.targetPkg.name] = `file:${versionOverride.linkTarget}`
+        continue
+      }
+      if (versionOverride.newPref.startsWith('link:') && dir) {
+        deps[versionOverride.targetPkg.name] = `link:${normalizePath(path.relative(dir, versionOverride.linkTarget))}`
+        continue
+      }
     }
     deps[versionOverride.targetPkg.name] = versionOverride.newPref
   }

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -267,7 +267,7 @@ test('createVersionsOverrider() overrides dependencies with file', () => {
     name: 'foo',
     version: '1.2.0',
     dependencies: {
-      qar: 'file:../../qar',
+      qar: `file:${path.resolve('../qar')}`,
     },
   })
 })

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -252,3 +252,22 @@ test('createVersionsOverrider() should work for scoped parent and scoped child',
     },
   })
 })
+
+test('createVersionsOverrider() overrides dependencies with file', () => {
+  const overrider = createVersionsOverrider({
+    qar: 'file:../qar',
+  }, process.cwd())
+  expect(overrider({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: '3.0.0',
+    },
+  }, path.resolve('pkg'))).toStrictEqual({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: 'file:../../qar',
+    },
+  })
+})

--- a/resolving/local-resolver/test/index.ts
+++ b/resolving/local-resolver/test/index.ts
@@ -12,6 +12,16 @@ test('resolve directory', async () => {
   expect(resolveResult!.resolution['type']).toEqual('directory')
 })
 
+test('resolve directory specified using absolute path', async () => {
+  const linkedDir = path.join(__dirname, '..')
+  const resolveResult = await resolveFromLocal({ pref: `link:${linkedDir}` }, { projectDir: __dirname })
+  expect(resolveResult!.id).toEqual('link:..')
+  expect(resolveResult!.normalizedPref).toEqual(`link:${linkedDir}`)
+  expect(resolveResult!['manifest']!.name).toEqual('@pnpm/local-resolver')
+  expect(resolveResult!.resolution['directory']).toEqual(normalize(linkedDir))
+  expect(resolveResult!.resolution['type']).toEqual('directory')
+})
+
 test('resolve injected directory', async () => {
   const resolveResult = await resolveFromLocal({ injected: true, pref: '..' }, { projectDir: __dirname })
   expect(resolveResult!.id).toEqual('file:..')

--- a/resolving/local-resolver/test/index.ts
+++ b/resolving/local-resolver/test/index.ts
@@ -14,11 +14,12 @@ test('resolve directory', async () => {
 
 test('resolve directory specified using absolute path', async () => {
   const linkedDir = path.join(__dirname, '..')
+  const normalizedLinkedDir = normalize(linkedDir)
   const resolveResult = await resolveFromLocal({ pref: `link:${linkedDir}` }, { projectDir: __dirname })
   expect(resolveResult!.id).toEqual('link:..')
-  expect(resolveResult!.normalizedPref).toEqual(`link:${linkedDir}`)
+  expect(resolveResult!.normalizedPref).toEqual(`link:${normalizedLinkedDir}`)
   expect(resolveResult!['manifest']!.name).toEqual('@pnpm/local-resolver')
-  expect(resolveResult!.resolution['directory']).toEqual(normalize(linkedDir))
+  expect(resolveResult!.resolution['directory']).toEqual(normalizedLinkedDir)
   expect(resolveResult!.resolution['type']).toEqual('directory')
 })
 


### PR DESCRIPTION
resolve #5493 

Fixed error reported when using the file protocol in overrides.

I'm not quite sure how to support the case of changing dependency to local files in `.pnpmfile.js`, when the files does not exist in the workspace directory, is it possible to retry to resolve the file in the root directory ?