### PR TITLE
fix(lifecycle hooks): fix lifecycle hook

### DIFF
--- a/.changeset/seven-badgers-heal.md
+++ b/.changeset/seven-badgers-heal.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/lifecycle": patch
+"@pnpm/core": patch
+"@pnpm/headless": patch
+---
+
+Check `neverBuiltDependencies` before a package runs it's lifecyle hooks. Fixes [#5407](https://github.com/pnpm/pnpm/issues/5407)

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -23,6 +23,7 @@ export interface RunLifecycleHookOptions {
   shellEmulator?: boolean
   stdio?: string
   unsafePerm: boolean
+  neverBuiltDependencies?: string[]
 }
 
 export async function runLifecycleHook (
@@ -30,6 +31,7 @@ export async function runLifecycleHook (
   manifest: ProjectManifest | DependencyManifest,
   opts: RunLifecycleHookOptions
 ) {
+  if (manifest.name && opts.neverBuiltDependencies?.includes(manifest.name)) return
   const optional = opts.optional === true
 
   const m = { _id: getId(manifest), ...manifest }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -254,6 +254,7 @@ export async function mutateModules (
       stdio: opts.ownLifecycleHooksStdio,
       storeController: opts.storeController,
       unsafePerm: opts.unsafePerm || false,
+      neverBuiltDependencies: opts.neverBuiltDependencies,
     }
 
     if (!opts.ignoreScripts && !opts.ignorePackageManifest && rootProjectManifest?.scripts?.[DEV_PREINSTALL]) {

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -152,6 +152,7 @@ export interface HeadlessOptions {
   enableModulesDir?: boolean
   nodeLinker?: 'isolated' | 'hoisted' | 'pnp'
   useGitBranchLockfile?: boolean
+  neverBuiltDependencies?: string[]
 }
 
 export async function headlessInstall (opts: HeadlessOptions) {
@@ -205,6 +206,7 @@ export async function headlessInstall (opts: HeadlessOptions) {
     stdio: opts.ownLifecycleHooksStdio ?? 'inherit',
     storeController: opts.storeController,
     unsafePerm: opts.unsafePerm || false,
+    neverBuiltDependencies: opts.neverBuiltDependencies,
   }
 
   const skipped = opts.skipped || new Set<string>()


### PR DESCRIPTION
Check `neverBuiltDependencies` before a package runs it's lifecyle hooks
Fixes https://github.com/pnpm/pnpm/issues/5407


Patch you can use to repro:
[repro-broken-neverBuiltDependencies.patch.txt](https://github.com/pnpm/pnpm/files/10125945/repro-broken-neverBuiltDependencies.patch.txt)
