### PR TITLE
feat: use Sync FS functions

### DIFF
--- a/.changeset/witty-adults-chew.md
+++ b/.changeset/witty-adults-chew.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/fs.indexed-pkg-importer": patch
+---
+
+Use sync FS functions to Hardlink files


### PR DESCRIPTION
Use `linkSync` instead of `link` to speedup the hardlink process.