### PR TITLE
fix: it should possible to use abolute file paths in overrides

### DIFF
--- a/.changeset/perfect-islands-trade.md
+++ b/.changeset/perfect-islands-trade.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
+---
+
+It should be possible to use overrides with absolute file paths [#5754](https://github.com/pnpm/pnpm/issues/5754).

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -18,7 +18,8 @@ export function createVersionsOverrider (
         }
         let linkFileTarget: string | undefined
         if (override.newPref.startsWith('file:')) {
-          linkFileTarget = path.join(rootDir, override.newPref.substring(5))
+          const pkgPath = override.newPref.substring(5)
+          linkFileTarget = path.isAbsolute(pkgPath) ? pkgPath : path.join(rootDir, pkgPath)
         }
         return {
           ...override,

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -271,3 +271,23 @@ test('createVersionsOverrider() overrides dependencies with file', () => {
     },
   })
 })
+
+test('createVersionsOverrider() overrides dependencies with file specified with absolute path', () => {
+  const absolutePath = path.join(__dirname, 'qar')
+  const overrider = createVersionsOverrider({
+    qar: `file:${absolutePath}`,
+  }, process.cwd())
+  expect(overrider({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: '3.0.0',
+    },
+  }, path.resolve('pkg'))).toStrictEqual({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: `file:${absolutePath}`,
+    },
+  })
+})


### PR DESCRIPTION
close #5754