### PR TITLE
chore(plugin-commands-publishing): output --json option in help info

### DIFF
--- a/.changeset/four-ducks-try.md
+++ b/.changeset/four-ducks-try.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"pnpm": patch
+---
+
+Added `--json` to the `pnpm publish --help` output [#5773](https://github.com/pnpm/pnpm/pull/5773).

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -66,6 +66,10 @@ export function help () {
             name: '--dry-run',
           },
           {
+            description: 'Show information in JSON format',
+            name: '--json',
+          },
+          {
             description: 'Registers the published package with the given tag. By default, the "latest" tag is used.',
             name: '--tag <tag>',
           },


### PR DESCRIPTION
show `--json` option for `pnpm publish --help`:

```
$ pd publish --help      
Version 7.18.1
Usage: pnpm publish [<tarball>|<dir>] [--tag <tag>] [--access <public|restricted>] [options]

Publishes a package to the npm registry.

Options:
      --access <public|restricted>  Tells the registry whether this package should be published as public
                                    or restricted
      --dry-run                     Does everything a publish would do except actually publishing to the
                                    registry
      --force                       Packages are proceeded to be published even if their current version
                                    is already in the registry. This is useful when a "prepublishOnly"
                                    script bumps the version of the package before it is published
      --ignore-scripts              Ignores any publish related lifecycle scripts (prepublishOnly,
                                    postpublish, and the like)
      --json                        Show information in JSON format
      --no-git-checks               Don't check if current branch is your publish branch, clean, and up
                                    to date
      --otp                         When publishing packages that require two-factor authentication, this
                                    option can specify a one-time password
      --publish-branch              Sets branch name to publish. Default is master
  -r, --recursive                   Publish all packages from the workspace
      --report-summary              Save the list of the newly published packages to
                                    "pnpm-publish-summary.json". Useful when some other tooling is used
                                    to report the list of published packages.
      --tag <tag>                   Registers the published package with the given tag. By default, the
                                    "latest" tag is used.

```