### PR TITLE
fix: throw an error while missing script start or server.js

### DIFF
--- a/.changeset/tricky-coats-join.md
+++ b/.changeset/tricky-coats-join.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/lifecycle": patch
+"pnpm": patch
 ---
 
-Throw an error while missing script start or file server.js
+Throw an error while missing script start or file `server.js` [#5782](https://github.com/pnpm/pnpm/pull/5782).

--- a/.changeset/tricky-coats-join.md
+++ b/.changeset/tricky-coats-join.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lifecycle": patch
+---
+
+Throw an error while missing script start or file server.js

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/directory-fetcher": "workspace:*",
+    "@pnpm/error": "workspace:*",
     "@pnpm/npm-lifecycle": "^2.0.0",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/store-controller-types": "workspace:*",

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@pnpm/lifecycle": "workspace:*",
+    "@pnpm/test-fixtures": "workspace:*",
     "@types/rimraf": "^3.0.2",
     "@zkochan/rimraf": "^2.1.2",
     "json-append": "1.1.1",

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -2,6 +2,8 @@ import { lifecycleLogger } from '@pnpm/core-loggers'
 import { globalWarn } from '@pnpm/logger'
 import lifecycle from '@pnpm/npm-lifecycle'
 import { DependencyManifest, ProjectManifest } from '@pnpm/types'
+import { PnpmError } from '@pnpm/error'
+import { existsSync } from 'fs'
 
 function noop () {} // eslint-disable-line:no-empty
 
@@ -35,6 +37,9 @@ export async function runLifecycleHook (
 
   if (stage === 'start' && !m.scripts.start) {
     m.scripts.start = 'node server.js'
+    if (!existsSync('server.js')) {
+      throw new PnpmError('NO_SCRIPT_OR_SERVER', 'Missing script start or file server.js')
+    }
   }
   if (opts.args?.length && m.scripts?.[stage]) {
     const escapedArgs = opts.args.map((arg) => JSON.stringify(arg))

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -36,10 +36,10 @@ export async function runLifecycleHook (
   m.scripts = { ...m.scripts }
 
   if (stage === 'start' && !m.scripts.start) {
-    m.scripts.start = 'node server.js'
     if (!existsSync('server.js')) {
       throw new PnpmError('NO_SCRIPT_OR_SERVER', 'Missing script start or file server.js')
     }
+    m.scripts.start = 'node server.js'
   }
   if (opts.args?.length && m.scripts?.[stage]) {
     const escapedArgs = opts.args.map((arg) => JSON.stringify(arg))

--- a/exec/lifecycle/test/fixtures/without-scriptstart-serverjs/package.json
+++ b/exec/lifecycle/test/fixtures/without-scriptstart-serverjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "without-scriptstart-serverjs",
+  "version": "1.0.0",
+  "scripts": {}
+}

--- a/exec/lifecycle/test/index.ts
+++ b/exec/lifecycle/test/index.ts
@@ -4,12 +4,13 @@ import { runLifecycleHook, runPostinstallHooks } from '@pnpm/lifecycle'
 import loadJsonFile from 'load-json-file'
 import rimraf from '@zkochan/rimraf'
 import { PnpmError } from '@pnpm/error'
+import { fixtures } from '@pnpm/test-fixtures'
 
-const fixtures = path.join(__dirname, 'fixtures')
+const f = fixtures(path.join(__dirname, 'fixtures'))
 const rootModulesDir = path.join(__dirname, '..', 'node_modules')
 
 test('runLifecycleHook()', async () => {
-  const pkgRoot = path.join(fixtures, 'simple')
+  const pkgRoot = f.find('simple')
   const pkg = await import(path.join(pkgRoot, 'package.json'))
   await runLifecycleHook('postinstall', pkg, {
     depPath: '/simple/1.0.0',
@@ -24,7 +25,7 @@ test('runLifecycleHook()', async () => {
 })
 
 test('runLifecycleHook() escapes the args passed to the script', async () => {
-  const pkgRoot = path.join(fixtures, 'escape-args')
+  const pkgRoot = f.find('escape-args')
   const pkg = await import(path.join(pkgRoot, 'package.json'))
   await runLifecycleHook('echo', pkg, {
     depPath: '/escape-args/1.0.0',
@@ -39,7 +40,7 @@ test('runLifecycleHook() escapes the args passed to the script', async () => {
 })
 
 test('runPostinstallHooks()', async () => {
-  const pkgRoot = path.join(fixtures, 'with-many-scripts')
+  const pkgRoot = f.find('with-many-scripts')
   await rimraf(path.join(pkgRoot, 'output.json'))
   await runPostinstallHooks({
     depPath: '/with-many-scripts/1.0.0',
@@ -54,7 +55,7 @@ test('runPostinstallHooks()', async () => {
 })
 
 test('runLifecycleHook() should throw an error while missing script start or file server.js', async () => {
-  const pkgRoot = path.join(fixtures, 'without-scriptstart-serverjs')
+  const pkgRoot = f.find('without-scriptstart-serverjs')
   const pkg = await import(path.join(pkgRoot, 'package.json'))
   await expect(
     runLifecycleHook('start', pkg, {

--- a/exec/lifecycle/tsconfig.json
+++ b/exec/lifecycle/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../packages/core-loggers"
     },
     {
+      "path": "../../packages/error"
+    },
+    {
       "path": "../../packages/types"
     },
     {

--- a/exec/lifecycle/tsconfig.json
+++ b/exec/lifecycle/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../__utils__/test-fixtures"
+    },
+    {
       "path": "../../fetching/directory-fetcher"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,6 +903,9 @@ importers:
       '@pnpm/directory-fetcher':
         specifier: workspace:*
         version: link:../../fetching/directory-fetcher
+      '@pnpm/error':
+        specifier: workspace:*
+        version: link:../../packages/error
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -931,6 +931,9 @@ importers:
       '@pnpm/lifecycle':
         specifier: workspace:*
         version: 'link:'
+      '@pnpm/test-fixtures':
+        specifier: workspace:*
+        version: link:../../__utils__/test-fixtures
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
Missing script start or server.js should print an error but got with: 
```
> node server.js

internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module '/xxx/server.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:75:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```