### PR TITLE
fix(dependencies-hierarchy): account for depth in getTree cache

### DIFF
--- a/.changeset/chilly-walls-melt.md
+++ b/.changeset/chilly-walls-melt.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"@pnpm/reviewing.dependencies-hierarchy": patch
+---
+
+Fix a situation where `pnpm list` and `pnpm why` may not respect the `--depth` argument.

--- a/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
+++ b/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
@@ -1,0 +1,13 @@
+import { PackageNode } from './PackageNode'
+
+export class DependenciesCache {
+  private readonly dependenciesCache = new Map<string, PackageNode[]>()
+
+  public get (packageAbsolutePath: string): PackageNode[] | undefined {
+    return this.dependenciesCache.get(packageAbsolutePath)
+  }
+
+  public set (packageAbsolutePath: string, dependencies: PackageNode[]): void {
+    this.dependenciesCache.set(packageAbsolutePath, dependencies)
+  }
+}

--- a/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
+++ b/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
@@ -1,13 +1,102 @@
 import { PackageNode } from './PackageNode'
 
-export class DependenciesCache {
-  private readonly dependenciesCache = new Map<string, PackageNode[]>()
+export interface GetDependenciesCacheEntryArgs {
+  readonly packageAbsolutePath: string
+  readonly requestedDepth: number
+}
 
-  public get (packageAbsolutePath: string): PackageNode[] | undefined {
-    return this.dependenciesCache.get(packageAbsolutePath)
+export interface TraversalResultFullyVisited {
+  readonly dependencies: PackageNode[]
+
+  /**
+   * Describes the height of the parent node in the fully enumerated dependency
+   * tree. A height of 0 means no entries are present in the dependencies array.
+   * A height of 1 means entries in the dependencies array do not have any of
+   * their own dependencies.
+   */
+  readonly height: number
+}
+
+export interface TraversalResultPartiallyVisited {
+  readonly dependencies: PackageNode[]
+
+  /**
+   * Describes how deep the dependencies tree was previously traversed. Since
+   * the traversal result was limited by a max depth, there are likely more
+   * dependencies present deeper in the tree not shown.
+   *
+   * A depth of 0 would indicate no entries in the dependencies array. A depth
+   * of 1 means entries in the dependencies array do not have any of their own
+   * dependencies.
+   */
+  readonly depth: number
+}
+
+/**
+ * A cache for the dependencies of a package.
+ *
+ * ## Depth Considerations
+ *
+ * Since the enumerated dependency tree can be limited by a max depth argument,
+ * several considerations have to be made when caching.
+ *
+ *   - If a package is visited with a requested depth greater than the cached
+ *     depth, the cache cannot be used. The tree needs to be enumerated again
+ *     deeper.
+ *   - If a package is visited with a requested depth less than the cached
+ *     depth, the cache probably can't be used. This depends on how strict the
+ *     depth constraint is and whether it's acceptable to exceed the max depth.
+ *     This cache assumes the max depth should not be exceeded.
+ *   - Cycles may or may not be cached. It depends on whether the cycle is
+ *     introduced by a package outside of the cached tree.
+ *
+ * This cache adds an optimization when a dependency tree has been fully
+ * enumerated and wasn't limited by a max depth argument. In that case,
+ * dependency trees cached can be used when the max depth argument is greater
+ * than or equal to the height of the tree root.
+ *
+ * ## Future Optimizations
+ *
+ * The necessity of this cache may be removed in the future with a refactor of
+ * the `pnpm list` command. This cache attempts to optimize runtime to O(# of
+ * unique packages), but the list command is O(# of nodes) anyway since every
+ * node needs to be printed. It's possible a generator function could be
+ * returned here to avoid computing large trees in-memory before passing to
+ * downstream commands.
+ */
+export class DependenciesCache {
+  private readonly fullyVisitedCache = new Map<string, TraversalResultFullyVisited>()
+
+  /**
+   *  Maps packageAbsolutePath -> visitedDepth -> dependencies
+   */
+  private readonly partiallyVisitedCache = new Map<string, Map<number, PackageNode[]>>()
+
+  public get (args: GetDependenciesCacheEntryArgs): PackageNode[] | undefined {
+    // The fully visited cache is only usable if the height doesn't exceed the
+    // requested depth. Otherwise the final dependencies listing will print
+    // entries with a greater depth than requested.
+    //
+    // If that is the case, the partially visited cache should be checked to see
+    // if dependencies were requested at that exact depth before.
+    const fullyVisitedEntry = this.fullyVisitedCache.get(args.packageAbsolutePath)
+    if (fullyVisitedEntry !== undefined && fullyVisitedEntry.height <= args.requestedDepth) {
+      return fullyVisitedEntry.dependencies
+    }
+
+    return this.partiallyVisitedCache.get(args.packageAbsolutePath)?.get(args.requestedDepth)
   }
 
-  public set (packageAbsolutePath: string, dependencies: PackageNode[]): void {
-    this.dependenciesCache.set(packageAbsolutePath, dependencies)
+  public addFullyVisitedResult (packageAbsolutePath: string, result: TraversalResultFullyVisited): void {
+    this.fullyVisitedCache.set(packageAbsolutePath, result)
+  }
+
+  public addPartiallyVisitedResult (packageAbsolutePath: string, result: TraversalResultPartiallyVisited): void {
+    const dependenciesByDepth = this.partiallyVisitedCache.get(packageAbsolutePath) ?? new Map()
+    if (!this.partiallyVisitedCache.has(packageAbsolutePath)) {
+      this.partiallyVisitedCache.set(packageAbsolutePath, dependenciesByDepth)
+    }
+
+    dependenciesByDepth.set(result.depth, result.dependencies)
   }
 }

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -6,6 +6,7 @@ import { refToRelative } from '@pnpm/dependency-path'
 import { SearchFunction } from './types'
 import { PackageNode } from './PackageNode'
 import { getPkgInfo } from './getPkgInfo'
+import { DependenciesCache } from './DependenciesCache'
 
 interface GetTreeOpts {
   currentDepth: number
@@ -26,13 +27,13 @@ export function getTree (
   keypath: string[],
   parentId: string
 ): PackageNode[] {
-  const dependenciesCache = new Map<string, PackageNode[]>()
+  const dependenciesCache = new DependenciesCache()
 
   return getTreeHelper(dependenciesCache, opts, keypath, parentId).dependencies
 }
 
 function getTreeHelper (
-  dependenciesCache: Map<string, PackageNode[]>,
+  dependenciesCache: DependenciesCache,
   opts: GetTreeOpts,
   keypath: string[],
   parentId: string

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -20,7 +20,23 @@ interface GetTreeOpts {
   wantedPackages: PackageSnapshots
 }
 
-interface DependencyInfo { circular?: true, dependencies: PackageNode[] }
+interface DependencyInfo {
+  dependencies: PackageNode[]
+
+  circular?: true
+
+  /**
+   * Whether or not the dependencies array was fully enumerated. This may not be
+   * the case if a max depth was hit.
+   */
+  isPartiallyVisited: boolean
+
+  /**
+   * The number of edges along longest path. null if the dependencies array is
+   * empty.
+   */
+  height: number | null
+}
 
 export function getTree (
   opts: GetTreeOpts,
@@ -38,8 +54,13 @@ function getTreeHelper (
   keypath: string[],
   parentId: string
 ): DependencyInfo {
-  const result: DependencyInfo = { dependencies: [] }
-  if (opts.currentDepth > opts.maxDepth || !opts.currentPackages || !opts.currentPackages[parentId]) return result
+  if (opts.currentDepth > opts.maxDepth) {
+    return { dependencies: [], isPartiallyVisited: true, height: null }
+  }
+
+  if (!opts.currentPackages?.[parentId]) {
+    return { dependencies: [], isPartiallyVisited: false, height: null }
+  }
 
   const deps = !opts.includeOptionalDependencies
     ? opts.currentPackages[parentId].dependencies
@@ -48,7 +69,9 @@ function getTreeHelper (
       ...opts.currentPackages[parentId].optionalDependencies,
     }
 
-  if (deps == null) return result
+  if (deps == null) {
+    return { dependencies: [], isPartiallyVisited: false, height: null }
+  }
 
   const getChildrenTree = getTreeHelper.bind(null, dependenciesCache, {
     ...opts,
@@ -56,6 +79,11 @@ function getTreeHelper (
   })
 
   const peers = new Set(Object.keys(opts.currentPackages[parentId].peerDependencies ?? {}))
+
+  const resultDependencies: PackageNode[] = []
+  let resultHeight = 0
+  let resultCircular: boolean = false
+  let resultIsPartiallyVisited = false
 
   Object.entries(deps).forEach(([alias, ref]) => {
     const { packageInfo, packageAbsolutePath } = getPkgInfo({
@@ -85,16 +113,28 @@ function getTreeHelper (
       if (circular) {
         dependencies = []
       } else {
-        dependencies = dependenciesCache.get(packageAbsolutePath)
+        const requestedDepth = opts.maxDepth - opts.currentDepth
+        dependencies = dependenciesCache.get({ packageAbsolutePath, requestedDepth })
 
         if (dependencies == null) {
           const children = getChildrenTree(keypath.concat([relativeId]), relativeId)
           dependencies = children.dependencies
+          const heightOfCurrentDepNode = children.height == null ? 0 : children.height + 1
+          resultHeight = Math.max(resultHeight, heightOfCurrentDepNode + 1)
+          resultIsPartiallyVisited = resultIsPartiallyVisited || children.isPartiallyVisited
 
           if (children.circular) {
-            result.circular = true
+            resultCircular = true
+          } else if (children.isPartiallyVisited) {
+            dependenciesCache.addPartiallyVisitedResult(packageAbsolutePath, {
+              dependencies,
+              depth: requestedDepth,
+            })
           } else {
-            dependenciesCache.set(packageAbsolutePath, dependencies)
+            dependenciesCache.addFullyVisitedResult(packageAbsolutePath, {
+              dependencies,
+              height: heightOfCurrentDepNode,
+            })
           }
         }
       }
@@ -111,14 +151,24 @@ function getTreeHelper (
     if (newEntry != null) {
       if (circular) {
         newEntry.circular = true
-        result.circular = true
+        resultCircular = true
       }
       if (matchedSearched) {
         newEntry.searched = true
       }
-      result.dependencies.push(newEntry)
+      resultDependencies.push(newEntry)
     }
   })
+
+  const result: DependencyInfo = {
+    dependencies: resultDependencies,
+    isPartiallyVisited: resultIsPartiallyVisited,
+    height: resultHeight,
+  }
+
+  if (resultCircular) {
+    result.circular = resultCircular
+  }
 
   return result
 }

--- a/reviewing/dependencies-hierarchy/test/getTree.test.ts
+++ b/reviewing/dependencies-hierarchy/test/getTree.test.ts
@@ -147,4 +147,138 @@ describe('getTree', () => {
       ])
     })
   })
+
+  // This group of tests attempts to check that package tree caching still
+  // respects max depth. See https://github.com/pnpm/pnpm/issues/4814
+  //
+  // This doesn't test the cache directly, but sets up situations that would
+  // result in incorrect output if the cache was used when it's not supposed to.
+  describe('prints at expected depth for cache regression testing cases', () => {
+    const commonMockGetTreeArgs = {
+      modulesDir: '',
+      includeOptionalDependencies: false,
+      skipped: new Set<string>(),
+      registries: {
+        default: 'mock-registry-for-testing.example',
+      },
+    }
+
+    test('revisiting package at lower depth prints dependenices not previously printed', () => {
+      // This tests the "glob" npm package on a subset of its dependency tree.
+      // Requested depth (max depth - current depth) shown in square brackets.
+      //
+      // root
+      // └─┬ glob [2]
+      //   ├─┬ inflight [1]
+      //   │ └── once [0]    <-- 1st time seen. No dependencies of "once" printed due to max depth.
+      //   └─┬ once [1]      <-- 2nd time seen, but at different depth. The "wrappy" dependency below should be printed.
+      //     └── wrappy [0]
+      //
+      const version = '1.0.0'
+      const currentPackages = generateMockCurrentPackages(version, {
+        root: ['glob'],
+        glob: ['inflight', 'once'],
+        inflight: ['once'],
+        once: ['wrappy'],
+      })
+      const rootDepPath = refToRelativeOrThrow(version, 'root')
+
+      const result = getTree({
+        ...commonMockGetTreeArgs,
+        currentDepth: 0,
+        maxDepth: 2,
+        currentPackages,
+        wantedPackages: currentPackages,
+      }, [rootDepPath], rootDepPath)
+
+      expect(normalizePackageNodeForTesting(result)).toEqual([
+        // depth 0
+        expect.objectContaining({
+          alias: 'glob',
+          dependencies: expect.arrayContaining([
+
+            // depth 1
+            expect.objectContaining({
+              alias: 'inflight',
+              dependencies: expect.arrayContaining([
+                // depth 2
+                expect.objectContaining({
+                  // The "once" package is first seen here at depth 2.
+                  alias: 'once',
+                }),
+              ]),
+            }),
+
+            // depth 1
+            expect.objectContaining({
+              alias: 'once',
+              dependencies: [
+                // The "once" package is seen again at depth 1. The "once"
+                // package contains a "wrappy" package that should be listed.
+                expect.objectContaining({ alias: 'wrappy' }),
+              ],
+            }),
+          ]),
+        }),
+      ])
+    })
+
+    test('revisiting package at higher depth does not print extra dependenices', () => {
+      // This tests the "glob" npm package on a subset of its dependency tree.
+      // Requested depth (max depth - current depth) shown in square brackets.
+      //
+      // root
+      // └─┬ a [2]
+      //   ├─┬ b [1]   <-- 1st time "b" is seen.
+      //   │ └── c [0]
+      //   └─┬ d [1]
+      //     └── b [0] <-- 2nd time "b" is seen. Dependencies should not be printed since "max depth === current depth".
+      const version = '1.0.0'
+      const currentPackages = generateMockCurrentPackages(version, {
+        root: ['a'],
+        a: ['b', 'd'],
+        b: ['c'],
+        d: ['b'],
+      })
+      const rootDepPath = refToRelativeOrThrow(version, 'root')
+
+      const result = getTree({
+        ...commonMockGetTreeArgs,
+        currentDepth: 0,
+        maxDepth: 2,
+        currentPackages,
+        wantedPackages: currentPackages,
+      }, [rootDepPath], rootDepPath)
+
+      expect(normalizePackageNodeForTesting(result)).toEqual([
+        expect.objectContaining({
+          alias: 'a',
+          dependencies: [
+
+            expect.objectContaining({
+              alias: 'b',
+              dependencies: [
+                expect.objectContaining({
+                  alias: 'c',
+                }),
+              ],
+            }),
+
+            expect.objectContaining({
+              alias: 'd',
+              dependencies: [
+                expect.objectContaining({
+                  alias: 'b',
+
+                  // The "b" package has a "c" dependency, but it should not be
+                  // printed since the max depth was reached.
+                  dependencies: undefined,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/4814.

I think this solution might be overly complex. If maintainers feel we should abandon caching, I can close this PR and put up an alternative that simply removes the (incorrect) cache.

## Performance

Since the cache cannot be reused at different depth levels, there's an expected performance regression with this change.


### Testing `--depth=3`

For rudimentary benchmarking, I ran `pnpm list --depth=3` on the root of the pnpm repo. I'm using node `v19.3.0` on a Apple M1 device.

**This PR**:
```
❯ hyperfine --warmup 2 --runs 50 "node $pnpm list --depth=3"
Benchmark 1: node $HOME/pnpm/pnpm/lib/pnpm.js list --depth=3
  Time (mean ± σ):     691.0 ms ±   8.0 ms    [User: 824.3 ms, System: 175.6 ms]
  Range (min … max):   676.4 ms … 711.8 ms    50 runs
```

**Commit d7ea8b486a420b93242ecba67eab0172266f391c (7.19.0)**
```
❯ hyperfine --warmup 2 --runs 50 "node $pnpm list --depth=3"
Benchmark 1: node $HOME/pnpm/pnpm/lib/pnpm.js list --depth=3
  Time (mean ± σ):     691.7 ms ±   8.9 ms    [User: 831.8 ms, System: 176.7 ms]
  Range (min … max):   670.9 ms … 721.2 ms    50 runs
```

For this case, the runs were very close in performance, but I'd expect other dependency graphs to have different performance characteristics.

### Testing `--depth=9999`

Not expecting any performance differences for a large max depth. In this case the fully visited cache will always be used over the partially visited cache. This would have similar performance characteristics before the changes in this PR split the cache.

**This PR**:
```
❯ hyperfine --warmup 2 --runs 50 "node $pnpm list --depth=9999"
Benchmark 1: node $HOME/pnpm/pnpm/lib/pnpm.js list --depth=9999
  Time (mean ± σ):      2.884 s ±  0.056 s    [User: 4.090 s, System: 0.562 s]
  Range (min … max):    2.811 s …  3.090 s    50 runs
```

**Commit d71dbf230bf4fc4adaa71741b325a44e2bcbd243**:
```
❯ hyperfine --warmup 2 --runs 50 "node $pnpm list --depth=9999"
Benchmark 1: node $HOME/pnpm/pnpm/lib/pnpm.js list --depth=9999
  Time (mean ± σ):      2.885 s ±  0.068 s    [User: 4.090 s, System: 0.570 s]
  Range (min … max):    2.806 s …  3.109 s    50 runs
```