### PR TITLE
feat(pnpm): add show alias to `pnpm view`

### DIFF
--- a/.changeset/red-planets-prove.md
+++ b/.changeset/red-planets-prove.md
@@ -2,4 +2,4 @@
 "pnpm": minor
 ---
 
-feat: add show alias to `pnpm view`
+Add show alias to `pnpm view` [#5835](https://github.com/pnpm/pnpm/pull/5835).

--- a/.changeset/red-planets-prove.md
+++ b/.changeset/red-planets-prove.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+feat: add show alias to `pnpm view`

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -49,6 +49,7 @@ const argv = process.argv.slice(2)
   case 'search':
   case 'set':
   case 'set-script':
+  case 'show':
   case 'star':
   case 'stars':
   case 'team':


### PR DESCRIPTION
Hi PNPM Team,

Thanks for the great tool!

I add the show alias to `pnpm view` according to [`npm view` docs](https://docs.npmjs.com/cli/v9/commands/npm-view) should support it like the below:

```sh
npm view [<package-spec>] [<field>[.subfield]...]

aliases: info, show, v
```