### PR TITLE
feat: add description field to output to licenses command output

### DIFF
--- a/.changeset/chilly-flies-bow.md
+++ b/.changeset/chilly-flies-bow.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/license-scanner": major
-"@pnpm/plugin-commands-licenses": major
+"@pnpm/license-scanner": patch
+"@pnpm/plugin-commands-licenses": patch
 ---
 
 Add the 'description'-field to the licenses output

--- a/.changeset/chilly-flies-bow.md
+++ b/.changeset/chilly-flies-bow.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/license-scanner": major
+"@pnpm/plugin-commands-licenses": major
+---
+
+Add the 'description'-field to the licenses output

--- a/.changeset/chilly-flies-bow.md
+++ b/.changeset/chilly-flies-bow.md
@@ -1,6 +1,7 @@
 ---
+"pnpm": minor
 "@pnpm/license-scanner": patch
 "@pnpm/plugin-commands-licenses": patch
 ---
 
-Add the 'description'-field to the licenses output
+Add the 'description'-field to the licenses output [#5836](https://github.com/pnpm/pnpm/pull/5836).

--- a/reviewing/license-scanner/src/licenses.ts
+++ b/reviewing/license-scanner/src/licenses.ts
@@ -19,6 +19,7 @@ export interface LicensePackage {
   licenseContents?: string
   author?: string
   homepage?: string
+  description?: string
   repository?: string
   path?: string
 }
@@ -52,6 +53,7 @@ function getDependenciesFromLicenseNode (
         licenseContents: dependencyNode.licenseContents,
         author: dependencyNode.author as string,
         homepage: dependencyNode.homepage as string,
+        description: dependencyNode.description,
         repository: dependencyNode.repository as string,
         path: dependencyNode.dir,
       },

--- a/reviewing/license-scanner/src/lockfileToLicenseNodeTree.ts
+++ b/reviewing/license-scanner/src/lockfileToLicenseNodeTree.ts
@@ -17,6 +17,7 @@ export interface LicenseNode {
   dir: string
   author?: string
   homepage?: string
+  description?: string
   repository?: string
   integrity?: string
   requires?: Record<string, string>
@@ -90,6 +91,7 @@ export async function lockfileToLicenseNode (
       licenseContents: packageInfo.licenseContents,
       author: packageInfo.author,
       homepage: packageInfo.homepage,
+      description: packageInfo.description,
       repository: packageInfo.repository,
       dir: packageInfo.path as string,
     }

--- a/reviewing/license-scanner/test/licenses.spec.ts
+++ b/reviewing/license-scanner/test/licenses.spec.ts
@@ -76,6 +76,7 @@ describe('licences', () => {
     expect(licensePackages).toEqual([
       {
         belongsTo: 'dependencies',
+        description: 'Package Description',
         version: '1.0.0',
         name: 'bar',
         license: 'MIT',
@@ -87,6 +88,7 @@ describe('licences', () => {
       },
       {
         belongsTo: 'dependencies',
+        description: 'Package Description',
         version: '1.0.0',
         name: 'foo',
         license: 'Unknown',

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -35,6 +35,9 @@ function renderDetails (licensePackage: LicensePackage) {
   if (licensePackage.author) {
     outputs.push(licensePackage.author)
   }
+  if (licensePackage.description) {
+    outputs.push(licensePackage.description)
+  }
   if (licensePackage.homepage) {
     outputs.push(chalk.underline(licensePackage.homepage))
   }
@@ -63,6 +66,7 @@ function renderLicensesJson (licensePackages: readonly LicensePackage[]) {
         licenseContents: licensePkg.licenseContents,
         author: licensePkg.author,
         homepage: licensePkg.homepage,
+        description: licensePkg.description,
       } as LicensePackageJson
     }),
   ].flat()

--- a/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
+++ b/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
@@ -7,53 +7,69 @@ exports[`pnpm licenses: output as json: found-license-types 1`] = `
 `;
 
 exports[`pnpm licenses: should correctly read LICENSE file with executable file mode: show-packages-details 1`] = `
-"┌──────────────────────────────┬─────────┬───────────────────────────────────────────────────────┐
-│ Package                      │ License │ Details                                               │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ inherits                     │ ISC     │ https://github.com/isaacs/inherits#readme             │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ sax                          │ ISC     │ Isaac Z. Schlueter                                    │
-│                              │         │ https://github.com/isaacs/sax-js#readme               │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ commander                    │ MIT     │ TJ Holowaychuk                                        │
-│                              │         │ https://github.com/tj/commander.js#readme             │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ core-util-is                 │ MIT     │ Isaac Z. Schlueter                                    │
-│                              │         │ https://github.com/isaacs/core-util-is#readme         │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ isarray                      │ MIT     │ Julian Gruber                                         │
-│                              │         │ https://github.com/juliangruber/isarray               │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ neatequal                    │ MIT     │ Nicolas Froidure                                      │
-│                              │         │ https://github.com/nfroidure/neatequal                │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ process-nextick-args         │ MIT     │ https://github.com/calvinmetcalf/process-nextick-args │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ readable-stream              │ MIT     │ https://github.com/nodejs/readable-stream#readme      │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ safe-buffer                  │ MIT     │ Feross Aboukhadijeh                                   │
-│                              │         │ https://github.com/feross/safe-buffer                 │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ string_decoder               │ MIT     │ https://github.com/nodejs/string_decoder              │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ string.fromcodepoint         │ MIT     │ Mathias Bynens                                        │
-│                              │         │ http://mths.be/fromcodepoint                          │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ string.prototype.codepointat │ MIT     │ Mathias Bynens                                        │
-│                              │         │ https://mths.be/codepointat                           │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ svg-pathdata                 │ MIT     │ Nicolas Froidure                                      │
-│                              │         │ https://github.com/nfroidure/SVGPathData#readme       │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ svgicons2svgfont             │ MIT     │ Nicolas Froidure                                      │
-│                              │         │ https://github.com/nfroidure/svgicons2svgfont         │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ util-deprecate               │ MIT     │ Nathan Rajlich                                        │
-│                              │         │ https://github.com/TooTallNate/util-deprecate         │
-├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
-│ varstream                    │ Unknown │ Nicolas Froidure                                      │
-│                              │         │ https://github.com/nfroidure/VarStream#readme         │
-└──────────────────────────────┴─────────┴───────────────────────────────────────────────────────┘
+"┌──────────────────────────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ Package                      │ License │ Details                                                                                                │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ inherits                     │ ISC     │ Browser-friendly inheritance fully compatible with standard node.js inherits()                         │
+│                              │         │ https://github.com/isaacs/inherits#readme                                                              │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ sax                          │ ISC     │ Isaac Z. Schlueter                                                                                     │
+│                              │         │ An evented streaming XML parser in JavaScript                                                          │
+│                              │         │ https://github.com/isaacs/sax-js#readme                                                                │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ commander                    │ MIT     │ TJ Holowaychuk                                                                                         │
+│                              │         │ the complete solution for node.js command-line programs                                                │
+│                              │         │ https://github.com/tj/commander.js#readme                                                              │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ core-util-is                 │ MIT     │ Isaac Z. Schlueter                                                                                     │
+│                              │         │ The \`util.is*\` functions introduced in Node v0.12.                                                     │
+│                              │         │ https://github.com/isaacs/core-util-is#readme                                                          │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ isarray                      │ MIT     │ Julian Gruber                                                                                          │
+│                              │         │ Array#isArray for older browsers                                                                       │
+│                              │         │ https://github.com/juliangruber/isarray                                                                │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ neatequal                    │ MIT     │ Nicolas Froidure                                                                                       │
+│                              │         │ Neat deep equal.                                                                                       │
+│                              │         │ https://github.com/nfroidure/neatequal                                                                 │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ process-nextick-args         │ MIT     │ process.nextTick but always with args                                                                  │
+│                              │         │ https://github.com/calvinmetcalf/process-nextick-args                                                  │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ readable-stream              │ MIT     │ Streams3, a user-land copy of the stream library from Node.js                                          │
+│                              │         │ https://github.com/nodejs/readable-stream#readme                                                       │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ safe-buffer                  │ MIT     │ Feross Aboukhadijeh                                                                                    │
+│                              │         │ Safer Node.js Buffer API                                                                               │
+│                              │         │ https://github.com/feross/safe-buffer                                                                  │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ string_decoder               │ MIT     │ The string_decoder module from Node core                                                               │
+│                              │         │ https://github.com/nodejs/string_decoder                                                               │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ string.fromcodepoint         │ MIT     │ Mathias Bynens                                                                                         │
+│                              │         │ A robust & optimized \`String.fromCodePoint\` polyfill, based on the ECMAScript 6 specification.         │
+│                              │         │ http://mths.be/fromcodepoint                                                                           │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ string.prototype.codepointat │ MIT     │ Mathias Bynens                                                                                         │
+│                              │         │ A robust & optimized \`String.prototype.codePointAt\` polyfill, based on the ECMAScript 6 specification. │
+│                              │         │ https://mths.be/codepointat                                                                            │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ svg-pathdata                 │ MIT     │ Nicolas Froidure                                                                                       │
+│                              │         │ Parse, transform and encode SVG Path Data.                                                             │
+│                              │         │ https://github.com/nfroidure/SVGPathData#readme                                                        │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ svgicons2svgfont             │ MIT     │ Nicolas Froidure                                                                                       │
+│                              │         │ Read a set of SVG icons and ouput a SVG font                                                           │
+│                              │         │ https://github.com/nfroidure/svgicons2svgfont                                                          │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ util-deprecate               │ MIT     │ Nathan Rajlich                                                                                         │
+│                              │         │ The Node.js \`util.deprecate()\` function with browser support                                           │
+│                              │         │ https://github.com/TooTallNate/util-deprecate                                                          │
+├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
+│ varstream                    │ Unknown │ Nicolas Froidure                                                                                       │
+│                              │         │ Stream variables beetween 2 JavaScript threads (client/server, ipc, worker/main thread).               │
+│                              │         │ https://github.com/nfroidure/VarStream#readme                                                          │
+└──────────────────────────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 "
 `;
 
@@ -62,6 +78,7 @@ exports[`pnpm licenses: show details: show-packages-details 1`] = `
 │ Package     │ License │ Details                                     │
 ├─────────────┼─────────┼─────────────────────────────────────────────┤
 │ is-positive │ MIT     │ Kevin Martensson                            │
+│             │         │ Check if something is a positive number     │
 │             │         │ https://github.com/kevva/is-positive#readme │
 └─────────────┴─────────┴─────────────────────────────────────────────┘
 "

--- a/reviewing/plugin-commands-licenses/test/index.ts
+++ b/reviewing/plugin-commands-licenses/test/index.ts
@@ -118,6 +118,7 @@ test('pnpm licenses: output as json', async () => {
     'license',
     'author',
     'homepage',
+    'description',
   ])
   expect(packagesWithMIT[0].name).toBe('is-positive')
 })


### PR DESCRIPTION
Add the `description`-field to the output of the `licenses list`-command so that for each package the description in the package manifest gets listed too.

As this is a added field I don't think this should be a breaking change