### PR TITLE
feat(plugin-commands-script-runners): support --resume-from for pnpm exec command

### DIFF
--- a/.changeset/silly-ties-arrive.md
+++ b/.changeset/silly-ties-arrive.md
@@ -3,4 +3,4 @@
 "pnpm": minor
 ---
 
-the `pnpm exec` command support `--resume-from` option. When used, the command will executed from given package [#4690](https://github.com/pnpm/pnpm/issues/4690).
+`pnpm exec` and `pnpm run` command support `--resume-from` option. When used, the command will executed from given package [#4690](https://github.com/pnpm/pnpm/issues/4690).

--- a/.changeset/silly-ties-arrive.md
+++ b/.changeset/silly-ties-arrive.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"pnpm": minor
+---
+
+the `pnpm exec` command support `--resume-from` option. When used, the command will executed from given package [#4690](https://github.com/pnpm/pnpm/issues/4690).

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -93,7 +93,7 @@ export function getResumedPackageChunks ({
     .find((prefix) => selectedProjectsGraph[prefix]?.package.manifest.name === resumeFrom)
 
   if (!resumeFromPackagePrefix) {
-    throw new PnpmError('RECURSIVE_EXEC_FAIL', `Cannot find package ${resumeFrom}. Could not determine where to resume from.`)
+    throw new PnpmError('RESUME_FROM_NOT_FOUND', `Cannot find package ${resumeFrom}. Could not determine where to resume from.`)
   }
 
   const chunkPosition = chunks.findIndex(chunk => chunk.includes(resumeFromPackagePrefix))

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -69,6 +69,7 @@ export function cliOptionsTypes () {
     ...IF_PRESENT_OPTION,
     recursive: Boolean,
     reverse: Boolean,
+    'resume-from': String,
   }
 }
 

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -552,3 +552,112 @@ testOnPosixOnly('pnpm recursive exec works with PnP', async () => {
   expect(outputs1).toStrictEqual(['project-1', 'project-2-prebuild', 'project-2', 'project-2-postbuild'])
   expect(outputs2).toStrictEqual(['project-1', 'project-3'])
 })
+
+test('pnpm recursive exec --resume-from should work', async () => {
+  preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        'json-append': '1',
+      },
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output1.json',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+      dependencies: {
+        'json-append': '1',
+        'project-1': '1',
+      },
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output1.json',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+      dependencies: {
+        'json-append': '1',
+        'project-1': '1',
+      },
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output1.json',
+      },
+    },
+    {
+      name: 'project-4',
+      version: '1.0.0',
+      dependencies: {
+        'json-append': '1',
+      },
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-4\')" | json-append ../output1.json',
+      },
+    },
+  ])
+
+  const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
+  await execa(pnpmBin, [
+    'install',
+    '-r',
+    '--registry',
+    REGISTRY_URL,
+    '--store-dir',
+    path.resolve(DEFAULT_OPTS.storeDir),
+  ])
+  await exec.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    selectedProjectsGraph,
+    recursive: true,
+    sort: true,
+    resumeFrom: 'project-3',
+  }, ['npm', 'run', 'build'])
+
+  const { default: outputs1 } = await import(path.resolve('output1.json'))
+  expect(outputs1).not.toContain('project-1')
+  expect(outputs1).not.toContain('project-4')
+  expect(outputs1).toContain('project-2')
+  expect(outputs1).toContain('project-3')
+})
+
+test('should throw error when the package specified by resume-from does not exist', async () => {
+  preparePackages([
+    {
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        'json-append': '1',
+      },
+      scripts: {
+        build: 'echo foo',
+      },
+    },
+  ])
+
+  const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
+  await execa(pnpmBin, [
+    'install',
+    '-r',
+    '--registry',
+    REGISTRY_URL,
+    '--store-dir',
+    path.resolve(DEFAULT_OPTS.storeDir),
+  ])
+
+  try {
+    await exec.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      selectedProjectsGraph,
+      recursive: true,
+      sort: true,
+      resumeFrom: 'project-2',
+    }, ['npm', 'run', 'build'])
+  } catch (err: any) { // eslint-disable-line
+    expect(err.code).toBe('ERR_PNPM_RECURSIVE_EXEC_FAIL')
+  }
+})

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -658,6 +658,6 @@ test('should throw error when the package specified by resume-from does not exis
       resumeFrom: 'project-2',
     }, ['npm', 'run', 'build'])
   } catch (err: any) { // eslint-disable-line
-    expect(err.code).toBe('ERR_PNPM_RECURSIVE_EXEC_FAIL')
+    expect(err.code).toBe('ERR_PNPM_RESUME_FROM_NOT_FOUND')
   }
 })

--- a/exec/plugin-commands-script-runners/test/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/runRecursive.ts
@@ -887,6 +887,6 @@ test('`pnpm -r --resume-from run` should executed from given package', async () 
 
   const { default: output1 } = await import(path.resolve('output1.json'))
   expect(output1).not.toContain('project-1')
-  expect(output1[0]).toContain('project-2')
-  expect(output1[1]).toContain('project-3')
+  expect(output1).toContain('project-2')
+  expect(output1).toContain('project-3')
 })

--- a/exec/plugin-commands-script-runners/test/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/runRecursive.ts
@@ -887,6 +887,6 @@ test('`pnpm -r --resume-from run` should executed from given package', async () 
 
   const { default: output1 } = await import(path.resolve('output1.json'))
   expect(output1).not.toContain('project-1')
-  expect(output1[0]).toBe('project-2')
-  expect(output1[1]).toBe('project-3')
+  expect(output1[0]).toContain('project-2')
+  expect(output1[1]).toContain('project-3')
 })

--- a/exec/plugin-commands-script-runners/test/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/runRecursive.ts
@@ -832,3 +832,61 @@ test('`pnpm recursive run` should fail when no script in package with requiredSc
   expect(err.message).toContain('Missing script "build" in packages: project-1, project-3')
   expect(err.code).toBe('ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT')
 })
+
+test('`pnpm -r --resume-from run` should executed from given package', async () => {
+  preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output1.json',
+      },
+      dependencies: {
+        'json-append': '1',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output1.json',
+      },
+      dependencies: {
+        'project-1': '1',
+        'json-append': '1',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output1.json',
+      },
+      dependencies: {
+        'project-1': '1',
+        'json-append': '1',
+      },
+    },
+  ])
+  await execa(pnpmBin, [
+    'install',
+    '-r',
+    '--registry',
+    REGISTRY_URL,
+    '--store-dir',
+    path.resolve(DEFAULT_OPTS.storeDir),
+  ])
+  await run.handler({
+    ...DEFAULT_OPTS,
+    ...await readProjects(process.cwd(), [{ namePattern: '*' }]),
+    dir: process.cwd(),
+    recursive: true,
+    resumeFrom: 'project-3',
+    workspaceDir: process.cwd(),
+  }, ['build'])
+
+  const { default: output1 } = await import(path.resolve('output1.json'))
+  expect(output1).not.toContain('project-1')
+  expect(output1[0]).toBe('project-2')
+  expect(output1[1]).toBe('project-3')
+})


### PR DESCRIPTION
close #4690

Implement `--resume-from` for `pnpm exec` command.

Not sure if `pnpm run` command also need this option, I personally think it is also quite useful, if it is okay, I can also update to support it :)