### PR TITLE
fix(dependencies-hierarchy): fix a few cases where max depth could be exceeded

### DIFF
--- a/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
+++ b/reviewing/dependencies-hierarchy/src/DependenciesCache.ts
@@ -34,8 +34,7 @@ export interface TraversalResultPartiallyVisited {
 
 export interface CacheHit {
   readonly dependencies: PackageNode[]
-  readonly height: number
-  readonly isPartiallyVisited: boolean
+  readonly height: number | 'unknown'
   // Circular dependencies are not stored in the cache.
   readonly circular: false
 }
@@ -92,7 +91,6 @@ export class DependenciesCache {
       return {
         dependencies: fullyVisitedEntry.dependencies,
         height: fullyVisitedEntry.height,
-        isPartiallyVisited: false,
         circular: false,
       }
     }
@@ -101,8 +99,7 @@ export class DependenciesCache {
     if (partiallyVisitedEntry != null) {
       return {
         dependencies: partiallyVisitedEntry,
-        height: args.requestedDepth,
-        isPartiallyVisited: true,
+        height: 'unknown',
         circular: false,
       }
     }

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -119,7 +119,7 @@ function getTreeHelper (
           const children = getChildrenTree(keypath.concat([relativeId]), relativeId)
           dependencies = children.dependencies
           const heightOfCurrentDepNode = children.height == null ? 0 : children.height + 1
-          resultHeight = Math.max(resultHeight ?? 0, heightOfCurrentDepNode + 1)
+          resultHeight = Math.max(resultHeight ?? 0, heightOfCurrentDepNode)
           resultIsPartiallyVisited = resultIsPartiallyVisited || children.isPartiallyVisited
 
           if (children.circular) {

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -80,7 +80,7 @@ function getTreeHelper (
   const peers = new Set(Object.keys(opts.currentPackages[parentId].peerDependencies ?? {}))
 
   const resultDependencies: PackageNode[] = []
-  let resultHeight = 0
+  let resultHeight: number | null = null
   let resultCircular: boolean = false
   let resultIsPartiallyVisited = false
 
@@ -119,7 +119,7 @@ function getTreeHelper (
           const children = getChildrenTree(keypath.concat([relativeId]), relativeId)
           dependencies = children.dependencies
           const heightOfCurrentDepNode = children.height == null ? 0 : children.height + 1
-          resultHeight = Math.max(resultHeight, heightOfCurrentDepNode + 1)
+          resultHeight = Math.max(resultHeight ?? 0, heightOfCurrentDepNode + 1)
           resultIsPartiallyVisited = resultIsPartiallyVisited || children.isPartiallyVisited
 
           if (children.circular) {

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -72,9 +72,10 @@ function getTreeHelper (
     return { dependencies: [], isPartiallyVisited: false, height: null }
   }
 
+  const childTreeMaxDepth = opts.maxDepth - 1
   const getChildrenTree = getTreeHelper.bind(null, dependenciesCache, {
     ...opts,
-    maxDepth: opts.maxDepth - 1,
+    maxDepth: childTreeMaxDepth,
   })
 
   const peers = new Set(Object.keys(opts.currentPackages[parentId].peerDependencies ?? {}))
@@ -112,8 +113,7 @@ function getTreeHelper (
       if (circular) {
         dependencies = []
       } else {
-        const requestedDepth = opts.maxDepth
-        dependencies = dependenciesCache.get({ packageAbsolutePath, requestedDepth })
+        dependencies = dependenciesCache.get({ packageAbsolutePath, requestedDepth: childTreeMaxDepth })
 
         if (dependencies == null) {
           const children = getChildrenTree(keypath.concat([relativeId]), relativeId)
@@ -127,7 +127,7 @@ function getTreeHelper (
           } else if (children.isPartiallyVisited) {
             dependenciesCache.addPartiallyVisitedResult(packageAbsolutePath, {
               dependencies,
-              depth: requestedDepth,
+              depth: childTreeMaxDepth,
             })
           } else {
             dependenciesCache.addFullyVisitedResult(packageAbsolutePath, {


### PR DESCRIPTION
## Problem

I noticed when running `pnpm list --depth=3` on the `pnpm` package itself that the `node-gyp` optional dependency printed `wrappy` one level too deep.

```sh
❯ cd pnpm

❯ node $pnpm list --depth=3
# ...
optionalDependencies:
node-gyp 9.3.1
├── env-paths 2.2.1
├─┬ glob 7.2.3
│ ├── fs.realpath 1.0.0
│ ├─┬ inflight 1.0.6
│ │ ├── once 1.4.0
│ │ └── wrappy 1.0.2
│ ├── inherits 2.0.4
│ ├─┬ minimatch 3.1.2
│ │ └── brace-expansion 1.1.11
│ ├─┬ once 1.4.0
│ │ └── wrappy 1.0.2
│ └── path-is-absolute 1.0.1
├── graceful-fs 4.2.10
├─┬ make-fetch-happen 10.2.1
│ ├─┬ agentkeepalive 4.2.1
│ │ ├── debug 4.3.4
│ │ ├── depd 1.1.2
│ │ └── humanize-ms 1.2.1
│ ├─┬ cacache 16.1.3
│ │ ├── @npmcli/fs 2.1.2
│ │ ├── @npmcli/move-file 2.0.1
│ │ ├── chownr 2.0.0
│ │ ├── fs-minipass 2.1.0
│ │ ├── glob 8.0.3
│ │ ├── infer-owner 1.0.4
│ │ ├── lru-cache 7.14.1
│ │ ├── minipass 3.3.6
│ │ ├── minipass-collect 1.0.2
│ │ ├── minipass-flush 1.0.5
│ │ ├── minipass-pipeline 1.2.4
│ │ ├── mkdirp 1.0.4
│ │ ├── p-map 4.0.0
│ │ ├── promise-inflight 1.0.1
│ │ ├── rimraf 3.0.2
│ │ ├── ssri 9.0.1
│ │ ├── tar 6.1.13
│ │ └── unique-filename 2.0.1
│ ├── http-cache-semantics 4.1.0
│ ├─┬ http-proxy-agent 5.0.0
│ │ ├── @tootallnate/once 2.0.0
│ │ ├── agent-base 6.0.2
│ │ └── debug 4.3.4
│ ├─┬ https-proxy-agent 5.0.1
│ │ ├── agent-base 6.0.2
│ │ └── debug 4.3.4
│ ├── is-lambda 1.0.1
│ ├── lru-cache 7.14.1
│ ├─┬ minipass 3.3.6
│ │ └── yallist 4.0.0
│ ├─┬ minipass-collect 1.0.2
│ │ └── minipass 3.3.6
│ ├─┬ minipass-fetch 2.1.2
│ │ ├── encoding 0.1.13
│ │ ├── minipass 3.3.6
│ │ ├── minipass-sized 1.0.3
│ │ └── minizlib 2.1.2
│ ├─┬ minipass-flush 1.0.5
│ │ └── minipass 3.3.6
│ ├─┬ minipass-pipeline 1.2.4
│ │ └── minipass 3.3.6
│ ├── negotiator 0.6.3
│ ├─┬ promise-retry 2.0.1
│ │ ├── err-code 2.0.3
│ │ └── retry 0.12.0
│ ├─┬ socks-proxy-agent 7.0.0
│ │ ├── agent-base 6.0.2
│ │ ├── debug 4.3.4
│ │ └── socks 2.7.1
│ └─┬ ssri 9.0.1
│   └── minipass 3.3.6
├─┬ nopt 6.0.0
│ └── abbrev 1.1.1
├─┬ npmlog 6.0.2
│ ├─┬ are-we-there-yet 3.0.1
│ │ ├── delegates 1.0.0
│ │ └── readable-stream 3.6.0
│ ├── console-control-strings 1.1.0
│ ├─┬ gauge 4.0.4
│ │ ├── aproba 2.0.0
│ │ ├── color-support 1.1.3
│ │ ├── console-control-strings 1.1.0
│ │ ├── has-unicode 2.0.1
│ │ ├── signal-exit 3.0.7
│ │ ├── string-width 4.2.3
│ │ ├── strip-ansi 6.0.1
│ │ └── wide-align 1.1.5
│ └── set-blocking 2.0.0
├─┬ rimraf 3.0.2
│ └─┬ glob 7.2.3
│   ├── fs.realpath 1.0.0
│   ├── inflight 1.0.6
│   ├── inherits 2.0.4
│   ├── minimatch 3.1.2
│   ├─┬ once 1.4.0
│   │ └── wrappy 1.0.2    # 👈 Depth of 4? The --depth argument was 3 though.
│   └── path-is-absolute 1.0.1
├─┬ semver 7.3.8
│ └─┬ lru-cache 6.0.0
│   └── yallist 4.0.0
├─┬ tar 6.1.13
│ ├── chownr 2.0.0
│ ├─┬ fs-minipass 2.1.0
│ │ └── minipass 3.3.6
│ ├─┬ minipass 4.0.0
│ │ └── yallist 4.0.0
│ ├─┬ minizlib 2.1.2
│ │ ├── minipass 3.3.6
│ │ └── yallist 4.0.0
│ ├── mkdirp 1.0.4
│ └── yallist 4.0.0
└─┬ which 2.0.2
  └── isexe 2.0.0
```

I don't believe printing this extra information is a big issue, but was indicative of a bug in some of my recently merged pull requests: https://github.com/pnpm/pnpm/pull/5817, https://github.com/pnpm/pnpm/pull/5828, https://github.com/pnpm/pnpm/pull/5858. I'd like to get this right.

I missed a few things upon deeper inspection.

## Notes for Reviewers

- No change log was added since https://github.com/pnpm/pnpm/pull/5817 has not been included in a release yet.
- Apologies that the first PR above had a few more issues.
- It should be easier to review this PR as separate commits. Each commit has a description that elaborates on the specific fix made. I copied most of these descriptions into GitHub to make it easier to view.

## Testing

Here's a diff of `pnpm list --depth=3` on the pnpm package before and after this PR.

```diff
diff --git a/before.txt b/after.txt
index 778bb6f56..b9570f515 100644
--- a/before.txt
+++ b/after.txt
@@ -289,8 +289,7 @@ devDependencies:
 │ │ └── brace-expansion 2.0.1
 │ ├── mkdirp 1.0.4
 │ ├─┬ mv 2.1.1
-│ │ ├─┬ mkdirp 0.5.6
-│ │ │ └── minimist 1.2.7
+│ │ ├── mkdirp 0.5.6
 │ │ ├── ncp 2.0.0
 │ │ └── rimraf 2.4.5
 │ ├─┬ pino 6.14.0
@@ -757,8 +756,7 @@ node-gyp 9.3.1
 │   ├── inflight 1.0.6
 │   ├── inherits 2.0.4
 │   ├── minimatch 3.1.2
-│   ├─┬ once 1.4.0
-│   │ └── wrappy 1.0.2
+│   ├── once 1.4.0
 │   └── path-is-absolute 1.0.1
 ├─┬ semver 7.3.8
 │ └─┬ lru-cache 6.0.0
```