### PR TITLE
feat: traverse through workspace packages in `why` and `list` commands

### DIFF
--- a/.changeset/giant-wasps-wink.md
+++ b/.changeset/giant-wasps-wink.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/reviewing.dependencies-hierarchy": minor
+---
+
+The `path` field for direct dependencies returned from `buildDependenciesHierarchy` was incorrect if the dependency used the `workspace:` or `link:` protocols.

--- a/.changeset/good-monkeys-explode.md
+++ b/.changeset/good-monkeys-explode.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/reviewing.dependencies-hierarchy": minor
+pnpm: minor
+---
+
+The `pnpm list` and `pnpm why` commands will now look through transitive dependencies of `workspace:` packages.

--- a/.changeset/good-monkeys-explode.md
+++ b/.changeset/good-monkeys-explode.md
@@ -3,4 +3,4 @@
 pnpm: minor
 ---
 
-The `pnpm list` and `pnpm why` commands will now look through transitive dependencies of `workspace:` packages.
+The `pnpm list` and `pnpm why` commands will now look through transitive dependencies of `workspace:` packages. A new `--only-projects` flag is available to only print `workspace:` packages.

--- a/__fixtures__/workspace-with-nested-workspace-deps/package.json
+++ b/__fixtures__/workspace-with-nested-workspace-deps/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "root",
+  "version": "1.0.0",
+  "dependencies": {
+    "@scope/a": "workspace:*"
+  }
+}

--- a/__fixtures__/workspace-with-nested-workspace-deps/packages/a/package.json
+++ b/__fixtures__/workspace-with-nested-workspace-deps/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@scope/a",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@scope/b": "workspace:*"
+  }
+}

--- a/__fixtures__/workspace-with-nested-workspace-deps/packages/b/package.json
+++ b/__fixtures__/workspace-with-nested-workspace-deps/packages/b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@scope/b",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@scope/c": "workspace:*",
+    "is-positive": "1.0.0"
+  }
+}

--- a/__fixtures__/workspace-with-nested-workspace-deps/packages/c/package.json
+++ b/__fixtures__/workspace-with-nested-workspace-deps/packages/c/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@scope/c",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
@@ -1,0 +1,33 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      '@scope/a': workspace:*
+    dependencies:
+      '@scope/a': link:packages/a
+
+  packages/a:
+    specifiers:
+      '@scope/b': workspace:*
+    dependencies:
+      '@scope/b': link:../b
+
+  packages/b:
+    specifiers:
+      '@scope/c': workspace:*
+      is-positive: 1.0.0
+    dependencies:
+      '@scope/c': link:../c
+      is-positive: 1.0.0
+
+  packages/c:
+    specifiers: {}
+
+packages:
+
+  /is-positive/1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/__fixtures__/workspace-with-nested-workspace-deps/pnpm-workspace.yaml
+++ b/__fixtures__/workspace-with-nested-workspace-deps/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/**'

--- a/reviewing/dependencies-hierarchy/src/TreeNodeId.ts
+++ b/reviewing/dependencies-hierarchy/src/TreeNodeId.ts
@@ -1,0 +1,20 @@
+export type TreeNodeId = TreeNodeIdPackage
+
+/**
+ * An npm package depended on externally.
+ */
+interface TreeNodeIdPackage {
+  readonly type: 'package'
+  readonly depPath: string
+}
+
+export function serializeTreeNodeId (treeNodeId: TreeNodeId): string {
+  switch (treeNodeId.type) {
+  case 'package': {
+    // Only serialize known fields from TreeNodeId. TypeScript is duck typed and
+    // objects can have any number of unknown extra fields.
+    const { type, depPath } = treeNodeId
+    return JSON.stringify({ type, depPath })
+  }
+  }
+}

--- a/reviewing/dependencies-hierarchy/src/TreeNodeId.ts
+++ b/reviewing/dependencies-hierarchy/src/TreeNodeId.ts
@@ -1,4 +1,12 @@
-export type TreeNodeId = TreeNodeIdPackage
+export type TreeNodeId = TreeNodeIdImporter | TreeNodeIdPackage
+
+/**
+ * A project local to the pnpm workspace.
+ */
+interface TreeNodeIdImporter {
+  readonly type: 'importer'
+  readonly importerId: string
+}
 
 /**
  * An npm package depended on externally.
@@ -10,9 +18,13 @@ interface TreeNodeIdPackage {
 
 export function serializeTreeNodeId (treeNodeId: TreeNodeId): string {
   switch (treeNodeId.type) {
-  case 'package': {
+  case 'importer': {
     // Only serialize known fields from TreeNodeId. TypeScript is duck typed and
     // objects can have any number of unknown extra fields.
+    const { type, importerId } = treeNodeId
+    return JSON.stringify({ type, importerId })
+  }
+  case 'package': {
     const { type, depPath } = treeNodeId
     return JSON.stringify({ type, depPath })
   }

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -138,7 +138,7 @@ async function dependenciesHierarchyForPackage (
       } else {
         const relativeId = refToRelative(ref, alias)
         if (relativeId) {
-          const dependencies = getChildrenTree([relativeId], relativeId)
+          const dependencies = getChildrenTree(relativeId)
           if (dependencies.length > 0) {
             newEntry = {
               ...packageInfo,

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -34,6 +34,7 @@ export async function buildDependenciesHierarchy (
     depth: number
     include?: { [dependenciesField in DependenciesField]: boolean }
     registries?: Registries
+    onlyProjects?: boolean
     search?: SearchFunction
     lockfileDir: string
   }
@@ -66,6 +67,7 @@ export async function buildDependenciesHierarchy (
       optionalDependencies: true,
     },
     lockfileDir: maybeOpts.lockfileDir,
+    onlyProjects: maybeOpts.onlyProjects,
     registries,
     search: maybeOpts.search,
     skipped: new Set(modules?.skipped ?? []),
@@ -90,6 +92,7 @@ async function dependenciesHierarchyForPackage (
     depth: number
     include: { [dependenciesField in DependenciesField]: boolean }
     registries: Registries
+    onlyProjects?: boolean
     search?: SearchFunction
     skipped: Set<string>
     lockfileDir: string
@@ -111,6 +114,7 @@ async function dependenciesHierarchyForPackage (
     importers: currentLockfile.importers,
     includeOptionalDependencies: opts.include.optionalDependencies,
     lockfileDir: opts.lockfileDir,
+    onlyProjects: opts.onlyProjects,
     rewriteLinkVersionDir: projectPath,
     maxDepth: opts.depth,
     modulesDir,
@@ -144,7 +148,9 @@ async function dependenciesHierarchyForPackage (
         lockfileDir: opts.lockfileDir,
         importers: currentLockfile.importers,
       })
-      if (nodeId == null) {
+      if (opts.onlyProjects && nodeId?.type !== 'importer') {
+        return
+      } else if (nodeId == null) {
         if ((opts.search != null) && !matchedSearched) return
         newEntry = packageInfo
       } else {

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -127,6 +127,7 @@ async function dependenciesHierarchyForPackage (
       const packageInfo = getPkgInfo({
         alias,
         currentPackages: currentLockfile.packages ?? {},
+        linkedPathBaseDir: projectPath,
         modulesDir,
         ref,
         registries: opts.registries,

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -111,6 +111,7 @@ async function dependenciesHierarchyForPackage (
     importers: currentLockfile.importers,
     includeOptionalDependencies: opts.include.optionalDependencies,
     lockfileDir: opts.lockfileDir,
+    rewriteLinkVersionDir: projectPath,
     maxDepth: opts.depth,
     modulesDir,
     registries: opts.registries,
@@ -127,6 +128,7 @@ async function dependenciesHierarchyForPackage (
       const packageInfo = getPkgInfo({
         alias,
         currentPackages: currentLockfile.packages ?? {},
+        rewriteLinkVersionDir: projectPath,
         linkedPathBaseDir: projectPath,
         modulesDir,
         ref,

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -121,7 +121,7 @@ async function dependenciesHierarchyForPackage (
     const topDeps = currentLockfile.importers[importerId][dependenciesField] ?? {}
     result[dependenciesField] = []
     Object.entries(topDeps).forEach(([alias, ref]) => {
-      const { packageInfo, packageAbsolutePath } = getPkgInfo({
+      const packageInfo = getPkgInfo({
         alias,
         currentPackages: currentLockfile.packages ?? {},
         modulesDir,
@@ -132,21 +132,19 @@ async function dependenciesHierarchyForPackage (
       })
       let newEntry: PackageNode | null = null
       const matchedSearched = opts.search?.(packageInfo)
+      const packageAbsolutePath = refToRelative(ref, alias)
       if (packageAbsolutePath === null) {
         if ((opts.search != null) && !matchedSearched) return
         newEntry = packageInfo
       } else {
-        const relativeId = refToRelative(ref, alias)
-        if (relativeId) {
-          const dependencies = getChildrenTree(relativeId)
-          if (dependencies.length > 0) {
-            newEntry = {
-              ...packageInfo,
-              dependencies,
-            }
-          } else if ((opts.search == null) || matchedSearched) {
-            newEntry = packageInfo
+        const dependencies = getChildrenTree(packageAbsolutePath)
+        if (dependencies.length > 0) {
+          newEntry = {
+            ...packageInfo,
+            dependencies,
           }
+        } else if ((opts.search == null) || matchedSearched) {
+          newEntry = packageInfo
         }
       }
       if (newEntry != null) {

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -11,13 +11,13 @@ import { normalizeRegistries } from '@pnpm/normalize-registries'
 import { readModulesDir } from '@pnpm/read-modules-dir'
 import { safeReadPackageJsonFromDir } from '@pnpm/read-package-json'
 import { DependenciesField, DEPENDENCIES_FIELDS, Registries } from '@pnpm/types'
-import { refToRelative } from '@pnpm/dependency-path'
 import normalizePath from 'normalize-path'
 import realpathMissing from 'realpath-missing'
 import resolveLinkTarget from 'resolve-link-target'
 import { PackageNode } from './PackageNode'
 import { SearchFunction } from './types'
 import { getTree } from './getTree'
+import { getTreeNodeChildId } from './getTreeNodeChildId'
 import { getPkgInfo } from './getPkgInfo'
 
 export interface DependenciesHierarchy {
@@ -132,12 +132,12 @@ async function dependenciesHierarchyForPackage (
       })
       let newEntry: PackageNode | null = null
       const matchedSearched = opts.search?.(packageInfo)
-      const packageAbsolutePath = refToRelative(ref, alias)
-      if (packageAbsolutePath === null) {
+      const nodeId = getTreeNodeChildId({ dep: { alias, ref } })
+      if (nodeId == null) {
         if ((opts.search != null) && !matchedSearched) return
         newEntry = packageInfo
       } else {
-        const dependencies = getChildrenTree(packageAbsolutePath)
+        const dependencies = getChildrenTree(nodeId)
         if (dependencies.length > 0) {
           newEntry = {
             ...packageInfo,

--- a/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
+++ b/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
@@ -57,7 +57,6 @@ export function getPkgInfo (
     name = opts.alias
     version = opts.ref
   }
-  const packageAbsolutePath = refToRelative(opts.ref, opts.alias)
   const packageInfo = {
     alias: opts.alias,
     isMissing,
@@ -76,8 +75,5 @@ export function getPkgInfo (
   if (typeof dev === 'boolean') {
     packageInfo['dev'] = dev
   }
-  return {
-    packageAbsolutePath,
-    packageInfo,
-  }
+  return packageInfo
 }

--- a/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
+++ b/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
@@ -19,6 +19,11 @@ export interface GetPkgInfoOpts {
   readonly registries: Registries
   readonly skipped: Set<string>
   readonly wantedPackages: PackageSnapshots
+
+  /**
+   * The base dir if the `ref` argument is a `"link:"` relative path.
+   */
+  readonly linkedPathBaseDir: string
 }
 
 export function getPkgInfo (opts: GetPkgInfoOpts) {
@@ -63,7 +68,9 @@ export function getPkgInfo (opts: GetPkgInfoOpts) {
     isPeer: Boolean(opts.peers?.has(opts.alias)),
     isSkipped,
     name,
-    path: depPath ? path.join(opts.modulesDir, '.pnpm', depPathToFilename(depPath)) : path.join(opts.modulesDir, '..', opts.ref.slice(5)),
+    path: depPath
+      ? path.join(opts.modulesDir, '.pnpm', depPathToFilename(depPath))
+      : path.join(opts.linkedPathBaseDir, opts.ref.slice(5)),
     version,
   }
   if (resolved) {

--- a/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
+++ b/reviewing/dependencies-hierarchy/src/getPkgInfo.ts
@@ -10,18 +10,18 @@ import {
 import { Registries } from '@pnpm/types'
 import { depPathToFilename, refToRelative } from '@pnpm/dependency-path'
 
-export function getPkgInfo (
-  opts: {
-    alias: string
-    modulesDir: string
-    ref: string
-    currentPackages: PackageSnapshots
-    peers?: Set<string>
-    registries: Registries
-    skipped: Set<string>
-    wantedPackages: PackageSnapshots
-  }
-) {
+export interface GetPkgInfoOpts {
+  readonly alias: string
+  readonly modulesDir: string
+  readonly ref: string
+  readonly currentPackages: PackageSnapshots
+  readonly peers?: Set<string>
+  readonly registries: Registries
+  readonly skipped: Set<string>
+  readonly wantedPackages: PackageSnapshots
+}
+
+export function getPkgInfo (opts: GetPkgInfoOpts) {
   let name!: string
   let version!: string
   let resolved: string | undefined

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -10,6 +10,7 @@ import { serializeTreeNodeId, TreeNodeId } from './TreeNodeId'
 
 interface GetTreeOpts {
   maxDepth: number
+  rewriteLinkVersionDir: string
   modulesDir: string
   includeOptionalDependencies: boolean
   lockfileDir: string
@@ -123,6 +124,7 @@ function getTreeHelper (
     const packageInfo = getPkgInfo({
       alias,
       currentPackages: opts.currentPackages,
+      rewriteLinkVersionDir: opts.rewriteLinkVersionDir,
       linkedPathBaseDir,
       modulesDir: opts.modulesDir,
       peers,

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -14,6 +14,7 @@ interface GetTreeOpts {
   modulesDir: string
   includeOptionalDependencies: boolean
   lockfileDir: string
+  onlyProjects?: boolean
   search?: SearchFunction
   skipped: Set<string>
   registries: Registries
@@ -143,7 +144,9 @@ function getTreeHelper (
       importers: opts.importers,
     })
 
-    if (nodeId == null) {
+    if (opts.onlyProjects && nodeId?.type !== 'importer') {
+      return
+    } else if (nodeId == null) {
       circular = false
       if (opts.search == null || matchedSearched) {
         newEntry = packageInfo

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -83,7 +83,7 @@ function getTreeHelper (
   let resultCircular: boolean = false
 
   Object.entries(deps).forEach(([alias, ref]) => {
-    const { packageInfo, packageAbsolutePath } = getPkgInfo({
+    const packageInfo = getPkgInfo({
       alias,
       currentPackages: opts.currentPackages,
       modulesDir: opts.modulesDir,
@@ -96,6 +96,7 @@ function getTreeHelper (
     let circular: boolean
     const matchedSearched = opts.search?.(packageInfo)
     let newEntry: PackageNode | null = null
+    const packageAbsolutePath = refToRelative(ref, alias)
     if (packageAbsolutePath === null) {
       circular = false
       if (opts.search == null || matchedSearched) {
@@ -104,14 +105,13 @@ function getTreeHelper (
     } else {
       let dependencies: PackageNode[] | undefined
 
-      const relativeId = refToRelative(ref, alias) as string // we know for sure that relative is not null if pkgPath is not null
-      circular = keypath.includes(relativeId)
+      circular = keypath.includes(packageAbsolutePath)
 
       if (circular) {
         dependencies = []
       } else {
         const cacheEntry = dependenciesCache.get({ packageAbsolutePath, requestedDepth: childTreeMaxDepth })
-        const children = cacheEntry ?? getChildrenTree(keypath.concat([relativeId]), relativeId)
+        const children = cacheEntry ?? getChildrenTree(keypath.concat([packageAbsolutePath]), packageAbsolutePath)
 
         if (cacheEntry == null && !children.circular) {
           if (children.height === 'unknown') {

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -38,12 +38,11 @@ interface DependencyInfo {
 
 export function getTree (
   opts: GetTreeOpts,
-  keypath: string[],
   parentId: string
 ): PackageNode[] {
   const dependenciesCache = new DependenciesCache()
 
-  return getTreeHelper(dependenciesCache, opts, keypath, parentId).dependencies
+  return getTreeHelper(dependenciesCache, opts, [parentId], parentId).dependencies
 }
 
 function getTreeHelper (

--- a/reviewing/dependencies-hierarchy/src/getTreeNodeChildId.ts
+++ b/reviewing/dependencies-hierarchy/src/getTreeNodeChildId.ts
@@ -1,0 +1,18 @@
+import { refToRelative } from '@pnpm/dependency-path'
+import { TreeNodeId } from './TreeNodeId'
+
+export interface getTreeNodeChildIdOpts {
+  readonly dep: {
+    readonly alias: string
+    readonly ref: string
+  }
+}
+
+export function getTreeNodeChildId (opts: getTreeNodeChildIdOpts): TreeNodeId | undefined {
+  const depPath = refToRelative(opts.dep.ref, opts.dep.alias)
+  if (depPath !== null) {
+    return { type: 'package', depPath }
+  }
+
+  return undefined
+}

--- a/reviewing/dependencies-hierarchy/src/getTreeNodeChildId.ts
+++ b/reviewing/dependencies-hierarchy/src/getTreeNodeChildId.ts
@@ -1,11 +1,16 @@
 import { refToRelative } from '@pnpm/dependency-path'
+import path from 'path'
+import { getLockfileImporterId, ProjectSnapshot } from '@pnpm/lockfile-file'
 import { TreeNodeId } from './TreeNodeId'
 
 export interface getTreeNodeChildIdOpts {
+  readonly parentId: TreeNodeId
   readonly dep: {
     readonly alias: string
     readonly ref: string
   }
+  readonly lockfileDir: string
+  readonly importers: Record<string, ProjectSnapshot>
 }
 
 export function getTreeNodeChildId (opts: getTreeNodeChildIdOpts): TreeNodeId | undefined {
@@ -14,5 +19,32 @@ export function getTreeNodeChildId (opts: getTreeNodeChildIdOpts): TreeNodeId | 
     return { type: 'package', depPath }
   }
 
-  return undefined
+  switch (opts.parentId.type) {
+  case 'importer': {
+    // This should be a link given depPath is null.
+    //
+    // TODO: Consider updating refToRelative (or writing a new function) to
+    // return an enum so there's no implicit assumptions.
+    const linkValue = opts.dep.ref.slice('link:'.length)
+
+    // It's a bit roundabout to prepend the lockfile dir only to remove it
+    // through getLockfileImporterId, but we can be more certain the right
+    // importerId is created by reusing the getLockfileImporterId function.
+    const absoluteLinkedPath = path.join(opts.lockfileDir, opts.parentId.importerId, linkValue)
+    const childImporterId = getLockfileImporterId(opts.lockfileDir, absoluteLinkedPath)
+
+    // A 'link:' reference may refer to a package outside of the pnpm workspace.
+    // Return undefined in that case since it would be difficult to list/traverse
+    // that package outside of the pnpm workspace.
+    const isLinkOutsideWorkspace = opts.importers[childImporterId] == null
+    return isLinkOutsideWorkspace
+      ? undefined
+      : { type: 'importer', importerId: childImporterId }
+  }
+  case 'package':
+    // In theory an external package could be overridden to link to a
+    // dependency in the pnpm workspace. Avoid traversing through this
+    // edge case for now.
+    return undefined
+  }
 }

--- a/reviewing/dependencies-hierarchy/test/getTree.test.ts
+++ b/reviewing/dependencies-hierarchy/test/getTree.test.ts
@@ -2,6 +2,7 @@ import { refToRelative } from '@pnpm/dependency-path'
 import { PackageSnapshots } from '@pnpm/lockfile-file'
 import { PackageNode } from '@pnpm/reviewing.dependencies-hierarchy'
 import { getTree } from '../lib/getTree'
+import { TreeNodeId } from '../lib/TreeNodeId'
 
 /**
  * Maps an npm package name to its dependencies.
@@ -79,7 +80,7 @@ describe('getTree', () => {
       b1: ['c1'],
       c1: ['d1'],
     })
-    const startingDepPath = refToRelativeOrThrow(version, 'a')
+    const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'a') }
 
     const getTreeArgs = {
       maxDepth: 0,
@@ -94,7 +95,7 @@ describe('getTree', () => {
     }
 
     test('full test case to print when max depth is large', () => {
-      const result = normalizePackageNodeForTesting(getTree({ ...getTreeArgs, maxDepth: 9999 }, startingDepPath))
+      const result = normalizePackageNodeForTesting(getTree({ ...getTreeArgs, maxDepth: 9999 }, rootNodeId))
 
       expect(result).toEqual([
         expect.objectContaining({
@@ -114,12 +115,12 @@ describe('getTree', () => {
     })
 
     test('no result when current depth exceeds max depth', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 0 }, startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 0 }, rootNodeId)
       expect(result).toEqual([])
     })
 
     test('max depth of 1 to print flat dependencies', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 1 }, startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 1 }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({ alias: 'b1', dependencies: undefined }),
@@ -129,7 +130,7 @@ describe('getTree', () => {
     })
 
     test('max depth of 2 to print a1 -> b1 -> c1, but not d1', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 2 }, startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 2 }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -181,14 +182,14 @@ describe('getTree', () => {
         inflight: ['once'],
         once: ['wrappy'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         // depth 0
@@ -239,14 +240,14 @@ describe('getTree', () => {
         b: ['c'],
         d: ['b'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -311,14 +312,14 @@ describe('getTree', () => {
         a: ['b'],
         b: ['c'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 4,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -363,14 +364,14 @@ describe('getTree', () => {
         c: ['d'],
         d: ['a'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 4,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       const expectedA = expect.objectContaining({
         alias: 'a',
@@ -414,14 +415,14 @@ describe('getTree', () => {
         c: ['d'],
         d: ['a'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -475,14 +476,14 @@ describe('getTree', () => {
         f: ['g'],
         g: ['a'],
       })
-      const rootDepPath = refToRelativeOrThrow(version, 'root')
+      const rootNodeId: TreeNodeId = { type: 'package', depPath: refToRelativeOrThrow(version, 'root') }
 
       const result = getTree({
         ...commonMockGetTreeArgs,
         maxDepth: 5,
         currentPackages,
         wantedPackages: currentPackages,
-      }, rootDepPath)
+      }, rootNodeId)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({

--- a/reviewing/dependencies-hierarchy/test/getTree.test.ts
+++ b/reviewing/dependencies-hierarchy/test/getTree.test.ts
@@ -84,6 +84,7 @@ describe('getTree', () => {
 
     const getTreeArgs = {
       maxDepth: 0,
+      rewriteLinkVersionDir: '',
       modulesDir: '',
       importers: {},
       includeOptionalDependencies: false,
@@ -158,6 +159,7 @@ describe('getTree', () => {
   // result in incorrect output if the cache was used when it's not supposed to.
   describe('prints at expected depth for cache regression testing cases', () => {
     const commonMockGetTreeArgs = {
+      rewriteLinkVersionDir: '',
       modulesDir: '',
       importers: {},
       includeOptionalDependencies: false,
@@ -292,6 +294,7 @@ describe('getTree', () => {
   // result in incorrect output if the cache was used when it's not supposed to.
   describe('fully visited cache optimization handles requested depth correctly', () => {
     const commonMockGetTreeArgs = {
+      rewriteLinkVersionDir: '',
       modulesDir: '',
       importers: {},
       includeOptionalDependencies: false,

--- a/reviewing/dependencies-hierarchy/test/getTree.test.ts
+++ b/reviewing/dependencies-hierarchy/test/getTree.test.ts
@@ -94,7 +94,7 @@ describe('getTree', () => {
     }
 
     test('full test case to print when max depth is large', () => {
-      const result = normalizePackageNodeForTesting(getTree({ ...getTreeArgs, maxDepth: 9999 }, [], startingDepPath))
+      const result = normalizePackageNodeForTesting(getTree({ ...getTreeArgs, maxDepth: 9999 }, startingDepPath))
 
       expect(result).toEqual([
         expect.objectContaining({
@@ -114,12 +114,12 @@ describe('getTree', () => {
     })
 
     test('no result when current depth exceeds max depth', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 0 }, [], startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 0 }, startingDepPath)
       expect(result).toEqual([])
     })
 
     test('max depth of 1 to print flat dependencies', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 1 }, [], startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 1 }, startingDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({ alias: 'b1', dependencies: undefined }),
@@ -129,7 +129,7 @@ describe('getTree', () => {
     })
 
     test('max depth of 2 to print a1 -> b1 -> c1, but not d1', () => {
-      const result = getTree({ ...getTreeArgs, maxDepth: 2 }, [], startingDepPath)
+      const result = getTree({ ...getTreeArgs, maxDepth: 2 }, startingDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -188,7 +188,7 @@ describe('getTree', () => {
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         // depth 0
@@ -246,7 +246,7 @@ describe('getTree', () => {
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -318,7 +318,7 @@ describe('getTree', () => {
         maxDepth: 4,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -370,7 +370,7 @@ describe('getTree', () => {
         maxDepth: 4,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       const expectedA = expect.objectContaining({
         alias: 'a',
@@ -421,7 +421,7 @@ describe('getTree', () => {
         maxDepth: 3,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({
@@ -482,7 +482,7 @@ describe('getTree', () => {
         maxDepth: 5,
         currentPackages,
         wantedPackages: currentPackages,
-      }, [rootDepPath], rootDepPath)
+      }, rootDepPath)
 
       expect(normalizePackageNodeForTesting(result)).toEqual([
         expect.objectContaining({

--- a/reviewing/dependencies-hierarchy/test/getTree.test.ts
+++ b/reviewing/dependencies-hierarchy/test/getTree.test.ts
@@ -85,7 +85,9 @@ describe('getTree', () => {
     const getTreeArgs = {
       maxDepth: 0,
       modulesDir: '',
+      importers: {},
       includeOptionalDependencies: false,
+      lockfileDir: '',
       skipped: new Set<string>(),
       registries: {
         default: 'mock-registry-for-testing.example',
@@ -157,7 +159,9 @@ describe('getTree', () => {
   describe('prints at expected depth for cache regression testing cases', () => {
     const commonMockGetTreeArgs = {
       modulesDir: '',
+      importers: {},
       includeOptionalDependencies: false,
+      lockfileDir: '',
       skipped: new Set<string>(),
       registries: {
         default: 'mock-registry-for-testing.example',
@@ -289,7 +293,9 @@ describe('getTree', () => {
   describe('fully visited cache optimization handles requested depth correctly', () => {
     const commonMockGetTreeArgs = {
       modulesDir: '',
+      importers: {},
       includeOptionalDependencies: false,
+      lockfileDir: '',
       skipped: new Set<string>(),
       registries: {
         default: 'mock-registry-for-testing.example',

--- a/reviewing/dependencies-hierarchy/test/index.ts
+++ b/reviewing/dependencies-hierarchy/test/index.ts
@@ -14,6 +14,7 @@ const withLinksOnlyFixture = f.find('fixtureWithLinks/with-links-only')
 const withUnsavedDepsFixture = f.find('with-unsaved-deps')
 const fixtureMonorepo = path.join(__dirname, '..', 'fixtureMonorepo')
 const withAliasedDepFixture = f.find('with-aliased-dep')
+const workspaceWithNestedWorkspaceDeps = f.find('workspace-with-nested-workspace-deps')
 
 test('one package depth 0', async () => {
   const tree = await buildDependenciesHierarchy([generalFixture], { depth: 0, lockfileDir: generalFixture })
@@ -374,6 +375,43 @@ test('on a package that has only links', async () => {
           path: path.join(f.find('fixtureWithLinks'), 'general'),
           version: 'link:../general',
         },
+      ],
+      devDependencies: [],
+      optionalDependencies: [],
+    },
+  })
+})
+
+// Test for feature request at https://github.com/pnpm/pnpm/issues/4154
+test('on a package with nested workspace links', async () => {
+  const tree = await buildDependenciesHierarchy(
+    [workspaceWithNestedWorkspaceDeps],
+    { depth: 1000, lockfileDir: workspaceWithNestedWorkspaceDeps }
+  )
+
+  expect(tree).toEqual({
+    [workspaceWithNestedWorkspaceDeps]: {
+      dependencies: [
+        expect.objectContaining({
+          alias: '@scope/a',
+          version: 'link:packages/a',
+          dependencies: [
+            expect.objectContaining({
+              alias: '@scope/b',
+              version: 'link:../b',
+              dependencies: [
+                expect.objectContaining({
+                  alias: '@scope/c',
+                  version: 'link:../c',
+                }),
+                expect.objectContaining({
+                  alias: 'is-positive',
+                  version: '1.0.0',
+                }),
+              ],
+            }),
+          ],
+        }),
       ],
       devDependencies: [],
       optionalDependencies: [],

--- a/reviewing/dependencies-hierarchy/test/index.ts
+++ b/reviewing/dependencies-hierarchy/test/index.ts
@@ -399,12 +399,12 @@ test('on a package with nested workspace links', async () => {
           dependencies: [
             expect.objectContaining({
               alias: '@scope/b',
-              version: 'link:../b',
+              version: 'link:packages/b',
               path: path.join(workspaceWithNestedWorkspaceDeps, 'packages/b'),
               dependencies: [
                 expect.objectContaining({
                   alias: '@scope/c',
-                  version: 'link:../c',
+                  version: 'link:packages/c',
                   path: path.join(workspaceWithNestedWorkspaceDeps, 'packages/c'),
                 }),
                 expect.objectContaining({

--- a/reviewing/dependencies-hierarchy/test/index.ts
+++ b/reviewing/dependencies-hierarchy/test/index.ts
@@ -395,14 +395,17 @@ test('on a package with nested workspace links', async () => {
         expect.objectContaining({
           alias: '@scope/a',
           version: 'link:packages/a',
+          path: path.join(workspaceWithNestedWorkspaceDeps, 'packages/a'),
           dependencies: [
             expect.objectContaining({
               alias: '@scope/b',
               version: 'link:../b',
+              path: path.join(workspaceWithNestedWorkspaceDeps, 'packages/b'),
               dependencies: [
                 expect.objectContaining({
                   alias: '@scope/c',
                   version: 'link:../c',
+                  path: path.join(workspaceWithNestedWorkspaceDeps, 'packages/c'),
                 }),
                 expect.objectContaining({
                   alias: 'is-positive',

--- a/reviewing/list/src/index.ts
+++ b/reviewing/list/src/index.ts
@@ -25,6 +25,7 @@ export async function listForPackages (
     lockfileDir: string
     long?: boolean
     include?: { [dependenciesField in DependenciesField]: boolean }
+    onlyProjects?: boolean
     reportAs?: 'parseable' | 'tree' | 'json'
     registries?: Registries
   }
@@ -38,6 +39,7 @@ export async function listForPackages (
       depth: opts.depth,
       include: maybeOpts?.include,
       lockfileDir: maybeOpts?.lockfileDir,
+      onlyProjects: maybeOpts?.onlyProjects,
       registries: opts.registries,
       search,
     }))
@@ -71,6 +73,7 @@ export async function list (
     lockfileDir: string
     long?: boolean
     include?: { [dependenciesField in DependenciesField]: boolean }
+    onlyProjects?: boolean
     reportAs?: 'parseable' | 'tree' | 'json'
     registries?: Registries
     showExtraneous?: boolean
@@ -89,6 +92,7 @@ export async function list (
           depth: opts.depth,
           include: maybeOpts?.include,
           lockfileDir: maybeOpts?.lockfileDir,
+          onlyProjects: maybeOpts?.onlyProjects,
           registries: opts.registries,
         })
     )

--- a/reviewing/list/test/index.ts
+++ b/reviewing/list/test/index.ts
@@ -796,3 +796,20 @@ ${highlighted(`ajv ${VERSION_CLR('6.10.2')}`)}
 ajv-keywords ${VERSION_CLR('3.4.1')}
 └── ${highlighted(`ajv ${VERSION_CLR('6.10.2')} peer`)}`)
 })
+
+test('--only-projects shows only projects', async () => {
+  const fixture = f.find('workspace-with-nested-workspace-deps')
+  const output = await list([fixture], { depth: 999, lockfileDir: fixture, onlyProjects: true })
+
+  // The "workspace-with-nested-workspace-deps" test case has an external
+  // dependency under @scope/b, but that package should not be printed when
+  // --only-projects is passed to the list command.
+  expect(output).toBe(`${LEGEND}
+
+${boldHighlighted(`root@1.0.0 ${fixture}`)}
+
+${DEPENDENCIES}
+@scope/a ${VERSION_CLR('link:packages/a')}
+└─┬ @scope/b ${VERSION_CLR('link:packages/b')}
+  └── @scope/c ${VERSION_CLR('link:packages/c')}`)
+})

--- a/reviewing/plugin-commands-listing/src/list.ts
+++ b/reviewing/plugin-commands-listing/src/list.ts
@@ -24,6 +24,7 @@ export function rcOptionsTypes () {
 
 export const cliOptionsTypes = () => ({
   ...rcOptionsTypes(),
+  'only-projects': Boolean,
   recursive: Boolean,
 })
 
@@ -92,6 +93,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
             shortAlias: '-D',
           },
           {
+            description: 'Display only dependencies that are also projects within the monorepo.',
+            name: '--only-projects',
+          },
+          {
             description: "Don't display packages from `optionalDependencies`",
             name: '--no-optional',
           },
@@ -121,6 +126,7 @@ export type ListCommandOptions = Pick<Config,
   lockfileDir?: string
   long?: boolean
   parseable?: boolean
+  onlyProjects?: boolean
   recursive?: boolean
 }
 
@@ -156,6 +162,7 @@ export async function render (
     lockfileDir: string
     long?: boolean
     json?: boolean
+    onlyProjects?: boolean
     parseable?: boolean
   }
 ) {
@@ -165,6 +172,7 @@ export async function render (
     include: opts.include,
     lockfileDir: opts.lockfileDir,
     long: opts.long,
+    onlyProjects: opts.onlyProjects,
     reportAs: (opts.parseable ? 'parseable' : (opts.json ? 'json' : 'tree')) as ('parseable' | 'json' | 'tree'),
     showExtraneous: false,
   }

--- a/reviewing/plugin-commands-listing/src/list.ts
+++ b/reviewing/plugin-commands-listing/src/list.ts
@@ -93,7 +93,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
             shortAlias: '-D',
           },
           {
-            description: 'Display only dependencies that are also projects within the monorepo.',
+            description: 'Display only dependencies that are also projects within the workspace',
             name: '--only-projects',
           },
           {


### PR DESCRIPTION
## Changes

This pull request implements the feature request described at https://github.com/pnpm/pnpm/issues/4154. The `pnpm why` and `pnpm list` commands are now aware of dependencies from transitive workspace dependencies.

### Before

One cool aspect of this change is that `pnpm why` previously returned no output for packages depended on transitively from a `workspace:` linked package.

<img width="842" alt="Screenshot 2023-01-01 at 2 02 26 AM" src="https://user-images.githubusercontent.com/906558/210163310-879b2890-558e-4af9-8070-5ddb6d545e84.png">

### After

With the changes in this PR, `pnpm why` becomes much smarter.

<img width="842" alt="Screenshot 2023-01-01 at 2 02 29 AM" src="https://user-images.githubusercontent.com/906558/210163312-01f61d87-d89c-4e26-b59d-f8153e057f50.png">

## Questions

1. Is this a breaking change? Users parsing `pnpm why --json <name>` or `pnpm list --json <name>` might be surprised by the additional output. We can gate this behavior behind a command line flag until the next major pnpm version if so.
1. Do we want a `--no-projects` filter regardless of whether this is a breaking change?
1. Do we want a `--only-projects` flag? That would be useful for https://github.com/pnpm/pnpm/issues/3398.
1. In `pnpm why` and `pnpm list` output, the path in the `link:...` matches the path from the `pnpm-lock.yaml` file. Is this desired, or should we rewrite these links to be relative to the current working directory?