### PR TITLE
fix(plugin-commands-script-runners): support directory with path delimiter when running local bin

### DIFF
--- a/.changeset/chatty-jars-speak.md
+++ b/.changeset/chatty-jars-speak.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+`pnpm run` should fail if the path to the project contains colon(s).

--- a/.changeset/plenty-ravens-sell.md
+++ b/.changeset/plenty-ravens-sell.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+`pnpm exec` should work when the path to the project contains colon(s) [#5846](https://github.com/pnpm/pnpm/issues/5846).

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { docsUrl, RecursiveSummary, throwOnCommandFail } from '@pnpm/cli-utils'
 import { Config, types } from '@pnpm/config'
 import { makeNodeRequireOption } from '@pnpm/lifecycle'
@@ -175,7 +174,7 @@ export async function handler (
               PNPM_PACKAGE_NAME: opts.selectedProjectsGraph[prefix]?.package.manifest.name,
             },
             prependPaths: [
-              path.join(prefix, 'node_modules/.bin'),
+              './node_modules/.bin',
               ...opts.extraBinPaths,
             ],
             userAgent: opts.userAgent,

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -202,7 +202,9 @@ export async function handler (
             return
           }
 
-          err['code'] = 'ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL'
+          if (!err['code']?.startsWith('ERR_PNPM_')) {
+            err['code'] = 'ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL'
+          }
           err['prefix'] = prefix
           /* eslint-enable @typescript-eslint/dot-notation */
           throw err

--- a/exec/plugin-commands-script-runners/src/makeEnv.ts
+++ b/exec/plugin-commands-script-runners/src/makeEnv.ts
@@ -1,3 +1,4 @@
+import { PnpmError } from '@pnpm/error'
 import path from 'path'
 import PATH from 'path-name'
 
@@ -8,6 +9,13 @@ export function makeEnv (
     prependPaths: string[]
   }
 ) {
+  for (const prependPath of opts.prependPaths) {
+    if (prependPath.includes(path.delimiter)) {
+      // Unfortunately, there is no way to escape the PATH delimiter,
+      // so directories added to the PATH should not contain it.
+      throw new PnpmError('BAD_PATH_DIR', `Cannot add ${prependPath} to PATH because it contains the path delimiter character (${path.delimiter})`)
+    }
+  }
   return {
     ...process.env,
     ...opts.extraEnv,

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -661,3 +661,38 @@ test('should throw error when the package specified by resume-from does not exis
     expect(err.code).toBe('ERR_PNPM_RESUME_FROM_NOT_FOUND')
   }
 })
+
+test('pnpm exec in directory with path delimiter', async () => {
+  preparePackages([
+    {
+      name: `foo${path.delimiter}delimiter`,
+      version: '1.0.0',
+      dependencies: {
+        cowsay: '1.5.0',
+      },
+    },
+  ])
+
+  const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
+  await execa(pnpmBin, [
+    'install',
+    '-r',
+    '--registry',
+    REGISTRY_URL,
+    '--store-dir',
+    path.resolve(DEFAULT_OPTS.storeDir),
+  ])
+
+  let error
+  try {
+    await exec.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      selectedProjectsGraph,
+      recursive: true,
+    }, ['cowsay', 'hi'])
+  } catch (err: any) { // eslint-disable-line
+    error = err
+  }
+  expect(error).toBeUndefined()
+})

--- a/exec/plugin-commands-script-runners/test/makeEnv.test.ts
+++ b/exec/plugin-commands-script-runners/test/makeEnv.test.ts
@@ -1,0 +1,9 @@
+import path from 'path'
+import { makeEnv } from '../src/makeEnv'
+
+test('makeEnv should fail if prependPaths has a path with a colon', () => {
+  const prependPath = '/foo/bar:/baz'
+  expect(() => makeEnv({
+    prependPaths: [prependPath],
+  })).toThrow(`Cannot add ${prependPath} to PATH because it contains the path delimiter character (${path.delimiter})`)
+})

--- a/exec/plugin-commands-script-runners/test/makeEnv.test.ts
+++ b/exec/plugin-commands-script-runners/test/makeEnv.test.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { makeEnv } from '../src/makeEnv'
 
 test('makeEnv should fail if prependPaths has a path with a colon', () => {
-  const prependPath = '/foo/bar:/baz'
+  const prependPath = `/foo/bar${path.delimiter}/baz`
   expect(() => makeEnv({
     prependPaths: [prependPath],
   })).toThrow(`Cannot add ${prependPath} to PATH because it contains the path delimiter character (${path.delimiter})`)


### PR DESCRIPTION
close #5846 

For the following project:

```
 // test/test_pnpm:colon/package.json
 {
  "name": "test-pnpm-example",
  "version": "1.0.0",
  "scripts": {
    "test": "cowsay 'hi'"
  },
  "dependencies": {
    "cowsay": "^1.5.0"
  }
}
```

After run `pd install` ,  `pd exec cowsay hi  ` or  `pd cowsay hi` will executed successfully.

However, currently, running the test script in package.json(`pd test`) still reports an command not found error. It seems to be consistent with the behavior of yarn classic.

If we want to support `pd test` in this case , we may need to change `@pnpm/npm-lifecycle`?