### PR TITLE
fix: re-add manually removed packages to node_modules when `node-linker` is set to `hoisted`

### DIFF
--- a/.changeset/rare-spoons-play.md
+++ b/.changeset/rare-spoons-play.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/headless": patch
+"pnpm": patch
+---
+
+If an external tool or a user have removed a package from node_modules, pnpm should add it back on install. This was only an issue with `node-linker=hoisted`.


### PR DESCRIPTION
TODO:
- [x] add a test