### PR TITLE
fix(dependency-path): fix lockfile v6 version parsing for a patched dependency

### DIFF
--- a/.changeset/tiny-needles-type.md
+++ b/.changeset/tiny-needles-type.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/dependency-path": patch
+---
+
+Fix lockfile v6 version parsing for a patched dependency

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -112,11 +112,18 @@ export function parse (dependencyPath: string) {
   if (version) {
     let peerSepIndex!: number
     let peersSuffix: string | undefined
+    let patchSuffix: string | undefined
     if (version.includes('(') && version.endsWith(')')) {
       peerSepIndex = version.indexOf('(')
       if (peerSepIndex !== -1) {
         peersSuffix = version.substring(peerSepIndex)
         version = version.substring(0, peerSepIndex)
+      }
+
+      const patchSepIndex = version.indexOf('_')
+      if (patchSepIndex !== -1) {
+        patchSuffix = version.substring(patchSepIndex)
+        version = version.substring(0, patchSepIndex)
       }
     } else {
       peerSepIndex = version.indexOf('_')
@@ -131,7 +138,7 @@ export function parse (dependencyPath: string) {
         isAbsolute: _isAbsolute,
         name,
         peersSuffix,
-        version,
+        version: patchSuffix ? `${version}${patchSuffix}` : version,
       }
     }
   }

--- a/packages/dependency-path/test/index.ts
+++ b/packages/dependency-path/test/index.ts
@@ -98,6 +98,14 @@ test('parse()', () => {
     version: '1.0.0',
   })
 
+  expect(parse('/foo/1.0.0_k5brw22k7hadiw3hedogf4eiee(bar@1.0.0)')).toStrictEqual({
+    host: undefined,
+    isAbsolute: false,
+    name: 'foo',
+    peersSuffix: '(bar@1.0.0)',
+    version: '1.0.0_k5brw22k7hadiw3hedogf4eiee',
+  })
+
   expect(() => parse('/foo/bar')).toThrow(/\/foo\/bar is an invalid relative dependency path/)
 })
 


### PR DESCRIPTION
Previously pnpm would fail to resolve patched package when lockfile v6 is used. This change correctly handles patch hash in the version suffix.