### PR TITLE
feat: more features about --no-shared-workspace-lockfile

### DIFF
--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -119,16 +119,19 @@ export interface PeerDependencyRules {
 
 export type AllowedDeprecatedVersions = Record<string, string>
 
-export type ProjectManifest = BaseManifest & {
-  pnpm?: {
-    neverBuiltDependencies?: string[]
-    onlyBuiltDependencies?: string[]
-    overrides?: Record<string, string>
-    packageExtensions?: Record<string, PackageExtension>
-    peerDependencyRules?: PeerDependencyRules
-    allowedDeprecatedVersions?: AllowedDeprecatedVersions
-    allowNonAppliedPatches?: boolean
-    patchedDependencies?: Record<string, string>
+export interface PnpmOptions {
+  neverBuiltDependencies?: string[]
+  onlyBuiltDependencies?: string[]
+  overrides?: Record<string, string>
+  packageExtensions?: Record<string, PackageExtension>
+  peerDependencyRules?: PeerDependencyRules
+  allowedDeprecatedVersions?: AllowedDeprecatedVersions
+  allowNonAppliedPatches?: boolean
+  patchedDependencies?: Record<string, string>
+}
+
+export interface PnpmManiFest {
+  pnpm?: PnpmOptions & {
     updateConfig?: {
       ignoreDependencies?: string[]
     }
@@ -137,8 +140,11 @@ export type ProjectManifest = BaseManifest & {
     }
     requiredScripts?: string[]
   }
-  private?: boolean
   resolutions?: Record<string, string>
+}
+
+export type ProjectManifest = BaseManifest & PnpmManiFest & {
+  private?: boolean
 }
 
 export type PackageManifest = DependencyManifest & {

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -58,6 +58,7 @@
     "is-inner-link": "^4.0.0",
     "load-json-file": "^6.2.0",
     "normalize-path": "^3.0.0",
+    "path-absolute": "^1.0.1",
     "p-every": "^2.0.0",
     "p-filter": "^2.1.0",
     "p-limit": "^3.1.0",

--- a/pkg-manager/core/src/getPeerDependencyIssues.ts
+++ b/pkg-manager/core/src/getPeerDependencyIssues.ts
@@ -3,24 +3,24 @@ import { PeerDependencyIssuesByProjects } from '@pnpm/types'
 import { getContext, GetContextOptions, ProjectOptions } from '@pnpm/get-context'
 import { createReadPackageHook } from '@pnpm/hooks.read-package-hook'
 import { getPreferredVersionsFromLockfile } from './install/getPreferredVersions'
-import { InstallOptions } from './install/extendInstallOptions'
+import { Hooks, InstallOptions } from './install/extendInstallOptions'
 import { DEFAULT_REGISTRIES } from '@pnpm/normalize-registries'
 
 export type ListMissingPeersOptions = Partial<GetContextOptions>
-& Pick<InstallOptions, 'hooks'
-| 'ignoreCompatibilityDb'
+& Pick<InstallOptions, 'ignoreCompatibilityDb'
 | 'linkWorkspacePackagesDepth'
 | 'nodeVersion'
 | 'nodeLinker'
-| 'overrides'
 | 'packageExtensions'
 | 'preferWorkspacePackages'
 | 'saveWorkspaceProtocol'
 | 'storeController'
 | 'useGitBranchLockfile'
 | 'workspacePackages'
->
-& Pick<GetContextOptions, 'storeDir'>
+> & {
+  hooks: Hooks
+  overrides: Record<string, string>
+} & Pick<GetContextOptions, 'storeDir'>
 
 export async function getPeerDependencyIssues (
   projects: ProjectOptions[],

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -19,6 +19,12 @@ import { pnpmPkgJson } from '../pnpmPkgJson'
 import { ReporterFunction } from '../types'
 import { PreResolutionHookContext } from './hooks'
 
+export interface Hooks {
+  readPackage?: ReadPackageHook[]
+  preResolution?: (ctx: PreResolutionHookContext) => Promise<void>
+  afterAllResolved?: Array<(lockfile: Lockfile) => Lockfile | Promise<Lockfile>>
+}
+
 export interface StrictInstallOptions {
   autoInstallPeers: boolean
   forceSharedLockfile: boolean
@@ -74,11 +80,7 @@ export interface StrictInstallOptions {
     version: string
   }
   pruneLockfileImporters: boolean
-  hooks: {
-    readPackage?: ReadPackageHook[]
-    preResolution?: (ctx: PreResolutionHookContext) => Promise<void>
-    afterAllResolved?: Array<(lockfile: Lockfile) => Lockfile | Promise<Lockfile>>
-  }
+  hooks: Hooks
   sideEffectsCacheRead: boolean
   sideEffectsCacheWrite: boolean
   strictPeerDependencies: boolean
@@ -123,6 +125,7 @@ export interface StrictInstallOptions {
   dedupeDirectDeps: boolean
   useLockfileV6?: boolean
   extendNodePath: boolean
+  pruneVirtualStore?: boolean
 }
 
 export type InstallOptions =

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -216,9 +216,14 @@ export async function mutateModules (
     })
   }
 
-  const pruneVirtualStore = ctx.modulesFile?.prunedAt && opts.modulesCacheMaxAge > 0
-    ? cacheExpired(ctx.modulesFile.prunedAt, opts.modulesCacheMaxAge)
-    : true
+  let pruneVirtualStore: boolean
+  if (typeof opts.pruneVirtualStore !== 'undefined') {
+    pruneVirtualStore = opts.pruneVirtualStore
+  } else {
+    pruneVirtualStore = ctx.modulesFile?.prunedAt && opts.modulesCacheMaxAge > 0
+      ? cacheExpired(ctx.modulesFile.prunedAt, opts.modulesCacheMaxAge)
+      : true
+  }
 
   if (!maybeOpts.ignorePackageManifest) {
     for (const { manifest, rootDir } of Object.values(ctx.projects)) {
@@ -571,6 +576,8 @@ export async function mutateModules (
     return result.projects
   }
 }
+
+export { mutateProjectsIndependently } from './noSharedLockfile'
 
 async function calcPatchHashes (patches: Record<string, string>, lockfileDir: string) {
   return pMapValues(async (patchFileRelativePath) => {

--- a/pkg-manager/core/src/install/noSharedLockfile.ts
+++ b/pkg-manager/core/src/install/noSharedLockfile.ts
@@ -1,0 +1,67 @@
+import {
+  PeerDependencyRules,
+  PnpmOptions,
+} from '@pnpm/types'
+import { Hooks, StrictInstallOptions } from './extendInstallOptions'
+import { ProjectOptions } from '@pnpm/get-context'
+import { ReporterFunction } from '../types'
+import { MutatedProject, mutateModules, MutateModulesOptions, UpdatedProject } from '.'
+import pathAbsolute from 'path-absolute'
+import path from 'path'
+
+/// FIXME: temporary solutions
+interface PartialOptions {
+  extraEnv?: Record<string, string>
+  linkWorkspacePackagesDepth?: number
+  reporter?: ReporterFunction
+  forcePublicHoistPattern?: boolean
+  modulesDir?: string
+  peerDependencyRules?: PeerDependencyRules
+  preferSymlinkedExecutables?: boolean
+  global?: boolean
+  forceHoistPattern?: boolean
+  forceShamefullyHoist?: boolean
+  dir?: string
+}
+
+type ProjectInfo = PnpmOptions & ProjectOptions & { hooks: Hooks }
+type SplitLockfileInstallOptions = Omit<StrictInstallOptions,
+keyof PnpmOptions | keyof PartialOptions | 'hooks' | 'lockfileDir' | 'allProjects'>
+& PartialOptions & {
+  allProjects: ProjectInfo[]
+  workspaceDir: string
+}
+
+type InstallOptions = Partial<SplitLockfileInstallOptions> & Pick<SplitLockfileInstallOptions, 'storeDir' | 'storeController' | 'workspaceDir'>
+
+export async function mutateProjectsIndependently (
+  projects: MutatedProject[],
+  maybeOpts: InstallOptions
+): Promise<UpdatedProject[]> {
+  if (maybeOpts.allProjects) {
+    const promises = maybeOpts.allProjects.map(project => task(projects, project, maybeOpts))
+    const results = await Promise.all(promises)
+    return results.flat()
+  } else {
+    return []
+  }
+}
+
+async function task (mutatedImports: MutatedProject[], project: ProjectInfo, splitLockFileOpts: InstallOptions) {
+  const modulesDir = splitLockFileOpts.modulesDir ?? 'node_modules'
+  const virtualStoreDir = pathAbsolute(path.resolve(modulesDir, '.pnpm'), splitLockFileOpts.workspaceDir)
+  const opts: MutateModulesOptions = {
+    ...splitLockFileOpts,
+    ...project,
+    virtualStoreDir,
+    lockfileDir: project.rootDir,
+    allProjects: [project],
+    pruneVirtualStore: false,
+  }
+  const mutatedImport = mutatedImports.find((p) => p.rootDir === project.rootDir)
+  if (!mutatedImport) {
+    return []
+  } else {
+    return mutateModules([mutatedImport], opts)
+  }
+}

--- a/pkg-manager/plugin-commands-installation/src/getOptionsFromRootManifest.ts
+++ b/pkg-manager/plugin-commands-installation/src/getOptionsFromRootManifest.ts
@@ -1,22 +1,11 @@
 import { PnpmError } from '@pnpm/error'
 import {
-  AllowedDeprecatedVersions,
-  PackageExtension,
-  PeerDependencyRules,
+  PnpmOptions,
   ProjectManifest,
 } from '@pnpm/types'
 import mapValues from 'ramda/src/map'
 
-export function getOptionsFromRootManifest (manifest: ProjectManifest): {
-  allowedDeprecatedVersions?: AllowedDeprecatedVersions
-  allowNonAppliedPatches?: boolean
-  overrides?: Record<string, string>
-  neverBuiltDependencies?: string[]
-  onlyBuiltDependencies?: string[]
-  packageExtensions?: Record<string, PackageExtension>
-  patchedDependencies?: Record<string, string>
-  peerDependencyRules?: PeerDependencyRules
-} {
+export function getOptionsFromRootManifest (manifest: ProjectManifest): PnpmOptions {
   // We read Yarn's resolutions field for compatibility
   // but we really replace the version specs to any other version spec, not only to exact versions,
   // so we cannot call it resolutions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2709,6 +2709,9 @@ importers:
       p-map-values:
         specifier: ^1.0.0
         version: 1.0.0
+      path-absolute:
+        specifier: ^1.0.1
+        version: 1.0.1
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4260,7 +4263,7 @@ importers:
         version: /safe-execa@0.1.2
       pkg:
         specifier: github:vercel/pkg#5.7.0
-        version: github.com/vercel/pkg/7e4fef9f0828b11c7a9655b95425f32094f2daa2_pp6fkuhwkrqq7cjcj7uqpf37e4
+        version: github.com/vercel/pkg/7e4fef9f0828b11c7a9655b95425f32094f2daa2(patch_hash=pp6fkuhwkrqq7cjcj7uqpf37e4)
 
   pnpm/artifacts/linux-arm64:
     devDependencies:
@@ -17378,7 +17381,7 @@ packages:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
     dev: false
 
-  github.com/vercel/pkg/7e4fef9f0828b11c7a9655b95425f32094f2daa2_pp6fkuhwkrqq7cjcj7uqpf37e4:
+  github.com/vercel/pkg/7e4fef9f0828b11c7a9655b95425f32094f2daa2(patch_hash=pp6fkuhwkrqq7cjcj7uqpf37e4):
     resolution: {tarball: https://codeload.github.com/vercel/pkg/tar.gz/7e4fef9f0828b11c7a9655b95425f32094f2daa2}
     id: github.com/vercel/pkg/7e4fef9f0828b11c7a9655b95425f32094f2daa2
     name: pkg

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -168,7 +168,7 @@ export async function main (inputArgv: string[]) {
   }
 
   if (
-    (cmd === 'install' || cmd === 'import' || cmd === "dedupe") &&
+    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe') &&
     typeof workspaceDir === 'string'
   ) {
     cliOptions['recursive'] = true
@@ -232,7 +232,9 @@ export async function main (inputArgv: string[]) {
 
   let { output, exitCode }: { output: string | null, exitCode: number } = await (async () => {
     // NOTE: we defer the next stage, otherwise reporter might not catch all the logs
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+    await new Promise<void>((resolve) => setTimeout(() => {
+      resolve()
+    }, 0))
 
     if (
       config.updateNotifier !== false &&

--- a/pnpm/test/server.ts
+++ b/pnpm/test/server.ts
@@ -230,8 +230,12 @@ async function testParallelServerStart (
     }
     serverProcessList.push(item)
 
-    byline(item.childProcess.stderr as Readable).on('data', (line: Buffer) => console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`))
-    byline(item.childProcess.stdout as Readable).on('data', (line: Buffer) => console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`))
+    byline(item.childProcess.stderr as Readable).on('data', (line: Buffer) => {
+      console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`)
+    })
+    byline(item.childProcess.stdout as Readable).on('data', (line: Buffer) => {
+      console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`)
+    })
 
     item.childProcess.on('exit', async (code: number | null, signal: string | null) => {
       options.onProcessClosed(item.childProcess, item.attemptedToKill)


### PR DESCRIPTION
ref: https://github.com/pnpm/pnpm/discussions/4967#discussioncomment-3455608

Goal of this draft: when `shared-workspace-lockfile=false`, then

1. There will be a `pnpm-lockfile.yaml` under each workspace (keep it as it is)
2. Each workspace shares a virtual store.
3. The pnpmOptions(such as `pnpm.overrides`) under each workspace take effect
4. The .pnpmfile.cjs under each workspace takes effect