### PR TITLE
fix: update without specify --latest should not update tag version

### DIFF
--- a/.changeset/tasty-coins-join.md
+++ b/.changeset/tasty-coins-join.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/resolve-dependencies": patch
+---
+
+Update without specify --latest should not update tag version

--- a/.changeset/tasty-coins-join.md
+++ b/.changeset/tasty-coins-join.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/plugin-commands-installation": patch
 "@pnpm/resolve-dependencies": patch
+"pnpm": patch
 ---
 
-Update without specify --latest should not update tag version
+The update command should not replace dependency versions specified via dist-tags [#5996](https://github.com/pnpm/pnpm/pull/5996).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -507,7 +507,7 @@ export async function mutateModules (
         updateWorkspaceDependencies: opts.update,
         nodeExecPath: opts.nodeExecPath,
       })
-        .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true }))
+        .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, isCaseInstall: true }))
 
       if (ctx.wantedLockfile?.importers) {
         forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies)
@@ -719,7 +719,7 @@ export type ImporterToUpdate = {
   pruneDirectDependencies: boolean
   removePackages?: string[]
   updatePackageManifest: boolean
-  wantedDependencies: Array<WantedDependency & { isNew?: boolean, updateSpec?: boolean }>
+  wantedDependencies: Array<WantedDependency & { isNew?: boolean, updateSpec?: boolean, isCaseInstall?: boolean }>
 } & DependenciesMutation
 
 export interface UpdatedProject {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -507,7 +507,7 @@ export async function mutateModules (
         updateWorkspaceDependencies: opts.update,
         nodeExecPath: opts.nodeExecPath,
       })
-        .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, isCaseInstall: true }))
+        .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
 
       if (ctx.wantedLockfile?.importers) {
         forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies)
@@ -719,7 +719,7 @@ export type ImporterToUpdate = {
   pruneDirectDependencies: boolean
   removePackages?: string[]
   updatePackageManifest: boolean
-  wantedDependencies: Array<WantedDependency & { isNew?: boolean, updateSpec?: boolean, isCaseInstall?: boolean }>
+  wantedDependencies: Array<WantedDependency & { isNew?: boolean, updateSpec?: boolean, preserveNonSemverVersionSpec?: boolean }>
 } & DependenciesMutation
 
 export interface UpdatedProject {

--- a/pkg-manager/plugin-commands-installation/test/update/update.ts
+++ b/pkg-manager/plugin-commands-installation/test/update/update.ts
@@ -345,7 +345,7 @@ test('should not update tag version when --latest not set', async () => {
     dependencies: {
       '@pnpm.e2e/peer-a': 'latest',
       '@pnpm.e2e/peer-c': 'canary',
-      '@pnpm.e2e/foo': '^1.0.0',
+      '@pnpm.e2e/foo': '1.0.0',
     },
   })
 
@@ -363,5 +363,5 @@ test('should not update tag version when --latest not set', async () => {
   const manifest = await loadJsonFile<ProjectManifest>('package.json')
   expect(manifest.dependencies?.['@pnpm.e2e/peer-a']).toBe('latest')
   expect(manifest.dependencies?.['@pnpm.e2e/peer-c']).toBe('canary')
-  expect(manifest.dependencies?.['@pnpm.e2e/foo']).toBe('^1.0.0')
+  expect(manifest.dependencies?.['@pnpm.e2e/foo']).toBe('1.0.0')
 })

--- a/pkg-manager/plugin-commands-installation/test/update/update.ts
+++ b/pkg-manager/plugin-commands-installation/test/update/update.ts
@@ -335,3 +335,33 @@ test('do not update anything if all the dependencies are ignored and trying to u
   const lockfileUpdated = await project.readLockfile()
   expect(lockfileUpdated.packages['/@pnpm.e2e/foo/100.0.0']).toBeTruthy()
 })
+
+test('should not update tag version when --latest not set', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.1', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '2.0.0', distTag: 'canary' })
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
+
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/peer-a': 'latest',
+      '@pnpm.e2e/peer-c': 'canary',
+      '@pnpm.e2e/foo': '^1.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    latest: false,
+  })
+
+  const manifest = await loadJsonFile<ProjectManifest>('package.json')
+  expect(manifest.dependencies?.['@pnpm.e2e/peer-a']).toBe('latest')
+  expect(manifest.dependencies?.['@pnpm.e2e/peer-c']).toBe('canary')
+  expect(manifest.dependencies?.['@pnpm.e2e/foo']).toBe('^1.0.0')
+})

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -73,7 +73,7 @@ export type ImporterToResolve = Importer<{
   pinnedVersion?: PinnedVersion
   raw: string
   updateSpec?: boolean
-  isCaseInstall?: boolean
+  preserveNonSemverVersionSpec?: boolean
 }>
 & {
   peer?: boolean

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -73,6 +73,7 @@ export type ImporterToResolve = Importer<{
   pinnedVersion?: PinnedVersion
   raw: string
   updateSpec?: boolean
+  isCaseInstall?: boolean
 }>
 & {
   peer?: boolean

--- a/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
+++ b/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
@@ -170,7 +170,7 @@ function getPrefPreferSpecifiedExoticSpec (
       }
     }
     const selector = versionSelectorType(specWithoutName)
-    if (!selector || opts.isNew === undefined) {
+    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.isNew === undefined) {
       return opts.specRaw.slice(opts.alias.length + 1)
     }
   }

--- a/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
+++ b/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
@@ -103,6 +103,7 @@ function resolvedDirectDepToSpecObject (
         specRaw,
         version,
         rolling: shouldUseWorkspaceProtocol && opts.saveWorkspaceProtocol === 'rolling',
+        isNew,
       })
     }
     if (
@@ -156,6 +157,7 @@ function getPrefPreferSpecifiedExoticSpec (
     specRaw: string
     pinnedVersion: PinnedVersion
     rolling: boolean
+    isNew?: Boolean
   }
 ) {
   const prefix = getPrefix(opts.alias, opts.name)
@@ -168,7 +170,7 @@ function getPrefPreferSpecifiedExoticSpec (
       }
     }
     const selector = versionSelectorType(specWithoutName)
-    if (!selector) {
+    if (!selector || opts.isNew === undefined) {
       return opts.specRaw.slice(opts.alias.length + 1)
     }
   }

--- a/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
+++ b/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
@@ -171,7 +171,10 @@ function getPrefPreferSpecifiedExoticSpec (
       }
     }
     const selector = versionSelectorType(specWithoutName)
-    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.preserveNonSemverVersionSpec) {
+    if (
+      ((selector == null) || (selector.type !== 'version' && selector.type !== 'range')) &&
+      opts.preserveNonSemverVersionSpec
+    ) {
       return opts.specRaw.slice(opts.alias.length + 1)
     }
   }

--- a/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
+++ b/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
@@ -25,7 +25,7 @@ export async function updateProjectManifest (
     .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
     .map((rdd, index) => {
       const wantedDep = importer.wantedDependencies[index]!
-      return resolvedDirectDepToSpecObject({ ...rdd, isNew: wantedDep.isNew, specRaw: wantedDep.raw }, importer, {
+      return resolvedDirectDepToSpecObject({ ...rdd, isNew: wantedDep.isNew, specRaw: wantedDep.raw, isCaseInstall: wantedDep.isCaseInstall }, importer, {
         nodeExecPath: wantedDep.nodeExecPath,
         pinnedVersion: wantedDep.pinnedVersion ?? importer.pinnedVersion ?? 'major',
         preserveWorkspaceProtocol: opts.preserveWorkspaceProtocol,
@@ -66,7 +66,8 @@ function resolvedDirectDepToSpecObject (
     resolution,
     specRaw,
     version,
-  }: ResolvedDirectDependency & { isNew?: Boolean, specRaw: string },
+    isCaseInstall,
+  }: ResolvedDirectDependency & { isNew?: Boolean, specRaw: string, isCaseInstall?: boolean },
   importer: ImporterToResolve,
   opts: {
     nodeExecPath?: string
@@ -103,7 +104,7 @@ function resolvedDirectDepToSpecObject (
         specRaw,
         version,
         rolling: shouldUseWorkspaceProtocol && opts.saveWorkspaceProtocol === 'rolling',
-        isNew,
+        isCaseInstall,
       })
     }
     if (
@@ -157,7 +158,7 @@ function getPrefPreferSpecifiedExoticSpec (
     specRaw: string
     pinnedVersion: PinnedVersion
     rolling: boolean
-    isNew?: Boolean
+    isCaseInstall?: boolean
   }
 ) {
   const prefix = getPrefix(opts.alias, opts.name)
@@ -170,7 +171,7 @@ function getPrefPreferSpecifiedExoticSpec (
       }
     }
     const selector = versionSelectorType(specWithoutName)
-    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.isNew === undefined) {
+    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.isCaseInstall) {
       return opts.specRaw.slice(opts.alias.length + 1)
     }
   }

--- a/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
+++ b/pkg-manager/resolve-dependencies/src/updateProjectManifest.ts
@@ -25,7 +25,7 @@ export async function updateProjectManifest (
     .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
     .map((rdd, index) => {
       const wantedDep = importer.wantedDependencies[index]!
-      return resolvedDirectDepToSpecObject({ ...rdd, isNew: wantedDep.isNew, specRaw: wantedDep.raw, isCaseInstall: wantedDep.isCaseInstall }, importer, {
+      return resolvedDirectDepToSpecObject({ ...rdd, isNew: wantedDep.isNew, specRaw: wantedDep.raw, preserveNonSemverVersionSpec: wantedDep.preserveNonSemverVersionSpec }, importer, {
         nodeExecPath: wantedDep.nodeExecPath,
         pinnedVersion: wantedDep.pinnedVersion ?? importer.pinnedVersion ?? 'major',
         preserveWorkspaceProtocol: opts.preserveWorkspaceProtocol,
@@ -66,8 +66,8 @@ function resolvedDirectDepToSpecObject (
     resolution,
     specRaw,
     version,
-    isCaseInstall,
-  }: ResolvedDirectDependency & { isNew?: Boolean, specRaw: string, isCaseInstall?: boolean },
+    preserveNonSemverVersionSpec,
+  }: ResolvedDirectDependency & { isNew?: Boolean, specRaw: string, preserveNonSemverVersionSpec?: boolean },
   importer: ImporterToResolve,
   opts: {
     nodeExecPath?: string
@@ -104,7 +104,7 @@ function resolvedDirectDepToSpecObject (
         specRaw,
         version,
         rolling: shouldUseWorkspaceProtocol && opts.saveWorkspaceProtocol === 'rolling',
-        isCaseInstall,
+        preserveNonSemverVersionSpec,
       })
     }
     if (
@@ -158,7 +158,7 @@ function getPrefPreferSpecifiedExoticSpec (
     specRaw: string
     pinnedVersion: PinnedVersion
     rolling: boolean
-    isCaseInstall?: boolean
+    preserveNonSemverVersionSpec?: boolean
   }
 ) {
   const prefix = getPrefix(opts.alias, opts.name)
@@ -171,7 +171,7 @@ function getPrefPreferSpecifiedExoticSpec (
       }
     }
     const selector = versionSelectorType(specWithoutName)
-    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.isCaseInstall) {
+    if (!((selector != null) && (selector.type === 'version' || selector.type === 'range')) && opts.preserveNonSemverVersionSpec) {
       return opts.specRaw.slice(opts.alias.length + 1)
     }
   }


### PR DESCRIPTION
As discussed in https://github.com/pnpm/pnpm/pull/5720#issuecomment-1366816792

given a example project like following:

```
//package.json
"dependencies": {
    "ava": "latest"
  }
```

After run `pnpm up` , currently we will get `ava: "^5.1.1"`. We should behave the same as before, keeping `latest` here.

