### PR TITLE
ci: set workflow dispatch inputs to Winget Releaser

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: pnpm.pnpm
+          version: ${{ github.event.inputs.version }}
+          release-tag: v${{ github.event.inputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
 
   post-to-reddit:


### PR DESCRIPTION
You will have to put the inputs to Winget Releaser manually if you are going to do a workflow dispatch. Please try triggering the workflow again after merging.