### PR TITLE
feat: support splitLockfile

### DIFF
--- a/lockfile/lockfile-file/src/read.ts
+++ b/lockfile/lockfile-file/src/read.ts
@@ -136,7 +136,7 @@ async function _read (
 export function createLockfileObject (
   importerIds: string[],
   opts: {
-    lockfileVersion: number | string
+    lockfileVersion?: number | string
   }
 ) {
   const importers = importerIds.reduce((acc, importerId) => {
@@ -148,7 +148,7 @@ export function createLockfileObject (
   }, {} as Lockfile['importers'])
   return {
     importers,
-    lockfileVersion: opts.lockfileVersion || LOCKFILE_VERSION,
+    lockfileVersion: opts.lockfileVersion ?? LOCKFILE_VERSION,
   }
 }
 

--- a/lockfile/split-lockfile/jest.config.js
+++ b/lockfile/split-lockfile/jest.config.js
@@ -1,0 +1,6 @@
+const config = require('../../jest.config.js')
+
+module.exports = {
+  ...config,
+  testMatch: [...config.testMatch, "!**/test/utils.ts"]
+}

--- a/lockfile/split-lockfile/package.json
+++ b/lockfile/split-lockfile/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@pnpm/split-lockfile",
+  "version": "0.1.0",
+  "description": "Split and merge lockfile by importer",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=14.6"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "scripts": {
+    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "_test": "jest",
+    "test": "pnpm run compile && pnpm run _test",
+    "prepublishOnly": "pnpm run compile",
+    "compile": "tsc --build && pnpm run lint --fix"
+  },
+  "repository": "https://github.com/pnpm/pnpm/blob/main/lockfile/split-lockfile",
+  "keywords": [
+    "pnpm7",
+    "pnpm",
+    "shrinkwrap",
+    "lockfile"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/lockfile/split-lockfile#readme",
+  "devDependencies": {
+    "@pnpm/split-lockfile": "workspace:*",
+    "@types/ramda": "0.28.20",
+    "ramda": "npm:@pnpm/ramda@0.28.1",
+    "tempy": "^1.0.1"
+  },
+  "dependencies": {
+    "@pnpm/lockfile-file": "workspace:*",
+    "@pnpm/lockfile-types": "workspace:*",
+    "@pnpm/types": "workspace:*",
+    "@pnpm/lockfile-walker": "workspace:*",
+    "@pnpm/merge-lockfile-changes": "workspace:*"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  }
+}

--- a/lockfile/split-lockfile/src/index.ts
+++ b/lockfile/split-lockfile/src/index.ts
@@ -1,0 +1,2 @@
+export { splitLockfile } from './splitLockfile'
+export { mergeSplittedLockfiles } from './mergeSplittedLockfiles'

--- a/lockfile/split-lockfile/src/mergeSplittedLockfiles.ts
+++ b/lockfile/split-lockfile/src/mergeSplittedLockfiles.ts
@@ -1,0 +1,32 @@
+import type { Lockfile } from '@pnpm/lockfile-types'
+import { mergeLockfileChanges } from '@pnpm/merge-lockfile-changes'
+import { pickLockfileInfo } from './utils'
+import { createLockfileObject } from '@pnpm/lockfile-file'
+
+const EMPTY_LOCKFILE: Lockfile = createLockfileObject([], {})
+
+export function mergeSplittedLockfiles (lockfiles: Record<string, Lockfile>): Lockfile {
+  const entires = Object.entries(lockfiles)
+  if (entires.length === 0) {
+    return EMPTY_LOCKFILE
+  }
+  const newLockfile = entires.reduce((prev, current) => {
+    const importers = {
+      [current[0]]: current[1].importers['.'],
+    }
+    const lockfile = {
+      ...current[1],
+      importers,
+    }
+    return mergeLockfileChanges(prev, lockfile)
+  }, EMPTY_LOCKFILE)
+  const rootLockfile = lockfiles['.']
+  if (!rootLockfile) {
+    throw Error('Can\'t find the root lockfiles')
+  } else {
+    return {
+      ...pickLockfileInfo(rootLockfile),
+      ...newLockfile,
+    }
+  }
+}

--- a/lockfile/split-lockfile/src/splitLockfile.ts
+++ b/lockfile/split-lockfile/src/splitLockfile.ts
@@ -1,0 +1,58 @@
+import type { Lockfile } from '@pnpm/lockfile-types'
+import type { LockfileWalkerStep } from '@pnpm/lockfile-walker'
+import { lockfileWalkerGroupImporterSteps } from '@pnpm/lockfile-walker'
+import { pickLockfileInfo } from './utils'
+
+export function splitLockfile (lockfile: Lockfile): Record<string, Lockfile> {
+  const importerIds = Object.keys(lockfile.importers)
+  if (importerIds.length === 1) {
+    return {
+      '.': lockfile,
+    }
+  }
+  const walkers = lockfileWalkerGroupImporterSteps(lockfile, importerIds)
+  const entires: Array<[string, Lockfile]> = walkers.map(({ importerId, step }) => {
+    const newLockfile = walk(importerId, lockfile, step)
+    if (importerId === '.') {
+      return [importerId, {
+        ...newLockfile,
+        ...pickLockfileInfo(lockfile),
+      }]
+    } else {
+      return [importerId, newLockfile]
+    }
+  })
+
+  return Object.fromEntries(entires)
+}
+
+function walk (importerId: string, lockfile: Lockfile, firstStep: LockfileWalkerStep): Lockfile {
+  const importers = lockfile.importers[importerId]
+  const newLockfile: Lockfile = {
+    importers: {
+      '.': importers,
+    },
+    packages: {},
+    lockfileVersion: lockfile.lockfileVersion,
+  }
+
+  dfs(newLockfile, firstStep)
+
+  if (newLockfile.packages && Object.keys(newLockfile.packages).length === 0) {
+    delete newLockfile.packages
+  }
+
+  return newLockfile
+
+  function dfs (newLockfile: Lockfile, step: LockfileWalkerStep) {
+    step.dependencies.forEach(dep => {
+      if (!newLockfile.packages) {
+        throw Error('unreachable')
+      }
+      if (!newLockfile.packages[dep.depPath]) {
+        newLockfile.packages[dep.depPath] = dep.pkgSnapshot
+        dfs(newLockfile, dep.next())
+      }
+    })
+  }
+}

--- a/lockfile/split-lockfile/src/utils.ts
+++ b/lockfile/split-lockfile/src/utils.ts
@@ -1,0 +1,26 @@
+import { Lockfile } from '@pnpm/lockfile-types'
+
+type Info = Omit<Lockfile, 'importers' | 'lockfileVersion' | 'packages'>
+function del (info: Info, property: keyof Info) {
+  if (typeof info[property] === 'undefined') {
+    delete info[property]
+  }
+}
+
+export function pickLockfileInfo (lockfile: Lockfile): Info {
+  const info = {
+    neverBuiltDependencies: lockfile.neverBuiltDependencies,
+    onlyBuiltDependencies: lockfile.onlyBuiltDependencies,
+    overrides: lockfile.overrides,
+    patchedDependencies: lockfile.patchedDependencies,
+    time: lockfile.time,
+    packageExtensionsChecksum: lockfile.packageExtensionsChecksum,
+  }
+  del(info, 'neverBuiltDependencies')
+  del(info, 'onlyBuiltDependencies')
+  del(info, 'overrides')
+  del(info, 'patchedDependencies')
+  del(info, 'time')
+  del(info, 'packageExtensionsChecksum')
+  return info
+}

--- a/lockfile/split-lockfile/test/__snapshots__/splitLockfile.test.ts.snap
+++ b/lockfile/split-lockfile/test/__snapshots__/splitLockfile.test.ts.snap
@@ -1,0 +1,222 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`splitLockfile() should add info in root lockfile: packages/root 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": undefined,
+      "devDependencies": undefined,
+      "optionalDependencies": undefined,
+      "specifiers": {},
+    },
+  },
+  "lockfileVersion": "6.0",
+  "overrides": {
+    "@babel/core": "7.20.0",
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v5.4: packages/a 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "is-positive": "1.0.0",
+      },
+      "specifiers": {
+        "is-positive": "1.0.0",
+      },
+    },
+  },
+  "lockfileVersion": 5.4,
+  "packages": {
+    "/is-positive/1.0.0": {
+      "dev": false,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v5.4: packages/b 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "@t/a": "link:../a",
+        "is-positive": "1.0.0",
+      },
+      "devDependencies": {
+        "is-negative": "1.0.0",
+      },
+      "specifiers": {
+        "@t/a": "workspace:*",
+        "is-negative": "1.0.0",
+        "is-positive": "1.0.0",
+      },
+    },
+  },
+  "lockfileVersion": 5.4,
+  "packages": {
+    "/is-negative/1.0.0": {
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v5.4: packages/c 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "is-negative": "1.0.1",
+      },
+      "specifiers": {
+        "is-negative": "1.0.1",
+      },
+    },
+  },
+  "lockfileVersion": 5.4,
+  "packages": {
+    "/is-negative/1.0.1": {
+      "dev": false,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v5.4: packages/root 1`] = `
+{
+  "importers": {
+    ".": {
+      "specifiers": {},
+    },
+  },
+  "lockfileVersion": 5.4,
+}
+`;
+
+exports[`splitLockfile() should works for v6: packages/a 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "is-positive": "1.0.0",
+      },
+      "devDependencies": undefined,
+      "optionalDependencies": undefined,
+      "specifiers": {
+        "is-positive": "1.0.0",
+      },
+    },
+  },
+  "lockfileVersion": "6.0",
+  "packages": {
+    "/is-positive/1.0.0": {
+      "dev": false,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v6: packages/b 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "@t/a": "link:../a",
+        "is-positive": "1.0.0",
+      },
+      "devDependencies": {
+        "is-negative": "1.0.0",
+      },
+      "optionalDependencies": undefined,
+      "specifiers": {
+        "@t/a": "workspace:*",
+        "is-negative": "1.0.0",
+        "is-positive": "1.0.0",
+      },
+    },
+  },
+  "lockfileVersion": "6.0",
+  "packages": {
+    "/is-negative/1.0.0": {
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v6: packages/c 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": {
+        "is-negative": "1.0.1",
+      },
+      "devDependencies": undefined,
+      "optionalDependencies": undefined,
+      "specifiers": {
+        "is-negative": "1.0.1",
+      },
+    },
+  },
+  "lockfileVersion": "6.0",
+  "packages": {
+    "/is-negative/1.0.1": {
+      "dev": false,
+      "engines": {
+        "node": ">=0.10.0",
+      },
+      "resolution": {
+        "integrity": "sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==",
+      },
+    },
+  },
+}
+`;
+
+exports[`splitLockfile() should works for v6: packages/root 1`] = `
+{
+  "importers": {
+    ".": {
+      "dependencies": undefined,
+      "devDependencies": undefined,
+      "optionalDependencies": undefined,
+      "specifiers": {},
+    },
+  },
+  "lockfileVersion": "6.0",
+}
+`;

--- a/lockfile/split-lockfile/test/fixture/info/pnpm-lock.yaml
+++ b/lockfile/split-lockfile/test/fixture/info/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '6.0'
+
+overrides:
+  '@babel/core': 7.20.0
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
+
+  packages/b:
+    dependencies:
+      '@t/a':
+        specifier: workspace:*
+        version: link:../a
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
+    devDependencies:
+      is-negative:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  /is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-positive@1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/lockfile/split-lockfile/test/fixture/single-import/pnpm-lock.yaml
+++ b/lockfile/split-lockfile/test/fixture/single-import/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '6.0'
+
+dependencies:
+  is-positive:
+    specifier: 1.0.0
+    version: 1.0.0
+
+devDependencies:
+  is-negative:
+    specifier: 1.0.0
+    version: 1.0.0
+
+packages:
+
+  /is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-positive@1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/lockfile/split-lockfile/test/fixture/v5.4/pnpm-lock.yaml
+++ b/lockfile/split-lockfile/test/fixture/v5.4/pnpm-lock.yaml
@@ -1,0 +1,46 @@
+lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers: {}
+
+  packages/a:
+    specifiers:
+      is-positive: 1.0.0
+    dependencies:
+      is-positive: 1.0.0
+
+  packages/b:
+    specifiers:
+      '@t/a': workspace:*
+      is-negative: 1.0.0
+      is-positive: 1.0.0
+    dependencies:
+      '@t/a': link:../a
+      is-positive: 1.0.0
+    devDependencies:
+      is-negative: 1.0.0
+
+  packages/c:
+    specifiers:
+      is-negative: 1.0.1
+    dependencies:
+      is-negative: 1.0.1
+
+packages:
+
+  /is-negative/1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-negative/1.0.1:
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-positive/1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/lockfile/split-lockfile/test/fixture/v6/pnpm-lock.yaml
+++ b/lockfile/split-lockfile/test/fixture/v6/pnpm-lock.yaml
@@ -1,0 +1,47 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
+
+  packages/b:
+    dependencies:
+      '@t/a':
+        specifier: workspace:*
+        version: link:../a
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
+    devDependencies:
+      is-negative:
+        specifier: 1.0.0
+        version: 1.0.0
+
+  packages/c:
+    dependencies:
+      is-negative:
+        specifier: 1.0.1
+        version: 1.0.1
+
+packages:
+
+  /is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-negative@1.0.1:
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-positive@1.0.0:
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
+    engines: {node: '>=0.10.0'}
+    dev: false

--- a/lockfile/split-lockfile/test/mergeSplittedLockfiles.test.ts
+++ b/lockfile/split-lockfile/test/mergeSplittedLockfiles.test.ts
@@ -1,0 +1,49 @@
+import { Lockfile } from '@pnpm/lockfile-types'
+import { isEmpty } from 'ramda'
+import { mergeSplittedLockfiles, splitLockfile } from '@pnpm/split-lockfile'
+import path from 'path'
+import { loadLockfile } from './utils'
+import { writeWantedLockfile } from '@pnpm/lockfile-file'
+import fs from 'fs'
+import tempy from 'tempy'
+
+function isEmptyLockfile (lockfile: Lockfile) {
+  return Object.values(lockfile.importers).every((importer) => isEmpty(importer.specifiers ?? {}) && isEmpty(importer.dependencies ?? {}))
+}
+
+test('mergeLockfile() should works for empty', async () => {
+  const lockfile = mergeSplittedLockfiles({})
+  expect(isEmptyLockfile(lockfile)).toBeTruthy()
+})
+
+test('mergeLockfile() should throw Error when it doesn\'t container root lockfile', async () => {
+  const lockfile = {
+    a: {
+      importers: {},
+      lockfileVersion: '5.4',
+    },
+  }
+  expect(() => mergeSplittedLockfiles(lockfile)).toThrowError()
+})
+
+function resolveLockfilePath (dir: string): string {
+  return path.resolve(dir, 'pnpm-lock.yaml')
+}
+
+describe('mergeLockfile should generate same data', () => {
+  const fixture = path.resolve(__dirname, './fixture')
+  const list = fs.readdirSync(fixture)
+  list.forEach((item) => {
+    const pkgPath = path.resolve(fixture, item)
+    test(`${pkgPath} should works`, async () => {
+      const lockfile = await loadLockfile(pkgPath)
+      const splitted = splitLockfile(lockfile)
+      const merged = mergeSplittedLockfiles(splitted)
+      const tempPath = tempy.directory()
+      await writeWantedLockfile(tempPath, merged)
+      const raw = (await fs.promises.readFile(resolveLockfilePath(pkgPath))).toString('utf-8')
+      const actual = (await fs.promises.readFile(resolveLockfilePath(tempPath))).toString('utf-8')
+      expect(actual).toBe(raw)
+    })
+  })
+})

--- a/lockfile/split-lockfile/test/splitLockfile.test.ts
+++ b/lockfile/split-lockfile/test/splitLockfile.test.ts
@@ -1,0 +1,37 @@
+import path from 'path'
+import { splitLockfile } from '@pnpm/split-lockfile'
+import { loadLockfile } from './utils'
+
+test('splitLockfile() should works for single importer', async () => {
+  const lockfile = await loadLockfile(path.resolve(__dirname, './fixture/single-import'))
+  const result = splitLockfile(lockfile)
+  expect(Object.keys(result).length).toBe(1)
+  expect(result['.']).toStrictEqual(lockfile)
+})
+
+test('splitLockfile() should works for v5.4', async () => {
+  const lockfile = await loadLockfile(path.resolve(__dirname, './fixture/v5.4'))
+  const result = splitLockfile(lockfile)
+  expect(Object.keys(result).length).toBe(4)
+  expect(result['.']).toMatchSnapshot('packages/root')
+  expect(result['packages/a']).toMatchSnapshot('packages/a')
+  expect(result['packages/b']).toMatchSnapshot('packages/b')
+  expect(result['packages/c']).toMatchSnapshot('packages/c')
+})
+
+test('splitLockfile() should works for v6', async () => {
+  const lockfile = await loadLockfile(path.resolve(__dirname, './fixture/v6'))
+  const result = splitLockfile(lockfile)
+  expect(Object.keys(result).length).toBe(4)
+  expect(result['.']).toMatchSnapshot('packages/root')
+  expect(result['packages/a']).toMatchSnapshot('packages/a')
+  expect(result['packages/b']).toMatchSnapshot('packages/b')
+  expect(result['packages/c']).toMatchSnapshot('packages/c')
+})
+
+test('splitLockfile() should add info in root lockfile', async () => {
+  const lockfile = await loadLockfile(path.resolve(__dirname, './fixture/info'))
+  const result = splitLockfile(lockfile)
+  expect(Object.keys(result).length).toBe(3)
+  expect(result['.']).toMatchSnapshot('packages/root')
+})

--- a/lockfile/split-lockfile/test/utils.ts
+++ b/lockfile/split-lockfile/test/utils.ts
@@ -1,0 +1,13 @@
+import { readWantedLockfile } from '@pnpm/lockfile-file'
+import type { Lockfile } from '@pnpm/lockfile-types'
+
+export async function loadLockfile (pkgPath: string): Promise<Lockfile> {
+  const lockfile = await readWantedLockfile(pkgPath, {
+    ignoreIncompatible: false,
+  })
+  if (!lockfile) {
+    throw Error('should lockfile successfully')
+  } else {
+    return lockfile
+  }
+}

--- a/lockfile/split-lockfile/tsconfig.json
+++ b/lockfile/split-lockfile/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../packages/types"
+    },
+    {
+      "path": "../lockfile-file"
+    },
+    {
+      "path": "../lockfile-types"
+    },
+    {
+      "path": "../lockfile-walker"
+    },
+    {
+      "path": "../merge-lockfile-changes"
+    }
+  ],
+  "composite": true
+}

--- a/lockfile/split-lockfile/tsconfig.lint.json
+++ b/lockfile/split-lockfile/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -43,6 +43,7 @@
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
+    "@pnpm/split-lockfile": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@zkochan/rimraf": "^2.1.2",
     "ci-info": "^3.7.1",

--- a/pkg-manager/get-context/tsconfig.json
+++ b/pkg-manager/get-context/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../lockfile/lockfile-file"
     },
     {
+      "path": "../../lockfile/split-lockfile"
+    },
+    {
       "path": "../../packages/constants"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2077,6 +2077,37 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
 
+  lockfile/split-lockfile:
+    dependencies:
+      '@pnpm/lockfile-file':
+        specifier: workspace:*
+        version: link:../lockfile-file
+      '@pnpm/lockfile-types':
+        specifier: workspace:*
+        version: link:../lockfile-types
+      '@pnpm/lockfile-walker':
+        specifier: workspace:*
+        version: link:../lockfile-walker
+      '@pnpm/merge-lockfile-changes':
+        specifier: workspace:*
+        version: link:../merge-lockfile-changes
+      '@pnpm/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+    devDependencies:
+      '@pnpm/split-lockfile':
+        specifier: workspace:*
+        version: 'link:'
+      '@types/ramda':
+        specifier: 0.28.20
+        version: 0.28.20
+      ramda:
+        specifier: npm:@pnpm/ramda@0.28.1
+        version: /@pnpm/ramda@0.28.1
+      tempy:
+        specifier: ^1.0.1
+        version: 1.0.1
+
   network/auth-header:
     dependencies:
       '@pnpm/error':
@@ -2879,6 +2910,9 @@ importers:
       '@pnpm/read-projects-context':
         specifier: workspace:*
         version: link:../read-projects-context
+      '@pnpm/split-lockfile':
+        specifier: workspace:*
+        version: link:../../lockfile/split-lockfile
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -7003,14 +7037,14 @@ packages:
       '@jest/test-result': 29.4.1
       '@jest/transform': 29.4.1(@babel/types@7.20.7)
       '@jest/types': 29.4.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.4.0
-      jest-config: 29.4.1(@babel/types@7.20.7)(@types/node@14.18.36)(ts-node@10.9.1)
+      jest-config: 29.4.1(@babel/types@7.20.7)(@types/node@18.11.18)(ts-node@10.9.1)
       jest-haste-map: 29.4.1
       jest-message-util: 29.4.1
       jest-regex-util: 29.2.0
@@ -7188,7 +7222,7 @@ packages:
       '@jest/schemas': 29.4.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -12920,6 +12954,47 @@ packages:
       - supports-color
     dev: true
 
+  /jest-config@29.4.1(@babel/types@7.20.7)(@types/node@18.11.18)(ts-node@10.9.1):
+    resolution: {integrity: sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      '@jest/test-sequencer': 29.4.1
+      '@jest/types': 29.4.1
+      '@types/node': 18.11.18
+      babel-jest: 29.4.1(@babel/core@7.20.12)(@babel/types@7.20.7)
+      chalk: 4.1.2
+      ci-info: 3.7.1
+      deepmerge: 4.3.0
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 29.4.1(@babel/types@7.20.7)
+      jest-environment-node: 29.4.1
+      jest-get-type: 29.2.0
+      jest-regex-util: 29.2.0
+      jest-resolve: 29.4.1
+      jest-runner: 29.4.1(@babel/types@7.20.7)
+      jest-util: 29.4.1
+      jest-validate: 29.4.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1(@types/node@14.18.36)(typescript@4.9.4)
+    transitivePeerDependencies:
+      - '@babel/types'
+      - supports-color
+    dev: true
+
   /jest-diff@29.4.1:
     resolution: {integrity: sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -13167,7 +13242,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10


### PR DESCRIPTION
This PR attempts to add a library called `@pnpm/split-lockfile` which:

- [splitLockfile](https://github.com/pnpm/pnpm/pull/6046/files#diff-951fa978b9bcd6d685936d48334affb2cfb966add8c9a2161aadd899769bcfd9R6): A single lockfile can be split into multiple according to importers. [test cases](https://github.com/pnpm/pnpm/pull/6046/files#diff-bb0d301f5b6fe464fea42949d4a82d37b6ca3eda31f458d237dfee5250a781fbR5)
- [mergeSplittedLockfiles](https://github.com/pnpm/pnpm/pull/6046/files#diff-99775276547637b4e5d3ce4f8e13dbdc404513a9a20a8075dcfe9a6da1f3b1a2R8): merge splitted lockfiles into one. [test cases](https://github.com/pnpm/pnpm/pull/6046/files#diff-4c5ade72bb012a59b9281a9470095e8aaaa73bf5e0af63e25a7d8e8c7e27e8cdR19)