### PR TITLE
fix: replace version number for namespaced workspace packages

### DIFF
--- a/.changeset/hip-lamps-attend.md
+++ b/.changeset/hip-lamps-attend.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exportable-manifest": patch
+"@pnpm/prepare": patch
+---
+
+Fix version number replacing for namespaced workspace packages

--- a/.changeset/hip-lamps-attend.md
+++ b/.changeset/hip-lamps-attend.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/exportable-manifest": patch
 "@pnpm/prepare": patch
+"pnpm": patch
 ---
 
-Fix version number replacing for namespaced workspace packages
+Fix version number replacing for namespaced workspace packages. `workspace:@foo/bar@*` should be replaced with `npm:@foo/bar@<version>` on publish [#6052](https://github.com/pnpm/pnpm/pull/6052).

--- a/__utils__/prepare/src/index.ts
+++ b/__utils__/prepare/src/index.ts
@@ -44,6 +44,7 @@ export function preparePackages (
 
   const dirname = path.dirname(pkgTmpPath)
   const result: { [name: string]: Project } = {}
+  const cwd = process.cwd()
   for (const aPkg of pkgs) {
     if (typeof (aPkg as LocationAndManifest).location === 'string') {
       result[(aPkg as LocationAndManifest).package.name!] = prepare((aPkg as LocationAndManifest).package, {
@@ -57,7 +58,7 @@ export function preparePackages (
       })
     }
   }
-  process.chdir('..')
+  process.chdir(cwd)
   return result
 }
 

--- a/pkg-manager/core/test/install/local.ts
+++ b/pkg-manager/core/test/install/local.ts
@@ -272,7 +272,7 @@ test('deep local', async () => {
       },
     },
   ])
-  process.chdir('../project-1')
+  process.chdir('project-1')
   await install(manifest1, await testDefaults())
 
   const lockfile = await readYamlFile<Lockfile>('pnpm-lock.yaml')

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -30,7 +30,11 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/pkg-manifest/exportable-manifest#readme",
   "devDependencies": {
     "@pnpm/exportable-manifest": "workspace:*",
-    "@types/ramda": "0.28.20"
+    "@pnpm/prepare": "workspace:*",
+    "@types/cross-spawn": "^6.0.2",
+    "@types/ramda": "0.28.20",
+    "cross-spawn": "^7.0.3",
+    "write-yaml-file": "^4.2.0"
   },
   "dependencies": {
     "@pnpm/error": "workspace:*",

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -64,7 +64,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   }
 
   // Dependencies with bare "*", "^" and "~" versions
-  const versionAliasSpecParts = /^workspace:([^@]+@)?([\^~*])$/.exec(depSpec)
+  const versionAliasSpecParts = /^workspace:(@?.*?)@?([\^~*])$/.exec(depSpec)
   if (versionAliasSpecParts != null) {
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const { manifest } = await tryReadProjectManifest(path.join(modulesDir, depName))

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -64,7 +64,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   }
 
   // Dependencies with bare "*", "^" and "~" versions
-  const versionAliasSpecParts = /^workspace:(@?.*?)@?([\^~*])$/.exec(depSpec)
+  const versionAliasSpecParts = /^workspace:(.*?)@?([\^~*])$/.exec(depSpec)
   if (versionAliasSpecParts != null) {
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const { manifest } = await tryReadProjectManifest(path.join(modulesDir, depName))

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -70,8 +70,9 @@ test('workspace deps are replaced', async () => {
     version: '1.0.0',
 
     dependencies: {
-      baz: 'workspace:baz@^',
       bar: 'workspace:@foo/bar@*',
+      baz: 'workspace:baz@^',
+      foo: 'workspace:*',
     },
   }
 
@@ -84,6 +85,10 @@ test('workspace deps are replaced', async () => {
     {
       name: '@foo/bar',
       version: '3.2.1',
+    },
+    {
+      name: 'foo',
+      version: '4.5.6',
     },
   ])
 
@@ -99,6 +104,7 @@ test('workspace deps are replaced', async () => {
     dependencies: {
       bar: 'npm:@foo/bar@3.2.1',
       baz: '^1.2.3',
+      foo: '4.5.6',
     },
   })
 })

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -1,5 +1,12 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import { createExportableManifest } from '@pnpm/exportable-manifest'
+import { preparePackages } from '@pnpm/prepare'
+import writeYamlFile from 'write-yaml-file'
+import { ProjectManifest } from '@pnpm/types'
+import crossSpawn from 'cross-spawn'
+import path from 'path'
+
+const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
 
 test('the pnpm options are removed', async () => {
   expect(await createExportableManifest(process.cwd(), {
@@ -54,5 +61,44 @@ test('readme added to published manifest', async () => {
     name: 'foo',
     version: '1.0.0',
     readme: 'readme content',
+  })
+})
+
+test('workspace deps are replaced', async () => {
+  const workspaceProtocolPackageManifest: ProjectManifest = {
+    name: 'workspace-protocol-package',
+    version: '1.0.0',
+
+    dependencies: {
+      baz: 'workspace:baz@^',
+      bar: 'workspace:@foo/bar@*',
+    },
+  }
+
+  preparePackages([
+    workspaceProtocolPackageManifest,
+    {
+      name: 'baz',
+      version: '1.2.3',
+    },
+    {
+      name: '@foo/bar',
+      version: '3.2.1',
+    },
+  ])
+
+  await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  crossSpawn.sync(pnpmBin, ['install', '--store-dir=store'])
+
+  process.chdir('workspace-protocol-package')
+
+  expect(await createExportableManifest(process.cwd(), workspaceProtocolPackageManifest)).toStrictEqual({
+    name: 'workspace-protocol-package',
+    version: '1.0.0',
+    dependencies: {
+      bar: 'npm:@foo/bar@3.2.1',
+      baz: '^1.2.3',
+    },
   })
 })

--- a/pkg-manifest/exportable-manifest/tsconfig.json
+++ b/pkg-manifest/exportable-manifest/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../__utils__/prepare"
+    },
+    {
       "path": "../../packages/error"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3841,9 +3841,21 @@ importers:
       '@pnpm/exportable-manifest':
         specifier: workspace:*
         version: 'link:'
+      '@pnpm/prepare':
+        specifier: workspace:*
+        version: link:../../__utils__/prepare
+      '@types/cross-spawn':
+        specifier: ^6.0.2
+        version: 6.0.2
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
+      cross-spawn:
+        specifier: ^7.0.3
+        version: 7.0.3
+      write-yaml-file:
+        specifier: ^4.2.0
+        version: 4.2.0
 
   pkg-manifest/manifest-utils:
     dependencies:
@@ -7003,14 +7015,14 @@ packages:
       '@jest/test-result': 29.4.1
       '@jest/transform': 29.4.1(@babel/types@7.20.7)
       '@jest/types': 29.4.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.7.1
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.4.0
-      jest-config: 29.4.1(@babel/types@7.20.7)(@types/node@14.18.36)(ts-node@10.9.1)
+      jest-config: 29.4.1(@babel/types@7.20.7)(@types/node@18.11.18)(ts-node@10.9.1)
       jest-haste-map: 29.4.1
       jest-message-util: 29.4.1
       jest-regex-util: 29.2.0
@@ -7188,7 +7200,7 @@ packages:
       '@jest/schemas': 29.4.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/yargs': 17.0.22
       chalk: 4.1.2
     dev: true
@@ -12920,6 +12932,47 @@ packages:
       - supports-color
     dev: true
 
+  /jest-config@29.4.1(@babel/types@7.20.7)(@types/node@18.11.18)(ts-node@10.9.1):
+    resolution: {integrity: sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      '@jest/test-sequencer': 29.4.1
+      '@jest/types': 29.4.1
+      '@types/node': 18.11.18
+      babel-jest: 29.4.1(@babel/core@7.20.12)(@babel/types@7.20.7)
+      chalk: 4.1.2
+      ci-info: 3.7.1
+      deepmerge: 4.3.0
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 29.4.1(@babel/types@7.20.7)
+      jest-environment-node: 29.4.1
+      jest-get-type: 29.2.0
+      jest-regex-util: 29.2.0
+      jest-resolve: 29.4.1
+      jest-runner: 29.4.1(@babel/types@7.20.7)
+      jest-util: 29.4.1
+      jest-validate: 29.4.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1(@types/node@14.18.36)(typescript@4.9.4)
+    transitivePeerDependencies:
+      - '@babel/types'
+      - supports-color
+    dev: true
+
   /jest-diff@29.4.1:
     resolution: {integrity: sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -13167,7 +13220,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.4.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       chalk: 4.1.2
       ci-info: 3.7.1
       graceful-fs: 4.2.10

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -952,8 +952,6 @@ test("shared-workspace-lockfile: don't install dependencies in projects that are
     },
   ])
 
-  process.chdir('..')
-
   await symlink('workspace-2/package-2', 'workspace-1/package-2')
 
   await writeYamlFile('workspace-1/pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
@@ -1031,8 +1029,6 @@ test('shared-workspace-lockfile: install dependencies in projects that are relat
       },
     },
   ])
-
-  process.chdir('..')
 
   await writeYamlFile('monorepo/workspace/pnpm-workspace.yaml', { packages: ['../**', '!store/**'] })
 
@@ -1596,7 +1592,6 @@ test('legacy directory filtering', async () => {
     },
   ])
 
-  process.chdir('..')
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
   await fs.writeFile('.npmrc', 'legacy-dir-filtering=true', 'utf8')
 
@@ -1624,7 +1619,6 @@ test('directory filtering', async () => {
     },
   ])
 
-  process.chdir('..')
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
 
   {
@@ -1671,7 +1665,6 @@ test('run --stream should prefix with dir name', async () => {
     },
   ])
 
-  process.chdir('..')
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
 
   const result = execPnpmSync([

--- a/pnpm/test/recursive/misc.ts
+++ b/pnpm/test/recursive/misc.ts
@@ -78,9 +78,9 @@ test('workspace .npmrc is always read', async () => {
   const storeDir = path.resolve('../store')
   await fs.writeFile('pnpm-workspace.yaml', '', 'utf8')
   await fs.writeFile('.npmrc', 'shamefully-flatten = true\nshared-workspace-lockfile=false', 'utf8')
-  await fs.writeFile('project-2/.npmrc', 'hoist=false', 'utf8')
+  await fs.writeFile('workspace/project-2/.npmrc', 'hoist=false', 'utf8')
 
-  process.chdir('project-1')
+  process.chdir('workspace/project-1')
   await execPnpm(['install', '--store-dir', storeDir, '--filter', '.'])
 
   expect(projects['project-1'].requireModule('is-positive')).toBeTruthy()
@@ -314,6 +314,7 @@ test('recursive command with filter from config', async () => {
     },
   ])
 
+  await fs.writeFile('package.json', '{}', 'utf8')
   await fs.writeFile('.npmrc', 'filter=project-1 project-2', 'utf8')
   await execPnpm(['recursive', 'install'])
 
@@ -457,6 +458,7 @@ test('set recursive-install to false in .npmrc would disable recursive install i
     },
   ])
 
+  process.chdir('workspace')
   await fs.writeFile('pnpm-workspace.yaml', '', 'utf8')
   await fs.writeFile('.npmrc', 'recursive-install = false', 'utf8')
 
@@ -493,6 +495,7 @@ test('set recursive-install to false would install as --filter {.}...', async ()
     },
   ])
 
+  process.chdir('workspace')
   await fs.writeFile('pnpm-workspace.yaml', '', 'utf8')
   await fs.writeFile('.npmrc', 'recursive-install = false', 'utf8')
 


### PR DESCRIPTION
Without this patch `workspace:@foo/bar@*` is replaced by `npm:@foo/bar@*` on publish, i.e. the `*` is not replaced by the actual version number from `@foo/bar`'s `package.json`.