### PR TITLE
docs: add `store path` description to cli help

### DIFF
--- a/.changeset/happy-dolphins-wave.md
+++ b/.changeset/happy-dolphins-wave.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Add `store path` description to the `pnpm` cli help.

--- a/pnpm/src/cmd/help.ts
+++ b/pnpm/src/cmd/help.ts
@@ -143,6 +143,10 @@ function getHelpText () {
             name: 'store add',
           },
           {
+            description: 'Prints the path to the active store directory',
+            name: 'store path',
+          },
+          {
             description: 'Removes unreferenced (extraneous, orphan) packages from the store',
             name: 'store prune',
           },


### PR DESCRIPTION
Add the `store path` command to the help of the CLI (`pnpm --help`).

### Before

```
...

Manage your store:
      store add            Adds new packages to the pnpm store directly. Does not modify any projects or files outside the store
      store prune          Removes unreferenced (extraneous, orphan) packages from the store
      store status         Checks for modified packages in the store

...
```

### After

```
...

Manage your store:
      store add            Adds new packages to the pnpm store directly. Does not modify any projects or files outside the store
      store path           Prints the path to the active store directory
      store prune          Removes unreferenced (extraneous, orphan) packages from the store
      store status         Checks for modified packages in the store

...
```