### PR TITLE
refactor(core): rename lockfileIsUpToDate to lockfileIsNotUpToDate

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -286,7 +286,7 @@ export async function mutateModules (
       opts.useLockfileV6 = ctx.wantedLockfile.lockfileVersion.toString().startsWith('6.')
     }
     let needsFullResolution = !maybeOpts.ignorePackageManifest &&
-      lockfileIsUpToDate(ctx.wantedLockfile, {
+      lockfileIsNotUpToDate(ctx.wantedLockfile, {
         overrides: opts.overrides,
         neverBuiltDependencies: opts.neverBuiltDependencies,
         onlyBuiltDependencies: opts.onlyBuiltDependencies,
@@ -585,7 +585,7 @@ async function calcPatchHashes (patches: Record<string, string>, lockfileDir: st
   }, patches)
 }
 
-function lockfileIsUpToDate (
+function lockfileIsNotUpToDate (
   lockfile: Lockfile,
   {
     neverBuiltDependencies,


### PR DESCRIPTION
Putting up a minor PR to address something that confused me as I was reading through pnpm source code.

I think there's a typo in the name of the internal `lockfileIsUpToDate` function in the `core` package. It checks if the lockfile is _not_ up to date.

https://github.com/pnpm/pnpm/blob/977caa7d7c9fb5809aa8b57270d03ead8f1e0175/pkg-manager/core/src/install/index.ts#L588-L607

The usage of this function seems to match the idea that it currently checks if the lock file is not up to date. The `needsFullResolution` variable should be `true` when `!maybeOpts.ignorePackageManifest && lockfileNotIsUpToDate(...)`

https://github.com/pnpm/pnpm/blob/977caa7d7c9fb5809aa8b57270d03ead8f1e0175/pkg-manager/core/src/install/index.ts#L288-L297