### PR TITLE
feat(publish): allow "pnpm" settings in manifest

### DIFF
--- a/.changeset/perfect-hornets-act.md
+++ b/.changeset/perfect-hornets-act.md
@@ -1,0 +1,5 @@
+---
+'@pnpm/exportable-manifest': minor
+---
+
+Allow the "pnpm" property to be included in the published manifest.

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -25,7 +25,7 @@ export async function createExportableManifest (
   originalManifest: ProjectManifest,
   opts?: MakePublishManifestOptions
 ) {
-  const publishManifest: ProjectManifest = omit(['pnpm', 'scripts'], originalManifest)
+  const publishManifest: ProjectManifest = omit(['scripts'], originalManifest)
   if (originalManifest.scripts != null) {
     publishManifest.scripts = omit(PREPUBLISH_SCRIPTS, originalManifest.scripts)
   }

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -8,27 +8,6 @@ import path from 'path'
 
 const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
 
-test('the pnpm options are removed', async () => {
-  expect(await createExportableManifest(process.cwd(), {
-    name: 'foo',
-    version: '1.0.0',
-    dependencies: {
-      qar: '2',
-    },
-    pnpm: {
-      overrides: {
-        bar: '1',
-      },
-    },
-  })).toStrictEqual({
-    name: 'foo',
-    version: '1.0.0',
-    dependencies: {
-      qar: '2',
-    },
-  })
-})
-
 test('publish lifecycle scripts are removed', async () => {
   expect(await createExportableManifest(process.cwd(), {
     name: 'foo',


### PR DESCRIPTION
This pull request enables the `pnpm` property to be included in the published package.json.

My main use case for doing so is so that `pnpm.peerDependencyRules.ignoreMissing` can be included to silence warnings and achieve feature parity with npm `peerDependenciesMeta.<pkg>.optional` which pnpm doesn't honor.

I can't think of a reason why it **shouldn't** be left up to the package author to decide which source properties to remove, if any. There are third party tools that handle this, for example, [clean-pkg-json](https://github.com/privatenumber/clean-pkg-json), but currently no way I could find to opt out. 

closes https://github.com/pnpm/pnpm/issues/6060