### PR TITLE
feat: add `parent>child` selector syntax to allowedVersions for peer dependency override capability

### DIFF
--- a/.changeset/large-turkeys-hope.md
+++ b/.changeset/large-turkeys-hope.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+---
+
+Extends the `pnpm.peerDependencyRules.allowedVersions` package.json option to support the
+`parent>child` selector syntax. This syntax allows for overriding specific peerDependencies.

--- a/.changeset/large-turkeys-hope.md
+++ b/.changeset/large-turkeys-hope.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/hooks.read-package-hook": patch
+"@pnpm/hooks.read-package-hook": minor
+"pnpm": minor
 ---
 
-Extends the `pnpm.peerDependencyRules.allowedVersions` package.json option to support the
-`parent>child` selector syntax. This syntax allows for overriding specific peerDependencies.
+Extends the `pnpm.peerDependencyRules.allowedVersions` `package.json` option to support the `parent>child` selector syntax. This syntax allows for extending specific `peerDependencies` [#6108](https://github.com/pnpm/pnpm/pull/6108).

--- a/config/parse-overrides/src/index.ts
+++ b/config/parse-overrides/src/index.ts
@@ -3,7 +3,7 @@ import { parseWantedDependency } from '@pnpm/parse-wanted-dependency'
 
 const DELIMITER_REGEX = /[^ |@]>/
 
-interface VersionOverride {
+export interface VersionOverride {
   parentPkg?: {
     name: string
     pref?: string

--- a/config/parse-overrides/src/index.ts
+++ b/config/parse-overrides/src/index.ts
@@ -41,7 +41,7 @@ export function parseOverrides (
 function parsePkgSelector (selector: string) {
   const wantedDep = parseWantedDependency(selector)
   if (!wantedDep.alias) {
-    throw new PnpmError('INVALID_OVERRIDE_SELECTOR', `Cannot parse the "${selector}" selector in the overrides`)
+    throw new PnpmError('INVALID_SELECTOR', `Cannot parse the "${selector}" selector`)
   }
   return {
     name: wantedDep.alias,

--- a/config/parse-overrides/test/index.ts
+++ b/config/parse-overrides/test/index.ts
@@ -48,5 +48,5 @@ test.each([
 })
 
 test('parseOverrides() throws an exception on invalid selector', () => {
-  expect(() => parseOverrides({ '%': '2' })).toThrow('Cannot parse the "%" selector in the overrides')
+  expect(() => parseOverrides({ '%': '2' })).toThrow('Cannot parse the "%" selector')
 })

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/hooks/read-package-hook#readme",
   "dependencies": {
+    "@pnpm/error": "workspace:*",
     "@pnpm/matcher": "workspace:*",
     "@pnpm/parse-overrides": "workspace:*",
     "@pnpm/parse-wanted-dependency": "workspace:*",

--- a/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
+++ b/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
@@ -1,6 +1,6 @@
 import semver from 'semver'
 import isEmpty from 'ramda/src/isEmpty'
-import { PeerDependencyRules, ReadPackageHook } from '@pnpm/types'
+import { PeerDependencyRules, ReadPackageHook, PackageManifest, ProjectManifest } from '@pnpm/types'
 import { PnpmError } from '@pnpm/error'
 import { parseOverrides, VersionOverride } from '@pnpm/parse-overrides'
 import { createMatcher } from '@pnpm/matcher'
@@ -13,45 +13,15 @@ export function createPeerDependencyPatcher (
   const ignoreMissingMatcher = createMatcher(ignoreMissingPatterns)
   const allowAnyPatterns = [...new Set(peerDependencyRules.allowAny ?? [])]
   const allowAnyMatcher = createMatcher(allowAnyPatterns)
-
-  let overrides: VersionOverride[]
-  try {
-    overrides = parseOverrides(peerDependencyRules.allowedVersions ?? {})
-  } catch (err) {
-    throw new PnpmError('INVALID_ALLOWED_VERSION_SELECTOR',
-      `${(err as PnpmError).message} in pnpm.peerDependencyRules.allowedVersions`)
-  }
-  const allowedVersionsMatchAll: Record<string, string[]> = {}
-  const overridesByParentPkgName: Record<string, Array<Required<Pick<VersionOverride, 'parentPkg' | 'targetPkg'>> & { ranges: string[] }>> = {}
-  for (const override of overrides) {
-    if (!override.parentPkg) {
-      allowedVersionsMatchAll[override.targetPkg.name] = parseVersions(override.newPref)
-      continue
-    }
-    if (!overridesByParentPkgName[override.parentPkg.name]) {
-      overridesByParentPkgName[override.parentPkg.name] = []
-    }
-    overridesByParentPkgName[override.parentPkg.name].push({
-      parentPkg: override.parentPkg,
-      targetPkg: override.targetPkg,
-      ranges: parseVersions(override.newPref),
-    })
-  }
+  const { allowedVersionsMatchAll, allowedVersionsByParentPkgName } = parseAllowedVersions(peerDependencyRules.allowedVersions ?? {})
+  const _allowedVersionsByParentPkg = allowedVersionsByParentPkg.bind(null, {
+    allowedVersionsMatchAll,
+    allowedVersionsByParentPkgName,
+  })
 
   return ((pkg) => {
     if (isEmpty(pkg.peerDependencies)) return pkg
-    let allowedVersions = allowedVersionsMatchAll
-    if (pkg.name && overridesByParentPkgName[pkg.name]) {
-      allowedVersions = { ...allowedVersions }
-      const pkgVer = pkg.version ?? ''
-      for (const override of overridesByParentPkgName[pkg.name]) {
-        if (!pkg.peerDependencies![override.targetPkg.name]) continue
-        if (!override.parentPkg.pref ||
-          (isSubRange(override.parentPkg.pref, pkgVer) || semver.satisfies(pkgVer, override.parentPkg.pref))) {
-          allowedVersions[override.targetPkg.name] = override.ranges
-        }
-      }
-    }
+    const allowedVersions = _allowedVersionsByParentPkg(pkg)
     for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
       if (
         ignoreMissingMatcher(peerName) &&
@@ -86,6 +56,63 @@ export function createPeerDependencyPatcher (
     }
     return pkg
   }) as ReadPackageHook
+}
+
+type AllowedVersionsByParentPkgName = Record<string, Array<Required<Pick<VersionOverride, 'parentPkg' | 'targetPkg'>> & { ranges: string[] }>>
+
+function parseAllowedVersions (allowedVersions: Record<string, string>) {
+  let overrides: VersionOverride[]
+  try {
+    overrides = parseOverrides(allowedVersions ?? {})
+  } catch (err) {
+    throw new PnpmError('INVALID_ALLOWED_VERSION_SELECTOR',
+      `${(err as PnpmError).message} in pnpm.peerDependencyRules.allowedVersions`)
+  }
+  const allowedVersionsMatchAll: Record<string, string[]> = {}
+  const allowedVersionsByParentPkgName: AllowedVersionsByParentPkgName = {}
+  for (const override of overrides) {
+    if (!override.parentPkg) {
+      allowedVersionsMatchAll[override.targetPkg.name] = parseVersions(override.newPref)
+      continue
+    }
+    if (!allowedVersionsByParentPkgName[override.parentPkg.name]) {
+      allowedVersionsByParentPkgName[override.parentPkg.name] = []
+    }
+    allowedVersionsByParentPkgName[override.parentPkg.name].push({
+      parentPkg: override.parentPkg,
+      targetPkg: override.targetPkg,
+      ranges: parseVersions(override.newPref),
+    })
+  }
+  return {
+    allowedVersionsMatchAll,
+    allowedVersionsByParentPkgName,
+  }
+}
+
+function allowedVersionsByParentPkg (
+  {
+    allowedVersionsMatchAll,
+    allowedVersionsByParentPkgName,
+  }: {
+    allowedVersionsMatchAll: Record<string, string[]>
+    allowedVersionsByParentPkgName: AllowedVersionsByParentPkgName
+  },
+  pkg: PackageManifest | ProjectManifest
+) {
+  let allowedVersions = allowedVersionsMatchAll
+  if (pkg.name && allowedVersionsByParentPkgName[pkg.name]) {
+    allowedVersions = { ...allowedVersions }
+    const pkgVer = pkg.version ?? ''
+    for (const override of allowedVersionsByParentPkgName[pkg.name]) {
+      if (!pkg.peerDependencies![override.targetPkg.name]) continue
+      if (!override.parentPkg.pref ||
+        (isSubRange(override.parentPkg.pref, pkgVer) || semver.satisfies(pkgVer, override.parentPkg.pref))) {
+        allowedVersions[override.targetPkg.name] = override.ranges
+      }
+    }
+  }
+  return allowedVersions
 }
 
 function parseVersions (versions: string): string[] {

--- a/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
+++ b/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
@@ -2,7 +2,7 @@ import semver from 'semver'
 import isEmpty from 'ramda/src/isEmpty'
 import { PeerDependencyRules, ReadPackageHook } from '@pnpm/types'
 import { PnpmError } from '@pnpm/error'
-import { parseOverrides } from '@pnpm/parse-overrides'
+import { parseOverrides, VersionOverride } from '@pnpm/parse-overrides'
 import { createMatcher } from '@pnpm/matcher'
 import { isSubRange } from '.'
 
@@ -14,16 +14,36 @@ export function createPeerDependencyPatcher (
   const allowAnyPatterns = [...new Set(peerDependencyRules.allowAny ?? [])]
   const allowAnyMatcher = createMatcher(allowAnyPatterns)
 
-  let overrides: ReturnType<typeof parseOverrides>
+  let overrides: VersionOverride[]
   try {
     overrides = parseOverrides(peerDependencyRules.allowedVersions ?? {})
-  } catch (e) {
+  } catch (err) {
     throw new PnpmError('INVALID_ALLOWED_VERSION_SELECTOR',
-      `${(e as PnpmError).message} in pnpm.peerDependencyRules.allowedVersions`)
+      `${(err as PnpmError).message} in pnpm.peerDependencyRules.allowedVersions`)
   }
+  const overridesByParentPkgName = overrides.reduce((acc, override) => {
+    if (!override.parentPkg) return acc
+    if (!acc[override.parentPkg.name]) {
+      acc[override.parentPkg.name] = []
+    }
+    acc[override.parentPkg.name].push(override as Required<VersionOverride>)
+    return acc
+  }, {} as Record<string, Array<Required<VersionOverride>>>)
 
   return ((pkg) => {
     if (isEmpty(pkg.peerDependencies)) return pkg
+    let allowedVersionsRaw = peerDependencyRules.allowedVersions ?? {}
+    if (pkg.name && overridesByParentPkgName[pkg.name]) {
+      allowedVersionsRaw = { ...allowedVersionsRaw }
+      const pkgVer = pkg.version ?? ''
+      for (const override of overridesByParentPkgName[pkg.name]) {
+        if (!pkg.peerDependencies![override.targetPkg.name]) continue
+        if (!override.parentPkg.pref ||
+          (isSubRange(override.parentPkg.pref, pkgVer) || semver.satisfies(pkgVer, override.parentPkg.pref))) {
+          allowedVersionsRaw[override.targetPkg.name] = override.newPref
+        }
+      }
+    }
     for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
       if (
         ignoreMissingMatcher(peerName) &&
@@ -46,7 +66,7 @@ export function createPeerDependencyPatcher (
         pkg.peerDependencies![peerName] = '*'
         continue
       }
-      const allowedVersions = parseVersions(peerDependencyRules.allowedVersions[peerName])
+      const allowedVersions = parseVersions(allowedVersionsRaw[peerName])
       const currentVersions = parseVersions(pkg.peerDependencies![peerName])
 
       allowedVersions.forEach(allowedVersion => {
@@ -57,17 +77,6 @@ export function createPeerDependencyPatcher (
 
       pkg.peerDependencies![peerName] = currentVersions.join(' || ')
     }
-
-    const peerDepsOverrides = overrides.filter((override) => override.parentPkg && override.parentPkg.name === pkg.name)
-
-    peerDepsOverrides.forEach(override => {
-      const pkgVer = pkg.version ?? ''
-
-      if (!override.parentPkg!.pref ||
-        (isSubRange(override.parentPkg!.pref, pkgVer) || semver.satisfies(pkgVer, override.parentPkg!.pref))) {
-        pkg.peerDependencies![override.targetPkg.name] = override.newPref
-      }
-    })
 
     return pkg
   }) as ReadPackageHook

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -11,13 +11,7 @@ export function createVersionsOverrider (
   overrides: Record<string, string>,
   rootDir: string
 ): ReadPackageHook {
-  let parsedOverrides: ReturnType<typeof parseOverrides>
-  try {
-    parsedOverrides = parseOverrides(overrides)
-  } catch (e) {
-    throw new PnpmError('INVALID_OVERRIDES_SELECTOR', `${(e as PnpmError).message} in pnpm.overrides`)
-  }
-
+  const parsedOverrides = tryParseOverrides(overrides)
   const [versionOverrides, genericVersionOverrides] = partition(({ parentPkg }) => parentPkg != null,
     parsedOverrides
       .map((override) => {
@@ -46,6 +40,14 @@ export function createVersionsOverrider (
     overrideDepsOfPkg({ manifest, dir }, genericVersionOverrides)
     return manifest
   }) as ReadPackageHook
+}
+
+function tryParseOverrides (overrides: Record<string, string>) {
+  try {
+    return parseOverrides(overrides)
+  } catch (e) {
+    throw new PnpmError('INVALID_OVERRIDES_SELECTOR', `${(e as PnpmError).message} in pnpm.overrides`)
+  }
 }
 
 interface VersionOverride {

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -5,7 +5,7 @@ import { Dependencies, PackageManifest, ReadPackageHook } from '@pnpm/types'
 import { PnpmError } from '@pnpm/error'
 import { parseOverrides } from '@pnpm/parse-overrides'
 import normalizePath from 'normalize-path'
-import { isSubRange } from '.'
+import { isSubRange } from './isSubRange'
 
 export function createVersionsOverrider (
   overrides: Record<string, string>,

--- a/hooks/read-package-hook/src/index.ts
+++ b/hooks/read-package-hook/src/index.ts
@@ -1,11 +1,1 @@
-import semver from 'semver'
-
 export { createReadPackageHook } from './createReadPackageHook'
-
-export function isSubRange (superRange: string | undefined, subRange: string) {
-  return !superRange ||
-  subRange === superRange ||
-  semver.validRange(subRange) != null &&
-  semver.validRange(superRange) != null &&
-  semver.subset(subRange, superRange)
-}

--- a/hooks/read-package-hook/src/index.ts
+++ b/hooks/read-package-hook/src/index.ts
@@ -1,1 +1,11 @@
+import semver from 'semver'
+
 export { createReadPackageHook } from './createReadPackageHook'
+
+export function isSubRange (superRange: string | undefined, subRange: string) {
+  return !superRange ||
+  subRange === superRange ||
+  semver.validRange(subRange) != null &&
+  semver.validRange(superRange) != null &&
+  semver.subset(subRange, superRange)
+}

--- a/hooks/read-package-hook/src/isSubRange.ts
+++ b/hooks/read-package-hook/src/isSubRange.ts
@@ -1,0 +1,9 @@
+import semver from 'semver'
+
+export function isSubRange (superRange: string | undefined, subRange: string) {
+  return !superRange ||
+  subRange === superRange ||
+  semver.validRange(subRange) != null &&
+  semver.validRange(superRange) != null &&
+  semver.subset(subRange, superRange)
+}

--- a/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
+++ b/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
@@ -114,3 +114,64 @@ test('createPeerDependencyPatcher() does not create duplicate extended ranges', 
     nopadding: '15.0.1 || 16 || ^17.0.1 || 18.x',
   })
 })
+
+test('createPeerDependencyPatcher() overrides peerDependencies when parent>child selector is used', () => {
+  const patcher = createPeerDependencyPatcher({
+    allowedVersions: {
+      bar: '2',
+      'foo>bar': '1',
+      'foo@2>bar': '2 || 3',
+      'foo@>=2.3.5 <3>bar': '4',
+    },
+  })
+  let patchedPkg = patcher({
+    name: 'foo',
+    peerDependencies: {
+      bar: '0 || 1',
+    },
+  }) as ProjectManifest
+  expect(patchedPkg.peerDependencies).toStrictEqual({
+    bar: '1',
+  })
+
+  patchedPkg = patcher({
+    name: 'foo',
+    version: '2',
+    peerDependencies: {
+      bar: '0 || 1',
+    },
+  }) as ProjectManifest
+  expect(patchedPkg.peerDependencies).toStrictEqual({
+    bar: '2 || 3',
+  })
+
+  patchedPkg = patcher({
+    name: 'foo',
+    version: '3',
+    peerDependencies: {
+      bar: '0 || 1',
+    },
+  }) as ProjectManifest
+  expect(patchedPkg.peerDependencies).toStrictEqual({
+    bar: '1',
+  })
+
+  patchedPkg = patcher({
+    name: 'foo',
+    version: '2.3.5',
+    peerDependencies: {
+      bar: '0 || 1',
+    },
+  }) as ProjectManifest
+  expect(patchedPkg.peerDependencies).toStrictEqual({
+    bar: '4',
+  })
+})
+
+test('createPeerDependencyPathcer() throws expected error if parent>child selector cannot parse', () => {
+  expect(() => createPeerDependencyPatcher({
+    allowedVersions: {
+      'foo > bar': '2',
+    },
+  })).toThrowError('Cannot parse the "foo > bar" selector in pnpm.peerDependencyRules.allowedVersions')
+})

--- a/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
+++ b/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
@@ -131,7 +131,7 @@ test('createPeerDependencyPatcher() overrides peerDependencies when parent>child
     },
   }) as ProjectManifest
   expect(patchedPkg.peerDependencies).toStrictEqual({
-    bar: '1',
+    bar: '0 || 1',
   })
 
   patchedPkg = patcher({
@@ -142,7 +142,7 @@ test('createPeerDependencyPatcher() overrides peerDependencies when parent>child
     },
   }) as ProjectManifest
   expect(patchedPkg.peerDependencies).toStrictEqual({
-    bar: '2 || 3',
+    bar: '0 || 1 || 2 || 3',
   })
 
   patchedPkg = patcher({
@@ -153,7 +153,7 @@ test('createPeerDependencyPatcher() overrides peerDependencies when parent>child
     },
   }) as ProjectManifest
   expect(patchedPkg.peerDependencies).toStrictEqual({
-    bar: '1',
+    bar: '0 || 1',
   })
 
   patchedPkg = patcher({
@@ -164,7 +164,7 @@ test('createPeerDependencyPatcher() overrides peerDependencies when parent>child
     },
   }) as ProjectManifest
   expect(patchedPkg.peerDependencies).toStrictEqual({
-    bar: '4',
+    bar: '0 || 1 || 4',
   })
 })
 

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -291,3 +291,9 @@ test('createVersionsOverrider() overrides dependencies with file specified with 
     },
   })
 })
+
+test('createVersionOverrider() throws error when supplied an invalid selector', () => {
+  expect(() => createVersionsOverrider({
+    'foo > bar': '2',
+  }, process.cwd())).toThrowError('Cannot parse the "foo > bar" selector in pnpm.overrides')
+})

--- a/hooks/read-package-hook/tsconfig.json
+++ b/hooks/read-package-hook/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../config/parse-overrides"
     },
     {
+      "path": "../../packages/error"
+    },
+    {
       "path": "../../packages/parse-wanted-dependency"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1606,6 +1606,9 @@ importers:
 
   hooks/read-package-hook:
     dependencies:
+      '@pnpm/error':
+        specifier: workspace:*
+        version: link:../../packages/error
       '@pnpm/matcher':
         specifier: workspace:*
         version: link:../../config/matcher


### PR DESCRIPTION
This feature gives people the ability to override peerDependencies at an individual package level. 