### PR TITLE
fix: check for peerDependenciesMeta in pkgIsLeaf to fix installation non-determinism

### DIFF
--- a/.changeset/lazy-brooms-search.md
+++ b/.changeset/lazy-brooms-search.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+pnpm: patch
+---
+
+Fix a case of installs not being deterministic and causing lockfile changes between repeat installs. When a dependency only declares `peerDependenciesMeta` and not `peerDependencies`, `dependencies`, or `optionalDependencies`, the dependency's peers were not considered deterministically before.

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1377,7 +1377,10 @@ function getMissingPeers (pkg: PackageManifest) {
 function pkgIsLeaf (pkg: PackageManifest) {
   return isEmpty(pkg.dependencies ?? {}) &&
     isEmpty(pkg.optionalDependencies ?? {}) &&
-    isEmpty(pkg.peerDependencies ?? {})
+    isEmpty(pkg.peerDependencies ?? {}) &&
+    // Package manifests can declare peerDependenciesMeta without declaring
+    // peerDependencies. peerDependenciesMeta implies the later.
+    isEmpty(pkg.peerDependenciesMeta ?? {})
 }
 
 function getResolvedPackage (


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/5106

## Issue Summary

A repro was provided where the `/cacache/12.0.4` dependency in a lockfile kept changing its `promise-inflight` resolution between `1.0.1` and `1.0.1_bluebird@3.7.2`.

```diff
   /cacache/12.0.4:
     resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}
     dependencies:
       bluebird: 3.7.2
       chownr: 1.1.4
       figgy-pudding: 3.5.2
       glob: 7.2.3
       graceful-fs: 4.2.9
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
       y18n: 4.0.3
     dev: true
```

Here's the definition of `promise-inflight` elsewhere in the lockfile.

```yaml
  /promise-inflight/1.0.1:
    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
    peerDependencies:
      bluebird: '*'
    peerDependenciesMeta:
      bluebird:
        optional: true
    dev: true
```

Since`cacache` has a `bluebird` dependency, the correct resolution should be the one with the `_bluebird@3.7.2` peers suffix.

## Explanation

In-memory, the `promise-inflight@1.0.1` package manifest looks like the following. The `peerDependenciesMeta` portion is patched in-memory through the [`@yarnpkg/extensions` compatibility database](https://github.com/yarnpkg/berry/blob/9b3f92b88753d58a12bf1aac637b2c4fcb62f4a8/packages/yarnpkg-extensions/sources/index.ts#L116-L121), but how it gets added isn't an important factor.

```json
{
  "name": "promise-inflight",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1",
  },
  "version": "1.0.1",
  "peerDependenciesMeta": {
    "bluebird": {
      "optional": true,
    },
  },
}
```

Specifying `peerDependenciesMeta` without `peerDependencies` implies the later. The above should be the same as:

```json
{
  "name": "promise-inflight",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1",
  },
  "version": "1.0.1",
  "peerDependencies": {
    "bluebird": "*"
  }
  "peerDependenciesMeta": {
    "bluebird": {
      "optional": true,
    },
  },
}
```

When converting `PackageManifest` to `ResolvedPackage`, peers are copied from `peerDependenciesMeta` over to `peerDependencies`.

https://github.com/pnpm/pnpm/blob/8890bcb39531ee370f6913f321fe1aacaa2d1f45/pkg-manager/resolve-dependencies/src/resolveDependencies.ts#L1454-L1459

However, the `pkgIsLeaf` method modified in this fix wasn't considering `peerDependenciesMeta`. The creation of `ResolvedPackage` above happens after `pkgIsLeaf` is called. `pkgIsLeaf` looks at the original `PackageManifest`.

### Why was this non-deterministic?

The `/cacache/12.0.4` dependency appears multiple times in the dependency tree of the repro. This dependency tree is built lazily, and there's different code paths for when a branch of the tree is eagerly evaluated vs built lazily. An arbitrarily chosen `/cacache/12.0.4` entry in the tree eventually gets saved to the dependency graph for the lockfile since it's assumed `/cacache/12.0.4` entries are the same throughout the tree. (In general, I think this assumption is safe.)

- When a branch of the dependency tree is built eagerly, `pkgIsLeaf` is used to create the `dependenciesTree` key here:
   https://github.com/pnpm/pnpm/blob/8890bcb39531ee370f6913f321fe1aacaa2d1f45/pkg-manager/resolve-dependencies/src/resolveDependencies.ts#L1232-L1236
   (This comment was fairly helpful for my understanding.)
- When a branch of the dependency tree is lazily evaluated, there's no `pkgIsLeaf` call:
   https://github.com/pnpm/pnpm/blob/8890bcb39531ee370f6913f321fe1aacaa2d1f45/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts#L256

See https://github.com/pnpm/pnpm/issues/5106#issuecomment-1435801968 for further notes on how `dependenciesTree` keys get transformed into a lockfile `depPath`.

## Testing

I tested this fix several times in the repro and the non-determinism is gone after 100 runs. Previously I was able to reproduce lockfile changes after 2-10 reruns.

## Automated Testing

I'm not sure what automated test makes sense for this.

- A unit test might be convoluted. We'd inspect whether a mock dependency similar `promise-inflight` is using `registry.npmjs.org/<name>/<version>` as a key in the dependency tree or a context-aware path like `>packages/workspace-2>/@storybook/builder-webpack5/6.4.19>/@storybook/core-common/6.4.19>/webpack/4.46.0>/terser-webpack-plugin/1.4.5>/cacache/12.0.4>/promise-inflight/1.0.1>`. This would basically be checking for `pkgIsLeaf` correctness, which is already fairly declarative in its definition.
- An integration test for non-determinism would be probabilistic and slow.

Open to suggestions if there's a good way to test this that I'm missing.
