### PR TITLE
fix: patch-commit should auto apply patches in workspaces

### DIFF
--- a/.changeset/gentle-spies-develop.md
+++ b/.changeset/gentle-spies-develop.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-patching": patch
+"pnpm": patch
 ---
 
 `patch-commit` should auto apply patches in workspaces [#6048](https://github.com/pnpm/pnpm/issues/6048)

--- a/.changeset/gentle-spies-develop.md
+++ b/.changeset/gentle-spies-develop.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+`patch-commit` should auto apply patches in workspaces [#6048](https://github.com/pnpm/pnpm/issues/6048)

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/patching/plugin-commands-patching#readme",
   "devDependencies": {
     "@pnpm/plugin-commands-patching": "workspace:*",
+    "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.4.0",
     "@types/ramda": "0.28.20",
@@ -43,7 +44,6 @@
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/config": "workspace:*",
     "@pnpm/error": "workspace:*",
-    "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/parse-wanted-dependency": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",
     "@pnpm/pick-registry-for-package": "workspace:*",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -36,12 +36,14 @@
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.4.0",
-    "@types/ramda": "0.28.20"
+    "@types/ramda": "0.28.20",
+    "write-yaml-file": "^4.2.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/config": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/parse-wanted-dependency": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",
     "@pnpm/pick-registry-for-package": "workspace:*",

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -5,6 +5,7 @@ import { types as allTypes } from '@pnpm/config'
 import { install } from '@pnpm/plugin-commands-installation'
 import { readPackageJsonFromDir } from '@pnpm/read-package-json'
 import { tryReadProjectManifest } from '@pnpm/read-project-manifest'
+import { readProjects } from '@pnpm/filter-workspace-packages'
 import pick from 'ramda/src/pick'
 import execa from 'safe-execa'
 import escapeStringRegexp from 'escape-string-regexp'
@@ -54,7 +55,13 @@ export async function handler (opts: install.InstallCommandOptions, params: stri
   }
   manifest.pnpm.patchedDependencies![pkgNameAndVersion] = `patches/${patchFileName}.patch`
   await writeProjectManifest(manifest)
-  return install.handler(opts)
+  const { selectedProjectsGraph, allProjects, allProjectsGraph } = await readProjects(lockfileDir, [])
+  return install.handler({
+    ...opts,
+    selectedProjectsGraph,
+    allProjects,
+    allProjectsGraph,
+  })
 }
 
 async function diffFolders (folderA: string, folderB: string) {

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -1,11 +1,10 @@
 import fs from 'fs'
 import path from 'path'
 import { docsUrl } from '@pnpm/cli-utils'
-import { types as allTypes } from '@pnpm/config'
+import { Config, types as allTypes } from '@pnpm/config'
 import { install } from '@pnpm/plugin-commands-installation'
 import { readPackageJsonFromDir } from '@pnpm/read-package-json'
 import { tryReadProjectManifest } from '@pnpm/read-project-manifest'
-import { readProjects } from '@pnpm/filter-workspace-packages'
 import pick from 'ramda/src/pick'
 import execa from 'safe-execa'
 import escapeStringRegexp from 'escape-string-regexp'
@@ -30,7 +29,7 @@ export function help () {
   })
 }
 
-export async function handler (opts: install.InstallCommandOptions, params: string[]) {
+export async function handler (opts: install.InstallCommandOptions & Pick<Config, 'rootProjectManifest'>, params: string[]) {
   const userDir = params[0]
   const lockfileDir = opts.lockfileDir ?? opts.dir ?? process.cwd()
   const patchesDir = path.join(lockfileDir, 'patches')
@@ -42,25 +41,30 @@ export async function handler (opts: install.InstallCommandOptions, params: stri
   const patchContent = await diffFolders(srcDir, userDir)
   const patchFileName = pkgNameAndVersion.replace('/', '__')
   await fs.promises.writeFile(path.join(patchesDir, `${patchFileName}.patch`), patchContent, 'utf8')
-  let { manifest, writeProjectManifest } = await tryReadProjectManifest(lockfileDir)
-  if (!manifest) {
-    manifest = {}
-  }
-  if (!manifest.pnpm) {
-    manifest.pnpm = {
+  const { writeProjectManifest, manifest } = await tryReadProjectManifest(lockfileDir)
+
+  const rootProjectManifest = opts.rootProjectManifest ?? manifest ?? {}
+
+  if (!rootProjectManifest.pnpm) {
+    rootProjectManifest.pnpm = {
       patchedDependencies: {},
     }
-  } else if (!manifest.pnpm.patchedDependencies) {
-    manifest.pnpm.patchedDependencies = {}
+  } else if (!rootProjectManifest.pnpm.patchedDependencies) {
+    rootProjectManifest.pnpm.patchedDependencies = {}
   }
-  manifest.pnpm.patchedDependencies![pkgNameAndVersion] = `patches/${patchFileName}.patch`
-  await writeProjectManifest(manifest)
-  const { selectedProjectsGraph, allProjects, allProjectsGraph } = await readProjects(lockfileDir, [])
+  rootProjectManifest.pnpm.patchedDependencies![pkgNameAndVersion] = `patches/${patchFileName}.patch`
+  await writeProjectManifest(rootProjectManifest)
+
+  if (opts?.selectedProjectsGraph?.[lockfileDir]) {
+    opts.selectedProjectsGraph[lockfileDir].package.manifest = rootProjectManifest
+  }
+
+  if (opts?.allProjectsGraph?.[lockfileDir].package.manifest) {
+    opts.allProjectsGraph[lockfileDir].package.manifest = rootProjectManifest
+  }
+
   return install.handler({
     ...opts,
-    selectedProjectsGraph,
-    allProjects,
-    allProjectsGraph,
   })
 }
 

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -63,9 +63,7 @@ export async function handler (opts: install.InstallCommandOptions & Pick<Config
     opts.allProjectsGraph[lockfileDir].package.manifest = rootProjectManifest
   }
 
-  return install.handler({
-    ...opts,
-  })
+  return install.handler(opts)
 }
 
 async function diffFolders (folderA: string, folderB: string) {

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -1,7 +1,10 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { prepare } from '@pnpm/prepare'
+import { prepare, preparePackages } from '@pnpm/prepare'
+import { install } from '@pnpm/plugin-commands-installation'
+import { readProjects } from '@pnpm/filter-workspace-packages'
+import writeYamlFile from 'write-yaml-file'
 import tempy from 'tempy'
 import { patch, patchCommit } from '@pnpm/plugin-commands-patching'
 import { readProjectManifest } from '@pnpm/read-project-manifest'
@@ -260,6 +263,103 @@ describe('patching should work when there is a no EOL in the patched file', () =
     const patchContent = fs.readFileSync('patches/safe-execa@0.1.2.patch', 'utf8')
     expect(patchContent).toContain('No newline at end of file')
     expect(fs.readFileSync('node_modules/safe-execa/lib/index.js', 'utf8')).toContain('//# sourceMappingURL=index.js.map// patch without newline')
+  })
+})
+
+describe('patch and commit in workspaces', () => {
+  let defaultPatchOption: patch.PatchCommandOptions
+  let cacheDir: string
+  let storeDir: string
+
+  beforeEach(() => {
+    preparePackages([
+      {
+        location: '.',
+        package: {
+          name: 'patch-commit-workspaces',
+        },
+      },
+      {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+      },
+      {
+        name: 'project-2',
+        version: '1.0.0',
+        dependencies: {
+          'is-positive': '1.0.0',
+          'project-1': '1',
+        },
+      },
+    ])
+
+    cacheDir = path.resolve('cache')
+    storeDir = path.resolve('store')
+
+    defaultPatchOption = {
+      cacheDir,
+      dir: process.cwd(),
+      pnpmHomeDir: '',
+      rawConfig: {
+        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
+      },
+      registries: { default: `http://localhost:${REGISTRY_MOCK_PORT}/` },
+      storeDir,
+      userConfig: {},
+    }
+  })
+
+  test('patch commit should work in workspaces', async () => {
+    await writeYamlFile('pnpm-workspace.yaml', { packages: ['project-1', 'project-2'] })
+    const { allProjects, allProjectsGraph, selectedProjectsGraph } = await readProjects(process.cwd(), [])
+    await install.handler({
+      ...DEFAULT_OPTS,
+      cacheDir,
+      storeDir,
+      allProjects,
+      allProjectsGraph,
+      dir: process.cwd(),
+      selectedProjectsGraph,
+      workspaceDir: process.cwd(),
+      saveLockfile: true,
+    })
+
+    const output = await patch.handler(defaultPatchOption, ['is-positive@1.0.0'])
+    const patchDir = getPatchDirFromPatchOutput(output)
+    const tempDir = os.tmpdir()
+
+    expect(patchDir).toContain(tempDir)
+    expect(fs.existsSync(patchDir)).toBe(true)
+
+    expect(fs.readFileSync(path.join(patchDir, 'license'), 'utf8')).toContain('The MIT License (MIT)')
+
+    fs.appendFileSync(path.join(patchDir, 'index.js'), '// test patching', 'utf8')
+    fs.unlinkSync(path.join(patchDir, 'license'))
+
+    await patchCommit.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      cacheDir,
+      storeDir,
+      lockfileDir: process.cwd(),
+      workspaceDir: process.cwd(),
+      saveLockfile: true,
+    }, [patchDir])
+
+    const { manifest } = await readProjectManifest(process.cwd())
+    expect(manifest.pnpm?.patchedDependencies).toStrictEqual({
+      'is-positive@1.0.0': 'patches/is-positive@1.0.0.patch',
+    })
+    const patchContent = fs.readFileSync('patches/is-positive@1.0.0.patch', 'utf8')
+    expect(patchContent).toContain('diff --git')
+    expect(patchContent).toContain('// test patching')
+    expect(fs.readFileSync('project-1/node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+    expect(fs.existsSync('project-1/node_modules/is-positive/license')).toBe(false)
+    expect(fs.readFileSync('project-2/node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
+    expect(fs.existsSync('project-2/node_modules/is-positive/license')).toBe(false)
   })
 })
 

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -341,6 +341,9 @@ describe('patch and commit in workspaces', () => {
 
     await patchCommit.handler({
       ...DEFAULT_OPTS,
+      allProjects,
+      allProjectsGraph,
+      selectedProjectsGraph,
       dir: process.cwd(),
       cacheDir,
       storeDir,

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../../store/store-connection-manager"
     },
     {
+      "path": "../../workspace/filter-workspace-packages"
+    },
+    {
       "path": "../apply-patch"
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2479,6 +2479,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
+      '@pnpm/filter-workspace-packages':
+        specifier: workspace:*
+        version: link:../../workspace/filter-workspace-packages
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
@@ -2531,6 +2534,9 @@ importers:
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
+      write-yaml-file:
+        specifier: ^4.2.0
+        version: 4.2.0
 
   pkg-manager/client:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2479,9 +2479,6 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
-      '@pnpm/filter-workspace-packages':
-        specifier: workspace:*
-        version: link:../../workspace/filter-workspace-packages
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
@@ -2522,6 +2519,9 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
     devDependencies:
+      '@pnpm/filter-workspace-packages':
+        specifier: workspace:*
+        version: link:../../workspace/filter-workspace-packages
       '@pnpm/plugin-commands-patching':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -168,7 +168,7 @@ export async function main (inputArgv: string[]) {
   }
 
   if (
-    (cmd === 'install' || cmd === 'import' || cmd === "dedupe") &&
+    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe' || cmd === 'patch-commit') &&
     typeof workspaceDir === 'string'
   ) {
     cliOptions['recursive'] = true


### PR DESCRIPTION
close #6048 

Many thanks to @shawnmcknight‘s research work.

Steps to reproduce: 

1. create a project as following:
```
// pnpm-workspace.yaml
packages:
 - packages/*
// package.json
{
  "name": "pnpm-patch",
  "version": "1.0.0",
}
// packages/a/package.json
{
  "name": "@pkg/a",
  "version": "1.0.0",
  "dependencies": {
    "express": "4.18.2"
  }
}
```

2. run `pnpm install` in project root directory.
3. run `pnpm patch express@4.18.2` and then edit `index.js` in temp dir:
![image](https://user-images.githubusercontent.com/41503212/220354364-74f13dbb-aa78-4ff5-8ee3-3307f6d7cd16.png)

4. run `pnpm patch-commit <temp-dir>`

We can see `patches/express@4.18.2` is generated successfully and `pnpm.patchedDependencies` also added in root package.json:

```
diff --git a/index.js b/index.js
index d219b0c878dc6136eb2096cffa140bf6bf2b8e9c..479633ae78ed075057d974ea56f7ab2f43d3a90e 100644
--- a/index.js
+++ b/index.js
@@ -7,5 +7,5 @@
  */
 
 'use strict';
-
+console.log('pnpm patch');
 module.exports = require('./lib/express');
```

However **`packages/a/node_modules/express/index.js` is still the unmodified version.**


This PR should fix the problem above ~


