### PR TITLE
fix: eslint issues

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -207,9 +207,9 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
   }
   if (scripts.lint) {
     if (fs.existsSync(path.join(dir, 'test'))) {
-      scripts.lint = 'eslint \'src/**/*.ts\' \'test/**/*.ts\''
+      scripts.lint = 'eslint "src/**/*.ts" "test/**/*.ts"'
     } else {
-      scripts.lint = 'eslint \'src/**/*.ts\''
+      scripts.lint = 'eslint "src/**/*.ts"'
     }
   }
   const files: string[] = []

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -207,7 +207,7 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
   }
   if (scripts.lint) {
     if (fs.existsSync(path.join(dir, 'test'))) {
-      scripts.lint = 'eslint \'src/**/*.ts test/**/*.ts\''
+      scripts.lint = 'eslint \'src/**/*.ts\' \'test/**/*.ts\''
     } else {
       scripts.lint = 'eslint \'src/**/*.ts\''
     }

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -207,9 +207,9 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
   }
   if (scripts.lint) {
     if (fs.existsSync(path.join(dir, 'test'))) {
-      scripts.lint = 'eslint src/**/*.ts test/**/*.ts'
+      scripts.lint = 'eslint \'src/**/*.ts test/**/*.ts\''
     } else {
-      scripts.lint = 'eslint src/**/*.ts'
+      scripts.lint = 'eslint \'src/**/*.ts\''
     }
   }
   const files: string[] = []

--- a/cli/cli-meta/package.json
+++ b/cli/cli-meta/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/cli-meta/package.json
+++ b/cli/cli-meta/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/cli-utils/package.json
+++ b/cli/cli-utils/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "test": "pnpm run compile"

--- a/cli/cli-utils/package.json
+++ b/cli/cli-utils/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "test": "pnpm run compile"

--- a/cli/command/package.json
+++ b/cli/command/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/command/package.json
+++ b/cli/command/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/common-cli-options-help/package.json
+++ b/cli/common-cli-options-help/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/common-cli-options-help/package.json
+++ b/cli/common-cli-options-help/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "just-test-preview": "ts-node test --type-check",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "just-test-preview": "ts-node test --type-check",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "just-test-preview": "ts-node test --type-check",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/cli/parse-cli-args/package.json
+++ b/cli/parse-cli-args/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/cli/parse-cli-args/package.json
+++ b/cli/parse-cli-args/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/cli/parse-cli-args/package.json
+++ b/cli/parse-cli-args/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test-with-preview": "ts-node test",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test-with-preview": "ts-node test",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test-with-preview": "ts-node test",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/config/matcher/package.json
+++ b/config/matcher/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/matcher/package.json
+++ b/config/matcher/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/matcher/package.json
+++ b/config/matcher/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/normalize-registries/package.json
+++ b/config/normalize-registries/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/pnpm/pnpm/blob/main/config/normalize-registries",
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/normalize-registries/package.json
+++ b/config/normalize-registries/package.json
@@ -21,7 +21,7 @@
   "repository": "https://github.com/pnpm/pnpm/blob/main/config/normalize-registries",
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -24,7 +24,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -24,7 +24,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -24,7 +24,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/parse-overrides/package.json
+++ b/config/parse-overrides/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/parse-overrides/package.json
+++ b/config/parse-overrides/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/parse-overrides/package.json
+++ b/config/parse-overrides/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/pick-registry-for-package/package.json
+++ b/config/pick-registry-for-package/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/pick-registry-for-package/package.json
+++ b/config/pick-registry-for-package/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/pick-registry-for-package/package.json
+++ b/config/pick-registry-for-package/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/plugin-commands-config/package.json
+++ b/config/plugin-commands-config/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/plugin-commands-config/package.json
+++ b/config/plugin-commands-config/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/plugin-commands-config/package.json
+++ b/config/plugin-commands-config/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -16,7 +16,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/run-npm/package.json
+++ b/exec/run-npm/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/exec/run-npm/package.json
+++ b/exec/run-npm/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fetching/directory-fetcher/package.json
+++ b/fetching/directory-fetcher/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/directory-fetcher/package.json
+++ b/fetching/directory-fetcher/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/directory-fetcher/package.json
+++ b/fetching/directory-fetcher/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/fetcher-base/package.json
+++ b/fetching/fetcher-base/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fetching/fetcher-base/package.json
+++ b/fetching/fetcher-base/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fetching/git-fetcher/package.json
+++ b/fetching/git-fetcher/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/git-fetcher/package.json
+++ b/fetching/git-fetcher/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/git-fetcher/package.json
+++ b/fetching/git-fetcher/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/pick-fetcher/package.json
+++ b/fetching/pick-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fetching/pick-fetcher/package.json
+++ b/fetching/pick-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fetching/pick-fetcher/package.json
+++ b/fetching/pick-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fetching/tarball-fetcher/package.json
+++ b/fetching/tarball-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fetching/tarball-fetcher/package.json
+++ b/fetching/tarball-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fetching/tarball-fetcher/package.json
+++ b/fetching/tarball-fetcher/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/find-packages/package.json
+++ b/fs/find-packages/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/find-packages/package.json
+++ b/fs/find-packages/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/find-packages/package.json
+++ b/fs/find-packages/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/graceful-fs/package.json
+++ b/fs/graceful-fs/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fs/graceful-fs/package.json
+++ b/fs/graceful-fs/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -29,7 +29,6 @@
     "url": "https://github.com/pnpm/pnpm/issues"
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/fs/hard-link-dir#readme",
-  "dependencies": {},
   "funding": "https://opencollective.com/pnpm",
   "devDependencies": {
     "@pnpm/fs.hard-link-dir": "workspace:*",

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/read-modules-dir/package.json
+++ b/fs/read-modules-dir/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fs/read-modules-dir/package.json
+++ b/fs/read-modules-dir/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fs/symlink-dependency/package.json
+++ b/fs/symlink-dependency/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/fs/symlink-dependency/package.json
+++ b/fs/symlink-dependency/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/fs/symlink-dependency/package.json
+++ b/fs/symlink-dependency/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/hooks/pnpmfile/package.json
+++ b/hooks/pnpmfile/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/pnpmfile/package.json
+++ b/hooks/pnpmfile/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/pnpmfile/package.json
+++ b/hooks/pnpmfile/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/filter-lockfile/package.json
+++ b/lockfile/filter-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/filter-lockfile/package.json
+++ b/lockfile/filter-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -43,13 +43,13 @@
   },
   "dependencies": {
     "@pnpm/constants": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
     "@pnpm/lockfile-walker": "workspace:*",
     "@pnpm/package-is-installable": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/lockfile/filter-lockfile/package.json
+++ b/lockfile/filter-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-file/package.json
+++ b/lockfile/lockfile-file/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-file/package.json
+++ b/lockfile/lockfile-file/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-file/package.json
+++ b/lockfile/lockfile-file/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-to-pnp/package.json
+++ b/lockfile/lockfile-to-pnp/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
@@ -40,11 +40,11 @@
     "rimraf": "^3.0.2"
   },
   "dependencies": {
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@yarnpkg/pnp": "^2.3.2",
-    "@pnpm/dependency-path": "workspace:*",
     "normalize-path": "^3.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },

--- a/lockfile/lockfile-to-pnp/package.json
+++ b/lockfile/lockfile-to-pnp/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",

--- a/lockfile/lockfile-to-pnp/package.json
+++ b/lockfile/lockfile-to-pnp/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",

--- a/lockfile/lockfile-types/package.json
+++ b/lockfile/lockfile-types/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-types#readme",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile"
   },

--- a/lockfile/lockfile-types/package.json
+++ b/lockfile/lockfile-types/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/lockfile/lockfile-types#readme",
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile"
   },

--- a/lockfile/lockfile-utils/package.json
+++ b/lockfile/lockfile-utils/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-utils/package.json
+++ b/lockfile/lockfile-utils/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -39,10 +39,10 @@
     "yaml-tag": "1.1.0"
   },
   "dependencies": {
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "get-npm-tarball-url": "^2.0.3",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },

--- a/lockfile/lockfile-utils/package.json
+++ b/lockfile/lockfile-utils/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-walker/package.json
+++ b/lockfile/lockfile-walker/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
@@ -35,9 +35,9 @@
     "tempy": "^1.0.1"
   },
   "dependencies": {
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/lockfile/lockfile-walker/package.json
+++ b/lockfile/lockfile-walker/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/lockfile/merge-lockfile-changes/package.json
+++ b/lockfile/merge-lockfile-changes/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/merge-lockfile-changes/package.json
+++ b/lockfile/merge-lockfile-changes/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/merge-lockfile-changes/package.json
+++ b/lockfile/merge-lockfile-changes/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/plugin-commands-audit/package.json
+++ b/lockfile/plugin-commands-audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/plugin-commands-audit/package.json
+++ b/lockfile/plugin-commands-audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/plugin-commands-audit/package.json
+++ b/lockfile/plugin-commands-audit/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/prune-lockfile/package.json
+++ b/lockfile/prune-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/prune-lockfile/package.json
+++ b/lockfile/prune-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@pnpm/constants": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/lockfile/prune-lockfile/package.json
+++ b/lockfile/prune-lockfile/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/auth-header/package.json
+++ b/network/auth-header/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/auth-header/package.json
+++ b/network/auth-header/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/auth-header/package.json
+++ b/network/auth-header/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetching-types/package.json
+++ b/network/fetching-types/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/network/fetching-types#readme",
   "scripts": {
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile"
   },

--- a/network/fetching-types/package.json
+++ b/network/fetching-types/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/network/fetching-types#readme",
   "scripts": {
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "husky install",
     "pretest": "pnpm run compile-only && pnpm --dir=__fixtures__ run prepareFixtures",
     "lint": "pnpm lint:meta && syncpack list-mismatches --workspace false && pnpm run lint:ts",
-    "lint:ts": "eslint **/src/**/*.ts **/test/**/*.ts",
+    "lint:ts": "eslint '**/src/**/*.ts' '**/test/**/*.ts'",
     "test-main": "pnpm pretest && pnpm lint --quiet && run-p -r verdaccio test-pkgs-main",
     "remove-temp-dir": "shx rm -rf ../pnpm_tmp",
     "test-pkgs-main": "pnpm remove-temp-dir && cross-env PNPM_REGISTRY_MOCK_UPLINK=http://localhost:7348 pnpm run --no-sort --workspace-concurrency=2 -r _test",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "husky install",
     "pretest": "pnpm run compile-only && pnpm --dir=__fixtures__ run prepareFixtures",
     "lint": "pnpm lint:meta && syncpack list-mismatches --workspace false && pnpm run lint:ts",
-    "lint:ts": "eslint '**/src/**/*.ts' '**/test/**/*.ts'",
+    "lint:ts": "eslint \"**/src/**/*.ts\" \"**/test/**/*.ts\"",
     "test-main": "pnpm pretest && pnpm lint --quiet && run-p -r verdaccio test-pkgs-main",
     "remove-temp-dir": "shx rm -rf ../pnpm_tmp",
     "test-pkgs-main": "pnpm remove-temp-dir && cross-env PNPM_REGISTRY_MOCK_UPLINK=http://localhost:7348 pnpm run --no-sort --workspace-concurrency=2 -r _test",

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/constants",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/constants",

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/crypto.base32-hash/package.json
+++ b/packages/crypto.base32-hash/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/crypto.base32-hash/package.json
+++ b/packages/crypto.base32-hash/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/crypto.base32-hash/package.json
+++ b/packages/crypto.base32-hash/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -37,8 +37,8 @@
     "semver": "^7.3.8"
   },
   "devDependencies": {
-    "@types/semver": "7.3.13",
-    "@pnpm/dependency-path": "workspace:*"
+    "@pnpm/dependency-path": "workspace:*",
+    "@types/semver": "7.3.13"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -14,7 +14,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -14,7 +14,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -14,7 +14,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/mount-modules/package.json
+++ b/packages/mount-modules/package.json
@@ -14,7 +14,7 @@
     "bin"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install --dir=test/__fixtures__/simple",

--- a/packages/mount-modules/package.json
+++ b/packages/mount-modules/package.json
@@ -14,7 +14,7 @@
     "bin"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install --dir=test/__fixtures__/simple",
@@ -44,12 +44,12 @@
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
     "@pnpm/config": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
     "@pnpm/logger": "^5.0.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "hyperdrive-schemas": "^2.0.0",
     "load-json-file": "^6.2.0",
     "normalize-path": "^3.0.0"

--- a/packages/mount-modules/package.json
+++ b/packages/mount-modules/package.json
@@ -14,7 +14,7 @@
     "bin"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install --dir=test/__fixtures__/simple",

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -25,7 +25,7 @@
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/parse-wanted-dependency",
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -25,7 +25,7 @@
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/parse-wanted-dependency",
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/plugin-commands-doctor/package.json
+++ b/packages/plugin-commands-doctor/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-doctor/package.json
+++ b/packages/plugin-commands-doctor/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-doctor/package.json
+++ b/packages/plugin-commands-doctor/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint \"src/**/*.ts\""
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/types",
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint 'src/**/*.ts'"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/packages/types",
   "keywords": [

--- a/packages/which-version-is-pinned/package.json
+++ b/packages/which-version-is-pinned/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/which-version-is-pinned/package.json
+++ b/packages/which-version-is-pinned/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/which-version-is-pinned/package.json
+++ b/packages/which-version-is-pinned/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/patching/apply-patch/package.json
+++ b/patching/apply-patch/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint 'src/**/*.ts'"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/patching/apply-patch",
   "keywords": [

--- a/patching/apply-patch/package.json
+++ b/patching/apply-patch/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint \"src/**/*.ts\""
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/patching/apply-patch",
   "keywords": [

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/client/package.json
+++ b/pkg-manager/client/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/client/package.json
+++ b/pkg-manager/client/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/client/package.json
+++ b/pkg-manager/client/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -138,7 +138,7 @@
     "?commit": "echo 'Run Git commit wizard'",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -138,7 +138,7 @@
     "?commit": "echo 'Run Git commit wizard'",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -138,7 +138,7 @@
     "?commit": "echo 'Run Git commit wizard'",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/direct-dep-linker/package.json
+++ b/pkg-manager/direct-dep-linker/package.json
@@ -29,7 +29,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/pkg-manager/direct-dep-linker",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/pkg-manager/direct-dep-linker/package.json
+++ b/pkg-manager/direct-dep-linker/package.json
@@ -29,7 +29,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/pkg-manager/direct-dep-linker",
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -55,7 +55,7 @@
     "start": "tsc --watch",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -55,7 +55,7 @@
     "start": "tsc --watch",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -55,7 +55,7 @@
     "start": "tsc --watch",
     "commit": "commit",
     "commitmsg": "commitlint -e",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/hoist/package.json
+++ b/pkg-manager/hoist/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/hoist/package.json
+++ b/pkg-manager/hoist/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/modules-cleaner/package.json
+++ b/pkg-manager/modules-cleaner/package.json
@@ -23,12 +23,13 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
     "@pnpm/core-loggers": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/filter-lockfile": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
@@ -37,7 +38,6 @@
     "@pnpm/store-controller-types": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@zkochan/rimraf": "^2.1.2",
-    "@pnpm/dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1"
   },
   "devDependencies": {

--- a/pkg-manager/modules-cleaner/package.json
+++ b/pkg-manager/modules-cleaner/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/modules-yaml/package.json
+++ b/pkg-manager/modules-yaml/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/modules-yaml/package.json
+++ b/pkg-manager/modules-yaml/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/modules-yaml/package.json
+++ b/pkg-manager/modules-yaml/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 pnpm run test:e2e",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/pkg-manager/read-projects-context/package.json
+++ b/pkg-manager/read-projects-context/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/read-projects-context/package.json
+++ b/pkg-manager/read-projects-context/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/real-hoist/package.json
+++ b/pkg-manager/real-hoist/package.json
@@ -25,15 +25,15 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
-    "@yarnpkg/nm": "4.0.0-rc.27",
-    "@pnpm/dependency-path": "workspace:*"
+    "@yarnpkg/nm": "4.0.0-rc.27"
   },
   "funding": "https://opencollective.com/pnpm",
   "devDependencies": {

--- a/pkg-manager/real-hoist/package.json
+++ b/pkg-manager/real-hoist/package.json
@@ -25,7 +25,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/real-hoist/package.json
+++ b/pkg-manager/real-hoist/package.json
@@ -25,7 +25,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/remove-bins/package.json
+++ b/pkg-manager/remove-bins/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/remove-bins/package.json
+++ b/pkg-manager/remove-bins/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"
@@ -31,6 +31,7 @@
   "dependencies": {
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
@@ -44,7 +45,6 @@
     "@pnpm/types": "workspace:*",
     "@pnpm/which-version-is-pinned": "workspace:*",
     "@yarnpkg/core": "4.0.0-rc.27",
-    "@pnpm/dependency-path": "workspace:*",
     "encode-registry": "^3.0.0",
     "filenamify": "^4.3.0",
     "get-npm-tarball-url": "^2.0.3",

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/pkg-manifest/manifest-utils/package.json
+++ b/pkg-manifest/manifest-utils/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manifest/manifest-utils/package.json
+++ b/pkg-manifest/manifest-utils/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manifest/manifest-utils/package.json
+++ b/pkg-manifest/manifest-utils/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manifest/read-package-json/package.json
+++ b/pkg-manifest/read-package-json/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-package-json/package.json
+++ b/pkg-manifest/read-package-json/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-package-json/package.json
+++ b/pkg-manifest/read-package-json/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/write-project-manifest/package.json
+++ b/pkg-manifest/write-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/write-project-manifest/package.json
+++ b/pkg-manifest/write-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/write-project-manifest/package.json
+++ b/pkg-manifest/write-project-manifest/package.json
@@ -12,7 +12,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "bundle": "cross-var esbuild lib/pnpm.js --bundle --platform=node --outfile=dist/pnpm.cjs --external:node-gyp --define:process.env.npm_package_name=\\\"$npm_package_name\\\" --define:process.env.npm_package_version=\\\"$npm_package_version\\\"",
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "pretest:e2e": "rimraf node_modules/.bin/pnpm",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "bundle": "cross-var esbuild lib/pnpm.js --bundle --platform=node --outfile=dist/pnpm.cjs --external:node-gyp --define:process.env.npm_package_name=\\\"$npm_package_name\\\" --define:process.env.npm_package_version=\\\"$npm_package_version\\\"",
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "pretest:e2e": "rimraf node_modules/.bin/pnpm",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -151,7 +151,7 @@
   "scripts": {
     "bundle": "cross-var esbuild lib/pnpm.js --bundle --platform=node --outfile=dist/pnpm.cjs --external:node-gyp --define:process.env.npm_package_name=\\\"$npm_package_name\\\" --define:process.env.npm_package_version=\\\"$npm_package_version\\\"",
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "pretest:e2e": "rimraf node_modules/.bin/pnpm",

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -232,7 +232,9 @@ export async function main (inputArgv: string[]) {
 
   let { output, exitCode }: { output: string | null, exitCode: number } = await (async () => {
     // NOTE: we defer the next stage, otherwise reporter might not catch all the logs
-    await new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+    await new Promise<void>((resolve) => setTimeout(() => {
+      resolve()
+    }, 0))
 
     if (
       config.updateNotifier !== false &&

--- a/pnpm/test/server.ts
+++ b/pnpm/test/server.ts
@@ -230,8 +230,12 @@ async function testParallelServerStart (
     }
     serverProcessList.push(item)
 
-    byline(item.childProcess.stderr as Readable).on('data', (line: Buffer) => console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`))
-    byline(item.childProcess.stdout as Readable).on('data', (line: Buffer) => console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`))
+    byline(item.childProcess.stderr as Readable).on('data', (line: Buffer) => {
+      console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`)
+    })
+    byline(item.childProcess.stdout as Readable).on('data', (line: Buffer) => {
+      console.log(`${item.childProcess.pid?.toString() ?? ''}: ${line.toString()}`)
+    })
 
     item.childProcess.on('exit', async (code: number | null, signal: string | null) => {
       options.onProcessClosed(item.childProcess, item.attemptedToKill)

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/resolving/default-resolver/package.json
+++ b/resolving/default-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/default-resolver/package.json
+++ b/resolving/default-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/default-resolver/package.json
+++ b/resolving/default-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/resolver-base/package.json
+++ b/resolving/resolver-base/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/resolving/resolver-base/package.json
+++ b/resolving/resolver-base/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/resolving/tarball-resolver/package.json
+++ b/resolving/tarball-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/resolving/tarball-resolver/package.json
+++ b/resolving/tarball-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/resolving/tarball-resolver/package.json
+++ b/resolving/tarball-resolver/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/reviewing/dependencies-hierarchy/package.json
+++ b/reviewing/dependencies-hierarchy/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/reviewing/dependencies-hierarchy/package.json
+++ b/reviewing/dependencies-hierarchy/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/reviewing/dependencies-hierarchy#readme",
   "dependencies": {
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
@@ -39,16 +40,15 @@
     "@pnpm/read-modules-dir": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "normalize-path": "^3.0.0",
     "realpath-missing": "^1.1.0",
     "resolve-link-target": "^2.0.0"
   },
   "devDependencies": {
     "@pnpm/constants": "workspace:*",
+    "@pnpm/reviewing.dependencies-hierarchy": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
-    "@types/normalize-path": "^3.0.0",
-    "@pnpm/reviewing.dependencies-hierarchy": "workspace:*"
+    "@types/normalize-path": "^3.0.0"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/reviewing/dependencies-hierarchy/package.json
+++ b/reviewing/dependencies-hierarchy/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/directory-fetcher": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
@@ -46,7 +47,6 @@
     "@pnpm/package-is-installable": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "load-json-file": "^6.2.0",
     "p-limit": "^3.1.0",
     "path-absolute": "^1.0.1",

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepareFixtures": "cd test && node ../../pnpm recursive install --no-link-workspace-packages --no-shared-workspace-lockfile -f && cd ..",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm run --filter dependencies-hierarchy pretest",

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepareFixtures": "cd test && node ../../pnpm recursive install --no-link-workspace-packages --no-shared-workspace-lockfile -f && cd ..",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm run --filter dependencies-hierarchy pretest",

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepareFixtures": "cd test && node ../../pnpm recursive install --no-link-workspace-packages --no-shared-workspace-lockfile -f && cd ..",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm run --filter dependencies-hierarchy pretest",
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/reviewing/list#readme",
   "dependencies": {
-    "@pnpm/reviewing.dependencies-hierarchy": "workspace:*",
     "@pnpm/matcher": "workspace:*",
     "@pnpm/npm-package-arg": "^1.0.0",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
+    "@pnpm/reviewing.dependencies-hierarchy": "workspace:*",
     "@pnpm/types": "workspace:*",
     "archy": "^1.0.0",
     "chalk": "^4.1.2",

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
@@ -38,6 +38,7 @@
   "dependencies": {
     "@pnpm/client": "workspace:*",
     "@pnpm/constants": "workspace:*",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/lockfile-utils": "workspace:*",
@@ -47,7 +48,6 @@
     "@pnpm/npm-resolver": "workspace:*",
     "@pnpm/pick-registry-for-package": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "@pnpm/dependency-path": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "semver": "^7.3.8"
   },

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "registry-mock": "registry-mock",
     "test:jest": "jest",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/store/cafs-types/package.json
+++ b/store/cafs-types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint 'src/**/*.ts'"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/store/cafs-types",
   "keywords": [

--- a/store/cafs-types/package.json
+++ b/store/cafs-types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint \"src/**/*.ts\""
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/store/cafs-types",
   "keywords": [

--- a/store/cafs/package.json
+++ b/store/cafs/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/store/cafs/package.json
+++ b/store/cafs/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/store/cafs/package.json
+++ b/store/cafs/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/store/create-cafs-store/package.json
+++ b/store/create-cafs-store/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/create-cafs-store/package.json
+++ b/store/create-cafs-store/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/package-store/package.json
+++ b/store/package-store/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/store/package-store/package.json
+++ b/store/package-store/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/store/package-store/package.json
+++ b/store/package-store/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/store/plugin-commands-server/package.json
+++ b/store/plugin-commands-server/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/plugin-commands-server/package.json
+++ b/store/plugin-commands-server/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
     "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",

--- a/store/server/package.json
+++ b/store/server/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest --detectOpenHandles",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/server/package.json
+++ b/store/server/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest --detectOpenHandles",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/server/package.json
+++ b/store/server/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest --detectOpenHandles",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/store-connection-manager/package.json
+++ b/store/store-connection-manager/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "pretest": "rimraf node_modules/.bin/pnpm",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",

--- a/store/store-connection-manager/package.json
+++ b/store/store-connection-manager/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "pretest": "rimraf node_modules/.bin/pnpm",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",

--- a/store/store-controller-types/package.json
+++ b/store/store-controller-types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint \"src/**/*.ts\""
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/store/store-controller-types",
   "keywords": [

--- a/store/store-controller-types/package.json
+++ b/store/store-controller-types/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint 'src/**/*.ts'"
   },
   "repository": "https://github.com/pnpm/pnpm/blob/main/store/store-controller-types",
   "keywords": [

--- a/store/store-path/package.json
+++ b/store/store-path/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/store-path/package.json
+++ b/store/store-path/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/store-path/package.json
+++ b/store/store-path/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/text/comments-parser/package.json
+++ b/text/comments-parser/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/text/comments-parser/package.json
+++ b/text/comments-parser/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/text/comments-parser/package.json
+++ b/text/comments-parser/package.json
@@ -23,7 +23,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-dir/package.json
+++ b/workspace/find-workspace-dir/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-dir/package.json
+++ b/workspace/find-workspace-dir/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-dir/package.json
+++ b/workspace/find-workspace-dir/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-packages/package.json
+++ b/workspace/find-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-packages/package.json
+++ b/workspace/find-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -31,9 +31,9 @@
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/constants": "workspace:*",
+    "@pnpm/fs.find-packages": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/util.lex-comparator": "1.0.0",
-    "@pnpm/fs.find-packages": "workspace:*",
     "read-yaml-file": "^2.1.0"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/workspace/find-workspace-packages/package.json
+++ b/workspace/find-workspace-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/pkgs-graph/package.json
+++ b/workspace/pkgs-graph/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
+    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/pkgs-graph/package.json
+++ b/workspace/pkgs-graph/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint 'src/**/*.ts test/**/*.ts'",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/workspace/pkgs-graph#readme",
   "devDependencies": {
+    "@pnpm/workspace.pkgs-graph": "workspace:*",
     "@types/ramda": "0.28.20",
-    "better-path-resolve": "1.0.0",
-    "@pnpm/workspace.pkgs-graph": "workspace:*"
+    "better-path-resolve": "1.0.0"
   },
   "dependencies": {
     "@pnpm/npm-package-arg": "^1.0.0",

--- a/workspace/pkgs-graph/package.json
+++ b/workspace/pkgs-graph/package.json
@@ -9,7 +9,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/resolve-workspace-range/package.json
+++ b/workspace/resolve-workspace-range/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/workspace/resolve-workspace-range/package.json
+++ b/workspace/resolve-workspace-range/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/workspace/sort-packages/package.json
+++ b/workspace/sort-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint 'src/**/*.ts'",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/workspace/sort-packages/package.json
+++ b/workspace/sort-packages/package.json
@@ -12,7 +12,7 @@
     "node": ">=14.6"
   },
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"


### PR DESCRIPTION
It seems that `eslint `does not check all `.ts` files when `git push` , for example:

![image](https://user-images.githubusercontent.com/41503212/220661107-0b0cbe9f-05d7-42aa-b82b-b36c9f95b50d.png)

`pnpm/src/main.ts` shows an eslint error in vscode, but  `pnpm lint:ts` does not report any error.

It looks like the shell would match multiple files passed to `process.argv` if it were  glob patterns here:
> https://github.com/nodejs/node/issues/15529

```
    "lint:ts": "eslint **/src/**/*.ts **/test/**/*.ts",
```

Then process.argv will be following and eslint will only check these files:

```
[
  '/xxxx/.nvm/versions/node/v16.15.1/bin/node',
  '/xxxx/pnpm/node_modules/eslint/bin/eslint.js',
  'pnpm/src/cmd/bin.ts',
  'pnpm/src/cmd/complete.ts',
  'pnpm/src/cmd/completion.ts',
  'pnpm/src/cmd/help.ts',
  'pnpm/src/cmd/index.ts',
  'pnpm/src/cmd/installTest.ts',
  'pnpm/src/cmd/recursive.ts',
  'pnpm/src/cmd/root.ts',
  'pnpm/src/reporter/index.ts',
  'pnpm/src/reporter/silentReporter.ts',
  'pnpm/test/install/global.ts',
  'pnpm/test/install/hoist.ts',
  'pnpm/test/install/hooks.ts',
  'pnpm/test/install/lifecycleScripts.ts',
  'pnpm/test/install/misc.ts',
  'pnpm/test/install/only.ts',
  'pnpm/test/install/optional.ts',
  'pnpm/test/install/preferOffline.ts',
  'pnpm/test/install/selfUpdate.ts',
  'pnpm/test/install/sideEffects.ts',
  'pnpm/test/monorepo/index.ts',
  'pnpm/test/recursive/misc.ts',
  'pnpm/test/recursive/rebuild.ts',
  'pnpm/test/recursive/run.ts',
  'pnpm/test/recursive/update.ts',
  'pnpm/test/utils/distTags.ts',
  'pnpm/test/utils/execPnpm.ts',
  'pnpm/test/utils/index.ts',
  'pnpm/test/utils/localPkg.ts',
  'pnpm/test/utils/retryLoadJsonFile.ts',
  'pnpm/test/utils/testDefaults.ts'
]
```



