### PR TITLE
feat: lockfile review

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4897,6 +4897,34 @@ importers:
         specifier: 7.3.13
         version: 7.3.13
 
+  reviewing/lockfile:
+    dependencies:
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
+      js-yaml:
+        specifier: npm:@zkochan/js-yaml@0.0.6
+        version: /@zkochan/js-yaml@0.0.6
+      semver:
+        specifier: 7.3.8
+        version: 7.3.8
+    devDependencies:
+      '@pnpm/lockfile-review':
+        specifier: workspace:*
+        version: 'link:'
+      '@pnpm/lockfile-types':
+        specifier: workspace:*
+        version: link:../../lockfile/lockfile-types
+      '@pnpm/types':
+        specifier: 8.10.0
+        version: link:../../packages/types
+      '@types/js-yaml':
+        specifier: 4.0.5
+        version: 4.0.5
+      '@types/semver':
+        specifier: 7.3.13
+        version: 7.3.13
+
   reviewing/outdated:
     dependencies:
       '@pnpm/client':
@@ -7984,7 +8012,7 @@ packages:
       '@pnpm/find-workspace-dir': 5.0.1
       '@pnpm/find-workspace-packages': 5.0.33(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/logger': 5.0.0
-      '@pnpm/types': 8.9.0
+      '@pnpm/types': 8.10.0
       '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
       load-json-file: 7.0.1
       meow: 10.1.5
@@ -8533,6 +8561,7 @@ packages:
   /@pnpm/types@8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
+    dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}

--- a/reviewing/lockfile/bin.js
+++ b/reviewing/lockfile/bin.js
@@ -1,0 +1,140 @@
+const args = process.argv.slice(2);
+
+
+if (args.length < 2) {
+  console.log(`
+lockfile-review [target-lockfile] [current-lockfile]
+lr [target-lockfile] [current-lockfile]
+
+Options:
+  --path:       Show introduction path
+  --workspace:   Differentiation by workspace
+`);
+  process.exit(0);
+}
+
+const path = require('path');
+const fs = require('fs/promises');
+const yaml = require('js-yaml');
+const chalk = require('chalk');
+const { createLockfileGraph, diffGraph } = require('./lib/index');
+
+async function readTask() {
+  const targetPath = args[0];
+  const currentPath = args[1];
+  async function task(p) {
+    return fs.readFile(path.resolve(p)).catch(() =>
+      fs.readFile(path.resolve(path.dirname(p), 'pnpm-lock.yaml'))
+    ).then(content => yaml.load(content.toString('utf-8')))
+  }
+  const [target, current] = await Promise.all([task(targetPath), task(currentPath)])
+  return { target, current }
+}
+
+async function run() {
+  const { target, current } = await readTask();
+  const targetGraph = createLockfileGraph(target);
+  const currentGraph = createLockfileGraph(current);
+  const diff = diffGraph(targetGraph, currentGraph);
+
+  const showPaths = args.includes('--paths');
+  const showWorkspace = args.includes('--workspace')
+  if (!showPaths && !showWorkspace) {
+    const added = diff.packages.added.map((key) => {
+      return chalk.green(`+ ${key}`)
+    });
+    const deleted = diff.packages.deleted.map((key) => {
+      return chalk.red(`- ${key}`)
+    });
+    const changed = [...deleted, ...added];
+    if (changed.length > 0) {
+      console.log(changed.join('\n'))
+    }
+    return;
+  }
+
+  if (showPaths && showWorkspace) {
+    const changed = {};
+    diff.packages.deleted.forEach(key => {
+      targetGraph.whoImportThisPackage(key).filter(Boolean).forEach(paths => {
+        const importerId = paths[0];
+        if (!targetGraph.getImporter(importerId)) {
+          return;
+        }
+        if (!changed[importerId]) {
+          changed[importerId] = {}
+        }
+        if (!changed[importerId][key]) {
+          changed[importerId][key] = [`  ${chalk.red(`- ${key}`)}:`]
+        }
+        changed[importerId][key].push(`      ${paths.join(' -> ')}`)
+      })
+    })
+    diff.packages.added.forEach(key => {
+      currentGraph.whoImportThisPackage(key).filter(Boolean).forEach(paths => {
+        const importerId = paths[0];
+        if (!currentGraph.getImporter(importerId)) {
+          return;
+        }
+        if (!changed[importerId]) {
+          changed[importerId] = {}
+        }
+        if (!changed[importerId][key]) {
+          changed[importerId][key] = [`  ${chalk.green(`+ ${key}`)}:`]
+        }
+        changed[importerId][key].push(`      ${paths.join(' -> ')}`)
+      })
+    })
+
+    for (const importerId in changed) {
+      console.log(`${importerId}:`);
+      for (const key in changed[importerId]) {
+        console.log(changed[importerId][key].join('\n'))
+      }
+    }
+
+  } else if (showWorkspace) {
+    const changed = {};
+    diff.packages.deleted.forEach(key => {
+      targetGraph.whoImportThisPackage(key).filter(Boolean).forEach(([importerId]) => {
+        if (!targetGraph.getImporter(importerId)) {
+          return;
+        }
+        if (!changed[importerId]) {
+          changed[importerId] = new Set()
+        }
+        changed[importerId].add(`  ${chalk.red(`- ${key}`)}`)
+      })
+    });
+    diff.packages.added.forEach(key => {
+      currentGraph.whoImportThisPackage(key).filter(Boolean).forEach(([importerId]) => {
+        if (!currentGraph.getImporter(importerId)) {
+          return;
+        }
+        if (!changed[importerId]) {
+          changed[importerId] = new Set();
+        }
+        changed[importerId].add(`  ${chalk.green(`+ ${key}`)}`)
+      })
+    });
+    for (const importerId in changed) {
+      console.log(`${importerId}:`);
+      console.log(Array.from(changed[importerId]).join('\n'))
+    }
+  } else if (showPaths) {
+    const added = diff.packages.added.map(key => {
+      const paths = currentGraph.whoImportThisPackage(key).filter(Boolean).map((item => item.join(' -> ')));
+      return [chalk.green(`+ ${key}:`), ...paths].join('\n  ');
+    })
+    const deleted = diff.packages.deleted.map(key => {
+      const paths = targetGraph.whoImportThisPackage(key).filter(Boolean).map((item => item.join(' -> ')));
+      return [chalk.red(`- ${key}:`), ...paths].join('\n  ');
+    })
+    const changed = [...deleted, ...added];
+    if (changed.length > 0) {
+      console.log(changed.join('\n'))
+    }
+  }
+}
+
+run();

--- a/reviewing/lockfile/jest.config.js
+++ b/reviewing/lockfile/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/reviewing/lockfile/package.json
+++ b/reviewing/lockfile/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@pnpm/lockfile-review",
+  "version": "0.1.0",
+  "description": "Review Lockfile",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "_test": "jest",
+    "test": "pnpm run compile && pnpm run _test",
+    "prepublishOnly": "pnpm run compile",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "start": "tsc --watch"
+  },
+  "repository": "https://github.com/pnpm/pnpm/blob/main/reviewing/lockfile",
+  "keywords": [
+    "pnpm7",
+    "pnpm",
+    "list",
+    "ls"
+  ],
+  "engines": {
+    "node": ">=14.6"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/reviewing/lockfile#readme",
+  "dependencies": {
+    "semver": "7.3.8",
+    "js-yaml": "npm:@zkochan/js-yaml@0.0.6",
+    "chalk": "4.1.2"
+  },
+  "devDependencies": {
+    "@pnpm/lockfile-review": "workspace:*",
+    "@types/js-yaml": "4.0.5",
+    "@pnpm/lockfile-types": "workspace:*",
+    "@pnpm/types": "8.10.0",
+    "@types/semver": "7.3.13"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  }
+}

--- a/reviewing/lockfile/src/graph/builder.ts
+++ b/reviewing/lockfile/src/graph/builder.ts
@@ -1,0 +1,211 @@
+import { Graph, GraphBuilderContext, ImporterNode, Importers, LockfileWalkerStep, NodeKind, PackageNode, Packages } from './types'
+
+function resolve (base: string, relative: string): string {
+  if (relative.startsWith('/')) {
+    return relative
+  }
+  const _base = base.split('/')
+  for (const current of relative.split('/')) {
+    if (current === '.') {
+      continue
+    } else if (current === '..') {
+      _base.pop()
+    } else if (current.length > 0) {
+      _base.push(current)
+    }
+  }
+  return _base.join('/')
+}
+
+export function createBuilder<
+  Importer,
+  Package extends { dependencies?: Record<string, string>, optionalDependencies?: Record<string, string> },
+  Lockfile extends { importers: Record<string, Importer>, packages?: Record<string, Package> }
+> (ctx: GraphBuilderContext<Importer, Package, Lockfile>) {
+  return function (rawLockfile: string): Graph {
+    const lockfile = ctx.parse(rawLockfile)
+    const importerIds = Object.keys(lockfile.importers)
+    const packagesIds = Object.keys(lockfile.packages ?? {})
+    const importers: Importers = new Map(
+      importerIds.map(
+        id => [
+          id,
+          {
+            key: id,
+            children: new Set(),
+            parents: new Set(),
+            missing: new Set(),
+            links: new Set(),
+            kind: 0,
+          },
+        ]
+      )
+    )
+
+    const packages: Packages = new Map(
+      packagesIds.map(
+        id => [
+          id,
+          {
+            key: id,
+            children: new Set(),
+            parents: new Set(),
+            missing: new Set(),
+            links: new Set(),
+            kind: 1,
+          },
+        ]
+      )
+    )
+
+    function step (nextDepPaths: string[]): LockfileWalkerStep {
+      const result: LockfileWalkerStep = {
+        dependencies: [],
+        links: [],
+        missing: [],
+      }
+
+      for (const depPath of nextDepPaths) {
+        const packageSnapshot = lockfile.packages?.[depPath]
+        if (packageSnapshot === null || typeof packageSnapshot === 'undefined') {
+          if (depPath.startsWith('link:')) {
+            result.links.push(depPath)
+            continue
+          }
+          result.missing.push(depPath)
+          continue
+        }
+        result.dependencies.push({
+          depPath,
+          next: () => step(ctx.nextPackages(packageSnapshot)),
+        })
+      }
+
+      return result
+    }
+
+    function dfs (pre: string, step: LockfileWalkerStep) {
+      const parent = packages.get(pre)
+      if (!parent) {
+        throw Error('unreachable')
+      }
+      step.links.forEach(link => {
+        const resolved = resolve(pre, link.slice(5))
+        if (resolved.startsWith('/')) {
+          const child = packages.get(resolved)!
+          parent.links.add(child)
+          child.parents.add(parent)
+        } else {
+          const child = importers.get(resolved)!
+          parent.links.add(child)
+          child.parents.add(parent)
+        }
+      })
+      if (step.links.length > 0) {
+        throw Error('')
+      }
+      step.missing.forEach(missing => {
+        parent.missing.add(missing)
+      })
+      step.dependencies.forEach(dep => {
+        const child = packages.get(dep.depPath)!
+        setPackageNodePath(child)
+        if (!parent.children.has(child)) {
+          parent.children.add(child)
+          child.parents.add(parent)
+          dfs(dep.depPath, dep.next())
+        }
+      })
+    }
+
+    importerIds.forEach(importId => {
+      const projectSnapshot = lockfile.importers[importId]
+      const entryNodes = ctx.entryNodes(projectSnapshot)
+      const importer = importers.get(importId)!
+      const firstStep = step(entryNodes)
+
+      firstStep.links.forEach(link => {
+        const resolved = resolve(importId, link.slice(5))
+        if (resolved.startsWith('/')) {
+          const child = packages.get(resolved)!
+          importer.links.add(child)
+          child.parents.add(importer)
+        } else {
+          const child = importers.get(resolved)!
+          importer.links.add(child)
+          child.parents.add(importer)
+        }
+      })
+      firstStep.missing.forEach(missing => {
+        importer.missing.add(missing)
+      })
+      firstStep.dependencies.forEach(dep => {
+        const child = packages.get(dep.depPath)!
+        setPackageNodePath(child)
+        importer.children.add(child)
+        child.parents.add(importer)
+        const next = dep.next()
+        dfs(dep.depPath, next)
+      })
+    })
+
+    function setPackageNodePath (node: PackageNode) {
+      const { host, name, version, peersSuffix } = ctx.parseDependencyPath(node.key)
+      if (host) {
+        node.host = host
+      }
+      if (name) {
+        node.name = name
+      }
+      if (version) {
+        node.version = version
+      }
+      if (peersSuffix) {
+        node.peersSuffix = peersSuffix
+      }
+    }
+
+    return build(importers, packages)
+  }
+}
+
+function build (importers: Importers, packages: Packages): Graph {
+  const importerIds = Array.from(importers.keys())
+  const packageKeys = Array.from(packages.keys())
+  return {
+    importerIds,
+    packageKeys,
+    getImporter (importerId) {
+      return importers.get(importerId)
+    },
+    getPackage (packageKey) {
+      return packages.get(packageKey)
+    },
+    whoImportThisPackage (packageKey) {
+      return whoImportThisPackage(packages, packageKey)
+    },
+  }
+}
+
+function whoImportThisPackage (packages: Packages, packageKey: string): string[][] | undefined {
+  const node = packages.get(packageKey)
+  if (!node) {
+    return undefined
+  }
+  const paths: string[][] = []
+  function dfs (prefix: Set<string>, node: PackageNode | ImporterNode) {
+    if (prefix.has(node.key)) {
+      paths.push([node.key + '|circle', ...prefix])
+      return
+    }
+    node.parents.forEach(next => {
+      if (next.kind === NodeKind.Importer) {
+        paths.push([next.key, node.key, ...prefix])
+      } else {
+        dfs(new Set([node.key, ...prefix]), next)
+      }
+    })
+  }
+  dfs(new Set(), node)
+  return paths
+}

--- a/reviewing/lockfile/src/graph/diff.ts
+++ b/reviewing/lockfile/src/graph/diff.ts
@@ -1,0 +1,56 @@
+import { Graph, NodeKind, PackageNode } from './types'
+
+function isSameNode (target: PackageNode, current: PackageNode): boolean {
+  if (target.kind !== current.kind) {
+    return false
+  } else if (target.kind === NodeKind.Importer) {
+    return target.key === current.key
+  } else if (target.key === current.key) {
+    return true
+  } else {
+    return target.name === current.name &&
+      target.version === current.version &&
+      target.peersSuffix === current.peersSuffix
+  }
+}
+
+function diffImporters (target: string[], current: string[]): Diff<string> {
+  const added = current.filter(key => !target.includes(key))
+  const deleted = target.filter(key => !current.includes(key))
+  return {
+    added,
+    deleted,
+  }
+}
+
+interface Diff<T> {
+  added: T[]
+  deleted: T[]
+}
+
+interface DiffGraph {
+  importers: Diff<string>
+  packages: Diff<string>
+}
+
+export function diffGraph (targetGraph: Graph, currentGraph: Graph): DiffGraph {
+  function diffPackages (target: string[], current: string[]): Diff<string> {
+    const added = current.filter(cur => {
+      const currentNode = currentGraph.getPackage(cur)!
+      return target.findIndex(tar => isSameNode(targetGraph.getPackage(tar)!, currentNode)) === -1
+    })
+    const deleted = target.filter(tar => {
+      const targetNode = targetGraph.getPackage(tar)!
+      return current.findIndex(cur => isSameNode(targetNode, currentGraph.getPackage(cur)!)) === -1
+    })
+    return {
+      added,
+      deleted,
+    }
+  }
+
+  return {
+    importers: diffImporters(targetGraph.importerIds, currentGraph.importerIds),
+    packages: diffPackages(targetGraph.packageKeys, currentGraph.packageKeys),
+  }
+}

--- a/reviewing/lockfile/src/graph/types.ts
+++ b/reviewing/lockfile/src/graph/types.ts
@@ -1,0 +1,65 @@
+export const enum NodeKind {
+  Importer,
+  Package,
+  Missing
+}
+
+interface Node {
+  key: string
+  children: Set<PackageNode | ImporterNode>
+  missing: Set<string>
+  links: Set<PackageNode | ImporterNode>
+  parents: Set<PackageNode | ImporterNode>
+  kind: NodeKind
+}
+
+export type ImporterNode = Node
+
+export interface PackageNode extends ImporterNode {
+  host?: string
+  name?: string
+  version?: string
+  peersSuffix?: string
+}
+
+export type ImporterPath = [ImporterNode, ...Array<PackageNode | string>]
+
+export type Importers = Map<string, ImporterNode>
+export type Packages = Map<string, PackageNode>
+
+export interface Graph {
+  importerIds: string[]
+  packageKeys: string[]
+  getImporter: (importerId: string) => ImporterNode | undefined
+  getPackage: (packageKey: string) => PackageNode | undefined
+  whoImportThisPackage: (packageKey: string) => string[][] | undefined
+}
+
+export interface DependencyPath {
+  host: string | undefined
+  isAbsolute: boolean
+  name?: string | undefined
+  peersSuffix?: string | undefined
+  version?: string | undefined
+}
+
+export interface GraphBuilderContext<
+  Importer,
+  Package extends { dependencies?: Record<string, string>, optionalDependencies?: Record<string, string> },
+  Lockfile extends { importers: Record<string, Importer>, packages?: Record<string, Package> }
+> {
+  parse: (rawLockfile: any) => Lockfile // eslint-disable-line
+  entryNodes: (importer: Importer) => string[]
+  nextPackages: (nowPackage: Package) => string[]
+  refToRelative: (reference: string, pkgName: string) => string | null
+  parseDependencyPath: (dependencyPath: string) => DependencyPath
+}
+
+export interface LockfileWalkerStep {
+  dependencies: Array<{
+    depPath: string
+    next: () => LockfileWalkerStep
+  }>
+  links: string[]
+  missing: string[]
+}

--- a/reviewing/lockfile/src/index.ts
+++ b/reviewing/lockfile/src/index.ts
@@ -1,0 +1,24 @@
+import type { Graph } from './graph/types'
+import * as v5 from './pnpm/v5'
+import * as v6 from './pnpm/v6'
+import { createBuilder } from './graph/builder'
+
+export function createLockfileGraph (lockfile: any): Graph { // eslint-disable-line
+  const version = lockfile.lockfileVersion
+  if (!version) {
+    throw Error('lockfileVersion is not defined')
+  }
+  if (v6.isExperimentalInlineSpecifiersFormat(lockfile)) {
+    return v6.graphBuilder(lockfile)
+  } else if (typeof version === 'number' && version >= 5 && version < 6) {
+    return v5.graphBuilder(lockfile)
+  } else {
+    throw Error('unsupported lockfile version')
+  }
+}
+
+export const createPnpmV5LockfileGraph = v5.graphBuilder
+export const createPnpmV6LockfileGraph = v6.graphBuilder
+export const createGraphBuilder = createBuilder
+export type { Graph }
+export { diffGraph } from './graph/diff'

--- a/reviewing/lockfile/src/pnpm/utils.ts
+++ b/reviewing/lockfile/src/pnpm/utils.ts
@@ -1,0 +1,55 @@
+import semver from 'semver'
+import type { DependencyPath } from '../graph/types'
+
+export function parseDependencyPath (
+  dependencyPath: string,
+  ctx: {
+    parseVersion: (version: string) => {
+      version: string
+      peersSuffix?: string
+    }
+    splitToParts: (dependencyPath: string) => string[]
+  }
+): DependencyPath {
+  if (typeof dependencyPath !== 'string') {
+    throw new TypeError(
+      `Expected \`dependencyPath\` to be of type \`string\`, got \`${dependencyPath === null ? 'null' : typeof dependencyPath
+      }\``
+    )
+  }
+  const isAbsolute = dependencyPath[0] !== '/'
+  const parts = ctx.splitToParts(dependencyPath)
+  if (!isAbsolute) {
+    parts.shift()
+  }
+  const host = isAbsolute ? parts.shift() : undefined
+  if (parts.length === 0) {
+    return {
+      host,
+      isAbsolute,
+    }
+  }
+  const name = parts[0].startsWith('@')
+    ? `${parts.shift()}/${parts.shift()}` // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    : parts.shift()
+  const _version = parts.join('/')
+  if (_version) {
+    const { version, peersSuffix } = ctx.parseVersion(_version)
+    if (semver.valid(version)) {
+      return {
+        host,
+        isAbsolute,
+        name,
+        peersSuffix,
+        version,
+      }
+    }
+  }
+  if (!isAbsolute) {
+    throw new Error(`${dependencyPath} is an invalid relative dependency path`)
+  }
+  return {
+    host,
+    isAbsolute,
+  }
+}

--- a/reviewing/lockfile/src/pnpm/v5.ts
+++ b/reviewing/lockfile/src/pnpm/v5.ts
@@ -1,0 +1,78 @@
+import type { Lockfile, PackageSnapshot, ProjectSnapshot } from '@pnpm/lockfile-types'
+import { DEPENDENCIES_FIELDS } from '@pnpm/types'
+import { createBuilder } from '../graph/builder'
+import * as utils from './utils'
+
+function convertFromLockfileFileMutable (lockfileFile: any): Lockfile { // eslint-disable-line
+  if (typeof lockfileFile.importers === 'undefined') {
+    lockfileFile.importers = {
+      '.': {
+        specifiers: lockfileFile.specifiers ?? {},
+        dependenciesMeta: lockfileFile.dependenciesMeta,
+        publishDirectory: lockfileFile.publishDirectory,
+      },
+    }
+    delete lockfileFile.specifiers
+    for (const depType of DEPENDENCIES_FIELDS) {
+      if (lockfileFile[depType] !== null && typeof lockfileFile[depType] !== 'undefined') {
+        lockfileFile.importers['.'][depType] = lockfileFile[depType]
+        delete lockfileFile[depType]
+      }
+    }
+  }
+  return lockfileFile as Lockfile
+}
+
+function refToRelative (reference: string, pkgName: string): string {
+  if (reference.startsWith('link:')) {
+    return reference
+  }
+  if (
+    !reference.includes('/') ||
+    (reference.includes('(') && reference.lastIndexOf('/', reference.indexOf('(')) === -1)
+  ) {
+    return `/${pkgName}/${reference}`
+  }
+  return reference
+}
+
+function entryNodes (projectSnapshot: ProjectSnapshot): string[] {
+  return Object.entries({
+    ...projectSnapshot.devDependencies,
+    ...projectSnapshot.dependencies,
+    ...projectSnapshot.optionalDependencies,
+  })
+    .map(([pkgName, reference]) => refToRelative(reference, pkgName))
+}
+
+function nextPackages (currentPackage: PackageSnapshot): string[] {
+  return Object.entries({
+    ...currentPackage.dependencies,
+    ...currentPackage.optionalDependencies,
+  })
+    .map(([pkgName, reference]) => refToRelative(reference, pkgName))
+}
+
+export const graphBuilder = createBuilder<ProjectSnapshot, PackageSnapshot, Lockfile>({
+  parse: convertFromLockfileFileMutable,
+  refToRelative,
+  entryNodes,
+  nextPackages,
+  parseDependencyPath (dependencyPath) {
+    return utils.parseDependencyPath(dependencyPath, {
+      splitToParts (depPath) {
+        return depPath.split('/')
+      },
+      parseVersion (version) {
+        const peerSepIndex = version.indexOf('_')
+        if (peerSepIndex !== -1) {
+          return {
+            version: version.substring(0, peerSepIndex),
+            peersSuffix: version.substring(peerSepIndex + 1),
+          }
+        }
+        return { version }
+      },
+    })
+  },
+})

--- a/reviewing/lockfile/src/pnpm/v6.ts
+++ b/reviewing/lockfile/src/pnpm/v6.ts
@@ -1,0 +1,110 @@
+import type { Lockfile, PackageSnapshot } from '@pnpm/lockfile-types'
+import { DEPENDENCIES_FIELDS } from '@pnpm/types'
+import type { DependenciesMeta } from '@pnpm/types'
+import { createBuilder } from '../graph/builder'
+import * as utils from './utils'
+
+interface InlineSpecifiersProjectSnapshot {
+  dependencies?: InlineSpecifiersResolvedDependencies
+  devDependencies?: InlineSpecifiersResolvedDependencies
+  optionalDependencies?: InlineSpecifiersResolvedDependencies
+  dependenciesMeta?: DependenciesMeta
+}
+
+interface InlineSpecifiersResolvedDependencies {
+  [depName: string]: SpecifierAndResolution
+}
+
+interface SpecifierAndResolution {
+  specifier: string
+  version: string
+}
+
+interface InlineSpecifiersLockfile extends Omit<Lockfile, 'lockfileVersion' | 'importers'> {
+  lockfileVersion: string
+  importers: Record<string, InlineSpecifiersProjectSnapshot>
+}
+
+const INLINE_SPECIFIERS_FORMAT_LOCKFILE_VERSION_SUFFIX = '-inlineSpecifiers'
+
+export function isExperimentalInlineSpecifiersFormat (
+  lockfile: Omit<Lockfile, 'lockfileVersion'> & { lockfileVersion: string | number }
+): boolean {
+  const { lockfileVersion } = lockfile
+  return lockfileVersion.toString().startsWith('6.') || typeof lockfileVersion === 'string' && lockfileVersion.endsWith(INLINE_SPECIFIERS_FORMAT_LOCKFILE_VERSION_SUFFIX)
+}
+
+function convertFromLockfileFileMutable (lockfileFile: any): InlineSpecifiersLockfile { // eslint-disable-line
+  if (typeof lockfileFile.importers === 'undefined') {
+    lockfileFile.importers = {
+      '.': {
+        dependenciesMeta: lockfileFile.dependenciesMeta,
+      },
+    }
+    for (const depType of DEPENDENCIES_FIELDS) {
+      if (lockfileFile[depType] !== null && typeof lockfileFile[depType] !== 'undefined') {
+        lockfileFile.importers['.'][depType] = lockfileFile[depType]
+        delete lockfileFile[depType]
+      }
+    }
+  }
+  return lockfileFile as InlineSpecifiersLockfile
+}
+
+function refToRelative (reference: string, pkgName: string): string {
+  if (reference.startsWith('link:')) {
+    return reference
+  }
+  if (!reference.includes('/') || !reference.replace(/(\([^)]+\))+$/, '').includes('/')) {
+    return `/${pkgName}@${reference}`
+  }
+  return reference
+}
+
+function entryNodes (projectSnapshot: InlineSpecifiersProjectSnapshot): string[] {
+  return Object.entries({
+    ...Object.fromEntries(
+      Object.entries(projectSnapshot.devDependencies ?? {}).map(([key, inline]) => [key, inline.version])
+    ),
+    ...Object.fromEntries(
+      Object.entries(projectSnapshot.dependencies ?? {}).map(([key, inline]) => [key, inline.version])
+    ),
+    ...Object.fromEntries(
+      Object.entries(projectSnapshot.optionalDependencies ?? {}).map(([key, inline]) => [key, inline.version])
+    ),
+  })
+    .map(([pkgName, reference]) => refToRelative(reference, pkgName))
+}
+
+function nextPackages (currentPackage: PackageSnapshot): string[] {
+  return Object.entries({
+    ...currentPackage.dependencies,
+    ...currentPackage.optionalDependencies,
+  })
+    .map(([pkgName, reference]) => refToRelative(reference, pkgName))
+}
+
+export const graphBuilder = createBuilder<InlineSpecifiersProjectSnapshot, PackageSnapshot, InlineSpecifiersLockfile>({
+  parse: convertFromLockfileFileMutable,
+  refToRelative,
+  entryNodes,
+  nextPackages,
+  parseDependencyPath (dependencyPath) {
+    return utils.parseDependencyPath(dependencyPath, {
+      splitToParts (depPath) {
+        const [pre, last] = depPath.split('@', 2)
+        return [...pre.split('/'), last]
+      },
+      parseVersion (version) {
+        const peerSepIndex = version.indexOf('_')
+        if (peerSepIndex !== -1) {
+          return {
+            version: version.substring(0, peerSepIndex),
+            peersSuffix: version.substring(peerSepIndex + 1),
+          }
+        }
+        return { version }
+      },
+    })
+  },
+})

--- a/reviewing/lockfile/test/fixture/case0.yaml
+++ b/reviewing/lockfile/test/fixture/case0.yaml
@@ -1,0 +1,21 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    devDependencies:
+      ws-a:
+        specifier: workspace:*
+        version: 'link:'
+
+  packages/b:
+    dependencies:
+      ws-a:
+        specifier: workspace:*
+        version: link:../a
+    devDependencies:
+      ws-b:
+        specifier: workspace:*
+        version: 'link:'

--- a/reviewing/lockfile/test/fixture/case1.yaml
+++ b/reviewing/lockfile/test/fixture/case1.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      ws-b:
+        specifier: workspace:*
+        version: link:../b
+    devDependencies:
+      ws-a:
+        specifier: workspace:*
+        version: 'link:'
+
+  packages/b:
+    dependencies:
+      ws-a:
+        specifier: workspace:*
+        version: link:../a
+    devDependencies:
+      ws-b:
+        specifier: workspace:*
+        version: 'link:'

--- a/reviewing/lockfile/test/fixture/case2.yaml
+++ b/reviewing/lockfile/test/fixture/case2.yaml
@@ -1,0 +1,48 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      ws-b:
+        specifier: workspace:*
+        version: link:../b
+    devDependencies:
+      ws-a:
+        specifier: workspace:*
+        version: 'link:'
+
+  packages/b:
+    dependencies:
+      react:
+        specifier: 18.0.0
+        version: 18.0.0
+      ws-a:
+        specifier: workspace:*
+        version: link:../a
+    devDependencies:
+      ws-b:
+        specifier: workspace:*
+        version: 'link:'
+
+packages:
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /react@18.0.0:
+    resolution: {integrity: sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false

--- a/reviewing/lockfile/test/fixture/case3.yaml
+++ b/reviewing/lockfile/test/fixture/case3.yaml
@@ -1,0 +1,48 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      ws-b:
+        specifier: workspace:*
+        version: link:../b
+    devDependencies:
+      ws-a:
+        specifier: workspace:*
+        version: 'link:'
+
+  packages/b:
+    dependencies:
+      react:
+        specifier: 18.1.0
+        version: 18.1.0
+      ws-a:
+        specifier: workspace:*
+        version: link:../a
+    devDependencies:
+      ws-b:
+        specifier: workspace:*
+        version: 'link:'
+
+packages:
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false

--- a/reviewing/lockfile/test/fixture/case4.yaml
+++ b/reviewing/lockfile/test/fixture/case4.yaml
@@ -1,0 +1,58 @@
+lockfileVersion: '6.0'
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      ws-b:
+        specifier: workspace:*
+        version: link:../b
+    devDependencies:
+      ws-a:
+        specifier: workspace:*
+        version: 'link:'
+
+  packages/b:
+    dependencies:
+      react:
+        specifier: 18.1.0
+        version: 18.1.0
+      ws-a:
+        specifier: workspace:*
+        version: link:../a
+    devDependencies:
+      ws-b:
+        specifier: workspace:*
+        version: 'link:'
+
+packages:
+
+  /js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: false
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
+
+  /react@18.1.0:
+    resolution: {integrity: sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false

--- a/reviewing/lockfile/test/graph.test.ts
+++ b/reviewing/lockfile/test/graph.test.ts
@@ -1,0 +1,43 @@
+import path from 'path'
+import yaml from 'js-yaml'
+import fs from 'fs/promises'
+import { createLockfileGraph, diffGraph } from '../src'
+import type { Graph } from '../src'
+
+test('basic circular should works', async () => {
+  const lockfile0 = await load(path.resolve(__dirname, './fixture/case0.yaml'))
+  const lockfile1 = await load(path.resolve(__dirname, './fixture/case1.yaml'))
+  const diff = diffGraph(lockfile0, lockfile1)
+  expect(diff.importers.added.length).toBe(0)
+  expect(diff.importers.deleted.length).toBe(0)
+  expect(diff.packages.added.length).toBe(0)
+  expect(diff.packages.deleted.length).toBe(0)
+})
+
+test('should works for add dependency', async () => {
+  const lockfile1 = await load(path.resolve(__dirname, './fixture/case1.yaml'))
+  const lockfile2 = await load(path.resolve(__dirname, './fixture/case2.yaml'))
+  const diff = diffGraph(lockfile1, lockfile2)
+  const added = diff.packages.added
+  expect(added.length).toBe(3)
+  expect(lockfile2.whoImportThisPackage(added[0])).toStrictEqual([['packages/b', '/react@18.0.0', '/loose-envify@1.4.0', '/js-tokens@4.0.0']])
+  expect(lockfile2.whoImportThisPackage(added[1])).toStrictEqual([['packages/b', '/react@18.0.0', '/loose-envify@1.4.0']])
+  expect(lockfile2.whoImportThisPackage(added[2])).toStrictEqual([['packages/b', '/react@18.0.0']])
+})
+
+test('should works for modified', async () => {
+  const lockfile2 = await load(path.resolve(__dirname, './fixture/case2.yaml'))
+  const lockfile3 = await load(path.resolve(__dirname, './fixture/case3.yaml'))
+  const diff = diffGraph(lockfile2, lockfile3)
+  const { added, deleted } = diff.packages
+  expect(added.length).toBe(1)
+  expect(deleted.length).toBe(1)
+  expect(lockfile3.whoImportThisPackage(added[0])).toStrictEqual([['packages/b', '/react@18.1.0']])
+  expect(lockfile2.whoImportThisPackage(deleted[0])).toStrictEqual([['packages/b', '/react@18.0.0']])
+})
+
+async function load (lockfilePath: string): Promise<Graph> {
+  const content = (await fs.readFile(lockfilePath)).toString('utf-8')
+  const loaded = yaml.load(content)
+  return createLockfileGraph(loaded)
+}

--- a/reviewing/lockfile/tsconfig.json
+++ b/reviewing/lockfile/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../lockfile/lockfile-types"
+    },
+    {
+      "path": "../../packages/types"
+    }
+  ],
+  "composite": true
+}

--- a/reviewing/lockfile/tsconfig.lint.json
+++ b/reviewing/lockfile/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
The goal of the PR is to implement a cli tools to facilitate the use of conflicting lockfiles in large projects. Relative issue: https://github.com/pnpm/pnpm/issues/6113

Currently, I'm looking for more suggestions, including but not limited to API design, CLI presentation, and specific features. 

Here's a demo of the features that come with this pr:

Suppose we have two lockfiles, the latter has some modifications based on the former: add `react@18.2.0` dependency in `packages/a`, modify `react@18.0.0` to `react@18.1.0` in `packages/b`.

Then, `lockfile-review <lockfile-a> <lockfile-b>` will show the changes of the entire repository dependency version:

<img width="441" alt="image" src="https://user-images.githubusercontent.com/30187863/221130293-59f9bf09-3d74-45ea-a877-7093edb34c7b.png">

`--paths` will show the path of dependency changes:

<img width="461" alt="image" src="https://user-images.githubusercontent.com/30187863/221130468-362dbb09-ba36-4af9-be7d-7f4138fdb298.png">

`--workspace` will be displayed in the project dimension 

<img width="484" alt="image" src="https://user-images.githubusercontent.com/30187863/221130584-520a714e-1eb2-4a58-befb-caeb31314123.png">

Of course, you can combine two parameters:

<img width="536" alt="image" src="https://user-images.githubusercontent.com/30187863/221130659-8f073067-8294-4173-a548-c17c6f5525b9.png">
