### PR TITLE
fix: should fail when add new dependency from not existing directory

### DIFF
--- a/resolving/local-resolver/src/index.ts
+++ b/resolving/local-resolver/src/index.ts
@@ -55,7 +55,7 @@ export async function resolveFromLocal (
     localDependencyManifest = await readProjectManifestOnly(spec.fetchSpec) as DependencyManifest
   } catch (internalErr: any) { // eslint-disable-line
     if (!existsSync(spec.fetchSpec)) {
-      if (spec.id.startsWith('file:')) {
+      if (spec.id.startsWith('file:') || wantedDependency.isNew) {
         throw new PnpmError('LINKED_PKG_DIR_NOT_FOUND',
           `Could not install from "${spec.fetchSpec}" as it does not exist.`)
       }

--- a/resolving/local-resolver/src/parsePref.ts
+++ b/resolving/local-resolver/src/parsePref.ts
@@ -20,6 +20,7 @@ export interface LocalPackageSpec {
 export interface WantedLocalDependency {
   pref: string
   injected?: boolean
+  isNew?: boolean
 }
 
 export function parsePref (

--- a/resolving/local-resolver/test/index.ts
+++ b/resolving/local-resolver/test/index.ts
@@ -136,6 +136,14 @@ test('do not fail when resolving from not existing directory', async () => {
   })
 })
 
+test('fail when add local dependency from not existing directory', async () => {
+  const wantedDependency = { pref: '@a/@b/c', isNew: true }
+  const projectDir = __dirname
+  await expect(
+    resolveFromLocal(wantedDependency, { projectDir })
+  ).rejects.toThrow(`Could not install from "${path.join(projectDir, '@a/@b/c')}" as it does not exist.`)
+})
+
 test('throw error when the path: protocol is used', async () => {
   try {
     await resolveFromLocal({ pref: 'path:..' }, { projectDir: __dirname })


### PR DESCRIPTION
fix: #6118 