### PR TITLE
fix: add report summary skipped status when script is missing

### DIFF
--- a/.changeset/cuddly-ducks-lay.md
+++ b/.changeset/cuddly-ducks-lay.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"@pnpm/cli-utils": patch
+---
+
+Add `skipped` status in exec report summary when script is missing.

--- a/.changeset/cuddly-ducks-lay.md
+++ b/.changeset/cuddly-ducks-lay.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/plugin-commands-script-runners": patch
 "@pnpm/cli-utils": patch
+"pnpm": patch
 ---
 
-Add `skipped` status in exec report summary when script is missing.
+Add `skipped` status in exec report summary when script is missing [#6139](https://github.com/pnpm/pnpm/pull/6139).

--- a/cli/cli-utils/src/recursiveSummary.ts
+++ b/cli/cli-utils/src/recursiveSummary.ts
@@ -9,7 +9,7 @@ interface ActionFailure {
 }
 
 export type RecursiveSummary = Record<string, {
-  status: 'passed' | 'queued' | 'running'
+  status: 'passed' | 'queued' | 'running' | 'skipped'
   duration?: number
 } | ActionFailure>
 

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -84,7 +84,9 @@ export async function runRecursive (
     const selectedScripts = chunk.map(prefix => {
       const pkg = opts.selectedProjectsGraph[prefix]
       const specifiedScripts = getSpecifiedScripts(pkg.package.manifest.scripts ?? {}, scriptName)
-
+      if (!specifiedScripts.length) {
+        result[prefix].status = 'skipped'
+      }
       return specifiedScripts.map(script => ({ prefix, scriptName: script }))
     }).flat()
 

--- a/exec/plugin-commands-script-runners/test/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/runRecursive.ts
@@ -1008,6 +1008,10 @@ test('pnpm recursive run report summary', async () => {
         build: 'exit 1',
       },
     },
+    {
+      name: 'project-5',
+      version: '1.0.0',
+    },
   ])
   let error
   try {
@@ -1033,6 +1037,7 @@ test('pnpm recursive run report summary', async () => {
   expect(executionStatus[path.resolve('project-3')].duration).not.toBeFalsy()
   expect(executionStatus[path.resolve('project-4')].status).toBe('failure')
   expect(executionStatus[path.resolve('project-4')].duration).not.toBeFalsy()
+  expect(executionStatus[path.resolve('project-5')].status).toBe('skipped')
 })
 
 test('pnpm recursive run report summary with --bail', async () => {
@@ -1065,6 +1070,10 @@ test('pnpm recursive run report summary with --bail', async () => {
         build: 'exit 1',
       },
     },
+    {
+      name: 'project-5',
+      version: '1.0.0',
+    },
   ])
   let error
   try {
@@ -1090,4 +1099,5 @@ test('pnpm recursive run report summary with --bail', async () => {
   expect(executionStatus[path.resolve('project-2')].duration).not.toBeFalsy()
   expect(executionStatus[path.resolve('project-3')].status).toBe('running')
   expect(executionStatus[path.resolve('project-4')].status).toBe('queued')
+  expect(executionStatus[path.resolve('project-5')].status).toBe('skipped')
 })


### PR DESCRIPTION
As discussed in https://github.com/pnpm/pnpm/pull/6098#issuecomment-1445258329, add a `skipped` status when script is missing.