### PR TITLE
fix: allowedVersions corner case when only parent>child selectors exist

### DIFF
--- a/.changeset/unlucky-avocados-unite.md
+++ b/.changeset/unlucky-avocados-unite.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+---
+
+Fixed issue where allowedVersions wouldn't apply correctly if only parent>child selectors were used

--- a/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
+++ b/hooks/read-package-hook/src/createPeerDependencyPatcher.ts
@@ -36,11 +36,10 @@ export function createPeerDependencyPatcher (
         pkg.peerDependencies![peerName] = '*'
         continue
       }
-      if (
-        !peerDependencyRules.allowedVersions?.[peerName] ||
-        peerVersion === '*'
-      ) continue
-      if (peerDependencyRules.allowedVersions[peerName] === '*') {
+      if (!allowedVersions?.[peerName] || peerVersion === '*') {
+        continue
+      }
+      if (allowedVersions?.[peerName].includes('*')) {
         pkg.peerDependencies![peerName] = '*'
         continue
       }

--- a/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
+++ b/hooks/read-package-hook/test/createPeerDependencyPatcher.test.ts
@@ -168,6 +168,25 @@ test('createPeerDependencyPatcher() overrides peerDependencies when parent>child
   })
 })
 
+// corner case exists when a 'parent>child' allowedVersion selector is used without a 'child' selector
+test('createPeerDependencyPatcher() corner case correctly applies override', () => {
+  const patcher = createPeerDependencyPatcher({
+    allowedVersions: {
+      'foo>bar': '2',
+    },
+  })
+
+  const patchedPkg = patcher({
+    name: 'foo',
+    peerDependencies: {
+      bar: '0 || 1',
+    },
+  }) as ProjectManifest
+  expect(patchedPkg.peerDependencies).toStrictEqual({
+    bar: '0 || 1 || 2',
+  })
+})
+
 test('createPeerDependencyPathcer() throws expected error if parent>child selector cannot parse', () => {
   expect(() => createPeerDependencyPatcher({
     allowedVersions: {


### PR DESCRIPTION
This fixes a corner case that was missed in the original implementation, which is when the `allowedVersions` option only contains `parent>child` selectors.

If anyone needs a temporary work around while waiting for this to make it into a release, they can circumvent the issue by defining a "bogus" `child` selector in conjunction with the `parent>child` selector(s).

```js
"allowedVersions": {
  "react": "0", // any version number lower than or equal to the defined peerDependencies
  "pkg-a>react": "18"
}
```