### PR TITLE
feat: add prefer-versions-from to control where init preferredVersions

### DIFF
--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -84,6 +84,7 @@ export interface Config {
   useStderr?: boolean
   nodeLinker?: 'hoisted' | 'isolated' | 'pnp'
   preferSymlinkedExecutables?: boolean
+  preferVersionsFrom?: 'lockfile' | 'lockfile-and-manifest'
   resolutionMode?: 'highest' | 'time-based' | 'lowest-direct'
   registrySupportsTimeField?: boolean
   failedToLoadBuiltInConfig: boolean

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -87,6 +87,7 @@ export const types = Object.assign({
   'prefer-offline': Boolean,
   'prefer-symlinked-executables': Boolean,
   'prefer-workspace-packages': Boolean,
+  'prefer-versions-from': ['lockfile', 'lockfile-and-manifest'],
   production: [null, true],
   'public-hoist-pattern': Array,
   'publish-branch': String,
@@ -207,6 +208,7 @@ export async function getConfig (
     'lockfile-include-tarball-url': false,
     'modules-cache-max-age': 7 * 24 * 60, // 7 days
     'node-linker': 'isolated',
+    'prefer-versions-from': 'lockfile-and-manifest',
     'package-lock': npmDefaults['package-lock'],
     pending: false,
     'prefer-workspace-packages': false,
@@ -273,6 +275,7 @@ export async function getConfig (
     ...npmConfig.list.slice(3, pnpmConfig.workspaceDir && pnpmConfig.workspaceDir !== cwd ? 5 : 4).reverse(),
     cliOptions,
   ] as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+  pnpmConfig.preferVersionsFrom = pnpmConfig.rawLocalConfig['prefer-versions-from']
   pnpmConfig.userAgent = pnpmConfig.rawLocalConfig['user-agent']
     ? pnpmConfig.rawLocalConfig['user-agent']
     : `${packageManager.name}/${packageManager.version} npm/? node/${process.version} ${process.platform} ${process.arch}`

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -993,3 +993,35 @@ test('read PNPM_HOME defined in environment variables', async () => {
 
   process.env = oldEnv
 })
+
+test('respect prefer-versions-from', async () => {
+  {
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+    expect(config.preferVersionsFrom).toBeUndefined()
+  }
+  {
+    prepareEmpty()
+
+    const npmrc = [
+      'prefer-versions-from=lockfile',
+    ].join('\n')
+
+    await fs.writeFile('.npmrc', npmrc, 'utf8')
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    expect(config.preferVersionsFrom).toEqual('lockfile')
+  }
+})

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -104,6 +104,7 @@ export interface StrictInstallOptions {
   allowedDeprecatedVersions: AllowedDeprecatedVersions
   allowNonAppliedPatches: boolean
   preferSymlinkedExecutables: boolean
+  preferVersionsFrom: 'lockfile' | 'lockfile-and-manifest'
   resolutionMode: 'highest' | 'time-based' | 'lowest-direct'
   resolvePeersFromWorkspaceRoot: boolean
 
@@ -210,6 +211,7 @@ const defaults = async (opts: InstallOptions) => {
     dedupeDirectDeps: false,
     resolvePeersFromWorkspaceRoot: false,
     extendNodePath: true,
+    preferVersionsFrom: 'lockfile-and-manifest',
   } as StrictInstallOptions
 }
 

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -798,9 +798,13 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     stage: 'resolution_started',
   })
 
+  const getPreferredVersions = opts.preferVersionsFrom === 'lockfile'
+    ? getPreferredVersionsFromLockfileAndManifests.bind(null, ctx.wantedLockfile.packages, [])
+    : getPreferredVersionsFromLockfileAndManifests.bind(null, ctx.wantedLockfile.packages, Object.values(ctx.projects).map(({ manifest }) => manifest))
+
   const preferredVersions = opts.preferredVersions ?? (
     !opts.update
-      ? getPreferredVersionsFromLockfileAndManifests(ctx.wantedLockfile.packages, Object.values(ctx.projects).map(({ manifest }) => manifest))
+      ? getPreferredVersions()
       : undefined
   )
   const forceFullResolution = ctx.wantedLockfile.lockfileVersion !== LOCKFILE_VERSION ||

--- a/pkg-manager/core/test/install/dedupeInWorkspace.ts
+++ b/pkg-manager/core/test/install/dedupeInWorkspace.ts
@@ -61,3 +61,58 @@ test('pick common range for a dependency used in two workspace projects', async 
   expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep/100.0.0'])
   expect(lockfile.packages).not.toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep/100.1.0'])
 })
+
+test('should not read manifest when preferred from lockfile', async () => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2' },
+    },
+  ])
+
+  const importers: MutatedProject[] = [
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-1'),
+    },
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-2'),
+    },
+  ]
+  const allProjects = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: {
+          '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.0.0',
+        },
+      },
+      rootDir: path.resolve('project-1'),
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-2',
+        version: '1.0.0',
+        dependencies: {
+          '@pnpm.e2e/dep-of-pkg-with-1-dep': '^100.0.0',
+        },
+      },
+      rootDir: path.resolve('project-2'),
+    },
+  ]
+  await mutateModules(importers, await testDefaults({ allProjects, lockfileOnly: true, preferVersionsFrom: 'lockfile' }))
+
+  const project = assertProject(process.cwd())
+  const lockfile = await project.readLockfile()
+  expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep/100.0.0'])
+  expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep/100.1.0'])
+})

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -284,6 +284,7 @@ export type InstallCommandOptions = Pick<Config,
 | 'workspaceConcurrency'
 | 'workspaceDir'
 | 'extraEnv'
+| 'preferVersionsFrom'
 > & CreateStoreControllerOptions & {
   argv: {
     original: string[]


### PR DESCRIPTION
## Background

In the previous process, the subprojects were independent: modifying a dependency under project A did not result in a change to the dependency version of project B. However, with the merging of https://github.com/pnpm/pnpm/pull/6026, this rule was broken, making it more difficult to tell what changes were causing the version changes.

In fact, at our company, we have a lot of completely unrelated projects that go under the same monorepo, so imagine how bad it is to be working on project A and then just rebase the master, and then find out that the version of your dependency has changed.

So, this pr tries to control that behavior with a configuration item.

## `prefer-versions-from`

Add a field named `prefer-versions-from` to npmrc.

- When its value is `lockfile-and-manifest`, it will read the package.json and lockfile files of all subprojects as the initial `preferredVersions`.
- When its value is `lockfile`, it only reads the lockfile file as the initial `preferredVersions`, which serves to maintain the independence between subprojects.