### PR TITLE
fix: should not throw an error when local dependency use file protocol

### DIFF
--- a/.changeset/flat-bees-fail.md
+++ b/.changeset/flat-bees-fail.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/plugin-commands-licenses": patch
 "@pnpm/license-scanner": patch
+"pnpm": patch
 ---
 
-Should not throw an error when local dependency use file protocol[#6115](https://github.com/pnpm/pnpm/issues/6115).
+Should not throw an error when local dependency use file protocol [#6115](https://github.com/pnpm/pnpm/issues/6115).

--- a/.changeset/flat-bees-fail.md
+++ b/.changeset/flat-bees-fail.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+"@pnpm/license-scanner": patch
+---
+
+Should not throw an error when local dependency use file protocol[#6115](https://github.com/pnpm/pnpm/issues/6115).

--- a/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
+++ b/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pnpm licenses should work with file protocol dependency: show-packages 1`] = `
+"┌─────────────────────────────────┬─────────┐
+│ Package                         │ License │
+├─────────────────────────────────┼─────────┤
+│ is-positive                     │ MIT     │
+├─────────────────────────────────┼─────────┤
+│ pnpm-with-file-protocol-sub-dep │ Unknown │
+└─────────────────────────────────┴─────────┘
+"
+`;
+
 exports[`pnpm licenses: output as json: found-license-types 1`] = `
 [
   "MIT",

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pnpm-with-file-protocol",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "is-positive": "^3.1.0",
+    "pnpm-with-file-protocol-sub-dep": "file:./sub-dep"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: 5.4
+
+specifiers:
+  is-positive: ^3.1.0
+  pnpm-with-file-protocol-sub-dep: file:./sub-dep
+
+dependencies:
+  is-positive: 3.1.0
+  pnpm-with-file-protocol-sub-dep: file:sub-dep
+
+packages:
+
+  /is-positive/3.1.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  file:sub-dep:
+    resolution: {directory: sub-dep, type: directory}
+    name: pnpm-with-file-protocol-sub-dep
+    version: 1.0.0
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/sub-dep/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/sub-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-with-file-protocol-sub-dep",
+  "version": "1.0.0"
+}

--- a/reviewing/plugin-commands-licenses/test/index.ts
+++ b/reviewing/plugin-commands-licenses/test/index.ts
@@ -162,3 +162,27 @@ test('pnpm licenses: should correctly read LICENSE file with executable file mod
   expect(exitCode).toBe(0)
   expect(stripAnsi(output)).toMatchSnapshot('show-packages-details')
 })
+
+test('pnpm licenses should work with file protocol dependency', async () => {
+  const workspaceDir = path.resolve('./test/fixtures/with-file-protocol')
+
+  const tmp = tempy.directory()
+  const storeDir = path.join(tmp, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  const { output, exitCode } = await licenses.handler({
+    ...LICENSES_OPTIONS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    long: false,
+    storeDir: path.resolve(storeDir, 'v3'),
+  }, ['list'])
+
+  expect(exitCode).toBe(0)
+  expect(stripAnsi(output)).toMatchSnapshot('show-packages')
+})


### PR DESCRIPTION
fix #6115 

For single project, given a package.json like following:

```
{
  "dependencies": {
    "safe-execa": "^0.1.3",
    "test-dep": "file:./test-dep"
  }
}
```
After run `pnpm licenses ls`, it will throw an error:

```
 ERR_PNPM_UNSUPPORTED_PACKAGE_TYPE  Unsupported package resolution type for file:test-dep
```

For package `foo` in workspaces, this error is also reported if `dependencyMeta.foo.inject` is set to `true`