### PR TITLE
fix: incorrect error block when subproject has been patched (#6183)

### DIFF
--- a/.changeset/violet-insects-attack.md
+++ b/.changeset/violet-insects-attack.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Fix the incorrect error block when subproject has been patched (#6183)

--- a/.changeset/violet-insects-attack.md
+++ b/.changeset/violet-insects-attack.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/resolve-dependencies": patch
+"pnpm": patch
 ---
 
-Fix the incorrect error block when subproject has been patched (#6183)
+Fix the incorrect error block when subproject has been patched [#6183](https://github.com/pnpm/pnpm/issues/6183)

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -120,7 +120,7 @@ export async function resolveDependencies (
   // We only check whether patches were applied in cases when the whole lockfile was reanalyzed.
   if (
     opts.patchedDependencies &&
-    (opts.forceFullResolution || !opts.wantedLockfile.packages?.length) &&
+    (opts.forceFullResolution || !Object.keys(opts.wantedLockfile.packages ?? {})?.length) &&
     Object.keys(opts.wantedLockfile.importers).length === importers.length
   ) {
     verifyPatches({


### PR DESCRIPTION
closes #6183 