### PR TITLE
fix: patch-package details on applyPatch, add patch

### DIFF
--- a/__patches__/patch-package@6.5.1.patch
+++ b/__patches__/patch-package@6.5.1.patch
@@ -1,0 +1,86 @@
+diff --git a/dist/PackageDetails.js b/dist/PackageDetails.js
+index b0ce14091af48797e9b7cf2ba1d7e092e66a677a..7967a9b6b9b9860560f7fe788fbe3309ac5801f0 100644
+--- a/dist/PackageDetails.js
++++ b/dist/PackageDetails.js
+@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.getPatchDetailsFromCliString = exports.getPackageDetailsFromPatchFilename = void 0;
+ const path_1 = require("./path");
+ function parseNameAndVersion(s) {
+-    const parts = s.split("+");
++    const parts = s.split("@");
+     switch (parts.length) {
+         case 1: {
+             return { name: parts[0] };
+@@ -19,8 +19,9 @@ function parseNameAndVersion(s) {
+             return { name: `${nameOrScope}/${versionOrName}` };
+         }
+         case 3: {
+-            const [scope, name, version] = parts;
+-            return { name: `${scope}/${name}`, version };
++            const [, pnpmPatchedPackageName, version] = parts
++            const [scope, name] = pnpmPatchedPackageName.split('__')
++            return { name: `@${scope}/${name}`, version }
+         }
+     }
+     return null;
+diff --git a/dist/pnpm.d.ts b/dist/pnpm.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..fed13a2d44fdb4578ba494aa57cc4898b5a44090
+--- /dev/null
++++ b/dist/pnpm.d.ts
+@@ -0,0 +1,25 @@
++export interface PackageDetails {
++  humanReadablePathSpecifier: string
++  pathSpecifier: string
++  path: string
++  name: string
++  isNested: boolean
++  packageNames: string[]
++}
++
++export interface PatchedPackageDetails extends PackageDetails {
++  version: string
++  patchFilename: string
++  isDevOnly: boolean
++}
++
++declare module 'patch-package/pnpm' {
++  export function applyPatch({
++    patchFilePath: string,
++    reverse: boolean = false,
++    packageDetails: PackageDetails,
++    patchDir: string,
++  }): void
++
++  export function getPackageDetailsFromPatchFilename(patchFilename: string): PackageDetails
++}
+\ No newline at end of file
+diff --git a/dist/pnpm.js b/dist/pnpm.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..e3909e69529bf444dd36df9bb3b0ec2ab319e0b5
+--- /dev/null
++++ b/dist/pnpm.js
+@@ -0,0 +1,2 @@
++exports.applyPatch = require('./applyPatches.js').applyPatch
++exports.getPackageDetailsFromPatchFilename = require('./PackageDetails.js').getPackageDetailsFromPatchFilename
+\ No newline at end of file
+diff --git a/package.json b/package.json
+index 1add0049e2115036f60ca43beb5701967aa4aed6..d208605e3829602eb07a8a8876b2d7475eaec0cd 100644
+--- a/package.json
++++ b/package.json
+@@ -6,6 +6,15 @@
+   "repository": "github:ds300/patch-package",
+   "author": "David Sheldrick",
+   "license": "MIT",
++  "exports": {
++    ".": {
++      "default": "./dist/index.js"
++    },
++    "./pnpm": {
++      "default": "./dist/pnpm.js",
++      "types": "./dist/pnpm.d.ts"
++    }
++  },
+   "engines": {
+     "node": ">=10",
+     "npm": ">5"

--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -1,157 +1,163 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-declare module '@pnpm/tabtab' {
-  const anything: any
-  export = anything
+declare module "@pnpm/tabtab" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'hyperdrive-schemas' {
-  const anything: any
-  export = anything
+declare module "hyperdrive-schemas" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'fuse-native' {
-  const anything: any
-  export = anything
+declare module "fuse-native" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@zkochan/libnpx/index' {
-  const anything: any
-  export = anything
+declare module "@zkochan/libnpx/index" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@pnpm/npm-conf' {
-  const anything: any
-  export = anything
+declare module "@pnpm/npm-conf" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@pnpm/npm-conf/lib/types' {
-  const anything: any
-  export = anything
+declare module "@pnpm/npm-conf/lib/types" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@pnpm/npm-lifecycle' {
-  const anything: any
-  export = anything
+declare module "@pnpm/npm-lifecycle" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@pnpm/npm-package-arg' {
-  const anything: any
-  export = anything
+declare module "@pnpm/npm-package-arg" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@zkochan/which' {
-  const anything: any
-  export = anything
+declare module "@zkochan/which" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'anonymous-npm-registry-client' {
-  const anything: any
-  export = anything
+declare module "anonymous-npm-registry-client" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'ansi-diff' {
-  const anything: any
-  export = anything
+declare module "ansi-diff" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'better-path-resolve' {
-  const anything: any
-  export = anything
+declare module "better-path-resolve" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@zkochan/diable' {
-  const anything: any
-  export = anything
+declare module "@zkochan/diable" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'dint' {
-  const anything: any
-  export = anything
+declare module "dint" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'exists-link' {
-  const anything: any
-  export = anything
+declare module "exists-link" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'graceful-git' {
-  const anything: any
-  export = anything
+declare module "graceful-git" {
+  const anything: any;
+  export = anything;
 }
 
-declare module '@pnpm/graph-sequencer' {
+declare module "@pnpm/graph-sequencer" {
   namespace graphSequencer {
-    type Graph<T> = Map<T, T[]>
-    type Groups<T> = T[][]
+    type Graph<T> = Map<T, T[]>;
+    type Groups<T> = T[][];
 
     interface Options<T> {
-      graph: Graph<T>
-      groups: Groups<T>
+      graph: Graph<T>;
+      groups: Groups<T>;
     }
 
     interface Result<T> {
-      safe: boolean
-      chunks: Groups<T>
-      cycles: Groups<T>
+      safe: boolean;
+      chunks: Groups<T>;
+      cycles: Groups<T>;
     }
 
-    type GraphSequencer = <T>(opts: Options<T>) => Result<T>
+    type GraphSequencer = <T>(opts: Options<T>) => Result<T>;
   }
 
-  const graphSequencer: graphSequencer.GraphSequencer
-  export = graphSequencer
+  const graphSequencer: graphSequencer.GraphSequencer;
+  export = graphSequencer;
 }
 
-declare module 'is-inner-link' {
-  const anything: any
-  export = anything
+declare module "is-inner-link" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'is-port-reachable' {
-  const anything: any
-  export = anything
+declare module "is-port-reachable" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'process-exists' {
-  const anything: any
-  export = anything
+declare module "process-exists" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'read-package-json' {
-  const anything: any
-  export = anything
+declare module "read-package-json" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'stacktracey' {
-  const anything: any
-  export = anything
+declare module "stacktracey" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'yaml-tag' {
-  const anything: any
-  export = anything
+declare module "yaml-tag" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'decompress-maybe' {
-  const anything: any
-  export = anything
+declare module "decompress-maybe" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'nerf-dart' {
-  const anything: any
-  export = anything
+declare module "nerf-dart" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'patch-package/dist/applyPatches' {
-  export function applyPatch (opts: any): boolean
+declare module "patch-package/pnpm" {
+  export function applyPatch(opts: any): void;
+  export function getPackageDetailsFromPatchFilename(
+    patchFilename: string
+  ): Record<string, unknown>;
 }
 
-declare module 'string.prototype.replaceall' {
-  const anything: any
-  export = anything
+declare module "string.prototype.replaceall" {
+  const anything: any;
+  export = anything;
 }
 
-declare module 'ramda/src/map' {
-  function map <K extends string | number | symbol, V, U> (fn: (x: V) => U, obj: Record<K, V>): Record<K, U>
-  export = map
+declare module "ramda/src/map" {
+  function map<K extends string | number | symbol, V, U>(
+    fn: (x: V) => U,
+    obj: Record<K, V>
+  ): Record<K, U>;
+  export = map;
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
       ]
     },
     "patchedDependencies": {
-      "pkg@5.7.0": "__patches__/pkg@5.7.0.patch"
+      "pkg@5.7.0": "__patches__/pkg@5.7.0.patch",
+      "patch-package@6.5.1": "__patches__/patch-package@6.5.1.patch"
     },
     "updateConfig": {
       "ignoreDependencies": [

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -1,22 +1,35 @@
-import { PnpmError } from '@pnpm/error'
-import { applyPatch } from 'patch-package/dist/applyPatches'
+import path from "path";
+import { PnpmError } from "@pnpm/error";
+import {
+  applyPatch,
+  getPackageDetailsFromPatchFilename,
+} from "patch-package/pnpm";
 
 export interface ApplyPatchToDirOpts {
-  patchedDir: string
-  patchFilePath: string
+  patchedDir: string;
+  patchFilePath: string;
 }
 
-export function applyPatchToDir (opts: ApplyPatchToDirOpts) {
+export function applyPatchToDir(opts: ApplyPatchToDirOpts) {
   // Ideally, we would just run "patch" or "git apply".
   // However, "patch" is not available on Windows and "git apply" is hard to execute on a subdirectory of an existing repository
-  const cwd = process.cwd()
-  process.chdir(opts.patchedDir)
-  const success = applyPatch({
-    patchDir: opts.patchedDir,
-    patchFilePath: opts.patchFilePath,
-  })
-  process.chdir(cwd)
-  if (!success) {
-    throw new PnpmError('PATCH_FAILED', `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}`)
+  const cwd = process.cwd();
+  process.chdir(opts.patchedDir);
+
+  try {
+    applyPatch({
+      packageDetails: getPackageDetailsFromPatchFilename(
+        path.basename(opts.patchFilePath)
+      ),
+      patchDir: opts.patchedDir,
+      patchFilePath: opts.patchFilePath,
+    });
+  } catch (err) {
+    throw new PnpmError(
+      "PATCH_FAILED",
+      `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}`
+    );
+  } finally {
+    process.chdir(cwd);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ overrides:
 packageExtensionsChecksum: 66c6aa53b7057053eae6c4a5ea9612f3
 
 patchedDependencies:
+  patch-package@6.5.1:
+    hash: ga4tzelqt2htwy6rss65x5wlge
+    path: __patches__/patch-package@6.5.1.patch
   pkg@5.7.0:
     hash: pp6fkuhwkrqq7cjcj7uqpf37e4
     path: __patches__/pkg@5.7.0.patch
@@ -2459,7 +2462,7 @@ importers:
         version: link:../../packages/error
       patch-package:
         specifier: ^6.5.1
-        version: 6.5.1
+        version: 6.5.1(patch_hash=ga4tzelqt2htwy6rss65x5wlge)
     devDependencies:
       '@pnpm/patching.apply-patch':
         specifier: workspace:*
@@ -7975,7 +7978,7 @@ packages:
       '@pnpm/find-workspace-dir': 5.0.1
       '@pnpm/find-workspace-packages': 5.0.33(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/logger': 5.0.0
-      '@pnpm/types': 8.10.0
+      '@pnpm/types': 8.9.0
       '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
       load-json-file: 7.0.1
       meow: 10.1.5
@@ -8234,7 +8237,7 @@ packages:
     engines: {node: '>=14.6'}
     dependencies:
       '@pnpm/error': 4.0.1
-      patch-package: 6.5.1
+      patch-package: 6.5.1(patch_hash=ga4tzelqt2htwy6rss65x5wlge)
     dev: true
 
   /@pnpm/pick-fetcher@1.0.0:
@@ -8524,7 +8527,6 @@ packages:
   /@pnpm/types@8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
-    dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}
@@ -8657,7 +8659,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 14.18.36
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -8665,7 +8667,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.13.0
+      '@types/node': 14.18.36
       '@types/responselike': 1.0.0
 
   /@types/concat-stream@2.0.0:
@@ -8693,7 +8695,7 @@ packages:
     resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.13.0
+      '@types/node': 14.18.36
     dev: true
 
   /@types/graceful-fs@4.1.6:
@@ -8767,7 +8769,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 14.18.36
 
   /@types/lodash@4.14.181:
     resolution: {integrity: sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==}
@@ -8810,7 +8812,6 @@ packages:
 
   /@types/node@14.18.36:
     resolution: {integrity: sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==}
-    dev: true
 
   /@types/node@18.13.0:
     resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
@@ -8847,7 +8848,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.13.0
+      '@types/node': 14.18.36
 
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -14384,6 +14385,7 @@ packages:
 
   /npmlog@4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
+    requiresBuild: true
     dependencies:
       are-we-there-yet: 1.1.7
       console-control-strings: 1.1.0
@@ -14707,7 +14709,7 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  /patch-package@6.5.1:
+  /patch-package@6.5.1(patch_hash=ga4tzelqt2htwy6rss65x5wlge):
     resolution: {integrity: sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==}
     engines: {node: '>=10', npm: '>5'}
     hasBin: true
@@ -14726,6 +14728,7 @@ packages:
       slash: 2.0.0
       tmp: 0.0.33
       yaml: 1.10.2
+    patched: true
 
   /path-absolute@1.0.1:
     resolution: {integrity: sha512-gds5iRhSeOcDtj8gfWkRHLtZKTPsFVuh7utbjYtvnclw4XM+ffRzJrwqMhOD1PVqef7nBLmgsu1vIujjvAJrAw==}


### PR DESCRIPTION
I closed #5279 in favor of this PR as it is taking a slightly different direction by patching `patch-package` in order to export the utilities needed to parse pnpm's flavor of patch-package's patch file naming

![image](https://user-images.githubusercontent.com/5033303/223209397-f27a5b59-a77b-41a9-b63c-51bdc5341dc5.png)

We could take this a step further and print the path relevant to the project directory