### PR TITLE
fix:  clean up child processes when process exited

### DIFF
--- a/.changeset/itchy-onions-battle.md
+++ b/.changeset/itchy-onions-battle.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Clean up child processes when process exited [#6162](https://github.com/pnpm/pnpm/issues/6162).

--- a/__fixtures__/multiple-scripts-error-exit/dev-bar.js
+++ b/__fixtures__/multiple-scripts-error-exit/dev-bar.js
@@ -1,0 +1,11 @@
+import { createServer } from 'http'
+const server = createServer()
+server.listen(9999, (err) => {
+  if (err) {
+    console.log(`[bar] dev error:`, err)
+  }
+  console.log(`[bar] server listen on 9999`)
+  setTimeout(() => {
+    throw new Error('[bar] server error, Oops')
+  }, 2000)
+})

--- a/__fixtures__/multiple-scripts-error-exit/dev-foo.js
+++ b/__fixtures__/multiple-scripts-error-exit/dev-foo.js
@@ -1,0 +1,2 @@
+import { spawn } from 'child_process'
+spawn('node', ['./process-foo.js'], { stdio: 'inherit' })

--- a/__fixtures__/multiple-scripts-error-exit/package.json
+++ b/__fixtures__/multiple-scripts-error-exit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "multiple-scripts-error-exit",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev:foo": "node ./dev-foo.js",
+    "dev:bar": "node ./dev-bar.js"
+  }
+}

--- a/__fixtures__/multiple-scripts-error-exit/process-foo.js
+++ b/__fixtures__/multiple-scripts-error-exit/process-foo.js
@@ -1,0 +1,8 @@
+import { createServer } from 'http'
+const server = createServer()
+server.listen(9990, (err) => {
+  if (err) {
+    console.log(`[foo] dev error:`, err)
+  }
+  console.log(`[foo] server listen on 9990`)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4225,6 +4225,9 @@ importers:
       path-name:
         specifier: ^1.0.0
         version: 1.0.0
+      pidtree:
+        specifier: ^0.6.0
+        version: 0.6.0
       ps-list:
         specifier: ^7.2.0
         version: 7.2.0
@@ -14843,6 +14846,12 @@ packages:
     hasBin: true
     dev: true
 
+  /pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
+
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
@@ -17648,6 +17657,7 @@ time:
   /path-exists@4.0.0: '2019-04-04T03:29:16.887Z'
   /path-name@1.0.0: '2016-10-20T18:43:50.780Z'
   /path-temp@2.0.0: '2019-05-04T14:35:52.401Z'
+  /pidtree@0.6.0: '2022-06-05T18:35:44.206Z'
   /pkg-deb@1.1.2: '2020-10-26T14:13:54.373Z'
   /pkg-rpm@1.0.3: '2021-01-12T09:42:07.762Z'
   /preferred-pm@3.0.3: '2021-02-09T01:16:52.150Z'

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -94,6 +94,7 @@
     "p-defer": "^3.0.0",
     "path-exists": "^4.0.0",
     "path-name": "^1.0.0",
+    "pidtree": "^0.6.0",
     "ps-list": "^7.2.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "read-yaml-file": "^2.1.0",

--- a/pnpm/src/errorHandler.ts
+++ b/pnpm/src/errorHandler.ts
@@ -1,5 +1,6 @@
 import { logger } from '@pnpm/logger'
 import { REPORTER_INITIALIZED } from './main'
+import kill from 'tree-kill'
 
 export function errorHandler (error: Error & { code?: string }) {
   if (error.name != null && error.name !== 'pnpm' && !error.name.startsWith('pnpm:')) {
@@ -32,5 +33,7 @@ export function errorHandler (error: Error & { code?: string }) {
   logger.error(error, error)
 
   // Deferring exit. Otherwise, the reporter wouldn't show the error
-  setTimeout(() => process.exit(1), 0)
+  setTimeout(() => {
+    kill(process.pid)
+  }, 0)
 }

--- a/pnpm/src/errorHandler.ts
+++ b/pnpm/src/errorHandler.ts
@@ -7,23 +7,6 @@ const getDescendentProcesses = promisify((pid: number, callback: (error: Error |
   pidTree(pid, { root: false }, callback)
 })
 
-const killProcesses = async () => {
-  try {
-    const descendentProcesses = await getDescendentProcesses(process.pid)
-    for (const pid of descendentProcesses) {
-      try {
-        process.kill(pid)
-      } catch (_err) {
-        // ignore error here
-      }
-    }
-  } catch (_err) {
-    // ignore error here
-  }
-
-  process.exit(1)
-}
-
 export async function errorHandler (error: Error & { code?: string }) {
   if (error.name != null && error.name !== 'pnpm' && !error.name.startsWith('pnpm:')) {
     try {
@@ -58,4 +41,20 @@ export async function errorHandler (error: Error & { code?: string }) {
   setTimeout(async () => {
     await killProcesses()
   }, 0)
+}
+
+async function killProcesses () {
+  try {
+    const descendentProcesses = await getDescendentProcesses(process.pid)
+    for (const pid of descendentProcesses) {
+      try {
+        process.kill(pid)
+      } catch (err) {
+        // ignore error here
+      }
+    }
+  } catch (err) {
+    // ignore error here
+  }
+  process.exit(1)
 }

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -71,7 +71,7 @@ async function runPnpm () {
     const { main } = await import('./main')
     await main(argv)
   } catch (err: any) { // eslint-disable-line
-    errorHandler(err)
+    await errorHandler(err)
   }
 }
 

--- a/pnpm/test/utils/execPnpm.ts
+++ b/pnpm/test/utils/execPnpm.ts
@@ -1,4 +1,4 @@
-import { ChildProcess as NodeChildProcess } from 'child_process'
+import { ChildProcess as NodeChildProcess, StdioOptions } from 'child_process'
 import path from 'path'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import isWindows from 'is-windows'
@@ -74,12 +74,13 @@ export interface ChildProcess {
   stderr: Object
 }
 
-export function execPnpmSync (args: string[], opts?: { env: Object }): ChildProcess {
+export function execPnpmSync (args: string[], opts?: { env: Object, stdio?: StdioOptions }): ChildProcess {
   return crossSpawn.sync(process.execPath, [pnpmBinLocation, ...args], {
     env: {
       ...createEnv(),
       ...opts?.env,
     } as NodeJS.ProcessEnv,
+    stdio: opts?.stdio,
   }) as ChildProcess
 }
 

--- a/pnpm/test/utils/isPortInUse.ts
+++ b/pnpm/test/utils/isPortInUse.ts
@@ -1,0 +1,18 @@
+import { createServer } from 'net'
+
+export const isPortInUse = (port: number) => new Promise<boolean>((resolve, reject) => {
+  const server = createServer()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.once('error', (err: any) => {
+    if (err?.code !== 'EADDRINUSE') {
+      reject(err); return
+    }
+    resolve(true)
+  })
+  server.once('listening', () => {
+    server.once('close', () => {
+      resolve(false)
+    }).close()
+  })
+  server.listen(port)
+})


### PR DESCRIPTION
close #6162 

When run multiple scripts at the same time, if one of them throw an error, the pnpm process exited, but the other script child processes may still be running.

Steps to reproduce:

1. `git clone git@github.com:await-ovo/pnpm-run-multiple-scripts-processes-exit-issues.git`
2. `cd pnpm-run-multiple-scripts-processes-exit-issues`
3. `pnpm run "/^dev:.*/"`

You can see that the node and web servers start on port `9999` and `9990` separately, and after waiting for 1 second, the node server throws an exception, then pnpm run process is exited.

But if you run `lsof -i:9990`, you can see that web server process doesn't exited:

```
$ lsof -i:9990    
COMMAND   PID         USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
node    98962 username  22u  IPv6 0x9fd9ab4f570298fd      0t0  TCP *:osm-appsrvr (LISTEN)
```