### PR TITLE
feat: when patch package does not specify a version, use locally installed version by default.

### DIFF
--- a/.changeset/khaki-icons-rest.md
+++ b/.changeset/khaki-icons-rest.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/plugin-commands-patching": patch
+"@pnpm/audit": patch
+"@pnpm/list": patch
+"pnpm": patch
+---
+
+When patch package does not specify a version, use locally installed version by default [#6192](https://github.com/pnpm/pnpm/issues/6192).

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ RELEASE.md
 
 ## custom modules-dir fixture
 __fixtures__/custom-modules-dir/**/fake_modules/
+__fixtures__/custom-modules-dir/cache/
+__fixtures__/custom-modules-dir/patches/

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -38,11 +38,13 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.5.0",
     "@types/ramda": "0.28.20",
+    "@types/semver": "7.3.13",
     "write-yaml-file": "^4.2.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/config": "workspace:*",
+    "@pnpm/constants": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/parse-wanted-dependency": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",
@@ -51,12 +53,14 @@
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/store-connection-manager": "workspace:*",
-    "@pnpm/list": "workspace:*",
+    "@pnpm/lockfile-file": "workspace:*",
+    "@pnpm/lockfile-utils": "workspace:*",
     "enquirer": "^2.3.6",
     "escape-string-regexp": "^4.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "render-help": "^1.0.3",
     "safe-execa": "^0.1.3",
+    "semver": "^7.3.8",
     "tempy": "^1.0.1"
   },
   "peerDependencies": {

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -51,6 +51,8 @@
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/store-connection-manager": "workspace:*",
+    "@pnpm/list": "workspace:*",
+    "enquirer": "^2.3.6",
     "escape-string-regexp": "^4.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "render-help": "^1.0.3",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -37,6 +37,7 @@
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.3.13",
     "write-yaml-file": "^4.2.0"
@@ -46,6 +47,7 @@
     "@pnpm/config": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/parse-wanted-dependency": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",
     "@pnpm/pick-registry-for-package": "workspace:*",
@@ -58,6 +60,7 @@
     "enquirer": "^2.3.6",
     "escape-string-regexp": "^4.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
+    "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
     "safe-execa": "^0.1.3",
     "semver": "^7.3.8",

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -15,7 +15,7 @@ export async function getPatchedDependency ({
   const dep = parseWantedDependency(pkg)
   let prefixes = [lockfileDir]
   if (selectedProjectsGraph) {
-    prefixes = Object.values(selectedProjectsGraph).map(wsPkg => wsPkg.package.dir)
+    prefixes = Object.values(selectedProjectsGraph).map(project => project.package.dir)
   }
   const pkgs = await searchForPackages([pkg], prefixes, {
     depth: Infinity,

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -1,0 +1,56 @@
+import { searchForPackages, flattenSearchedPackages } from '@pnpm/list'
+import { parseWantedDependency, ParseWantedDependencyResult } from '@pnpm/parse-wanted-dependency'
+import { prompt } from 'enquirer'
+import { logger } from '@pnpm/logger'
+import type { Config } from '@pnpm/config'
+
+export async function getPatchedDependency ({
+  pkg,
+  selectedProjectsGraph,
+  lockfileDir,
+}: {
+  pkg: string
+  lockfileDir: string
+} & Pick<Config, 'selectedProjectsGraph'>): Promise<ParseWantedDependencyResult> {
+  const dep = parseWantedDependency(pkg)
+  let prefixes = [lockfileDir]
+  if (selectedProjectsGraph) {
+    prefixes = Object.values(selectedProjectsGraph).map(wsPkg => wsPkg.package.dir)
+  }
+  const pkgs = await searchForPackages([pkg], prefixes, {
+    depth: Infinity,
+    lockfileDir,
+  })
+
+  const versions = Array.from(new Set(flattenSearchedPackages(pkgs, { lockfileDir })
+    .map(({ version }) => version)))
+    .filter(Boolean) as string[]
+
+  if (dep.alias && dep.pref) {
+    if (!versions.length) {
+      logger.warn({
+        message: `Can not find ${dep.alias}@${dep.pref} in project ${lockfileDir}${versions.length ? `, you can specify currently installed version: ${versions.join(', ')} ` : ''}`,
+        prefix: lockfileDir,
+      })
+    }
+  }
+
+  if (versions.length) {
+    dep.alias = dep.alias ?? pkg
+    if (versions.length > 1) {
+      const { version } = await prompt<{
+        version: string
+      }>({
+        type: 'select',
+        name: 'version',
+        message: 'Choose which version to patch',
+        choices: versions,
+      })
+      dep.pref = version
+    } else {
+      dep.pref = versions[0]
+    }
+  }
+
+  return dep
+}

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -11,7 +11,9 @@ import pick from 'ramda/src/pick'
 import renderHelp from 'render-help'
 import tempy from 'tempy'
 import { PnpmError } from '@pnpm/error'
-import { writePackage, ParseWantedDependencyResult } from './writePackage'
+import { ParseWantedDependencyResult } from '@pnpm/parse-wanted-dependency'
+import { writePackage } from './writePackage'
+import { getPatchedDependency } from './getPatchedDependency'
 
 export function rcOptionsTypes () {
   return pick([], allTypes)
@@ -48,7 +50,7 @@ export function help () {
   })
 }
 
-export type PatchCommandOptions = Pick<Config, 'dir' | 'registries' | 'tag' | 'storeDir' | 'rootProjectManifest' | 'lockfileDir'> & CreateStoreControllerOptions & {
+export type PatchCommandOptions = Pick<Config, 'dir' | 'registries' | 'tag' | 'storeDir' | 'rootProjectManifest' | 'lockfileDir' | 'selectedProjectsGraph' | 'allProjectsGraph'> & CreateStoreControllerOptions & {
   editDir?: string
   reporter?: (logObj: LogBase) => void
   ignoreExisting?: boolean
@@ -58,14 +60,24 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
   if (opts.editDir && fs.existsSync(opts.editDir) && fs.readdirSync(opts.editDir).length > 0) {
     throw new PnpmError('PATCH_EDIT_DIR_EXISTS', `The target directory already exists: '${opts.editDir}'`)
   }
+  if (!params[0]) {
+    throw new PnpmError('MISSING_PACKAGE_NAME', '`pnpm patch` requires the package name')
+  }
   const editDir = opts.editDir ?? tempy.directory()
-  const patchedDep = await writePackage(params[0], editDir, opts)
+  const lockfileDir = opts.lockfileDir ?? opts.dir ?? process.cwd()
+  const patchedDep = await getPatchedDependency({
+    pkg: params[0],
+    lockfileDir,
+    selectedProjectsGraph: opts.selectedProjectsGraph,
+  })
+
+  await writePackage(patchedDep, editDir, opts)
   if (!opts.ignoreExisting && opts.rootProjectManifest?.pnpm?.patchedDependencies) {
     tryPatchWithExistingPatchFile({
       patchedDep,
       patchedDir: editDir,
       patchedDependencies: opts.rootProjectManifest.pnpm.patchedDependencies,
-      lockfileDir: opts.lockfileDir ?? opts.dir ?? process.cwd(),
+      lockfileDir,
     })
   }
   return `You can now edit the following folder: ${editDir}

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -50,7 +50,16 @@ export function help () {
   })
 }
 
-export type PatchCommandOptions = Pick<Config, 'dir' | 'registries' | 'tag' | 'storeDir' | 'rootProjectManifest' | 'lockfileDir' | 'selectedProjectsGraph' | 'allProjectsGraph'> & CreateStoreControllerOptions & {
+export type PatchCommandOptions = Pick<Config,
+| 'dir'
+| 'registries'
+| 'tag'
+| 'storeDir'
+| 'rootProjectManifest'
+| 'lockfileDir'
+| 'modulesDir'
+| 'virtualStoreDir'
+> & CreateStoreControllerOptions & {
   editDir?: string
   reporter?: (logObj: LogBase) => void
   ignoreExisting?: boolean
@@ -65,7 +74,11 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
   }
   const editDir = opts.editDir ?? tempy.directory()
   const lockfileDir = opts.lockfileDir ?? opts.dir ?? process.cwd()
-  const patchedDep = await getPatchedDependency(params[0], lockfileDir)
+  const patchedDep = await getPatchedDependency(params[0], {
+    lockfileDir,
+    modulesDir: opts.modulesDir,
+    virtualStoreDir: opts.virtualStoreDir,
+  })
 
   await writePackage(patchedDep, editDir, opts)
   if (!opts.ignoreExisting && opts.rootProjectManifest?.pnpm?.patchedDependencies) {

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -65,11 +65,7 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
   }
   const editDir = opts.editDir ?? tempy.directory()
   const lockfileDir = opts.lockfileDir ?? opts.dir ?? process.cwd()
-  const patchedDep = await getPatchedDependency({
-    pkg: params[0],
-    lockfileDir,
-    selectedProjectsGraph: opts.selectedProjectsGraph,
-  })
+  const patchedDep = await getPatchedDependency(params[0], lockfileDir)
 
   await writePackage(patchedDep, editDir, opts)
   if (!opts.ignoreExisting && opts.rootProjectManifest?.pnpm?.patchedDependencies) {

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -11,6 +11,7 @@ import escapeStringRegexp from 'escape-string-regexp'
 import renderHelp from 'render-help'
 import tempy from 'tempy'
 import { writePackage } from './writePackage'
+import { parseWantedDependency } from '@pnpm/parse-wanted-dependency'
 
 export const rcOptionsTypes = cliOptionsTypes
 
@@ -37,7 +38,7 @@ export async function handler (opts: install.InstallCommandOptions & Pick<Config
   const patchedPkgManifest = await readPackageJsonFromDir(userDir)
   const pkgNameAndVersion = `${patchedPkgManifest.name}@${patchedPkgManifest.version}`
   const srcDir = tempy.directory()
-  await writePackage(pkgNameAndVersion, srcDir, opts)
+  await writePackage(parseWantedDependency(pkgNameAndVersion), srcDir, opts)
   const patchContent = await diffFolders(srcDir, userDir)
   const patchFileName = pkgNameAndVersion.replace('/', '__')
   await fs.promises.writeFile(path.join(patchesDir, `${patchFileName}.patch`), patchContent, 'utf8')

--- a/patching/plugin-commands-patching/src/writePackage.ts
+++ b/patching/plugin-commands-patching/src/writePackage.ts
@@ -4,14 +4,11 @@ import {
   CreateStoreControllerOptions,
 } from '@pnpm/store-connection-manager'
 import { pickRegistryForPackage } from '@pnpm/pick-registry-for-package'
-import { parseWantedDependency, ParseWantedDependencyResult } from '@pnpm/parse-wanted-dependency'
-
-export { ParseWantedDependencyResult }
+import type { ParseWantedDependencyResult } from '@pnpm/parse-wanted-dependency'
 
 export type WritePackageOptions = CreateStoreControllerOptions & Pick<Config, 'registries'>
 
-export async function writePackage (pkg: string, dest: string, opts: WritePackageOptions): Promise<ParseWantedDependencyResult> {
-  const dep = parseWantedDependency(pkg)
+export async function writePackage (dep: ParseWantedDependencyResult, dest: string, opts: WritePackageOptions) {
   const store = await createOrConnectStoreController({
     ...opts,
     packageImportMethod: 'clone-or-copy',
@@ -28,5 +25,4 @@ export async function writePackage (pkg: string, dest: string, opts: WritePackag
     filesResponse,
     force: true,
   })
-  return dep
 }

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -69,6 +69,8 @@ describe('patch and commit', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())
@@ -98,6 +100,8 @@ describe('patch and commit', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
@@ -125,6 +129,8 @@ describe('patch and commit', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).toContain('// test patching')
@@ -140,6 +146,8 @@ describe('patch and commit', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())
@@ -185,6 +193,8 @@ describe('patch and commit', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())
@@ -344,6 +354,8 @@ describe('patching should work when there is a no EOL in the patched file', () =
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [userPatchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())
@@ -370,6 +382,8 @@ describe('patching should work when there is a no EOL in the patched file', () =
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [userPatchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())
@@ -466,6 +480,8 @@ describe('patch and commit in workspaces', () => {
       lockfileDir: process.cwd(),
       workspaceDir: process.cwd(),
       saveLockfile: true,
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -292,6 +292,8 @@ describe('prompt to choose version', () => {
     await patchCommit.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      frozenLockfile: false,
+      fixLockfile: true,
     }, [patchDir])
 
     const { manifest } = await readProjectManifest(process.cwd())

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -22,6 +22,15 @@
       "path": "../../config/pick-registry-for-package"
     },
     {
+      "path": "../../lockfile/lockfile-file"
+    },
+    {
+      "path": "../../lockfile/lockfile-utils"
+    },
+    {
+      "path": "../../packages/constants"
+    },
+    {
       "path": "../../packages/error"
     },
     {
@@ -35,9 +44,6 @@
     },
     {
       "path": "../../pkg-manifest/read-project-manifest"
-    },
-    {
-      "path": "../../reviewing/list"
     },
     {
       "path": "../../store/store-connection-manager"

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../__utils__/test-fixtures"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {
@@ -35,6 +38,9 @@
     },
     {
       "path": "../../packages/parse-wanted-dependency"
+    },
+    {
+      "path": "../../pkg-manager/modules-yaml"
     },
     {
       "path": "../../pkg-manager/plugin-commands-installation"

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../../pkg-manifest/read-project-manifest"
     },
     {
+      "path": "../../reviewing/list"
+    },
+    {
       "path": "../../store/store-connection-manager"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2498,6 +2498,9 @@ importers:
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
+      '@pnpm/modules-yaml':
+        specifier: workspace:*
+        version: link:../../pkg-manager/modules-yaml
       '@pnpm/parse-wanted-dependency':
         specifier: workspace:*
         version: link:../../packages/parse-wanted-dependency
@@ -2528,6 +2531,9 @@ importers:
       ramda:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
+      realpath-missing:
+        specifier: ^1.1.0
+        version: 1.1.0
       render-help:
         specifier: ^1.0.3
         version: 1.0.3
@@ -2553,6 +2559,9 @@ importers:
       '@pnpm/registry-mock':
         specifier: 3.5.0
         version: 3.5.0(typanion@3.12.1)
+      '@pnpm/test-fixtures':
+        specifier: workspace:*
+        version: link:../../__utils__/test-fixtures
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2483,12 +2483,18 @@ importers:
       '@pnpm/config':
         specifier: workspace:*
         version: link:../../config/config
+      '@pnpm/constants':
+        specifier: workspace:*
+        version: link:../../packages/constants
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
-      '@pnpm/list':
+      '@pnpm/lockfile-file':
         specifier: workspace:*
-        version: link:../../reviewing/list
+        version: link:../../lockfile/lockfile-file
+      '@pnpm/lockfile-utils':
+        specifier: workspace:*
+        version: link:../../lockfile/lockfile-utils
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
@@ -2528,6 +2534,9 @@ importers:
       safe-execa:
         specifier: ^0.1.3
         version: 0.1.3
+      semver:
+        specifier: ^7.3.8
+        version: 7.3.8
       tempy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -2547,6 +2556,9 @@ importers:
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
+      '@types/semver':
+        specifier: 7.3.13
+        version: 7.3.13
       write-yaml-file:
         specifier: ^4.2.0
         version: 4.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2486,6 +2486,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
+      '@pnpm/list':
+        specifier: workspace:*
+        version: link:../../reviewing/list
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
@@ -2510,6 +2513,9 @@ importers:
       '@pnpm/store-connection-manager':
         specifier: workspace:*
         version: link:../../store/store-connection-manager
+      enquirer:
+        specifier: ^2.3.6
+        version: 2.3.6
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
@@ -8000,7 +8006,7 @@ packages:
       '@pnpm/find-workspace-dir': 5.0.1
       '@pnpm/find-workspace-packages': 5.0.36(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/logger': 5.0.0
-      '@pnpm/types': 8.10.0
+      '@pnpm/types': 8.9.0
       '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
       load-json-file: 7.0.1
       meow: 10.1.5
@@ -8549,7 +8555,6 @@ packages:
   /@pnpm/types@8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
-    dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -168,7 +168,7 @@ export async function main (inputArgv: string[]) {
   }
 
   if (
-    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe' || cmd === 'patch-commit') &&
+    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe' || cmd === 'patch-commit' || cmd === 'patch') &&
     typeof workspaceDir === 'string'
   ) {
     cliOptions['recursive'] = true

--- a/reviewing/list/src/index.ts
+++ b/reviewing/list/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { readProjectManifestOnly } from '@pnpm/read-project-manifest'
 import { DependenciesField, Registries } from '@pnpm/types'
-import { DependenciesHierarchy, PackageNode, buildDependenciesHierarchy } from '@pnpm/reviewing.dependencies-hierarchy'
+import { PackageNode, buildDependenciesHierarchy } from '@pnpm/reviewing.dependencies-hierarchy'
 import { createPackagesSearcher } from './createPackagesSearcher'
 import { renderJson } from './renderJson'
 import { renderParseable } from './renderParseable'
@@ -19,20 +19,10 @@ const DEFAULTS = {
   showExtraneous: true,
 }
 
-export function flattenSearchedPackages (pkgs: Array<DependenciesHierarchy & {
-  name?: string
-  version?: string
-  path: string
-  private?: boolean
-}>, opts: {
+export function flattenSearchedPackages (pkgs: PackageDependencyHierarchy[], opts: {
   lockfileDir: string
 }) {
-  const flattedPkgs: Array<{
-    name?: string
-    version?: string
-    path: string
-    depPath: string
-  }> = []
+  const flattedPkgs: Array<PackageDependencyHierarchy & { depPath: string }> = []
   for (const pkg of pkgs) {
     _walker([
       ...(pkg.optionalDependencies ?? []),
@@ -41,6 +31,8 @@ export function flattenSearchedPackages (pkgs: Array<DependenciesHierarchy & {
       ...(pkg.unsavedDependencies ?? []),
     ], path.relative(opts.lockfileDir, pkg.path) || '.')
   }
+
+  return flattedPkgs
 
   function _walker (packages: PackageNode[], depPath: string) {
     for (const pkg of packages) {
@@ -55,7 +47,6 @@ export function flattenSearchedPackages (pkgs: Array<DependenciesHierarchy & {
       }
     }
   }
-  return flattedPkgs
 }
 
 export async function searchForPackages (


### PR DESCRIPTION
close #6192 

The following changes were added:
1. Throws a meaningful error when `pnpm patch` does not specify a package:

```
$ pd patch        
 ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm patch` requires the package name
```


2. If the locally installed version is `foo@1.0.0`, running `pnpm patch foo@2` will display a warning message:

```
$ pd patch foo@2  
 WARN  Can not find foo@2 in project /project-dir
```
3.  If no version is specified(`pnpm patch foo`) and there is only one version of `foo` installed locally, then the locally installed version is used directly.

4. If no version is specified(`pnpm patch foo`) and there are multiple versions of foo installed locally, the user will need to manually select which version of foo to patch:

```
$ pd why chalk
Legend: production dependency, optional only, dev only
test-publish@1.0.0

dependencies:
ava 5.2.0
└── chalk 5.2.0
chalk 4.1.2

$ pd patch chalk  
? Choose which version to patch … 
❯ 5.2.0
  4.1.2
```
