### PR TITLE
fix: sort patchedDependencies consistently in lockfiles

### DIFF
--- a/.changeset/loud-geese-obey.md
+++ b/.changeset/loud-geese-obey.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/lockfile-file": patch
+"pnpm": patch
 ---
 
-patchedDependencies are now sorted consistently in the lockfile
+`patchedDependencies` are now sorted consistently in the lockfile [#6208](https://github.com/pnpm/pnpm/pull/6208).

--- a/.changeset/loud-geese-obey.md
+++ b/.changeset/loud-geese-obey.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lockfile-file": patch
+---
+
+patchedDependencies are now sorted consistently in the lockfile

--- a/lockfile/lockfile-file/src/sortLockfileKeys.ts
+++ b/lockfile/lockfile-file/src/sortLockfileKeys.ts
@@ -77,12 +77,9 @@ export function sortLockfileKeys (lockfile: LockfileFile) {
       })
     }
   }
-  if (lockfile.patchedDependencies) {
-    lockfile.patchedDependencies = sortKeys(lockfile.patchedDependencies)
-  }
-  for (const key of ['specifiers', 'dependencies', 'devDependencies', 'optionalDependencies', 'time'] as const) {
+  for (const key of ['specifiers', 'dependencies', 'devDependencies', 'optionalDependencies', 'time', 'patchedDependencies'] as const) {
     if (!lockfile[key]) continue
-    lockfile[key] = sortKeys(lockfile[key]!)
+    lockfile[key] = sortKeys<any>(lockfile[key]) // eslint-disable-line @typescript-eslint/no-explicit-any
   }
   return sortKeys(lockfile, { compare: compareRootKeys })
 }

--- a/lockfile/lockfile-file/src/sortLockfileKeys.ts
+++ b/lockfile/lockfile-file/src/sortLockfileKeys.ts
@@ -77,6 +77,9 @@ export function sortLockfileKeys (lockfile: LockfileFile) {
       })
     }
   }
+  if (lockfile.patchedDependencies) {
+    lockfile.patchedDependencies = sortKeys(lockfile.patchedDependencies)
+  }
   for (const key of ['specifiers', 'dependencies', 'devDependencies', 'optionalDependencies', 'time'] as const) {
     if (!lockfile[key]) continue
     lockfile[key] = sortKeys(lockfile[key]!)

--- a/lockfile/lockfile-file/test/sortLockfileKeys.test.ts
+++ b/lockfile/lockfile-file/test/sortLockfileKeys.test.ts
@@ -26,6 +26,11 @@ test('sorts keys alphabetically', () => {
         },
       },
     },
+    patchedDependencies: {
+      zzz: { path: 'foo', hash: 'bar' },
+      bar: { path: 'foo', hash: 'bar' },
+      aaa: { path: 'foo', hash: 'bar' },
+    },
   })
 
   expect(normalizedLockfile).toStrictEqual({
@@ -52,9 +57,15 @@ test('sorts keys alphabetically', () => {
         },
       },
     },
+    patchedDependencies: {
+      aaa: { path: 'foo', hash: 'bar' },
+      bar: { path: 'foo', hash: 'bar' },
+      zzz: { path: 'foo', hash: 'bar' },
+    },
   })
   expect(Object.keys(normalizedLockfile.importers?.foo.dependencies ?? {})).toStrictEqual(['aaa', 'bar', 'zzz'])
   expect(Object.keys(normalizedLockfile.importers?.foo.specifiers ?? {})).toStrictEqual(['aaa', 'bar', 'zzz'])
+  expect(Object.keys(normalizedLockfile.patchedDependencies ?? {})).toStrictEqual(['aaa', 'bar', 'zzz'])
 })
 
 test('sorting does not care about locale (e.g. Czech has "ch" as a single character after "h")', () => {


### PR DESCRIPTION
We've been seeing seemingly-random reordering of `patchedDependencies` in the lockfile as different people regenerate it at different times. Sorting in a consistent order should prevent that from happening.