### PR TITLE
feat: support resolving peers with npm aliases

### DIFF
--- a/.changeset/wild-dolphins-work.md
+++ b/.changeset/wild-dolphins-work.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+Aliased packages should be used to resolve peer dependencies too [#4301](https://github.com/pnpm/pnpm/issues/4301).

--- a/__utils__/assert-project/package.json
+++ b/__utils__/assert-project/package.json
@@ -44,7 +44,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/types": "workspace:*",
     "is-windows": "^1.0.2",
     "isexe": "2.0.0",

--- a/__utils__/assert-project/package.json
+++ b/__utils__/assert-project/package.json
@@ -44,7 +44,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/types": "workspace:*",
     "is-windows": "^1.0.2",
     "isexe": "2.0.0",

--- a/__utils__/assert-store/package.json
+++ b/__utils__/assert-store/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {

--- a/__utils__/assert-store/package.json
+++ b/__utils__/assert-store/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-rebuild": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.3.13",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-rebuild": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.3.13",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -37,7 +37,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.28.20",
     "is-windows": "^1.0.2",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -37,7 +37,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.28.20",
     "is-windows": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt-cli": "^17.4.4",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "0.2.2",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^29.4.0",
     "@types/node": "^14.18.37",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt-cli": "^17.4.4",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "0.2.2",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^29.4.0",
     "@types/node": "^14.18.37",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -36,7 +36,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -36,7 +36,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -78,7 +78,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -78,7 +78,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1389,69 +1389,6 @@ test('deduplicate packages that have peers, when adding new dependency in a work
   expect(depPaths).toContain(`/@pnpm.e2e/abc-parent-with-ab@1.0.0${createPeersFolderSuffix([{ name: '@pnpm.e2e/peer-c', version: '1.0.0' }])}`)
 })
 
-test('find correct peer dependency with aliases', async () => {
-  const opts = await testDefaults({ strictPeerDependencies: false })
-
-  prepareEmpty()
-  await addDependenciesToPackage({}, [
-    'ajv@6.0.0',
-    'ajv-next@npm:ajv@7.0.0',
-    'ajv-keywords@3.0.0', // with peer ajv@^6
-    'ajv-keywords-next@npm:ajv-keywords@4.0.0', // with peer ajv@^7
-  ], opts)
-
-  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-
-  expect(lockfile.dependencies).toStrictEqual({
-    ajv: {
-      specifier: '6.0.0',
-      version: '6.0.0',
-    },
-    'ajv-next': {
-      specifier: 'npm:ajv@7.0.0',
-      version: '/ajv@7.0.0',
-    },
-    'ajv-keywords': {
-      specifier: '3.0.0',
-      version: '3.0.0(ajv@6.0.0)',
-    },
-    'ajv-keywords-next': {
-      specifier: 'npm:ajv-keywords@4.0.0',
-      version: '/ajv-keywords@4.0.0(ajv@7.0.0)',
-    },
-  })
-  expect(lockfile.packages['/ajv-keywords@3.0.0(ajv@6.0.0)'].dependencies['ajv']).toEqual('6.0.0')
-  expect(lockfile.packages['/ajv-keywords@4.0.0(ajv@7.0.0)'].dependencies['ajv']).toEqual('7.0.0')
-})
-
-test('if multiple packages satisfy peer dependencies semver, prefer the one that is not aliased', async () => {
-  const opts = await testDefaults({ strictPeerDependencies: false })
-
-  prepareEmpty()
-  await addDependenciesToPackage({}, [
-    'ajv@6.0.0',
-    'ajv-next@npm:ajv@6.1.0',
-    'ajv-keywords@3.0.0', // with peer ajv@^6
-  ], opts)
-
-  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-
-  expect(lockfile.dependencies).toStrictEqual({
-    ajv: {
-      specifier: '6.0.0',
-      version: '6.0.0',
-    },
-    'ajv-next': {
-      specifier: 'npm:ajv@6.1.0',
-      version: '/ajv@6.1.0',
-    },
-    'ajv-keywords': {
-      specifier: '3.0.0',
-      version: '3.0.0(ajv@6.0.0)',
-    },
-  })
-})
-
 test('resolve peer dependencies from aliased subdependencies if they are dependencies of a parent package', async () => {
   prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1415,11 +1415,28 @@ test('resolve peer dependency from aliased direct dependency', async () => {
   expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)']).toBeTruthy()
 })
 
+test('resolve peer dependency using the alias that differs from the real name of the direct dependency', async () => {
+  prepareEmpty()
+
+  const opts = await testDefaults({ autoInstallPeers: false, strictPeerDependencies: false })
+  const manifest = await addDependenciesToPackage({}, ['@pnpm.e2e/peer-b@npm:@pnpm.e2e/peer-a@1.0.0'], opts)
+  await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
+
+  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)']).toBeTruthy()
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)']?.dependencies['@pnpm.e2e/peer-a']).toBe('1.0.0')
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)']?.dependencies['@pnpm.e2e/peer-b']).toBe('/@pnpm.e2e/peer-a@1.0.0')
+})
+
 test('when there are several aliased dependencies of the same package, pick the one with the highest version to resolve peers', async () => {
   prepareEmpty()
 
   const opts = await testDefaults({ autoInstallPeers: false, strictPeerDependencies: false })
-  const manifest = await addDependenciesToPackage({}, ['peer-c3@npm:@pnpm.e2e/peer-c@1.0.0', 'peer-c2@npm:@pnpm.e2e/peer-c@1.0.1', 'peer-c1@npm:@pnpm.e2e/peer-c@2.0.0'], opts)
+  const manifest = await addDependenciesToPackage({}, [
+    'peer-c3@npm:@pnpm.e2e/peer-c@1.0.0',
+    'peer-c2@npm:@pnpm.e2e/peer-c@1.0.1',
+    'peer-c1@npm:@pnpm.e2e/peer-c@2.0.0',
+  ], opts)
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1464,5 +1464,5 @@ test('resolve peer dependencies from aliased subdependencies if they are depende
   )
 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  expect(lockfile.packages).toHaveProperty('/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)')
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)']).toBeTruthy()
 })

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1425,3 +1425,13 @@ test('when there are several aliased dependencies of the same package, pick the 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
   expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
 })
+
+test('in a subdependency, when there are several aliased dependencies of the same package, pick the one with the highest version to resolve peers', async () => {
+  prepareEmpty()
+
+  await addDependenciesToPackage({}, ['@pnpm.e2e/abc-parent-with-aliases-of-same-pkg@1.0.0'], await testDefaults({ autoInstallPeers: false, strictPeerDependencies: false }))
+
+  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+  console.log(lockfile)
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
+})

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1432,6 +1432,5 @@ test('in a subdependency, when there are several aliased dependencies of the sam
   await addDependenciesToPackage({}, ['@pnpm.e2e/abc-parent-with-aliases-of-same-pkg@1.0.0'], await testDefaults({ autoInstallPeers: false, strictPeerDependencies: false }))
 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  console.log(lockfile)
   expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
 })

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1388,3 +1388,66 @@ test('deduplicate packages that have peers, when adding new dependency in a work
   expect(depPaths).toContain(`/@pnpm.e2e/abc@1.0.0${createPeersFolderSuffix([{ name: '@pnpm.e2e/peer-a', version: '1.0.0' }, { name: '@pnpm.e2e/peer-b', version: '1.0.0' }, { name: '@pnpm.e2e/peer-c', version: '1.0.0' }])}`)
   expect(depPaths).toContain(`/@pnpm.e2e/abc-parent-with-ab@1.0.0${createPeersFolderSuffix([{ name: '@pnpm.e2e/peer-c', version: '1.0.0' }])}`)
 })
+
+test('find correct peer dependency with aliases', async () => {
+  const opts = await testDefaults({ strictPeerDependencies: false })
+
+  prepareEmpty()
+  await addDependenciesToPackage({}, [
+    'ajv@6.0.0',
+    'ajv-next@npm:ajv@7.0.0',
+    'ajv-keywords@3.0.0', // with peer ajv@^6
+    'ajv-keywords-next@npm:ajv-keywords@4.0.0', // with peer ajv@^7
+  ], opts)
+
+  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+
+  expect(lockfile.dependencies).toStrictEqual({
+    ajv: {
+      specifier: '6.0.0',
+      version: '6.0.0',
+    },
+    'ajv-next': {
+      specifier: 'npm:ajv@7.0.0',
+      version: '/ajv@7.0.0',
+    },
+    'ajv-keywords': {
+      specifier: '3.0.0',
+      version: '3.0.0(ajv@6.0.0)',
+    },
+    'ajv-keywords-next': {
+      specifier: 'npm:ajv-keywords@4.0.0',
+      version: '/ajv-keywords@4.0.0(ajv@7.0.0)',
+    },
+  })
+  expect(lockfile.packages['/ajv-keywords@3.0.0(ajv@6.0.0)'].dependencies['ajv']).toEqual('6.0.0')
+  expect(lockfile.packages['/ajv-keywords@4.0.0(ajv@7.0.0)'].dependencies['ajv']).toEqual('7.0.0')
+})
+
+test('if multiple packages satisfy peer dependencies semver, prefer the one that is not aliased', async () => {
+  const opts = await testDefaults({ strictPeerDependencies: false })
+
+  prepareEmpty()
+  await addDependenciesToPackage({}, [
+    'ajv@6.0.0',
+    'ajv-next@npm:ajv@6.1.0',
+    'ajv-keywords@3.0.0', // with peer ajv@^6
+  ], opts)
+
+  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+
+  expect(lockfile.dependencies).toStrictEqual({
+    ajv: {
+      specifier: '6.0.0',
+      version: '6.0.0',
+    },
+    'ajv-next': {
+      specifier: 'npm:ajv@6.1.0',
+      version: '/ajv@6.1.0',
+    },
+    'ajv-keywords': {
+      specifier: '3.0.0',
+      version: '3.0.0(ajv@6.0.0)',
+    },
+  })
+})

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1451,3 +1451,18 @@ test('if multiple packages satisfy peer dependencies semver, prefer the one that
     },
   })
 })
+
+test('resolve peer dependencies from aliased subdependencies if they are dependencies of a parent package', async () => {
+  prepareEmpty()
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/abc-parent-with-aliases'],
+    await testDefaults({ autoInstallPeers: false, strictPeerDependencies: false })
+  )
+
+  const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+  expect(lockfile.packages).toHaveProperty('/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)')
+})

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1412,7 +1412,7 @@ test('resolve peer dependency from aliased direct dependency', async () => {
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)'])
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)']).toBeTruthy()
 })
 
 test('when there are several aliased dependencies of the same package, pick the one with the highest version to resolve peers', async () => {
@@ -1423,5 +1423,5 @@ test('when there are several aliased dependencies of the same package, pick the 
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
 
   const lockfile = await readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)'])
+  expect(lockfile.packages['/@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
 })

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -22,7 +22,7 @@
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -22,7 +22,7 @@
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -68,7 +68,7 @@
     "@pnpm/client": "workspace:*",
     "@pnpm/create-cafs-store": "workspace:*",
     "@pnpm/package-requester": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -68,7 +68,7 @@
     "@pnpm/client": "workspace:*",
     "@pnpm/create-cafs-store": "workspace:*",
     "@pnpm/package-requester": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -38,7 +38,7 @@
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/proxyquire": "^1.3.28",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -38,7 +38,7 @@
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/proxyquire": "^1.3.28",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from '@pnpm/types'
 import promiseShare from 'promise-share'
 import difference from 'ramda/src/difference'
+import zipWith from 'ramda/src/zipWith'
 import { getWantedDependencies, type WantedDependency } from './getWantedDependencies'
 import { depPathToRef } from './depPathToRef'
 import { createNodeIdForLinkedLocalPkg, type UpdateMatchingFunction } from './resolveDependencies'
@@ -440,13 +441,17 @@ function getAliasToDependencyTypeMap (manifest: ProjectManifest): Record<string,
   return depTypesOfAliases
 }
 
-async function getTopParents (pkgNames: string[], modules: string) {
+async function getTopParents (pkgAliases: string[], modulesDir: string) {
   const pkgs = await Promise.all(
-    pkgNames.map((pkgName) => path.join(modules, pkgName)).map(safeReadPackageJsonFromDir)
+    pkgAliases.map((alias) => path.join(modulesDir, alias)).map(safeReadPackageJsonFromDir)
   )
-  return (
-    pkgs
-      .filter(Boolean) as DependencyManifest[]
-  )
-    .map(({ name, version }: DependencyManifest, index) => ({ name, version, alias: pkgNames[index] }))
+  return zipWith((manifest, alias) => {
+    if (!manifest) return null
+    return {
+      alias,
+      name: manifest.name,
+      version: manifest.version,
+    }
+  }, pkgs, pkgAliases)
+    .filter(Boolean) as DependencyManifest[]
 }

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -173,7 +173,7 @@ export async function resolveDependencies (
       )
     }
 
-    const topParents: Array<{ name: string, version: string, linkedDir?: string }> = project.manifest
+    const topParents: Array<{ name: string, version: string, alias?: string, linkedDir?: string }> = project.manifest
       ? await getTopParents(
         difference(
           Object.keys(getAllDependenciesFromManifest(project.manifest)),
@@ -448,5 +448,5 @@ async function getTopParents (pkgNames: string[], modules: string) {
     pkgs
       .filter(Boolean) as DependencyManifest[]
   )
-    .map(({ name, version }: DependencyManifest) => ({ name, version }))
+    .map(({ name, version }: DependencyManifest, index) => ({ name, version, alias: pkgNames[index] }))
 }

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -1,10 +1,12 @@
 import filenamify from 'filenamify'
 import path from 'path'
 import { semverUtils } from '@yarnpkg/core'
-import {
-  type Dependencies,
-  type PeerDependencyIssues,
-  type PeerDependencyIssuesByProjects,
+import type {
+  BadPeerDependencyIssue,
+  Dependencies,
+  PeerDependencyIssues,
+  PeerDependencyIssuesByProjects,
+  ProjectManifest,
 } from '@pnpm/types'
 import { depPathToFilename, createPeersFolderSuffixNewFormat } from '@pnpm/dependency-path'
 import { type KeyValuePair } from 'ramda'
@@ -48,6 +50,7 @@ export interface GenericDependenciesGraph<T extends PartialResolvedPackage> {
 }
 
 export interface ProjectToResolve {
+  manifest: ProjectManifest
   directNodeIdsByAlias: { [alias: string]: string }
   // only the top dependencies that were already installed
   // to avoid warnings about unresolved peer dependencies
@@ -77,16 +80,30 @@ export function resolvePeers<T extends PartialResolvedPackage> (
   const rootPkgsByName = opts.resolvePeersFromWorkspaceRoot ? getRootPkgsByName(opts.dependenciesTree, opts.projects) : {}
   const peerDependencyIssuesByProjects: PeerDependencyIssuesByProjects = {}
 
-  for (const { directNodeIdsByAlias, topParents, rootDir, id } of opts.projects) {
+  for (const { directNodeIdsByAlias, manifest, topParents, rootDir, id } of opts.projects) {
     const peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'> = { bad: {}, missing: {} }
     const pkgsByName = {
       ...rootPkgsByName,
       ..._createPkgsByName({ directNodeIdsByAlias, topParents }),
     }
 
+    const aliases: Record<string, string[]> = {}
+    const allDependencies = {
+      ...manifest.dependencies,
+      ...manifest.devDependencies,
+    }
+    for (const [pkgName, version] of Object.entries(allDependencies)) {
+      if (version.startsWith('npm:')) {
+        const aliasedPkgName = version.substring(4).split('@')[0]
+        aliases[aliasedPkgName] = aliases[aliasedPkgName] ?? []
+        aliases[aliasedPkgName].push(pkgName)
+      }
+    }
+
     resolvePeersOfChildren(directNodeIdsByAlias, pkgsByName, {
       dependenciesTree: opts.dependenciesTree,
       depGraph,
+      aliases,
       lockfileDir: opts.lockfileDir,
       pathsByNodeId,
       depPathsByPkgId,
@@ -232,6 +249,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
   ctx: ResolvePeersContext & {
     dependenciesTree: DependenciesTree<T>
     depGraph: GenericDependenciesGraph<T>
+    aliases: Record<string, string[]>
     virtualStoreDir: string
     peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'>
     peersCache: PeersCache
@@ -303,6 +321,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
       currentDepth: node.depth,
       dependenciesTree: ctx.dependenciesTree,
       lockfileDir: ctx.lockfileDir,
+      aliases: ctx.aliases,
       nodeId,
       parentPkgs,
       peerDependencyIssues: ctx.peerDependencyIssues,
@@ -434,6 +453,7 @@ function resolvePeersOfChildren<T extends PartialResolvedPackage> (
   },
   parentPkgs: ParentRefs,
   ctx: ResolvePeersContext & {
+    aliases: Record<string, string[]>
     peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'>
     peersCache: PeersCache
     virtualStoreDir: string
@@ -462,6 +482,7 @@ function _resolvePeers<T extends PartialResolvedPackage> (
   ctx: {
     currentDepth: number
     lockfileDir: string
+    aliases: Record<string, string[]>
     nodeId: string
     parentPkgs: ParentRefs
     resolvedPackage: T
@@ -475,52 +496,66 @@ function _resolvePeers<T extends PartialResolvedPackage> (
   for (const peerName in ctx.resolvedPackage.peerDependencies) { // eslint-disable-line:forin
     const peerVersionRange = ctx.resolvedPackage.peerDependencies[peerName].replace(/^workspace:/, '')
 
-    const resolved = ctx.parentPkgs[peerName]
+    const pkgsToCheck = [
+      ctx.parentPkgs[peerName],
+      ...(ctx.aliases[peerName] || []).map((alias) => ctx.parentPkgs[alias]),
+    ].filter(Boolean)
+
     const optionalPeer = ctx.resolvedPackage.peerDependenciesMeta?.[peerName]?.optional === true
+    const badPeerIssues: BadPeerDependencyIssue[] = []
+    let foundPeer = false
 
-    if (!resolved) {
-      missingPeers.push(peerName)
-      const location = getLocationFromNodeIdAndPkg({
-        dependenciesTree: ctx.dependenciesTree,
-        nodeId: ctx.nodeId,
-        pkg: ctx.resolvedPackage,
-      })
-      if (!ctx.peerDependencyIssues.missing[peerName]) {
-        ctx.peerDependencyIssues.missing[peerName] = []
-      }
-      ctx.peerDependencyIssues.missing[peerName].push({
-        parents: location.parents,
-        optional: optionalPeer,
-        wantedRange: peerVersionRange,
-      })
-      continue
-    }
-
-    if (!semverUtils.satisfiesWithPrereleases(resolved.version, peerVersionRange, true)) {
-      const location = getLocationFromNodeIdAndPkg({
-        dependenciesTree: ctx.dependenciesTree,
-        nodeId: ctx.nodeId,
-        pkg: ctx.resolvedPackage,
-      })
-      if (!ctx.peerDependencyIssues.bad[peerName]) {
-        ctx.peerDependencyIssues.bad[peerName] = []
-      }
-      const peerLocation = resolved.nodeId == null
-        ? []
-        : getLocationFromNodeId({
+    for (const resolved of pkgsToCheck) {
+      if (!semverUtils.satisfiesWithPrereleases(resolved.version, peerVersionRange, true)) {
+        const location = getLocationFromNodeIdAndPkg({
           dependenciesTree: ctx.dependenciesTree,
-          nodeId: resolved.nodeId,
-        }).parents
-      ctx.peerDependencyIssues.bad[peerName].push({
-        foundVersion: resolved.version,
-        resolvedFrom: peerLocation,
-        parents: location.parents,
-        optional: optionalPeer,
-        wantedRange: peerVersionRange,
-      })
+          nodeId: ctx.nodeId,
+          pkg: ctx.resolvedPackage,
+        })
+        const peerLocation = resolved.nodeId == null
+          ? []
+          : getLocationFromNodeId({
+            dependenciesTree: ctx.dependenciesTree,
+            nodeId: resolved.nodeId,
+          }).parents
+        badPeerIssues.push({
+          foundVersion: resolved.version,
+          resolvedFrom: peerLocation,
+          parents: location.parents,
+          optional: optionalPeer,
+          wantedRange: peerVersionRange,
+        })
+      } else {
+        if (resolved?.nodeId) resolvedPeers[peerName] = resolved.nodeId
+        foundPeer = true
+        break
+      }
     }
 
-    if (resolved?.nodeId) resolvedPeers[peerName] = resolved.nodeId
+    if (!foundPeer) {
+      if (badPeerIssues.length) {
+        if (!ctx.peerDependencyIssues.bad[peerName]) {
+          ctx.peerDependencyIssues.bad[peerName] = []
+        }
+        ctx.peerDependencyIssues.bad[peerName].push(...badPeerIssues)
+        if (pkgsToCheck[0]?.nodeId) resolvedPeers[peerName] = pkgsToCheck[0].nodeId
+      } else {
+        missingPeers.push(peerName)
+        const location = getLocationFromNodeIdAndPkg({
+          dependenciesTree: ctx.dependenciesTree,
+          nodeId: ctx.nodeId,
+          pkg: ctx.resolvedPackage,
+        })
+        if (!ctx.peerDependencyIssues.missing[peerName]) {
+          ctx.peerDependencyIssues.missing[peerName] = []
+        }
+        ctx.peerDependencyIssues.missing[peerName].push({
+          parents: location.parents,
+          optional: optionalPeer,
+          wantedRange: peerVersionRange,
+        })
+      }
+    }
   }
   return { resolvedPeers, missingPeers }
 }

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -6,10 +6,8 @@ import type {
   Dependencies,
   PeerDependencyIssues,
   PeerDependencyIssuesByProjects,
-  ProjectManifest,
 } from '@pnpm/types'
 import { depPathToFilename, createPeersFolderSuffixNewFormat } from '@pnpm/dependency-path'
-import { type KeyValuePair } from 'ramda'
 import isEmpty from 'ramda/src/isEmpty'
 import mapValues from 'ramda/src/map'
 import pick from 'ramda/src/pick'
@@ -50,7 +48,6 @@ export interface GenericDependenciesGraph<T extends PartialResolvedPackage> {
 }
 
 export interface ProjectToResolve {
-  manifest: ProjectManifest
   directNodeIdsByAlias: { [alias: string]: string }
   // only the top dependencies that were already installed
   // to avoid warnings about unresolved peer dependencies
@@ -80,7 +77,7 @@ export function resolvePeers<T extends PartialResolvedPackage> (
   const rootPkgsByName = opts.resolvePeersFromWorkspaceRoot ? getRootPkgsByName(opts.dependenciesTree, opts.projects) : {}
   const peerDependencyIssuesByProjects: PeerDependencyIssuesByProjects = {}
 
-  for (const { directNodeIdsByAlias, manifest, topParents, rootDir, id } of opts.projects) {
+  for (const { directNodeIdsByAlias, topParents, rootDir, id } of opts.projects) {
     const peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'> = { bad: {}, missing: {} }
     const pkgsByName = {
       ...rootPkgsByName,
@@ -486,7 +483,7 @@ function _resolvePeers<T extends PartialResolvedPackage> (
   for (const peerName in ctx.resolvedPackage.peerDependencies) { // eslint-disable-line:forin
     const peerVersionRange = ctx.resolvedPackage.peerDependencies[peerName].replace(/^workspace:/, '')
 
-    const pkgsToCheck = ctx.parentPkgs[peerName]
+    const pkgsToCheck = ctx.parentPkgs[peerName] || []
 
     const optionalPeer = ctx.resolvedPackage.peerDependenciesMeta?.[peerName]?.optional === true
     const badPeerIssues: BadPeerDependencyIssue[] = []

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -199,10 +199,8 @@ function createPkgsByName<T extends PartialResolvedPackage> (
       const aliasedPkgVersion = version.slice(index + 1)
       pkg.alias = aliasedPkgName
       updateParentRefs(parentRefs, aliasedPkgName, aliasedPkgVersion, pkg)
-    } else if (alias) {
-      updateParentRefs(parentRefs, alias, version, pkg)
     } else {
-      updateParentRefs(parentRefs, name, version, pkg)
+      updateParentRefs(parentRefs, alias ?? name, version, pkg)
     }
   }
   Object.assign(parentRefs, toPkgByName(

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -184,15 +184,7 @@ function createPkgsByName<T extends PartialResolvedPackage> (
     topParents: Array<{ name: string, version: string, linkedDir?: string }>
   }
 ) {
-  const parentRefs = toPkgByName(
-    Object
-      .keys(directNodeIdsByAlias)
-      .map((alias) => ({
-        alias,
-        node: dependenciesTree[directNodeIdsByAlias[alias]],
-        nodeId: directNodeIdsByAlias[alias],
-      }))
-  )
+  const parentRefs: ParentRefs = {}
   for (const { name, version, linkedDir } of topParents) {
     const pkg = {
       depth: 0,
@@ -201,11 +193,21 @@ function createPkgsByName<T extends PartialResolvedPackage> (
     }
     parentRefs[name] = pkg
     if (version.startsWith('npm:')) {
-      const aliasedPkgName = version.substring(4).split('@')[0]
+      const index = version.lastIndexOf('@')
+      const aliasedPkgName = version.slice(4, index)
       if (parentRefs[aliasedPkgName]) continue
       parentRefs[aliasedPkgName] = pkg
     }
   }
+  Object.assign(parentRefs, toPkgByName(
+    Object
+      .keys(directNodeIdsByAlias)
+      .map((alias) => ({
+        alias,
+        node: dependenciesTree[directNodeIdsByAlias[alias]],
+        nodeId: directNodeIdsByAlias[alias],
+      }))
+  ))
   return parentRefs
 }
 

--- a/pkg-manager/resolve-dependencies/test/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/test/resolvePeers.ts
@@ -607,8 +607,8 @@ test('resolve peer dependencies with npm aliases', () => {
   })
   expect(Object.keys(dependenciesGraph)).toStrictEqual([
     'bar/1.0.0',
-    'foo/1.0.0_bar@1.0.0',
+    'foo/1.0.0(bar@1.0.0)',
     'bar/2.0.0',
-    'foo/2.0.0_bar@2.0.0',
+    'foo/2.0.0(bar@2.0.0)',
   ])
 })

--- a/pkg-manager/resolve-dependencies/test/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/test/resolvePeers.ts
@@ -23,7 +23,6 @@ test('resolve peer dependencies of cyclic dependencies', () => {
   const { dependenciesGraph } = resolvePeers({
     projects: [
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>foo/1.0.0>',
         },
@@ -131,7 +130,6 @@ test('when a package is referenced twice in the dependencies graph and one of th
   const { dependenciesGraph } = resolvePeers({
     projects: [
       {
-        manifest: {},
         directNodeIdsByAlias: {
           zoo: '>zoo/1.0.0>',
           bar: '>bar/1.0.0>',
@@ -258,7 +256,6 @@ describe('peer dependency issues', () => {
   const { peerDependencyIssuesByProjects } = resolvePeers({
     projects: [
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project1>foo/1.0.0>',
         },
@@ -267,7 +264,6 @@ describe('peer dependency issues', () => {
         id: 'project1',
       },
       {
-        manifest: {},
         directNodeIdsByAlias: {
           bar: '>project2>bar/1.0.0>',
         },
@@ -276,7 +272,6 @@ describe('peer dependency issues', () => {
         id: 'project2',
       },
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project3>foo/1.0.0>',
           bar: '>project3>bar/1.0.0>',
@@ -286,7 +281,6 @@ describe('peer dependency issues', () => {
         id: 'project3',
       },
       {
-        manifest: {},
         directNodeIdsByAlias: {
           bar: '>project4>bar/1.0.0>',
           qar: '>project4>qar/1.0.0>',
@@ -296,7 +290,6 @@ describe('peer dependency issues', () => {
         id: 'project4',
       },
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project5>foo/1.0.0>',
           bar: '>project5>bar/2.0.0>',
@@ -306,7 +299,6 @@ describe('peer dependency issues', () => {
         id: 'project5',
       },
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project6>foo/2.0.0>',
           bar: '>project6>bar/2.0.0>',
@@ -406,7 +398,6 @@ describe('unmet peer dependency issues', () => {
   const { peerDependencyIssuesByProjects } = resolvePeers({
     projects: [
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project1>foo/1.0.0>',
           peer1: '>project1>peer1/1.0.0-rc.0>',
@@ -470,7 +461,6 @@ describe('unmet peer dependency issue resolved from subdependency', () => {
   const { peerDependencyIssuesByProjects } = resolvePeers({
     projects: [
       {
-        manifest: {},
         directNodeIdsByAlias: {
           foo: '>project>foo/1.0.0>',
         },
@@ -559,14 +549,6 @@ test('resolve peer dependencies with npm aliases', () => {
   const { dependenciesGraph } = resolvePeers({
     projects: [
       {
-        manifest: {
-          dependencies: {
-            foo: '^1.0.0',
-            bar: '^1.0.0',
-            'foo-next': 'npm:foo@^2.0.0',
-            'bar-next': 'npm:bar@^2.0.0',
-          },
-        },
         directNodeIdsByAlias: {
           foo: '>foo/1.0.0>',
           bar: '>bar/1.0.0>',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 0.2.2
         version: 0.2.2(typanion@3.12.1)
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/tsconfig':
         specifier: workspace:*
         version: link:__utils__/tsconfig
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -215,8 +215,8 @@ importers:
         specifier: workspace:*
         version: link:../../store/cafs
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1103,8 +1103,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -1212,8 +1212,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@types/is-windows':
         specifier: ^1.0.0
         version: 1.0.0
@@ -2563,8 +2563,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2811,8 +2811,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3075,8 +3075,8 @@ importers:
         specifier: workspace:*
         version: link:../read-projects-context
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3438,8 +3438,8 @@ importers:
         specifier: workspace:*
         version: 'link:'
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -3625,8 +3625,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4166,8 +4166,8 @@ importers:
         specifier: workspace:*
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -4420,8 +4420,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
 
   releasing/plugin-commands-publishing:
     dependencies:
@@ -4517,8 +4517,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2
@@ -5065,8 +5065,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5129,8 +5129,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5226,8 +5226,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5573,8 +5573,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.6.0
-        version: 3.6.0(typanion@3.12.1)
+        specifier: 3.7.0
+        version: 3.7.0(typanion@3.12.1)
       '@types/archy':
         specifier: 0.0.32
         version: 0.0.32
@@ -8143,7 +8143,7 @@ packages:
       '@pnpm/find-workspace-dir': 5.0.1
       '@pnpm/find-workspace-packages': 5.0.42(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/logger': 5.0.0
-      '@pnpm/types': 8.9.0
+      '@pnpm/types': 8.10.0
       '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
       load-json-file: 7.0.1
       meow: 10.1.5
@@ -8531,8 +8531,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/registry-mock@3.6.0(typanion@3.12.1):
-    resolution: {integrity: sha512-8L6gbqsbPJQKKkfZjIdWRODNCGVuJNnw93lRJ9pjdYwldNNxKz+sDja75ObayVeYpCMHMbtVBxuF2L3dYzlAPA==}
+  /@pnpm/registry-mock@3.7.0(typanion@3.12.1):
+    resolution: {integrity: sha512-W8yuEfiDyUi/h7ybUltXqY4XkXYjBBDSq7ZyIoIDenVS0dL3wT0lyIgVx8L+Bgf5zX8IWa3jhHIxIZNJ2KjaDg==}
     engines: {node: '>=10.13'}
     hasBin: true
     dependencies:
@@ -8698,6 +8698,7 @@ packages:
   /@pnpm/types@8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
+    dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}
@@ -8836,7 +8837,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 14.18.37
+      '@types/node': 18.15.5
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -8991,8 +8992,8 @@ packages:
     resolution: {integrity: sha512-1y36CC5iL5CMyKALzwX9cwwxcWIxvIBe3gzs4GrXWXEQ8klQnCZ2U/WDGiNrXHmQcUhnaun17XG9TEIDlGj2RA==}
     dev: true
 
-  /@types/node@18.15.3:
-    resolution: {integrity: sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==}
+  /@types/node@18.15.5:
+    resolution: {integrity: sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==}
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -9504,7 +9505,7 @@ packages:
     resolution: {integrity: sha512-Y5CCMK38k0mrdG7qo5cVpqiQ9+poegNBo3tHv44OPfoF8ktR1BcIqlAcCh0B4D2+lo1PjA411JeRxa0izTyP4Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 18.15.5
       '@yarnpkg/fslib': 3.0.0-rc.25
 
   /@yarnpkg/shell@3.2.0-rc.8(typanion@3.12.1):
@@ -9712,7 +9713,7 @@ packages:
     resolution: {integrity: sha512-ym3GCDQU8B6PZrswCvanRiWoSg2QrrlPwoRlMr4oCpGvyK2KlwTujdCZfxrGapqxrqEY3TpxEqLf+7PhFnyaLA==}
     dependencies:
       concat-stream: 1.6.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       normalize-package-data: 2.5.0
       npm-package-arg: 6.1.1
       once: 1.4.0
@@ -10760,7 +10761,7 @@ packages:
     resolution: {integrity: sha512-Xch4PXQ/KC8lJ+KfJ9JI6eG/nmppLrPPWg5Q+vh65Qr9EjuJEubxh/H/Le1TmCZ7+Xv7iJuNRqapyOFZB+wsxA==}
     hasBin: true
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       minimist: 1.2.8
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -17766,6 +17767,7 @@ packages:
 
 time:
   /@pnpm/ramda@0.28.1: '2022-08-03T13:56:59.597Z'
+  /@pnpm/registry-mock@3.7.0: '2023-03-22T00:44:25.728Z'
   /@types/byline@4.2.33: '2021-07-06T18:22:06.440Z'
   /@types/table@6.0.0: '2020-09-17T17:56:44.787Z'
   /@zkochan/hosted-git-info@4.0.2: '2021-09-05T21:33:51.709Z'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 0.2.2
         version: 0.2.2(typanion@3.12.1)
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/tsconfig':
         specifier: workspace:*
         version: link:__utils__/tsconfig
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -215,8 +215,8 @@ importers:
         specifier: workspace:*
         version: link:../../store/cafs
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1103,8 +1103,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -1212,8 +1212,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@types/is-windows':
         specifier: ^1.0.0
         version: 1.0.0
@@ -2563,8 +2563,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2811,8 +2811,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3075,8 +3075,8 @@ importers:
         specifier: workspace:*
         version: link:../read-projects-context
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3438,8 +3438,8 @@ importers:
         specifier: workspace:*
         version: 'link:'
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -3625,8 +3625,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4166,8 +4166,8 @@ importers:
         specifier: workspace:*
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -4420,8 +4420,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
 
   releasing/plugin-commands-publishing:
     dependencies:
@@ -4517,8 +4517,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2
@@ -5065,8 +5065,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5129,8 +5129,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5226,8 +5226,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5573,8 +5573,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.5.0
-        version: 3.5.0(typanion@3.12.1)
+        specifier: 3.6.0
+        version: 3.6.0(typanion@3.12.1)
       '@types/archy':
         specifier: 0.0.32
         version: 0.0.32
@@ -5970,7 +5970,7 @@ packages:
     resolution: {integrity: sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
@@ -5990,7 +5990,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.0):
@@ -6036,28 +6036,28 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-module-transforms@7.21.2:
@@ -6071,7 +6071,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6080,7 +6080,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-plugin-utils@7.20.2:
@@ -6097,7 +6097,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6106,21 +6106,21 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-string-parser@7.19.4:
@@ -6143,7 +6143,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.2
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6398,8 +6398,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.2(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/traverse@7.21.2:
@@ -6412,8 +6412,8 @@ packages:
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.2(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -7156,7 +7156,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
       jest-config: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
       jest-haste-map: 29.5.0
@@ -7258,7 +7258,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.2.1(@babel/types@7.21.2)
       istanbul-lib-report: 3.0.0
@@ -7289,7 +7289,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       callsites: 3.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /@jest/test-result@29.5.0:
@@ -7307,7 +7307,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.5.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-haste-map: 29.5.0
       slash: 3.0.0
     dev: true
@@ -7323,7 +7323,31 @@ packages:
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.5.0
+      jest-regex-util: 29.4.3
+      jest-util: 29.5.0
+      micromatch: 4.0.5
+      pirates: 4.0.5
+      slash: 3.0.0
+      write-file-atomic: 4.0.2
+    transitivePeerDependencies:
+      - '@babel/types'
+      - supports-color
+    dev: true
+
+  /@jest/transform@29.5.0(@babel/types@7.21.3):
+    resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@babel/core': 7.21.0
+      '@jest/types': 29.5.0
+      '@jridgewell/trace-mapping': 0.3.17
+      babel-plugin-istanbul: 6.1.1(@babel/types@7.21.3)
+      chalk: 4.1.2
+      convert-source-map: 2.0.0
+      fast-json-stable-stringify: 2.1.0
+      graceful-fs: 4.2.11
       jest-haste-map: 29.5.0
       jest-regex-util: 29.4.3
       jest-util: 29.5.0
@@ -7464,8 +7488,8 @@ packages:
     dev: false
     optional: true
 
-  /@pnpm/build-modules@10.1.8(@pnpm/logger@5.0.0)(typanion@3.12.1):
-    resolution: {integrity: sha512-yGIvV/juXomlVWsdWIEwaUagTiuJajwGIPQNJ3baB9rO2ZGFu57MJngpQ4VGK4Sx4N/FKnQ8qMY6W3SnMCc2iQ==}
+  /@pnpm/build-modules@10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1):
+    resolution: {integrity: sha512-n+edccgztg0XSwNmKFnAYROMcnqI7Mn8aoARIrhIW+R49HupLASBarfSlBUdyUfQ5aoyEdMHqZ2r9xrvBUYVGA==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
@@ -7475,7 +7499,7 @@ packages:
       '@pnpm/fs.hard-link-dir': 1.0.3
       '@pnpm/graph-sequencer': 1.0.0
       '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
-      '@pnpm/link-bins': 8.0.10(@pnpm/logger@5.0.0)
+      '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/logger': 5.0.0
       '@pnpm/patching.apply-patch': 1.0.0
       '@pnpm/read-package-json': 7.0.5
@@ -7529,15 +7553,15 @@ packages:
       load-json-file: 6.2.0
     dev: true
 
-  /@pnpm/cli-utils@1.1.6(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-ZFgZNdpo0FVqZkF8oM1MS9uFYutMZdloUArXlzmaQ8Tovivh/2gQOQvPlCzGMNx+/1PELCVyE6TZgecNbmqNrg==}
+  /@pnpm/cli-utils@1.1.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-zP6m14iSXSrDkoznyFbI31op0KsmdOiUvWM3fSPr/JaALkRy1aIJ+qA4P6lbC5SlFpkAsCt4ofJ+u9GtT/S1xw==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
       '@pnpm/cli-meta': 4.0.3
-      '@pnpm/config': 17.0.1(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
-      '@pnpm/default-reporter': 11.0.41(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/config': 17.0.2(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/default-reporter': 11.0.42(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/error': 4.0.1
       '@pnpm/logger': 5.0.0
       '@pnpm/manifest-utils': 4.1.4(@pnpm/logger@5.0.0)
@@ -7565,8 +7589,8 @@ packages:
     resolution: {integrity: sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==}
     engines: {node: '>=12.22.0'}
 
-  /@pnpm/config@17.0.1(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-/if9AXUEv4wnI9yJ1pXrDkkI1wpC/UWFAubA8fzZLkBYKhn9riUiEVupOljPw/2bJh8YqQXKntARN+EazKndUA==}
+  /@pnpm/config@17.0.2(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-sSvJNOm/O0tceOaiIfCLtjYvePcQiuHjLec5IOrZpMXCHM63Du5eCD43W1JIgPVhdQvAZDPa7b3B5OY125/IUQ==}
     engines: {node: '>=14.6'}
     dependencies:
       '@pnpm/config.env-replace': 1.0.0
@@ -7575,7 +7599,7 @@ packages:
       '@pnpm/git-utils': 0.1.0
       '@pnpm/matcher': 4.0.1
       '@pnpm/npm-conf': 2.0.4
-      '@pnpm/pnpmfile': 4.0.39(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/pnpmfile': 4.0.40(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/read-project-manifest': 4.1.4
       '@pnpm/types': 8.10.0
       camelcase: 6.3.0
@@ -7613,13 +7637,13 @@ packages:
       '@pnpm/types': 8.10.0
     dev: true
 
-  /@pnpm/core@8.0.3(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-rqUdtHKCdb0lVjfQgMjNivA6E8XM6haW97sMDB/L0XvIjQGCz9t7J5tcjrm8zS+cKj0vKBQIUZM8kzJBvsEveg==}
+  /@pnpm/core@8.0.4(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-J/vmcla+hihIyEwnaZWq6SWmkAHmTNq3fXmDcka/38SN2e9hVcxu7b9zv6G8Nzbdb/uDv8XmG/xy21C4gsNHcw==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/build-modules': 10.1.8(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1)
       '@pnpm/calc-dep-state': 3.0.2
       '@pnpm/constants': 6.2.0
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
@@ -7629,11 +7653,11 @@ packages:
       '@pnpm/filter-lockfile': 7.0.10(@pnpm/logger@5.0.0)
       '@pnpm/get-context': 8.2.4(@pnpm/logger@5.0.0)
       '@pnpm/graph-sequencer': 1.0.0
-      '@pnpm/headless': 19.5.3(@pnpm/logger@5.0.0)(typanion@3.12.1)
-      '@pnpm/hoist': 7.0.17(@pnpm/logger@5.0.0)
+      '@pnpm/headless': 19.5.4(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/hoist': 7.0.18(@pnpm/logger@5.0.0)
       '@pnpm/hooks.read-package-hook': 2.1.1(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
-      '@pnpm/link-bins': 8.0.10(@pnpm/logger@5.0.0)
+      '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-file': 7.0.6(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-to-pnp': 2.0.14(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-utils': 5.0.7
@@ -7687,13 +7711,13 @@ packages:
       rfc4648: 1.5.2
     dev: true
 
-  /@pnpm/default-reporter@11.0.41(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-6+2nDVA46Kx2UPQug32512zLhCb99dGPmKh/XL8hgeRLjNfO+w0a0+Yjx5oQZ+iCaA+ZDqXcL98ENtjletYqlg==}
+  /@pnpm/default-reporter@11.0.42(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-rrhfXtyKx32wqbZtrl6FWzgcp3Bx7qJ6AUlD2rTAL21S8BgHKRiQGXyehRPNLtXyKfn3i5KVB8Je2Xp86QvZrg==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/config': 17.0.1(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/config': 17.0.2(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/error': 4.0.1
       '@pnpm/logger': 5.0.0
@@ -7803,11 +7827,11 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /@pnpm/find-workspace-packages@5.0.41(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-dlaatAiYvmF4asXTckBBdaaOIz54WLAdoPzxOln6+Jvxk/ZUOTufUaD6PKBAUkxbpMw1KVGlJC6R6xiweH5f1g==}
+  /@pnpm/find-workspace-packages@5.0.42(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-tfnAnDTKy96p5+vky3TCao82BDzVm1jSiJfvPDi/4I2ycS2UzcATiPTYRRmELzUlCoiKrMu+fZRW3DPfkAqpNQ==}
     engines: {node: '>=14.6'}
     dependencies:
-      '@pnpm/cli-utils': 1.1.6(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/cli-utils': 1.1.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/constants': 6.2.0
       '@pnpm/fs.find-packages': 1.0.3
       '@pnpm/types': 8.10.0
@@ -7869,28 +7893,28 @@ packages:
     resolution: {integrity: sha512-cCUDP2jSm+Y44tVtZncrue0jXb6NrJWETQS/CQKguj/nnOqwX4Uk+9mXuhf0e/V/3ZIKe4TyDGFP1FjvWgKp1A==}
     engines: {node: '>=14.6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /@pnpm/graph-sequencer@1.0.0:
     resolution: {integrity: sha512-iIJhmi7QjmafhijaEkh34Yxhjq3S/eiZnxww9K/SRXuDB5/30QnCyihR4R7vep8ONsGIR29hNPAtaNGd1rC/VA==}
 
-  /@pnpm/headless@19.5.3(@pnpm/logger@5.0.0)(typanion@3.12.1):
-    resolution: {integrity: sha512-7B3kL7BA1vL/vO97iSn3QNoO6hEsty41BsXU+KSIIQwKBQoQm6llKMQ0ef84l4XNoh67Nawi8nAGsIxs9bLgBw==}
+  /@pnpm/headless@19.5.4(@pnpm/logger@5.0.0)(typanion@3.12.1):
+    resolution: {integrity: sha512-WJytv7MzVC6XP1CR/ZKLa3lZ5CB3E2CwiHm/UVYet6F3OLvKHF8k6UayzZ5DToaHySq8i/tSeAAtFTRXuZm7LA==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/build-modules': 10.1.8(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1)
       '@pnpm/calc-dep-state': 3.0.2
       '@pnpm/constants': 6.2.0
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/dependency-path': 1.1.3
       '@pnpm/error': 4.0.1
       '@pnpm/filter-lockfile': 7.0.10(@pnpm/logger@5.0.0)
-      '@pnpm/hoist': 7.0.17(@pnpm/logger@5.0.0)
+      '@pnpm/hoist': 7.0.18(@pnpm/logger@5.0.0)
       '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
-      '@pnpm/link-bins': 8.0.10(@pnpm/logger@5.0.0)
+      '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-file': 7.0.6(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-to-pnp': 2.0.14(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-utils': 5.0.7
@@ -7918,8 +7942,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/hoist@7.0.17(@pnpm/logger@5.0.0):
-    resolution: {integrity: sha512-Tazjrn8fGYaTzE3HjIqOJPDL7a/sRg29khrFEDvRy9hia8GJfUqghjEfA9zns0bNPT7v5ffxZYzBQOgNzQ14CA==}
+  /@pnpm/hoist@7.0.18(@pnpm/logger@5.0.0):
+    resolution: {integrity: sha512-Wvxel5mCiA96RmIkhWLBz6l30+QgSep8pbWzFFM43IDrv476GvyInESYt7ARKWyhiHVBgzSUNYhCvfLZoJNpxQ==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
@@ -7927,7 +7951,7 @@ packages:
       '@pnpm/constants': 6.2.0
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/dependency-path': 1.1.3
-      '@pnpm/link-bins': 8.0.10(@pnpm/logger@5.0.0)
+      '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-types': 4.3.6
       '@pnpm/lockfile-utils': 5.0.7
       '@pnpm/lockfile-walker': 6.0.8
@@ -7980,8 +8004,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/link-bins@8.0.10(@pnpm/logger@5.0.0):
-    resolution: {integrity: sha512-SKs0EOi91iV5MLkBYsHPtcbDWA6ZrruYvZfsUBTBYBA4epoaafNzbjuDeoNrSYd28xnAbJMcY3OCJYiIZgs1Qw==}
+  /@pnpm/link-bins@8.0.11(@pnpm/logger@5.0.0):
+    resolution: {integrity: sha512-5L3d8bgvl6yL5oyYUnlmmjbS7dyqCnf21xz8T4W6+dGz919pXgbA1U23H24JwOkI++QrTj1mUt7hsf3vjDQVaA==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
@@ -7994,7 +8018,7 @@ packages:
       '@pnpm/read-package-json': 7.0.5
       '@pnpm/read-project-manifest': 4.1.4
       '@pnpm/types': 8.10.0
-      '@zkochan/cmd-shim': 5.4.1
+      '@zkochan/cmd-shim': 6.0.0
       '@zkochan/rimraf': 2.1.2
       bin-links: 4.0.1
       is-subdir: 1.2.0
@@ -8117,9 +8141,9 @@ packages:
     hasBin: true
     dependencies:
       '@pnpm/find-workspace-dir': 5.0.1
-      '@pnpm/find-workspace-packages': 5.0.41(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/find-workspace-packages': 5.0.42(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/logger': 5.0.0
-      '@pnpm/types': 8.10.0
+      '@pnpm/types': 8.9.0
       '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
       load-json-file: 7.0.1
       meow: 10.1.5
@@ -8408,13 +8432,13 @@ packages:
       resolve-link-target: 2.0.0
     dev: true
 
-  /@pnpm/pnpmfile@4.0.39(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
-    resolution: {integrity: sha512-hKMCcmGEbLApc4cvP+CYA+Z6Un75/XVufIZdT/jQ912YXfSoUKEC/eHZwGaGOBudfgUQYILsflKxUxUi26R5Ew==}
+  /@pnpm/pnpmfile@4.0.40(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+    resolution: {integrity: sha512-OEOVJAGf3CdRHyHWAiuHeGSUsarfJ/AZoHJgwI6xStVIWyDxVZlQF/k8CxRxuGfXEv8c4rSmXR80N83eOfQbdw==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/core': 8.0.3(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/core': 8.0.4(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/error': 4.0.1
       '@pnpm/lockfile-types': 4.3.6
@@ -8449,7 +8473,7 @@ packages:
     resolution: {integrity: sha512-DibYeEAUznQolMvqqtjKnMdal1LpltRTXtKMXv6KNJTKVt8ikcR2njUfW4GiyDU3QeQlNDDglfsN++13615svg==}
     engines: {node: '>=14.6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /@pnpm/read-package-json@7.0.5:
@@ -8507,8 +8531,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/registry-mock@3.5.0(typanion@3.12.1):
-    resolution: {integrity: sha512-llz2BE8GB3vc/hFAQmKJtSrFoVnI0E2Nx+TPeIdn7zXTia+J03UYI6K3TPJMWcB37895BSMaFxDZh5abGASDgQ==}
+  /@pnpm/registry-mock@3.6.0(typanion@3.12.1):
+    resolution: {integrity: sha512-8L6gbqsbPJQKKkfZjIdWRODNCGVuJNnw93lRJ9pjdYwldNNxKz+sDja75ObayVeYpCMHMbtVBxuF2L3dYzlAPA==}
     engines: {node: '>=10.13'}
     hasBin: true
     dependencies:
@@ -8668,7 +8692,6 @@ packages:
   /@pnpm/types@8.9.0:
     resolution: {integrity: sha512-3MYHYm8epnciApn6w5Fzx6sepawmsNU7l6lvIq+ER22/DPSrr83YMhU/EQWnf4lORn2YyiXFj0FJSyJzEtIGmw==}
     engines: {node: '>=14.6'}
-    dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}
@@ -8774,8 +8797,8 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -8784,20 +8807,20 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__traverse@7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/braces@3.0.1:
@@ -8807,7 +8830,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.15.3
+      '@types/node': 14.18.37
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -8843,7 +8866,7 @@ packages:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.14.3
+      '@types/node': 14.18.37
     dev: true
 
   /@types/graceful-fs@4.1.6:
@@ -9394,39 +9417,6 @@ packages:
     transitivePeerDependencies:
       - typanion
 
-  /@yarnpkg/core@4.0.0-rc.39(typanion@3.12.1):
-    resolution: {integrity: sha512-OgPR4btSH1nsCA+cXUVIwCGMbqjcSDEb25iOlcMnqTFn0is1ydX46gp3MktLGkyN3udjEsBK7MLi/oYd/SFLPw==}
-    engines: {node: '>=14.15.0'}
-    dependencies:
-      '@arcanis/slice-ansi': 1.1.1
-      '@types/lodash': 4.14.181
-      '@types/semver': 7.3.13
-      '@types/treeify': 1.0.0
-      '@yarnpkg/fslib': 3.0.0-rc.25
-      '@yarnpkg/libzip': 3.0.0-rc.25(@yarnpkg/fslib@3.0.0-rc.25)
-      '@yarnpkg/parsers': 3.0.0-rc.39
-      '@yarnpkg/shell': 4.0.0-rc.39(typanion@3.12.1)
-      camelcase: 5.3.1
-      chalk: 3.0.0
-      ci-info: 3.8.0
-      clipanion: 3.2.0-rc.6(typanion@3.12.1)
-      cross-spawn: 7.0.3
-      diff: 5.1.0
-      globby: 11.1.0
-      got: 11.8.6
-      lodash: 4.17.21
-      micromatch: 4.0.5
-      p-limit: 2.3.0
-      semver: 7.3.8
-      strip-ansi: 6.0.1
-      tar: 6.1.13
-      tinylogic: 2.0.0
-      treeify: 1.1.0
-      tslib: 2.5.0
-      tunnel: 0.0.6
-    transitivePeerDependencies:
-      - typanion
-
   /@yarnpkg/extensions@2.0.0-rc.9(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-WWXBCKyIhG4pkpS42erPUkxgPXt3NEjGb3ha+HlEKgSVdJThNFE9CmwSyDdfdiV3QhCDkZR2R0jQVmbrCrigRw==}
     engines: {node: '>=14.15.0'}
@@ -9468,9 +9458,9 @@ packages:
     resolution: {integrity: sha512-KfoYI38XY0PjpPu+LGvRHxg3OFO+5nwbQy/c5FuLR0ipQkXcinS3JbG+de17Mf6QdKnBTcghA7mdrUKs5JbxyA==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@yarnpkg/core': 4.0.0-rc.39(typanion@3.12.1)
+      '@yarnpkg/core': 4.0.0-rc.27(typanion@3.12.1)
       '@yarnpkg/fslib': 3.0.0-rc.25
-      '@yarnpkg/pnp': 4.0.0-rc.39
+      '@yarnpkg/pnp': 4.0.0-rc.40
     transitivePeerDependencies:
       - typanion
 
@@ -9504,8 +9494,8 @@ packages:
       '@yarnpkg/fslib': 3.0.0-rc.25
       tslib: 1.14.1
 
-  /@yarnpkg/pnp@4.0.0-rc.39:
-    resolution: {integrity: sha512-NpXoa9pJZ6IM67X0xe0iHL9hlP5B0A5ltesbH5PDl/wZCYJ/QUt+aFOVLTR+SAUHEPvRh4HqWtXo7Z8zYupGGQ==}
+  /@yarnpkg/pnp@4.0.0-rc.40:
+    resolution: {integrity: sha512-Y5CCMK38k0mrdG7qo5cVpqiQ9+poegNBo3tHv44OPfoF8ktR1BcIqlAcCh0B4D2+lo1PjA411JeRxa0izTyP4Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
       '@types/node': 18.15.3
@@ -9544,15 +9534,6 @@ packages:
     transitivePeerDependencies:
       - typanion
 
-  /@zkochan/cmd-shim@5.4.1:
-    resolution: {integrity: sha512-odWb1qUzt0dIOEUPyWBEpFDYQPRjEMr/dbHHAfgBkVkYR9aO7Zo+I7oYWrXIxl+cKlC7+49ftPm8uJxL1MA9kw==}
-    engines: {node: '>=10.13'}
-    dependencies:
-      cmd-extension: 1.0.2
-      graceful-fs: 4.2.10
-      is-windows: 1.0.2
-    dev: true
-
   /@zkochan/cmd-shim@6.0.0:
     resolution: {integrity: sha512-kLBj0hJjqIw/KkIs8tvFaG1AY/yX2iUJqj47Jgoo5WoeQJd552ijJsj4GAOQnmyfoFLLEKZ+aSYfCpMjyg2hJw==}
     engines: {node: '>=14.6'}
@@ -9560,7 +9541,6 @@ packages:
       cmd-extension: 1.0.2
       graceful-fs: 4.2.11
       is-windows: 1.0.2
-    dev: false
 
   /@zkochan/diable@1.0.2:
     resolution: {integrity: sha512-LvXkwkWyrsRulnXVfp0BfuEQqV6I2j0l3kQwvBHKFMI6Sg5j2GrUCLsEKqYB3jlxM+0ofScvlE4vB6knevdBmg==}
@@ -9667,6 +9647,17 @@ packages:
     dependencies:
       debug: 4.3.4
       depd: 1.1.2
+      humanize-ms: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /agentkeepalive@4.3.0:
+    resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      debug: 4.3.4
+      depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -9835,7 +9826,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -9848,6 +9839,12 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  /array-buffer-byte-length@1.0.0:
+    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
+    dependencies:
+      call-bind: 1.0.2
+      is-array-buffer: 3.0.2
 
   /array-find-index@1.0.2:
     resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
@@ -9963,7 +9960,7 @@ packages:
       babel-plugin-istanbul: 6.1.1(@babel/types@7.21.2)
       babel-preset-jest: 29.5.0(@babel/core@7.21.0)
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - '@babel/types'
@@ -9984,12 +9981,26 @@ packages:
       - supports-color
     dev: true
 
+  /babel-plugin-istanbul@6.1.1(@babel/types@7.21.3):
+    resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-instrument: 5.2.1(@babel/types@7.21.3)
+      test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - '@babel/types'
+      - supports-color
+    dev: true
+
   /babel-plugin-jest-hoist@29.5.0:
     resolution: {integrity: sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
     dev: true
@@ -10063,7 +10074,7 @@ packages:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
 
   /body-parser@1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -10613,7 +10624,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
       typedarray: 0.0.6
 
   /config-chain@1.1.13:
@@ -10964,7 +10975,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       globby: 11.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-glob: 4.0.3
       is-path-cwd: 2.2.0
       is-path-inside: 3.0.3
@@ -11202,6 +11213,45 @@ packages:
       object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
       safe-regex-test: 1.0.0
+      string.prototype.trimend: 1.0.6
+      string.prototype.trimstart: 1.0.6
+      typed-array-length: 1.0.4
+      unbox-primitive: 1.0.2
+      which-typed-array: 1.1.9
+
+  /es-abstract@1.21.2:
+    resolution: {integrity: sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      es-set-tostringtag: 2.0.1
+      es-to-primitive: 1.2.1
+      function.prototype.name: 1.1.5
+      get-intrinsic: 1.2.0
+      get-symbol-description: 1.0.0
+      globalthis: 1.0.3
+      gopd: 1.0.1
+      has: 1.0.3
+      has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.5
+      is-array-buffer: 3.0.2
+      is-callable: 1.2.7
+      is-negative-zero: 2.0.2
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      is-string: 1.0.7
+      is-typed-array: 1.1.10
+      is-weakref: 1.0.2
+      object-inspect: 1.12.3
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.4.3
+      safe-regex-test: 1.0.0
+      string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
       typed-array-length: 1.0.4
@@ -11936,7 +11986,7 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
 
@@ -11951,7 +12001,7 @@ packages:
   /fs-extra@4.0.3:
     resolution: {integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -11960,7 +12010,7 @@ packages:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -11969,7 +12019,7 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: true
@@ -11979,7 +12029,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
 
@@ -11993,7 +12043,7 @@ packages:
     resolution: {integrity: sha512-+vSd9frUnapVC2RZYfL3FCB2p3g4TBhaUmrsWlSudsGdnxIuUvBB2QM1VZeBtc49QFwrp+wQLrDs3+xxDgI5gQ==}
     engines: {node: '>= 0.10'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       through2: 2.0.5
     dev: true
 
@@ -12669,6 +12719,13 @@ packages:
       get-intrinsic: 1.2.0
       is-typed-array: 1.1.10
 
+  /is-array-buffer@3.0.2:
+    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
+
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -12972,6 +13029,20 @@ packages:
       - supports-color
     dev: true
 
+  /istanbul-lib-instrument@5.2.1(@babel/types@7.21.3):
+    resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.0
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - '@babel/types'
+      - supports-color
+    dev: true
+
   /istanbul-lib-report@3.0.0:
     resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
     engines: {node: '>=8'}
@@ -13044,7 +13115,7 @@ packages:
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       import-local: 3.1.0
       jest-config: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
       jest-util: 29.5.0
@@ -13079,7 +13150,7 @@ packages:
       ci-info: 3.8.0
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-circus: 29.5.0(@babel/types@7.21.2)
       jest-environment-node: 29.5.0
       jest-get-type: 29.4.3
@@ -13153,7 +13224,7 @@ packages:
       '@types/node': 14.18.37
       anymatch: 3.1.3
       fb-watchman: 2.0.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-regex-util: 29.4.3
       jest-util: 29.5.0
       jest-worker: 29.5.0
@@ -13199,7 +13270,7 @@ packages:
       '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       micromatch: 4.0.5
       pretty-format: 29.5.0
       slash: 3.0.0
@@ -13247,7 +13318,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       chalk: 4.1.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-haste-map: 29.5.0
       jest-pnp-resolver: 1.2.3(jest-resolve@29.5.0)
       jest-util: 29.5.0
@@ -13269,7 +13340,7 @@ packages:
       '@types/node': 14.18.37
       chalk: 4.1.2
       emittery: 0.13.1
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-docblock: 29.4.3
       jest-environment-node: 29.5.0
       jest-haste-map: 29.5.0
@@ -13303,7 +13374,7 @@ packages:
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       glob: 7.2.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
@@ -13327,16 +13398,16 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.0)
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.21.0)
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@jest/expect-utils': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@types/babel__traverse': 7.18.3
       '@types/prettier': 2.7.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.0)
       chalk: 4.1.2
       expect: 29.5.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jest-diff: 29.5.0
       jest-get-type: 29.4.3
       jest-matcher-utils: 29.5.0
@@ -13357,7 +13428,7 @@ packages:
       '@types/node': 14.18.37
       chalk: 4.1.2
       ci-info: 3.8.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       picomatch: 2.3.1
     dev: true
 
@@ -13369,7 +13440,7 @@ packages:
       '@types/node': 14.18.37
       chalk: 4.1.2
       ci-info: 3.8.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       picomatch: 2.3.1
     dev: true
 
@@ -13492,7 +13563,7 @@ packages:
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
     dev: true
 
   /jsonfile@6.1.0:
@@ -13500,7 +13571,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -13560,7 +13631,7 @@ packages:
   /klaw-sync@6.0.0:
     resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -13623,7 +13694,7 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -13647,7 +13718,7 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -13788,7 +13859,7 @@ packages:
     resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-promise: 2.2.2
       lodash: 4.17.21
       pify: 3.0.0
@@ -13897,7 +13968,7 @@ packages:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
     engines: {node: '>= 10'}
     dependencies:
-      agentkeepalive: 4.2.1
+      agentkeepalive: 4.3.0
       cacache: 15.3.0
       http-cache-semantics: 4.1.1
       http-proxy-agent: 4.0.1
@@ -14322,7 +14393,7 @@ packages:
     dependencies:
       json-stringify-safe: 5.0.1
       minimist: 1.2.8
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
       split2: 3.2.2
       through2: 4.0.2
 
@@ -14431,7 +14502,7 @@ packages:
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       make-fetch-happen: 9.1.0
       nopt: /@pnpm/nopt@0.2.1
       npmlog: 6.0.2
@@ -15478,7 +15549,7 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -15517,7 +15588,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    dev: true
 
   /realpath-missing@1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
@@ -16198,7 +16268,7 @@ packages:
   /split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
     dependencies:
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -16262,7 +16332,7 @@ packages:
   /steno@0.4.4:
     resolution: {integrity: sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   /stream-buffers@3.0.2:
     resolution: {integrity: sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==}
@@ -16341,10 +16411,18 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.2.0
-      es-abstract: 1.21.1
+      es-abstract: 1.21.2
       get-intrinsic: 1.2.0
       has-symbols: 1.0.3
       is-regex: 1.1.4
+
+  /string.prototype.trim@1.2.7:
+    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.21.2
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
@@ -16580,7 +16658,7 @@ packages:
   /through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
     dependencies:
-      readable-stream: 3.6.1
+      readable-stream: 3.6.2
 
   /through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -17264,7 +17342,7 @@ packages:
     dependencies:
       fs-mkdirp-stream: 1.0.0
       glob-stream: 6.1.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-valid-glob: 1.0.0
       lazystream: 1.0.1
       lead: 1.0.0
@@ -17287,7 +17365,7 @@ packages:
     dependencies:
       append-buffer: 1.0.2
       convert-source-map: 1.9.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       normalize-path: 2.1.1
       now-and-later: 2.0.1
       remove-bom-buffer: 3.0.0
@@ -17310,7 +17388,7 @@ packages:
     resolution: {integrity: sha512-kFveRaZ4n8Qyg/HsE+WeZpf0LDfJrA/0t1sqLLnYtnl++VBsd/g7iI4CkQ4SIvrDI1nCjmiJhRnBORb7MIOLjQ==}
     dependencies:
       each-limit: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       lodash.assign: 4.2.0
       lodash.isobject: 3.0.2
       lodash.isundefined: 3.0.1
@@ -17391,7 +17469,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
 
   /widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
@@ -17429,7 +17507,7 @@ packages:
   /write-file-atomic@2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
@@ -17680,253 +17758,11 @@ packages:
     patched: true
 
 time:
-  /@babel/core@7.21.0: '2023-02-20T15:31:22.823Z'
-  /@babel/plugin-proposal-dynamic-import@7.18.6: '2022-06-27T19:49:50.843Z'
-  /@babel/plugin-transform-modules-commonjs@7.21.2: '2023-02-23T09:31:39.683Z'
-  /@babel/preset-typescript@7.21.0: '2023-02-20T15:31:22.789Z'
-  /@babel/types@7.21.2: '2023-02-23T09:31:35.164Z'
-  /@changesets/cli@2.26.0: '2022-12-18T11:42:17.936Z'
-  /@commitlint/cli@17.4.4: '2023-02-17T15:34:43.117Z'
-  /@commitlint/config-conventional@17.4.4: '2023-02-17T15:34:43.196Z'
-  /@commitlint/prompt-cli@17.4.4: '2023-02-17T15:34:46.836Z'
-  /@gwhitney/detect-indent@7.0.1: '2022-11-22T14:07:22.341Z'
-  /@pnpm/byline@1.0.0: '2021-10-31T23:25:00.031Z'
-  /@pnpm/colorize-semver-diff@1.0.1: '2020-10-25T15:50:17.812Z'
-  /@pnpm/config.env-replace@1.0.0: '2022-11-11T20:22:17.274Z'
-  /@pnpm/exec@2.0.0: '2020-10-29T23:51:01.271Z'
-  /@pnpm/graph-sequencer@1.0.0: '2022-03-20T20:48:58.797Z'
-  /@pnpm/logger@5.0.0: '2022-10-14T13:56:04.285Z'
-  /@pnpm/meta-updater@0.2.2: '2022-11-18T12:00:42.706Z'
-  /@pnpm/network.agent@0.1.0: '2023-02-18T01:03:06.709Z'
-  /@pnpm/nopt@0.2.1: '2021-06-01T19:45:54.552Z'
-  /@pnpm/npm-conf@2.0.4: '2022-11-11T20:26:48.028Z'
-  /@pnpm/npm-lifecycle@2.0.0: '2022-11-30T19:58:42.868Z'
-  /@pnpm/npm-package-arg@1.0.0: '2022-06-28T12:48:31.287Z'
-  /@pnpm/os.env.path-extender@0.2.10: '2023-02-28T01:46:02.862Z'
   /@pnpm/ramda@0.28.1: '2022-08-03T13:56:59.597Z'
-  /@pnpm/registry-mock@3.5.0: '2023-03-02T17:51:20.657Z'
-  /@pnpm/semver-diff@1.1.0: '2021-11-16T12:40:59.941Z'
-  /@pnpm/tabtab@0.1.2: '2021-03-05T17:31:19.932Z'
-  /@pnpm/types@8.9.0: '2022-11-09T23:07:02.862Z'
-  /@pnpm/util.lex-comparator@1.0.0: '2022-11-04T01:03:46.134Z'
-  /@types/adm-zip@0.5.0: '2022-04-01T08:01:50.776Z'
-  /@types/archy@0.0.32: '2021-07-06T18:11:33.301Z'
   /@types/byline@4.2.33: '2021-07-06T18:22:06.440Z'
-  /@types/concat-stream@2.0.0: '2022-02-01T09:02:05.296Z'
-  /@types/cross-spawn@6.0.2: '2020-05-15T04:43:58.956Z'
-  /@types/fs-extra@9.0.13: '2021-09-21T19:02:27.512Z'
-  /@types/graceful-fs@4.1.6: '2023-01-09T00:02:51.051Z'
-  /@types/hosted-git-info@3.0.2: '2021-07-06T21:35:19.353Z'
-  /@types/ini@1.3.31: '2021-10-07T21:01:49.672Z'
-  /@types/is-windows@1.0.0: '2019-11-19T19:37:55.992Z'
-  /@types/isexe@2.0.1: '2021-07-06T21:42:29.330Z'
-  /@types/jest@29.4.0: '2023-01-25T07:32:37.744Z'
-  /@types/js-yaml@4.0.5: '2021-11-19T18:01:41.484Z'
-  /@types/micromatch@4.0.2: '2021-07-06T22:16:07.649Z'
-  /@types/mz@2.7.4: '2021-07-07T00:08:08.635Z'
-  /@types/node@14.18.37: '2023-03-02T04:34:14.890Z'
-  /@types/normalize-package-data@2.4.1: '2021-07-07T16:35:08.730Z'
-  /@types/normalize-path@3.0.0: '2018-12-25T05:20:59.823Z'
-  /@types/npm-packlist@3.0.0: '2022-03-02T17:32:47.919Z'
-  /@types/parse-json@4.0.0: '2017-11-14T00:31:12.629Z'
-  /@types/proxyquire@1.3.28: '2017-08-21T22:01:15.006Z'
-  /@types/ramda@0.28.20: '2022-11-11T10:32:59.530Z'
-  /@types/retry@0.12.2: '2022-04-26T19:32:23.281Z'
-  /@types/rimraf@3.0.2: '2021-08-18T21:02:03.570Z'
-  /@types/semver@7.3.13: '2022-10-26T20:03:07.384Z'
-  /@types/signal-exit@3.0.1: '2021-07-06T17:09:42.542Z'
-  /@types/sinon@10.0.13: '2022-07-20T05:32:19.345Z'
-  /@types/ssri@7.1.1: '2021-07-06T17:33:37.041Z'
   /@types/table@6.0.0: '2020-09-17T17:56:44.787Z'
-  /@types/tar-stream@2.2.2: '2021-10-17T15:01:27.866Z'
-  /@types/tar@6.1.4: '2023-02-16T06:02:41.170Z'
-  /@types/touch@3.1.2: '2021-07-02T19:48:20.467Z'
-  /@types/uuid@8.3.4: '2022-01-06T07:32:21.196Z'
-  /@types/validate-npm-package-name@4.0.0: '2022-06-23T08:01:45.971Z'
-  /@types/which@2.0.2: '2023-02-14T10:32:38.403Z'
-  /@types/wrap-ansi@8.0.1: '2021-07-02T19:06:52.938Z'
-  /@types/write-file-atomic@4.0.0: '2022-02-10T19:02:13.425Z'
-  /@types/yarnpkg__lockfile@1.1.5: '2021-07-02T16:36:17.969Z'
-  /@typescript-eslint/eslint-plugin@5.54.0: '2023-02-27T17:18:03.867Z'
-  /@typescript-eslint/parser@5.54.0: '2023-02-27T17:17:32.820Z'
-  /@yarnpkg/core@4.0.0-rc.27: '2022-10-28T20:14:12.960Z'
-  /@yarnpkg/extensions@2.0.0-rc.9: '2022-10-28T20:09:02.171Z'
-  /@yarnpkg/lockfile@1.1.0: '2018-09-10T13:37:58.652Z'
-  /@yarnpkg/nm@4.0.0-rc.27: '2022-10-28T20:14:26.306Z'
-  /@yarnpkg/parsers@3.0.0-rc.27: '2022-10-28T20:12:42.896Z'
-  /@yarnpkg/pnp@2.3.2: '2020-11-30T14:45:51.504Z'
-  /@zkochan/cmd-shim@6.0.0: '2023-03-16T02:26:12.592Z'
-  /@zkochan/diable@1.0.2: '2020-07-07T02:01:35.635Z'
   /@zkochan/hosted-git-info@4.0.2: '2021-09-05T21:33:51.709Z'
   /@zkochan/js-yaml@0.0.6: '2022-05-10T14:42:39.813Z'
-  /@zkochan/retry@0.2.0: '2020-06-06T23:36:55.687Z'
-  /@zkochan/rimraf@2.1.2: '2022-01-30T23:37:31.206Z'
-  /@zkochan/table@1.0.0: '2020-10-28T20:34:59.396Z'
-  /@zkochan/which@2.0.3: '2021-09-14T23:50:27.657Z'
-  /adm-zip@0.5.10: '2022-12-20T11:08:08.848Z'
-  /ansi-diff@1.1.1: '2018-06-16T13:37:28.365Z'
-  /archy@1.0.0: '2014-09-14T07:57:58.806Z'
-  /better-path-resolve@1.0.0: '2019-03-01T23:22:26.750Z'
-  /bin-links@4.0.1: '2022-10-17T19:35:27.798Z'
-  /boxen@5.1.2: '2021-09-17T05:31:40.311Z'
-  /c8@7.13.0: '2023-02-16T16:59:27.148Z'
-  /camelcase-keys@6.2.2: '2020-04-03T03:51:03.816Z'
-  /camelcase@6.3.0: '2022-01-01T20:29:34.388Z'
-  /can-link@2.0.0: '2021-02-11T22:53:11.538Z'
-  /can-write-to-dir@1.1.1: '2021-04-01T00:51:46.475Z'
-  /chalk@4.1.2: '2021-07-30T12:02:52.839Z'
-  /ci-info@3.8.0: '2023-02-11T14:11:34.779Z'
-  /cli-columns@4.0.0: '2021-09-23T18:51:13.897Z'
-  /cmd-extension@1.0.2: '2021-09-28T21:08:51.481Z'
-  /comver-to-semver@1.0.0: '2021-04-04T23:59:39.895Z'
-  /concat-stream@2.0.0: '2018-12-21T14:22:15.876Z'
-  /cross-env@7.0.3: '2020-12-01T20:25:26.541Z'
-  /cross-spawn@7.0.3: '2020-05-25T15:35:07.209Z'
-  /cross-var-no-babel@1.2.0: '2017-11-12T10:58:04.011Z'
-  /decompress-maybe@1.0.0: '2016-08-22T09:02:46.873Z'
-  /deep-require-cwd@1.0.0: '2017-05-08T20:09:31.558Z'
-  /delay@5.0.0: '2021-02-01T15:29:35.501Z'
-  /detect-libc@2.0.1: '2022-02-14T10:44:10.231Z'
-  /didyoumean2@5.0.0: '2021-05-27T03:31:55.835Z'
-  /dint@5.1.0: '2021-02-12T01:22:54.214Z'
-  /dir-is-case-sensitive@2.0.0: '2021-02-11T22:53:28.072Z'
-  /encode-registry@3.0.0: '2020-10-28T18:56:36.241Z'
-  /enquirer@2.3.6: '2020-07-02T13:00:19.453Z'
-  /esbuild@0.17.12: '2023-03-17T06:17:56.026Z'
-  /escape-string-regexp@4.0.0: '2020-04-23T07:31:25.491Z'
-  /eslint-config-standard-with-typescript@34.0.1: '2023-03-14T09:26:58.154Z'
-  /eslint-plugin-import@2.27.5: '2023-01-16T19:44:39.790Z'
-  /eslint-plugin-n@15.6.1: '2023-01-11T03:52:38.490Z'
-  /eslint-plugin-node@11.1.0: '2020-03-28T11:46:46.795Z'
-  /eslint-plugin-promise@6.1.1: '2022-10-19T21:06:14.552Z'
-  /eslint@8.36.0: '2023-03-10T22:16:38.111Z'
-  /exists-link@2.0.0: '2017-03-02T20:50:23.918Z'
-  /fast-deep-equal@3.1.3: '2020-06-08T07:27:28.474Z'
-  /fast-glob@3.2.12: '2022-09-09T06:40:27.748Z'
-  /filenamify@4.3.0: '2021-04-26T16:15:18.365Z'
-  /find-up@5.0.0: '2020-08-11T18:44:24.748Z'
-  /fs-extra@11.1.0: '2022-11-29T23:39:46.795Z'
   /fuse-native@2.2.6: '2020-06-03T19:26:36.838Z'
-  /get-npm-tarball-url@2.0.3: '2021-11-22T22:17:09.184Z'
-  /get-port@5.1.1: '2020-01-15T08:08:35.951Z'
-  /get-stream@6.0.1: '2021-04-15T04:56:42.936Z'
-  /ghooks@2.0.4: '2018-04-29T00:47:15.439Z'
-  /graceful-fs@4.2.11: '2023-03-16T19:30:19.323Z'
-  /graceful-git@3.1.2: '2021-09-16T00:23:26.185Z'
-  /husky@8.0.3: '2023-01-03T08:01:18.807Z'
-  /hyperdrive-schemas@2.0.0: '2020-07-14T11:16:33.671Z'
-  /ini@3.0.1: '2022-08-22T17:22:43.830Z'
-  /is-inner-link@4.0.0: '2021-02-11T22:54:33.386Z'
-  /is-port-reachable@3.0.0: '2019-11-12T09:49:42.096Z'
-  /is-subdir@1.2.0: '2021-01-05T16:52:45.485Z'
-  /is-windows@1.0.2: '2018-02-14T07:36:43.207Z'
-  /isexe@2.0.0: '2017-03-23T00:53:16.356Z'
-  /jest-diff@29.5.0: '2023-03-06T13:33:30.577Z'
-  /jest@29.5.0: '2023-03-06T13:33:57.077Z'
-  /json-append@1.1.1: '2017-01-07T04:45:27.600Z'
-  /json5@2.2.3: '2022-12-31T17:11:32.047Z'
-  /keyv@4.5.2: '2022-11-07T15:23:30.660Z'
-  /lcov-result-merger@3.3.0: '2022-06-21T06:32:52.863Z'
-  /load-json-file@6.2.0: '2019-07-11T08:30:09.981Z'
-  /loud-rejection@2.2.0: '2019-09-28T16:02:58.271Z'
-  /lru-cache@8.0.4: '2023-03-17T23:05:36.272Z'
-  /make-empty-dir@2.0.0: '2021-04-11T12:30:52.269Z'
-  /mdast-util-to-string@2.0.0: '2020-11-11T09:15:26.835Z'
-  /mem@8.1.1: '2021-04-20T15:49:07.407Z'
-  /micromatch@4.0.5: '2022-03-24T19:31:47.722Z'
-  /nerf-dart@1.0.0: '2015-08-20T12:22:17.009Z'
-  /nock@13.3.0: '2023-01-10T20:34:45.381Z'
-  /node-fetch@3.0.0-beta.9: '2020-09-05T12:52:27.791Z'
   /node-gyp@9.3.1: '2022-12-19T22:43:10.187Z'
-  /normalize-newline@3.0.0: '2016-09-06T12:35:43.571Z'
-  /normalize-package-data@5.0.0: '2022-10-14T05:22:41.916Z'
-  /normalize-path@3.0.0: '2018-04-19T14:54:47.609Z'
-  /normalize-registry-url@2.0.0: '2021-11-22T21:36:37.421Z'
-  /npm-packlist@5.1.3: '2022-08-25T19:33:59.963Z'
-  /npm-run-all@4.1.5: '2018-11-24T13:52:41.635Z'
-  /p-any@3.0.0: '2020-02-22T14:44:06.005Z'
-  /p-defer@3.0.0: '2019-06-07T08:11:13.854Z'
-  /p-every@2.0.0: '2019-03-15T09:22:34.849Z'
-  /p-filter@2.1.0: '2019-04-04T04:54:11.010Z'
-  /p-limit@3.1.0: '2020-11-25T07:42:37.364Z'
-  /p-map-values@1.0.0: '2022-11-19T01:54:52.912Z'
-  /p-memoize@4.0.1: '2020-09-24T12:12:05.234Z'
-  /p-queue@6.6.2: '2020-10-11T19:09:45.773Z'
-  /p-settle@4.1.1: '2020-05-29T08:07:35.109Z'
-  /parse-json@5.2.0: '2021-01-18T11:15:13.459Z'
-  /parse-npm-tarball-url@3.0.0: '2019-05-27T23:50:09.183Z'
-  /patch-package@6.5.1: '2023-01-03T17:56:53.472Z'
-  /path-absolute@1.0.1: '2018-11-28T20:25:53.253Z'
-  /path-exists@4.0.0: '2019-04-04T03:29:16.887Z'
-  /path-name@1.0.0: '2016-10-20T18:43:50.780Z'
-  /path-temp@2.0.0: '2019-05-04T14:35:52.401Z'
-  /pidtree@0.6.0: '2022-06-05T18:35:44.206Z'
-  /pkg-deb@1.1.2: '2020-10-26T14:13:54.373Z'
-  /pkg-rpm@1.0.3: '2021-01-12T09:42:07.762Z'
-  /preferred-pm@3.0.3: '2021-02-09T01:16:52.150Z'
-  /pretty-bytes@5.6.0: '2021-02-21T14:04:35.036Z'
-  /pretty-ms@7.0.1: '2020-09-24T09:37:39.213Z'
-  /process-exists@4.1.0: '2021-07-09T07:06:51.313Z'
-  /promise-share@1.0.0: '2019-09-13T19:01:32.578Z'
-  /proxyquire@2.1.3: '2019-08-12T13:54:46.049Z'
-  /ps-list@7.2.0: '2020-06-17T09:02:36.119Z'
-  /publish-packed@4.1.1: '2022-01-04T09:56:54.476Z'
-  /read-ini-file@4.0.0: '2022-12-23T20:19:57.971Z'
-  /read-yaml-file@2.1.0: '2021-02-11T22:53:46.064Z'
-  /realpath-missing@1.1.0: '2021-02-11T22:53:50.718Z'
-  /remark-parse@9.0.0: '2020-10-14T08:48:35.392Z'
-  /remark-stringify@9.0.1: '2020-12-09T17:54:33.099Z'
-  /rename-overwrite@4.0.3: '2022-10-31T02:06:57.577Z'
-  /render-help@1.0.3: '2023-01-29T01:46:41.262Z'
-  /resolve-link-target@2.0.0: '2021-02-11T22:54:11.438Z'
-  /rfc4648@1.5.2: '2022-05-30T17:55:52.370Z'
-  /right-pad@1.0.1: '2016-08-04T20:06:31.415Z'
-  /rimraf@3.0.2: '2020-02-09T06:18:37.504Z'
-  /root-link-target@3.1.0: '2021-02-11T22:54:37.968Z'
-  /run-groups@3.0.1: '2020-06-06T16:33:09.423Z'
-  /rxjs@7.8.0: '2022-12-15T23:25:47.887Z'
-  /safe-buffer@5.2.1: '2020-05-10T16:37:30.776Z'
   /safe-execa@0.1.2: '2022-07-18T01:09:17.517Z'
-  /safe-execa@0.1.3: '2023-01-04T13:29:20.746Z'
-  /safe-promise-defer@1.0.1: '2022-06-18T13:48:40.297Z'
-  /sanitize-filename@1.6.3: '2019-08-26T02:10:56.988Z'
-  /semver-range-intersect@0.3.1: '2019-07-20T15:11:40.243Z'
-  /semver-utils@1.1.4: '2018-10-09T04:14:32.485Z'
-  /semver@7.3.8: '2022-10-04T19:40:47.960Z'
-  /shx@0.3.4: '2022-01-10T02:16:53.953Z'
-  /signal-exit@3.0.7: '2022-02-03T21:05:34.544Z'
-  /sinon@15.0.2: '2023-03-12T21:14:20.275Z'
-  /sort-keys@4.2.0: '2020-12-30T07:11:45.350Z'
-  /split-cmd@1.0.1: '2020-01-22T19:18:26.255Z'
-  /ssri@10.0.1: '2022-12-07T20:32:53.754Z'
-  /stacktracey@2.1.8: '2022-01-10T09:22:17.926Z'
-  /string-length@4.0.2: '2021-03-17T06:47:19.439Z'
-  /string.prototype.replaceall@1.0.7: '2022-11-07T19:04:29.156Z'
-  /strip-ansi@6.0.1: '2021-09-23T16:34:41.798Z'
-  /strip-bom@4.0.0: '2019-04-28T04:40:47.887Z'
-  /strip-comments-strings@1.2.0: '2022-06-12T23:34:53.852Z'
-  /symlink-dir@5.1.1: '2023-02-01T00:19:14.193Z'
-  /syncpack@8.5.14: '2023-02-07T19:51:38.723Z'
-  /tar-stream@2.2.0: '2020-12-29T10:22:57.508Z'
-  /tar@6.1.13: '2022-12-07T20:32:39.620Z'
-  /tempy@1.0.1: '2021-03-17T07:03:04.830Z'
-  /touch@3.1.0: '2017-06-30T23:40:39.606Z'
-  /tree-kill@1.2.2: '2019-12-11T18:34:21.876Z'
-  /ts-jest@29.0.3: '2022-09-29T06:14:41.529Z'
-  /ts-node@10.9.1: '2022-07-14T02:33:44.792Z'
-  /typescript@5.0.2: '2023-03-16T16:41:18.461Z'
-  /unified@9.2.2: '2021-07-01T16:39:11.345Z'
-  /unique-string@2.0.0: '2019-04-29T04:18:06.804Z'
-  /uuid@9.0.0: '2022-09-05T20:03:54.869Z'
-  /validate-npm-package-name@5.0.0: '2022-10-14T05:22:33.343Z'
-  /verdaccio@5.20.1: '2023-01-29T15:45:43.205Z'
-  /version-selector-type@3.0.0: '2020-05-02T19:53:43.038Z'
-  /which@3.0.0: '2022-11-01T19:20:24.475Z'
-  /wrap-ansi@7.0.0: '2020-04-22T16:53:23.889Z'
-  /write-file-atomic@5.0.0: '2022-10-14T05:22:38.937Z'
-  /write-ini-file@4.0.1: '2022-12-23T20:19:59.977Z'
-  /write-json-file@4.3.0: '2020-02-07T08:54:49.528Z'
-  /write-json5-file@3.1.0: '2021-02-11T22:54:24.439Z'
-  /write-pkg@4.0.0: '2019-04-29T10:37:09.855Z'
-  /write-yaml-file@4.2.0: '2021-02-11T22:54:29.120Z'
-  /yaml-tag@1.1.0: '2017-06-06T16:19:00.523Z'

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -60,7 +60,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/run-npm": "workspace:*",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/test-fixtures": "workspace:*",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -60,7 +60,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/run-npm": "workspace:*",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/test-fixtures": "workspace:*",

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -42,7 +42,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/plugin-commands-deploy": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0"
+    "@pnpm/registry-mock": "3.7.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -42,7 +42,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/plugin-commands-deploy": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0"
+    "@pnpm/registry-mock": "3.6.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/is-windows": "^1.0.0",
     "@types/npm-packlist": "^3.0.0",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/is-windows": "^1.0.0",
     "@types/npm-packlist": "^3.0.0",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-licenses": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",
     "@types/zkochan__table": "npm:@types/table@6.0.0",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-licenses": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",
     "@types/zkochan__table": "npm:@types/table@6.0.0",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -37,7 +37,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-listing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@types/ramda": "0.28.20",
     "execa": "npm:safe-execa@0.1.2",
     "strip-ansi": "^6.0.1",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -37,7 +37,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-listing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@types/ramda": "0.28.20",
     "execa": "npm:safe-execa@0.1.2",
     "strip-ansi": "^6.0.1",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-outdated": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-outdated": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -37,7 +37,7 @@
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.6.0",
+    "@pnpm/registry-mock": "3.7.0",
     "@types/archy": "0.0.32",
     "@types/ramda": "0.28.20",
     "@types/ssri": "^7.1.1",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -37,7 +37,7 @@
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.5.0",
+    "@pnpm/registry-mock": "3.6.0",
     "@types/archy": "0.0.32",
     "@types/ramda": "0.28.20",
     "@types/ssri": "^7.1.1",


### PR DESCRIPTION
Background: #4301

My solution is:

- Use the manifest (package.json) to generate a map of NPM aliases.
- When resolving peers, we should check `ctx.parentPkgs[peerName]` and the packages in `npmAliases[peerName]`. Assume we combine the two sources to an array named `pkgsToCheck`.
  - Check each item in `pkgsToCheck`, not only the original `ctx.parentPkgs[peerName]`.
  - During checking, we use a temp var `badPeerIssues` to record the bad peer issues instead of the original `ctx.peerDependencyIssues.bad[peerName]`.
  - If we found a version that satisfies the semver, we found the peer, no need to check more items.
- The result should be one of the following:
  - When we found the peer, nothing bad happens.
  - Else, if there are items in `badPeerIssues`, we add them to `ctx.peerDependencyIssues.bad[peerName]`. We also need to treat the first item of `pkgsToCheck` as the resolved peer (the current version of PNPM will use the `ctx.parentPkgs[peerName]` as the resolved peer).
  - Else, the `missingPeers` should be raised, because we didn't find a satisfying peer and there is no bad peer either.