### PR TITLE
refactor: move usage of PNPM_HOME into getDataDir

### DIFF
--- a/.changeset/rotten-students-agree.md
+++ b/.changeset/rotten-students-agree.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+move use of PNPM_HOME into getDataDir

--- a/.changeset/rotten-students-agree.md
+++ b/.changeset/rotten-students-agree.md
@@ -1,5 +1,0 @@
----
-"@pnpm/config": patch
----
-
-move use of PNPM_HOME into getDataDir

--- a/config/config/src/dirs.ts
+++ b/config/config/src/dirs.ts
@@ -46,6 +46,9 @@ export function getDataDir (
     platform: string
   }
 ) {
+  if (opts.env.PNPM_HOME) {
+    return opts.env.PNPM_HOME
+  }
   if (opts.env.XDG_DATA_HOME) {
     return path.join(opts.env.XDG_DATA_HOME, 'pnpm')
   }

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -312,7 +312,7 @@ export async function getConfig (
     }
     return undefined
   })()
-  pnpmConfig.pnpmHomeDir = process.env.PNPM_HOME ?? getDataDir(process)
+  pnpmConfig.pnpmHomeDir = getDataDir(process)
 
   if (cliOptions['global']) {
     let globalDirRoot

--- a/config/config/test/dirs.test.ts
+++ b/config/config/test/dirs.test.ts
@@ -59,6 +59,12 @@ test('getStateDir()', () => {
 test('getDataDir()', () => {
   expect(getDataDir({
     env: {
+      PNPM_HOME: '/home/foo/data',
+    },
+    platform: 'linux',
+  })).toBe('/home/foo/data')
+  expect(getDataDir({
+    env: {
       XDG_DATA_HOME: '/home/foo/data',
     },
     platform: 'linux',


### PR DESCRIPTION
Code was added on Oct 29, 2022 that prioritizes the environment variable `PNPM_HOME` for use setting the home / store-dir / data-dir: https://github.com/pnpm/pnpm/pull/5566

This refactor does not change any logic. It simply moves the PNPM_HOME option onto the top of list of other options in the function where the data-dir is defined: `getDataDir`. This is the only place in the code where `getDataDir` is used aside from tests.

This should make the code more readable and maintainable.