### PR TITLE
handle git+ssh with semver

### DIFF
--- a/.changeset/khaki-spoons-decide.md
+++ b/.changeset/khaki-spoons-decide.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/git-resolver": patch
+"pnpm": patch
+---
+
+Fix git-hosted dependencies referenced via `git+ssh` that use semver selectors [#6239](https://github.com/pnpm/pnpm/pull/6239).

--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -423,3 +423,63 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/heads/master\
     resolvedVia: 'git-repository',
   })
 })
+
+test('resolve an internal repository using SSH protocol with range semver', async () => {
+  git.mockImplementation(async (args: string[]) => {
+    if (!args.includes('ssh://git@example.com/org/repo.git')) throw new Error('')
+    if (args.includes('--refs')) {
+      return {
+        stdout: '\
+ed3de20970d980cf21a07fd8b8732c70d5182303\trefs/tags/v0.0.38\n\
+cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39\
+',
+      }
+    }
+    return {
+      stdout: '0000000000000000000000000000000000000000\tHEAD\n\
+ed3de20970d980cf21a07fd8b8732c70d5182303\trefs/tags/v0.0.38\n\
+cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
+    }
+  })
+  const resolveResult = await resolveFromGit({ pref: 'git+ssh://git@example.com/org/repo.git#semver:~0.0.38' })
+  expect(resolveResult).toStrictEqual({
+    id: 'example.com/org/repo/cba04669e621b85fbdb33371604de1a2898e68e9',
+    normalizedPref: 'git+ssh://git@example.com/org/repo.git#semver:~0.0.38',
+    resolution: {
+      commit: 'cba04669e621b85fbdb33371604de1a2898e68e9',
+      repo: 'ssh://git@example.com/org/repo.git',
+      type: 'git',
+    },
+    resolvedVia: 'git-repository',
+  })
+})
+
+test('resolve an internal repository using SSH protocol with range semver and SCP-like URL', async () => {
+  git.mockImplementation(async (args: string[]) => {
+    if (!args.includes('ssh://git@example.com/org/repo.git')) throw new Error('')
+    if (args.includes('--refs')) {
+      return {
+        stdout: '\
+ed3de20970d980cf21a07fd8b8732c70d5182303\trefs/tags/v0.0.38\n\
+cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39\
+',
+      }
+    }
+    return {
+      stdout: '0000000000000000000000000000000000000000\tHEAD\n\
+ed3de20970d980cf21a07fd8b8732c70d5182303\trefs/tags/v0.0.38\n\
+cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
+    }
+  })
+  const resolveResult = await resolveFromGit({ pref: 'git+ssh://git@example.com:org/repo.git#semver:~0.0.38' })
+  expect(resolveResult).toStrictEqual({
+    id: 'example.com/org/repo/cba04669e621b85fbdb33371604de1a2898e68e9',
+    normalizedPref: 'git+ssh://git@example.com:org/repo.git#semver:~0.0.38',
+    resolution: {
+      commit: 'cba04669e621b85fbdb33371604de1a2898e68e9',
+      repo: 'ssh://git@example.com/org/repo.git',
+      type: 'git',
+    },
+    resolvedVia: 'git-repository',
+  })
+})


### PR DESCRIPTION
5 years later I'm still pestering you with git+ssh+semver @zkochan :)

Currently pnpm fails to install `git+ssh://git@example.com:org/repo.git#semver:~1.2.3` (where example.com is an internal git server, not github.com) because it will end up looking for refspec `/~1.2.3` which doesn't match any git tag. We end up there both because of escaping the colon in `semver`, but also because we assume git+ssh URL cannot accept semver range spec.

Trying to install `https://example.com/org/repo.git#semver:~1.2.3` works as expected.

Looking through the code, we had quite a few patches to handle SCP-like urls, because we wanted to use `new URL`, and not the deprecated `url.parse`.

Yarn has this patch https://github.com/yarnpkg/yarn/blob/master/src/util/git.js#L103
but npm https://github.com/npm/git/blob/f60bb15da404679160c4bb6ad1c31a66d5f6ae72/lib/clone.js#L20 was mentioning the shim in https://github.com/npm/hosted-git-info/blob/f03bfbd3022c8f6283a991ff879ed97704ac35fa/lib/parse-url.js#L42

The shim didn't work out, so a similar take as yarn's landed in this PR.