### PR TITLE
fix!: save the whole tarball URL, when it doesn't use the standard format

### DIFF
--- a/.changeset/beige-eggs-study.md
+++ b/.changeset/beige-eggs-study.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": major
+"pnpm": major
+---
+
+Save the whole tarball URL in the lockfile, if it doesn't use the standard format [#6265](https://github.com/pnpm/pnpm/pull/6265).

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -768,7 +768,7 @@ test('save tarball URL when it is non-standard', async () => {
 
   const lockfile = await project.readLockfile()
 
-  expect((lockfile.packages['/esprima-fb@3001.1.0-dev-harmony-fb'].resolution as TarballResolution).tarball).toBe('esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz')
+  expect((lockfile.packages['/esprima-fb@3001.1.0-dev-harmony-fb'].resolution as TarballResolution).tarball).toBe(`http://localhost:${REGISTRY_MOCK_PORT}/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz`)
 })
 
 test('packages installed via tarball URL from the default registry are normalized', async () => {

--- a/pkg-manager/resolve-dependencies/src/updateLockfile.ts
+++ b/pkg-manager/resolve-dependencies/src/updateLockfile.ts
@@ -252,7 +252,7 @@ function toLockfileResolution (
   if (removeProtocol(expectedTarball) !== removeProtocol(actualTarball)) {
     return {
       integrity: resolution['integrity'],
-      tarball: relativeTarball(resolution['tarball'], registry),
+      tarball: resolution['tarball'],
     }
   }
   return {
@@ -262,21 +262,4 @@ function toLockfileResolution (
 
 function removeProtocol (url: string) {
   return url.split('://')[1]
-}
-
-export function relativeTarball (tarball: string, registry: string) {
-  // It is important to save the tarball URL as "relative-path" (without the leading '/').
-  // Sometimes registries are located in a subdirectory of a website.
-  // For instance, https://mycompany.jfrog.io/mycompany/api/npm/npm-local/
-  // So the tarball location should be relative to the directory,
-  // it is not an absolute-path reference.
-  // So we add @mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz
-  // not /@mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz
-  // Related issue: https://github.com/pnpm/pnpm/issues/1827
-  if (tarball.slice(0, registry.length) !== registry) {
-    return tarball
-  }
-  const relative = tarball.slice(registry.length)
-  if (relative[0] === '/') return relative.substring(1)
-  return relative
 }

--- a/pkg-manager/resolve-dependencies/test/relativeTarball.test.ts
+++ b/pkg-manager/resolve-dependencies/test/relativeTarball.test.ts
@@ -1,7 +1,0 @@
-/// <reference path="../../../__typings__/index.d.ts" />
-import { relativeTarball } from '../lib/updateLockfile'
-
-test('relativeTarball()', () => {
-  expect(relativeTarball('https://registry.com/foo/bar.tgz', 'https://registry.com/foo')).toBe('bar.tgz')
-  expect(relativeTarball('https://registry.com/foo/bar.tgz', 'https://registry.com/foo/')).toBe('bar.tgz')
-})


### PR DESCRIPTION
pnpm doesn't store the URLs to package tarballs, when the package tarball URL may be calculated automatically using the registry, package name and version.

For instance, if we know that the package is hosted in the `https://registry.npmjs.org` registry and the name of the package is `is-odd` and the version of the package is `1.0.0`, then we know that we can download the tarball from:

```
https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz
```

However, if the registry uses a different URL format for storing the tarballs, then we can't calculate it automatically and in this case we need to store that tarball URL in the lockfile. Currently, we don't store the whole URL in the lockfile, just the URL path. So, for instance, if the tarball was hosted at `https://registry.npmjs.org/tar/is-odd@1.0.0.tgz`, then we would add this to the lockfile:

```
tarball: tar/is-odd@1.0.0.tgz
```

The disadvantage of this approach is that if someone changes the registry and tries to run `pnpm install`, installation will probably fail with a 404 error because the other registry may use a different tarball URL.