### PR TITLE
fix: should use the one with parent syntax when both override rules match the same target

### DIFF
--- a/.changeset/few-wasps-enjoy.md
+++ b/.changeset/few-wasps-enjoy.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Should use the one with parent syntax when both override rules match the same target [#6210](https://github.com/pnpm/pnpm/issues/6210).
+Should use most specific override rule when multiple rules match the same target [#6210](https://github.com/pnpm/pnpm/issues/6210).

--- a/.changeset/few-wasps-enjoy.md
+++ b/.changeset/few-wasps-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
+---
+
+Should use the one with parent syntax when both override rules match the same target [#6210](https://github.com/pnpm/pnpm/issues/6210).

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -91,15 +91,18 @@ function overrideDeps (
 ) {
   for (const [name, pref] of Object.entries(deps)) {
     const versionOverride =
-      versionOverrides.find(
-        ({ targetPkg }) =>
-          targetPkg.name === name && isSubRange(targetPkg.pref, pref)
-      ) ??
-      genericVersionOverrides.find(
+    pickMostSpecificVersionOverride(
+      versionOverrides.filter(
         ({ targetPkg }) =>
           targetPkg.name === name && isSubRange(targetPkg.pref, pref)
       )
-
+    ) ??
+    pickMostSpecificVersionOverride(
+      genericVersionOverrides.filter(
+        ({ targetPkg }) =>
+          targetPkg.name === name && isSubRange(targetPkg.pref, pref)
+      )
+    )
     if (!versionOverride) continue
 
     if (versionOverride.linkTarget && dir) {
@@ -116,4 +119,8 @@ function overrideDeps (
     }
     deps[versionOverride.targetPkg.name] = versionOverride.newPref
   }
+}
+
+function pickMostSpecificVersionOverride (versionOverrides: VersionOverride[]): VersionOverride | undefined {
+  return versionOverrides.sort((a, b) => isSubRange(b.targetPkg.pref ?? '', a.targetPkg.pref ?? '') ? -1 : 1)[0]
 }

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -292,6 +292,50 @@ test('createVersionsOverrider() overrides dependencies with file specified with 
   })
 })
 
+test('createVersionOverride() should use the one with parent syntax when both override rules match the same target', () => {
+  const overrider = createVersionsOverrider({
+    'foo@2': '2.12.0',
+    'bar>foo@2': 'github:org/foo',
+  }, process.cwd())
+  expect(
+    overrider({
+      dependencies: {
+        foo: '^1.0.0',
+      },
+    })
+  ).toStrictEqual({
+    dependencies: {
+      foo: '^1.0.0',
+    },
+  })
+  expect(
+    overrider({
+      dependencies: {
+        foo: '^2.0.0',
+      },
+    })
+  ).toStrictEqual({
+    dependencies: {
+      foo: '2.12.0',
+    },
+  })
+  expect(
+    overrider({
+      name: 'bar',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^2.0.0',
+      },
+    })
+  ).toStrictEqual({
+    name: 'bar',
+    version: '1.0.0',
+    dependencies: {
+      foo: 'github:org/foo',
+    },
+  })
+})
+
 test('createVersionOverrider() throws error when supplied an invalid selector', () => {
   expect(() => createVersionsOverrider({
     'foo > bar': '2',

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -294,7 +294,7 @@ test('createVersionsOverrider() overrides dependencies with file specified with 
 
 test('createVersionOverride() should use the one with parent syntax when both override rules match the same target', () => {
   const overrider = createVersionsOverrider({
-    'foo@2': '2.12.0',
+    foo: '2.12.0',
     'bar>foo@2': 'github:org/foo',
   }, process.cwd())
   expect(
@@ -305,7 +305,7 @@ test('createVersionOverride() should use the one with parent syntax when both ov
     })
   ).toStrictEqual({
     dependencies: {
-      foo: '^1.0.0',
+      foo: '2.12.0',
     },
   })
   expect(

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -292,20 +292,34 @@ test('createVersionsOverrider() overrides dependencies with file specified with 
   })
 })
 
-test('createVersionOverride() should use the one with parent syntax when both override rules match the same target', () => {
+test('createVersionOverride() should use the most specific rule when both override rules match the same target', () => {
   const overrider = createVersionsOverrider({
-    foo: '2.12.0',
+    foo: '3.0.0',
+    'foo@3': '4.0.0',
+    'foo@2': '2.12.0',
     'bar>foo@2': 'github:org/foo',
+    'bar>foo@3': '5.0.0',
   }, process.cwd())
   expect(
     overrider({
       dependencies: {
-        foo: '^1.0.0',
+        foo: '^3.0.0',
       },
     })
   ).toStrictEqual({
     dependencies: {
-      foo: '2.12.0',
+      foo: '4.0.0',
+    },
+  })
+  expect(
+    overrider({
+      dependencies: {
+        foo: '^4.0.0',
+      },
+    })
+  ).toStrictEqual({
+    dependencies: {
+      foo: '3.0.0',
     },
   })
   expect(
@@ -332,6 +346,21 @@ test('createVersionOverride() should use the one with parent syntax when both ov
     version: '1.0.0',
     dependencies: {
       foo: 'github:org/foo',
+    },
+  })
+  expect(
+    overrider({
+      name: 'bar',
+      version: '1.0.0',
+      dependencies: {
+        foo: '^3.0.0',
+      },
+    })
+  ).toStrictEqual({
+    name: 'bar',
+    version: '1.0.0',
+    dependencies: {
+      foo: '5.0.0',
     },
   })
 })


### PR DESCRIPTION
fix #6210 