### PR TITLE
fix: `dedupe-peer-dependents` should not remove peer deps from workspace root

### DIFF
--- a/.changeset/eighty-brooms-cover.md
+++ b/.changeset/eighty-brooms-cover.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+Don't remove automatically installed peer dependencies from the root workspace project, when `dedupe-peer-dependents` is `true` [#6154](https://github.com/pnpm/pnpm/issues/6154).

--- a/__utils__/assert-project/package.json
+++ b/__utils__/assert-project/package.json
@@ -44,7 +44,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/types": "workspace:*",
     "is-windows": "^1.0.2",
     "isexe": "2.0.0",

--- a/__utils__/assert-store/package.json
+++ b/__utils__/assert-store/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@pnpm/cafs": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "path-exists": "^4.0.0"
   },
   "devDependencies": {

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-rebuild": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.3.13",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -37,7 +37,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.28.20",
     "is-windows": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@commitlint/prompt-cli": "^17.4.4",
     "@pnpm/eslint-config": "workspace:*",
     "@pnpm/meta-updater": "0.2.2",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/tsconfig": "workspace:*",
     "@types/jest": "^29.4.0",
     "@types/node": "^14.18.37",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -36,7 +36,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-patching": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -78,7 +78,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -22,7 +22,7 @@
     "@pnpm/package-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -68,7 +68,7 @@
     "@pnpm/client": "workspace:*",
     "@pnpm/create-cafs-store": "workspace:*",
     "@pnpm/package-requester": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -38,7 +38,7 @@
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/proxyquire": "^1.3.28",
     "@types/ramda": "0.28.20",

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -264,7 +264,7 @@ export async function recursive (
     }
     if (opts.dedupePeerDependents) {
       for (const rootDir of Object.keys(opts.allProjectsGraph)) {
-        if (opts.selectedProjectsGraph[rootDir]) continue
+        if (opts.selectedProjectsGraph[rootDir] || rootDir === opts.workspaceDir) continue
         const { writeProjectManifest } = manifestsByPath[rootDir]
         writeProjectManifests.push(writeProjectManifest)
         mutatedImporters.push({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 0.2.2
         version: 0.2.2(typanion@3.12.1)
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/tsconfig':
         specifier: workspace:*
         version: link:__utils__/tsconfig
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -215,8 +215,8 @@ importers:
         specifier: workspace:*
         version: link:../../store/cafs
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1103,8 +1103,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -1212,8 +1212,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@types/is-windows':
         specifier: ^1.0.0
         version: 1.0.0
@@ -2563,8 +2563,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2811,8 +2811,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3075,8 +3075,8 @@ importers:
         specifier: workspace:*
         version: link:../read-projects-context
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -3438,8 +3438,8 @@ importers:
         specifier: workspace:*
         version: 'link:'
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -3625,8 +3625,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4166,8 +4166,8 @@ importers:
         specifier: workspace:*
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -4420,8 +4420,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
 
   releasing/plugin-commands-publishing:
     dependencies:
@@ -4517,8 +4517,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@types/cross-spawn':
         specifier: ^6.0.2
         version: 6.0.2
@@ -5065,8 +5065,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5129,8 +5129,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -5226,8 +5226,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5573,8 +5573,8 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
-        specifier: 3.7.0
-        version: 3.7.0(typanion@3.12.1)
+        specifier: 3.8.0
+        version: 3.8.0(typanion@3.12.1)
       '@types/archy':
         specifier: 0.0.32
         version: 0.0.32
@@ -8531,8 +8531,8 @@ packages:
       - typanion
     dev: true
 
-  /@pnpm/registry-mock@3.7.0(typanion@3.12.1):
-    resolution: {integrity: sha512-W8yuEfiDyUi/h7ybUltXqY4XkXYjBBDSq7ZyIoIDenVS0dL3wT0lyIgVx8L+Bgf5zX8IWa3jhHIxIZNJ2KjaDg==}
+  /@pnpm/registry-mock@3.8.0(typanion@3.12.1):
+    resolution: {integrity: sha512-gLVTermIw6dnEdKIfPtbU3TcA+CyS8zRy3gc4ZEr0BEvJjld13O7tHM14yxutkr1EEYHhI3PR0wQZYVw+/fksQ==}
     engines: {node: '>=10.13'}
     hasBin: true
     dependencies:
@@ -8837,7 +8837,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.15.5
+      '@types/node': 18.15.9
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -8992,8 +8992,8 @@ packages:
     resolution: {integrity: sha512-1y36CC5iL5CMyKALzwX9cwwxcWIxvIBe3gzs4GrXWXEQ8klQnCZ2U/WDGiNrXHmQcUhnaun17XG9TEIDlGj2RA==}
     dev: true
 
-  /@types/node@18.15.5:
-    resolution: {integrity: sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==}
+  /@types/node@18.15.9:
+    resolution: {integrity: sha512-dUxhiNzBLr6IqlZXz6e/rN2YQXlFgOei/Dxy+e3cyXTJ4txSUbGT2/fmnD6zd/75jDMeW5bDee+YXxlFKHoV0A==}
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -9505,7 +9505,7 @@ packages:
     resolution: {integrity: sha512-Y5CCMK38k0mrdG7qo5cVpqiQ9+poegNBo3tHv44OPfoF8ktR1BcIqlAcCh0B4D2+lo1PjA411JeRxa0izTyP4Q==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@types/node': 18.15.5
+      '@types/node': 18.15.9
       '@yarnpkg/fslib': 3.0.0-rc.25
 
   /@yarnpkg/shell@3.2.0-rc.8(typanion@3.12.1):
@@ -17767,7 +17767,7 @@ packages:
 
 time:
   /@pnpm/ramda@0.28.1: '2022-08-03T13:56:59.597Z'
-  /@pnpm/registry-mock@3.7.0: '2023-03-22T00:44:25.728Z'
+  /@pnpm/registry-mock@3.8.0: '2023-03-25T20:52:46.924Z'
   /@types/byline@4.2.33: '2021-07-06T18:22:06.440Z'
   /@types/table@6.0.0: '2020-09-17T17:56:44.787Z'
   /@zkochan/hosted-git-info@4.0.2: '2021-09-05T21:33:51.709Z'

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -60,7 +60,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/run-npm": "workspace:*",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/test-fixtures": "workspace:*",

--- a/pnpm/test/monorepo/dedupePeers.test.ts
+++ b/pnpm/test/monorepo/dedupePeers.test.ts
@@ -90,3 +90,34 @@ auto-install-peers=false`, 'utf8')
   expect(loadJsonFile<any>('project-1/package.json').dependencies['@pnpm.e2e/abc-grand-parent-with-c']).toBe('^1.0.0') // eslint-disable-line
   expect(loadJsonFile<any>('project-2/package.json').dependencies['@pnpm.e2e/abc-grand-parent-with-c']).toBe('^1.0.1') // eslint-disable-line
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/6154
+test('peer dependents deduplication should not remove peer dependencies', async () => {
+  preparePackages([
+    {
+      location: '',
+      package: {
+        name: 'project-1',
+
+        dependencies: {
+          '@pnpm.e2e/abc-parent-with-missing-peers': '1.0.0',
+        },
+      },
+    },
+    {
+      location: 'project-2',
+      package: {
+        name: 'project-2',
+      },
+    },
+  ])
+
+  writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+  writeFileSync('.npmrc', `dedupe-peer-dependents=true
+auto-install-peers=true`, 'utf8')
+  await execPnpm(['install'])
+  await execPnpm(['--filter=project-2', 'add', 'is-positive@1.0.0'])
+
+  const lockfile = readYamlFile<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
+  expect(lockfile.importers['.']?.dependencies?.['@pnpm.e2e/abc-parent-with-missing-peers'].version).toStrictEqual('1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)')
+})

--- a/pnpm/test/monorepo/dedupePeers.test.ts
+++ b/pnpm/test/monorepo/dedupePeers.test.ts
@@ -93,6 +93,9 @@ auto-install-peers=false`, 'utf8')
 
 // Covers https://github.com/pnpm/pnpm/issues/6154
 test('peer dependents deduplication should not remove peer dependencies', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
   preparePackages([
     {
       location: '',

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -42,7 +42,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "@pnpm/plugin-commands-deploy": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0"
+    "@pnpm/registry-mock": "3.8.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -38,7 +38,7 @@
     "@pnpm/filter-workspace-packages": "workspace:*",
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/is-windows": "^1.0.0",
     "@types/npm-packlist": "^3.0.0",

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-licenses": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",
     "@types/zkochan__table": "npm:@types/table@6.0.0",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -37,7 +37,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-listing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@types/ramda": "0.28.20",
     "execa": "npm:safe-execa@0.1.2",
     "strip-ansi": "^6.0.1",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -38,7 +38,7 @@
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/plugin-commands-outdated": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/wrap-ansi": "^8.0.1",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -37,7 +37,7 @@
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@pnpm/registry-mock": "3.7.0",
+    "@pnpm/registry-mock": "3.8.0",
     "@types/archy": "0.0.32",
     "@types/ramda": "0.28.20",
     "@types/ssri": "^7.1.1",


### PR DESCRIPTION
close #6154