### PR TITLE
perf(pkgs-graph): optimize createPkgGraph by calling Object.values only once

### DIFF
--- a/.changeset/green-scissors-battle.md
+++ b/.changeset/green-scissors-battle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.pkgs-graph": patch
+---
+
+Optimize createPkgGraph by calling Object.values only once

--- a/workspace/pkgs-graph/src/index.ts
+++ b/workspace/pkgs-graph/src/index.ts
@@ -35,6 +35,7 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
     unmatched: Array<{ pkgName: string, range: string }>
   } {
   const pkgMap = createPkgMap(pkgs)
+  const pkgMapValues = Object.values(pkgMap)
   const unmatched: Array<{ pkgName: string, range: string }> = []
   const graph = mapValues((pkg) => ({
     dependencies: createNode(pkg),
@@ -66,7 +67,7 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
         }
 
         if (spec.type === 'directory') {
-          const matchedPkg = Object.values(pkgMap).find(pkg => path.relative(pkg.dir, spec.fetchSpec) === '')
+          const matchedPkg = pkgMapValues.find(pkg => path.relative(pkg.dir, spec.fetchSpec) === '')
           if (matchedPkg == null) {
             return ''
           }
@@ -75,7 +76,7 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
 
         if (spec.type !== 'version' && spec.type !== 'range') return ''
 
-        const pkgs = Object.values(pkgMap).filter(pkg => pkg.manifest.name === depName)
+        const pkgs = pkgMapValues.filter(pkg => pkg.manifest.name === depName)
         if (pkgs.length === 0) return ''
         const versions = pkgs.filter(({ manifest }) => manifest.version)
           .map(pkg => pkg.manifest.version) as string[]


### PR DESCRIPTION
For #6277

One easy way to optimize this code is to avoid calling `Object.values` on `pkgMap` over and over again; this code does not modify `pkgMap` in any way, so we can just get it once at the top and then reuse it. This saves the bulk of the time on DefinitelyTyped, a monorepo with >9000 packages.

This function is still quadradic, as it scans all of `pkgMap` for every entry of `pkgMap`, but improving that will require a more complicated change, whereas this PR is very safe.