### PR TITLE
perf(headless): hoist importerManifestsByImporterId calculation

### DIFF
--- a/.changeset/fifty-boats-drum.md
+++ b/.changeset/fifty-boats-drum.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/headless": patch
+---
+
+Hoist importerManifestsByImporterId calculation


### PR DESCRIPTION
For #6277 (ish)

Like #6281, this calculation was happening quadradically, but we can just calculate this one time and reuse it.