### PR TITLE
perf(pkgs-graph): optimize createNode by using Map

### DIFF
--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -664,11 +664,27 @@ async function getRootPackagesToLink (
   }
 ): Promise<LinkedDirectDep[]> {
   const projectSnapshot = lockfile.importers[opts.importerId]
-  const allDeps = {
-    ...projectSnapshot.devDependencies,
-    ...projectSnapshot.dependencies,
-    ...projectSnapshot.optionalDependencies,
+  const allDeps = new Map<string, string>();
+
+  const devDependencies = projectSnapshot.devDependencies
+  if (devDependencies) {
+    for (const name in devDependencies) {
+      allDeps.set(name, devDependencies[name])
+    }
   }
+  const requiredDependencies = projectSnapshot.dependencies
+  if (requiredDependencies) {
+    for (const name in requiredDependencies) {
+      allDeps.set(name, requiredDependencies[name])
+    }
+  }
+  const optionalDependencies = projectSnapshot.optionalDependencies
+  if (optionalDependencies) {
+    for (const name in optionalDependencies) {
+      allDeps.set(name, optionalDependencies[name])
+    }
+  }
+
   return (await Promise.all(
     Object.entries(allDeps)
       .map(async ([alias, ref]) => {

--- a/workspace/pkgs-graph/src/index.ts
+++ b/workspace/pkgs-graph/src/index.ts
@@ -44,10 +44,20 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
   return { graph, unmatched }
 
   function createNode (pkg: Package): string[] {
-    const dependencies = {
-      ...(!opts?.ignoreDevDeps && pkg.manifest.devDependencies),
-      ...pkg.manifest.optionalDependencies,
-      ...pkg.manifest.dependencies,
+    const dependencies = new Map<string, string>();
+    if (!opts?.ignoreDevDeps) {
+      const devDependencies = pkg.manifest.devDependencies
+      for (const name in devDependencies) {
+        dependencies.set(name, devDependencies[name])
+      }
+    }
+    const optionalDependencies = pkg.manifest.optionalDependencies;
+    for (const name in optionalDependencies) {
+      dependencies.set(name, optionalDependencies[name])
+    }
+    const requiredDependencies = pkg.manifest.dependencies
+    for (const name in requiredDependencies) {
+      dependencies.set(name, requiredDependencies[name])
     }
 
     return Object.entries(dependencies)


### PR DESCRIPTION
This PR rewrites the object spreading of dependencies into using a `Map` as the backing store. Leveraging this excellent test case from @jakebailey https://github.com/jakebailey/DefinitelyTyped/tree/pnpm-workspaces-working the changes in this PR sped up the fresh install time noticeably.

| Before | After |
|--:|--:|
| 1:06 min | 0:38min |

Investigation sparked by this twitter thread: https://twitter.com/andhaveaniceday/status/1639851859480551425 