### PR TITLE
perf(npm-resolver): reduce max memory usage

### DIFF
--- a/.changeset/silver-cameras-count.md
+++ b/.changeset/silver-cameras-count.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": patch
+---
+
+Reduce max memory usage in npm-resolver


### PR DESCRIPTION
I was doing some memory profiling to understand why pnpm was OOMing on my laptop.

A heap snapshot showed that about 500 MB of the memory usage of pnpm is instances of Limiter (and the objects they reference) that can't be garbage collected because they're referenced by `metafileOperationLimits`.

To fix this, we can instead keep track of how many times each limiter is currently being used. Whenever the refcount hits zero, we can safely drop the object.

I measured the peak memory usage using `time` before and after. Before, we get:

```
Done in 2m 12.1s
$@   152.69s  user 41.42s system 146% cpu 2:12.51 total
max memory:                2237 MB
```

After, we have:

```
Done in 2m 9.9s
$@   139.49s  user 39.27s system 137% cpu 2:10.20 total
max memory:                1525 MB
```

Representing a reduction in peak memory usage by about 700MB or so, roughly in line with the profile.

The simplest thing here was to wrap the function, which changed its indent level; the diff here will be better viewed with whitespace disabled: https://github.com/pnpm/pnpm/pull/6296/files?w=1

Cross linking #6277 though at this point I'm just optimizing everything I can find.