### PR TITLE
Make the `FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` error and hint messages more clear

### DIFF
--- a/.changeset/tender-ties-punch.md
+++ b/.changeset/tender-ties-punch.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Improve the outdated lockfile error message [#6304](https://github.com/pnpm/pnpm/pull/6304).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -354,11 +354,11 @@ export async function mutateModules (
         throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
           'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
           {
-            hint: 'Try either: '
-              + '1. aligning the version of pnpm which generated the lockfile with the version that installs from it or '
-              + '2. migrate the lockfile so that it is compatible with the newer version of pnpm or '
-              + '3. use "pnpm install --no-frozen-lockfile". '
-              + 'Note that in CI environments this setting is true by default',
+            hint: 'Try either: ' +
+              '1. aligning the version of pnpm which generated the lockfile with the version that installs from it or ' +
+              '2. migrate the lockfile so that it is compatible with the newer version of pnpm or ' +
+              '3. use "pnpm install --no-frozen-lockfile". ' +
+              'Note that in CI environments this setting is true by default',
           }
         )
       }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -354,11 +354,11 @@ export async function mutateModules (
         throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
           'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
           {
-            hint: 'Try either: ' +
-              '1. aligning the version of pnpm which generated the lockfile with the version that installs from it or ' +
-              '2. migrate the lockfile so that it is compatible with the newer version of pnpm or ' +
-              '3. use "pnpm install --no-frozen-lockfile". ' +
-              'Note that in CI environments this setting is true by default',
+            hint: `Try either:
+1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
+2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
+3. Using "pnpm install --no-frozen-lockfile".
+Note that in CI environments, this setting is enabled by default.`,
           }
         )
       }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -351,8 +351,8 @@ export async function mutateModules (
       )
     ) {
       if (needsFullResolution) {
-        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE', 'Cannot perform a frozen installation because the lockfile needs updates', {
-          hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
+        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE', 'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm', {
+          hint: 'Try either: 1. aligning the version of pnpm which generated the lockfile with the version that installs from it or 2. migrate the lockfile so that it is compatible with the newer version of pnpm or 3. use "pnpm install --no-frozen-lockfile". Note that in CI environments this setting is true by default',
         })
       }
       if (opts.lockfileOnly) {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -351,9 +351,16 @@ export async function mutateModules (
       )
     ) {
       if (needsFullResolution) {
-        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE', 'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm', {
-          hint: 'Try either: 1. aligning the version of pnpm which generated the lockfile with the version that installs from it or 2. migrate the lockfile so that it is compatible with the newer version of pnpm or 3. use "pnpm install --no-frozen-lockfile". Note that in CI environments this setting is true by default',
-        })
+        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+          'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
+          {
+            hint: 'Try either: '
+              + '1. aligning the version of pnpm which generated the lockfile with the version that installs from it or '
+              + '2. migrate the lockfile so that it is compatible with the newer version of pnpm or '
+              + '3. use "pnpm install --no-frozen-lockfile". '
+              + 'Note that in CI environments this setting is true by default',
+          }
+        )
       }
       if (opts.lockfileOnly) {
         // The lockfile will only be changed if the workspace will have new projects with no dependencies.

--- a/pkg-manager/core/test/install/overrides.ts
+++ b/pkg-manager/core/test/install/overrides.ts
@@ -95,7 +95,7 @@ test('versions are replaced with versions specified through overrides option', a
     }, await testDefaults({ frozenLockfile: true, overrides }))
   ).rejects.toThrow(
     new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
-      'Cannot perform a frozen installation because the lockfile needs updates'
+      'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm'
     )
   )
 })

--- a/pkg-manager/core/test/install/packageExtensions.ts
+++ b/pkg-manager/core/test/install/packageExtensions.ts
@@ -89,7 +89,7 @@ test('manifests are extended with fields specified by packageExtensions', async 
     }, await testDefaults({ frozenLockfile: true, packageExtensions }))
   ).rejects.toThrow(
     new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
-      'Cannot perform a frozen installation because the lockfile needs updates'
+      'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm'
     )
   )
 })


### PR DESCRIPTION
The current error and hint messages for `FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE` is not very straightforward in explaining what the issue is.

This PR attempt to fix this by being a bit more explicit as to what the required upgrade is (lockfile version incompatibility).

The original message was too confusing as per this post last year: https://github.com/orgs/pnpm/discussions/4847