### PR TITLE
perf(pkgs-graph): speed up createPkgGraph when directory specifiers are present

### DIFF
--- a/.changeset/twelve-gifts-rescue.md
+++ b/.changeset/twelve-gifts-rescue.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.pkgs-graph": patch
+---
+
+Speed up createPkgGraph when directory specifiers are present

--- a/workspace/pkgs-graph/src/index.ts
+++ b/workspace/pkgs-graph/src/index.ts
@@ -36,7 +36,7 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
   } {
   const pkgMap = createPkgMap(pkgs)
   const pkgMapValues = Object.values(pkgMap)
-  const pkgMapByManifestName = getPkgMapByManifestName(pkgMapValues)
+  let pkgMapByManifestName: Record<string, Package[] | undefined> | undefined
   let pkgMapByDir: Record<string, Package | undefined> | undefined
   const unmatched: Array<{ pkgName: string, range: string }> = []
   const graph = mapValues((pkg) => ({
@@ -87,6 +87,7 @@ export function createPkgGraph<T> (pkgs: Array<Package & T>, opts?: {
 
         if (spec.type !== 'version' && spec.type !== 'range') return ''
 
+        pkgMapByManifestName ??= getPkgMapByManifestName(pkgMapValues)
         const pkgs = pkgMapByManifestName[depName]
         if (!pkgs || pkgs.length === 0) return ''
         const versions = pkgs.filter(({ manifest }) => manifest.version)


### PR DESCRIPTION
This speeds up the install of "with paths" test case (https://github.com/jakebailey/DefinitelyTyped/tree/blog-pnpm-workspaces-with-paths) from 49.7s to 14s.

Time spent in `createPkgMap` has been reduced from ~35s to ~200ms, matching the performance in #6287.

Fixes #6281 (for real this time)