### PR TITLE
feat(hooks): pass registries to preResolution hook

### DIFF
--- a/.changeset/forty-bears-smoke.md
+++ b/.changeset/forty-bears-smoke.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Registries are now passed to the preResolution hook.

--- a/pkg-manager/core/src/install/hooks.ts
+++ b/pkg-manager/core/src/install/hooks.ts
@@ -1,4 +1,5 @@
 import type { Lockfile } from '@pnpm/lockfile-file'
+import type { Registries } from '@pnpm/types'
 
 export interface PreResolutionHookContext {
   wantedLockfile: Lockfile
@@ -7,6 +8,7 @@ export interface PreResolutionHookContext {
   existsWantedLockfile: boolean
   lockfileDir: string
   storeDir: string
+  registries: Registries
 }
 
 export interface PreResolutionHookLogger {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -239,6 +239,7 @@ export async function mutateModules (
       existsWantedLockfile: ctx.existsWantedLockfile,
       lockfileDir: ctx.lockfileDir,
       storeDir: ctx.storeDir,
+      registries: ctx.registries,
     })
   }
 

--- a/pnpm/test/install/hooks.ts
+++ b/pnpm/test/install/hooks.ts
@@ -632,6 +632,7 @@ test('preResolution hook', async () => {
 
   const npmrc = `
     global-pnpmfile=.pnpmfile.cjs
+    @foo:registry=https://foo.com
   `
 
   await fs.writeFile('.npmrc', npmrc, 'utf8')
@@ -646,4 +647,9 @@ test('preResolution hook', async () => {
   expect(ctx.storeDir).toBeDefined()
   expect(ctx.existsCurrentLockfile).toBe(false)
   expect(ctx.existsWantedLockfile).toBe(false)
+
+  expect(ctx.registries).toEqual({
+    default: 'http://localhost:7776/',
+    '@foo': 'https://foo.com/',
+  })
 })


### PR DESCRIPTION
This PR makes sure that `registries` are passed to the `preResolution` hook as part of the `ctx`.