### PR TITLE
perf(npm-resolver): improve performance of semver.satisfies

### DIFF
--- a/.changeset/pretty-toys-agree.md
+++ b/.changeset/pretty-toys-agree.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": patch
+---
+
+Improve performance of clean install by preconverting and caching semver objects


### PR DESCRIPTION
As noted in a recent twitter thread, a large fraction of the clean install of DT is just `semver.satisfies`:

![image](https://user-images.githubusercontent.com/5341706/229234586-824ab185-a20a-434d-a0be-d4c0319587dc.png)

We can work around this in two ways:

- Cache the Range objects.
- Make sure we pass in `SemVer` to `Range.test`, as that avoids re-parsing the same semver string over and over again.

After doing this, we get:

![image](https://user-images.githubusercontent.com/5341706/229236372-6c723c0a-b4bb-4b2e-8755-80dac5d34fbd.png)


For a `git clean -fdx && pnpm install --offline`, this nets a significant time savings.

Before:
```
Done in 2m 38.7s
total time:  158.99s
user time:   188.91s
system time: 31.17s
CPU percent: 138%
max memory:  1686 MB
```

After:
```
Done in 2m 9s
total time:  129.24s
user time:   156.34s
system time: 32.13s
CPU percent: 145%
max memory:  1667 MB
```

It turns out that I independently figured out the same level of caching that yarn berry uses: https://github.com/yarnpkg/berry/blob/dd660311021046a4d09525b2cb59e15a7be99ed5/packages/yarnpkg-core/sources/semverUtils.ts#L20

Even faster was to cache the comparison itself, however, this greatly increases memory usage due to all pairs of versions/ranges getting stored in a huge map, so, I'm instead opting for a middle ground with no memory usage impact.