### PR TITLE
chore(deps): dedupe @types/jest@7.21.2 with 7.21.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-proposal-dynamic-import": "^7.18.6",
     "@babel/plugin-transform-modules-commonjs": "^7.21.2",
     "@babel/preset-typescript": "^7.21.0",
-    "@babel/types": "^7.21.2",
+    "@babel/types": "^7.21.3",
     "@changesets/cli": "^2.26.0",
     "@commitlint/cli": "^17.4.4",
     "@commitlint/config-conventional": "^17.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^7.21.0
         version: 7.21.0(@babel/core@7.21.0)
       '@babel/types':
-        specifier: ^7.21.2
-        version: 7.21.2
+        specifier: ^7.21.3
+        version: 7.21.3
       '@changesets/cli':
         specifier: ^2.26.0
         version: 2.26.0
@@ -88,7 +88,7 @@ importers:
         version: 8.0.3
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
+        version: 29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1)
       keyv:
         specifier: 4.5.2
         version: 4.5.2
@@ -5953,10 +5953,10 @@ packages:
       '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.21.0)
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -5980,7 +5980,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-compilation-targets@7.20.7(@babel/core@7.21.0):
@@ -6026,28 +6026,28 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.0:
     resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-module-transforms@7.21.2:
@@ -6061,7 +6061,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6070,7 +6070,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-plugin-utils@7.20.2:
@@ -6087,7 +6087,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6096,21 +6096,21 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/helper-string-parser@7.19.4:
@@ -6133,7 +6133,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6154,16 +6154,6 @@ packages:
       '@babel/types': '*'
     dependencies:
       '@babel/types': 7.17.10
-    dev: true
-
-  /@babel/parser@7.21.3(@babel/types@7.21.2):
-    resolution: {integrity: sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    peerDependencies:
-      '@babel/types': '*'
-    dependencies:
-      '@babel/types': 7.21.2
     dev: true
 
   /@babel/parser@7.21.3(@babel/types@7.21.3):
@@ -6379,8 +6369,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
     dev: true
 
   /@babel/traverse@7.21.3:
@@ -6405,15 +6395,6 @@ packages:
     resolution: {integrity: sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      to-fast-properties: 2.0.0
-    dev: true
-
-  /@babel/types@7.21.2:
-    resolution: {integrity: sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
@@ -7100,7 +7081,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core@29.5.0(@babel/types@7.21.2)(ts-node@10.9.1):
+  /@jest/core@29.5.0(@babel/types@7.21.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -7110,9 +7091,9 @@ packages:
         optional: true
     dependencies:
       '@jest/console': 29.5.0
-      '@jest/reporters': 29.5.0(@babel/types@7.21.2)
+      '@jest/reporters': 29.5.0(@babel/types@7.21.3)
       '@jest/test-result': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@types/node': 14.18.37
       ansi-escapes: 4.3.2
@@ -7121,14 +7102,14 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
+      jest-config: 29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
       jest-resolve: 29.5.0
       jest-resolve-dependencies: 29.5.0
-      jest-runner: 29.5.0(@babel/types@7.21.2)
-      jest-runtime: 29.5.0(@babel/types@7.21.2)
+      jest-runner: 29.5.0(@babel/types@7.21.3)
+      jest-runtime: 29.5.0(@babel/types@7.21.3)
       jest-snapshot: 29.5.0
       jest-util: 29.5.0
       jest-validate: 29.5.0
@@ -7194,7 +7175,7 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/reporters@29.5.0(@babel/types@7.21.2):
+  /@jest/reporters@29.5.0(@babel/types@7.21.3):
     resolution: {integrity: sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -7206,7 +7187,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.5.0
       '@jest/test-result': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.17
       '@types/node': 14.18.37
@@ -7216,7 +7197,7 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.0
-      istanbul-lib-instrument: 5.2.1(@babel/types@7.21.2)
+      istanbul-lib-instrument: 5.2.1(@babel/types@7.21.3)
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: /@zkochan/istanbul-reports@3.0.2
@@ -7268,14 +7249,14 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/transform@29.5.0(@babel/types@7.21.2):
+  /@jest/transform@29.5.0(@babel/types@7.21.3):
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.21.0
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.17
-      babel-plugin-istanbul: 6.1.1(@babel/types@7.21.2)
+      babel-plugin-istanbul: 6.1.1(@babel/types@7.21.3)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8755,8 +8736,8 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -8765,20 +8746,20 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
-      '@babel/types': 7.21.2
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/babel__traverse@7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
     dev: true
 
   /@types/braces@3.0.1:
@@ -8788,7 +8769,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.15.9
+      '@types/node': 14.18.37
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -8796,7 +8777,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.15.9
+      '@types/node': 14.18.37
       '@types/responselike': 1.0.0
 
   /@types/concat-stream@2.0.0:
@@ -8898,7 +8879,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.15.9
+      '@types/node': 14.18.37
 
   /@types/lodash@4.14.181:
     resolution: {integrity: sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==}
@@ -8977,7 +8958,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.15.9
+      '@types/node': 14.18.37
 
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -9924,16 +9905,16 @@ packages:
     resolution: {integrity: sha512-aX6/FqpWQve8VN9kyTExy7GlmwNShvxcCWWD5QVR3ZbRlyBGtCrG5Autu95xxSPH4CRs+5PSV4d7PRnWpmqFlA==}
     dev: false
 
-  /babel-jest@29.5.0(@babel/core@7.21.0)(@babel/types@7.21.2):
+  /babel-jest@29.5.0(@babel/core@7.21.0)(@babel/types@7.21.3):
     resolution: {integrity: sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.8.0
     dependencies:
       '@babel/core': 7.21.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@types/babel__core': 7.20.0
-      babel-plugin-istanbul: 6.1.1(@babel/types@7.21.2)
+      babel-plugin-istanbul: 6.1.1(@babel/types@7.21.3)
       babel-preset-jest: 29.5.0(@babel/core@7.21.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
@@ -9943,14 +9924,14 @@ packages:
       - supports-color
     dev: true
 
-  /babel-plugin-istanbul@6.1.1(@babel/types@7.21.2):
+  /babel-plugin-istanbul@6.1.1(@babel/types@7.21.3):
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1(@babel/types@7.21.2)
+      istanbul-lib-instrument: 5.2.1(@babel/types@7.21.3)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - '@babel/types'
@@ -9962,7 +9943,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.3
     dev: true
@@ -12930,12 +12911,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /istanbul-lib-instrument@5.2.1(@babel/types@7.21.2):
+  /istanbul-lib-instrument@5.2.1(@babel/types@7.21.3):
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/parser': 7.21.3(@babel/types@7.21.2)
+      '@babel/parser': 7.21.3(@babel/types@7.21.3)
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -12972,7 +12953,7 @@ packages:
       p-limit: 3.1.0
     dev: true
 
-  /jest-circus@29.5.0(@babel/types@7.21.2):
+  /jest-circus@29.5.0(@babel/types@7.21.3):
     resolution: {integrity: sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
@@ -12988,7 +12969,7 @@ packages:
       jest-each: 29.5.0
       jest-matcher-utils: 29.5.0
       jest-message-util: 29.5.0
-      jest-runtime: 29.5.0(@babel/types@7.21.2)
+      jest-runtime: 29.5.0(@babel/types@7.21.3)
       jest-snapshot: 29.5.0
       jest-util: 29.5.0
       p-limit: 3.1.0
@@ -13001,7 +12982,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1):
+  /jest-cli@29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1):
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -13011,14 +12992,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(@babel/types@7.21.2)(ts-node@10.9.1)
+      '@jest/core': 29.5.0(@babel/types@7.21.3)(ts-node@10.9.1)
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
+      jest-config: 29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -13030,7 +13011,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1):
+  /jest-config@29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1):
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -13046,18 +13027,18 @@ packages:
       '@jest/test-sequencer': 29.5.0
       '@jest/types': 29.5.0
       '@types/node': 14.18.37
-      babel-jest: 29.5.0(@babel/core@7.21.0)(@babel/types@7.21.2)
+      babel-jest: 29.5.0(@babel/core@7.21.0)(@babel/types@7.21.3)
       chalk: 4.1.2
       ci-info: 3.8.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.5.0(@babel/types@7.21.2)
+      jest-circus: 29.5.0(@babel/types@7.21.3)
       jest-environment-node: 29.5.0
       jest-get-type: 29.4.3
       jest-regex-util: 29.4.3
       jest-resolve: 29.5.0
-      jest-runner: 29.5.0(@babel/types@7.21.2)
+      jest-runner: 29.5.0(@babel/types@7.21.3)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       micromatch: 4.0.5
@@ -13219,14 +13200,14 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /jest-runner@29.5.0(@babel/types@7.21.2):
+  /jest-runner@29.5.0(@babel/types@7.21.3):
     resolution: {integrity: sha512-m7b6ypERhFghJsslMLhydaXBiLf7+jXy8FwGRHO3BGV1mcQpPbwiqiKUR2zU2NJuNeMenJmlFZCsIqzJCTeGLQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.5.0
       '@jest/environment': 29.5.0
       '@jest/test-result': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@types/node': 14.18.37
       chalk: 4.1.2
@@ -13238,7 +13219,7 @@ packages:
       jest-leak-detector: 29.5.0
       jest-message-util: 29.5.0
       jest-resolve: 29.5.0
-      jest-runtime: 29.5.0(@babel/types@7.21.2)
+      jest-runtime: 29.5.0(@babel/types@7.21.3)
       jest-util: 29.5.0
       jest-watcher: 29.5.0
       jest-worker: 29.5.0
@@ -13249,7 +13230,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-runtime@29.5.0(@babel/types@7.21.2):
+  /jest-runtime@29.5.0(@babel/types@7.21.3):
     resolution: {integrity: sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
@@ -13258,7 +13239,7 @@ packages:
       '@jest/globals': 29.5.0
       '@jest/source-map': 29.4.3
       '@jest/test-result': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@types/node': 14.18.37
       chalk: 4.1.2
@@ -13289,9 +13270,9 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.0)
       '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.21.0)
       '@babel/traverse': 7.21.3
-      '@babel/types': 7.21.2
+      '@babel/types': 7.21.3
       '@jest/expect-utils': 29.5.0
-      '@jest/transform': 29.5.0(@babel/types@7.21.2)
+      '@jest/transform': 29.5.0(@babel/types@7.21.3)
       '@jest/types': 29.5.0
       '@types/babel__traverse': 7.18.3
       '@types/prettier': 2.7.2
@@ -13359,7 +13340,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1):
+  /jest@29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1):
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -13369,10 +13350,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 29.5.0(@babel/types@7.21.2)(ts-node@10.9.1)
+      '@jest/core': 29.5.0(@babel/types@7.21.3)(ts-node@10.9.1)
       '@jest/types': 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
+      jest-cli: 29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@babel/types'
       - '@types/node'
@@ -16669,7 +16650,7 @@ packages:
       '@babel/core': 7.21.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@babel/types@7.21.2)(@types/node@14.18.37)(ts-node@10.9.1)
+      jest: 29.5.0(@babel/types@7.21.3)(@types/node@14.18.37)(ts-node@10.9.1)
       jest-util: 29.5.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -17587,7 +17568,7 @@ time:
   /@babel/plugin-proposal-dynamic-import@7.18.6: '2022-06-27T19:49:50.843Z'
   /@babel/plugin-transform-modules-commonjs@7.21.2: '2023-02-23T09:31:39.683Z'
   /@babel/preset-typescript@7.21.0: '2023-02-20T15:31:22.789Z'
-  /@babel/types@7.21.2: '2023-02-23T09:31:35.164Z'
+  /@babel/types@7.21.3: '2023-03-14T14:59:36.447Z'
   /@changesets/cli@2.26.0: '2022-12-18T11:42:17.936Z'
   /@commitlint/cli@17.4.4: '2023-02-17T15:34:43.117Z'
   /@commitlint/config-conventional@17.4.4: '2023-02-17T15:34:43.196Z'


### PR DESCRIPTION
## Before

While working in this repo, I noticed changes in `pnpm-lock.yaml` that weren't expected after adding a new dependency. To reproduce:

1. Check out `main` commit d86fce63e4b66b8f2ca9c53b2b63aadd1b847f47
2. Delete the `neverBuiltDependencies` dependencies block
3. Rerun `pnpm install`
4. Observe many transitive dependencies shifting `@types/jest` from `7.21.2` to `7.21.3`.

Both `7.21.2` and `7.21.3` are appearing in the lockfile because:

- The older `7.21.2` version is a direct dep of the workspace:
   https://github.com/pnpm/pnpm/blob/d86fce63e4b66b8f2ca9c53b2b63aadd1b847f47/pnpm-lock.yaml#L44-L46
- The newer `7.21.3` version is required by `@babel/generator@7.21.3`.
   https://github.com/pnpm/pnpm/blob/d86fce63e4b66b8f2ca9c53b2b63aadd1b847f47/pnpm-lock.yaml#L5969-L5973

## After

It's a bit strange that deleting `neverBuiltDependencies` from the lockfile and rerunning `pnpm install` causes changes. I usually test lockfile consistency by deleting `neverBuiltDependencies` since it regenerates the same way.

Updating the root `@babel/types` dependency specifier to remove some duplicates.

## Note about `pnpm dedupe`

It's a bit unfortunate `pnpm dedupe` isn't able to remove this. It doesn't today because the resolution algorithm prefers the version selected by direct dependents when it can, which makes sense.

To be smarter, we would need to update the resolution algorithm to prefer the lowest version with the most semver overlaps. That can get tricky.