### PR TITLE
fix(default-reporter): should print error summary as expected

### DIFF
--- a/.changeset/red-knives-decide.md
+++ b/.changeset/red-knives-decide.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+Should report error summary as expected.

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -258,10 +258,10 @@ function reportLockfileBreakingChange (err: Error, msg: object) {
   }
 }
 
-function formatRecursiveCommandSummary (msg: { fails: Array<Error & { prefix: string }>, passes: number }) {
-  const output = EOL + `Summary: ${chalk.red(`${msg.fails.length} fails`)}, ${msg.passes} passes` + EOL + EOL +
-    msg.fails.map((fail) => {
-      return fail.prefix + ':' + EOL + formatErrorSummary(fail.message)
+function formatRecursiveCommandSummary (msg: { failures: Array<Error & { prefix: string }>, passes: number }) {
+  const output = EOL + `Summary: ${chalk.red(`${msg.failures.length} fails`)}, ${msg.passes} passes` + EOL + EOL +
+    msg.failures.map(({ message, prefix }) => {
+      return prefix + ':' + EOL + formatErrorSummary(message)
     }).join(EOL + EOL)
   return {
     title: '',

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -572,7 +572,7 @@ ${formatError('ERROR', 'f failed')}`)
   })
 
   const err = new PnpmError('RECURSIVE_FAIL', '...')
-  err['fails'] = [
+  err['failures'] = [
     {
       message: 'a failed',
       prefix: '/a',

--- a/pnpm/test/errorHandler.test.ts
+++ b/pnpm/test/errorHandler.test.ts
@@ -47,3 +47,36 @@ test('should clean up child processes when process exited', async () => {
   expect(await isPortInUse(9990)).toBe(false)
   expect(await isPortInUse(9999)).toBe(false)
 })
+
+test('should print error summary when some packages fail with --no-bail', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: {
+        scripts: {
+          build: 'echo "build project-1"',
+        },
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+      scripts: {
+        build: 'exit 1',
+      },
+    },
+    {
+      name: 'project-3',
+      version: '1.0.0',
+      scripts: {
+        build: 'echo "build project-3"',
+      },
+    },
+  ])
+  await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+  const { stdout } = execPnpmSync(['-r', '--no-bail', 'run', 'build'])
+  const output = stdout.toString()
+  expect(output).toContain('ERR_PNPM_RECURSIVE_FAIL')
+  expect(output).toContain('Summary: 1 fails, 2 passes')
+  expect(output).toContain('ERROR  project-2@1.0.0 build: `exit 1`')
+})


### PR DESCRIPTION
As discussed in  https://github.com/pnpm/pnpm/pull/6190#issuecomment-1490570242, When executing `pnpm -r --no-bail run build`, if some packages report an error on build, we don't see the error summary at the moment, only the following message:

```
$ pnpm -r --no-bail run build
Cannot read properties of undefined (reading 'length')
```