### PR TITLE
fix: `pnpm config get <key>` returns empty when the value is a boolean

### DIFF
--- a/.changeset/little-badgers-sort.md
+++ b/.changeset/little-badgers-sort.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-config": patch
+---
+
+`pnpm config get <key>` returns empty when the value is a boolean

--- a/config/plugin-commands-config/src/configGet.ts
+++ b/config/plugin-commands-config/src/configGet.ts
@@ -1,5 +1,6 @@
 import { type ConfigCommandOptions } from './ConfigCommandOptions'
 
 export function configGet (opts: ConfigCommandOptions, key: string) {
-  return opts.rawConfig[key]
+  const config = opts.rawConfig[key]
+  return typeof config === 'boolean' ? config.toString() : config
 }

--- a/config/plugin-commands-config/test/configGet.test.ts
+++ b/config/plugin-commands-config/test/configGet.test.ts
@@ -13,3 +13,17 @@ test('config get', async () => {
 
   expect(configKey).toEqual('~/store')
 })
+
+test('config get a boolean should return string format', async () => {
+  const configKey = await config.handler({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: true,
+    rawConfig: {
+      'update-notifier': true,
+    },
+  }, ['get', 'update-notifier'])
+
+  expect(configKey).toEqual('true')
+})


### PR DESCRIPTION
Due to [main](https://github.com/pnpm/pnpm/blob/main/pnpm/src/main.ts#L291~#L294), the boolean format cannot be printed by `pnpm config get <key>` now. Need to transform it into string format.

## Before
![image](https://user-images.githubusercontent.com/29809148/230139028-c89453e2-b697-4f58-a5c9-be2aa70f9842.png)

## After
![image](https://user-images.githubusercontent.com/29809148/230139160-9dd1e77c-db48-4013-9c6b-d93dfce38273.png)

