### PR TITLE
fix: add -g to mismatch registries error info when original command has -g option

### DIFF
--- a/.changeset/tender-birds-wave.md
+++ b/.changeset/tender-birds-wave.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/get-context": patch
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Add -g to mismatch registries error info when original command has -g option [#6224](https://github.com/pnpm/pnpm/issues/6224).

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -1070,7 +1070,7 @@ test('lockfile is not getting broken if the used registry changes', async () => 
   ])
 })
 
-test('When using a different registry, add -g to the error report according to options.global', async () => {
+test('when using a different registry, add -g to the error report according to options.global', async () => {
   prepareEmpty()
 
   const manifest = await addDependenciesToPackage({}, ['is-positive@1'], await testDefaults())

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -1070,6 +1070,22 @@ test('lockfile is not getting broken if the used registry changes', async () => 
   ])
 })
 
+test('When using a different registry, add -g to the error report according to options.global', async () => {
+  prepareEmpty()
+
+  const manifest = await addDependenciesToPackage({}, ['is-positive@1'], await testDefaults())
+
+  const newOpts = await testDefaults({ registries: { default: 'https://registry.npmjs.org/' }, global: true })
+  let err!: PnpmError
+  try {
+    await addDependenciesToPackage(manifest, ['is-negative@1'], newOpts)
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+  expect(err.code).toBe('ERR_PNPM_REGISTRIES_MISMATCH')
+  expect(err.message).toContain('pnpm install -g')
+})
+
 test('broken lockfile is fixed even if it seems like up to date at first. Unless frozenLockfile option is set to true', async () => {
   const project = prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -93,6 +93,7 @@ export interface GetContextOptions {
 
   publicHoistPattern?: string[] | undefined
   forcePublicHoistPattern?: boolean
+  global?: boolean
 }
 
 export async function getContext (
@@ -119,6 +120,7 @@ export async function getContext (
 
       forcePublicHoistPattern: opts.forcePublicHoistPattern,
       publicHoistPattern: opts.publicHoistPattern,
+      global: opts.global,
     })
     if (purged) {
       importersContext = await readProjectsContext(opts.allProjects, {
@@ -215,6 +217,7 @@ async function validateModules (
 
     publicHoistPattern?: string[] | undefined
     forcePublicHoistPattern?: boolean
+    global?: boolean
   }
 ): Promise<{ purged: boolean }> {
   const rootProject = projects.find(({ id }) => id === '.')
@@ -278,7 +281,7 @@ async function validateModules (
       await Promise.all(projects.map(purgeModulesDirsOfImporter.bind(null, opts.virtualStoreDir)))
       return { purged: true }
     }
-    throw new PnpmError('REGISTRIES_MISMATCH', `This modules directory was created using the following registries configuration: ${JSON.stringify(modules.registries)}. The current configuration is ${JSON.stringify(opts.registries)}. To recreate the modules directory using the new settings, run "pnpm install".`)
+    throw new PnpmError('REGISTRIES_MISMATCH', `This modules directory was created using the following registries configuration: ${JSON.stringify(modules.registries)}. The current configuration is ${JSON.stringify(opts.registries)}. To recreate the modules directory using the new settings, run "pnpm install${opts.global ? ' -g' : ''}".`)
   }
   if (purged && (rootProject == null)) {
     await purgeModulesDirsOfImporter(opts.virtualStoreDir, {


### PR DESCRIPTION
fix #6224 