### PR TITLE
feat: don't add linked in deps to the lockfile when `excludeLinksFromLockfile` is set to `true`

### DIFF
--- a/.changeset/brave-radios-cough.md
+++ b/.changeset/brave-radios-cough.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lockfile-utils": major
+---
+
+Breaking changes to the API of `satisfiesPackageManifest`.

--- a/.changeset/tiny-camels-divide.md
+++ b/.changeset/tiny-camels-divide.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolve-dependencies": minor
+"@pnpm/headless": minor
+"@pnpm/core": minor
+---
+
+When `excludeLinksFromLockfile` is set to `true`, linked dependencies are not added to the lockfile.

--- a/lockfile/lockfile-utils/test/satisfiesPackageManifest.ts
+++ b/lockfile/lockfile-utils/test/satisfiesPackageManifest.ts
@@ -1,130 +1,113 @@
 import { satisfiesPackageManifest } from '@pnpm/lockfile-utils'
 
-const DEFAULT_LOCKFILE_FIELDS = {
-  lockfileVersion: 3,
-}
-
 const DEFAULT_PKG_FIELDS = {
   name: 'project',
   version: '1.0.0',
 }
 
 test('satisfiesPackageManifest()', () => {
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(true)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        devDependencies: {},
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(true)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      devDependencies: {},
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(true)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        devDependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(true)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      devDependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    devDependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(true)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        optionalDependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      devDependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(true)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      optionalDependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    optionalDependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(true)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      optionalDependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(true)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    optionalDependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(false)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      optionalDependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(false)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.1.0' },
-  }, '.')).toBe(false)
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.1.0' },
+    }
+  )).toBe(false)
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0', bar: '2.0.0' },
-  }, '.')).toBe(false)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0', bar: '2.0.0' },
+    }
+  )).toBe(false)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0', bar: '2.0.0' },
-      },
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0' },
+      specifiers: { foo: '^1.0.0', bar: '2.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0', bar: '2.0.0' },
-  }, '.')).toBe(false)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0', bar: '2.0.0' },
+    }
+  )).toBe(false)
 
   {
-    const lockfile = {
-      ...DEFAULT_LOCKFILE_FIELDS,
-      importers: {
-        '.': {
-          dependencies: {
-            foo: '1.0.0',
-          },
-          optionalDependencies: {
-            bar: '2.0.0',
-          },
-          specifiers: {
-            bar: '2.0.0',
-            foo: '^1.0.0',
-          },
-        },
+    const importer = {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      optionalDependencies: {
+        bar: '2.0.0',
+      },
+      specifiers: {
+        bar: '2.0.0',
+        foo: '^1.0.0',
       },
     }
     const pkg = {
@@ -137,23 +120,18 @@ test('satisfiesPackageManifest()', () => {
         bar: '2.0.0',
       },
     }
-    expect(satisfiesPackageManifest(lockfile, pkg, '.')).toBe(true)
+    expect(satisfiesPackageManifest({}, importer, pkg)).toBe(true)
   }
 
   {
-    const lockfile = {
-      ...DEFAULT_LOCKFILE_FIELDS,
-      importers: {
-        '.': {
-          dependencies: {
-            bar: '2.0.0',
-            qar: '1.0.0',
-          },
-          specifiers: {
-            bar: '2.0.0',
-            qar: '^1.0.0',
-          },
-        },
+    const importer = {
+      dependencies: {
+        bar: '2.0.0',
+        qar: '1.0.0',
+      },
+      specifiers: {
+        bar: '2.0.0',
+        qar: '^1.0.0',
       },
     }
     const pkg = {
@@ -162,22 +140,17 @@ test('satisfiesPackageManifest()', () => {
         bar: '2.0.0',
       },
     }
-    expect(satisfiesPackageManifest(lockfile, pkg, '.')).toBe(false)
+    expect(satisfiesPackageManifest({}, importer, pkg)).toBe(false)
   }
 
   {
-    const lockfile = {
-      ...DEFAULT_LOCKFILE_FIELDS,
-      importers: {
-        '.': {
-          dependencies: {
-            bar: '2.0.0',
-            qar: '1.0.0',
-          },
-          specifiers: {
-            bar: '2.0.0',
-          },
-        },
+    const importer = {
+      dependencies: {
+        bar: '2.0.0',
+        qar: '1.0.0',
+      },
+      specifiers: {
+        bar: '2.0.0',
       },
     }
     const pkg = {
@@ -186,185 +159,195 @@ test('satisfiesPackageManifest()', () => {
         bar: '2.0.0',
       },
     }
-    expect(satisfiesPackageManifest(lockfile, pkg, '.')).toBe(false)
+    expect(satisfiesPackageManifest({}, importer, pkg)).toBe(false)
   }
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: { foo: '1.0.0', linked: 'link:../linked' },
-        specifiers: { foo: '^1.0.0' },
-      },
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0', linked: 'link:../linked' },
+      specifiers: { foo: '^1.0.0' },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      'packages/foo': {
-        dependencies: { foo: '1.0.0' },
-        specifiers: { foo: '^1.0.0' },
-      },
-    },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: { foo: '^1.0.0' },
-  }, '.')).toBe(false)
+  expect(satisfiesPackageManifest(
+    {},
+    undefined,
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0' },
+    }
+  )).toBe(false)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          foo: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-        },
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
       },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      foo: '1.0.0',
-    },
-    devDependencies: {
-      foo: '1.0.0',
-    },
-  }, '.')).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+      },
+      devDependencies: {
+        foo: '1.0.0',
+      },
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          foo: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-        },
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
       },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      foo: '1.0.0',
-    },
-    devDependencies: {
-      foo: '1.0.0',
-    },
-    dependenciesMeta: {},
-  }, '.')).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+      },
+      devDependencies: {
+        foo: '1.0.0',
+      },
+      dependenciesMeta: {},
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          foo: '1.0.0',
-          bar: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-          bar: '^1.0.0',
-        },
+  expect(satisfiesPackageManifest(
+    { autoInstallPeers: true },
+    {
+      dependencies: {
+        foo: '1.0.0',
+        bar: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
+        bar: '^1.0.0',
       },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      foo: '1.0.0',
-    },
-    peerDependencies: {
-      bar: '^1.0.0',
-    },
-  }, '.', { autoInstallPeers: true })).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+      },
+      peerDependencies: {
+        bar: '^1.0.0',
+      },
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          qar: '1.0.0',
-        },
-        optionalDependencies: {
-          bar: '1.0.0',
-        },
-        devDependencies: {
-          foo: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-          bar: '1.0.0',
-          qar: '1.0.0',
-        },
+  expect(satisfiesPackageManifest(
+    { autoInstallPeers: true },
+    {
+      dependencies: {
+        qar: '1.0.0',
+      },
+      optionalDependencies: {
+        bar: '1.0.0',
+      },
+      devDependencies: {
+        foo: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
+        bar: '1.0.0',
+        qar: '1.0.0',
       },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      qar: '1.0.0',
-    },
-    optionalDependencies: {
-      bar: '1.0.0',
-    },
-    devDependencies: {
-      foo: '1.0.0',
-    },
-    peerDependencies: {
-      foo: '^1.0.0',
-      bar: '^1.0.0',
-      qar: '^1.0.0',
-    },
-  }, '.', { autoInstallPeers: true })).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        qar: '1.0.0',
+      },
+      optionalDependencies: {
+        bar: '1.0.0',
+      },
+      devDependencies: {
+        foo: '1.0.0',
+      },
+      peerDependencies: {
+        foo: '^1.0.0',
+        bar: '^1.0.0',
+        qar: '^1.0.0',
+      },
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          foo: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-        },
-        publishDirectory: 'dist',
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: {
+        foo: '1.0.0',
       },
+      specifiers: {
+        foo: '1.0.0',
+      },
+      publishDirectory: 'dist',
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      foo: '1.0.0',
-    },
-    publishConfig: {
-      directory: 'dist',
-    },
-  }, '.')).toBe(true)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+      },
+      publishConfig: {
+        directory: 'dist',
+      },
+    }
+  )).toBe(true)
 
-  expect(satisfiesPackageManifest({
-    ...DEFAULT_LOCKFILE_FIELDS,
-    importers: {
-      '.': {
-        dependencies: {
-          foo: '1.0.0',
-        },
-        specifiers: {
-          foo: '1.0.0',
-        },
-        publishDirectory: 'dist',
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
+      },
+      publishDirectory: 'dist',
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+      },
+      publishConfig: {
+        directory: 'lib',
+      },
+    }
+  )).toBe(false)
+
+  expect(satisfiesPackageManifest(
+    {
+      excludeLinksFromLockfile: true,
+    },
+    {
+      dependencies: {
+        foo: '1.0.0',
+      },
+      specifiers: {
+        foo: '1.0.0',
       },
     },
-  }, {
-    ...DEFAULT_PKG_FIELDS,
-    dependencies: {
-      foo: '1.0.0',
-    },
-    publishConfig: {
-      directory: 'lib',
-    },
-  }, '.')).toBe(false)
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: {
+        foo: '1.0.0',
+        bar: 'link:../bar',
+      },
+    }
+  )).toBe(true)
 })

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -20,13 +20,17 @@ export async function allProjectsAreUpToDate (
   projects: Array<ProjectOptions & { id: string }>,
   opts: {
     autoInstallPeers: boolean
+    excludeLinksFromLockfile: boolean
     linkWorkspacePackages: boolean
     wantedLockfile: Lockfile
     workspacePackages: WorkspacePackages
   }
 ) {
   const manifestsByDir = opts.workspacePackages ? getWorkspacePackagesByDirectory(opts.workspacePackages) : {}
-  const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, opts.wantedLockfile)
+  const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, {
+    autoInstallPeers: opts.autoInstallPeers,
+    excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+  })
   const _linkedPackagesAreUpToDate = linkedPackagesAreUpToDate.bind(null, {
     linkWorkspacePackages: opts.linkWorkspacePackages,
     manifestsByDir,
@@ -35,7 +39,7 @@ export async function allProjectsAreUpToDate (
   return pEvery(projects, (project) => {
     const importer = opts.wantedLockfile.importers[project.id]
     return !hasLocalTarballDepsInRoot(importer) &&
-      _satisfiesPackageManifest(project.manifest, project.id, { autoInstallPeers: opts.autoInstallPeers }) &&
+      _satisfiesPackageManifest(importer, project.manifest) &&
       _linkedPackagesAreUpToDate({
         dir: project.rootDir,
         manifest: project.manifest,

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -120,6 +120,7 @@ export interface StrictInstallOptions {
   dedupeDirectDeps: boolean
   dedupePeerDependents: boolean
   extendNodePath: boolean
+  excludeLinksFromLockfile: boolean
 }
 
 export type InstallOptions =
@@ -207,6 +208,7 @@ const defaults = async (opts: InstallOptions) => {
     resolvePeersFromWorkspaceRoot: true,
     extendNodePath: true,
     ignoreWorkspaceCycles: false,
+    excludeLinksFromLockfile: false,
   } as StrictInstallOptions
 }
 

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -345,6 +345,7 @@ export async function mutateModules (
         ) &&
         await allProjectsAreUpToDate(Object.values(ctx.projects), {
           autoInstallPeers: opts.autoInstallPeers,
+          excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
           linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
           wantedLockfile: ctx.wantedLockfile,
           workspacePackages: opts.workspacePackages,
@@ -892,6 +893,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       dedupePeerDependents: opts.dedupePeerDependents,
       dryRun: opts.lockfileOnly,
       engineStrict: opts.engineStrict,
+      excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
       force: opts.force,
       forceFullResolution,
       ignoreScripts: opts.ignoreScripts,

--- a/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
+++ b/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
@@ -33,6 +33,7 @@ test('allProjectsAreUpToDate(): works with packages linked through the workspace
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
@@ -74,6 +75,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies', async ()
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
@@ -115,6 +117,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies that speci
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
@@ -156,6 +159,7 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
@@ -230,6 +234,7 @@ test('allProjectsAreUpToDate(): use link and registry version if linkWorkspacePa
       ],
       {
         autoInstallPeers: false,
+        excludeLinksFromLockfile: false,
         linkWorkspacePackages: false,
         wantedLockfile: {
           importers: {
@@ -296,6 +301,7 @@ test('allProjectsAreUpToDate(): returns false if dependenciesMeta differs', asyn
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {
@@ -342,6 +348,7 @@ test('allProjectsAreUpToDate(): returns true if dependenciesMeta matches', async
     },
   ], {
     autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
       importers: {

--- a/pkg-manager/core/test/install/excludeLinksFromLockfile.ts
+++ b/pkg-manager/core/test/install/excludeLinksFromLockfile.ts
@@ -1,0 +1,109 @@
+import fs from 'fs'
+import path from 'path'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import {
+  mutateModules,
+  type MutatedProject,
+  type ProjectOptions,
+} from '@pnpm/core'
+import { type LockfileV6 } from '@pnpm/lockfile-types'
+import { preparePackages, tempDir } from '@pnpm/prepare'
+import rimraf from '@zkochan/rimraf'
+import readYamlFile from 'read-yaml-file'
+import { testDefaults } from '../utils'
+
+test('links are not added to the lockfile when excludeLinksFromLockfile is true', async () => {
+  const externalPkg1 = tempDir(false)
+  const externalPkg2 = tempDir(false)
+  const externalPkg3 = tempDir(false)
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2' },
+    },
+  ])
+  const importers: MutatedProject[] = [
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-1'),
+    },
+    {
+      mutation: 'install',
+      rootDir: path.resolve('project-2'),
+    },
+  ]
+  const project1Dir = path.resolve('project-1')
+  const project2Dir = path.resolve('project-2')
+  const allProjects: ProjectOptions[] = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+
+        dependencies: {
+          'is-positive': '1.0.0',
+          'external-1': `link:${path.relative(project1Dir, externalPkg1)}`,
+        },
+      },
+      rootDir: project1Dir,
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-2',
+        version: '1.0.0',
+
+        dependencies: {
+          'is-negative': '1.0.0',
+          'external-2': `link:${path.relative(project2Dir, externalPkg2)}`,
+        },
+      },
+      rootDir: project2Dir,
+    },
+  ]
+  await mutateModules(importers, await testDefaults({ allProjects, excludeLinksFromLockfile: true }))
+  const lockfile: LockfileV6 = await readYamlFile(WANTED_LOCKFILE)
+  expect(lockfile.importers['project-1'].dependencies?.['external-1']).toBeUndefined()
+  expect(lockfile.importers['project-2'].dependencies?.['external-2']).toBeUndefined()
+
+  expect(fs.existsSync(path.resolve('project-1/node_modules/external-1'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('project-2/node_modules/external-2'))).toBeTruthy()
+
+  await rimraf('node_modules')
+  await rimraf('project-1/node_modules')
+  await rimraf('project-2/node_modules')
+
+  await mutateModules(importers, await testDefaults({ allProjects, excludeLinksFromLockfile: true, frozenLockfile: true }))
+  expect(lockfile.importers['project-1'].dependencies?.['external-1']).toBeUndefined()
+  expect(lockfile.importers['project-2'].dependencies?.['external-2']).toBeUndefined()
+
+  expect(fs.existsSync(path.resolve('project-1/node_modules/external-1'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('project-2/node_modules/external-2'))).toBeTruthy()
+
+  await rimraf('node_modules')
+  await rimraf('project-1/node_modules')
+  await rimraf('project-2/node_modules')
+
+  await mutateModules(importers, await testDefaults({ allProjects, excludeLinksFromLockfile: true, frozenLockfile: false, preferFrozenLockfile: false }))
+  expect(lockfile.importers['project-1'].dependencies?.['external-1']).toBeUndefined()
+  expect(lockfile.importers['project-2'].dependencies?.['external-2']).toBeUndefined()
+
+  expect(fs.existsSync(path.resolve('project-1/node_modules/external-1'))).toBeTruthy()
+  expect(fs.existsSync(path.resolve('project-2/node_modules/external-2'))).toBeTruthy()
+
+  delete allProjects[1].manifest.dependencies!['external-2']
+  allProjects[1].manifest.dependencies!['external-3'] = `link:${path.relative(project2Dir, externalPkg3)}`
+  await mutateModules(importers, await testDefaults({ allProjects, excludeLinksFromLockfile: true }))
+  expect(lockfile.importers['project-1'].dependencies?.['external-1']).toBeUndefined()
+  expect(lockfile.importers['project-2'].dependencies?.['external-2']).toBeUndefined()
+  expect(lockfile.importers['project-2'].dependencies?.['external-3']).toBeUndefined()
+
+  expect(fs.existsSync(path.resolve('project-1/node_modules/external-1'))).toBeTruthy()
+  // expect(fs.existsSync(path.resolve('project-2/node_modules/external-2'))).toBeFalsy() // Should we remove external links that are not in deps anymore?
+  expect(fs.existsSync(path.resolve('project-2/node_modules/external-3'))).toBeTruthy()
+})

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -94,6 +94,7 @@ export async function resolveDependencies (
   opts: ResolveDependenciesOptions & {
     defaultUpdateDepth: number
     dedupePeerDependents?: boolean
+    excludeLinksFromLockfile?: boolean
     preserveWorkspaceProtocol: boolean
     saveWorkspaceProtocol: 'rolling' | boolean
     lockfileIncludeTarballUrl?: boolean
@@ -170,7 +171,7 @@ export async function resolveDependencies (
         resolvedImporter.linkedDependencies,
         resolvedImporter.directDependencies,
         opts.registries,
-        opts.autoInstallPeers
+        opts.excludeLinksFromLockfile
       )
     }
 
@@ -354,7 +355,7 @@ function addDirectDependenciesToLockfile (
   linkedPackages: Array<{ alias: string }>,
   directDependencies: ResolvedDirectDependency[],
   registries: Registries,
-  autoInstallPeers?: boolean
+  excludeLinksFromLockfile?: boolean
 ): ProjectSnapshot {
   const newProjectSnapshot: ProjectSnapshot & Required<Pick<ProjectSnapshot, 'dependencies' | 'devDependencies' | 'optionalDependencies'>> = {
     dependencies: {},
@@ -379,7 +380,7 @@ function addDirectDependenciesToLockfile (
   const allDeps = Array.from(new Set(Object.keys(getAllDependenciesFromManifest(newManifest))))
 
   for (const alias of allDeps) {
-    if (directDependenciesByAlias[alias]) {
+    if (directDependenciesByAlias[alias] && (!excludeLinksFromLockfile || !(directDependenciesByAlias[alias] as LinkedDependency).isLinkedDependency)) {
       const dep = directDependenciesByAlias[alias]
       const ref = depPathToRef(dep.pkgId, {
         alias: dep.alias,


### PR DESCRIPTION
This is needed for when pnpm is used in Bit CLI via its API (related PR: https://github.com/teambit/bit/pull/7176). Bit adds some local dependencies to the project dynamically. And the locations of these local dependencies may differ on different machines. Hence, it doesn't make sense to add these dependencies to the lockfile.

Would this setting be useful to other users too? Would it make sense to make it `true` by default in a future version? Right now I did not make it configurable for the pnpm CLI. It seems like duplicating the local dependency specifiers to the lockfile is not required. The local dependency specifier is always resolved to the same location, so it is enough if it is only in `package.json`.