### PR TITLE
feat(default-reporter): a new option added

### DIFF
--- a/.changeset/lovely-balloons-drive.md
+++ b/.changeset/lovely-balloons-drive.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": minor
+---
+
+In order to filter out packages from the installation summary, a filter function may be passed to the reporter: filterPkgsDiff.

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -9,6 +9,7 @@ import { mergeOutputs } from './mergeOutputs'
 import { reporterForClient } from './reporterForClient'
 import { formatWarn } from './reporterForClient/utils/formatWarn'
 import { reporterForServer } from './reporterForServer'
+import { type FilterPkgsDiff } from './reporterForClient/reportSummary'
 
 export { formatWarn }
 
@@ -30,6 +31,7 @@ export function initDefaultReporter (
       env?: NodeJS.ProcessEnv
       process?: NodeJS.Process
     }
+    filterPkgsDiff?: FilterPkgsDiff
   }
 ): () => void {
   if (opts.context.argv[0] === 'server') {
@@ -108,6 +110,7 @@ export function toOutput$ (
       env?: NodeJS.ProcessEnv
       process?: NodeJS.Process
     }
+    filterPkgsDiff?: FilterPkgsDiff
   }
 ): Rx.Observable<string> {
   opts = opts || {}
@@ -247,6 +250,7 @@ export function toOutput$ (
       cmd: opts.context.argv[0],
       config: opts.context.config,
       env: opts.context.env ?? process.env,
+      filterPkgsDiff: opts.filterPkgsDiff,
       process: opts.context.process ?? process,
       isRecursive: opts.context.config?.['recursive'] === true,
       logLevel: opts.reportingOptions?.logLevel,

--- a/cli/default-reporter/src/reporterForClient/index.ts
+++ b/cli/default-reporter/src/reporterForClient/index.ts
@@ -17,7 +17,7 @@ import { reportRequestRetry } from './reportRequestRetry'
 import { reportScope } from './reportScope'
 import { reportSkippedOptionalDependencies } from './reportSkippedOptionalDependencies'
 import { reportStats } from './reportStats'
-import { reportSummary } from './reportSummary'
+import { reportSummary, type FilterPkgsDiff } from './reportSummary'
 import { reportUpdateCheck } from './reportUpdateCheck'
 
 const PRINT_EXECUTION_TIME_IN_COMMANDS = {
@@ -57,6 +57,7 @@ export function reporterForClient (
     cmd: string
     config?: Config
     env: NodeJS.ProcessEnv
+    filterPkgsDiff?: FilterPkgsDiff
     process: NodeJS.Process
     isRecursive: boolean
     logLevel?: LogLevel
@@ -139,6 +140,7 @@ export function reporterForClient (
     outputs.push(reportSummary(log$, {
       cwd,
       env: opts.env,
+      filterPkgsDiff: opts.filterPkgsDiff,
       pnpmConfig: opts.pnpmConfig,
     }))
   }

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -35,7 +35,7 @@ const h1 = chalk.cyanBright
 
 const EOL = '\n'
 
-test.only('prints summary (of current package only)', (done) => {
+test('prints summary (of current package only)', (done) => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -225,6 +225,68 @@ ${ADD} qar ${versionColor('2.0.0')}
 
 ${h1('node_modules:')}
 ${ADD} is-linked2 ${chalk.grey(`<- ${path.relative(prefix, '/src/is-linked2')}`)}
+`)
+    },
+  })
+})
+
+test('prints summary without the filtered out entries', (done) => {
+  const prefix = '/home/jane/project'
+  const output$ = toOutput$({
+    context: {
+      argv: ['install'],
+      config: {
+        dir: prefix,
+      } as Config,
+    },
+    streamParser: createStreamParser(),
+    filterPkgsDiff: (diff) => diff.name !== 'bar',
+  })
+
+  rootLogger.debug({
+    added: {
+      dependencyType: 'prod',
+      id: 'registry.npmjs.org/foo/1.0.0',
+      latest: '2.0.0',
+      name: 'foo',
+      realName: 'foo',
+      version: '1.0.0',
+    },
+    prefix,
+  })
+  rootLogger.debug({
+    added: {
+      dependencyType: 'prod',
+      id: 'registry.npmjs.org/bar/2.0.0',
+      latest: '1.0.0', // this won't be printed in summary because latest is less than current version
+      name: 'bar',
+      realName: 'bar',
+      version: '2.0.0',
+    },
+    prefix,
+  })
+  packageManifestLogger.debug({
+    prefix,
+    updated: {
+      dependencies: {
+        'is-negative': '^1.0.0',
+      },
+      devDependencies: {
+        'is-13': '^1.0.0',
+      },
+    },
+  })
+  summaryLogger.debug({ prefix })
+
+  expect.assertions(1)
+
+  output$.pipe(take(1), map(normalizeNewline)).subscribe({
+    complete: () => done(),
+    error: done,
+    next: output => {
+      expect(output).toBe(EOL + `\
+${h1('dependencies:')}
+${ADD} foo ${versionColor('1.0.0')} ${versionColor('(2.0.0 is available)')}
 `)
     },
   })


### PR DESCRIPTION
In order to filter out packages from the installation summary, a filter function may be passed to the reporter: filterPkgsDiff.

This feature is only useful for Bit CLI currently. Related PR: https://github.com/teambit/bit/pull/7176