### PR TITLE
perf: bump semver to 7.4.0

### DIFF
--- a/.changeset/swift-schools-poke.md
+++ b/.changeset/swift-schools-poke.md
@@ -1,0 +1,23 @@
+---
+"@pnpm/plugin-commands-patching": patch
+"@pnpm/resolve-workspace-range": patch
+"@pnpm/resolve-dependencies": patch
+"@pnpm/merge-lockfile-changes": patch
+"@pnpm/package-is-installable": patch
+"@pnpm/package-requester": patch
+"@pnpm/plugin-commands-rebuild": patch
+"@pnpm/dependency-path": patch
+"@pnpm/plugin-commands-env": patch
+"@pnpm/hooks.read-package-hook": patch
+"@pnpm/lockfile-file": patch
+"@pnpm/git-resolver": patch
+"@pnpm/npm-resolver": patch
+"@pnpm/default-reporter": patch
+"@pnpm/outdated": patch
+"@pnpm/node.resolver": patch
+"@pnpm/core": patch
+"@pnpm/list": patch
+"pnpm": patch
+---
+
+bump semver to 7.4.0

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -47,7 +47,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "right-pad": "^1.0.1",
     "rxjs": "^7.8.0",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "stacktracey": "^2.1.8",
     "string-length": "^4.0.2",
     "strip-ansi": "^6.0.1"

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -35,7 +35,7 @@
     "detect-libc": "^2.0.1",
     "execa": "npm:safe-execa@0.1.2",
     "mem": "^8.1.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/package-is-installable": "workspace:*",

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@pnpm/fetching-types": "workspace:*",
     "@pnpm/node.fetcher": "workspace:*",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "version-selector-type": "^3.0.0"
   },
   "devDependencies": {

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -43,7 +43,7 @@
     "@zkochan/rimraf": "^2.1.2",
     "load-json-file": "^6.2.0",
     "render-help": "^1.0.3",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "write-json-file": "^4.3.0"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -76,7 +76,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "render-help": "^1.0.3",
     "run-groups": "^3.0.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "peerDependencies": {
     "@pnpm/logger": "^5.0.0"

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -36,7 +36,7 @@
     "@yarnpkg/extensions": "2.0.0-rc.22",
     "normalize-path": "^3.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/hooks.read-package-hook": "workspace:*",

--- a/lockfile/lockfile-file/package.json
+++ b/lockfile/lockfile-file/package.json
@@ -59,7 +59,7 @@
     "js-yaml": "npm:@zkochan/js-yaml@0.0.6",
     "normalize-path": "^3.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "sort-keys": "^4.2.0",
     "strip-bom": "^4.0.0",
     "write-file-atomic": "^5.0.0"

--- a/lockfile/merge-lockfile-changes/package.json
+++ b/lockfile/merge-lockfile-changes/package.json
@@ -34,7 +34,7 @@
     "@pnpm/lockfile-types": "workspace:*",
     "comver-to-semver": "^1.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "funding": "https://opencollective.com/pnpm",
   "devDependencies": {

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -34,7 +34,7 @@
     "@pnpm/crypto.base32-hash": "workspace:*",
     "@pnpm/types": "workspace:*",
     "encode-registry": "^3.0.0",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/dependency-path": "workspace:*",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -65,7 +65,7 @@
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
     "safe-execa": "^0.1.3",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "tempy": "^1.0.1"
   },
   "peerDependencies": {

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -65,7 +65,7 @@
     "path-exists": "^4.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "run-groups": "^3.0.1",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "version-selector-type": "^3.0.0"
   },
   "devDependencies": {

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -60,7 +60,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "rename-overwrite": "^4.0.3",
     "safe-promise-defer": "^1.0.1",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "ssri": "10.0.1"
   },
   "devDependencies": {

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -57,7 +57,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "rename-overwrite": "^4.0.3",
     "safe-promise-defer": "^1.0.1",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "semver-range-intersect": "^0.3.1",
     "version-selector-type": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       stacktracey:
         specifier: ^2.1.8
         version: 2.1.8
@@ -670,8 +670,8 @@ importers:
         specifier: ^8.1.1
         version: 8.1.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/package-is-installable':
         specifier: workspace:*
@@ -804,8 +804,8 @@ importers:
         specifier: workspace:*
         version: link:../node.fetcher
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       version-selector-type:
         specifier: ^3.0.0
         version: 3.0.0
@@ -862,8 +862,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       write-json-file:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1087,8 +1087,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/assert-project':
         specifier: workspace:*
@@ -1644,8 +1644,8 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/hooks.read-package-hook':
         specifier: workspace:*
@@ -1815,8 +1815,8 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       sort-keys:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1982,8 +1982,8 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/merge-lockfile-changes':
         specifier: workspace:*
@@ -2210,8 +2210,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/dependency-path':
         specifier: workspace:*
@@ -2553,8 +2553,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       tempy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -2783,8 +2783,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       version-selector-type:
         specifier: ^3.0.0
         version: 3.0.0
@@ -3425,8 +3425,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       ssri:
         specifier: 10.0.1
         version: 10.0.1
@@ -3859,8 +3859,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       semver-range-intersect:
         specifier: ^0.3.1
         version: 0.3.1
@@ -4286,8 +4286,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       split-cmd:
         specifier: ^1.0.1
         version: 1.0.1
@@ -4614,8 +4614,8 @@ importers:
         specifier: npm:@zkochan/hosted-git-info@4.0.2
         version: /@zkochan/hosted-git-info@4.0.2
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/git-resolver':
         specifier: workspace:*
@@ -4727,8 +4727,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
       ssri:
         specifier: 10.0.1
         version: 10.0.1
@@ -4933,8 +4933,8 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/list':
         specifier: workspace:*
@@ -4997,8 +4997,8 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/outdated':
         specifier: workspace:*
@@ -5897,8 +5897,8 @@ importers:
   workspace/resolve-workspace-range:
     dependencies:
       semver:
-        specifier: ^7.3.8
-        version: 7.3.8
+        specifier: ^7.4.0
+        version: 7.4.0
     devDependencies:
       '@pnpm/resolve-workspace-range':
         specifier: workspace:*
@@ -7384,14 +7384,14 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.8
+      semver: 7.4.0
 
   /@npmcli/fs@2.1.2:
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.8
+      semver: 7.4.0
     dev: false
     optional: true
 
@@ -7625,7 +7625,7 @@ packages:
       path-exists: 4.0.0
       ramda: /@pnpm/ramda@0.28.1
       run-groups: 3.0.1
-      semver: 7.3.8
+      semver: 7.4.0
       version-selector-type: 3.0.0
     transitivePeerDependencies:
       - '@yarnpkg/core'
@@ -7663,7 +7663,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       right-pad: 1.0.1
       rxjs: 7.8.0
-      semver: 7.3.8
+      semver: 7.4.0
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -7682,7 +7682,7 @@ packages:
       '@pnpm/crypto.base32-hash': 1.0.1
       '@pnpm/types': 8.10.0
       encode-registry: 3.0.0
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /@pnpm/directory-fetcher@5.1.6(@pnpm/logger@5.0.0):
@@ -7908,7 +7908,7 @@ packages:
       '@yarnpkg/extensions': 2.0.0-rc.9(@yarnpkg/core@4.0.0-rc.14)
       normalize-path: 3.0.0
       ramda: /@pnpm/ramda@0.28.1
-      semver: 7.3.8
+      semver: 7.4.0
     transitivePeerDependencies:
       - '@yarnpkg/core'
     dev: true
@@ -7980,7 +7980,7 @@ packages:
       js-yaml: /@zkochan/js-yaml@0.0.6
       normalize-path: 3.0.0
       ramda: /@pnpm/ramda@0.28.1
-      semver: 7.3.8
+      semver: 7.4.0
       sort-keys: 4.2.0
       strip-bom: 4.0.0
       write-file-atomic: 5.0.0
@@ -8063,7 +8063,7 @@ packages:
       '@pnpm/lockfile-types': 4.3.6
       comver-to-semver: 1.0.0
       ramda: /@pnpm/ramda@0.28.1
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /@pnpm/meta-updater@0.2.2(typanion@3.12.1):
@@ -8206,7 +8206,7 @@ packages:
     engines: {node: '>=14.6'}
     dependencies:
       hosted-git-info: /@zkochan/hosted-git-info@4.0.2
-      semver: 7.3.8
+      semver: 7.4.0
       validate-npm-package-name: 4.0.0
 
   /@pnpm/npm-resolver@15.0.10(@pnpm/logger@5.0.0):
@@ -8234,7 +8234,7 @@ packages:
       path-temp: 2.0.0
       ramda: /@pnpm/ramda@0.28.1
       rename-overwrite: 4.0.3
-      semver: 7.3.8
+      semver: 7.4.0
       ssri: 10.0.1
       version-selector-type: 3.0.0
     transitivePeerDependencies:
@@ -8287,7 +8287,7 @@ packages:
       detect-libc: 2.0.1
       execa: /safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /@pnpm/package-requester@20.1.7(@pnpm/logger@5.0.0):
@@ -8319,7 +8319,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       rename-overwrite: 4.0.3
       safe-promise-defer: 1.0.1
-      semver: 7.3.8
+      semver: 7.4.0
       ssri: 10.0.1
     dev: true
 
@@ -8551,7 +8551,7 @@ packages:
       ramda: /@pnpm/ramda@0.28.1
       rename-overwrite: 4.0.3
       safe-promise-defer: 1.0.1
-      semver: 7.3.8
+      semver: 7.4.0
       semver-range-intersect: 0.3.1
       string.prototype.replaceall: 1.0.7
       version-selector-type: 3.0.0
@@ -8564,7 +8564,7 @@ packages:
     resolution: {integrity: sha512-MrXdfTe7CA76zvivatQHJz7Ui02nziKz7Fpht+npsKfOvAyVUcERks2mxPi1IlSFhKDeDLfe/K0v5qqMFcb54A==}
     engines: {node: '>=14.6'}
     dependencies:
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /@pnpm/resolver-base@9.2.0:
@@ -8786,7 +8786,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 18.15.11
+      '@types/node': 14.18.42
       '@types/responselike': 1.0.0
 
   /@types/concat-stream@2.0.0:
@@ -8888,7 +8888,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 14.18.42
 
   /@types/lodash@4.14.181:
     resolution: {integrity: sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==}
@@ -8931,7 +8931,6 @@ packages:
 
   /@types/node@14.18.42:
     resolution: {integrity: sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==}
-    dev: true
 
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
@@ -8968,7 +8967,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 14.18.42
 
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -9171,7 +9170,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.8
+      semver: 7.4.0
       tsutils: 3.21.0(typescript@5.0.2)
       typescript: 5.0.2
     transitivePeerDependencies:
@@ -9192,7 +9191,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.2)
       eslint: 8.37.0
       eslint-scope: 5.1.1
-      semver: 7.3.8
+      semver: 7.4.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9321,7 +9320,7 @@ packages:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.3.8
+      semver: 7.4.0
       strip-ansi: 6.0.1
       tar: 6.1.13
       tinylogic: 2.0.0
@@ -9355,7 +9354,7 @@ packages:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.3.8
+      semver: 7.4.0
       strip-ansi: 6.0.1
       tar: 6.1.13
       tinylogic: 2.0.0
@@ -9389,7 +9388,7 @@ packages:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.3.8
+      semver: 7.4.0
       strip-ansi: 6.0.1
       tar: 6.1.13
       tinylogic: 2.0.0
@@ -9699,7 +9698,7 @@ packages:
       request: 2.88.2
       retry: 0.13.1
       safe-buffer: 5.2.1
-      semver: 7.3.8
+      semver: 7.4.0
       slide: 1.1.6
       ssri: 8.0.1
     optionalDependencies:
@@ -10162,7 +10161,7 @@ packages:
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
-      semver: 7.3.8
+      semver: 7.4.0
 
   /bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -13318,7 +13317,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.3.8
+      semver: 7.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13475,7 +13474,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.3.8
+      semver: 7.4.0
 
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -14398,7 +14397,7 @@ packages:
       nopt: /@pnpm/nopt@0.2.1
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.3.8
+      semver: 7.4.0
       tar: 6.1.13
       which: 2.0.2
     transitivePeerDependencies:
@@ -14418,7 +14417,7 @@ packages:
       nopt: 6.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
-      semver: 7.3.8
+      semver: 7.4.0
       tar: 6.1.13
       which: 2.0.2
     transitivePeerDependencies:
@@ -14469,7 +14468,7 @@ packages:
     dependencies:
       hosted-git-info: /@zkochan/hosted-git-info@4.0.2
       is-core-module: 2.11.0
-      semver: 7.3.8
+      semver: 7.4.0
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -14479,7 +14478,7 @@ packages:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.11.0
-      semver: 7.3.8
+      semver: 7.4.0
       validate-npm-package-license: 3.0.4
 
   /normalize-path@2.1.1:
@@ -15052,7 +15051,7 @@ packages:
       https-proxy-agent: 5.0.1
       node-fetch: 2.6.9
       progress: 2.0.3
-      semver: 7.3.8
+      semver: 7.4.0
       tar-fs: 2.1.1
       yargs: 16.2.0
     transitivePeerDependencies:
@@ -15856,6 +15855,13 @@ packages:
 
   /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+
+  /semver@7.4.0:
+    resolution: {integrity: sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -16687,7 +16693,7 @@ packages:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.3.8
+      semver: 7.4.0
       typescript: 5.0.2
       yargs-parser: 21.1.1
     dev: true
@@ -17156,7 +17162,7 @@ packages:
     resolution: {integrity: sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==}
     engines: {node: '>=10.13'}
     dependencies:
-      semver: 7.3.8
+      semver: 7.4.0
 
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
@@ -17808,7 +17814,7 @@ time:
   /sanitize-filename@1.6.3: '2019-08-26T02:10:56.988Z'
   /semver-range-intersect@0.3.1: '2019-07-20T15:11:40.243Z'
   /semver-utils@1.1.4: '2018-10-09T04:14:32.485Z'
-  /semver@7.3.8: '2022-10-04T19:40:47.960Z'
+  /semver@7.4.0: '2023-04-10T21:57:46.268Z'
   /shx@0.3.4: '2022-01-10T02:16:53.953Z'
   /signal-exit@3.0.7: '2022-02-03T21:05:34.544Z'
   /sinon@15.0.3: '2023-03-26T18:23:58.418Z'

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -99,7 +99,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "read-yaml-file": "^2.1.0",
     "render-help": "^1.0.3",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "split-cmd": "^1.0.1",
     "strip-ansi": "^6.0.1",
     "symlink-dir": "^5.1.1",

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -36,7 +36,7 @@
     "@pnpm/resolver-base": "workspace:*",
     "graceful-git": "^3.1.2",
     "hosted-git-info": "npm:@zkochan/hosted-git-info@4.0.2",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/git-resolver": "workspace:*",

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -52,7 +52,7 @@
     "path-temp": "^2.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "rename-overwrite": "^4.0.3",
-    "semver": "^7.3.8",
+    "semver": "^7.4.0",
     "ssri": "10.0.1",
     "version-selector-type": "^3.0.0"
   },

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -45,7 +45,7 @@
     "cli-columns": "^4.0.0",
     "p-limit": "^3.1.0",
     "ramda": "npm:@pnpm/ramda@0.28.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/list": "workspace:*",

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -49,7 +49,7 @@
     "@pnpm/pick-registry-for-package": "workspace:*",
     "@pnpm/types": "workspace:*",
     "ramda": "npm:@pnpm/ramda@0.28.1",
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/outdated": "workspace:*",

--- a/workspace/resolve-workspace-range/package.json
+++ b/workspace/resolve-workspace-range/package.json
@@ -25,7 +25,7 @@
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
-    "semver": "^7.3.8"
+    "semver": "^7.4.0"
   },
   "devDependencies": {
     "@pnpm/resolve-workspace-range": "workspace:*",


### PR DESCRIPTION
This picks up the performance improvements by @H4ad.

On DT using `git clean -fdx; pnpm install --offline`, before:

```
Done in 2m 15.1s
total time:  135.31s
user time:   162.02s
system time: 31.29s
CPU percent: 142%
max memory:  1797 MB
```

After:

```
Done in 1m 43.6s
total time:  103.89s
user time:   115.92s
system time: 30.47s
CPU percent: 140%
max memory:  1858 MB
```

~30% faster.