### PR TITLE
fix(hard-link-dir): prevent fatal error on ENOENT

### DIFF
--- a/.changeset/fuzzy-parents-juggle.md
+++ b/.changeset/fuzzy-parents-juggle.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/fs.hard-link-dir": patch
+"pnpm": patch
 ---
 
-Warn user when publishConfig.directory of an injected workspace dependency does not exist
+Warn user when `publishConfig.directory` of an injected workspace dependency does not exist [#6396](https://github.com/pnpm/pnpm/pull/6396).

--- a/.changeset/fuzzy-parents-juggle.md
+++ b/.changeset/fuzzy-parents-juggle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/fs.hard-link-dir": patch
+---
+
+Warn user when publishConfig.directory of an injected workspace dependency does not exist

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -30,14 +30,14 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/fs/hard-link-dir#readme",
   "funding": "https://opencollective.com/pnpm",
+  "peerDependencies": {
+    "@pnpm/logger": "^5.0.0"
+  },
   "devDependencies": {
     "@pnpm/fs.hard-link-dir": "workspace:*",
     "@pnpm/prepare": "workspace:*"
   },
   "exports": {
     ".": "./lib/index.js"
-  },
-  "dependencies": {
-    "@pnpm/logger": "^5.0.0"
   }
 }

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -36,5 +36,8 @@
   },
   "exports": {
     ".": "./lib/index.js"
+  },
+  "dependencies": {
+    "@pnpm/logger": "^5.0.0"
   }
 }

--- a/fs/hard-link-dir/src/index.ts
+++ b/fs/hard-link-dir/src/index.ts
@@ -17,9 +17,7 @@ async function _hardLinkDir (src: string, destDirs: string[], isRoot?: boolean) 
     if (!isRoot || err.code !== 'ENOENT') throw err
     globalWarn(`Source directory not found when creating hardLinks for: ${src}. Creating destinations as empty: ${destDirs.join(', ')}`)
     await Promise.all(
-      destDirs.map(async (dir) => {
-        await fs.mkdir(dir, { recursive: true })
-      })
+      destDirs.map((dir) => fs.mkdir(dir, { recursive: true }))
     )
     return
   }

--- a/fs/hard-link-dir/test/index.ts
+++ b/fs/hard-link-dir/test/index.ts
@@ -8,6 +8,8 @@ test('hardLinkDirectory()', async () => {
   const srcDir = path.join(tempDir, 'source')
   const dest1Dir = path.join(tempDir, 'dest1')
   const dest2Dir = path.join(tempDir, 'dest2')
+  const missingDirSrc = path.join(tempDir, 'missing_source')
+  const missingDirDest = path.join(tempDir, 'missing_dest')
 
   fs.mkdirSync(srcDir, { recursive: true })
   fs.mkdirSync(dest1Dir, { recursive: true })
@@ -31,4 +33,10 @@ test('hardLinkDirectory()', async () => {
   // It should not link files from node_modules
   expect(fs.existsSync(path.join(dest1Dir, 'node_modules/file.txt'))).toBe(false)
   expect(fs.existsSync(path.join(dest2Dir, 'node_modules/file.txt'))).toBe(false)
+
+  await hardLinkDir(missingDirSrc, [missingDirDest])
+
+  // It should create an empty dest dir if src does not exist
+  expect(fs.existsSync(missingDirSrc)).toBe(false)
+  expect(fs.existsSync(missingDirDest)).toBe(true)
 })

--- a/fs/hard-link-dir/test/index.ts
+++ b/fs/hard-link-dir/test/index.ts
@@ -8,8 +8,6 @@ test('hardLinkDirectory()', async () => {
   const srcDir = path.join(tempDir, 'source')
   const dest1Dir = path.join(tempDir, 'dest1')
   const dest2Dir = path.join(tempDir, 'dest2')
-  const missingDirSrc = path.join(tempDir, 'missing_source')
-  const missingDirDest = path.join(tempDir, 'missing_dest')
 
   fs.mkdirSync(srcDir, { recursive: true })
   fs.mkdirSync(dest1Dir, { recursive: true })
@@ -33,6 +31,12 @@ test('hardLinkDirectory()', async () => {
   // It should not link files from node_modules
   expect(fs.existsSync(path.join(dest1Dir, 'node_modules/file.txt'))).toBe(false)
   expect(fs.existsSync(path.join(dest2Dir, 'node_modules/file.txt'))).toBe(false)
+})
+
+test("don't fail on missing source and dest directories", async () => {
+  const tempDir = createTempDir()
+  const missingDirSrc = path.join(tempDir, 'missing_source')
+  const missingDirDest = path.join(tempDir, 'missing_dest')
 
   await hardLinkDir(missingDirSrc, [missingDirDest])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: link:__utils__/eslint-config
       '@pnpm/meta-updater':
         specifier: 0.2.2
-        version: 0.2.2(typanion@3.12.1)
+        version: 0.2.2
       '@pnpm/registry-mock':
         specifier: 3.8.0
         version: 3.8.0(typanion@3.12.1)
@@ -1488,6 +1488,10 @@ importers:
         version: 4.1.6
 
   fs/hard-link-dir:
+    dependencies:
+      '@pnpm/logger':
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@pnpm/fs.hard-link-dir':
         specifier: workspace:*
@@ -7430,7 +7434,7 @@ packages:
     dev: false
     optional: true
 
-  /@pnpm/build-modules@10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1):
+  /@pnpm/build-modules@10.1.9(@pnpm/logger@5.0.0):
     resolution: {integrity: sha512-n+edccgztg0XSwNmKFnAYROMcnqI7Mn8aoARIrhIW+R49HupLASBarfSlBUdyUfQ5aoyEdMHqZ2r9xrvBUYVGA==}
     engines: {node: '>=14.6'}
     peerDependencies:
@@ -7440,7 +7444,7 @@ packages:
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/fs.hard-link-dir': 1.0.3
       '@pnpm/graph-sequencer': 1.0.0
-      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)
       '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/logger': 5.0.0
       '@pnpm/patching.apply-patch': 1.0.0
@@ -7495,15 +7499,15 @@ packages:
       load-json-file: 6.2.0
     dev: true
 
-  /@pnpm/cli-utils@1.1.10(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/cli-utils@1.1.10(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-yox3nCdl6CsHMsCkYceIp/hQ3mel4FMpoFTTiUbf9bRka7pHF0OcW/nCZ9q/hal6TOupPVk27UwJeIJR1liEbQ==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
       '@pnpm/cli-meta': 4.0.3
-      '@pnpm/config': 17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
-      '@pnpm/default-reporter': 11.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/config': 17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
+      '@pnpm/default-reporter': 11.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/error': 4.0.1
       '@pnpm/logger': 5.0.0
       '@pnpm/manifest-utils': 4.1.4(@pnpm/logger@5.0.0)
@@ -7537,7 +7541,7 @@ packages:
     engines: {node: '>=12.22.0'}
     dev: false
 
-  /@pnpm/config@17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/config@17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-4bvc74xa95gs1uPx8bkdujqHA8gB0UiDzUXXglisFTvMBbnCZTEeGyFlbzjy+2TNEyhITwVmg0nh2V9PqJ3Fow==}
     engines: {node: '>=14.6'}
     dependencies:
@@ -7547,7 +7551,7 @@ packages:
       '@pnpm/git-utils': 0.1.0
       '@pnpm/matcher': 4.0.1
       '@pnpm/npm-conf': 2.0.4
-      '@pnpm/pnpmfile': 4.0.43(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/pnpmfile': 4.0.43(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/read-project-manifest': 4.1.4
       '@pnpm/types': 8.10.0
       camelcase: 6.3.0
@@ -7585,13 +7589,13 @@ packages:
       '@pnpm/types': 8.10.0
     dev: true
 
-  /@pnpm/core@8.0.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/core@8.0.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-UvPWO5NiLa68axpXbQUFSjAVYEuZLFHj7ZJnOucAvfceL6UIGa1S18bpc3zMuyB7HbxM/f5Fykj4ZbTqYvTqBw==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)
       '@pnpm/calc-dep-state': 3.0.2
       '@pnpm/constants': 6.2.0
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
@@ -7601,10 +7605,10 @@ packages:
       '@pnpm/filter-lockfile': 7.0.10(@pnpm/logger@5.0.0)
       '@pnpm/get-context': 8.3.0(@pnpm/logger@5.0.0)
       '@pnpm/graph-sequencer': 1.0.0
-      '@pnpm/headless': 19.5.4(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/headless': 19.5.4(@pnpm/logger@5.0.0)
       '@pnpm/hoist': 7.0.18(@pnpm/logger@5.0.0)
       '@pnpm/hooks.read-package-hook': 2.1.2(@yarnpkg/core@4.0.0-rc.14)
-      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)
       '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-file': 7.0.6(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-to-pnp': 2.0.14(@pnpm/logger@5.0.0)
@@ -7625,7 +7629,7 @@ packages:
       '@pnpm/read-package-json': 7.0.5
       '@pnpm/read-project-manifest': 4.1.4
       '@pnpm/remove-bins': 4.0.5(@pnpm/logger@5.0.0)
-      '@pnpm/resolve-dependencies': 30.0.5(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/resolve-dependencies': 30.0.5(@pnpm/logger@5.0.0)
       '@pnpm/resolver-base': 9.2.0
       '@pnpm/store-controller-types': 14.3.1
       '@pnpm/symlink-dependency': 6.0.3(@pnpm/logger@5.0.0)
@@ -7659,13 +7663,13 @@ packages:
       rfc4648: 1.5.2
     dev: true
 
-  /@pnpm/default-reporter@11.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/default-reporter@11.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-gg9CpPE9uPN4Gw1V4AWUeb6Bb9B+eJLAQUgYSL66e3U6tGm09iUhBannlBRnsdLkWoODrH0pX+5N89wJSbSxCg==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/config': 17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/config': 17.0.5(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/error': 4.0.1
       '@pnpm/logger': 5.0.0
@@ -7775,11 +7779,11 @@ packages:
       find-up: 5.0.0
     dev: true
 
-  /@pnpm/find-workspace-packages@5.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/find-workspace-packages@5.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-nJHjsSUueSbHRCc9RApjWTCirwe96l+3Tkhi/qfXvzqCBairxQyDk4i5vAYHlDHjh7JQ5V1IumdkTlprp2pH7Q==}
     engines: {node: '>=14.6'}
     dependencies:
-      '@pnpm/cli-utils': 1.1.10(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/cli-utils': 1.1.10(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/constants': 6.2.0
       '@pnpm/fs.find-packages': 1.0.3
       '@pnpm/types': 8.10.0
@@ -7847,13 +7851,13 @@ packages:
   /@pnpm/graph-sequencer@1.0.0:
     resolution: {integrity: sha512-iIJhmi7QjmafhijaEkh34Yxhjq3S/eiZnxww9K/SRXuDB5/30QnCyihR4R7vep8ONsGIR29hNPAtaNGd1rC/VA==}
 
-  /@pnpm/headless@19.5.4(@pnpm/logger@5.0.0)(typanion@3.12.1):
+  /@pnpm/headless@19.5.4(@pnpm/logger@5.0.0):
     resolution: {integrity: sha512-WJytv7MzVC6XP1CR/ZKLa3lZ5CB3E2CwiHm/UVYet6F3OLvKHF8k6UayzZ5DToaHySq8i/tSeAAtFTRXuZm7LA==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/build-modules': 10.1.9(@pnpm/logger@5.0.0)
       '@pnpm/calc-dep-state': 3.0.2
       '@pnpm/constants': 6.2.0
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
@@ -7861,7 +7865,7 @@ packages:
       '@pnpm/error': 4.0.1
       '@pnpm/filter-lockfile': 7.0.10(@pnpm/logger@5.0.0)
       '@pnpm/hoist': 7.0.18(@pnpm/logger@5.0.0)
-      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1)
+      '@pnpm/lifecycle': 14.1.7(@pnpm/logger@5.0.0)
       '@pnpm/link-bins': 8.0.11(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-file': 7.0.6(@pnpm/logger@5.0.0)
       '@pnpm/lockfile-to-pnp': 2.0.14(@pnpm/logger@5.0.0)
@@ -7874,7 +7878,7 @@ packages:
       '@pnpm/pkg-manager.direct-dep-linker': 1.0.2(@pnpm/logger@5.0.0)
       '@pnpm/read-package-json': 7.0.5
       '@pnpm/read-project-manifest': 4.1.4
-      '@pnpm/real-hoist': 1.1.6(typanion@3.12.1)
+      '@pnpm/real-hoist': 1.1.6
       '@pnpm/store-controller-types': 14.3.1
       '@pnpm/symlink-dependency': 6.0.3(@pnpm/logger@5.0.0)
       '@pnpm/types': 8.10.0
@@ -7930,7 +7934,7 @@ packages:
       - '@yarnpkg/core'
     dev: true
 
-  /@pnpm/lifecycle@14.1.7(@pnpm/logger@5.0.0)(typanion@3.12.1):
+  /@pnpm/lifecycle@14.1.7(@pnpm/logger@5.0.0):
     resolution: {integrity: sha512-ZOJ+0lTb3vFazZw2/6324KqR+xcBiOzdvWSrKXy8GyzKn8CZ6BCPjrXt7hw9LxYwYv0iT91ZFFyCsloE6DhIdw==}
     engines: {node: '>=14.6'}
     peerDependencies:
@@ -8083,16 +8087,16 @@ packages:
       semver: 7.4.0
     dev: true
 
-  /@pnpm/meta-updater@0.2.2(typanion@3.12.1):
+  /@pnpm/meta-updater@0.2.2:
     resolution: {integrity: sha512-wh3LdQYM1aTl4vbuh+7Lv6amaDrQTu+iAIs0qsovIVnQfhHvRpwEdICHZTKC/xdthd4uGUmNZRvhoITzGLu1tg==}
     engines: {node: '>=10.12'}
     hasBin: true
     dependencies:
       '@pnpm/find-workspace-dir': 5.0.1
-      '@pnpm/find-workspace-packages': 5.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/find-workspace-packages': 5.0.45(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/logger': 5.0.0
       '@pnpm/types': 8.10.0
-      '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
+      '@yarnpkg/core': 4.0.0-rc.14
       load-json-file: 7.0.1
       meow: 10.1.5
       print-diff: 1.0.0
@@ -8390,13 +8394,13 @@ packages:
       resolve-link-target: 2.0.0
     dev: true
 
-  /@pnpm/pnpmfile@4.0.43(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1):
+  /@pnpm/pnpmfile@4.0.43(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14):
     resolution: {integrity: sha512-yXXfU38Tx7DvpOQI6y2EzdT5XS5LdXIJ1LaFSsor+g883GJd2TQcTDi5BuVfA2doGvS8OJYB9S3OKBTlNfFJ4A==}
     engines: {node: '>=14.6'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/core': 8.0.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)(typanion@3.12.1)
+      '@pnpm/core': 8.0.7(@pnpm/logger@5.0.0)(@yarnpkg/core@4.0.0-rc.14)
       '@pnpm/core-loggers': 8.0.3(@pnpm/logger@5.0.0)
       '@pnpm/error': 4.0.1
       '@pnpm/lockfile-types': 4.3.6
@@ -8477,14 +8481,14 @@ packages:
       realpath-missing: 1.1.0
     dev: true
 
-  /@pnpm/real-hoist@1.1.6(typanion@3.12.1):
+  /@pnpm/real-hoist@1.1.6:
     resolution: {integrity: sha512-PDM3YG2ghd/32ROx6U2XjLaNASnaaOVSn1cSu1mdoX+qQOASO4clczlUUl9oYMYe0Ik99sH0PipPIslwavxGMQ==}
     engines: {node: '>=14.6'}
     dependencies:
       '@pnpm/dependency-path': 1.1.3
       '@pnpm/error': 4.0.1
       '@pnpm/lockfile-utils': 5.0.7
-      '@yarnpkg/nm': 4.0.0-rc.27(typanion@3.12.1)
+      '@yarnpkg/nm': 4.0.0-rc.27
     transitivePeerDependencies:
       - typanion
     dev: true
@@ -8533,7 +8537,7 @@ packages:
       cli-columns: 4.0.0
     dev: true
 
-  /@pnpm/resolve-dependencies@30.0.5(@pnpm/logger@5.0.0)(typanion@3.12.1):
+  /@pnpm/resolve-dependencies@30.0.5(@pnpm/logger@5.0.0):
     resolution: {integrity: sha512-HZLm+euu8SF9FoTqYmLfmhR7+4PmnwoRxJP9Vd6+pl4ZrvR7SXvLXqZywW7tw2usx/2V/ZvU32MhWJ3Uu9kMiw==}
     engines: {node: '>=14.6'}
     peerDependencies:
@@ -8555,7 +8559,7 @@ packages:
       '@pnpm/store-controller-types': 14.3.1
       '@pnpm/types': 8.10.0
       '@pnpm/which-version-is-pinned': 4.0.0
-      '@yarnpkg/core': 4.0.0-rc.27(typanion@3.12.1)
+      '@yarnpkg/core': 4.0.0-rc.27
       encode-registry: 3.0.0
       filenamify: 4.3.0
       get-npm-tarball-url: 2.0.3
@@ -8795,7 +8799,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 14.18.42
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -9314,7 +9318,7 @@ packages:
       minimatch: 3.1.2
       semver: 7.3.8
 
-  /@yarnpkg/core@4.0.0-rc.14(typanion@3.12.1):
+  /@yarnpkg/core@4.0.0-rc.14:
     resolution: {integrity: sha512-SWq+T56I7GiRMrMECGsvCJvQmbXi+pBexjX9sYICPj+OgTHbWDmIOh/OrSC8honE6WEE2ZzPNmwF4Y355NKgew==}
     engines: {node: '>=14.15.0'}
     dependencies:
@@ -9348,7 +9352,7 @@ packages:
       - typanion
     dev: true
 
-  /@yarnpkg/core@4.0.0-rc.27(typanion@3.12.1):
+  /@yarnpkg/core@4.0.0-rc.27:
     resolution: {integrity: sha512-y5PKe+7SVIsDmz+YEOzNme5rf0myiTxGF2xCFvdYQKHNnJ+qylEEFpULD9i74LTEx2HLdXttH2aP+uXnhTkDww==}
     engines: {node: '>=14.15.0'}
     dependencies:
@@ -9430,7 +9434,7 @@ packages:
     peerDependencies:
       '@yarnpkg/core': '*'
     dependencies:
-      '@yarnpkg/core': 4.0.0-rc.14(typanion@3.12.1)
+      '@yarnpkg/core': 4.0.0-rc.14
     dev: true
 
   /@yarnpkg/fslib@3.0.0-rc.25:
@@ -9452,7 +9456,7 @@ packages:
   /@yarnpkg/lockfile@1.1.0:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
-  /@yarnpkg/nm@4.0.0-rc.27(typanion@3.12.1):
+  /@yarnpkg/nm@4.0.0-rc.27:
     resolution: {integrity: sha512-KfoYI38XY0PjpPu+LGvRHxg3OFO+5nwbQy/c5FuLR0ipQkXcinS3JbG+de17Mf6QdKnBTcghA7mdrUKs5JbxyA==}
     engines: {node: '>=14.15.0'}
     dependencies:


### PR DESCRIPTION
I was running into an issue where I have a workspace package (`@my-org/my-app`) that has a dependency on `@my-org/my-lib`. In turn, `my-lib` has a `dist` directory that is in the root of the monorepo (this is how nx sets things up). It uses `publishConfig.directory` and `publishConfig.linkDirectory`.

`package.json (my-app)`
```JSON
{
  "dependencies": {
    "@my-org/my-lib": "workspace:^"
  },
  "dependenciesMeta": {
    "@my-org/my-lib": { "injected": true }
  }
}
```

`package.json (my-lib)`
```JSON
{
  "publishConfig": {
    "directory": "../../dist/lib/my-lib",
    "linkDirectory": true
  }
}
```

There is an issue with pnpm where, given the above conditions, if you run `pnpm install` but `dist/lib/my-lib` does not exist, the process will fail with a ENOENT error.

This change request makes it so that the install process can continue while making an empty destination directory for the hardlinks.