### PR TITLE
refactor: call installDeps directly in dedupe command handler 

### DIFF
--- a/.changeset/fast-icons-retire.md
+++ b/.changeset/fast-icons-retire.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Internal refactor to call installDeps directly in the pnpm dedupe command handler. No behavior changes are expected with this refactor.

--- a/.changeset/sixty-scissors-enjoy.md
+++ b/.changeset/sixty-scissors-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": major
+---
+
+Remove the `dedupe` option from `InstallCommandOptions`. This was not intentionally part of the public install command's API when it was added.

--- a/pkg-manager/plugin-commands-installation/src/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/src/dedupe.ts
@@ -1,7 +1,8 @@
 import { docsUrl } from '@pnpm/cli-utils'
 import { UNIVERSAL_OPTIONS } from '@pnpm/common-cli-options-help'
 import renderHelp from 'render-help'
-import * as install from './install'
+import { type InstallCommandOptions } from './install'
+import { installDeps } from './installDeps'
 
 export const rcOptionsTypes = cliOptionsTypes
 
@@ -27,11 +28,16 @@ export function help () {
   })
 }
 
-export async function handler (
-  opts: install.InstallCommandOptions
-) {
-  return install.handler({
+export async function handler (opts: InstallCommandOptions) {
+  const include = {
+    dependencies: opts.production !== false,
+    devDependencies: opts.dev !== false,
+    optionalDependencies: opts.optional !== false,
+  }
+  return installDeps({
     ...opts,
     dedupe: true,
-  })
+    include,
+    includeDirect: include,
+  }, [])
 }

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -296,7 +296,6 @@ export type InstallCommandOptions = Pick<Config,
   pruneDirectDependencies?: boolean
   pruneStore?: boolean
   recursive?: boolean
-  dedupe?: boolean
   saveLockfile?: boolean
   workspace?: boolean
   includeOnlyPackageFiles?: boolean


### PR DESCRIPTION
## PR Stack

This PR supports `pnpm dedupe --check`. Splitting the change into multiple PRs to make it easier to review.

- [ ] https://github.com/pnpm/pnpm/pull/6403
- [ ] https://github.com/pnpm/pnpm/pull/6404
- [ ] https://github.com/pnpm/pnpm/pull/6402

## Changes

This allows the `dedupe` command handler to pass options to the `installDeps` function that aren't available on the pnpm install command line or config interface. (The next pull request adds a `lockfileCheck` option to the `installDeps` function.)

The new setup better matches the setup in the `add` and `update` command handlers, which also call `installDeps` directly.

https://github.com/pnpm/pnpm/blob/ee61ca4cb7ce6b3cb177f892940edb55b19b9e17/pkg-manager/plugin-commands-installation/src/add.ts#L207

The previous setup mimicked the `prune` command. Keeping the dedupe and install commands as similar as possible was the original goal of having the dedupe command reuse the install command handler, but this may not be necessary due to how small the install command handler is.

There should be no expected behavior changes in this commit. The `frozenLockfile` setting was not necessary to copy the `dedupe` option skips all frozen lockfile logic.