### PR TITLE
feat: add internal lockfileCheck option for lockfile only diff installs

### DIFF
--- a/.changeset/fuzzy-spiders-begin.md
+++ b/.changeset/fuzzy-spiders-begin.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/core": patch
+---
+
+Add lockfileCheck option for lockfile only diff installs

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -42,6 +42,7 @@ export interface StrictInstallOptions {
   ignorePackageManifest: boolean
   preferFrozenLockfile: boolean
   saveWorkspaceProtocol: boolean | 'rolling'
+  lockfileCheck?: (prev: Lockfile, next: Lockfile) => void
   lockfileIncludeTarballUrl: boolean
   preferWorkspacePackages: boolean
   preserveWorkspaceProtocol: boolean

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -7,6 +7,7 @@ import { type Config } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
 import { filterPkgsBySelectorObjects } from '@pnpm/filter-workspace-packages'
 import { arrayOfWorkspacePackagesToMap, findWorkspacePackages } from '@pnpm/find-workspace-packages'
+import { type Lockfile } from '@pnpm/lockfile-types'
 import { rebuildProjects } from '@pnpm/plugin-commands-rebuild'
 import { createOrConnectStoreController, type CreateStoreControllerOptions } from '@pnpm/store-connection-manager'
 import { type IncludedDependencies, type Project, type ProjectsGraph } from '@pnpm/types'
@@ -88,6 +89,17 @@ export type InstallDepsOptions = Pick<Config,
   include?: IncludedDependencies
   includeDirect?: IncludedDependencies
   latest?: boolean
+  /**
+   * If specified, the installation will only be performed for comparison of the
+   * wanted lockfile. The wanted lockfile will not be updated on disk and no
+   * modules will be linked.
+   *
+   * The given callback is passed the wanted lockfile before installation and
+   * after. This allows functions to reasonably determine whether the wanted
+   * lockfile will change on disk after installation. The lockfile arguments
+   * passed to this callback should not be mutated.
+   */
+  lockfileCheck?: (prev: Lockfile, next: Lockfile) => void
   update?: boolean
   updateMatching?: (pkgName: string) => boolean
   updatePackageManifest?: boolean


### PR DESCRIPTION
## PR Stack

This PR supports `pnpm dedupe --check`. Splitting the change into multiple PRs to make it easier to review.

- https://github.com/pnpm/pnpm/pull/6403
- https://github.com/pnpm/pnpm/pull/6404
- https://github.com/pnpm/pnpm/pull/6408

## Changes

Adding a `lockfileCheck` option to `installDeps`. See the new JSDoc for details.

## Motivation

- This will be useful for `pnpm dedupe --check`.
- The `pnpm check-lockfile` command discussed in https://github.com/pnpm/pnpm/issues/6105#issuecomment-1437739132 would benefit from this too.