### PR TITLE
feat(pack): add pack-gzip-level

### DIFF
--- a/.changeset/khaki-bats-learn.md
+++ b/.changeset/khaki-bats-learn.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-publishing": minor
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+A custom compression level may be specified for the `pnpm pack` command using the `pack-gzip-level` setting [#6393](https://github.com/pnpm/pnpm/issues/6393).

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -159,6 +159,7 @@ export interface Config {
   dedupePeerDependents?: boolean
   patchesDir?: string
   ignoreWorkspaceCycles?: boolean
+  packGzipLevel?: number
 
   registries: Registries
   ignoreWorkspaceRootCheck: boolean

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -85,6 +85,7 @@ export const types = Object.assign({
   'npm-path': String,
   offline: Boolean,
   'only-built-dependencies': [String],
+  'pack-gzip-level': Number,
   'package-import-method': ['auto', 'hardlink', 'clone', 'copy'],
   'patches-dir': String,
   pnpmfile: String,

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -113,6 +113,7 @@ export async function handler (
     projectDir: dir,
     embedReadme: opts.embedReadme,
     modulesDir: path.join(opts.dir, 'node_modules'),
+    packGzipLevel: opts.packGzipLevel,
   })
   if (!opts.ignoreScripts) {
     await _runScriptsIfPresent(['postpack'], entryManifest)

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -30,6 +30,9 @@ export function rcOptionsTypes () {
 export function cliOptionsTypes () {
   return {
     'pack-destination': String,
+    ...pick([
+      'pack-gzip-level',
+    ], allTypes),
   }
 }
 

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -133,7 +133,7 @@ export async function publish (
     engineStrict?: boolean
     recursive?: boolean
     workspaceDir?: string
-  } & Pick<Config, 'allProjects' | 'gitChecks' | 'ignoreScripts' | 'publishBranch' | 'embedReadme'>,
+  } & Pick<Config, 'allProjects' | 'gitChecks' | 'ignoreScripts' | 'publishBranch' | 'embedReadme' | 'packGzipLevel'>,
   params: string[]
 ) {
   if (opts.gitChecks !== false && await isGitRepo()) {

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -280,3 +280,21 @@ test('pack to custom destination directory', async () => {
 
   expect(output).toBe(path.resolve('custom-dest/custom-dest-0.0.0.tgz'))
 })
+
+test('pack: custom pack-gzip-level', async () => {
+  prepare({
+    name: 'test-publish-package.json',
+    version: '0.0.0',
+  })
+
+  await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    packGzipLevel: 9,
+  })
+
+  expect(await exists('test-publish-package.json-0.0.0.tgz')).toBeTruthy()
+  expect(await exists('package.json')).toBeTruthy()
+})

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -287,14 +287,25 @@ test('pack: custom pack-gzip-level', async () => {
     version: '0.0.0',
   })
 
-  await pack.handler({
+  const packOpts = {
     ...DEFAULT_OPTS,
     argv: { original: [] },
     dir: process.cwd(),
     extraBinPaths: [],
+  }
+  await pack.handler({
+    ...packOpts,
     packGzipLevel: 9,
+    packDestination: path.resolve('../small'),
   })
 
-  expect(await exists('test-publish-package.json-0.0.0.tgz')).toBeTruthy()
-  expect(await exists('package.json')).toBeTruthy()
+  await pack.handler({
+    ...packOpts,
+    packGzipLevel: 0,
+    packDestination: path.resolve('../big'),
+  })
+
+  const tgz1 = fs.statSync(path.resolve('../small/test-publish-package.json-0.0.0.tgz'))
+  const tgz2 = fs.statSync(path.resolve('../big/test-publish-package.json-0.0.0.tgz'))
+  expect(tgz1.size).not.toEqual(tgz2.size)
 })


### PR DESCRIPTION
This options allows specifying custom compression level.
Underlying node implementation enforces correct number ranges,
but silently ignores `NaN`, so we explicitly check that provided value is valid.

More information about this `level` option can be found in [node docs](https://nodejs.org/api/zlib.html#class-options) and [zlib specs](https://zlib.net/manual.html#Advanced).

Supported values are (`6` is default in node):
```c
// Compression levels.
#define Z_NO_COMPRESSION         0
#define Z_BEST_SPEED             1
#define Z_BEST_COMPRESSION       9
#define Z_DEFAULT_COMPRESSION  (-1)
```

I didn't add any test but I tested manually
that compressing with `-1`, `0` and `1` create an installable package.

Also tested manually that using `pnpm config set pack-gzip-level 0` and `--pack-gzip-level=0` both work as expected.

fix #6393
