### PR TITLE
fix: update node-fetch for node v20 compatibility

### DIFF
--- a/.changeset/polite-hats-impress.md
+++ b/.changeset/polite-hats-impress.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/plugin-commands-env": patch
+"@pnpm/fetching-types": patch
+"@pnpm/node.fetcher": patch
+"@pnpm/fetch": patch
+"@pnpm/server": patch
+---
+
+update node-fetch for Node v20 compatibility

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -51,6 +51,6 @@
     "@pnpm/node.fetcher": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@types/adm-zip": "^0.5.0",
-    "node-fetch": "3.0.0-beta.9"
+    "node-fetch": "^3.3.1"
   }
 }

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -58,7 +58,7 @@
     "adm-zip": "^0.5.10",
     "execa": "npm:safe-execa@0.1.2",
     "nock": "13.3.0",
-    "node-fetch": "3.0.0-beta.9",
+    "node-fetch": "^3.3.1",
     "path-name": "^1.0.0"
   },
   "exports": {

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -37,7 +37,7 @@
     "@pnpm/fetching-types": "workspace:*",
     "@pnpm/network.agent": "0.1.0",
     "@zkochan/retry": "^0.2.0",
-    "node-fetch": "3.0.0-beta.9"
+    "node-fetch": "^3.3.1"
   },
   "devDependencies": {
     "@pnpm/fetch": "workspace:*",

--- a/network/fetching-types/package.json
+++ b/network/fetching-types/package.json
@@ -31,7 +31,7 @@
   "funding": "https://opencollective.com/pnpm",
   "dependencies": {
     "@zkochan/retry": "^0.2.0",
-    "node-fetch": "3.0.0-beta.9"
+    "node-fetch": "^3.3.1"
   },
   "devDependencies": {
     "@pnpm/fetching-types": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,8 +845,8 @@ importers:
         specifier: ^0.5.0
         version: 0.5.0
       node-fetch:
-        specifier: 3.0.0-beta.9
-        version: 3.0.0-beta.9
+        specifier: ^3.3.1
+        version: 3.3.1
 
   env/node.resolver:
     dependencies:
@@ -952,8 +952,8 @@ importers:
         specifier: 13.3.0
         version: 13.3.0
       node-fetch:
-        specifier: 3.0.0-beta.9
-        version: 3.0.0-beta.9
+        specifier: ^3.3.1
+        version: 3.3.1
       path-name:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2209,8 +2209,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       node-fetch:
-        specifier: 3.0.0-beta.9
-        version: 3.0.0-beta.9
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@pnpm/fetch':
         specifier: workspace:*
@@ -2225,8 +2225,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       node-fetch:
-        specifier: 3.0.0-beta.9
-        version: 3.0.0-beta.9
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@pnpm/fetching-types':
         specifier: workspace:*
@@ -5743,8 +5743,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0
       node-fetch:
-        specifier: 3.0.0-beta.9
-        version: 3.0.0-beta.9
+        specifier: ^3.3.1
+        version: 3.3.1
       tempy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -10917,6 +10917,11 @@ packages:
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   /dayjs@1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
@@ -11838,6 +11843,14 @@ packages:
     peerDependenciesMeta:
       domexception:
         optional: true
+    dev: true
+
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
 
   /figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -11973,6 +11986,12 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
 
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -14438,6 +14457,10 @@ packages:
       semver: 5.7.1
     dev: true
 
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
   /node-fetch@2.6.8:
     resolution: {integrity: sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==}
     engines: {node: 4.x || >=6.0.0}
@@ -14469,6 +14492,15 @@ packages:
       fetch-blob: 2.1.2
     transitivePeerDependencies:
       - domexception
+    dev: true
+
+  /node-fetch@3.3.1:
+    resolution: {integrity: sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   /node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
@@ -17348,6 +17380,10 @@ packages:
       defaults: 1.0.4
     dev: true
 
+  /web-streams-polyfill@3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -17856,7 +17892,7 @@ time:
   /micromatch@4.0.5: '2022-03-24T19:31:47.722Z'
   /nerf-dart@1.0.0: '2015-08-20T12:22:17.009Z'
   /nock@13.3.0: '2023-01-10T20:34:45.381Z'
-  /node-fetch@3.0.0-beta.9: '2020-09-05T12:52:27.791Z'
+  /node-fetch@3.3.1: '2023-03-11T10:47:49.391Z'
   /node-gyp@9.3.1: '2022-12-19T22:43:10.187Z'
   /normalize-newline@3.0.0: '2016-09-06T12:35:43.571Z'
   /normalize-package-data@5.0.0: '2022-10-14T05:22:41.916Z'

--- a/store/server/package.json
+++ b/store/server/package.json
@@ -43,7 +43,7 @@
     "get-port": "^5.1.1",
     "is-port-reachable": "3.0.0",
     "load-json-file": "^6.2.0",
-    "node-fetch": "3.0.0-beta.9",
+    "node-fetch": "^3.3.1",
     "tempy": "^1.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #6424 (probably)

Unfortunately, the old version of fetch appears to still be in the lockfile. I'm pretty sure that's because there are some cycles caused by `@pnpm/meta-updater` which depends on a bunch of old pnpm monorepo packages which are duplicating the tree.