### PR TITLE
fix: spnpmImportsPlugin not work as expectation in pd

### DIFF
--- a/.changeset/little-waves-tease.md
+++ b/.changeset/little-waves-tease.md
@@ -1,5 +1,0 @@
----
-"pnpm": patch
----
-
-fix spnpmImportsPlugin to resolve the source code in pd

--- a/.changeset/little-waves-tease.md
+++ b/.changeset/little-waves-tease.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+fix spnpmImportsPlugin to resolve the source code in pd

--- a/pnpm/dev/pd.js
+++ b/pnpm/dev/pd.js
@@ -22,17 +22,13 @@ const pnpmPackageJson = JSON.parse(fs.readFileSync(pathLib.join(__dirname, 'pack
     name: 'spnpmImports',
     setup: (build) => {
       // E.g. @pnpm/config -> /<some_dir>/pnpm/packages/config/src/index.ts
-      build.onResolve({ filter: /@pnpm\// }, ({path, resolveDir}) => {
-        const pathParts = path.split('/')
-        const packageName = pathParts[1]
-
+      build.onResolve({ filter: /@pnpm\// }, ({ path, resolveDir }) => {
         // Bail if the package isn't present locally
-        if (!localPackages.includes(packageName)) {
+        if (!localPackages.includes(path)) {
           return
         }
 
-        const newPath = pathLib.resolve(dirByPackageName[packageName], packageName, 'src', 'index.ts')
-
+        const newPath = pathLib.resolve(dirByPackageName[path], 'src', 'index.ts')
         return {
           path: newPath
         }


### PR DESCRIPTION
 "spnpmImportsPlugin" didn't work as expected because of the wrong path in line:27

[pnpm/dev/pd.js#L26-L30](https://github.com/pnpm/pnpm/blob/8db1b48095e06de55725be99a17e5424e6e75b02/pnpm/dev/pd.js#L26-L30)

localPackages are ["@pnpm/constants", "@pnpm/xxx", ...] but the pathPart is `constants` `xxx` etc



