### PR TITLE
feat(pkg-manager): add new hoisting limits config

### DIFF
--- a/.changeset/few-falcons-search.md
+++ b/.changeset/few-falcons-search.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolve-dependencies": patch
+"@pnpm/real-hoist": patch
+"@pnpm/core": patch
+---
+
+fix incorrect frozen lockfile error when lockfile not present in hoisted mode

--- a/.changeset/kind-eagles-clean.md
+++ b/.changeset/kind-eagles-clean.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/resolve-dependencies": major
+"@pnpm/manifest-utils": major
+"@pnpm/real-hoist": major
+"@pnpm/headless": major
+"@pnpm/core": major
+"@pnpm/config": major
+---
+
+Change hoisting limit API to match yarn's nmHoistingLimit"

--- a/.changeset/twenty-taxis-film.md
+++ b/.changeset/twenty-taxis-film.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/resolve-dependencies": minor
+"@pnpm/real-hoist": minor
+"@pnpm/headless": minor
+"@pnpm/core": minor
+"@pnpm/config": minor
+---
+
+Add new hoisting-limit-mode config that controls hoisting limits in node-linker=hoisted

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -62,6 +62,7 @@ export const types = Object.assign({
   'git-branch-lockfile': Boolean,
   hoist: Boolean,
   'hoist-pattern': Array,
+  'hoisting-limit-mode': Boolean,
   'ignore-compatibility-db': Boolean,
   'ignore-dep-scripts': Boolean,
   'ignore-pnpmfile': Boolean,

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -62,7 +62,7 @@ export const types = Object.assign({
   'git-branch-lockfile': Boolean,
   hoist: Boolean,
   'hoist-pattern': Array,
-  'hoisting-limit-mode': Boolean,
+  'hoisting-limits': ['none', 'workspaces', 'dependencies'],
   'ignore-compatibility-db': Boolean,
   'ignore-dep-scripts': Boolean,
   'ignore-pnpmfile': Boolean,

--- a/pkg-manager/core/src/link/index.ts
+++ b/pkg-manager/core/src/link/index.ts
@@ -131,7 +131,10 @@ export async function link (
   if (opts.targetDependenciesField) {
     newPkg = await updateProjectManifestObject(opts.dir, opts.manifest, specsToUpsert)
     for (const { alias } of specsToUpsert) {
-      updatedWantedLockfile.importers[importerId].specifiers[alias] = getSpecFromPackageManifest(newPkg, alias)
+      const spec = getSpecFromPackageManifest(newPkg, alias)
+      if (spec != null) {
+        updatedWantedLockfile.importers[importerId].specifiers[alias] = spec
+      }
     }
   } else {
     newPkg = opts.manifest
@@ -182,7 +185,7 @@ function addLinkToLockfile (
   if (opts.manifest == null) return
 
   const availableSpec = getSpecFromPackageManifest(opts.manifest, opts.linkedPkgName)
-  if (availableSpec) {
+  if (availableSpec != null) {
     projectSnapshot.specifiers[opts.linkedPkgName] = availableSpec
   } else {
     delete projectSnapshot.specifiers[opts.linkedPkgName]

--- a/pkg-manager/core/test/hoistedNodeLinker/install.ts
+++ b/pkg-manager/core/test/hoistedNodeLinker/install.ts
@@ -219,15 +219,13 @@ test('running install scripts in a workspace that has no root project', async ()
 test('hoistingLimits should prevent packages to be hoisted', async () => {
   prepareEmpty()
 
-  const hoistingLimits = new Map()
-  hoistingLimits.set('.@', new Set(['send']))
   await install({
     dependencies: {
       send: '0.17.2',
     },
   }, await testDefaults({
     nodeLinker: 'hoisted',
-    hoistingLimits,
+    hoistingLimits: 'dependencies',
   }))
 
   expect(fs.existsSync('node_modules/ms')).toBeFalsy()

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -48,7 +48,7 @@ import {
   type IncludedDependencies,
   writeModulesManifest,
 } from '@pnpm/modules-yaml'
-import { getHoistingLimits, type HoistingLimitMode, type HoistingLimits } from '@pnpm/real-hoist'
+import { type HoistingLimits } from '@pnpm/real-hoist'
 import { readPackageJsonFromDir } from '@pnpm/read-package-json'
 import { readProjectManifestOnly, safeReadProjectManifestOnly } from '@pnpm/read-project-manifest'
 import {
@@ -73,9 +73,10 @@ import {
   type DirectDependenciesByImporterId,
   type DependenciesGraph,
   type DependenciesGraphNode,
+  type LockfileToDepGraphOptions,
   lockfileToDepGraph,
 } from './lockfileToDepGraph'
-import { lockfileToHoistedDepGraph, type LockfileToHoistedDepGraphOptions } from './lockfileToHoistedDepGraph'
+import { lockfileToHoistedDepGraph } from './lockfileToHoistedDepGraph'
 import { linkDirectDeps, type LinkedDirectDep } from '@pnpm/pkg-manager.direct-dep-linker'
 
 export type { HoistingLimits }
@@ -152,7 +153,6 @@ export interface HeadlessOptions {
   skipped: Set<string>
   enableModulesDir?: boolean
   nodeLinker?: 'isolated' | 'hoisted' | 'pnp'
-  hoistingLimitMode?: HoistingLimitMode
   useGitBranchLockfile?: boolean
   useLockfile?: boolean
 }
@@ -315,12 +315,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     virtualStoreDir,
     nodeVersion: opts.currentEngine.nodeVersion,
     pnpmVersion: opts.currentEngine.pnpmVersion,
-  } as LockfileToHoistedDepGraphOptions
-
-  if (opts.nodeLinker === 'hoisted' && !opts.hoistingLimits) {
-    lockfileToDepGraphOpts.hoistingLimits = getHoistingLimits(filteredLockfile, opts.hoistingLimitMode)
-  }
-
+  } as LockfileToDepGraphOptions
   const {
     directDependenciesByImporterId,
     graph,

--- a/pkg-manager/real-hoist/src/index.ts
+++ b/pkg-manager/real-hoist/src/index.ts
@@ -6,8 +6,6 @@ import {
 import * as dp from '@pnpm/dependency-path'
 import { hoist as _hoist, HoisterDependencyKind, type HoisterTree, type HoisterResult } from '@yarnpkg/nm'
 
-export type HoistingLimits = Map<string, Set<string>>
-
 export type { HoisterResult }
 
 /**
@@ -33,9 +31,9 @@ export type { HoisterResult }
  * - /packages/A/node_modules/B
  * - /packages/A/node_modules/B/node_modules/C
  */
-export type HoistingLimitMode = 'none' | 'workspaces' | 'dependencies'
+export type HoistingLimits = 'none' | 'workspaces' | 'dependencies'
 
-export function getHoistingLimits (lockfile: Lockfile, mode: HoistingLimitMode | undefined): HoistingLimits | undefined {
+function getHoistingLimits (lockfile: Lockfile, mode: HoistingLimits | undefined): Map<string, Set<string>> | undefined {
   if (!mode || mode === 'none') return undefined
 
   const hoistingLimits = new Map<string, Set<string>>()
@@ -115,7 +113,8 @@ export function hoist (
     node.dependencies.add(importerNode)
   }
 
-  const hoisterResult = _hoist(node, opts)
+  const hoistingLimits = getHoistingLimits(lockfile, opts?.hoistingLimits)
+  const hoisterResult = _hoist(node, { ...opts, hoistingLimits })
   if (opts?.externalDependencies) {
     for (const hoistedDep of hoisterResult.dependencies.values()) {
       if (opts.externalDependencies.has(hoistedDep.name)) {

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -376,7 +376,10 @@ function addDirectDependenciesToLockfile (
   }
 
   linkedPackages.forEach((linkedPkg) => {
-    newProjectSnapshot.specifiers[linkedPkg.alias] = getSpecFromPackageManifest(newManifest, linkedPkg.alias)
+    const spec = getSpecFromPackageManifest(newManifest, linkedPkg.alias)
+    if (spec != null) {
+      newProjectSnapshot.specifiers[linkedPkg.alias] = spec
+    }
   })
 
   const directDependenciesByAlias = directDependencies.reduce((acc, directDependency) => {
@@ -402,7 +405,10 @@ function addDirectDependenciesToLockfile (
       } else {
         newProjectSnapshot.dependencies[dep.alias] = ref
       }
-      newProjectSnapshot.specifiers[dep.alias] = getSpecFromPackageManifest(newManifest, dep.alias)
+      const spec = getSpecFromPackageManifest(newManifest, dep.alias)
+      if (spec != null) {
+        newProjectSnapshot.specifiers[dep.alias] = spec
+      }
     } else if (projectSnapshot.specifiers[alias]) {
       newProjectSnapshot.specifiers[alias] = projectSnapshot.specifiers[alias]
       if (projectSnapshot.dependencies?.[alias]) {

--- a/pkg-manifest/manifest-utils/src/getSpecFromPackageManifest.ts
+++ b/pkg-manifest/manifest-utils/src/getSpecFromPackageManifest.ts
@@ -3,10 +3,9 @@ import { type ProjectManifest, type DependenciesOrPeersField } from '@pnpm/types
 export function getSpecFromPackageManifest (
   manifest: Pick<ProjectManifest, DependenciesOrPeersField>,
   depName: string
-) {
+): string | undefined {
   return manifest.optionalDependencies?.[depName] ??
     manifest.dependencies?.[depName] ??
     manifest.devDependencies?.[depName] ??
-    manifest.peerDependencies?.[depName] ??
-    ''
+    manifest.peerDependencies?.[depName]
 }

--- a/pkg-manifest/manifest-utils/test/getSpecFromPackageManifest.test.ts
+++ b/pkg-manifest/manifest-utils/test/getSpecFromPackageManifest.test.ts
@@ -30,4 +30,8 @@ test('getSpecFromPackageManifest()', () => {
         foo: '2.0.0',
       },
     }, 'foo')).toEqual('2.0.0')
+
+  expect(
+    getSpecFromPackageManifest({}, 'foo')
+  ).toBeUndefined()
 })


### PR DESCRIPTION
Fixes #6457

This adds a new option which behaves the same as yarn's `nmHoistingLimits` config when pnpm is using `node-linker=hoisted`.

I have reused the same config names, however, they may require tweaking to reflect `pnpm`'s terminology. I'd love some feedback on that.

It also includes a bugfix needed to get things working; I can split that into another PR.

This PR needs tests, I'm pretty sure. Will work on that.