### PR TITLE
feat: the installation API should return installation stats

### DIFF
--- a/.changeset/dirty-comics-press.md
+++ b/.changeset/dirty-comics-press.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/core": major
+---
+
+Return installation stats. Breaking change to the API.

--- a/.changeset/selfish-dingos-confess.md
+++ b/.changeset/selfish-dingos-confess.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pkg-manager.direct-dep-linker": minor
+---
+
+Return the amount of linked dependencies.

--- a/.changeset/wild-radios-drum.md
+++ b/.changeset/wild-radios-drum.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/headless": minor
+---
+
+Return installation stats.

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -14,7 +14,7 @@ import {
 import { createBase32HashFromFile } from '@pnpm/crypto.base32-hash'
 import { PnpmError } from '@pnpm/error'
 import { getContext, type PnpmContext } from '@pnpm/get-context'
-import { headlessInstall } from '@pnpm/headless'
+import { headlessInstall, type InstallationResultStats } from '@pnpm/headless'
 import {
   makeNodeRequireOption,
   runLifecycleHook,
@@ -137,7 +137,7 @@ export async function install (
   } & InstallMutationOptions
 ) {
   const rootDir = opts.dir ?? process.cwd()
-  const projects = await mutateModules(
+  const { updatedProjects: projects } = await mutateModules(
     [
       {
         mutation: 'install',
@@ -186,7 +186,7 @@ export async function mutateModulesInSingleProject (
   },
   maybeOpts: Omit<MutateModulesOptions, 'allProjects'> & InstallMutationOptions
 ): Promise<UpdatedProject> {
-  const [updatedProject] = await mutateModules(
+  const result = await mutateModules(
     [
       {
         ...project,
@@ -203,13 +203,18 @@ export async function mutateModulesInSingleProject (
       }],
     }
   )
-  return updatedProject
+  return result.updatedProjects[0]
+}
+
+interface MutateModulesResult {
+  updatedProjects: UpdatedProject[]
+  stats: InstallationResultStats
 }
 
 export async function mutateModules (
   projects: MutatedProject[],
   maybeOpts: MutateModulesOptions
-): Promise<UpdatedProject[]> {
+): Promise<MutateModulesResult> {
   const reporter = maybeOpts?.reporter
   if ((reporter != null) && typeof reporter === 'function') {
     streamParser.on('data', reporter)
@@ -273,7 +278,7 @@ export async function mutateModules (
 
   return result
 
-  async function _install (): Promise<UpdatedProject[]> {
+  async function _install (): Promise<{ updatedProjects: UpdatedProject[], stats: InstallationResultStats }> {
     const scriptsOpts: RunLifecycleHooksConcurrentlyOptions = {
       extraBinPaths: opts.extraBinPaths,
       extraEnv: opts.extraEnv,
@@ -369,7 +374,13 @@ Note that in CI environments, this setting is enabled by default.`,
       if (opts.lockfileOnly) {
         // The lockfile will only be changed if the workspace will have new projects with no dependencies.
         await writeWantedLockfile(ctx.lockfileDir, ctx.wantedLockfile)
-        return projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir])
+        return {
+          updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
+          stats: {
+            added: 0,
+            linkedToRoot: 0,
+          },
+        }
       }
       if (!ctx.existsWantedLockfile) {
         if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
@@ -382,7 +393,7 @@ Note that in CI environments, this setting is enabled by default.`,
           logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
         }
         try {
-          await headlessInstall({
+          const { stats } = await headlessInstall({
             ...ctx,
             ...opts,
             currentEngine: {
@@ -409,13 +420,16 @@ Note that in CI environments, this setting is enabled by default.`,
               mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
             })
           }
-          return projects.map((mutatedProject) => {
-            const project = ctx.projects[mutatedProject.rootDir]
-            return {
-              ...project,
-              manifest: project.originalManifest ?? project.manifest,
-            }
-          })
+          return {
+            updatedProjects: projects.map((mutatedProject) => {
+              const project = ctx.projects[mutatedProject.rootDir]
+              return {
+                ...project,
+                manifest: project.originalManifest ?? project.manifest,
+              }
+            }),
+            stats,
+          }
         } catch (error: any) { // eslint-disable-line
           if (
             frozenLockfile ||
@@ -492,7 +506,13 @@ Note that in CI environments, this setting is enabled by default.`,
           }
         }
         if (packagesToInstall.length === 0) {
-          return projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir])
+          return {
+            updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
+            stats: {
+              added: 0,
+              linkedToRoot: 0,
+            },
+          }
         }
 
         // TODO: install only those that were unlinked
@@ -524,7 +544,13 @@ Note that in CI environments, this setting is enabled by default.`,
           }
         }
         if (packagesToInstall.length === 0) {
-          return projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir])
+          return {
+            updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
+            stats: {
+              added: 0,
+              linkedToRoot: 0,
+            },
+          }
         }
 
         // TODO: install only those that were unlinked
@@ -611,7 +637,10 @@ Note that in CI environments, this setting is enabled by default.`,
       patchedDependencies: patchedDependenciesWithResolvedPath,
     })
 
-    return result.projects
+    return {
+      updatedProjects: result.projects,
+      stats: result.stats,
+    }
   }
 }
 
@@ -721,7 +750,7 @@ export async function addDependenciesToPackage (
   } & InstallMutationOptions
 ) {
   const rootDir = opts.dir ?? process.cwd()
-  const projects = await mutateModules(
+  const { updatedProjects: projects } = await mutateModules(
     [
       {
         allowNew: opts.allowNew,
@@ -775,6 +804,7 @@ export interface UpdatedProject {
 interface InstallFunctionResult {
   newLockfile: Lockfile
   projects: UpdatedProject[]
+  stats: InstallationResultStats
 }
 
 type InstallFunction = (
@@ -980,6 +1010,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     useGitBranchLockfile: opts.useGitBranchLockfile,
     mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
   }
+  let added = 0
+  let linkedToRoot = 0
   if (!opts.lockfileOnly && !isInstallationOnlyForLockfileCheck && opts.enableModulesDir) {
     const result = await linkPackages(
       projects,
@@ -1014,6 +1046,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         wantedToBeSkippedPackageIds,
       }
     )
+    added = result.stats.added
+    linkedToRoot = result.stats.linkedToRoot
     await finishLockfileUpdates()
     if (opts.enablePnp) {
       const importerNames = Object.fromEntries(
@@ -1255,6 +1289,10 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       peerDependencyIssues: peerDependencyIssuesByProjects[id],
       rootDir,
     })),
+    stats: {
+      added,
+      linkedToRoot,
+    },
   }
 }
 
@@ -1281,7 +1319,7 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
         ...opts,
         lockfileOnly: true,
       })
-      await headlessInstall({
+      const { stats } = await headlessInstall({
         ...ctx,
         ...opts,
         currentEngine: {
@@ -1295,7 +1333,10 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
         wantedLockfile: result.newLockfile,
         useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
       })
-      return result
+      return {
+        ...result,
+        stats,
+      }
     }
     return await _installInContext(projects, ctx, opts)
   } catch (error: any) { // eslint-disable-line

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -378,6 +378,7 @@ Note that in CI environments, this setting is enabled by default.`,
           updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
           stats: {
             added: 0,
+            removed: 0,
             linkedToRoot: 0,
           },
         }
@@ -510,6 +511,7 @@ Note that in CI environments, this setting is enabled by default.`,
             updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
             stats: {
               added: 0,
+              removed: 0,
               linkedToRoot: 0,
             },
           }
@@ -548,6 +550,7 @@ Note that in CI environments, this setting is enabled by default.`,
             updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
             stats: {
               added: 0,
+              removed: 0,
               linkedToRoot: 0,
             },
           }
@@ -1011,6 +1014,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
   }
   let added = 0
+  let removed = 0
   let linkedToRoot = 0
   if (!opts.lockfileOnly && !isInstallationOnlyForLockfileCheck && opts.enableModulesDir) {
     const result = await linkPackages(
@@ -1047,6 +1051,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       }
     )
     added = result.stats.added
+    removed = result.stats.removed
     linkedToRoot = result.stats.linkedToRoot
     await finishLockfileUpdates()
     if (opts.enablePnp) {
@@ -1291,6 +1296,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     })),
     stats: {
       added,
+      removed,
       linkedToRoot,
     },
   }

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -76,7 +76,7 @@ export async function linkPackages (
     newDepPaths: string[]
     newHoistedDependencies: HoistedDependencies
     removedDepPaths: Set<string>
-    stats: { added: number, linkedToRoot: number }
+    stats: { added: number, removed: number, linkedToRoot: number }
   }> {
   let depNodes = Object.values(depGraph).filter(({ depPath, id }) => {
     if (((opts.wantedLockfile.packages?.[depPath]) != null) && !opts.wantedLockfile.packages[depPath].optional) {
@@ -276,7 +276,11 @@ export async function linkPackages (
     newDepPaths,
     newHoistedDependencies,
     removedDepPaths,
-    stats: { added, linkedToRoot },
+    stats: {
+      added,
+      removed: removedDepPaths.size,
+      linkedToRoot,
+    },
   }
 }
 

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -10,6 +10,7 @@ import {
   filterLockfileByImporters,
 } from '@pnpm/filter-lockfile'
 import { linkDirectDeps } from '@pnpm/pkg-manager.direct-dep-linker'
+import { type InstallationResultStats } from '@pnpm/headless'
 import { hoist } from '@pnpm/hoist'
 import { type Lockfile } from '@pnpm/lockfile-file'
 import { logger } from '@pnpm/logger'
@@ -76,7 +77,7 @@ export async function linkPackages (
     newDepPaths: string[]
     newHoistedDependencies: HoistedDependencies
     removedDepPaths: Set<string>
-    stats: { added: number, removed: number, linkedToRoot: number }
+    stats: InstallationResultStats
   }> {
   let depNodes = Object.values(depGraph).filter(({ depPath, id }) => {
     if (((opts.wantedLockfile.packages?.[depPath]) != null) && !opts.wantedLockfile.packages[depPath].optional) {

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -76,6 +76,7 @@ export async function linkPackages (
     newDepPaths: string[]
     newHoistedDependencies: HoistedDependencies
     removedDepPaths: Set<string>
+    stats: { added: number, linkedToRoot: number }
   }> {
   let depNodes = Object.values(depGraph).filter(({ depPath, id }) => {
     if (((opts.wantedLockfile.packages?.[depPath]) != null) && !opts.wantedLockfile.packages[depPath].optional) {
@@ -131,7 +132,7 @@ export async function linkPackages (
     failOnMissingDependencies: true,
     skipped: new Set(),
   })
-  const newDepPaths = await linkNewPackages(
+  const { newDepPaths, added } = await linkNewPackages(
     filterLockfileByImporters(opts.currentLockfile, projectIds, {
       ...filterOpts,
       failOnMissingDependencies: false,
@@ -223,6 +224,7 @@ export async function linkPackages (
     newHoistedDependencies = opts.hoistedDependencies
   }
 
+  let linkedToRoot = 0
   if (opts.symlink) {
     const projectsToLink = Object.fromEntries(await Promise.all(
       projects.map(async ({ id, manifest, modulesDir, rootDir }) => {
@@ -266,7 +268,7 @@ export async function linkPackages (
         }]
       }))
     )
-    await linkDirectDeps(projectsToLink, { dedupe: opts.dedupeDirectDeps })
+    linkedToRoot = await linkDirectDeps(projectsToLink, { dedupe: opts.dedupeDirectDeps })
   }
 
   return {
@@ -274,6 +276,7 @@ export async function linkPackages (
     newDepPaths,
     newHoistedDependencies,
     removedDepPaths,
+    stats: { added, linkedToRoot },
   }
 }
 
@@ -301,7 +304,7 @@ async function linkNewPackages (
     storeController: StoreController
     virtualStoreDir: string
   }
-): Promise<string[]> {
+): Promise<{ newDepPaths: string[], added: number }> {
   const wantedRelDepPaths = difference(Object.keys(wantedLockfile.packages ?? {}), Array.from(opts.skipped))
 
   let newDepPathsSet: Set<string>
@@ -316,8 +319,9 @@ async function linkNewPackages (
     newDepPathsSet = await selectNewFromWantedDeps(wantedRelDepPaths, currentLockfile, depGraph)
   }
 
+  const added = newDepPathsSet.size
   statsLogger.debug({
-    added: newDepPathsSet.size,
+    added,
     prefix: opts.lockfileDir,
   })
 
@@ -338,7 +342,7 @@ async function linkNewPackages (
     }
   }
 
-  if (!newDepPathsSet.size && (existingWithUpdatedDeps.length === 0)) return []
+  if (!newDepPathsSet.size && (existingWithUpdatedDeps.length === 0)) return { newDepPaths: [], added }
 
   const newDepPaths = Array.from(newDepPathsSet)
 
@@ -362,7 +366,7 @@ async function linkNewPackages (
     }),
   ])
 
-  return newDepPaths
+  return { newDepPaths, added }
 }
 
 async function selectNewFromWantedDeps (

--- a/pkg-manager/core/test/hoistedNodeLinker/install.ts
+++ b/pkg-manager/core/test/hoistedNodeLinker/install.ts
@@ -114,7 +114,7 @@ test('preserve subdeps on update', async () => {
 test('adding a new dependency to one of the workspace projects', async () => {
   prepareEmpty()
 
-  let [{ manifest }] = await mutateModules([
+  let [{ manifest }] = (await mutateModules([
     {
       mutation: 'install',
       rootDir: path.resolve('project-1'),
@@ -151,7 +151,7 @@ test('adding a new dependency to one of the workspace projects', async () => {
       },
     ],
     nodeLinker: 'hoisted',
-  }))
+  }))).updatedProjects
   manifest = await addDependenciesToPackage(
     manifest,
     ['is-negative@1.0.0'],

--- a/pkg-manager/core/test/install/injectLocalPackages.ts
+++ b/pkg-manager/core/test/install/injectLocalPackages.ts
@@ -1481,11 +1481,11 @@ test('do not modify the manifest of the injected workpspace project', async () =
       },
     },
   }
-  const [project1] = await mutateModules(importers, await testDefaults({
+  const [project1] = (await mutateModules(importers, await testDefaults({
     autoInstallPeers: false,
     allProjects,
     workspacePackages,
-  }))
+  }))).updatedProjects
   expect(project1.manifest).toStrictEqual({
     name: 'project-1',
     version: '1.0.0',

--- a/pkg-manager/core/test/install/multipleImporters.ts
+++ b/pkg-manager/core/test/install/multipleImporters.ts
@@ -248,7 +248,7 @@ test('dependencies of other importers are not pruned when installing for a subse
     },
   ])
 
-  const [{ manifest }] = await mutateModules([
+  const [{ manifest }] = (await mutateModules([
     {
       mutation: 'install',
       rootDir: path.resolve('project-1'),
@@ -284,7 +284,7 @@ test('dependencies of other importers are not pruned when installing for a subse
         rootDir: path.resolve('project-2'),
       },
     ],
-  }))
+  }))).updatedProjects
 
   await addDependenciesToPackage(manifest, ['is-positive@2'], await testDefaults({
     dir: path.resolve('project-1'),
@@ -357,7 +357,7 @@ test('dependencies of other importers are not pruned when (headless) installing 
       rootDir: path.resolve('project-2'),
     },
   ]
-  const [{ manifest }] = await mutateModules(importers, await testDefaults({ allProjects }))
+  const [{ manifest }] = (await mutateModules(importers, await testDefaults({ allProjects }))).updatedProjects
 
   await addDependenciesToPackage(manifest, ['is-positive@2'], await testDefaults({
     dir: path.resolve('project-1'),
@@ -384,7 +384,7 @@ test('dependencies of other importers are not pruned when (headless) installing 
 test('adding a new dev dependency to project that uses a shared lockfile', async () => {
   prepareEmpty()
 
-  let [{ manifest }] = await mutateModules([
+  let [{ manifest }] = (await mutateModules([
     {
       mutation: 'install',
       rootDir: path.resolve('project-1'),
@@ -404,7 +404,7 @@ test('adding a new dev dependency to project that uses a shared lockfile', async
         rootDir: path.resolve('project-1'),
       },
     ],
-  }))
+  }))).updatedProjects
   manifest = await addDependenciesToPackage(manifest, ['is-negative@1.0.0'], await testDefaults({ prefix: path.resolve('project-1'), targetDependenciesField: 'devDependencies' }))
 
   expect(manifest.dependencies).toStrictEqual({ 'is-positive': '1.0.0' })
@@ -922,7 +922,7 @@ test('adding a new dependency with the workspace: protocol and save-workspace-pr
 test('update workspace range', async () => {
   prepareEmpty()
 
-  const updatedImporters = await mutateModules([
+  const { updatedProjects: updatedImporters } = await mutateModules([
     {
       dependencySelectors: ['dep1', 'dep2', 'dep3', 'dep4', 'dep5', 'dep6'],
       mutation: 'installSome',
@@ -1068,7 +1068,7 @@ test('update workspace range', async () => {
 test('update workspace range when save-workspace-protocol is "rolling"', async () => {
   prepareEmpty()
 
-  const updatedImporters = await mutateModules([
+  const { updatedProjects: updatedImporters } = await mutateModules([
     {
       dependencySelectors: ['dep1', 'dep2', 'dep3', 'dep4', 'dep5', 'dep6'],
       mutation: 'installSome',

--- a/pkg-manager/core/test/install/optionalDependencies.ts
+++ b/pkg-manager/core/test/install/optionalDependencies.ts
@@ -465,7 +465,7 @@ test('skip optional dependency that does not support the current OS, when doing 
     },
   ])
 
-  const [{ manifest }] = await mutateModules(
+  const [{ manifest }] = (await mutateModules(
     [
       {
         mutation: 'install',
@@ -506,7 +506,7 @@ test('skip optional dependency that does not support the current OS, when doing 
       lockfileDir: process.cwd(),
       lockfileOnly: true,
     })
-  )
+  )).updatedProjects
 
   await mutateModulesInSingleProject({
     manifest,

--- a/pkg-manager/core/test/install/stats.ts
+++ b/pkg-manager/core/test/install/stats.ts
@@ -1,0 +1,57 @@
+import { prepareEmpty } from '@pnpm/prepare'
+import {
+  mutateModules,
+  type MutatedProject,
+} from '@pnpm/core'
+import rimraf from '@zkochan/rimraf'
+import { testDefaults } from '../utils'
+
+test('spec not specified in package.json.dependencies', async () => {
+  prepareEmpty()
+
+  const importers: MutatedProject[] = [
+    {
+      mutation: 'install',
+      rootDir: process.cwd(),
+    },
+  ]
+  const allProjects = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        version: '1.0.0',
+
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+      },
+      rootDir: process.cwd(),
+    },
+  ]
+  {
+    const { stats } = await mutateModules(importers, await testDefaults({ allProjects }))
+    expect(stats.added).toEqual(1)
+    expect(stats.removed).toEqual(0)
+    expect(stats.linkedToRoot).toEqual(1)
+  }
+  await rimraf('node_modules')
+  {
+    const { stats } = await mutateModules(importers, await testDefaults({ allProjects, frozenLockfile: true }))
+    expect(stats.added).toEqual(1)
+    expect(stats.removed).toEqual(0)
+    expect(stats.linkedToRoot).toEqual(1)
+  }
+  {
+    const { stats } = await mutateModules([
+      {
+        mutation: 'uninstallSome',
+        dependencyNames: ['is-positive'],
+        rootDir: process.cwd(),
+      },
+    ], await testDefaults({ allProjects, frozenLockfile: true }))
+    expect(stats.added).toEqual(0)
+    expect(stats.removed).toEqual(1)
+    expect(stats.linkedToRoot).toEqual(0)
+  }
+})

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -159,6 +159,7 @@ export interface HeadlessOptions {
 
 export interface InstallationResultStats {
   added: number
+  removed: number
   linkedToRoot: number
 }
 
@@ -224,9 +225,10 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   }
 
   const skipped = opts.skipped || new Set<string>()
+  let removed = 0
   if (opts.nodeLinker !== 'hoisted') {
     if (currentLockfile != null && !opts.ignorePackageManifest) {
-      await prune(
+      const removedDepPaths = await prune(
         selectedProjects,
         {
           currentLockfile,
@@ -245,6 +247,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
           wantedLockfile,
         }
       )
+      removed = removedDepPaths.size
     } else {
       statsLogger.debug({
         prefix: lockfileDir,
@@ -616,6 +619,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   return {
     stats: {
       added,
+      removed,
       linkedToRoot,
     },
   }

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -277,7 +277,7 @@ export async function recursive (
       throw new PnpmError('NO_PACKAGE_IN_DEPENDENCIES',
         'None of the specified packages were found in the dependencies of any of the projects.')
     }
-    const mutatedPkgs = await mutateModules(mutatedImporters, {
+    const { updatedProjects: mutatedPkgs } = await mutateModules(mutatedImporters, {
       ...installOpts,
       storeController: store.ctrl,
     })
@@ -340,14 +340,14 @@ export async function recursive (
           break
         case 'remove':
           action = async (manifest: PackageManifest, opts: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-            const [{ manifest: newManifest }] = await mutateModules([
+            const mutationResult = await mutateModules([
               {
                 dependencyNames: currentInput,
                 mutation: 'uninstallSome',
                 rootDir,
               },
             ], opts)
-            return newManifest
+            return mutationResult.updatedProjects[0].manifest
           }
           break
         default:


### PR DESCRIPTION
The `stats` object is useful for detecting if there were changes done to the `node_modules` during installation.