### PR TITLE
feat: expanded missing command error, including 'did you mean'

### DIFF
--- a/.changeset/pink-tips-rule.md
+++ b/.changeset/pink-tips-rule.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"@pnpm/cli-utils": patch
+---
+
+feat: expanded missing command error, including 'did you mean'

--- a/.changeset/pink-tips-rule.md
+++ b/.changeset/pink-tips-rule.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/plugin-commands-script-runners": minor
 "@pnpm/cli-utils": patch
+"pnpm": patch
 ---
 
-feat: expanded missing command error, including 'did you mean'
+Expanded missing command error, including 'did you mean' [#6492](https://github.com/pnpm/pnpm/issues/6492).

--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -39,7 +39,7 @@ declare module '@pnpm/npm-package-arg' {
   export = anything
 }
 
-declare module '@zkochan/which' {
+declare module '@pnpm/which' {
   const anything: any
   export = anything
 }

--- a/cli/cli-utils/src/readProjectManifest.ts
+++ b/cli/cli-utils/src/readProjectManifest.ts
@@ -23,7 +23,7 @@ export async function readProjectManifestOnly (
   opts: {
     engineStrict?: boolean
     nodeVersion?: string
-  }
+  } = {}
 ): Promise<ProjectManifest> {
   const manifest = await utils.readProjectManifestOnly(projectDir)
   packageIsInstallable(projectDir, manifest as any, opts) // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -58,6 +58,7 @@
     "@pnpm/store-path": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@zkochan/rimraf": "^2.1.2",
+    "didyoumean2": "^5.0.0",
     "execa": "npm:safe-execa@0.1.2",
     "p-limit": "^3.1.0",
     "path-exists": "^4.0.0",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -67,7 +67,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
-    "which": "^3.0.0",
+    "which": "npm:@zkochan/which@^2.0.3",
     "write-json-file": "^4.3.0"
   },
   "peerDependencies": {

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -67,7 +67,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
-    "which": "npm:@zkochan/which@^2.0.3",
+    "which": "npm:@pnpm/which@^3.0.1",
     "write-json-file": "^4.3.0"
   },
   "peerDependencies": {

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -40,6 +40,7 @@
     "@pnpm/registry-mock": "3.8.0",
     "@types/is-windows": "^1.0.0",
     "@types/ramda": "0.28.20",
+    "@types/which": "^2.0.2",
     "is-windows": "^1.0.2",
     "write-yaml-file": "^5.0.0"
   },
@@ -66,6 +67,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
+    "which": "^3.0.0",
     "write-json-file": "^4.3.0"
   },
   "peerDependencies": {

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -9,7 +9,7 @@ export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageS
   })
 
   if (nearestCommand) {
-    hint += ` Did you mean "pnpm run ${nearestCommand}"`
+    hint += ` Did you mean "pnpm run ${nearestCommand}"?`
   }
 
   return hint

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -1,0 +1,16 @@
+import { type PackageScripts } from '@pnpm/types'
+import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
+
+export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {
+  let hint = `Command "${scriptName}" not found.`
+
+  const nearestCommand = scripts && didYouMean(scriptName, Object.keys(scripts), {
+    returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
+  })
+
+  if (nearestCommand) {
+    hint += ` Did you mean "pnpm run ${nearestCommand}"`
+  }
+
+  return hint
+}

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { docsUrl, type RecursiveSummary, throwOnCommandFail } from '@pnpm/cli-utils'
+import { docsUrl, type RecursiveSummary, throwOnCommandFail, readProjectManifestOnly } from '@pnpm/cli-utils'
 import { type Config, types } from '@pnpm/config'
 import { makeNodeRequireOption } from '@pnpm/lifecycle'
 import { logger } from '@pnpm/logger'
@@ -20,6 +20,7 @@ import {
 } from './run'
 import { PnpmError } from '@pnpm/error'
 import writeJsonFile from 'write-json-file'
+import { buildCommandNotFoundHint } from './buildCommandNotFoundHint'
 
 export const shorthands = {
   parallel: runShorthands.parallel,
@@ -224,6 +225,10 @@ export async function handler (
 
           if (!opts.bail) {
             return
+          }
+
+          if (err.originalMessage === `spawn ${params[0]} ENOENT`) {
+            err.hint = buildCommandNotFoundHint(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
           }
 
           if (!err['code']?.startsWith('ERR_PNPM_')) {

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -212,7 +212,8 @@ export async function handler (
         } catch (err: any) { // eslint-disable-line
           if (await isErrorCommandNotFound(params[0], err)) {
             err.hint = buildCommandNotFoundHint(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
-          } else if (!opts.recursive && typeof err.exitCode === 'number') {
+          }
+          if (!opts.recursive && typeof err.exitCode === 'number') {
             exitCode = err.exitCode
             return
           }

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -212,8 +212,7 @@ export async function handler (
         } catch (err: any) { // eslint-disable-line
           if (await isErrorCommandNotFound(params[0], err)) {
             err.hint = buildCommandNotFoundHint(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
-          }
-          if (!opts.recursive && typeof err.exitCode === 'number') {
+          } else if (!opts.recursive && typeof err.exitCode === 'number') {
             exitCode = err.exitCode
             return
           }

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -21,6 +21,7 @@ import renderHelp from 'render-help'
 import { runRecursive, type RecursiveRunOpts, getSpecifiedScripts as getSpecifiedScriptWithoutStartCommand } from './runRecursive'
 import { existsInDir } from './existsInDir'
 import { handler as exec } from './exec'
+import { buildCommandNotFoundHint } from './buildCommandNotFoundHint'
 
 export const IF_PRESENT_OPTION = {
   'if-present': Boolean,
@@ -197,7 +198,10 @@ so you may run "pnpm -w run ${scriptName}"`,
         })
       }
     }
-    throw new PnpmError('NO_SCRIPT', `Missing script: ${scriptName}`)
+
+    throw new PnpmError('NO_SCRIPT', `Missing script: ${scriptName}`, {
+      hint: buildCommandNotFoundHint(scriptName, manifest.scripts),
+    })
   }
   const lifecycleOpts: RunLifecycleHookOptions = {
     depPath: dir,

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -832,5 +832,5 @@ test('pnpm exec command not found', async () => {
   } catch (err: any) { // eslint-disable-line
     error = err
   }
-  expect(error?.hint).toBe('Command "buil" not found. Did you mean "pnpm run build"')
+  expect(error?.hint).toBe('Command "buil" not found. Did you mean "pnpm run build"?')
 })

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -811,3 +811,26 @@ test('pnpm recursive exec report summary with --bail', async () => {
   expect(executionStatus[path.resolve('project-3')].status).toBe('running')
   expect(executionStatus[path.resolve('project-4')].status).toBe('queued')
 })
+
+test('pnpm exec command not found', async () => {
+  prepare({
+    scripts: {
+      build: 'echo hello',
+    },
+  })
+
+  const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
+  let error!: Error & { hint: string }
+  try {
+    await exec.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      recursive: false,
+      bail: true,
+      selectedProjectsGraph,
+    }, ['buil'])
+  } catch (err: any) { // eslint-disable-line
+    error = err
+  }
+  expect(error?.hint).toBe('Command "buil" not found. Did you mean "pnpm run build"')
+})

--- a/exec/plugin-commands-script-runners/test/index.ts
+++ b/exec/plugin-commands-script-runners/test/index.ts
@@ -585,3 +585,22 @@ test('pnpm run with RegExp script selector with flag should throw error', async 
   }
   expect(err.message).toBe('RegExp flags are not supported in script command selector')
 })
+
+test('pnpm run with slightly incorrect command suggests correct one', async () => {
+  prepare({
+    scripts: {
+      build: 'echo 0',
+    },
+  })
+
+  await expect(run.handler({
+    dir: process.cwd(),
+    extraBinPaths: [],
+    extraEnv: {},
+    rawConfig: {},
+    workspaceConcurrency: 1,
+  }, ['buil'])).rejects.toEqual(expect.objectContaining({
+    code: 'ERR_PNPM_NO_SCRIPT',
+    hint: 'Command "buil" not found. Did you mean "pnpm run build"',
+  }))
+})

--- a/exec/plugin-commands-script-runners/test/index.ts
+++ b/exec/plugin-commands-script-runners/test/index.ts
@@ -601,6 +601,6 @@ test('pnpm run with slightly incorrect command suggests correct one', async () =
     workspaceConcurrency: 1,
   }, ['buil'])).rejects.toEqual(expect.objectContaining({
     code: 'ERR_PNPM_NO_SCRIPT',
-    hint: 'Command "buil" not found. Did you mean "pnpm run build"',
+    hint: 'Command "buil" not found. Did you mean "pnpm run build"?',
   }))
 })

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -90,7 +90,7 @@
     "@yarnpkg/parsers": "3.0.0-rc.42",
     "@zkochan/rimraf": "^2.1.2",
     "@zkochan/table": "^2.0.1",
-    "@zkochan/which": "^2.0.3",
+    "@pnpm/which": "^3.0.1",
     "chalk": "^4.1.2",
     "ci-info": "^3.8.0",
     "enquirer": "^2.3.6",

--- a/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
+++ b/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import which from '@zkochan/which'
+import which from '@pnpm/which'
 
 export async function getNodeExecPath () {
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,6 +1267,9 @@ importers:
       render-help:
         specifier: ^1.0.3
         version: 1.0.3
+      which:
+        specifier: ^3.0.0
+        version: 3.0.0
       write-json-file:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1289,6 +1292,9 @@ importers:
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
+      '@types/which':
+        specifier: ^2.0.2
+        version: 2.0.2
       is-windows:
         specifier: ^1.0.2
         version: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1243,6 +1243,9 @@ importers:
       '@zkochan/rimraf':
         specifier: ^2.1.2
         version: 2.1.2
+      didyoumean2:
+        specifier: ^5.0.0
+        version: 5.0.0
       execa:
         specifier: npm:safe-execa@0.1.2
         version: /safe-execa@0.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,8 +1268,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       which:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: npm:@zkochan/which@^2.0.3
+        version: /@zkochan/which@2.0.3
       write-json-file:
         specifier: ^4.3.0
         version: 4.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1268,8 +1268,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       which:
-        specifier: npm:@zkochan/which@^2.0.3
-        version: /@zkochan/which@2.0.3
+        specifier: npm:@pnpm/which@^3.0.1
+        version: /@pnpm/which@3.0.1
       write-json-file:
         specifier: ^4.3.0
         version: 4.3.0
@@ -3652,6 +3652,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@pnpm/which':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@pnpm/workspace.pkgs-graph':
         specifier: workspace:*
         version: link:../../workspace/pkgs-graph
@@ -3670,9 +3673,6 @@ importers:
       '@zkochan/table':
         specifier: ^2.0.1
         version: 2.0.1
-      '@zkochan/which':
-        specifier: ^2.0.3
-        version: 2.0.3
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -8759,6 +8759,14 @@ packages:
     dependencies:
       semver-utils: 1.1.4
     dev: true
+
+  /@pnpm/which@3.0.1:
+    resolution: {integrity: sha512-4ivtS12Oni9axgGefaq+gTPD+7N0VPCFdxFH8izCaWfnxLQblX3iVxba+25ZoagStlzUs8sQg8OMKlCVhyGWTw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
 
   /@pnpm/write-project-manifest@4.1.2:
     resolution: {integrity: sha512-/C0j7SsE9tGoj++f0dwePIV7zNZHcX8TcYL6pXNvZZCq4HsOMCBsIlcU9oMI/AGe+KMDfHFQSayWPO9QUuGE5w==}
@@ -17766,6 +17774,7 @@ time:
   /@pnpm/semver-diff@1.1.0: '2021-11-16T12:40:59.941Z'
   /@pnpm/tabtab@0.1.2: '2021-03-05T17:31:19.932Z'
   /@pnpm/util.lex-comparator@1.0.0: '2022-11-04T01:03:46.134Z'
+  /@pnpm/which@3.0.1: '2023-05-14T22:08:27.551Z'
   /@types/adm-zip@0.5.0: '2022-04-01T08:01:50.776Z'
   /@types/archy@0.0.32: '2021-07-06T18:11:33.301Z'
   /@types/byline@4.2.33: '2021-07-06T18:22:06.440Z'
@@ -17819,7 +17828,6 @@ time:
   /@zkochan/retry@0.2.0: '2020-06-06T23:36:55.687Z'
   /@zkochan/rimraf@2.1.2: '2022-01-30T23:37:31.206Z'
   /@zkochan/table@2.0.1: '2023-03-20T00:49:51.928Z'
-  /@zkochan/which@2.0.3: '2021-09-14T23:50:27.657Z'
   /adm-zip@0.5.10: '2022-12-20T11:08:08.848Z'
   /ansi-diff@1.1.1: '2018-06-16T13:37:28.365Z'
   /archy@1.0.0: '2014-09-14T07:57:58.806Z'


### PR DESCRIPTION
Fixes #6492

For both the `exec` and `run` commands, adds a `hint` property based on a new `buildCommandNotFoundHint` utility.

Reuses the [`didyoumean2`](https://npmjs.com/package/didyoumean2) package already used elsewhere in pnpm (and, fun fact, npm & yarn!).

Co-authored-by: Zoltan Kochan <z@kochan.io>