### PR TITLE
chore: update root corepack packageManager field for Node 20 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "verdaccio": "5.20.1"
   },
   "engines": {
-    "pnpm": ">=8.0.0-beta.0"
+    "pnpm": ">=8.5.0"
   },
-  "packageManager": "pnpm@8.0.0-beta.0",
+  "packageManager": "pnpm@8.5.0",
   "pnpm": {
     "overrides": {
       "@yarnpkg/fslib": "3.0.0-rc.25",


### PR DESCRIPTION
I've moved my local default to Node 20 and am now hitting the case where the pnpm version set by corepack is really really old (which then hits the `this` errors); this bumps it to the latest.

Not sure if I should also bump the `engines` too, though. Probably yes?