### PR TITLE
do not throw MISSING_HOISTED_LOCATIONS for optional packages

### DIFF
--- a/.changeset/kind-windows-reflect.md
+++ b/.changeset/kind-windows-reflect.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-rebuild": patch
+"pnpm": patch
+---
+
+`pnpm rebuild` should not fail when `node-linker` is set to `hoisted` and there are skipped optional dependencies [#6553](https://github.com/pnpm/pnpm/pull/6553).

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -281,9 +281,13 @@ async function _rebuild (
         ? (ctx.modulesFile?.hoistedLocations?.[depPath] ?? []).map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
         : [path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath), 'node_modules', pkgInfo.name)]
       if (pkgRoots.length === 0) {
-        throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
-          hint: 'If you installed your node_modules with pnpm older than v7.19.0, you may need to remove it and run "pnpm install"',
-        })
+        if (pkgSnapshot.optional) {
+          return
+        } else {
+          throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
+            hint: 'If you installed your node_modules with pnpm older than v7.19.0, you may need to remove it and run "pnpm install"',
+          })
+        }
       }
       const pkgRoot = pkgRoots[0]
       try {

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -281,13 +281,10 @@ async function _rebuild (
         ? (ctx.modulesFile?.hoistedLocations?.[depPath] ?? []).map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
         : [path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath), 'node_modules', pkgInfo.name)]
       if (pkgRoots.length === 0) {
-        if (pkgSnapshot.optional) {
-          return
-        } else {
-          throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
-            hint: 'If you installed your node_modules with pnpm older than v7.19.0, you may need to remove it and run "pnpm install"',
-          })
-        }
+        if (pkgSnapshot.optional) return
+        throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
+          hint: 'If you installed your node_modules with pnpm older than v7.19.0, you may need to remove it and run "pnpm install"',
+        })
       }
       const pkgRoot = pkgRoots[0]
       try {


### PR DESCRIPTION
When using node-linker=hoisted the MISSING_HOISTED_LOCATIONS error (added by https://github.com/pnpm/pnpm/pull/5819) is thrown if an optional dependency is missing in the hoisted locations in `node_modules/.modules.yaml`.

This makes it impossible to have a successful install.

See https://github.com/pnpm/pnpm/issues/6092 which was similar but for skipped dependencies.