### PR TITLE
fix: lifecycle buildindex sort

### DIFF
--- a/.changeset/twelve-ears-thank.md
+++ b/.changeset/twelve-ears-thank.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lifecycle": patch
+"pnpm": patch
+---
+
+Build projects in a workspace in correct order [#6568](https://github.com/pnpm/pnpm/pull/6568).

--- a/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
+++ b/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
@@ -38,7 +38,7 @@ export async function runLifecycleHooksConcurrently (
       importersByBuildIndex.get(importer.buildIndex)!.push(importer)
     }
   }
-  const sortedBuildIndexes = Array.from(importersByBuildIndex.keys()).sort()
+  const sortedBuildIndexes = Array.from(importersByBuildIndex.keys()).sort((a, b) => a - b)
   const groups = sortedBuildIndexes.map((buildIndex) => {
     const importers = importersByBuildIndex.get(buildIndex)!
     return importers.map(({ manifest, modulesDir, rootDir, stages: importerStages, targetDirs }) =>


### PR DESCRIPTION
when I use pnpm with workspace, I found that the execution order of lifecycle script is wrong. When the maximum value of buildIndex is greater than `10`, this problem will be caused. The reason is that when sorting buildIndex, because the type of buildIndex is number, no compare function is added, resulting in disordered order after sorting.

In the figure below, the following one is expected

![image](https://github.com/pnpm/pnpm/assets/34960995/75de778c-7e5d-4015-bb6b-fd1a68175e37)
