### PR TITLE
fix!: update direct deps to latest versions satisfying the range

### DIFF
--- a/.changeset/hip-walls-rest.md
+++ b/.changeset/hip-walls-rest.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/types": minor
+---
+
+Add new types.

--- a/.changeset/purple-hotels-arrive.md
+++ b/.changeset/purple-hotels-arrive.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/manifest-utils": patch
+---
+
+Don't update peer dependencies.

--- a/.changeset/sixty-waves-smoke.md
+++ b/.changeset/sixty-waves-smoke.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/config": major
+"@pnpm/core": minor
+"pnpm": minor
+---
+
+This is a semi-breaking change as the default value of the `resolution-mode` setting is changed to `highest`. This change has been requested by template authors.
+
+When running install on a project without a lockfile, the dependencies of the project will be updated to the latest versions that satisfy the ranges in `package.json`.
+
+Related PR: [#6575](https://github.com/pnpm/pnpm/pull/6575).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -227,7 +227,7 @@ export async function getConfig (
     ],
     'recursive-install': true,
     registry: npmDefaults.registry,
-    'resolution-mode': 'lowest-direct',
+    'resolution-mode': 'highest',
     'resolve-peers-from-workspace-root': true,
     'save-peer': false,
     'save-workspace-protocol': 'rolling',

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -9,6 +9,11 @@ export const DEPENDENCIES_FIELDS: DependenciesField[] = [
   'devDependencies',
 ]
 
+export const DEPENDENCIES_OR_PEER_FIELDS: DependenciesOrPeersField[] = [
+  ...DEPENDENCIES_FIELDS,
+  'peerDependencies',
+]
+
 export interface Registries {
   default: string
   [scope: string]: string

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -529,9 +529,12 @@ Note that in CI environments, this setting is enabled by default.`,
         })
         break
       case 'install': {
+        const updatePackageManifest = (projectOpts as InstallDepsMutation).updatePackageManifest ??
+          (projectOpts as InstallDepsMutation).update ??
+          (!ctx.existsWantedLockfile && !ctx.existsCurrentLockfile)
         await installCase({
           ...projectOpts,
-          updatePackageManifest: (projectOpts as InstallDepsMutation).updatePackageManifest ?? (projectOpts as InstallDepsMutation).update,
+          updatePackageManifest,
         })
         break
       }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -531,7 +531,7 @@ Note that in CI environments, this setting is enabled by default.`,
       case 'install': {
         const updatePackageManifest = (projectOpts as InstallDepsMutation).updatePackageManifest ??
           (projectOpts as InstallDepsMutation).update ??
-          (!ctx.existsWantedLockfile && !ctx.existsCurrentLockfile)
+          (opts.resolutionMode === 'highest' && !ctx.existsWantedLockfile && !ctx.existsCurrentLockfile)
         await installCase({
           ...projectOpts,
           updatePackageManifest,

--- a/pkg-manager/core/test/install/resolutionMode.ts
+++ b/pkg-manager/core/test/install/resolutionMode.ts
@@ -34,32 +34,6 @@ test('time-based resolution mode with a registry that supports the time field in
   ])
 })
 
-test('the lowest version of a direct dependency is installed when resolution mode is time-based', async () => {
-  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
-  const project = prepareEmpty()
-
-  let manifest = await install({
-    dependencies: {
-      '@pnpm.e2e/foo': '^100.0.0',
-    },
-  }, await testDefaults({ resolutionMode: 'time-based' }))
-
-  {
-    const lockfile = await project.readLockfile()
-    expect(lockfile.packages['/@pnpm.e2e/foo@100.0.0']).toBeTruthy()
-  }
-
-  manifest = await install(manifest, await testDefaults({ resolutionMode: 'time-based', update: true }))
-
-  {
-    const lockfile = await project.readLockfile()
-    expect(lockfile.packages['/@pnpm.e2e/foo@100.1.0']).toBeTruthy()
-  }
-  expect(manifest.dependencies).toStrictEqual({
-    '@pnpm.e2e/foo': '^100.1.0',
-  })
-})
-
 test('time-based resolution mode should not fail when publishedBy date cannot be calculated', async () => {
   prepareEmpty()
   await install({}, await testDefaults({ resolutionMode: 'time-based' }))

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -290,7 +290,7 @@ when running add/update with the --workspace option')
   }
 
   const updatedManifest = await install(manifest, installOpts)
-  if ((opts.update === true || (opts.update !== false && opts.resolutionMode === 'highest')) && opts.save !== false) {
+  if ((opts.update === true || (opts.update === undefined && opts.resolutionMode === 'highest')) && opts.save !== false) {
     await writeProjectManifest(updatedManifest)
   }
 

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -290,7 +290,7 @@ when running add/update with the --workspace option')
   }
 
   const updatedManifest = await install(manifest, installOpts)
-  if (opts.update === true && opts.save !== false) {
+  if (opts.update !== false && opts.save !== false) {
     await writeProjectManifest(updatedManifest)
   }
 

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -290,7 +290,7 @@ when running add/update with the --workspace option')
   }
 
   const updatedManifest = await install(manifest, installOpts)
-  if ((opts.update || opts.update !== false && opts.resolutionMode === 'highest') && opts.save !== false) {
+  if ((opts.update === true || (opts.update !== false && opts.resolutionMode === 'highest')) && opts.save !== false) {
     await writeProjectManifest(updatedManifest)
   }
 

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -290,7 +290,7 @@ when running add/update with the --workspace option')
   }
 
   const updatedManifest = await install(manifest, installOpts)
-  if (opts.update !== false && opts.save !== false) {
+  if ((opts.update || opts.update !== false && opts.resolutionMode === 'highest') && opts.save !== false) {
     await writeProjectManifest(updatedManifest)
   }
 

--- a/pkg-manifest/manifest-utils/src/updateProjectManifestObject.ts
+++ b/pkg-manifest/manifest-utils/src/updateProjectManifestObject.ts
@@ -1,7 +1,9 @@
 import { packageManifestLogger } from '@pnpm/core-loggers'
 import {
+  type DependenciesOrPeersField,
   type DependenciesField,
   DEPENDENCIES_FIELDS,
+  DEPENDENCIES_OR_PEER_FIELDS,
   type ProjectManifest,
 } from '@pnpm/types'
 
@@ -36,8 +38,10 @@ export async function updateProjectManifestObject (
       }
     } else if (packageSpec.pref) {
       const usedDepType = guessDependencyType(packageSpec.alias, packageManifest) ?? 'dependencies'
-      packageManifest[usedDepType] = packageManifest[usedDepType] ?? {}
-      packageManifest[usedDepType]![packageSpec.alias] = packageSpec.pref
+      if (usedDepType !== 'peerDependencies') {
+        packageManifest[usedDepType] = packageManifest[usedDepType] ?? {}
+        packageManifest[usedDepType]![packageSpec.alias] = packageSpec.pref
+      }
     }
     if (packageSpec.nodeExecPath) {
       if (packageManifest.dependenciesMeta == null) {
@@ -59,7 +63,7 @@ function findSpec (alias: string, manifest: ProjectManifest): string | undefined
   return foundDepType && manifest[foundDepType]![alias]
 }
 
-export function guessDependencyType (alias: string, manifest: ProjectManifest): DependenciesField | undefined {
-  return DEPENDENCIES_FIELDS
+export function guessDependencyType (alias: string, manifest: ProjectManifest): DependenciesOrPeersField | undefined {
+  return DEPENDENCIES_OR_PEER_FIELDS
     .find((depField) => manifest[depField]?.[alias] === '' || Boolean(manifest[depField]?.[alias]))
 }

--- a/pnpm/test/hooks.ts
+++ b/pnpm/test/hooks.ts
@@ -21,6 +21,7 @@ test('readPackage hook in single project doesn\'t modify manifest', async () => 
       }
   `
   await fs.writeFile('.pnpmfile.cjs', pnpmfile, 'utf8')
+  await fs.writeFile('.npmrc', 'resolution-mode=lowest-direct', 'utf8')
   await execPnpm(['add', 'is-positive@1.0.0'])
   let pkg: PackageManifest = await loadJsonFile(path.resolve('package.json'))
   expect(pkg?.dependencies).toStrictEqual({ 'is-positive': '1.0.0' }) // add dependency & readPackage hook work

--- a/pnpm/test/install/hooks.ts
+++ b/pnpm/test/install/hooks.ts
@@ -567,7 +567,7 @@ test('readPackage hook overrides project package', async () => {
     }
   `, 'utf8')
 
-  await execPnpm(['install'])
+  await execPnpm(['install', '--config.resolution-mode=lowest-direct'])
 
   await project.has('is-positive')
 

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -454,10 +454,14 @@ test('installation fails with a timeout error', async () => {
 test('install on a project with no lockfile updates the ranges in package.json', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/qar', version: '100.1.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/bravo-dep', version: '1.1.0', distTag: 'latest' })
   prepare({
     dependencies: {
       '@pnpm.e2e/foo': '100.0.0',
       '@pnpm.e2e/bar': '^100.0.0',
+      qar: 'npm:@pnpm.e2e/qar@100.0.0',
+      bravo: 'npm:@pnpm.e2e/bravo-dep@^1.0.0',
     },
   })
   await execPnpm(['install'])
@@ -465,5 +469,7 @@ test('install on a project with no lockfile updates the ranges in package.json',
   expect(pkg.dependencies).toStrictEqual({
     '@pnpm.e2e/foo': '100.0.0',
     '@pnpm.e2e/bar': '^100.1.0',
+    qar: 'npm:@pnpm.e2e/qar@100.0.0',
+    bravo: 'npm:@pnpm.e2e/bravo-dep@^1.1.0',
   })
 })

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -463,6 +463,9 @@ test('install on a project with no lockfile updates the ranges in package.json',
       qar: 'npm:@pnpm.e2e/qar@100.0.0',
       bravo: 'npm:@pnpm.e2e/bravo-dep@^1.0.0',
     },
+    peerDependencies: {
+      'is-positive': '^3.0.0',
+    },
   })
   await execPnpm(['install'])
   const pkg = await readPackageJsonFromDir(process.cwd())
@@ -471,5 +474,8 @@ test('install on a project with no lockfile updates the ranges in package.json',
     '@pnpm.e2e/bar': '^100.1.0',
     qar: 'npm:@pnpm.e2e/qar@100.0.0',
     bravo: 'npm:@pnpm.e2e/bravo-dep@^1.1.0',
+  })
+  expect(pkg.peerDependencies).toStrictEqual({
+    'is-positive': '^3.0.0',
   })
 })

--- a/pnpm/test/monorepo/dedupePeers.test.ts
+++ b/pnpm/test/monorepo/dedupePeers.test.ts
@@ -80,7 +80,8 @@ test('partial update in a workspace should work with dedupe-peer-dependents is t
 
   writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
   writeFileSync('.npmrc', `dedupe-peer-dependents=true
-auto-install-peers=false`, 'utf8')
+auto-install-peers=false
+resolution-mode=lowest-direct`, 'utf8')
   await execPnpm(['install'])
   await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.1', distTag: 'latest' })
   process.chdir('project-2')


### PR DESCRIPTION
When there is no lockfile and no `node_modules` present, `pnpm install` should update direct dependencies to the latest versions satisfying the range. The updated ranges are saved to the `package.json` file in order to prevent a situation in which a user uses a new feature of a dependency without bumping the version in `package.json`.

close #6463