### PR TITLE
fix: tag from workspace headlessInstall

### DIFF
--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -15,6 +15,7 @@ import {
 import pEvery from 'p-every'
 import any from 'ramda/src/any'
 import semver from 'semver'
+import getVersionSelectorType from 'version-selector-type'
 
 export async function allProjectsAreUpToDate (
   projects: Array<ProjectOptions & { id: string }>,
@@ -94,6 +95,8 @@ async function linkedPackagesAreUpToDate (
       ) {
         continue
       }
+      const spec = getVersionSelectorType(currentSpec)
+
       const linkedDir = isLinked
         ? path.join(project.dir, lockfileRef.slice(5))
         : workspacePackages?.[depName]?.[lockfileRef]?.dir
@@ -106,7 +109,7 @@ async function linkedPackagesAreUpToDate (
       const linkedPkg = manifestsByDir[linkedDir] ?? await safeReadPackageJsonFromDir(linkedDir)
       const availableRange = getVersionRange(currentSpec)
       // This should pass the same options to semver as @pnpm/npm-resolver
-      const localPackageSatisfiesRange = availableRange === '*' || availableRange === '^' || availableRange === '~' ||
+      const localPackageSatisfiesRange = availableRange === '*' || availableRange === '^' || availableRange === '~' || spec?.type === 'tag' ||
         linkedPkg && semver.satisfies(linkedPkg.version, availableRange, { loose: true })
       if (isLinked !== localPackageSatisfiesRange) return false
     }

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -15,7 +15,6 @@ import {
 import pEvery from 'p-every'
 import any from 'ramda/src/any'
 import semver from 'semver'
-import getVersionSelectorType from 'version-selector-type'
 
 export async function allProjectsAreUpToDate (
   projects: Array<ProjectOptions & { id: string }>,
@@ -95,8 +94,6 @@ async function linkedPackagesAreUpToDate (
       ) {
         continue
       }
-      const spec = getVersionSelectorType(currentSpec)
-
       const linkedDir = isLinked
         ? path.join(project.dir, lockfileRef.slice(5))
         : workspacePackages?.[depName]?.[lockfileRef]?.dir
@@ -109,7 +106,7 @@ async function linkedPackagesAreUpToDate (
       const linkedPkg = manifestsByDir[linkedDir] ?? await safeReadPackageJsonFromDir(linkedDir)
       const availableRange = getVersionRange(currentSpec)
       // This should pass the same options to semver as @pnpm/npm-resolver
-      const localPackageSatisfiesRange = availableRange === '*' || availableRange === '^' || availableRange === '~' || spec?.type === 'tag' ||
+      const localPackageSatisfiesRange = availableRange === '*' || availableRange === '^' || availableRange === '~' ||
         linkedPkg && semver.satisfies(linkedPkg.version, availableRange, { loose: true })
       if (isLinked !== localPackageSatisfiesRange) return false
     }

--- a/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
+++ b/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
@@ -374,3 +374,36 @@ test('allProjectsAreUpToDate(): returns true if dependenciesMeta matches', async
     workspacePackages,
   })).toBeTruthy()
 })
+
+test('allProjectsAreUpToDate(): returns true if a dist tag is used', async () => {
+  expect(await allProjectsAreUpToDate([
+    {
+      buildIndex: 0,
+      id: 'bar',
+      manifest: {
+        dependencies: {
+          zoo: 'latest',
+        },
+      },
+      rootDir: 'bar',
+    },
+  ], {
+    autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: true,
+    wantedLockfile: {
+      importers: {
+        bar: {
+          dependencies: {
+            zoo: '1.0.0',
+          },
+          specifiers: {
+            zoo: 'latest',
+          },
+        },
+      },
+      lockfileVersion: 5,
+    },
+    workspacePackages,
+  })).toBeTruthy()
+})

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -198,7 +198,7 @@ async function resolveNpm (
       }
     }
     const localVersion = pickMatchingLocalVersionOrNull(workspacePackages[pickedPackage.name], spec)
-    if (localVersion && (semver.gt(localVersion, pickedPackage.version) || opts.preferWorkspacePackages)) {
+    if (localVersion && spec.type !== 'tag' && (semver.gt(localVersion, pickedPackage.version) || opts.preferWorkspacePackages)) {
       return {
         ...resolveFromLocalPackage(workspacePackages[pickedPackage.name][localVersion], spec.normalizedPref, {
           projectDir: opts.projectDir,

--- a/resolving/npm-resolver/test/index.ts
+++ b/resolving/npm-resolver/test/index.ts
@@ -1852,3 +1852,57 @@ test('pick lowest version by * when there are only prerelease versions', async (
   expect(resolveResult!.manifest!.name).toBe('is-positive')
   expect(resolveResult!.manifest!.version).toBe('1.0.0-alpha.1')
 })
+
+test('tag exist registry not resolve from workspace', async () => {
+  nock(registry)
+    .get('/is-positive')
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    cacheDir,
+  })
+  const resolveResult = await resolve({ alias: 'is-positive', pref: 'latest' }, {
+    projectDir: '/home/istvan/src',
+    registry,
+    workspacePackages: {
+      'is-positive': {
+        '1.0.0': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '1.0.0',
+          },
+        },
+      },
+    },
+  })
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+})
+
+test('tag not exist registry resolve from workspace', async () => {
+  nock(registry)
+    .get('/is-positive')
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = tempy.directory()
+  const resolve = createResolveFromNpm({
+    cacheDir,
+  })
+  const resolveResult = await resolve({ alias: 'is-positive', pref: 'beta' }, {
+    projectDir: '/home/istvan/src',
+    registry,
+    workspacePackages: {
+      'is-positive': {
+        '1.0.0': {
+          dir: '/home/istvan/src/is-positive',
+          manifest: {
+            name: 'is-positive',
+            version: '1.0.0',
+          },
+        },
+      },
+    },
+  })
+  expect(resolveResult!.resolvedVia).toBe('local-filesystem')
+})


### PR DESCRIPTION
When tag was resovled from workspace, headlessInstall will be skipped. The expected is using headless installation.