### PR TITLE
Hoist tsconfigs by default

### DIFF
--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -224,6 +224,7 @@ export async function getConfig (
     'public-hoist-pattern': [
       '*eslint*',
       '*prettier*',
+      '*tsconfig*'
     ],
     'recursive-install': true,
     registry: npmDefaults.registry,

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -224,7 +224,7 @@ export async function getConfig (
     'public-hoist-pattern': [
       '*eslint*',
       '*prettier*',
-      '*tsconfig*'
+      '*tsconfig*',
     ],
     'recursive-install': true,
     registry: npmDefaults.registry,


### PR DESCRIPTION
Deeply dependent tsconfigs are not available unless hoisted.

E.g. 

```
package-a
  - tsconfig.json

package-b
  - tsconfig.json (extends package-a/tsconfig.json)

package-c
  - tsconfig.json (extends package-b/tsconfig.json)
```

package-c throws a tsc error that package-a/tsconfig.json cannot be found.