### PR TITLE
fix: `pnpm patch` should ignore files that are not included in the patched package

### DIFF
--- a/.changeset/blue-numbers-rest.md
+++ b/.changeset/blue-numbers-rest.md
@@ -1,5 +1,6 @@
 ---
-"@pnpm/plugin-commands-patching": major
+"@pnpm/plugin-commands-patching": patch
+"pnpm": patch
 ---
 
-add support for ignoring files/folders specified in ignorePatchedCommitDependencies [#6565](https://github.com/pnpm/pnpm/issues/6565)
+When patching a dependency, only consider files specified in the 'files' field of its package.json. Ignore all others [#6565](https://github.com/pnpm/pnpm/issues/6565)

--- a/.changeset/blue-numbers-rest.md
+++ b/.changeset/blue-numbers-rest.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": major
+---
+
+add support for ignoring files/folders specified in ignorePatchedCommitDependencies [#6565](https://github.com/pnpm/pnpm/issues/6565)

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -61,6 +61,7 @@
     "@pnpm/store-connection-manager": "workspace:*",
     "enquirer": "^2.3.6",
     "escape-string-regexp": "^4.0.0",
+    "fast-glob": "^3.2.12",
     "normalize-path": "^3.0.0",
     "npm-packlist": "^5.1.3",
     "ramda": "npm:@pnpm/ramda@0.28.1",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -39,6 +39,7 @@
     "@pnpm/registry-mock": "3.8.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/normalize-path": "^3.0.0",
+    "@types/npm-packlist": "^3.0.0",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.3.13",
     "write-yaml-file": "^5.0.0"
@@ -61,6 +62,7 @@
     "enquirer": "^2.3.6",
     "escape-string-regexp": "^4.0.0",
     "normalize-path": "^3.0.0",
+    "npm-packlist": "^5.1.3",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -158,13 +158,16 @@ async function filterAndCopyFiles (source: string, destination: string) {
   return destination
 }
 async function checkIfAllFilesExist (files: string[], basePath: string) {
-  for (const file of files) {
+  const promises = files.map(async (file) => {
     const filePath = path.join(basePath, file)
     try {
       await fs.promises.access(filePath)
     } catch (error) {
-      return false // File doesn't exist
+      return false
     }
-  }
-  return true // All files exist
+    return true // File exists
+  })
+
+  const results = await Promise.all(promises)
+  return results.every((result) => result) // Check if all files exist
 }

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -135,9 +135,12 @@ function removeTrailingAndLeadingSlash (p: string) {
 }
 async function filterAndCopyFiles (source: string, destination: string) {
   const files = await packlist({ path: source })
-  if (files.length === 0) {
+  const shouldCopyFiles = await checkIfAllFilesExist(files, source)
+
+  if (!shouldCopyFiles) {
     return source
   }
+
   await Promise.all(
     files.map(async (file) => {
       const sourcePath = path.join(source, file)
@@ -149,4 +152,15 @@ async function filterAndCopyFiles (source: string, destination: string) {
   )
 
   return destination
+}
+async function checkIfAllFilesExist (files: string[], basePath: string) {
+  for (const file of files) {
+    const filePath = path.join(basePath, file)
+    try {
+      await fs.promises.access(filePath)
+    } catch (error) {
+      return false // File doesn't exist
+    }
+  }
+  return true // All files exist
 }

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -33,6 +33,10 @@ export function help () {
           description: 'The generated patch file will be saved to this directory',
           name: '--patches-dir',
         },
+        {
+          description: 'Filters and copies the files from the `patches-dir` directory. If the `files` field exists in the `package.json` file of the `patches-dir`, only the files specified in the `files` field will be included.',
+          name: '--filter-files',
+        },
       ],
     }],
     url: docsUrl('patch-commit'),

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -137,7 +137,7 @@ function removeTrailingAndLeadingSlash (p: string) {
 }
 
 async function filterAndCopyFiles (src: string) {
-  const files = await packlist({ path: src })
+  const files = Array.from(new Set((await packlist({ path: src })).map((f) => path.join(f))))
   // If there are no extra files in the source directories, then there is no reason
   // to copy.
   if (await allFilesAreIncluded(files, src)) {
@@ -150,7 +150,7 @@ async function filterAndCopyFiles (src: string) {
       const destFile = path.join(dest, file)
       const destDir = path.dirname(destFile)
       await fs.promises.mkdir(destDir, { recursive: true })
-      await fs.promises.copyFile(srcFile, destFile)
+      await fs.promises.link(srcFile, destFile)
     })
   )
   return dest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2632,6 +2632,9 @@ importers:
       normalize-path:
         specifier: ^3.0.0
         version: 3.0.0
+      npm-packlist:
+        specifier: ^5.1.3
+        version: 5.1.3
       ramda:
         specifier: npm:@pnpm/ramda@0.28.1
         version: /@pnpm/ramda@0.28.1
@@ -2667,6 +2670,9 @@ importers:
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
       '@types/normalize-path':
+        specifier: ^3.0.0
+        version: 3.0.0
+      '@types/npm-packlist':
         specifier: ^3.0.0
         version: 3.0.0
       '@types/ramda':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 neverBuiltDependencies:
   - core-js
@@ -2629,6 +2633,9 @@ importers:
       escape-string-regexp:
         specifier: ^4.0.0
         version: 4.0.0
+      fast-glob:
+        specifier: ^3.2.12
+        version: 3.2.12
       normalize-path:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
This PR adds a feature to ignore files/folders specified in `rootProjectManifest.pnpm.ignorePatchedCommitDependencies`. If this configuration property exists, the corresponding files/folders in the `rootProjectManifest.pnpm.ignorePatchedCommitDependencies[pkgNameAndVersion]` array will be ignored during the patching commit process. 

close #6565