### PR TITLE
fix:  should always treat local file dependency as new dependency 

### DIFF
--- a/.changeset/grumpy-falcons-flow.md
+++ b/.changeset/grumpy-falcons-flow.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Should always treat local file dependency as new dependency [#5381](https://github.com/pnpm/pnpm/issues/5381)

--- a/.changeset/grumpy-falcons-flow.md
+++ b/.changeset/grumpy-falcons-flow.md
@@ -1,5 +1,7 @@
 ---
 "@pnpm/core": patch
+"@pnpm/lockfile-utils": patch
+"@pnpm/headless": patch
 "pnpm": patch
 ---
 

--- a/lockfile/lockfile-utils/src/index.ts
+++ b/lockfile/lockfile-utils/src/index.ts
@@ -6,6 +6,7 @@ export { packageIdFromSnapshot } from './packageIdFromSnapshot'
 export { packageIsIndependent } from './packageIsIndependent'
 export { pkgSnapshotToResolution } from './pkgSnapshotToResolution'
 export { satisfiesPackageManifest } from './satisfiesPackageManifest'
+export { refIsLocalTarball, refIsLocalDirectory } from './refIsLocalTarball'
 export * from '@pnpm/lockfile-types'
 
 // for backward compatibility

--- a/lockfile/lockfile-utils/src/refIsLocalTarball.ts
+++ b/lockfile/lockfile-utils/src/refIsLocalTarball.ts
@@ -1,0 +1,7 @@
+export function refIsLocalTarball (ref: string) {
+  return ref.startsWith('file:') && (ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
+}
+
+export function refIsLocalDirectory (ref: string) {
+  return ref.startsWith('file:') && !refIsLocalTarball(ref)
+}

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -142,7 +142,7 @@
     "commitmsg": "commitlint -e",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
-    "test:jest": "jest",
+    "test:jest": "jest /Users/zhenwei.song/Documents/projects/pnpm/pkg-manager/core/test/allProjectsAreUpToDate.test.ts",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "test-with-preview": "preview && pnpm run test:e2e",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=4873 pnpm run test:e2e",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -142,7 +142,7 @@
     "commitmsg": "commitlint -e",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "registry-mock": "registry-mock",
-    "test:jest": "jest /Users/zhenwei.song/Documents/projects/pnpm/pkg-manager/core/test/allProjectsAreUpToDate.test.ts",
+    "test:jest": "jest",
     "test:e2e": "registry-mock prepare && run-p -r registry-mock test:jest",
     "test-with-preview": "preview && pnpm run test:e2e",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=4873 pnpm run test:e2e",

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -47,6 +47,13 @@ export async function allProjectsAreUpToDate (
       })
   })
 }
+export function refIsLocalPkg (ref: string) {
+  return ref.startsWith('file:')
+}
+
+export function refIsLocalDirectoryPkg (ref: string) {
+  return refIsLocalPkg(ref) && !(ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
+}
 
 function getWorkspacePackagesByDirectory (workspacePackages: WorkspacePackages) {
   const workspacePackagesByDirectory: Record<string, DependencyManifest> = {}
@@ -132,11 +139,7 @@ function getVersionRange (spec: string) {
 }
 
 function hasLocalTarballDepsInRoot (importer: ProjectSnapshot) {
-  return any(refIsLocalTarball, Object.values(importer.dependencies ?? {})) ||
-    any(refIsLocalTarball, Object.values(importer.devDependencies ?? {})) ||
-    any(refIsLocalTarball, Object.values(importer.optionalDependencies ?? {}))
-}
-
-function refIsLocalTarball (ref: string) {
-  return ref.startsWith('file:') && (ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
+  return any(refIsLocalPkg, Object.values(importer.dependencies ?? {})) ||
+    any(refIsLocalPkg, Object.values(importer.devDependencies ?? {})) ||
+    any(refIsLocalPkg, Object.values(importer.optionalDependencies ?? {}))
 }

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -1,14 +1,17 @@
 import path from 'path'
 import { type ProjectOptions } from '@pnpm/get-context'
 import {
+  type PackageSnapshot,
   type Lockfile,
   type ProjectSnapshot,
+  type PackageSnapshots,
 } from '@pnpm/lockfile-file'
-import { satisfiesPackageManifest } from '@pnpm/lockfile-utils'
+import { refIsLocalDirectory, refIsLocalTarball, satisfiesPackageManifest } from '@pnpm/lockfile-utils'
 import { safeReadPackageJsonFromDir } from '@pnpm/read-package-json'
-import { type WorkspacePackages } from '@pnpm/resolver-base'
+import { type DirectoryResolution, type WorkspacePackages } from '@pnpm/resolver-base'
 import {
   DEPENDENCIES_FIELDS,
+  DEPENDENCIES_OR_PEER_FIELDS,
   type DependencyManifest,
   type ProjectManifest,
 } from '@pnpm/types'
@@ -24,6 +27,7 @@ export async function allProjectsAreUpToDate (
     linkWorkspacePackages: boolean
     wantedLockfile: Lockfile
     workspacePackages: WorkspacePackages
+    lockfileDir: string
   }
 ) {
   const manifestsByDir = opts.workspacePackages ? getWorkspacePackagesByDirectory(opts.workspacePackages) : {}
@@ -35,6 +39,8 @@ export async function allProjectsAreUpToDate (
     linkWorkspacePackages: opts.linkWorkspacePackages,
     manifestsByDir,
     workspacePackages: opts.workspacePackages,
+    lockfilePackages: opts.wantedLockfile.packages,
+    lockfileDir: opts.lockfileDir,
   })
   return pEvery(projects, (project) => {
     const importer = opts.wantedLockfile.importers[project.id]
@@ -63,10 +69,14 @@ async function linkedPackagesAreUpToDate (
     linkWorkspacePackages,
     manifestsByDir,
     workspacePackages,
+    lockfilePackages,
+    lockfileDir,
   }: {
     linkWorkspacePackages: boolean
     manifestsByDir: Record<string, DependencyManifest>
     workspacePackages: WorkspacePackages
+    lockfilePackages?: PackageSnapshots
+    lockfileDir: string
   },
   project: {
     dir: string
@@ -87,6 +97,10 @@ async function linkedPackagesAreUpToDate (
           const currentSpec = manifestDeps[depName]
           if (!currentSpec) return true
           const lockfileRef = lockfileDeps[depName]
+          if (refIsLocalDirectory(lockfileRef)) {
+            return isLocalFileDepUpdated(lockfileDir, lockfilePackages?.[lockfileRef])
+          }
+
           const isLinked = lockfileRef.startsWith('link:')
           if (
             isLinked &&
@@ -120,6 +134,31 @@ async function linkedPackagesAreUpToDate (
   )
 }
 
+async function isLocalFileDepUpdated (lockfileDir: string, pkgSnapshot: PackageSnapshot | undefined) {
+  if (!pkgSnapshot) return false
+  const localDepDir = path.join(lockfileDir, (pkgSnapshot.resolution as DirectoryResolution).directory)
+  const manifest = await safeReadPackageJsonFromDir(localDepDir)
+  if (!manifest) return false
+  for (const depField of DEPENDENCIES_OR_PEER_FIELDS) {
+    if (depField === 'devDependencies') continue
+    const manifestDeps = manifest[depField] ?? {}
+    const lockfileDeps = pkgSnapshot[depField] ?? {}
+    for (const depName of Object.keys(manifestDeps)) {
+      if (!lockfileDeps[depName]) {
+        return false
+      }
+      const currentSpec = manifestDeps[depName]
+      if (currentSpec.startsWith('file:') || currentSpec.startsWith('link:') || currentSpec.startsWith('workspace:')) continue
+      if (semver.satisfies(lockfileDeps[depName], getVersionRange(currentSpec), { loose: true })) {
+        continue
+      } else {
+        return false
+      }
+    }
+  }
+  return true
+}
+
 function getVersionRange (spec: string) {
   if (spec.startsWith('workspace:')) return spec.slice(10)
   if (spec.startsWith('npm:')) {
@@ -135,8 +174,4 @@ function hasLocalTarballDepsInRoot (importer: ProjectSnapshot) {
   return any(refIsLocalTarball, Object.values(importer.dependencies ?? {})) ||
     any(refIsLocalTarball, Object.values(importer.devDependencies ?? {})) ||
     any(refIsLocalTarball, Object.values(importer.optionalDependencies ?? {}))
-}
-
-function refIsLocalTarball (ref: string) {
-  return ref.startsWith('file:') && (ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
 }

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -97,10 +97,9 @@ async function linkedPackagesAreUpToDate (
           const currentSpec = manifestDeps[depName]
           if (!currentSpec) return true
           const lockfileRef = lockfileDeps[depName]
-          if (refIsLocalDirectory(lockfileRef)) {
+          if (refIsLocalDirectory(project.snapshot.specifiers[depName])) {
             return isLocalFileDepUpdated(lockfileDir, lockfilePackages?.[lockfileRef])
           }
-
           const isLinked = lockfileRef.startsWith('link:')
           if (
             isLinked &&

--- a/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allProjectsAreUpToDate.ts
@@ -47,13 +47,6 @@ export async function allProjectsAreUpToDate (
       })
   })
 }
-export function refIsLocalPkg (ref: string) {
-  return ref.startsWith('file:')
-}
-
-export function refIsLocalDirectoryPkg (ref: string) {
-  return refIsLocalPkg(ref) && !(ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
-}
 
 function getWorkspacePackagesByDirectory (workspacePackages: WorkspacePackages) {
   const workspacePackagesByDirectory: Record<string, DependencyManifest> = {}
@@ -139,7 +132,11 @@ function getVersionRange (spec: string) {
 }
 
 function hasLocalTarballDepsInRoot (importer: ProjectSnapshot) {
-  return any(refIsLocalPkg, Object.values(importer.dependencies ?? {})) ||
-    any(refIsLocalPkg, Object.values(importer.devDependencies ?? {})) ||
-    any(refIsLocalPkg, Object.values(importer.optionalDependencies ?? {}))
+  return any(refIsLocalTarball, Object.values(importer.dependencies ?? {})) ||
+    any(refIsLocalTarball, Object.values(importer.devDependencies ?? {})) ||
+    any(refIsLocalTarball, Object.values(importer.optionalDependencies ?? {}))
+}
+
+function refIsLocalTarball (ref: string) {
+  return ref.startsWith('file:') && (ref.endsWith('.tgz') || ref.endsWith('.tar.gz') || ref.endsWith('.tar'))
 }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -386,6 +386,7 @@ export async function mutateModules (
           linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
           wantedLockfile: ctx.wantedLockfile,
           workspacePackages: opts.workspacePackages,
+          lockfileDir: opts.lockfileDir,
         })
       )
     ) {

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -37,6 +37,7 @@ import pick from 'ramda/src/pick'
 import pickBy from 'ramda/src/pickBy'
 import props from 'ramda/src/props'
 import { type ImporterToUpdate } from './index'
+import { refIsLocalDirectoryPkg } from './allProjectsAreUpToDate'
 
 const brokenModulesLogger = logger('_broken_node_modules')
 
@@ -389,6 +390,9 @@ async function selectNewFromWantedDeps (
         const prevDep = prevDeps[depPath]
         if (
           prevDep &&
+          // Local file should always be treated as a new dependency
+          // https://github.com/pnpm/pnpm/issues/5381
+          !refIsLocalDirectoryPkg(depNode.depPath) &&
           (depNode.resolution as TarballResolution).integrity === (prevDep.resolution as TarballResolution).integrity
         ) {
           if (await pathExists(depNode.dir)) {

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -37,7 +37,7 @@ import pick from 'ramda/src/pick'
 import pickBy from 'ramda/src/pickBy'
 import props from 'ramda/src/props'
 import { type ImporterToUpdate } from './index'
-import { refIsLocalDirectoryPkg } from './allProjectsAreUpToDate'
+import { refIsLocalDirectory } from '@pnpm/lockfile-utils'
 
 const brokenModulesLogger = logger('_broken_node_modules')
 
@@ -392,7 +392,7 @@ async function selectNewFromWantedDeps (
           prevDep &&
           // Local file should always be treated as a new dependency
           // https://github.com/pnpm/pnpm/issues/5381
-          !refIsLocalDirectoryPkg(depNode.depPath) &&
+          !refIsLocalDirectory(depNode.depPath) &&
           (depNode.resolution as TarballResolution).integrity === (prevDep.resolution as TarballResolution).integrity
         ) {
           if (await pathExists(depNode.dir)) {

--- a/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
+++ b/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
@@ -484,4 +484,16 @@ describe('local file dependency', () => {
       lockfileDir: process.cwd(),
     })).toBeFalsy()
   })
+
+  test('allProjectsAreUpToDate(): returns false if remove dependency in local file', async () => {
+    await writeFile('./local-dir/package.json', JSON.stringify({
+      name: 'local-dir',
+      version: '1.0.0',
+      dependencies: {},
+    }))
+    expect(await allProjectsAreUpToDate(projects, {
+      ...options,
+      lockfileDir: process.cwd(),
+    })).toBeFalsy()
+  })
 })

--- a/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
+++ b/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
@@ -374,3 +374,48 @@ test('allProjectsAreUpToDate(): returns true if dependenciesMeta matches', async
     workspacePackages,
   })).toBeTruthy()
 })
+
+test('allProjectsAreUpToDate(): returns false if has dependency with file: protocol', async () => {
+  expect(await allProjectsAreUpToDate([
+    {
+      buildIndex: 0,
+      id: 'bar',
+      manifest: {
+        dependencies: {
+          foo: 'workspace:*',
+          local: 'file:../local-dir',
+        },
+      },
+      rootDir: 'bar',
+    },
+    {
+      buildIndex: 0,
+      id: 'foo',
+      manifest: fooManifest,
+      rootDir: 'foo',
+    },
+  ], {
+    autoInstallPeers: false,
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: true,
+    wantedLockfile: {
+      importers: {
+        bar: {
+          dependencies: {
+            foo: 'link:../foo',
+            local: 'file:../local-dir',
+          },
+          specifiers: {
+            foo: 'workspace:../foo',
+            local: 'file:../local-dir',
+          },
+        },
+        foo: {
+          specifiers: {},
+        },
+      },
+      lockfileVersion: 5,
+    },
+    workspacePackages,
+  })).toBeFalsy()
+})

--- a/pkg-manager/headless/src/lockfileToDepGraph.ts
+++ b/pkg-manager/headless/src/lockfileToDepGraph.ts
@@ -11,6 +11,7 @@ import {
   nameVerFromPkgSnapshot,
   packageIdFromSnapshot,
   pkgSnapshotToResolution,
+  refIsLocalDirectory,
 } from '@pnpm/lockfile-utils'
 import { logger } from '@pnpm/logger'
 import { type IncludedDependencies } from '@pnpm/modules-yaml'
@@ -127,6 +128,7 @@ export async function lockfileToDepGraph (
         }
         const dir = path.join(modules, pkgName)
         if (
+          !refIsLocalDirectory(depPath) &&
           currentPackages[depPath] && equals(currentPackages[depPath].dependencies, lockfile.packages![depPath].dependencies) &&
           equals(currentPackages[depPath].optionalDependencies, lockfile.packages![depPath].optionalDependencies)
         ) {


### PR DESCRIPTION
fix #5381, #6502 

Let's say we have a project like the following:

```
// pkg-foo/package.json
{
  "name": "pkg-foo",
  "dependencies": {
    "local-file": "file:../local-file"
  }
}

// local-file/package.json
{
  "name": "local-file",
  "version": "1.0.0",
  "dependencies": {
   "is-positive": "2.0.0" 
  }
}
```



The comparison between this PR and the current pnpm install or update is as follows:

* Before

|  | add new file  to  local-file directory | change is-positive to 3.0.0 |
| --- | --- | --- |
| pnpm update | Not synced | synced |
| pnpm update —latest | Not synced | Synced |
| pnpm update local-file | Not synced | synced |
| pnpm install | Not synced | Not synced |

* After this PR

|  | add new file  to  local-file directory | change is-positive to 3.0.0 |
| --- | --- | --- |
| pnpm update | Synced | Synced |
| pnpm update —latest | Synced | Synced |
| pnpm update local-file | Synced |Synced |
| pnpm install | Synced | Synced |


```
$ pnpm -v
8.6.1
```
