### PR TITLE
ci: change winget job runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -30,7 +30,7 @@ jobs:
         npm dist-tag add @pnpm/exe@${{ github.event.inputs.version }} ${{ github.event.inputs.tag }}
 
   publish-to-winget:
-    runs-on: windows-latest # Action can only be run on windows
+    runs-on: ubuntu-latest
     environment: release
     needs: tag-in-registry
     steps:


### PR DESCRIPTION
Winget Releaser now supports all runners. I think the workflow would be slightly faster if it's not using the Windows runner; I would like to test that here 😅.