### PR TITLE
chore: cancel previous CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ permissions:
 
 jobs:
   build:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.node }}
       cancel-in-progress: true
 
     strategy:


### PR DESCRIPTION
This uses the native [`concurrency` property](https://docs.github.com/en/actions/using-jobs/using-concurrency) of GitHub Actions jobs to cancel runs on previous commits when there exists a newer commit. It will help with not getting redundant fail alerts as well as to save CI minutes