### PR TITLE
chore: introduce 1-hour timeout for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,10 @@ jobs:
         # key: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-${{ github.run_id }}
         # restore-keys: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-
     - name: run tests (main)
+      timeout-minutes: 60
       if: github.ref == 'refs/heads/main'
       run: pnpm run test-main
     - name: run tests (branch)
+      timeout-minutes: 60
       if: github.ref != 'refs/heads/main'
       run: pnpm run test-branch


### PR DESCRIPTION
Somehow, certain workflows can take over 6 hours to complete, probably due to an infinite execution. I think that 1 hour is a reasonable limit for CI jobs, and it will allow to quickly react to rogue CI runs

Source: https://github.com/pnpm/pnpm/actions/runs/5267002956/jobs/9521690045?pr=6674