### PR TITLE
node-linker=hoisted support autoinstallpeers

### DIFF
--- a/.changeset/quiet-moons-sparkle.md
+++ b/.changeset/quiet-moons-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/real-hoist": patch
+"@pnpm/headless": patch
+"pnpm": patch
+---
+
+Peer dependencies of subdependencies should be installed, when `node-linker` is set to `hoisted` [#6680](https://github.com/pnpm/pnpm/pull/6680).

--- a/pkg-manager/core/test/hoistedNodeLinker/install.ts
+++ b/pkg-manager/core/test/hoistedNodeLinker/install.ts
@@ -316,3 +316,17 @@ test('linking bins of local projects when node-linker is set to hoisted', async 
 
   expect(fs.existsSync('project-1/node_modules/.bin/project-2')).toBeTruthy()
 })
+
+test('peerDependencies should be installed when autoInstallPeers is set to true and nodeLinker is set to hoisted', async () => {
+  prepareEmpty()
+  await install({
+    dependencies: {
+      'react-dom': '18.2.0',
+    },
+  }, await testDefaults({
+    nodeLinker: 'hoisted',
+    autoInstallPeers: true,
+  }))
+
+  expect(fs.existsSync('node_modules/react')).toBeTruthy()
+})

--- a/pkg-manager/headless/src/lockfileToDepGraph.ts
+++ b/pkg-manager/headless/src/lockfileToDepGraph.ts
@@ -53,6 +53,7 @@ export interface DependenciesGraph {
 }
 
 export interface LockfileToDepGraphOptions {
+  autoInstallPeers: boolean
   engineStrict: boolean
   force: boolean
   importerIds: string[]

--- a/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
+++ b/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
@@ -27,6 +27,7 @@ import {
 } from './lockfileToDepGraph'
 
 export interface LockfileToHoistedDepGraphOptions {
+  autoInstallPeers: boolean
   engineStrict: boolean
   force: boolean
   hoistingLimits?: HoistingLimits
@@ -68,7 +69,11 @@ async function _lockfileToHoistedDepGraph (
   lockfile: Lockfile,
   opts: LockfileToHoistedDepGraphOptions
 ): Promise<Omit<LockfileToDepGraphResult, 'prevGraph'>> {
-  const tree = hoist(lockfile, { hoistingLimits: opts.hoistingLimits, externalDependencies: opts.externalDependencies })
+  const tree = hoist(lockfile, {
+    hoistingLimits: opts.hoistingLimits,
+    externalDependencies: opts.externalDependencies,
+    autoInstallPeers: opts.autoInstallPeers,
+  })
   const graph: DependenciesGraph = {}
   const modulesDir = path.join(opts.lockfileDir, 'node_modules')
   const fetchDepsOpts = {


### PR DESCRIPTION
PeerDependencies should be installed when `autoInstallPeers` is set to true and `nodeLinker` is set to `hoisted`.