### PR TITLE
fix: license ls should work even when there is a patched git protocol dependency

### DIFF
--- a/.changeset/wet-laws-retire.md
+++ b/.changeset/wet-laws-retire.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+"@pnpm/license-scanner": patch
+"pnpm": patch
+---
+
+`pnpm license ls` should work even when there is a patched git protocol dependency [#6595](https://github.com/pnpm/pnpm/issues/6595)

--- a/reviewing/license-scanner/src/getPkgInfo.ts
+++ b/reviewing/license-scanner/src/getPkgInfo.ts
@@ -196,9 +196,9 @@ export async function readPackageIndexFile (
     )
   } else if (!packageResolution.type && packageResolution.tarball) {
     // If the package resolution has a tarball then we need to clean up
-    // the call to depPathToFilename as it adds '_[hash]' part to the
+    // the return value to depPathToFilename as it adds peer deps(e.g. a@1.0.0_peer-foo@18.0.0_peer-bar@18.0.0) or patch hash(a@1.0.0_patch_hash=xxxx) part to the
     // directory for the package in the content-addressable store
-    const packageDirInStore = depPathToFilename(depPath.split('_')[0])
+    const packageDirInStore = depPathToFilename(depPath).split('_')[0]
     pkgIndexFilePath = path.join(
       opts.storeDir,
       packageDirInStore,

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "with-patched-deps",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "github:kevva/is-positive"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "is-positive@3.1.0": "patches/is-positive@3.1.0.patch"
+    }
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/patches/is-positive@3.1.0.patch
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/patches/is-positive@3.1.0.patch
@@ -1,0 +1,10 @@
+diff --git a/index.js b/index.js
+index ce27efbbbf6aaecfae5709f67181a15fe20dc602..4ba2734688ebdd8e8041bf6d373e5434c1c38ddb 100644
+--- a/index.js
++++ b/index.js
+@@ -1,4 +1,5 @@
+ 'use strict';
++console.log('patched')
+ module.exports = function (n) {
+ 	return toString.call(n) === '[object Number]' && n > 0;
+ };

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-peer-deps/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-peer-deps/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "with-git-protocol-peer-deps",
+  "version": "1.0.0",
+  "dependencies": {
+    "ajv-keywords": "github:ajv-validator/ajv-keywords"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/index.ts
+++ b/reviewing/plugin-commands-licenses/test/index.ts
@@ -169,3 +169,49 @@ test('pnpm licenses should work with file protocol dependency', async () => {
   expect(exitCode).toBe(0)
   expect(stripAnsi(output)).toMatchSnapshot('show-packages')
 })
+
+test('pnpm licenses should work with git protocol dep that have patches', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-git-protocol-patched-deps', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  const { exitCode } = await licenses.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    long: false,
+    storeDir: path.resolve(storeDir, 'v3'),
+  }, ['list'])
+
+  expect(exitCode).toBe(0)
+})
+
+test('pnpm licenses should work with git protocol dep that have peerDependencies', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-git-protocol-peer-deps', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  const { exitCode } = await licenses.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    long: false,
+    storeDir: path.resolve(storeDir, 'v3'),
+  }, ['list'])
+
+  expect(exitCode).toBe(0)
+})


### PR DESCRIPTION
fix #6595 