### PR TITLE
fix: applyPatch add packageDetails

### DIFF
--- a/.changeset/strange-lamps-sit.md
+++ b/.changeset/strange-lamps-sit.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/patching.apply-patch": major
+"@pnpm/plugin-commands-patching": minor
+"@pnpm/build-modules": minor
+---
+
+applyPatch add packageDetails

--- a/exec/build-modules/src/buildSequence.ts
+++ b/exec/build-modules/src/buildSequence.ts
@@ -17,6 +17,7 @@ export interface DependenciesGraphNode {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   requiresBuild?: boolean | any // this is a durty workaround added in https://github.com/pnpm/pnpm/pull/4898
   patchFile?: PatchFile
+  name: string
 }
 
 export interface DependenciesGraph {

--- a/exec/build-modules/src/index.ts
+++ b/exec/build-modules/src/index.ts
@@ -106,7 +106,7 @@ async function buildDependency (
     await linkBinsOfDependencies(depNode, depGraph, opts)
     const isPatched = depNode.patchFile?.path != null
     if (isPatched) {
-      applyPatchToDir({ patchedDir: depNode.dir, patchFilePath: depNode.patchFile!.path })
+      applyPatchToDir({ patchedDir: depNode.dir, patchFilePath: depNode.patchFile!.path, name: depNode.name })
     }
     const hasSideEffects = !opts.ignoreScripts && await runPostinstallHooks({
       depPath,

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -4,6 +4,7 @@ import { applyPatch } from 'patch-package/dist/applyPatches'
 export interface ApplyPatchToDirOpts {
   patchedDir: string
   patchFilePath: string
+  name: string
 }
 
 export function applyPatchToDir (opts: ApplyPatchToDirOpts) {
@@ -14,6 +15,10 @@ export function applyPatchToDir (opts: ApplyPatchToDirOpts) {
   const success = applyPatch({
     patchDir: opts.patchedDir,
     patchFilePath: opts.patchFilePath,
+    packageDetails: {
+      pathSpecifier: opts.name,
+      humanReadablePath: opts.name,
+    },
   })
   process.chdir(cwd)
   if (!success) {

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -82,11 +82,13 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
 
   await writePackage(patchedDep, editDir, opts)
   if (!opts.ignoreExisting && opts.rootProjectManifest?.pnpm?.patchedDependencies) {
+    const [name] = params[0].split('@')
     tryPatchWithExistingPatchFile({
       patchedDep,
       patchedDir: editDir,
       patchedDependencies: opts.rootProjectManifest.pnpm.patchedDependencies,
       lockfileDir,
+      name
     })
   }
   return `You can now edit the following folder: ${editDir}
@@ -100,11 +102,13 @@ function tryPatchWithExistingPatchFile (
     patchedDir,
     patchedDependencies,
     lockfileDir,
+    name
   }: {
     patchedDep: ParseWantedDependencyResult
     patchedDir: string
     patchedDependencies: Record<string, string>
     lockfileDir: string
+    name: string
   }
 ) {
   if (!patchedDep.alias || !patchedDep.pref) {
@@ -118,5 +122,5 @@ function tryPatchWithExistingPatchFile (
   if (!fs.existsSync(existingPatchFilePath)) {
     throw new PnpmError('PATCH_FILE_NOT_FOUND', `Unable to find patch file ${existingPatchFilePath}`)
   }
-  applyPatchToDir({ patchedDir, patchFilePath: existingPatchFilePath })
+  applyPatchToDir({ patchedDir, patchFilePath: existingPatchFilePath, name })
 }

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -88,7 +88,7 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
       patchedDir: editDir,
       patchedDependencies: opts.rootProjectManifest.pnpm.patchedDependencies,
       lockfileDir,
-      name
+      name,
     })
   }
   return `You can now edit the following folder: ${editDir}
@@ -102,7 +102,7 @@ function tryPatchWithExistingPatchFile (
     patchedDir,
     patchedDependencies,
     lockfileDir,
-    name
+    name,
   }: {
     patchedDep: ParseWantedDependencyResult
     patchedDir: string


### PR DESCRIPTION
If the execution of `parsePatchFile` fails and lacks detail, the catch will also fail.

https://github.com/ds300/patch-package/blob/0b9b0150a2348bf53087198fcad84e862a35eebb/src/patch/read.ts#L18

https://github.com/ds300/patch-package/blob/0b9b0150a2348bf53087198fcad84e862a35eebb/src/patch/read.ts#L36