### PR TITLE
fix: don't include the version for local directory dependencies

### DIFF
--- a/.changeset/stupid-pets-melt.md
+++ b/.changeset/stupid-pets-melt.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+Don't add the version of a local directory dependency to the lockfile. This information is not used anywhere by pnpm and is only causing more Git conflicts [#6695](https://github.com/pnpm/pnpm/pull/6695).

--- a/pkg-manager/core/test/install/injectLocalPackages.ts
+++ b/pkg-manager/core/test/install/injectLocalPackages.ts
@@ -151,7 +151,6 @@ test('inject local packages', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -168,7 +167,6 @@ test('inject local packages', async () => {
       },
       id: 'file:project-2',
       name: 'project-2',
-      version: '1.0.0',
       dependencies: {
         'project-1': 'file:project-1(is-positive@2.0.0)',
       },
@@ -223,7 +221,6 @@ test('inject local packages', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -383,7 +380,6 @@ test('inject local packages declared via file protocol', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -400,7 +396,6 @@ test('inject local packages declared via file protocol', async () => {
       },
       id: 'file:project-2',
       name: 'project-2',
-      version: '1.0.0',
       dependencies: {
         'project-1': 'file:project-1(is-positive@2.0.0)',
       },
@@ -456,7 +451,6 @@ test('inject local packages declared via file protocol', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -601,7 +595,6 @@ test('inject local packages when the file protocol is used', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -618,7 +611,6 @@ test('inject local packages when the file protocol is used', async () => {
       },
       id: 'file:project-2',
       name: 'project-2',
-      version: '1.0.0',
       dependencies: {
         'project-1': 'file:project-1(is-positive@2.0.0)',
       },
@@ -673,7 +665,6 @@ test('inject local packages when the file protocol is used', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -796,7 +787,6 @@ test('inject local packages and relink them after build', async () => {
     },
     id: 'file:project-1',
     name: 'project-1',
-    version: '1.0.0',
     peerDependencies: {
       'is-positive': '1.0.0',
     },
@@ -907,7 +897,6 @@ test('inject local packages and relink them after build (file protocol is used)'
     },
     id: 'file:project-1',
     name: 'project-1',
-    version: '1.0.0',
     peerDependencies: {
       'is-positive': '1.0.0',
     },
@@ -1081,7 +1070,6 @@ test('inject local packages when node-linker is hoisted', async () => {
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -1099,7 +1087,6 @@ test('inject local packages when node-linker is hoisted', async () => {
       },
       id: 'file:project-2',
       name: 'project-2',
-      version: '1.0.0',
       dependencies: {
         '@pnpm.e2e/dep-of-pkg-with-1-dep': '101.0.0',
         'project-1': 'file:project-1(is-positive@2.0.0)',
@@ -1266,7 +1253,6 @@ test('inject local packages when node-linker is hoisted and dependenciesMeta is 
       },
       id: 'file:project-1',
       name: 'project-1',
-      version: '1.0.0',
       peerDependencies: {
         'is-positive': '>=1.0.0',
       },
@@ -1282,7 +1268,6 @@ test('inject local packages when node-linker is hoisted and dependenciesMeta is 
         directory: 'project-2',
         type: 'directory',
       },
-      id: 'file:project-2',
       name: 'project-2',
       version: '1.0.0',
       dependencies: {

--- a/pkg-manager/core/test/install/injectLocalPackages.ts
+++ b/pkg-manager/core/test/install/injectLocalPackages.ts
@@ -1268,8 +1268,8 @@ test('inject local packages when node-linker is hoisted and dependenciesMeta is 
         directory: 'project-2',
         type: 'directory',
       },
+      id: 'file:project-2',
       name: 'project-2',
-      version: '1.0.0',
       dependencies: {
         '@pnpm.e2e/dep-of-pkg-with-1-dep': '101.0.0',
         'project-1': 'file:project-1(is-positive@2.0.0)',

--- a/pkg-manager/core/test/install/local.ts
+++ b/pkg-manager/core/test/install/local.ts
@@ -436,7 +436,6 @@ test('re-install should update local file dependency', async () => {
       'file:../local-pkg': {
         resolution: { directory: '../local-pkg', type: 'directory' },
         name: 'local-pkg',
-        version: '1.0.0',
         dev: false,
         dependencies: {
           'is-positive': '1.0.0',

--- a/pkg-manager/core/test/install/local.ts
+++ b/pkg-manager/core/test/install/local.ts
@@ -460,7 +460,6 @@ test('re-install should update local file dependency', async () => {
       'file:../local-pkg': {
         resolution: { directory: '../local-pkg', type: 'directory' },
         name: 'local-pkg',
-        version: '1.0.0',
         dev: false,
         dependencies: {
           'is-positive': '2.0.0',

--- a/pkg-manager/core/test/install/local.ts
+++ b/pkg-manager/core/test/install/local.ts
@@ -403,7 +403,6 @@ test('re-install should update local file dependency', async () => {
       'file:../local-pkg': {
         resolution: { directory: '../local-pkg', type: 'directory' },
         name: 'local-pkg',
-        version: '1.0.0',
         dev: false,
       },
     },

--- a/pkg-manager/resolve-dependencies/src/updateLockfile.ts
+++ b/pkg-manager/resolve-dependencies/src/updateLockfile.ts
@@ -97,8 +97,8 @@ function toLockfileDependency (
   if (dp.isAbsolute(opts.depPath)) {
     result['name'] = pkg.name
 
-    // There is no guarantee that a non-npmjs.org-hosted package
-    // is going to have a version field
+    // There is no guarantee that a non-npmjs.org-hosted package is going to have a version field.
+    // Also, for local directory dependencies, the version is not needed.
     if (pkg.version && (lockfileResolution as DirectoryResolution).type !== 'directory') {
       result['version'] = pkg.version
     }

--- a/pkg-manager/resolve-dependencies/src/updateLockfile.ts
+++ b/pkg-manager/resolve-dependencies/src/updateLockfile.ts
@@ -6,7 +6,7 @@ import {
   pruneSharedLockfile,
   type ResolvedDependencies,
 } from '@pnpm/prune-lockfile'
-import { type Resolution } from '@pnpm/resolver-base'
+import { type DirectoryResolution, type Resolution } from '@pnpm/resolver-base'
 import { type Registries } from '@pnpm/types'
 import * as dp from '@pnpm/dependency-path'
 import getNpmTarballUrl from 'get-npm-tarball-url'
@@ -99,7 +99,7 @@ function toLockfileDependency (
 
     // There is no guarantee that a non-npmjs.org-hosted package
     // is going to have a version field
-    if (pkg.version) {
+    if (pkg.version && (lockfileResolution as DirectoryResolution).type !== 'directory') {
       result['version'] = pkg.version
     }
   }


### PR DESCRIPTION
There is no need to include the version of a dependency in the lockfile,

if that dependency is installed from a local directory