### PR TITLE
feat: support multiple node versions in workspaces

### DIFF
--- a/.changeset/short-zebras-unite.md
+++ b/.changeset/short-zebras-unite.md
@@ -1,7 +1,7 @@
 ---
 "@pnpm/plugin-commands-script-runners": minor
-"@pnpm/plugin-commands-env": minor
 "@pnpm/config": minor
+"@pnpm/types": patch
 "pnpm": minor
 ---
 

--- a/.changeset/short-zebras-unite.md
+++ b/.changeset/short-zebras-unite.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"@pnpm/plugin-commands-env": minor
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+Enable support for per-package Node.js version specification in workspaces [#6720](hhttps://github.com/pnpm/pnpm/issues/6720).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -551,8 +551,20 @@ export async function getConfig (
   }
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig
+  pnpmConfig.useNodeVersion = await getNodeVersion(pnpmConfig)
 
   return { config: pnpmConfig, warnings }
+}
+
+async function getNodeVersion (
+  opts: Pick<Config, 'dir' | 'workspaceDir' | 'rootProjectManifest' | 'useNodeVersion'>
+): Promise<string | undefined> {
+  if (opts.dir === opts.workspaceDir) {
+    return opts.rootProjectManifest?.pnpm?.useNodeVersion ?? opts.useNodeVersion
+  }
+
+  const currentProjectManifest = await safeReadProjectManifestOnly(opts.dir) ?? undefined
+  return currentProjectManifest?.pnpm?.useNodeVersion ?? opts.useNodeVersion
 }
 
 function getProcessEnv (env: string) {

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -53,6 +53,7 @@
     "@pnpm/lifecycle": "workspace:*",
     "@pnpm/package-bins": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
+    "@pnpm/plugin-commands-env": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/sort-packages": "workspace:*",

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -12,7 +12,7 @@ import pLimit from 'p-limit'
 import realpathMissing from 'realpath-missing'
 import { existsInDir } from './existsInDir'
 import { createEmptyRecursiveSummary, getExecutionDuration, getResumedPackageChunks, writeRecursiveSummary } from './exec'
-import { runScript } from './run'
+import { runScript, getExtraBinPaths } from './run'
 import { tryBuildRegExpFromCommand } from './regexpCommand'
 import { type PackageScripts } from '@pnpm/types'
 
@@ -25,6 +25,8 @@ export type RecursiveRunOpts = Pick<Config,
 | 'scriptShell'
 | 'shellEmulator'
 | 'stream'
+| 'bin'
+| 'pnpmHomeDir'
 > & Required<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir' | 'dir'>> &
 Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'reverse' | 'sort' | 'workspaceConcurrency'>> &
 {
@@ -107,7 +109,7 @@ export async function runRecursive (
         try {
           const lifecycleOpts: RunLifecycleHookOptions = {
             depPath: prefix,
-            extraBinPaths: opts.extraBinPaths,
+            extraBinPaths: await getExtraBinPaths(opts, pkg.package.manifest),
             extraEnv: opts.extraEnv,
             pkgRoot: prefix,
             rawConfig: opts.rawConfig,

--- a/exec/plugin-commands-script-runners/test/index.ts
+++ b/exec/plugin-commands-script-runners/test/index.ts
@@ -29,6 +29,8 @@ test('pnpm run: returns correct exit code', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['exit0'])
 
   let err!: Error & { errno: number }
@@ -38,6 +40,8 @@ test('pnpm run: returns correct exit code', async () => {
       extraBinPaths: [],
       extraEnv: {},
       rawConfig: {},
+      pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+      bin: DEFAULT_OPTS.bin,
     }, ['exit1'])
   } catch (_err: any) { // eslint-disable-line
     err = _err
@@ -60,6 +64,8 @@ test('pnpm run --no-bail never fails', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['exit1'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -84,6 +90,8 @@ test('run: pass the args to the command that is specified in the build script', 
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['foo', 'arg', '--flag=true', '--help', '-h'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -106,6 +114,8 @@ test('run: pass the args to the command that is specified in the build script of
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['foo', 'arg', '--flag=true', '--help', '-h'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -128,6 +138,8 @@ test('test: pass the args to the command that is specified in the build script o
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['arg', '--flag=true', '--help', '-h'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -150,6 +162,8 @@ test('run start: pass the args to the command that is specified in the build scr
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['start', 'arg', '--flag=true', '--help', '-h'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -172,6 +186,8 @@ test('run stop: pass the args to the command that is specified in the build scri
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['stop', 'arg', '--flag=true', '--help', '-h'])
 
   const { default: args } = await import(path.resolve('args.json'))
@@ -201,6 +217,8 @@ test('restart: run stop, restart and start', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, [])
 
   const { default: scriptsRan } = await import(path.resolve('output.json'))
@@ -235,6 +253,8 @@ test('restart: run stop, restart and start and all the pre/post scripts', async 
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, [])
 
   const { default: scriptsRan } = await import(path.resolve('output.json'))
@@ -264,6 +284,8 @@ test('"pnpm run" prints the list of available commands', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, [])
 
   expect(output).toBe(`\
@@ -315,6 +337,8 @@ test('"pnpm run" prints the list of available commands, including commands of th
       rawConfig: {},
       selectedProjectsGraph,
       workspaceDir,
+      pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+      bin: DEFAULT_OPTS.bin,
     }, [])
 
     expect(output).toBe(`\
@@ -342,6 +366,8 @@ Commands of the root workspace project (to run them, use "pnpm -w run"):
       rawConfig: {},
       selectedProjectsGraph,
       workspaceDir,
+      pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+      bin: DEFAULT_OPTS.bin,
     }, [])
 
     expect(output).toBe(`\
@@ -364,6 +390,8 @@ test('pnpm run does not fail with --if-present even if the wanted script is not 
     extraEnv: {},
     ifPresent: true,
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['build'])
 })
 
@@ -432,6 +460,8 @@ test('scripts work with PnP', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['foo'])
 
   const { default: scriptsRan } = await import(path.resolve('output.json'))
@@ -461,6 +491,8 @@ test('pnpm run with custom shell', async () => {
     extraEnv: {},
     rawConfig: {},
     scriptShell: path.resolve(`node_modules/.bin/shell-mock${isWindows() ? '.cmd' : ''}`),
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['build'])
 
   expect((await import(path.resolve('shell-input.json'))).default).toStrictEqual(['-c', 'foo bar'])
@@ -485,6 +517,8 @@ test('pnpm run with RegExp script selector should work', async () => {
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['/^(lint|build):.*/'])
 
   expect(await fs.readFile('output-build-a.txt', { encoding: 'utf-8' })).toEqual('a')
@@ -510,6 +544,8 @@ test('pnpm run with RegExp script selector should work also for pre/post script'
     extraEnv: {},
     rawConfig: {},
     enablePrePostScripts: true,
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['/build:.*/'])
 
   expect(await fs.readFile('output-a.txt', { encoding: 'utf-8' })).toEqual('a')
@@ -531,6 +567,8 @@ test('pnpm run with RegExp script selector should work parallel as a default beh
     extraBinPaths: [],
     extraEnv: {},
     rawConfig: {},
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['/build:.*/'])
 
   const { default: outputsA } = await import(path.resolve('output-a.json'))
@@ -555,6 +593,8 @@ test('pnpm run with RegExp script selector should work sequentially with --works
     extraEnv: {},
     rawConfig: {},
     workspaceConcurrency: 1,
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['/build:.*/'])
 
   const { default: outputsA } = await import(path.resolve('output-a.json'))
@@ -579,6 +619,8 @@ test('pnpm run with RegExp script selector with flag should throw error', async 
       extraEnv: {},
       rawConfig: {},
       workspaceConcurrency: 1,
+      pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+      bin: DEFAULT_OPTS.bin,
     }, ['/build:.*/i'])
   } catch (_err: any) { // eslint-disable-line
     err = _err
@@ -599,6 +641,8 @@ test('pnpm run with slightly incorrect command suggests correct one', async () =
     extraEnv: {},
     rawConfig: {},
     workspaceConcurrency: 1,
+    pnpmHomeDir: DEFAULT_OPTS.pnpmHomeDir,
+    bin: DEFAULT_OPTS.bin,
   }, ['buil'])).rejects.toEqual(expect.objectContaining({
     code: 'ERR_PNPM_NO_SCRIPT',
     hint: 'Command "buil" not found. Did you mean "pnpm run build"?',

--- a/exec/plugin-commands-script-runners/test/utils/index.ts
+++ b/exec/plugin-commands-script-runners/test/utils/index.ts
@@ -49,6 +49,7 @@ export const DEFAULT_OPTS = {
   useRunningStoreServer: false,
   useStoreServer: false,
   workspaceConcurrency: 4,
+  bin: process.env.PNPM_HOME as string,
 }
 
 export const DLX_DEFAULT_OPTS = {

--- a/exec/plugin-commands-script-runners/tsconfig.json
+++ b/exec/plugin-commands-script-runners/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../config/config"
     },
     {
+      "path": "../../env/plugin-commands-env"
+    },
+    {
       "path": "../../packages/error"
     },
     {

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -138,6 +138,7 @@ export type ProjectManifest = BaseManifest & {
       ignoreCves?: string[]
     }
     requiredScripts?: string[]
+    useNodeVersion?: string
   }
   private?: boolean
   resolutions?: Record<string, string>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1315,6 +1315,9 @@ importers:
       '@pnpm/package-bins':
         specifier: workspace:*
         version: link:../../pkg-manager/package-bins
+      '@pnpm/plugin-commands-env':
+        specifier: workspace:*
+        version: link:../../env/plugin-commands-env
       '@pnpm/plugin-commands-installation':
         specifier: workspace:*
         version: link:../../pkg-manager/plugin-commands-installation
@@ -9065,7 +9068,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 20.4.2
+      '@types/node': 14.18.53
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -9073,7 +9076,7 @@ packages:
     dependencies:
       '@types/http-cache-semantics': 4.0.1
       '@types/keyv': 3.1.4
-      '@types/node': 20.4.2
+      '@types/node': 14.18.53
       '@types/responselike': 1.0.0
 
   /@types/concat-stream@2.0.0:
@@ -9101,7 +9104,7 @@ packages:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.4.2
+      '@types/node': 14.18.53
     dev: true
 
   /@types/graceful-fs@4.1.6:
@@ -9181,7 +9184,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.4.2
+      '@types/node': 14.18.53
 
   /@types/lodash.clonedeep@4.5.7:
     resolution: {integrity: sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==}
@@ -9230,7 +9233,6 @@ packages:
 
   /@types/node@14.18.53:
     resolution: {integrity: sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==}
-    dev: true
 
   /@types/node@18.16.19:
     resolution: {integrity: sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==}
@@ -9270,7 +9272,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 20.4.2
+      '@types/node': 14.18.53
 
   /@types/retry@0.12.2:
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -14004,12 +14006,6 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
-  /lru-cache@10.0.0:
-    resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
-    engines: {node: 14 || >=16.14}
-    dev: false
-    optional: true
-
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -15186,7 +15182,7 @@ packages:
     resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
-      lru-cache: 10.0.0
+      lru-cache: 9.1.2
       minipass: 5.0.0
     dev: false
     optional: true

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -267,7 +267,7 @@ export async function main (inputArgv: string[]) {
       ...(workspaceDir ? { workspacePrefix: workspaceDir } : {}),
     })
 
-    if (config.useNodeVersion != null) {
+    if (config.useNodeVersion != null && !config.recursive) {
       const nodePath = await node.getNodeBinDir(config)
       config.extraBinPaths.push(nodePath)
       config.nodeVersion = config.useNodeVersion


### PR DESCRIPTION
Close #6720 

This PR implements the support for specifying multiple Node.js versions in a workspace environment for multiple packages. This feature is handy in multi-package workspace environments, enabling seamless version switching for each package - more details in the linked issue.

The version for each package can be specified using the `pnpm` config in the `package.json` of each project in a workspace.

#### Notes

I kept `use-node-version` support for `.npmrc` for backward compatibility. Only root-level is supported, and if set - it will be applied to all packages. The per-package version must be assigned in the `package.json`'s `pnpm` config of the desired package. I can see a case when `.npmrc` already exists with `use-node-version` set to default for all packages, but some might opt-in to use the `pnpm` config to select another version to use.

I tested it with multiple configurations, including nested calls.

It would be easier to implement if the `pnpm/src/main.ts` were executed on every script separately with the correct path to each package, but I am unsure of complications that will occur, and it's too much of a change.