### PR TITLE
perf(resolve-dependencies): avoid copying preferredVersions object

### DIFF
--- a/.changeset/brave-clouds-sing.md
+++ b/.changeset/brave-clouds-sing.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+replacing object copying with a prototype chain, avoiding extra memory allocations in resolveDependencies function

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -522,7 +522,7 @@ export async function resolveDependencies (
       postponedPeersResolutionQueue.push(postponedPeersResolution)
     }
   })
-  const newPreferredVersions = { ...preferredVersions }
+  const newPreferredVersions = Object.create(preferredVersions) as PreferredVersions
   const currentParentPkgAliases: Record<string, PkgAddress | true> = {}
   for (const pkgAddress of pkgAddresses) {
     if (currentParentPkgAliases[pkgAddress.alias] !== true) {


### PR DESCRIPTION
Replacing object spread with a prototype chain, avoiding extra memory allocations in `resolveDependencies`

This becomes noticeable on relatively large monorepo(~2k packages) reducing memory usage and making it faster

Also in my case:
1. allowing to complete `pnpm install` without `--max_old_space_size=8192` (it is slower, but at least works without OOM crash)
2. prevents OOM issue with `auto-install-peers=true` (for me this is crashing otherwise no matter `max_old_space_size`)

--- 

flame graph using pprof-it, running `NODE_OPTIONS="--max_old_space_size=8192" pprof-it ../pnpm/pnpm/bin/pnpm.cjs install --offline --resolution-only`

before: 
<img width="1066" alt="Screenshot 2023-06-29 at 23 17 56" src="https://github.com/pnpm/pnpm/assets/446117/d5a93d9e-1582-44d1-97fc-fddd733f4655">

after:
<img width="1069" alt="Screenshot 2023-06-29 at 23 18 17" src="https://github.com/pnpm/pnpm/assets/446117/699306d6-ac22-453f-85fa-43e53cf271cd">


