### PR TITLE
perf(resolve-dependencies): avoid object copy in resolvePeersOfNode

### DIFF
--- a/.changeset/brown-mayflies-sparkle.md
+++ b/.changeset/brown-mayflies-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+replacing object copying with a prototype chain, avoiding extra memory allocations in resolvePeersOfNode function

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -289,16 +289,16 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
   const children = node.children
   const parentPkgs = isEmpty(children)
     ? parentParentPkgs
-    : {
-      ...parentParentPkgs,
-      ...toPkgByName(
+    : Object.assign(
+      Object.create(parentParentPkgs),
+      toPkgByName(
         Object.entries(children).map(([alias, nodeId]) => ({
           alias,
           node: ctx.dependenciesTree[nodeId],
           nodeId,
         }))
-      ),
-    }
+      )
+    )
   const hit = ctx.peersCache.get(resolvedPackage.depPath)?.find((cache) =>
     cache.resolvedPeers
       .every(([name, cachedNodeId]) => {


### PR DESCRIPTION
Replacing object spread with a prototype chain, avoiding extra memory allocations in `resolvePeersOfNode`(similar to #6735)

This becomes noticeable on relatively large monorepo(~2k packages) reducing memory usage and making it almost twice faster in my case

--- 

flame graph using pprof-it, running `NODE_OPTIONS="--max_old_space_size=8192" pprof-it ../pnpm/pnpm/bin/pnpm.cjs install --offline --resolution-only`

before: 
<img width="1084" alt="Screenshot 2023-06-29 at 23 25 39" src="https://github.com/pnpm/pnpm/assets/446117/19768e33-4d23-4027-9d35-cdb6b4d526cf">

after:
<img width="1085" alt="Screenshot 2023-06-29 at 23 25 58" src="https://github.com/pnpm/pnpm/assets/446117/78b0c8c7-6f05-4b32-90ae-8649a60f12e9">


