### PR TITLE
fix: always resolve manifest promise even if the dependency does not have package.json

### DIFF
--- a/.changeset/dull-moles-notice.md
+++ b/.changeset/dull-moles-notice.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"@pnpm/cafs": patch
+---
+
+always resolve manifest promise even if the dependency does not have package.json [#6721](https://github.com/pnpm/pnpm/issues/6721).

--- a/pkg-manager/core/test/install/fromRepo.ts
+++ b/pkg-manager/core/test/install/fromRepo.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import { type RootLog } from '@pnpm/core-loggers'
 import { prepareEmpty } from '@pnpm/prepare'
 import {
@@ -179,6 +180,14 @@ test('from a github repo the has no package.json file', async () => {
   expect(manifest.dependencies).toStrictEqual({
     'for-testing.no-package-json': 'github:pnpm/for-testing.no-package-json',
   })
+  fs.rmSync(path.join(project.dir(), 'node_modules'), {
+    recursive: true, force: true,
+  })
+  fs.rmSync(path.join(project.dir(), 'pnpm-lock.yaml'))
+  // if there is an unresolved promise, this test will hang until timeout.
+  // e.g. thrown: "Exceeded timeout of 240000 ms for a test.
+  await addDependenciesToPackage({}, ['pnpm/for-testing.no-package-json'], await testDefaults())
+  await project.has('for-testing.no-package-json')
 })
 
 test('from a github repo that needs to be built. isolated node linker is used', async () => {

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -81,6 +81,9 @@ async function checkFilesIntegrity (
         })
       )
   )
+  if (manifest && !files['package.json']) {
+    manifest.resolve(undefined)
+  }
   return allVerified
 }
 


### PR DESCRIPTION
fix #6721 

When we have never installed `pnpm/for-testing.no-package-json` before, the first installation will succeed:

```
$ pnpm add pnpm/for-testing.no-package-json
Packages: +1
+
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/Library/pnpm/store/v3
  Virtual store is at:             node_modules/.pnpm

dependencies:
+ for-testing.no-package-json 0.0.0

Progress: resolved 1, reused 0, downloaded 1, added 1, done
Done in 2.8s
```
When reinstalling this dependency again, node will exit silently:

```
$ rm -rf node_modules pnpm-lock.yaml
$ pnpm add pnpm/for-testing.no-package-json
Progress: resolved 0, reused 1, downloaded 0, added 0
```
