### PR TITLE
feat: include a workspace root when running --parallel in a single project; collapse an output of --parallel

### DIFF
--- a/.changeset/eleven-balloons-melt.md
+++ b/.changeset/eleven-balloons-melt.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"pnpm": minor
+---
+
+Include a workspace root when running --parallel in a single project #6692; collapse an output of parallel scripts #3076

--- a/.changeset/eleven-balloons-melt.md
+++ b/.changeset/eleven-balloons-melt.md
@@ -3,4 +3,4 @@
 "pnpm": minor
 ---
 
-Include a workspace root when running --parallel in a single project #6692; collapse an output of parallel scripts #3076
+Include a workspace root when running --parallel in a single project #6692; add a --collapse-output option that collapses the output of --parallel #3076

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -17,6 +17,7 @@ export interface Config {
   autoInstallPeers?: boolean
   bail: boolean
   color: 'always' | 'auto' | 'never'
+  collapseOutput: boolean
   cliOptions: Record<string, any>, // eslint-disable-line
   useBetaCli: boolean
   excludeLinksFromLockfile: boolean

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -16,7 +16,9 @@ import {
   PARALLEL_OPTION_HELP,
   REPORT_SUMMARY_OPTION_HELP,
   RESUME_FROM_OPTION_HELP,
+  COLLAPSE_OUTPUT_OPTION_HELP,
   shorthands as runShorthands,
+  COLLAPSE_OUTPUT_OPTION,
 } from './run'
 import { PnpmError } from '@pnpm/error'
 import which from 'which'
@@ -47,6 +49,7 @@ export function rcOptionsTypes () {
 
 export const cliOptionsTypes = () => ({
   ...rcOptionsTypes(),
+  ...COLLAPSE_OUTPUT_OPTION,
   recursive: Boolean,
   reverse: Boolean,
 })
@@ -76,6 +79,7 @@ The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
           },
           RESUME_FROM_OPTION_HELP,
           REPORT_SUMMARY_OPTION_HELP,
+          COLLAPSE_OUTPUT_OPTION_HELP,
         ],
       },
     ],

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -55,10 +55,20 @@ export const REPORT_SUMMARY_OPTION_HELP = {
   name: '--report-summary',
 }
 
+export const COLLAPSE_OUTPUT_OPTION = {
+  'collapse-output': Boolean,
+}
+
+export const COLLAPSE_OUTPUT_OPTION_HELP = {
+  description: 'Collapse the output of --parallel by disabling the --stream option, which is enabled by default when you run --parallel.',
+  name: '--collapse-output',
+}
+
 export const shorthands = {
   parallel: [
     '--workspace-concurrency=Infinity',
     '--no-sort',
+    '--stream',
     '--recursive',
   ],
   sequential: [
@@ -86,6 +96,7 @@ export function cliOptionsTypes () {
       'scripts-prepend-node-path',
     ], allTypes),
     ...IF_PRESENT_OPTION,
+    ...COLLAPSE_OUTPUT_OPTION,
     recursive: Boolean,
     reverse: Boolean,
     'resume-from': String,
@@ -129,6 +140,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           ...UNIVERSAL_OPTIONS,
           SEQUENTIAL_OPTION_HELP,
           REPORT_SUMMARY_OPTION_HELP,
+          COLLAPSE_OUTPUT_OPTION_HELP,
         ],
       },
       FILTERING,

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -59,7 +59,6 @@ export const shorthands = {
   parallel: [
     '--workspace-concurrency=Infinity',
     '--no-sort',
-    '--stream',
     '--recursive',
   ],
   sequential: [

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -59,8 +59,7 @@ export async function runRecursive (
   const limitRun = pLimit(opts.workspaceConcurrency ?? 4)
   const stdio =
     !opts.stream &&
-    (opts.workspaceConcurrency === 1 ||
-      (packageChunks.length === 1 && packageChunks[0].length === 1))
+    (opts.workspaceConcurrency === 1)
       ? 'inherit'
       : 'pipe'
   const existsPnp = existsInDir.bind(null, '.pnp.cjs')

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -26,7 +26,7 @@ export type RecursiveRunOpts = Pick<Config,
 | 'shellEmulator'
 | 'stream'
 > & Required<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir' | 'dir'>> &
-Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'reverse' | 'sort' | 'workspaceConcurrency'>> &
+Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'reverse' | 'sort' | 'workspaceConcurrency' | 'collapseOutput'>> &
 {
   ifPresent?: boolean
   resumeFrom?: string
@@ -59,7 +59,9 @@ export async function runRecursive (
   const limitRun = pLimit(opts.workspaceConcurrency ?? 4)
   const stdio =
     !opts.stream &&
-    (opts.workspaceConcurrency === 1)
+    !opts.collapseOutput &&
+    (opts.workspaceConcurrency === 1 ||
+      (packageChunks.length === 1 && packageChunks[0].length === 1))
       ? 'inherit'
       : 'pipe'
   const existsPnp = existsInDir.bind(null, '.pnp.cjs')

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -216,6 +216,11 @@ export async function main (inputArgv: string[]) {
     }
     config.allProjectsGraph = filterResults.allProjectsGraph
     config.selectedProjectsGraph = filterResults.selectedProjectsGraph
+    const isParallel = cliOptions['sort'] === false && cliOptions['workspace-concurrency'] === Number.POSITIVE_INFINITY
+    const isSingleProject = filterResults.allProjects.length === 1 && filterResults.allProjects[0].dir === wsDir
+    if (isParallel && isSingleProject) {
+      config.selectedProjectsGraph = filterResults.allProjectsGraph
+    }
     if (isEmpty(config.selectedProjectsGraph)) {
       if (printLogs) {
         console.log(`No projects matched the filters in "${wsDir}"`)

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -119,6 +119,12 @@ export async function main (inputArgv: string[]) {
     return
   }
 
+  const isParallel = cliOptions['sort'] === false && cliOptions['stream'] === true && cliOptions['workspace-concurrency'] === Number.POSITIVE_INFINITY
+  if (isParallel && cliOptions['collapse-output']) {
+    cliOptions['stream'] = false
+    config.stream = false
+  }
+
   let write: (text: string) => void = process.stdout.write.bind(process.stdout)
   // chalk reads the FORCE_COLOR env variable
   if (config.color === 'always') {
@@ -216,7 +222,6 @@ export async function main (inputArgv: string[]) {
     }
     config.allProjectsGraph = filterResults.allProjectsGraph
     config.selectedProjectsGraph = filterResults.selectedProjectsGraph
-    const isParallel = cliOptions['sort'] === false && cliOptions['workspace-concurrency'] === Number.POSITIVE_INFINITY
     const isSingleProject = filterResults.allProjects.length === 1 && filterResults.allProjects[0].dir === wsDir
     if (isParallel && isSingleProject) {
       config.selectedProjectsGraph = filterResults.allProjectsGraph

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -1600,6 +1600,52 @@ test('pnpm run should include the workspace root when include-workspace-root is 
   expect(await exists('project/test')).toBeTruthy()
 })
 
+test('pnpm run --parallel should include the workspace root in a single project', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        scripts: {
+          test: "node -e \"require('fs').writeFileSync('test','','utf8')\"",
+        },
+      },
+    },
+  ])
+
+  await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  await execPnpm(['run', '--parallel', 'test'])
+
+  expect(await exists('test')).toBeTruthy()
+})
+
+test('pnpm run --parallel should not include the workspace root in a monorepo', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        scripts: {
+          test: "node -e \"require('fs').writeFileSync('test','','utf8')\"",
+        },
+      },
+    },
+    {
+      name: 'project',
+      version: '1.0.0',
+      scripts: {
+        test: "node -e \"require('fs').writeFileSync('test','','utf8')\"",
+      },
+    },
+  ])
+
+  await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  await execPnpm(['run', '--parallel', 'test'])
+
+  expect(await exists('project/test')).toBeTruthy()
+  expect(await exists('test')).toBeFalsy()
+})
+
 test('legacy directory filtering', async () => {
   preparePackages([
     {


### PR DESCRIPTION
cc @ai fixes #6692 & fixes #3076

I've added a check to see if a user is running --parallel in a single project, and if so, include that project (see file pnpm/src/main.ts).

I've removed the --stream option from the --parallel shorthand in order to collapse an output:
![image](https://github.com/pnpm/pnpm/assets/79661007/98c756b2-73bc-44ce-935a-06d1dd759860)

I've removed the changes introduced in this commit: https://github.com/pnpm/pnpm/commit/079942f1e8719104c867ab6266b5fa633a2eb691 in order to display a better output when running --parallel in a single project.
For example, here is the output of a --parallel when run in a single project without this change:
![image](https://github.com/pnpm/pnpm/assets/79661007/94ed62b0-7f6a-406f-8e35-45d5ca83f0bd)
With this change:
![image](https://github.com/pnpm/pnpm/assets/79661007/47195d11-7c82-4cc4-8588-f048f659fba5)


