### PR TITLE
perf(resolve-dependencies): preferredVersions in resolveDependenciesOfImporters

### DIFF
--- a/.changeset/fluffy-eggs-matter.md
+++ b/.changeset/fluffy-eggs-matter.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Replacing object spread with a prototype chain, avoiding extra memory allocations in resolveDependenciesOfImporters.

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -395,7 +395,7 @@ async function resolveDependenciesOfImporters (
     }
   }
   const pkgAddressesByImportersWithoutPeers = await Promise.all(zipWith(async (importer, { pkgAddresses, postponedResolutionsQueue, postponedPeersResolutionQueue }) => {
-    const newPreferredVersions = { ...importer.preferredVersions }
+    const newPreferredVersions = Object.create(importer.preferredVersions) as PreferredVersions
     const currentParentPkgAliases: Record<string, PkgAddress | true> = {}
     for (const pkgAddress of pkgAddresses) {
       if (currentParentPkgAliases[pkgAddress.alias] !== true) {
@@ -406,8 +406,8 @@ async function resolveDependenciesOfImporters (
       }
       const resolvedPackage = ctx.resolvedPackagesByDepPath[pkgAddress.depPath]
       if (!resolvedPackage) continue // This will happen only with linked dependencies
-      if (!newPreferredVersions[resolvedPackage.name]) {
-        newPreferredVersions[resolvedPackage.name] = {}
+      if (!Object.prototype.hasOwnProperty.call(newPreferredVersions, resolvedPackage.name)) {
+        newPreferredVersions[resolvedPackage.name] = { ...importer.preferredVersions[resolvedPackage.name] }
       }
       if (!newPreferredVersions[resolvedPackage.name][resolvedPackage.version]) {
         newPreferredVersions[resolvedPackage.name][resolvedPackage.version] = {


### PR DESCRIPTION
Replacing object spread with a prototype chain, avoiding extra memory allocations in `resolveDependenciesOfImporters`

similar to #6735

also, fixing for the edge case when `importer.preferredVersions` can be overridden unintentionally

before:
<img width="1012" alt="Screenshot 2023-07-02 at 09 02 58" src="https://github.com/pnpm/pnpm/assets/446117/594029f0-65fe-41ee-91f4-6ee7e71bf792">

after:
<img width="1014" alt="Screenshot 2023-07-02 at 09 06 32" src="https://github.com/pnpm/pnpm/assets/446117/7ac72422-f863-485a-aef3-5ae8fc457614">
