### PR TITLE
refactor(resolve-dependencies): use Maps and Sets instead of objects

### DIFF
--- a/.changeset/fair-apples-mix.md
+++ b/.changeset/fair-apples-mix.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Refactor resolve-dependencies to use maps and sets instead of objects

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -158,8 +158,7 @@ function deduplicateDepPaths<T extends PartialResolvedPackage> (
 
   for (const depPaths of duplicates) {
     const unresolvedDepPaths = new Set(depPaths.values())
-    let currentDepPaths = [...depPaths]
-    currentDepPaths.sort(depCountSorter)
+    let currentDepPaths = [...depPaths].sort(depCountSorter)
 
     while (currentDepPaths.length) {
       const depPath1 = currentDepPaths.pop()!

--- a/pkg-manager/resolve-dependencies/test/dedupeDepPaths.test.ts
+++ b/pkg-manager/resolve-dependencies/test/dedupeDepPaths.test.ts
@@ -1,7 +1,8 @@
-import { resolvePeers } from '../lib/resolvePeers'
+import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers'
+import { type DependenciesTreeNode } from '../lib/resolveDependencies'
 
 test('packages are not deduplicated when versions do not match', () => {
-  const fooPkg = {
+  const fooPkg: PartialResolvedPackage = {
     name: 'foo',
     version: '1.0.0',
     depPath: 'foo/1.0.0',
@@ -16,7 +17,7 @@ test('packages are not deduplicated when versions do not match', () => {
     },
   }
 
-  const peers = Object.fromEntries(
+  const peers: Record<string, PartialResolvedPackage> = Object.fromEntries(
     [
       ['bar', '1.0.0'],
       ['bar', '2.0.0'],
@@ -29,7 +30,7 @@ test('packages are not deduplicated when versions do not match', () => {
         version,
         depPath: `${name}/${version}`,
         peerDependencies: {},
-      },
+      } satisfies PartialResolvedPackage,
     ])
   )
 
@@ -74,7 +75,7 @@ test('packages are not deduplicated when versions do not match', () => {
         id: 'project4',
       },
     ],
-    dependenciesTree: Object.fromEntries([
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>(([
       ['>project1>foo/1.0.0>', fooPkg],
       ['>project1>bar/1.0.0>', peers.bar_1_0_0],
 
@@ -89,12 +90,12 @@ test('packages are not deduplicated when versions do not match', () => {
       ['>project4>bar/2.0.0>', peers.bar_2_0_0],
       ['>project4>baz/2.0.0>', peers.baz_2_0_0],
 
-    ].map(([path, resolvedPackage]) => [path, {
+    ] satisfies Array<[string, PartialResolvedPackage]>).map(([path, resolvedPackage]) => [path, {
       children: {},
       installable: {},
       resolvedPackage,
       depth: 0,
-    }])),
+    } as DependenciesTreeNode<PartialResolvedPackage>])),
     dedupePeerDependents: true,
     virtualStoreDir: '',
     lockfileDir: '',

--- a/pkg-manager/resolve-dependencies/test/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/test/resolvePeers.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts" />
-import { resolvePeers } from '../lib/resolvePeers'
+import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers'
+import { type DependenciesTreeNode } from '../lib/resolveDependencies'
 
 test('resolve peer dependencies of cyclic dependencies', () => {
   const fooPkg = {
@@ -31,24 +32,24 @@ test('resolve peer dependencies of cyclic dependencies', () => {
         id: '',
       },
     ],
-    dependenciesTree: {
-      '>foo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>foo/1.0.0>', {
         children: {
           bar: '>foo/1.0.0>bar/1.0.0>',
         },
         installable: true,
         resolvedPackage: fooPkg,
         depth: 0,
-      },
-      '>foo/1.0.0>bar/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>', {
         children: {
           qar: '>foo/1.0.0>bar/1.0.0>qar/1.0.0>',
         },
         installable: true,
         resolvedPackage: barPkg,
         depth: 1,
-      },
-      '>foo/1.0.0>bar/1.0.0>qar/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>qar/1.0.0>', {
         children: {
           zoo: '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>',
         },
@@ -63,8 +64,8 @@ test('resolve peer dependencies of cyclic dependencies', () => {
           },
         },
         depth: 2,
-      },
-      '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>', {
         children: {
           foo: '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>foo/1.0.0>',
           bar: '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>bar/1.0.0>',
@@ -79,20 +80,20 @@ test('resolve peer dependencies of cyclic dependencies', () => {
           },
         },
         depth: 3,
-      },
-      '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>foo/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 4,
-      },
-      '>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>bar/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>qar/1.0.0>zoo/1.0.0>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 4,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })
@@ -139,22 +140,22 @@ test('when a package is referenced twice in the dependencies graph and one of th
         id: '',
       },
     ],
-    dependenciesTree: {
-      '>zoo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>zoo/1.0.0>', {
         children: {
           foo: '>zoo/1.0.0>foo/1.0.0>',
         },
         installable: true,
         resolvedPackage: zooPkg,
         depth: 0,
-      },
-      '>zoo/1.0.0>foo/1.0.0>': {
+      }],
+      ['>zoo/1.0.0>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 1,
-      },
-      '>bar/1.0.0>': {
+      }],
+      ['>bar/1.0.0>', {
         children: {
           zoo: '>bar/1.0.0>zoo/1.0.0>',
           qar: '>bar/1.0.0>qar/1.0.0>',
@@ -162,22 +163,22 @@ test('when a package is referenced twice in the dependencies graph and one of th
         installable: true,
         resolvedPackage: barPkg,
         depth: 0,
-      },
-      '>bar/1.0.0>zoo/1.0.0>': {
+      }],
+      ['>bar/1.0.0>zoo/1.0.0>', {
         children: {
           foo: '>bar/1.0.0>zoo/1.0.0>foo/1.0.0>',
         },
         installable: true,
         resolvedPackage: zooPkg,
         depth: 1,
-      },
-      '>bar/1.0.0>zoo/1.0.0>foo/1.0.0>': {
+      }],
+      ['>bar/1.0.0>zoo/1.0.0>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 2,
-      },
-      '>bar/1.0.0>qar/1.0.0>': {
+      }],
+      ['>bar/1.0.0>qar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -187,8 +188,8 @@ test('when a package is referenced twice in the dependencies graph and one of th
           peerDependencies: {},
         },
         depth: 1,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })
@@ -308,68 +309,68 @@ describe('peer dependency issues', () => {
         id: 'project6',
       },
     ],
-    dependenciesTree: {
-      '>project1>foo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>project1>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 0,
-      },
-      '>project2>bar/1.0.0>': {
+      }],
+      ['>project2>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 0,
-      },
-      '>project3>foo/1.0.0>': {
+      }],
+      ['>project3>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 0,
-      },
-      '>project3>bar/1.0.0>': {
+      }],
+      ['>project3>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 0,
-      },
-      '>project4>bar/1.0.0>': {
+      }],
+      ['>project4>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 0,
-      },
-      '>project4>qar/1.0.0>': {
+      }],
+      ['>project4>qar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: qarPkg,
         depth: 0,
-      },
-      '>project5>foo/1.0.0>': {
+      }],
+      ['>project5>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooPkg,
         depth: 0,
-      },
-      '>project5>bar/2.0.0>': {
+      }],
+      ['>project5>bar/2.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barWithOptionalPeer,
         depth: 0,
-      },
-      '>project6>foo/2.0.0>': {
+      }],
+      ['>project6>foo/2.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: fooWithOptionalPeer,
         depth: 0,
-      },
-      '>project6>bar/2.0.0>': {
+      }],
+      ['>project6>bar/2.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barWithOptionalPeer,
         depth: 0,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })
@@ -408,8 +409,8 @@ describe('unmet peer dependency issues', () => {
         id: 'project1',
       },
     ],
-    dependenciesTree: {
-      '>project1>foo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>project1>foo/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -422,8 +423,8 @@ describe('unmet peer dependency issues', () => {
           },
         },
         depth: 0,
-      },
-      '>project1>peer1/1.0.0-rc.0>': {
+      }],
+      ['>project1>peer1/1.0.0-rc.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -433,8 +434,8 @@ describe('unmet peer dependency issues', () => {
           peerDependencies: {},
         },
         depth: 0,
-      },
-      '>project1>peer2/1.1.0-rc.0>': {
+      }],
+      ['>project1>peer2/1.1.0-rc.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -444,8 +445,8 @@ describe('unmet peer dependency issues', () => {
           peerDependencies: {},
         },
         depth: 0,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })
@@ -469,8 +470,8 @@ describe('unmet peer dependency issue resolved from subdependency', () => {
         id: 'project',
       },
     ],
-    dependenciesTree: {
-      '>project>foo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>project>foo/1.0.0>', {
         children: {
           dep: '>project>foo/1.0.0>dep/1.0.0>',
           bar: '>project>foo/1.0.0>bar/1.0.0>',
@@ -483,8 +484,8 @@ describe('unmet peer dependency issue resolved from subdependency', () => {
           peerDependencies: {},
         },
         depth: 0,
-      },
-      '>project>foo/1.0.0>dep/1.0.0>': {
+      }],
+      ['>project>foo/1.0.0>dep/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -494,8 +495,8 @@ describe('unmet peer dependency issue resolved from subdependency', () => {
           peerDependencies: {},
         },
         depth: 1,
-      },
-      '>project>foo/1.0.0>bar/1.0.0>': {
+      }],
+      ['>project>foo/1.0.0>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: {
@@ -507,8 +508,8 @@ describe('unmet peer dependency issue resolved from subdependency', () => {
           },
         },
         depth: 1,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })
@@ -560,48 +561,48 @@ test('resolve peer dependencies with npm aliases', () => {
         id: '',
       },
     ],
-    dependenciesTree: {
-      '>foo/1.0.0>': {
+    dependenciesTree: new Map<string, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>foo/1.0.0>', {
         children: {
           bar: '>foo/1.0.0>bar/1.0.0>',
         },
         installable: true,
         resolvedPackage: fooPkg,
         depth: 0,
-      },
-      '>foo/1.0.0>bar/1.0.0>': {
+      }],
+      ['>foo/1.0.0>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 1,
-      },
-      '>foo/2.0.0>': {
+      }],
+      ['>foo/2.0.0>', {
         children: {
           bar: '>foo/2.0.0>bar/2.0.0>',
         },
         installable: true,
         resolvedPackage: fooAliasPkg,
         depth: 0,
-      },
-      '>foo/2.0.0>bar/2.0.0>': {
+      }],
+      ['>foo/2.0.0>bar/2.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barAliasPkg,
         depth: 1,
-      },
-      '>bar/1.0.0>': {
+      }],
+      ['>bar/1.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barPkg,
         depth: 0,
-      },
-      '>bar/2.0.0>': {
+      }],
+      ['>bar/2.0.0>', {
         children: {},
         installable: true,
         resolvedPackage: barAliasPkg,
         depth: 0,
-      },
-    },
+      }],
+    ]),
     virtualStoreDir: '',
     lockfileDir: '',
   })


### PR DESCRIPTION
- use `Map` of Sets for `depPathsByPkgId`
- use `Map` for `pathsByNodeId`
- make `DependenciesTree` a `Map` instead of a dictionary object
- use `Set` for `resolvedPeerNames`
- use `Map` for `resolvedPeers`, avoiding conversions
- avoid unnecessary conversion from `Set` to `Array`


before:
<img width="1012" alt="Screenshot 2023-07-02 at 09 02 58" src="https://github.com/pnpm/pnpm/assets/446117/594029f0-65fe-41ee-91f4-6ee7e71bf792">

after:
<img width="1013" alt="Screenshot 2023-07-02 at 09 03 50" src="https://github.com/pnpm/pnpm/assets/446117/1f68650b-d93d-455c-ac23-419911eeb5a4">
