### PR TITLE
refactor(resolve-dependencies): remove ramda isEmpty usages

### DIFF
--- a/.changeset/bright-ants-stare.md
+++ b/.changeset/bright-ants-stare.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Replacing usages of ramda isEmpty, which happens to be slow and resource intensive

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -44,7 +44,6 @@ import normalizePath from 'normalize-path'
 import exists from 'path-exists'
 import pDefer from 'p-defer'
 import pShare from 'promise-share'
-import isEmpty from 'ramda/src/isEmpty'
 import pickBy from 'ramda/src/pickBy'
 import omit from 'ramda/src/omit'
 import zipWith from 'ramda/src/zipWith'
@@ -1231,7 +1230,7 @@ async function resolveDependency (
     ) {
       pkg.deprecated = currentPkg.dependencyLockfile.deprecated
     }
-    hasBin = Boolean((pkg.bin && !isEmpty(pkg.bin)) ?? pkg.directories?.bin)
+    hasBin = Boolean((pkg.bin && !(pkg.bin === '' || Object.keys(pkg.bin).length === 0)) ?? pkg.directories?.bin)
     /* eslint-enable @typescript-eslint/dot-notation */
   }
   if (options.currentDepth === 0 && pkgResponse.body.latest && pkgResponse.body.latest !== pkg.version) {
@@ -1384,12 +1383,12 @@ function getMissingPeers (pkg: PackageManifest) {
 }
 
 function pkgIsLeaf (pkg: PackageManifest) {
-  return isEmpty(pkg.dependencies ?? {}) &&
-    isEmpty(pkg.optionalDependencies ?? {}) &&
-    isEmpty(pkg.peerDependencies ?? {}) &&
+  return Object.keys(pkg.dependencies ?? {}).length === 0 &&
+    Object.keys(pkg.optionalDependencies ?? {}).length === 0 &&
+    Object.keys(pkg.peerDependencies ?? {}).length === 0 &&
     // Package manifests can declare peerDependenciesMeta without declaring
     // peerDependencies. peerDependenciesMeta implies the later.
-    isEmpty(pkg.peerDependenciesMeta ?? {})
+    Object.keys(pkg.peerDependenciesMeta ?? {}).length === 0
 }
 
 function getResolvedPackage (
@@ -1466,6 +1465,6 @@ function peerDependenciesWithoutOwn (pkg: PackageManifest) {
       result[peerName] = '*'
     }
   }
-  if (isEmpty(result)) return undefined
+  if (Object.keys(result).length === 0) return undefined
   return result
 }

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -8,7 +8,6 @@ import type {
   PeerDependencyIssuesByProjects,
 } from '@pnpm/types'
 import { depPathToFilename, createPeersFolderSuffix } from '@pnpm/dependency-path'
-import isEmpty from 'ramda/src/isEmpty'
 import mapValues from 'ramda/src/map'
 import pick from 'ramda/src/pick'
 import pickBy from 'ramda/src/pickBy'
@@ -96,7 +95,7 @@ export function resolvePeers<T extends PartialResolvedPackage> (
       rootDir,
       virtualStoreDir: opts.virtualStoreDir,
     })
-    if (!isEmpty(peerDependencyIssues.bad) || !isEmpty(peerDependencyIssues.missing)) {
+    if (Object.keys(peerDependencyIssues.bad).length !== 0 || Object.keys(peerDependencyIssues.missing).length !== 0) {
       peerDependencyIssuesByProjects[id] = {
         ...peerDependencyIssues,
         ...mergePeers(peerDependencyIssues.missing),
@@ -278,7 +277,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
   if (
     ctx.purePkgs.has(resolvedPackage.depPath) &&
     ctx.depGraph[resolvedPackage.depPath].depth <= node.depth &&
-    isEmpty(resolvedPackage.peerDependencies)
+    Object.keys(resolvedPackage.peerDependencies).length === 0
   ) {
     ctx.pathsByNodeId[nodeId] = resolvedPackage.depPath
     return { resolvedPeers: {}, missingPeers: [] }
@@ -287,7 +286,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
     node.children = node.children()
   }
   const children = node.children
-  const parentPkgs = isEmpty(children)
+  const parentPkgs = Object.keys(children).length === 0
     ? parentParentPkgs
     : Object.assign(
       Object.create(parentParentPkgs),
@@ -332,7 +331,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
     missingPeers: missingPeersOfChildren,
   } = resolvePeersOfChildren(children, parentPkgs, ctx)
 
-  const { resolvedPeers, missingPeers } = isEmpty(resolvedPackage.peerDependencies)
+  const { resolvedPeers, missingPeers } = Object.keys(resolvedPackage.peerDependencies).length === 0
     ? { resolvedPeers: {}, missingPeers: [] }
     : _resolvePeers({
       currentDepth: node.depth,
@@ -350,7 +349,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
   const allMissingPeers = Array.from(new Set([...missingPeersOfChildren, ...missingPeers]))
 
   let depPath: string
-  if (isEmpty(allResolvedPeers)) {
+  if (Object.keys(allResolvedPeers).length === 0) {
     depPath = resolvedPackage.depPath
   } else {
     const peersFolderSuffix = createPeersFolderSuffix(
@@ -371,7 +370,7 @@ function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
   const localLocation = path.join(ctx.virtualStoreDir, depPathToFilename(depPath))
   const modules = path.join(localLocation, 'node_modules')
-  const isPure = isEmpty(allResolvedPeers) && allMissingPeers.length === 0
+  const isPure = Object.keys(allResolvedPeers).length === 0 && allMissingPeers.length === 0
   if (isPure) {
     ctx.purePkgs.add(resolvedPackage.depPath)
   } else {

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -95,7 +95,7 @@ export function resolvePeers<T extends PartialResolvedPackage> (
       rootDir,
       virtualStoreDir: opts.virtualStoreDir,
     })
-    if (Object.keys(peerDependencyIssues.bad).length !== 0 || Object.keys(peerDependencyIssues.missing).length !== 0) {
+    if (Object.keys(peerDependencyIssues.bad).length > 0 || Object.keys(peerDependencyIssues.missing).length > 0) {
       peerDependencyIssuesByProjects[id] = {
         ...peerDependencyIssues,
         ...mergePeers(peerDependencyIssues.missing),

--- a/pkg-manager/resolve-dependencies/src/updateLockfile.ts
+++ b/pkg-manager/resolve-dependencies/src/updateLockfile.ts
@@ -11,7 +11,6 @@ import { type Registries } from '@pnpm/types'
 import * as dp from '@pnpm/dependency-path'
 import getNpmTarballUrl from 'get-npm-tarball-url'
 import { type KeyValuePair } from 'ramda'
-import isEmpty from 'ramda/src/isEmpty'
 import mergeRight from 'ramda/src/mergeRight'
 import partition from 'ramda/src/partition'
 import { type SafePromiseDefer } from 'safe-promise-defer'
@@ -103,10 +102,10 @@ function toLockfileDependency (
       result['version'] = pkg.version
     }
   }
-  if (!isEmpty(newResolvedDeps)) {
+  if (Object.keys(newResolvedDeps).length !== 0) {
     result['dependencies'] = newResolvedDeps
   }
-  if (!isEmpty(newResolvedOptionalDeps)) {
+  if (Object.keys(newResolvedOptionalDeps).length !== 0) {
     result['optionalDependencies'] = newResolvedOptionalDeps
   }
   if (pkg.dev && !pkg.prod) {
@@ -120,7 +119,7 @@ function toLockfileDependency (
   if (opts.depPath[0] !== '/' && !pkg.id.endsWith(opts.depPath)) {
     result['id'] = pkg.id
   }
-  if (!isEmpty(pkg.peerDependencies ?? {})) {
+  if (Object.keys(pkg.peerDependencies ?? {}).length !== 0) {
     result['peerDependencies'] = pkg.peerDependencies
   }
   if (pkg.transitivePeerDependencies.size) {

--- a/pkg-manager/resolve-dependencies/src/updateLockfile.ts
+++ b/pkg-manager/resolve-dependencies/src/updateLockfile.ts
@@ -102,10 +102,10 @@ function toLockfileDependency (
       result['version'] = pkg.version
     }
   }
-  if (Object.keys(newResolvedDeps).length !== 0) {
+  if (Object.keys(newResolvedDeps).length > 0) {
     result['dependencies'] = newResolvedDeps
   }
-  if (Object.keys(newResolvedOptionalDeps).length !== 0) {
+  if (Object.keys(newResolvedOptionalDeps).length > 0) {
     result['optionalDependencies'] = newResolvedOptionalDeps
   }
   if (pkg.dev && !pkg.prod) {
@@ -119,7 +119,7 @@ function toLockfileDependency (
   if (opts.depPath[0] !== '/' && !pkg.id.endsWith(opts.depPath)) {
     result['id'] = pkg.id
   }
-  if (Object.keys(pkg.peerDependencies ?? {}).length !== 0) {
+  if (Object.keys(pkg.peerDependencies ?? {}).length > 0) {
     result['peerDependencies'] = pkg.peerDependencies
   }
   if (pkg.transitivePeerDependencies.size) {


### PR DESCRIPTION
Replacing usages of Ramda `isEmpty` with alternatives.

To my surprise - I have discovered that it is really slow.
(it looks like because of allowing too many possible input types, it does a lot of unnecessary work).

before:
<img width="1135" alt="Screenshot 2023-07-02 at 16 57 26" src="https://github.com/pnpm/pnpm/assets/446117/8bb7d204-b658-4f3d-84f2-5dc2062e24a3">

after:
<img width="1133" alt="Screenshot 2023-07-02 at 17 01 33" src="https://github.com/pnpm/pnpm/assets/446117/f4458511-f434-4524-bb51-abf07e4ec34a">

that is around 15%, faster by just not using it 