### PR TITLE
fix(resolve-dependencies): optimize splitNodeId, fix invalid nodeId

### DIFF
--- a/.changeset/nice-geese-fly.md
+++ b/.changeset/nice-geese-fly.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Fix edge case where invalid "nodeId" was created. Small optimization.

--- a/pkg-manager/resolve-dependencies/src/nodeIdUtils.ts
+++ b/pkg-manager/resolve-dependencies/src/nodeIdUtils.ts
@@ -18,5 +18,5 @@ export function createNodeId (parentNodeId: string, pkgId: string) {
 }
 
 export function splitNodeId (nodeId: string) {
-  return nodeId.slice(1, -1).split('>')
+  return nodeId.split('>').slice(1, -1)
 }

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1241,7 +1241,7 @@ async function resolveDependency (
   // In case of leaf dependencies (dependencies that have no prod deps or peer deps),
   // we only ever need to analyze one leaf dep in a graph, so the nodeId can be short and stateless.
   const nodeId = pkgIsLeaf(pkg)
-    ? pkgResponse.body.id
+    ? `>${depPath}>`
     : createNodeId(options.parentPkg.nodeId, depPath)
 
   const parentIsInstallable = options.parentPkg.installable === undefined || options.parentPkg.installable


### PR DESCRIPTION
Fix to avoid creating invalid nodeId, small optimization