### PR TITLE
fix(dependencies-hierarchy): fix loading multiple copies of lockfile

### DIFF
--- a/.changeset/ninety-rats-breathe.md
+++ b/.changeset/ninety-rats-breathe.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/reviewing.dependencies-hierarchy": patch
+---
+
+Move loading `wantedLockfile` outside `dependenciesHierarchyForPackage`, preventing OOM crash when loading the same lock file too many times


### PR DESCRIPTION
Moving loading wantedLockfile outside dependenciesHierarchyForPackage, reducing memory usage and preventing OOM crash on larger cases when loading the same lock file too many times

Flame graph running `pnpm why`

before: 
<img width="982" alt="Screenshot 2023-07-03 at 14 48 46" src="https://github.com/pnpm/pnpm/assets/446117/92a38256-72de-4465-b0e8-2adad9bda298">

after:
<img width="986" alt="Screenshot 2023-07-03 at 14 49 11" src="https://github.com/pnpm/pnpm/assets/446117/e9869833-abfb-4555-86df-1c63a3b1769f">
