### PR TITLE
perf(modules-cleaner): replace ramda difference with better alternative

### DIFF
--- a/.changeset/young-scissors-grow.md
+++ b/.changeset/young-scissors-grow.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/modules-cleaner": patch
+---
+
+Replace ineffective use of ramda `difference` with better alternative


### PR DESCRIPTION
Ramda's `difference` happens to be slow, for the case how it is used in `prune` function.

before:
<img width="938" alt="Screenshot 2023-07-03 at 20 59 08" src="https://github.com/pnpm/pnpm/assets/446117/d9593fd7-0758-4c31-876d-11ac6c2e93e8">

after:
<img width="944" alt="Screenshot 2023-07-03 at 20 59 38" src="https://github.com/pnpm/pnpm/assets/446117/302ebf35-333c-49cd-88a2-47c0bc257890">
