### PR TITLE
fix: don't run postpublish of git-hosted dependency

### DIFF
--- a/.changeset/small-windows-brush.md
+++ b/.changeset/small-windows-brush.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/prepare-package": patch
+"pnpm": patch
+---
+
+The "postpublish" script of a git-hosted dependency is not executed, while building the dependency [#6822](https://github.com/pnpm/pnpm/issues/6846).

--- a/exec/prepare-package/src/index.ts
+++ b/exec/prepare-package/src/index.ts
@@ -12,7 +12,6 @@ const PREPUBLISH_SCRIPTS = [
   'prepublishOnly',
   'prepack',
   'publish',
-  'postpublish',
 ]
 
 export interface PreparePackageOptions {

--- a/exec/prepare-package/test/__fixtures__/has-prepublish-script/package.json
+++ b/exec/prepare-package/test/__fixtures__/has-prepublish-script/package.json
@@ -2,7 +2,8 @@
   "name": "has-prepublish-script",
   "version": "1.0.0",
   "scripts": {
-    "prepublish": "node -e \"process.stdout.write('prepublish')\" | json-append output.json"
+    "prepublish": "node -e \"process.stdout.write('prepublish')\" | json-append output.json",
+    "postpublish": "node -e \"process.stdout.write('postpublish')\" | json-append output.json"
   },
   "devDependencies": {
     "json-append": "1.1.1"


### PR DESCRIPTION
close #6846