### PR TITLE
fix: negate error on install without lockfile

### DIFF
--- a/.changeset/chilled-terms-matter.md
+++ b/.changeset/chilled-terms-matter.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/core": patch
+---
+
+Change the install error message when a lockfile is wanted but absent to
+indicate the wanted lockfile is absent, not present. This now reflects
+the actual error.

--- a/.changeset/chilled-terms-matter.md
+++ b/.changeset/chilled-terms-matter.md
@@ -1,7 +1,6 @@
 ---
 "@pnpm/core": patch
+"pnpm": patch
 ---
 
-Change the install error message when a lockfile is wanted but absent to
-indicate the wanted lockfile is absent, not present. This now reflects
-the actual error.
+Change the install error message when a lockfile is wanted but absent to indicate the wanted lockfile is absent, not present. This now reflects the actual error [#6851](https://github.com/pnpm/pnpm/pull/6851).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -416,7 +416,7 @@ Note that in CI environments, this setting is enabled by default.`,
           if (!satisfies) {
             if (!ctx.existsWantedLockfile) {
               throw new PnpmError('NO_LOCKFILE',
-                `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is present`, {
+                `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`, {
                   hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
                 })
             }

--- a/pkg-manager/core/test/install/frozenLockfile.ts
+++ b/pkg-manager/core/test/install/frozenLockfile.ts
@@ -124,7 +124,7 @@ test(`frozen-lockfile: should fail if no ${WANTED_LOCKFILE} is present`, async (
         'is-positive': '^3.0.0',
       },
     }, await testDefaults({ frozenLockfile: true }))
-  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is present`)
+  ).rejects.toThrow(`Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`)
 })
 
 test(`prefer-frozen-lockfile: should prefer headless installation when ${WANTED_LOCKFILE} satisfies package.json`, async () => {


### PR DESCRIPTION
Change the error message to indicate the wanted lockfile is absent, not present. This now reflects the actual error.

All the other locations use the correct error description.

(Draft PR because I still need to set up my environment for contributing.)