### PR TITLE
feat(always-auth): add https port parsing on registry matching for artifactory compatibility

### DIFF
--- a/.changeset/yellow-nails-divide.md
+++ b/.changeset/yellow-nails-divide.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.auth-header": patch
+"pnpm": patch
+---
+
+Authorization token should be found in the configuration, when the requested URL is explicitly specified with a default port (443 on HTTPS or 80 on HTTP) [#6863](https://github.com/pnpm/pnpm/pull/6864).

--- a/network/auth-header/src/index.ts
+++ b/network/auth-header/src/index.ts
@@ -38,8 +38,18 @@ function getAuthHeaderByURI (authHeaders: Record<string, string>, maxParts: numb
 }
 
 function removePort (originalUrl: string) {
+  const hasHTTPS = originalUrl.match(':443')
   const urlObj = new URL(originalUrl)
+
+  /**
+   * @artifactory adds a https port in the middle of their urls and URL.parse will not return ports in that range
+   */
+  if (hasHTTPS && urlObj.port === '') {
+    return urlObj.href
+  }
+
   if (urlObj.port === '') return originalUrl
+
   urlObj.port = ''
   return urlObj.toString()
 }

--- a/network/auth-header/src/index.ts
+++ b/network/auth-header/src/index.ts
@@ -39,9 +39,7 @@ function getAuthHeaderByURI (authHeaders: Record<string, string>, maxParts: numb
 
 function removePort (originalUrl: string) {
   const urlObj = new URL(originalUrl)
-
   if (urlObj.port === '') return urlObj.href
-
   urlObj.port = ''
   return urlObj.toString()
 }

--- a/network/auth-header/src/index.ts
+++ b/network/auth-header/src/index.ts
@@ -38,17 +38,9 @@ function getAuthHeaderByURI (authHeaders: Record<string, string>, maxParts: numb
 }
 
 function removePort (originalUrl: string) {
-  const hasHTTPS = originalUrl.match(':443')
   const urlObj = new URL(originalUrl)
 
-  /**
-   * @artifactory adds a https port in the middle of their urls and URL.parse will not return ports in that range
-   */
-  if (hasHTTPS && urlObj.port === '') {
-    return urlObj.href
-  }
-
-  if (urlObj.port === '') return originalUrl
+  if (urlObj.port === '') return urlObj.href
 
   urlObj.port = ''
   return urlObj.toString()

--- a/network/auth-header/test/getAuthHeaderByURI.ts
+++ b/network/auth-header/test/getAuthHeaderByURI.ts
@@ -17,6 +17,17 @@ test('getAuthHeaderByURI()', () => {
   expect(getAuthHeaderByURI('https://reg.gg:8888/foo/-/foo-1.0.0.tgz')).toBe('Bearer 0000')
 })
 
+test('getAuthHeaderByURI() when default ports are specified', () => {
+  const getAuthHeaderByURI = createGetAuthHeaderByURI({
+    allSettings: {
+      '//reg.com/:_authToken': 'abc123',
+    },
+    userSettings: {},
+  })
+  expect(getAuthHeaderByURI('https://reg.com:443/')).toBe('Bearer abc123')
+  expect(getAuthHeaderByURI('http://reg.com:80/')).toBe('Bearer abc123')
+})
+
 test('returns undefined when the auth header is not found', () => {
   expect(createGetAuthHeaderByURI({ allSettings: {}, userSettings: {} })('http://reg.com')).toBe(undefined)
 })


### PR DESCRIPTION
### Changes

 ~~* add compatibility back for `always-auth=true` so the authorization is still passed to components not matching the registry urls~~ Removed due to security issue.
* add https (:443 ) port filter in the URL parsing section so that authorization headers are added if the registry request matches.
* This fixes problems with large organizations that use and share multiple scopes across registries

### Issue

~~1. `pnpm` was deleting the authorization header, making registries that act as pass-through registries fail to fetch their tarball file download when attempting to access another registry with shared scope.~~ Removed due to security issue.
2. `pnpm` was skipping https ports IE `:443` that artifactory was transforming. This caused a registry mismatch and it skipped authorization. This is related to URL which does not return `well-known` ports (0-1023) in the `.ports` param. It still however parses and removes the https port.

### Solution

**Initial fix:**
~~1. Add a logic block to protect against deletion of authorization if `always-auth` is provided in `.npmrc` (<=Node16) or the pnpm config >=Node18.~~ Removed due to security issue.
2. Adding a matcher for `:443` fixes the port problem so that when communicating with artifactory the authorization is not removed due to url mismatch.

**Possible follow-up fixes related to auth (excluded from this PR scope)**
- add url parsing so that the authorization urls approved and authorization is not being passed to packages outside registry scope accidentally. 
  - Example if you provided the `registry=https://vllc.dev/artifactory/api/npm/npm-virtual/` adding a second key `registry-root=https://vllc.dev/artifactory/api/npm/` would capture and add auth to all other registries in this structure and delete the rest.

pnpm config file
```
registry-root=https://vllc.dev/artifactory/api/npm/
registry=https://vllc.dev/artifactory/api/npm/npm-virtual/
```

### Use case

This problem applies to all Artifactory registries with (>=2) registries and with scoped packages mixed across each registry. FYI this is a real world problem.

- Any usage of another registry that could have blended scope
  - Example Installing a scope of `@platform` could resolve to multiple registries resolved by artifactory authorization.
- Any usage of artifactory with more than 1 registry with blended scopes.

Due to a scoped package being unknown which registry to use, using the `@platform:registry=https://<company_domain>/artifactory/api/npm/npm-virtual/` will not properly resolve the package correctly, this is because package-a could point to `npm-virtual` but package-b could point to `npm-virtual-v2` and so on.

**Artifactory** continues to[ recommend in npm v9 ](https://jfrog.com/help/r/artifactory-changes-to-the-login-behavior-in-npm-v9/users-authenticating-with-the-npm-login-command) to use the `always-auth=true` flag (which is deprecated in 18).