### PR TITLE
fix: don't print added stats when installing lockfile only

### DIFF
--- a/.changeset/giant-feet-cheat.md
+++ b/.changeset/giant-feet-cheat.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+Don't print "added" stats, when installing with `--lockfile-only`.

--- a/cli/default-reporter/src/index.ts
+++ b/cli/default-reporter/src/index.ts
@@ -24,6 +24,7 @@ export function initDefaultReporter (
       aggregateOutput?: boolean
       throttleProgress?: number
       outputMaxWidth?: number
+      hideAddedPkgsProgress?: boolean
     }
     context: {
       argv: string[]
@@ -103,6 +104,7 @@ export function toOutput$ (
       streamLifecycleOutput?: boolean
       aggregateOutput?: boolean
       throttleProgress?: number
+      hideAddedPkgsProgress?: boolean
     }
     context: {
       argv: string[]
@@ -259,6 +261,7 @@ export function toOutput$ (
       aggregateOutput: opts.reportingOptions?.aggregateOutput,
       throttleProgress: opts.reportingOptions?.throttleProgress,
       width: opts.reportingOptions?.outputMaxWidth,
+      hideAddedPkgsProgress: opts.reportingOptions?.hideAddedPkgsProgress,
     }
   )
 

--- a/cli/default-reporter/src/reporterForClient/index.ts
+++ b/cli/default-reporter/src/reporterForClient/index.ts
@@ -66,6 +66,7 @@ export function reporterForClient (
     aggregateOutput?: boolean
     throttleProgress?: number
     width?: number
+    hideAddedPkgsProgress?: boolean
   }
 ): Array<Rx.Observable<Rx.Observable<{ msg: string }>>> {
   const width = opts.width ?? process.stdout.columns ?? 80
@@ -122,6 +123,7 @@ export function reporterForClient (
       reportProgress(log$, {
         cwd,
         throttle,
+        hideAddedPkgsProgress: opts.hideAddedPkgsProgress,
       }),
       ...reportStats(log$, {
         cmd: opts.cmd,

--- a/cli/default-reporter/src/reporterForClient/reportProgress.ts
+++ b/cli/default-reporter/src/reporterForClient/reportProgress.ts
@@ -26,9 +26,10 @@ export function reportProgress (
     cwd: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     throttle?: Rx.OperatorFunction<any, any>
+    hideAddedPkgsProgress?: boolean
   }
 ) {
-  const progressOutput = throttledProgressOutput.bind(null, opts.throttle)
+  const progressOutput = throttledProgressOutput.bind(null, opts)
 
   return getModulesInstallProgress$(log$.stage, log$.progress).pipe(
     map(({ importingDone$, progress$, requirer }) => {
@@ -48,13 +49,16 @@ export function reportProgress (
 }
 
 function throttledProgressOutput (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  throttle: Rx.OperatorFunction<any, any> | undefined,
+  opts: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    throttle?: Rx.OperatorFunction<any, any>
+    hideAddedPkgsProgress?: boolean
+  },
   importingDone$: Rx.Observable<boolean>,
   progress$: Rx.Observable<ProgressStats>
 ) {
-  if (throttle != null) {
-    progress$ = progress$.pipe(throttle)
+  if (opts.throttle != null) {
+    progress$ = progress$.pipe(opts.throttle)
   }
   const combinedProgress = Rx.combineLatest(
     progress$,
@@ -63,7 +67,7 @@ function throttledProgressOutput (
     // Avoid logs after all resolved packages were downloaded.
     // Fixing issue: https://github.com/pnpm/pnpm/issues/1028#issuecomment-364782901
     .pipe(takeWhile(([, importingDone]) => !importingDone, true))
-  return combinedProgress.pipe(map(createStatusMessage))
+  return combinedProgress.pipe(map(opts.hideAddedPkgsProgress ? createStatusMessageWithoutAdded : createStatusMessage))
 }
 
 function getModulesInstallProgress$ (
@@ -152,6 +156,21 @@ function getProgressStatsPushStreamByRequirer (progress$: Rx.Observable<Progress
 
 function createStatusMessage ([progress, importingDone]: [ProgressStats, boolean]) {
   const msg = `Progress: resolved ${hlValue(progress.resolved.toString())}, reused ${hlValue(progress.reused.toString())}, downloaded ${hlValue(progress.fetched.toString())}, added ${hlValue(progress.imported.toString())}`
+  if (importingDone) {
+    return {
+      done: true,
+      fixed: false,
+      msg: `${msg}, done`,
+    }
+  }
+  return {
+    fixed: true,
+    msg,
+  }
+}
+
+function createStatusMessageWithoutAdded ([progress, importingDone]: [ProgressStats, boolean]) {
+  const msg = `Progress: resolved ${hlValue(progress.resolved.toString())}, reused ${hlValue(progress.reused.toString())}, downloaded ${hlValue(progress.fetched.toString())}`
   if (importingDone) {
     return {
       done: true,

--- a/pnpm/src/reporter/index.ts
+++ b/pnpm/src/reporter/index.ts
@@ -25,6 +25,7 @@ export function initReporter (
         logLevel: opts.config.loglevel as LogLevel,
         streamLifecycleOutput: opts.config.stream,
         throttleProgress: 200,
+        hideAddedPkgsProgress: opts.config.lockfileOnly,
       },
       streamParser,
     })


### PR DESCRIPTION
Related: https://github.com/teambit/bit/pull/7703