### PR TITLE
fix: should not swallows empty string in params

### DIFF
--- a/.changeset/lemon-meals-lick.md
+++ b/.changeset/lemon-meals-lick.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/parse-cli-args": patch
+---
+
+Should not swallows empty string in params [#6594](https://github.com/pnpm/pnpm/issues/6594)

--- a/.changeset/lemon-meals-lick.md
+++ b/.changeset/lemon-meals-lick.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/parse-cli-args": patch
+"pnpm": patch
 ---
 
-Should not swallows empty string in params [#6594](https://github.com/pnpm/pnpm/issues/6594)
+Don't ignore empty strings in params [#6594](https://github.com/pnpm/pnpm/issues/6594).

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -84,7 +84,7 @@ export async function parseCliArgs (
     if (recursiveCommandUsed) {
       args = args.slice(1)
     }
-    if (opts.getCommandLongName(args[0]) !== 'install' || args.length === 1) {
+    if (opts.getCommandLongName(args[0]) !== 'install' || args.filter(Boolean).length === 1) {
       return args[0]
     }
     return 'add'
@@ -139,8 +139,7 @@ export async function parseCliArgs (
     }
   }
 
-  // `pnpm install ""` is going to be just `pnpm install`
-  const params = argv.remain.slice(1).filter(Boolean)
+  const params = argv.remain.slice(1)
 
   if (options['recursive'] !== true && (options['filter'] || options['filter-prod'] || recursiveCommandUsed)) {
     options['recursive'] = true
@@ -163,10 +162,6 @@ export async function parseCliArgs (
       throw new PnpmError('NOT_IN_WORKSPACE', '--workspace-root may only be used inside a workspace')
     }
     options['dir'] = workspaceDir
-  }
-
-  if (cmd === 'install' && params.length > 0) {
-    cmd = 'add'
   }
   if (!cmd && options['recursive']) {
     cmd = 'recursive'

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -84,7 +84,7 @@ export async function parseCliArgs (
     if (recursiveCommandUsed) {
       args = args.slice(1)
     }
-    if (opts.getCommandLongName(args[0]) !== 'install' || args.filter(Boolean).length === 1) {
+    if (opts.getCommandLongName(args[0]) !== 'install' || args.length === 1) {
       return args[0]
     }
     return 'add'
@@ -162,6 +162,10 @@ export async function parseCliArgs (
       throw new PnpmError('NOT_IN_WORKSPACE', '--workspace-root may only be used inside a workspace')
     }
     options['dir'] = workspaceDir
+  }
+
+  if (cmd === 'install' && params.length > 0) {
+    cmd = 'add'
   }
   if (!cmd && options['recursive']) {
     cmd = 'recursive'

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -324,7 +324,7 @@ test('`pnpm install ""` is going to be just `pnpm install`', async () => {
   const { params, cmd } = await parseCliArgs({
     ...DEFAULT_OPTS,
   }, ['install', ''])
-  expect(cmd).toBe('install')
+  expect(cmd).toBe('add')
   // empty string in params will be filtered at: https://github.com/pnpm/pnpm/blob/main/pkg-manager/plugin-commands-installation/src/installDeps.ts#L196
   expect(params).toStrictEqual([''])
 })

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -319,3 +319,20 @@ test('everything after an escape arg is a parameter, even if it has a help optio
   expect(cmd).toBe('exec')
   expect(params).toStrictEqual(['rm', '--help'])
 })
+
+test('`pnpm install ""` is going to be just `pnpm install`', async () => {
+  const { params, cmd } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+  }, ['install', ''])
+  expect(cmd).toBe('install')
+  // empty string in params will be filtered at: https://github.com/pnpm/pnpm/blob/main/pkg-manager/plugin-commands-installation/src/installDeps.ts#L196
+  expect(params).toStrictEqual([''])
+})
+
+test('should not swallows empty string in params', async () => {
+  const { params, cmd } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+  }, ['run', 'echo', '', 'foo', '', 'bar'])
+  expect(cmd).toBe('run')
+  expect(params).toStrictEqual(['echo', '', 'foo', '', 'bar'])
+})


### PR DESCRIPTION
fix #6594 

Also, currently `pnpm install ""` will report an error

```
$ pnpm install ""         
 ERR_PNPM_MISSING_PACKAGE_NAME  `pnpm add` requires the package name
```
that was fixed in this pr as well.