### PR TITLE
feat: friendlier error message when command not found

### DIFF
--- a/.changeset/chatty-houses-build.md
+++ b/.changeset/chatty-houses-build.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+Make the error message when user attempting to run a command that does not exist friendlier

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -9,11 +9,25 @@ export function getNearest (name: string, list?: readonly string[]) {
   })
 }
 
-export async function getNearestProgram (programName: string) {
+export async function getNearestProgram (opts: {
+  programName: string,
+  dir: string,
+  workspaceDir: string | undefined,
+}) {
   try {
-    const binDir = path.join(process.cwd(), 'node_modules', '.bin')
-    const programList = await readdir(binDir)
-    return getNearest(programName, programList)
+    const { programName, dir, workspaceDir } = opts
+    const binDir = path.join(dir, 'node_modules', '.bin')
+    const programListPromise = readdir(binDir) // await is omitted to take advantage of concurrency
+    let programList!: string[]
+    if (workspaceDir && workspaceDir !== dir) {
+      const workspaceBinDir = path.join(workspaceDir, 'node_modules', '.bin')
+      const programListExtension = await readdir(workspaceBinDir)
+      programList = await programListPromise
+      programList.push(...programListExtension)
+    } else {
+      programList = await programListPromise
+    }
+    return getNearest(programName, await programListPromise)
   } catch (_err) {
     return null
   }

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -9,6 +9,16 @@ export function getNearest (name: string, list?: readonly string[]) {
   })
 }
 
+function readProgramsFromDir(binDir: string): string[] {
+  const list = readdirSync(binDir)
+  if (process.platform !== 'win32') return list
+  const executableExtensions = ['.cmd', '.bat', '.ps1', '.exe', '.com']
+  return list.map((fullName) => {
+    const { name, ext } = path.parse(fullName)
+    return executableExtensions.includes(ext) ? name : fullName
+  })
+}
+
 export function getNearestProgram (opts: {
   programName: string,
   dir: string,
@@ -17,10 +27,10 @@ export function getNearestProgram (opts: {
   try {
     const { programName, dir, workspaceDir } = opts
     const binDir = path.join(dir, 'node_modules', '.bin')
-    const programList = readdirSync(binDir)
+    const programList = readProgramsFromDir(binDir)
     if (workspaceDir && workspaceDir !== dir) {
       const workspaceBinDir = path.join(workspaceDir, 'node_modules', '.bin')
-      programList.push(...readdirSync(workspaceBinDir))
+      programList.push(...readProgramsFromDir(workspaceBinDir))
     }
     return getNearest(programName, programList)
   } catch (_err) {

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -20,9 +20,9 @@ function readProgramsFromDir (binDir: string): string[] {
 }
 
 export function getNearestProgram (opts: {
-  programName: string,
-  dir: string,
-  workspaceDir: string | undefined,
+  programName: string
+  dir: string
+  workspaceDir: string | undefined
 }) {
   try {
     const { programName, dir, workspaceDir } = opts

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -10,9 +10,13 @@ export function getNearest (name: string, list?: readonly string[]) {
 }
 
 export async function getNearestProgram (programName: string) {
-  const binDir = path.join(process.cwd(), 'node_modules', '.bin')
-  const programList = await readdir(binDir)
-  return getNearest(programName, programList)
+  try {
+    const binDir = path.join(process.cwd(), 'node_modules', '.bin')
+    const programList = await readdir(binDir)
+    return getNearest(programName, programList)
+  } catch (_err) {
+    return null
+  }
 }
 
 export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -9,7 +9,7 @@ export function getNearest (name: string, list?: readonly string[]) {
   })
 }
 
-function readProgramsFromDir(binDir: string): string[] {
+function readProgramsFromDir (binDir: string): string[] {
   const list = readdirSync(binDir)
   if (process.platform !== 'win32') return list
   const executableExtensions = ['.cmd', '.bat', '.ps1', '.exe', '.com']

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -1,12 +1,16 @@
 import { type PackageScripts } from '@pnpm/types'
 import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
 
+export function getNearestCommand (scriptName: string, scripts?: PackageScripts | undefined) {
+  return scripts && didYouMean(scriptName, Object.keys(scripts), {
+    returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
+  })
+}
+
 export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {
   let hint = `Command "${scriptName}" not found.`
 
-  const nearestCommand = scripts && didYouMean(scriptName, Object.keys(scripts), {
-    returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
-  })
+  const nearestCommand = getNearestCommand(scriptName, scripts)
 
   if (nearestCommand) {
     hint += ` Did you mean "pnpm run ${nearestCommand}"?`

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -3,22 +3,22 @@ import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
 import { readdir } from 'fs/promises'
 import path from 'path'
 
-export function getNearestCommand (name: string, list?: readonly string[]) {
+export function getNearest (name: string, list?: readonly string[]) {
   return list && didYouMean(name, list || [], {
     returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
   })
 }
 
-export async function buildProgramNotFoundHint (programName: string) {
+export async function getNearestProgram (programName: string) {
   const binDir = path.join(process.cwd(), 'node_modules', '.bin')
   const programList = await readdir(binDir)
-  return getNearestCommand(programName, programList)
+  return getNearest(programName, programList)
 }
 
 export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {
   let hint = `Command "${scriptName}" not found.`
 
-  const nearestCommand = getNearestCommand(scriptName, scripts && Object.keys(scripts))
+  const nearestCommand = getNearest(scriptName, scripts && Object.keys(scripts))
 
   if (nearestCommand) {
     hint += ` Did you mean "pnpm run ${nearestCommand}"?`

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -1,6 +1,6 @@
 import { type PackageScripts } from '@pnpm/types'
 import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
-import { readdir } from 'fs/promises'
+import { readdirSync } from 'fs'
 import path from 'path'
 
 export function getNearest (name: string, list?: readonly string[]) {
@@ -9,7 +9,7 @@ export function getNearest (name: string, list?: readonly string[]) {
   })
 }
 
-export async function getNearestProgram (opts: {
+export function getNearestProgram (opts: {
   programName: string,
   dir: string,
   workspaceDir: string | undefined,
@@ -17,17 +17,12 @@ export async function getNearestProgram (opts: {
   try {
     const { programName, dir, workspaceDir } = opts
     const binDir = path.join(dir, 'node_modules', '.bin')
-    const programListPromise = readdir(binDir) // await is omitted to take advantage of concurrency
-    let programList!: string[]
+    const programList = readdirSync(binDir)
     if (workspaceDir && workspaceDir !== dir) {
       const workspaceBinDir = path.join(workspaceDir, 'node_modules', '.bin')
-      const programListExtension = await readdir(workspaceBinDir)
-      programList = await programListPromise
-      programList.push(...programListExtension)
-    } else {
-      programList = await programListPromise
+      programList.push(...readdirSync(workspaceBinDir))
     }
-    return getNearest(programName, await programListPromise)
+    return getNearest(programName, programList)
   } catch (_err) {
     return null
   }

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -1,16 +1,24 @@
 import { type PackageScripts } from '@pnpm/types'
 import didYouMean, { ReturnTypeEnums } from 'didyoumean2'
+import { readdir } from 'fs/promises'
+import path from 'path'
 
-export function getNearestCommand (scriptName: string, scripts?: PackageScripts | undefined) {
-  return scripts && didYouMean(scriptName, Object.keys(scripts), {
+export function getNearestCommand (name: string, list?: readonly string[]) {
+  return list && didYouMean(name, list || [], {
     returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
   })
+}
+
+export async function buildProgramNotFoundHint (programName: string) {
+  const binDir = path.join(process.cwd(), 'node_modules', '.bin')
+  const programList = await readdir(binDir)
+  return getNearestCommand(programName, programList)
 }
 
 export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {
   let hint = `Command "${scriptName}" not found.`
 
-  const nearestCommand = getNearestCommand(scriptName, scripts)
+  const nearestCommand = getNearestCommand(scriptName, scripts && Object.keys(scripts))
 
   if (nearestCommand) {
     hint += ` Did you mean "pnpm run ${nearestCommand}"?`

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -19,10 +19,14 @@ export async function getNearestProgram (programName: string) {
   }
 }
 
+export function getNearestScript (scriptName: string, scripts?: PackageScripts | undefined) {
+  return getNearest(scriptName, scripts && Object.keys(scripts))
+}
+
 export function buildCommandNotFoundHint (scriptName: string, scripts?: PackageScripts | undefined) {
   let hint = `Command "${scriptName}" not found.`
 
-  const nearestCommand = getNearest(scriptName, scripts && Object.keys(scripts))
+  const nearestCommand = getNearestScript(scriptName, scripts)
 
   if (nearestCommand) {
     hint += ` Did you mean "pnpm run ${nearestCommand}"?`

--- a/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
+++ b/exec/plugin-commands-script-runners/src/buildCommandNotFoundHint.ts
@@ -4,7 +4,7 @@ import { readdir } from 'fs/promises'
 import path from 'path'
 
 export function getNearest (name: string, list?: readonly string[]) {
-  return list && didYouMean(name, list || [], {
+  return list && didYouMean(name, list ?? [], {
     returnType: ReturnTypeEnums.FIRST_CLOSEST_MATCH,
   })
 }

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -222,7 +222,7 @@ export async function handler (
               if (nearestScript) {
                 err.hint = `Did you mean "pnpm ${nearestScript}"?`
               } else {
-                const nearestProgram = await getNearestProgram({
+                const nearestProgram = getNearestProgram({
                   programName: params[0],
                   dir: opts.dir,
                   workspaceDir: opts.workspaceDir,
@@ -232,7 +232,7 @@ export async function handler (
                 }
               }
             } else {
-              const nearestProgram = await getNearestProgram({
+              const nearestProgram = getNearestProgram({
                 programName: params[0],
                 dir: opts.dir,
                 workspaceDir: opts.workspaceDir,

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -21,7 +21,7 @@ import {
 import { PnpmError } from '@pnpm/error'
 import which from 'which'
 import writeJsonFile from 'write-json-file'
-import { getNearestCommand } from './buildCommandNotFoundHint'
+import { buildProgramNotFoundHint } from './buildCommandNotFoundHint'
 
 export const shorthands = {
   parallel: runShorthands.parallel,
@@ -214,7 +214,7 @@ export async function handler (
           if (await isErrorCommandNotFound(params[0], err)) {
             err.message = `Command "${params[0]}" not found`
 
-            const nearestCommand = getNearestCommand(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
+            const nearestCommand = await buildProgramNotFoundHint(params[0])
             if (nearestCommand) {
               err.hint = `Did you mean "pnpm exec ${nearestCommand}"?`
             }

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -222,13 +222,21 @@ export async function handler (
               if (nearestScript) {
                 err.hint = `Did you mean "pnpm ${nearestScript}"?`
               } else {
-                const nearestProgram = await getNearestProgram(params[0])
+                const nearestProgram = await getNearestProgram({
+                  programName: params[0],
+                  dir: opts.dir,
+                  workspaceDir: opts.workspaceDir,
+                })
                 if (nearestProgram) {
                   err.hint = `Did you mean "pnpm ${nearestProgram}"?`
                 }
               }
             } else {
-              const nearestProgram = await getNearestProgram(params[0])
+              const nearestProgram = await getNearestProgram({
+                programName: params[0],
+                dir: opts.dir,
+                workspaceDir: opts.workspaceDir,
+              })
               if (nearestProgram) {
                 err.hint = `Did you mean "pnpm exec ${nearestProgram}"?`
               }

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -215,17 +215,18 @@ export async function handler (
           if (await isErrorCommandNotFound(params[0], err)) {
             err.message = `Command "${params[0]}" not found`
             if (opts.implicitlyFellbackFromRun) {
+              let nearestScript: string | null | undefined = undefined
               try {
-                const nearestScript = getNearestScript(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
-                if (nearestScript) {
-                  err.hint = `Did you mean "pnpm ${nearestScript}"?`
-                } else {
-                  const nearestProgram = await getNearestProgram(params[0])
-                  if (nearestProgram) {
-                    err.hint = `Did you mean "pnpm ${nearestProgram}"?`
-                  }
-                }
+                nearestScript = getNearestScript(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
               } catch (_err) {}
+              if (nearestScript) {
+                err.hint = `Did you mean "pnpm ${nearestScript}"?`
+              } else {
+                const nearestProgram = await getNearestProgram(params[0])
+                if (nearestProgram) {
+                  err.hint = `Did you mean "pnpm ${nearestProgram}"?`
+                }
+              }
             } else {
               const nearestProgram = await getNearestProgram(params[0])
               if (nearestProgram) {

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -215,7 +215,7 @@ export async function handler (
           if (await isErrorCommandNotFound(params[0], err)) {
             err.message = `Command "${params[0]}" not found`
             if (opts.implicitlyFellbackFromRun) {
-              let nearestScript: string | null | undefined = undefined
+              let nearestScript: string | null | undefined
               try {
                 nearestScript = getNearestScript(params[0], (await readProjectManifestOnly(opts.dir)).scripts)
               } catch (_err) {}

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { docsUrl, type RecursiveSummary, throwOnCommandFail, readProjectManifestOnly } from '@pnpm/cli-utils'
+import { docsUrl, type RecursiveSummary, throwOnCommandFail } from '@pnpm/cli-utils'
 import { type Config, types } from '@pnpm/config'
 import { makeNodeRequireOption } from '@pnpm/lifecycle'
 import { logger } from '@pnpm/logger'

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -21,7 +21,7 @@ import {
 import { PnpmError } from '@pnpm/error'
 import which from 'which'
 import writeJsonFile from 'write-json-file'
-import { buildProgramNotFoundHint } from './buildCommandNotFoundHint'
+import { getNearestProgram } from './buildCommandNotFoundHint'
 
 export const shorthands = {
   parallel: runShorthands.parallel,
@@ -214,7 +214,7 @@ export async function handler (
           if (await isErrorCommandNotFound(params[0], err)) {
             err.message = `Command "${params[0]}" not found`
 
-            const nearestCommand = await buildProgramNotFoundHint(params[0])
+            const nearestCommand = await getNearestProgram(params[0])
             if (nearestCommand) {
               err.hint = `Did you mean "pnpm exec ${nearestCommand}"?`
             }

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -186,6 +186,7 @@ export async function handler (
       if (opts.argv == null) throw new Error('Could not fallback because opts.argv.original was not passed to the script runner')
       return exec({
         selectedProjectsGraph: {},
+        implicitlyFellbackFromRun: true,
         ...opts,
       }, opts.argv.original.slice(1))
     }

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -812,7 +812,7 @@ test('pnpm recursive exec report summary with --bail', async () => {
   expect(executionStatus[path.resolve('project-4')].status).toBe('queued')
 })
 
-test('pnpm exec command not found', async () => {
+test('pnpm exec command not found (implicit fallback)', async () => {
   prepare({
     scripts: {
       build: 'echo hello',
@@ -820,7 +820,7 @@ test('pnpm exec command not found', async () => {
   })
 
   const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
-  let error!: Error & { hint: string }
+  let error!: Error & { hint?: string }
   try {
     await exec.handler({
       ...DEFAULT_OPTS,
@@ -828,9 +828,11 @@ test('pnpm exec command not found', async () => {
       recursive: false,
       bail: true,
       selectedProjectsGraph,
+      implicitlyFellbackFromRun: true,
     }, ['buil'])
   } catch (err: any) { // eslint-disable-line
     error = err
   }
-  expect(error?.hint).toBe('Command "buil" not found. Did you mean "pnpm run build"?')
+  expect(error?.message).toBe('Command "buil" not found')
+  expect(error?.hint).toBe('Did you mean "pnpm build"?')
 })

--- a/exec/plugin-commands-script-runners/test/exec.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/exec.e2e.ts
@@ -836,3 +836,28 @@ test('pnpm exec command not found (implicit fallback)', async () => {
   expect(error?.message).toBe('Command "buil" not found')
   expect(error?.hint).toBe('Did you mean "pnpm build"?')
 })
+
+test('pnpm exec command not found (explicit call, without near name packages)', async () => {
+  prepare({
+    scripts: {
+      cwsay: 'echo hello',
+    },
+  })
+
+  const { selectedProjectsGraph } = await readProjects(process.cwd(), [])
+  let error!: Error & { hint?: string }
+  try {
+    await exec.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      recursive: false,
+      bail: true,
+      selectedProjectsGraph,
+      implicitlyFellbackFromRun: false,
+    }, ['cwsay'])
+  } catch (err: any) { // eslint-disable-line
+    error = err
+  }
+  expect(error?.message).toBe('Command "cwsay" not found')
+  expect(error?.hint).toBeFalsy()
+})


### PR DESCRIPTION
Related comment: https://github.com/scaffold-eth/scaffold-eth-2/pull/444#discussion_r1273164114

Initially, I have hoped that I can create a hint for `pnpm $script` in general, but since I don't know how to distinguish between `pnpm $script` and `pnpm exec $script`, I have to settle for `pnpm exec $script` only.