### PR TITLE
fix(plugin-commands-patching): patch should works correctly when shared-workspace-file is false

### DIFF
--- a/.changeset/cyan-oranges-wait.md
+++ b/.changeset/cyan-oranges-wait.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/filter-workspace-packages": patch
+"@pnpm/plugin-commands-patching": patch
+"@pnpm/workspace.find-packages": patch
+"pnpm": patch
+---
+
+`pnpm patch` should works correctly when shared-workspace-file is false [#6885](https://github.com/pnpm/pnpm/issues/6885)

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -64,7 +64,7 @@ export async function handler (opts: install.InstallCommandOptions & Pick<Config
   await fs.promises.writeFile(path.join(patchesDir, `${patchFileName}.patch`), patchContent, 'utf8')
   const { writeProjectManifest, manifest } = await tryReadProjectManifest(lockfileDir)
 
-  const rootProjectManifest = opts.rootProjectManifest ?? manifest ?? {}
+  const rootProjectManifest = (!opts.sharedWorkspaceLockfile ? manifest : (opts.rootProjectManifest ?? manifest)) ?? {}
 
   if (!rootProjectManifest.pnpm) {
     rootProjectManifest.pnpm = {

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -89,6 +89,7 @@ export type ImportCommandOptions = Pick<Config,
 | 'selectedProjectsGraph'
 | 'workspaceDir'
 | 'ignoreWorkspaceCycles'
+| 'sharedWorkspaceLockfile'
 > & CreateStoreControllerOptions & Omit<InstallOptions, 'storeController' | 'lockfileOnly' | 'preferredVersions'>
 
 export async function handler (

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -91,6 +91,7 @@ export async function handler (
   | 'saveOptional'
   | 'saveProd'
   | 'workspaceDir'
+  | 'sharedWorkspaceLockfile'
   > & Partial<Pick<Config, 'linkWorkspacePackages'>>,
   params?: string[]
 ) {

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -148,6 +148,7 @@ export async function handler (
   | 'saveProd'
   | 'selectedProjectsGraph'
   | 'workspaceDir'
+  | 'sharedWorkspaceLockfile'
   > & {
     recursive?: boolean
   },

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -205,6 +205,7 @@ export async function main (inputArgv: string[]) {
       testPattern: config.testPattern,
       changedFilesIgnorePattern: config.changedFilesIgnorePattern,
       useGlobDirFiltering: !config.legacyDirFiltering,
+      sharedWorkspaceLockfile: config.sharedWorkspaceLockfile,
     })
 
     if (filterResults.allProjects.length === 0) {

--- a/workspace/filter-workspace-packages/src/index.ts
+++ b/workspace/filter-workspace-packages/src/index.ts
@@ -64,6 +64,7 @@ export interface FilterPackagesOptions {
   testPattern?: string[]
   changedFilesIgnorePattern?: string[]
   useGlobDirFiltering?: boolean
+  sharedWorkspaceLockfile?: boolean
 }
 
 export async function filterPackagesFromDir (
@@ -71,7 +72,7 @@ export async function filterPackagesFromDir (
   filter: WorkspaceFilter[],
   opts: FilterPackagesOptions & { engineStrict?: boolean, patterns: string[] }
 ) {
-  const allProjects = await findWorkspacePackages(workspaceDir, { engineStrict: opts?.engineStrict, patterns: opts.patterns })
+  const allProjects = await findWorkspacePackages(workspaceDir, { engineStrict: opts?.engineStrict, patterns: opts.patterns, sharedWorkspaceLockfile: opts.sharedWorkspaceLockfile })
   return {
     allProjects,
     ...(await filterPackages(allProjects, filter, opts)),

--- a/workspace/find-packages/src/index.ts
+++ b/workspace/find-packages/src/index.ts
@@ -15,12 +15,14 @@ export async function findWorkspacePackages (
     engineStrict?: boolean
     nodeVersion?: string
     patterns?: string[]
+    sharedWorkspaceLockfile?: boolean
   }
 ): Promise<Project[]> {
   const pkgs = await findWorkspacePackagesNoCheck(workspaceRoot, opts)
   for (const pkg of pkgs) {
     packageIsInstallable(pkg.dir, pkg.manifest, opts ?? {})
-    if (pkg.dir !== workspaceRoot) {
+    // When setting shared-workspace-lockfile=false, `pnpm` can be set in sub-project's package.json.
+    if (opts?.sharedWorkspaceLockfile && pkg.dir !== workspaceRoot) {
       checkNonRootProjectManifest(pkg)
     }
   }

--- a/workspace/find-packages/test/index.ts
+++ b/workspace/find-packages/test/index.ts
@@ -38,7 +38,9 @@ test('findWorkspacePackagesNoCheck() skips engine checks', async () => {
 test('findWorkspacePackages() output warnings for non-root workspace project', async () => {
   const fixturePath = path.join(__dirname, '__fixtures__/warning-for-non-root-project')
 
-  const pkgs = await findWorkspacePackages(fixturePath)
+  const pkgs = await findWorkspacePackages(fixturePath, {
+    sharedWorkspaceLockfile: true,
+  })
   expect(pkgs.length).toBe(3)
   expect(logger.warn).toBeCalledTimes(3)
   const fooPath = path.join(fixturePath, 'packages/foo')


### PR DESCRIPTION
ref #6885 

1. only check non-root project manifest when `shared-workspace-file` is true.
2. `pnpm patch` and `pnpm patch-commit` should works correctly when shared-workspace-file is false