### PR TITLE
feat(cli-output): harmonize download progress out

### DIFF
--- a/.changeset/new-windows-drum.md
+++ b/.changeset/new-windows-drum.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+When showing the download progress of big tarball files, always display the same number of digits after the dot [#6902](https://github.com/pnpm/pnpm/issues/6901).

--- a/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
+++ b/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
@@ -8,6 +8,10 @@ import {
 } from './outputConstants'
 
 const BIG_TARBALL_SIZE = 1024 * 1024 * 5 // 5 MB
+const PRETTY_OPTS = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+}
 
 export function reportBigTarballProgress (
   log$: {
@@ -22,17 +26,14 @@ export function reportBigTarballProgress (
       log.attempt === 1
     ),
     map((startedLog: FetchingProgressLog) => {
-      const size = prettyBytes(startedLog['size'])
+      const size = prettyBytes(startedLog['size'], PRETTY_OPTS)
       return log$.fetchingProgress.pipe(
         filter((log: FetchingProgressLog) => log.status === 'in_progress' && log.packageId === startedLog['packageId']),
         map((log: FetchingProgressLog) => log['downloaded']),
         startWith(0),
         map((downloadedRaw: number) => {
           const done = startedLog['size'] === downloadedRaw
-          const downloaded = prettyBytes(downloadedRaw, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })
+          const downloaded = prettyBytes(downloadedRaw, PRETTY_OPTS)
           return {
             fixed: !done,
             msg: `Downloading ${hlPkgId(startedLog['packageId'])}: ${hlValue(downloaded)}/${hlValue(size)}${done ? ', done' : ''}`,

--- a/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
+++ b/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
@@ -29,7 +29,7 @@ export function reportBigTarballProgress (
         startWith(0),
         map((downloadedRaw: number) => {
           const done = startedLog['size'] === downloadedRaw
-          const downloaded = prettyBytes(downloadedRaw)
+          const downloaded = prettyBytes(downloadedRaw, {minimumFractionDigits: 2, maximumFractionDigits: 2})
           return {
             fixed: !done,
             msg: `Downloading ${hlPkgId(startedLog['packageId'])}: ${hlValue(downloaded)}/${hlValue(size)}${done ? ', done' : ''}`,

--- a/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
+++ b/cli/default-reporter/src/reporterForClient/reportBigTarballsProgress.ts
@@ -29,7 +29,10 @@ export function reportBigTarballProgress (
         startWith(0),
         map((downloadedRaw: number) => {
           const done = startedLog['size'] === downloadedRaw
-          const downloaded = prettyBytes(downloadedRaw, {minimumFractionDigits: 2, maximumFractionDigits: 2})
+          const downloaded = prettyBytes(downloadedRaw, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          })
           return {
             fixed: !done,
             msg: `Downloading ${hlPkgId(startedLog['packageId'])}: ${hlValue(downloaded)}/${hlValue(size)}${done ? ', done' : ''}`,

--- a/cli/default-reporter/test/reportingProgress.ts
+++ b/cli/default-reporter/test/reportingProgress.ts
@@ -363,29 +363,29 @@ test('prints progress of big files download', (done) => {
       case 1:
         expect(output).toBe(`\
 Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('0 B')}/${hlValue('10.5 MB')}`)
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('0.00 B')}/${hlValue('10.49 MB')}`)
         return
       case 2:
         expect(output).toBe(`\
 Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('5.77 MB')}/${hlValue('10.5 MB')}`)
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('5.77 MB')}/${hlValue('10.49 MB')}`)
         return
       case 4:
         expect(output).toBe(`\
 Progress: resolved ${hlValue('2')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.5 MB')}`)
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}`)
         return
       case 7:
         expect(output).toBe(`\
 Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.5 MB')}
-Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.9 MB')}/${hlValue('21 MB')}`)
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}
+Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
         return
       case 8:
         expect(output).toBe(`\
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('10.5 MB')}/${hlValue('10.5 MB')}, done
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('10.49 MB')}/${hlValue('10.49 MB')}, done
 Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.9 MB')}/${hlValue('21 MB')}`)
+Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
         return // eslint-disable-line
       }
     })


### PR DESCRIPTION
When running the CLI, downloads will show their progress, e.g. `1.12 MB/ 3 MB`, showing only significant digits.

As the output is constantly updated, the length of the line in the output might constantly change (2.99 -> 3 -> 3.3 -> 3.33), leading to a visually very noisy display.

https://github.com/pnpm/pnpm/assets/219373/7e98d064-9702-4d61-9cc5-01884dc6b74b

Tbh, I don't know much typescript and no pnpm - so i did not even build and test these changes ... *duckaway*.

Changes boil down to use [pretty-bytes according to their documentation](https://www.npmjs.com/package/pretty-bytes).

Fixes #6901