### PR TITLE
chore: remove useless async keyword

### DIFF
--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -130,7 +130,7 @@ export type InstallOptions =
   & Partial<StrictInstallOptions>
   & Pick<StrictInstallOptions, 'storeDir' | 'storeController'>
 
-const defaults = async (opts: InstallOptions) => {
+const defaults = (opts: InstallOptions) => {
   const packageManager = opts.packageManager ?? {
     name: pnpmPkgJson.name,
     version: pnpmPkgJson.version,
@@ -221,9 +221,9 @@ export type ProcessedInstallOptions = StrictInstallOptions & {
   readPackageHook?: ReadPackageHook
 }
 
-export async function extendOptions (
+export function extendOptions (
   opts: InstallOptions
-): Promise<ProcessedInstallOptions> {
+): ProcessedInstallOptions {
   if (opts) {
     for (const key in opts) {
       if (opts[key as keyof InstallOptions] === undefined) {
@@ -234,7 +234,7 @@ export async function extendOptions (
   if (opts.onlyBuiltDependencies && opts.neverBuiltDependencies) {
     throw new PnpmError('CONFIG_CONFLICT_BUILT_DEPENDENCIES', 'Cannot have both neverBuiltDependencies and onlyBuiltDependencies')
   }
-  const defaultOpts = await defaults(opts)
+  const defaultOpts = defaults(opts)
   const extendedOpts: ProcessedInstallOptions = {
     ...defaultOpts,
     ...opts,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -230,7 +230,7 @@ export async function mutateModules (
     streamParser.on('data', reporter)
   }
 
-  const opts = await extendOptions(maybeOpts)
+  const opts = extendOptions(maybeOpts)
 
   if (!opts.include.dependencies && opts.include.optionalDependencies) {
     throw new PnpmError('OPTIONAL_DEPS_REQUIRE_PROD_DEPS', 'Optional dependencies cannot be installed without production dependencies')


### PR DESCRIPTION
function `extendOptions` does not use any async function now. So just make it a normal function call.