### PR TITLE
fix: add support for npm lockfile v3 in `import`

### DIFF
--- a/.changeset/hungry-geckos-roll.md
+++ b/.changeset/hungry-geckos-roll.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Add support for npm lockfile v3 in `pnpm import`.

--- a/.changeset/hungry-geckos-roll.md
+++ b/.changeset/hungry-geckos-roll.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-installation": patch
+"pnpm": patch
 ---
 
-Add support for npm lockfile v3 in `pnpm import`.
+Add support for npm lockfile v3 in `pnpm import` [#6233](https://github.com/pnpm/pnpm/issues/6233).

--- a/__fixtures__/has-package-lock-v3-json/.gitignore
+++ b/__fixtures__/has-package-lock-v3-json/.gitignore
@@ -1,0 +1,1 @@
+!package-lock.json

--- a/__fixtures__/has-package-lock-v3-json/package-lock.json
+++ b/__fixtures__/has-package-lock-v3-json/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "has-package-lock-json",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "version": "0.0.0",
+      "dependencies": {
+        "@pnpm.e2e/pkg-with-1-dep": "100.0.0"
+      }
+    },
+    "node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep": {
+      "version": "101.0.0"
+    },
+    "node_modules/@pnpm.e2e/pkg-with-1-dep": {
+      "version": "100.0.0",
+      "dependencies": {
+        "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0"
+      }
+    }
+  }
+}

--- a/__fixtures__/has-package-lock-v3-json/package.json
+++ b/__fixtures__/has-package-lock-v3-json/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "has-package-lock-v3-json",
+  "version": "0.0.0",
+  "dependencies": {
+    "@pnpm.e2e/dep-of-pkg-with-1-dep": "^101.0.0",
+    "@pnpm.e2e/pkg-with-1-dep": "*"
+  },
+  "scripts": {
+    "prepare": "exit 1"
+  }
+}

--- a/__fixtures__/pnpm-workspace.yaml
+++ b/__fixtures__/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - '!has-npm-shrinkwrap-json'
   - '!has-outdated-deps'
   - '!has-package-lock-json'
+  - '!has-package-lock-v3-json'
   - '!hello-world-js-bin'
   - '!has-yarn-lock'
   - '!has-yarn2-lock'

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -29,9 +29,7 @@ import { yarnLockFileKeyNormalizer } from './yarnUtil'
 interface NpmPackageLock {
   dependencies: LockedPackagesMap
   packages: LockedPackagesMap
-  lockfileVersion: number
   name?: string
-
 }
 
 interface LockedPackage {

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -36,8 +36,12 @@ interface LockedPackage {
   version: string
   lockfileVersion: number
   name?: string
-  dependencies?: LockedPackagesMap
+  dependencies?: LockedPackagesMap | SimpleDependenciesMap
   packages?: LockedPackagesMap
+}
+
+interface SimpleDependenciesMap {
+  [name: string]: string
 }
 
 interface LockedPackagesMap {
@@ -264,7 +268,7 @@ function getAllVersionsByPackageNames (
   versionsByPackageNames: VersionsByPackageNames
 ): void {
   if (pkg.dependencies) {
-    extractDependencies(versionsByPackageNames, pkg.dependencies)
+    extractDependencies(versionsByPackageNames, pkg.dependencies as LockedPackagesMap)
   }
   if ('packages' in pkg && pkg.packages) {
     extractDependencies(versionsByPackageNames, pkg.packages)
@@ -294,7 +298,6 @@ function extractDependencies (
         if (!versionsByPackageNames[pkgName1]) {
           versionsByPackageNames[pkgName1] = new Set<string>()
         }
-        // @ts-expect-error
         versionsByPackageNames[pkgName1].add(version)
       }
     }

--- a/pkg-manager/plugin-commands-installation/test/import.ts
+++ b/pkg-manager/plugin-commands-installation/test/import.ts
@@ -131,3 +131,22 @@ test('import fails when no lockfiles are found', async () => {
     new PnpmError('LOCKFILE_NOT_FOUND', 'No lockfile found')
   )
 })
+
+test('import from package-lock-v3.json', async () => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  f.prepare('has-package-lock-v3-json')
+
+  await importCommand.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  }, [])
+
+  const project = assertProject(process.cwd())
+  const lockfile = await project.readLockfile()
+  expect(lockfile.packages).toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+  expect(lockfile.packages).not.toHaveProperty(['/@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+
+  // node_modules is not created
+  await project.hasNot('@pnpm.e2e/dep-of-pkg-with-1-dep')
+  await project.hasNot('@pnpm.e2e/pkg-with-1-dep')
+})

--- a/pkg-manager/plugin-commands-installation/test/import.ts
+++ b/pkg-manager/plugin-commands-installation/test/import.ts
@@ -132,7 +132,7 @@ test('import fails when no lockfiles are found', async () => {
   )
 })
 
-test('import from package-lock-v3.json', async () => {
+test('import from package-lock.json v3', async () => {
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
   f.prepare('has-package-lock-v3-json')
 


### PR DESCRIPTION
closes #6233