### PR TITLE
fix(store): Don't prematurely bail out of adding source files if ENOENT is thrown

### DIFF
--- a/store/cafs/src/addFilesFromDir.ts
+++ b/store/cafs/src/addFilesFromDir.ts
@@ -41,7 +41,7 @@ async function _retrieveFileIntegrities (
 ) {
   try {
     const files = await fs.readdir(currDir)
-    await Promise.all(files.map(async (file) => {
+    await Promise.allSettled(files.map(async (file) => {
       const fullPath = path.join(currDir, file)
       const stat = await fs.stat(fullPath)
       if (stat.isDirectory()) {

--- a/store/cafs/test/fixtures/broken-symlink/doesnt-exist
+++ b/store/cafs/test/fixtures/broken-symlink/doesnt-exist
@@ -1,0 +1,1 @@
+../doesnt-exist

--- a/store/cafs/test/index.ts
+++ b/store/cafs/test/index.ts
@@ -43,6 +43,16 @@ describe('cafs', () => {
     expect(await fs.readFile(filePath, 'utf8')).toBe('foo\n')
     expect(await manifest.promise).toEqual(undefined)
   })
+
+  it('ignores broken symlinks when traversing subdirectories', async () => {
+    const storeDir = tempy.directory()
+    const srcDir = path.join(__dirname, 'fixtures/broken-symlink')
+    const manifest = pDefer<DependencyManifest>()
+    const addFiles = async () => createCafs(storeDir).addFilesFromDir(srcDir, manifest)
+
+    const filesIndex = await addFiles()
+    expect(filesIndex['subdir/should-exist.txt']).toBeDefined()
+  })
 })
 
 describe('checkPkgFilesIntegrity()', () => {


### PR DESCRIPTION
Broken symbolic links will cause a `stat'-call to throw resulting in an
arbitrary amount of promises that won't get to settle before the index is
returned.

Processing subdirectories in the following iteration in the event loop makes
this consistently reproducible.

Awaiting with `allSettled` makes sure all files are processed before returning.