### PR TITLE
feat(npm-resolver): force resolve from npm if npm protocol

### DIFF
--- a/.changeset/sixty-months-sort.md
+++ b/.changeset/sixty-months-sort.md
@@ -1,0 +1,20 @@
+---
+"@pnpm/npm-resolver": minor
+---
+
+Force resolving from npm when using `npm:` protocol.
+
+Even if a package exists in local workspace with a matching version, it will be ignored
+if the dependency explicitly uses the `npm:` protocol prefix.
+
+```
+{
+  "name": "my-other-package",
+  "dependencies": {
+    "my-package-via-workspace": "workspace:my-package",
+    "my-package-via-npm": "npm:my-package"
+  }
+}
+```
+
+Closes https://github.com/pnpm/pnpm/issues/6992

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -132,7 +132,8 @@ async function resolveNpm (
   opts: ResolveFromNpmOptions
 ): Promise<ResolveResult | null> {
   const defaultTag = opts.defaultTag ?? 'latest'
-  if (wantedDependency.pref?.startsWith('workspace:')) {
+  const forceNpm = wantedDependency.pref?.startsWith('npm:') ?? false
+  if (!forceNpm && wantedDependency.pref?.startsWith('workspace:')) {
     if (wantedDependency.pref.startsWith('workspace:.')) return null
     const resolvedFromWorkspace = tryResolveFromWorkspace(wantedDependency, {
       defaultTag,
@@ -163,7 +164,7 @@ async function resolveNpm (
       registry: opts.registry,
     })
   } catch (err: any) { // eslint-disable-line
-    if ((workspacePackages != null) && opts.projectDir) {
+    if (!forceNpm && (workspacePackages != null) && opts.projectDir) {
       try {
         return tryResolveFromWorkspacePackages(workspacePackages, spec, {
           wantedDependency,
@@ -180,7 +181,7 @@ async function resolveNpm (
   const pickedPackage = pickResult.pickedPackage
   const meta = pickResult.meta
   if (pickedPackage == null) {
-    if ((workspacePackages != null) && opts.projectDir) {
+    if (!forceNpm && (workspacePackages != null) && opts.projectDir) {
       try {
         return tryResolveFromWorkspacePackages(workspacePackages, spec, {
           wantedDependency,
@@ -195,7 +196,7 @@ async function resolveNpm (
     throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta })
   }
 
-  if (((workspacePackages?.[pickedPackage.name]) != null) && opts.projectDir) {
+  if (!forceNpm && ((workspacePackages?.[pickedPackage.name]) != null) && opts.projectDir) {
     if (workspacePackages[pickedPackage.name][pickedPackage.version]) {
       return {
         ...resolveFromLocalPackage(workspacePackages[pickedPackage.name][pickedPackage.version], spec.normalizedPref, {


### PR DESCRIPTION
Force resolving from npm when using `npm:` protocol. Even if a package exists in local workspace with a matching version, it will be ignored if the dependency explicitly uses the `npm:` protocol prefix.

Closes https://github.com/pnpm/pnpm/issues/6992