### PR TITLE
chore: remove unused eslint-disable directive

### DIFF
--- a/pkg-manifest/read-project-manifest/src/index.ts
+++ b/pkg-manifest/read-project-manifest/src/index.ts
@@ -214,7 +214,7 @@ const dependencyKeys = new Set([
 ])
 
 function normalize (manifest: ProjectManifest) {
-  const result: Record<string, unknown> = {} // eslint-disable-line @typescript-eslint/no-explicit-any
+  const result: Record<string, unknown> = {}
   for (const key in manifest) {
     if (Object.prototype.hasOwnProperty.call(manifest, key)) {
       const value = manifest[key as keyof ProjectManifest]


### PR DESCRIPTION
Noticing a warning for `@typescript-eslint/no-explicit-any` when running `pnpm lint:ts`.

```
❯ pnpm lint:ts

> monorepo-root@ lint:ts /Users/gluxon/Developer/pnpm2
> eslint "**/src/**/*.ts" "**/test/**/*.ts"

/Users/gluxon/pnpm2/pkg-manifest/read-project-manifest/src/index.ts
  217:46  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')

✖ 1 problem (0 errors, 1 warning)
  0 errors and 1 warning potentially fixable with the `--fix` option.
```

## Fix

It looks like this ESLint disable is no longer needed. The `any` type here was changed to `unknown` recently https://github.com/pnpm/pnpm/commit/b4892acc5fe6bbb993c01dc497c3721db653d33c#diff-9772b105160de4e18e6f731a919c7c84a353d9f1f48ede962d923b4fc6b86fbc.