### PR TITLE
chore(deps): update `@typescript-eslint` dependencies to v6

### DIFF
--- a/.changeset/heavy-months-wash.md
+++ b/.changeset/heavy-months-wash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/eslint-config": minor
+---
+
+Update @typescript-eslint dependencies to v6. Version specifiers were changed from `^5.62.0` to `6.5.0`.

--- a/.changeset/little-queens-design.md
+++ b/.changeset/little-queens-design.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/eslint-config": minor
+---
+
+Update `eslint-config-standard-with-typescript` dependency minimum version from 37.0.0 to 39.0.0.

--- a/.changeset/ten-ladybugs-sin.md
+++ b/.changeset/ten-ladybugs-sin.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/exportable-manifest": patch
+"@pnpm/plugin-commands-rebuild": patch
+"@pnpm/lockfile-utils": patch
+"@pnpm/fs.find-packages": patch
+"@pnpm/lifecycle": patch
+"pnpm": patch
+---
+
+Apply fixes from @typescript-eslint v6 for nullish coalescing and optional chains. No behavior changes are expected with this change.

--- a/__fixtures__/circular/pnpm-lock.yaml
+++ b/__fixtures__/circular/pnpm-lock.yaml
@@ -8,20 +8,20 @@ dependencies:
 packages:
 
   /d@1.0.0:
-    resolution: {integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=}
+    resolution: {integrity: sha512-9x1NruMD5YQ7xccKbGEy/bjitRfn5LEIhJIXIOAXC8I1laA5gfezUMVES1/vjLxfGzZjirLLBzEqxMO2/LzGxQ==}
     dependencies:
       es5-ext: 0.10.24
     dev: false
 
   /es5-ext@0.10.24:
-    resolution: {integrity: sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=}
+    resolution: {integrity: sha512-qHKgM1mKhstIAZ1cxefVIOmWREJ2rgQv7aGg9BuCLq9G1vRjkV1K8M4LcSklsYPJwo2dqnOfb3IuNGOp3DxgUw==}
     dependencies:
       es6-iterator: 2.0.1
       es6-symbol: 3.1.1
     dev: false
 
   /es6-iterator@2.0.1:
-    resolution: {integrity: sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=}
+    resolution: {integrity: sha512-6QdxKjEfkAutL86ORbUgbZjfmssn3hfrFZDz5utw2BH9EJWYCVVqn9dN/WvsWSzsZ7Ox/fMrHXexX96fF5vEsw==}
     dependencies:
       d: 1.0.0
       es5-ext: 0.10.24
@@ -29,7 +29,7 @@ packages:
     dev: false
 
   /es6-symbol@3.1.1:
-    resolution: {integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=}
+    resolution: {integrity: sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==}
     dependencies:
       d: 1.0.0
       es5-ext: 0.10.24

--- a/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
@@ -11,6 +11,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixture/pnpm-lock.yaml
+++ b/__fixtures__/fixture/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
@@ -21,7 +21,7 @@ devDependencies:
 packages:
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.11:
@@ -32,11 +32,11 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /glob@6.0.4:
-    resolution: {integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=}
+    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.3
@@ -46,24 +46,24 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-negative@1.0.0:
-    resolution: {integrity: sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=}
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
     engines: {node: '>=0.10.0'}
     dev: false
     optional: true
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -74,23 +74,23 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /rimraf@2.5.1:
-    resolution: {integrity: sha1-UuHpRvP5ubDV2JiLoxkaryotvUM=}
+    resolution: {integrity: sha512-CNymZDrSR9PfkqZnBWaIki7Wlba4c7GzSkSKsHHvjXswXmJA1hM8ZHFrNWIt4L/WcR9kOwvsJZpbxV4fygtXag==}
     hasBin: true
     dependencies:
       glob: 6.0.4
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/general/pnpm-lock.yaml
+++ b/__fixtures__/general/pnpm-lock.yaml
@@ -21,22 +21,22 @@ devDependencies:
 packages:
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.8:
-    resolution: {integrity: sha1-wHshHHyVLsH479Uad+8NHTmQopI=}
+    resolution: {integrity: sha512-Dnfc9ROAPrkkeLIUweEbh7LFT9Mc53tO/bbM044rKjhgAEyIGKvKXg97PM/kRizZIfUHaROZIoeEaWao+Unzfw==}
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /glob@6.0.4:
-    resolution: {integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=}
+    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.3
@@ -46,14 +46,14 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-negative@1.0.0:
@@ -64,7 +64,7 @@ packages:
     optional: true
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -75,23 +75,23 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /rimraf@2.5.1:
-    resolution: {integrity: sha1-UuHpRvP5ubDV2JiLoxkaryotvUM=}
+    resolution: {integrity: sha512-CNymZDrSR9PfkqZnBWaIki7Wlba4c7GzSkSKsHHvjXswXmJA1hM8ZHFrNWIt4L/WcR9kOwvsJZpbxV4fygtXag==}
     hasBin: true
     dependencies:
       glob: 6.0.4
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
@@ -13,11 +13,11 @@ devDependencies:
 packages:
 
   /is-negative@1.0.1:
-    resolution: {integrity: sha1-3GuHKO69A8db+HYIftzVDpy1aZQ=}
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
@@ -13,11 +13,11 @@ devDependencies:
 packages:
 
   /is-negative@1.0.1:
-    resolution: {integrity: sha1-3GuHKO69A8db+HYIftzVDpy1aZQ=}
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
@@ -9,13 +9,13 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=
+      integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==
   /is-positive/2.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-sU8GvS24EK5sixJ0HRNr+u8Nh70=
+      integrity: sha512-uJQLtRnc7RP/Xo8tjkK9MJsWdnuKhiD5e8x+idmkUqr2p0R+n/ZdDFG1LEt98WwoRzWhSefhPnyLBleKZhg/Lg==
 specifiers:
   is-negative: 1.0.0
   is-positive: 2.0.0

--- a/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
@@ -6,11 +6,11 @@ packages:
   /is-negative/2.1.0:
     dev: false
     resolution:
-      integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
+      integrity: sha512-+iCKT4ZcvjRnjkHnQjZ8/qfciLLGD8BFKS0GNR5VjDU6jEiwh899R0GSMkaYcuTNd7fEKXb3Qib0webe6HczNw==
   /is-positive/3.1.0:
     dev: false
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==
 specifiers:
   is-negative: ^2.1.0
   is-positive: ^3.1.0

--- a/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
@@ -10,7 +10,7 @@ lockfileVersion: 5
 packages:
   /is-negative/1.1.0:
     resolution:
-      integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
+      integrity: sha512-+iCKT4ZcvjRnjkHnQjZ8/qfciLLGD8BFKS0GNR5VjDU6jEiwh899R0GSMkaYcuTNd7fEKXb3Qib0webe6HczNw==
   /is-positive/3.1.0:
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==

--- a/__fixtures__/has-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps/pnpm-lock.yaml
@@ -26,6 +26,6 @@ packages:
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/monorepo/pnpm-lock.yaml
+++ b/__fixtures__/monorepo/pnpm-lock.yaml
@@ -11,4 +11,4 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==

--- a/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
+++ b/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
@@ -18,7 +18,7 @@ packages:
   /array-flatten/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+      integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
   /body-parser/1.19.0:
     dependencies:
       bytes: 3.1.0
@@ -59,7 +59,7 @@ packages:
   /cookie-signature/1.0.6:
     dev: false
     resolution:
-      integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+      integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
   /cookie/0.4.0:
     dev: false
     engines:
@@ -77,31 +77,31 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+      integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
   /destroy/1.0.4:
     dev: false
     resolution:
-      integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+      integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==
   /ee-first/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+      integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
   /encodeurl/1.0.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+      integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
   /escape-html/1.0.3:
     dev: false
     resolution:
-      integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+      integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
   /etag/1.8.1:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+      integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
   /express/4.17.1:
     dependencies:
       accepts: 1.3.7
@@ -158,13 +158,13 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+      integrity: sha512-Ua9xNhH0b8pwE3yRbFfXJvfdWF0UHNCdeyb2sbi9Ul/M+r3PTdrz7Cv4SCfZRMjmzEM9PhraqfZFbGTIg3OMyA==
   /fresh/0.5.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+      integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
   /http-errors/1.7.2:
     dependencies:
       depd: 1.1.2
@@ -200,7 +200,7 @@ packages:
   /inherits/2.0.3:
     dev: false
     resolution:
-      integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+      integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
   /inherits/2.0.4:
     dev: false
     resolution:
@@ -216,17 +216,17 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+      integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+      integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
   /methods/1.1.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+      integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
   /mime-db/1.44.0:
     dev: false
     engines:
@@ -251,7 +251,7 @@ packages:
   /ms/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+      integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
   /ms/2.1.1:
     dev: false
     resolution:
@@ -269,7 +269,7 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+      integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
   /parseurl/1.3.3:
     dev: false
     engines:
@@ -279,7 +279,7 @@ packages:
   /path-to-regexp/0.1.7:
     dev: false
     resolution:
-      integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+      integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
   /proxy-addr/2.0.6:
     dependencies:
       forwarded: 0.1.2
@@ -360,7 +360,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+      integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
   /toidentifier/1.0.0:
     dev: false
     engines:
@@ -381,16 +381,16 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+      integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
   /utils-merge/1.0.1:
     dev: false
     engines:
       node: '>= 0.4.0'
     resolution:
-      integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+      integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
   /vary/1.1.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+      integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==

--- a/__fixtures__/with-file-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-file-dep/pnpm-lock.yaml
@@ -11,6 +11,6 @@ dependencies:
 packages:
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/with-peer/pnpm-lock.yaml
+++ b/__fixtures__/with-peer/pnpm-lock.yaml
@@ -28,11 +28,11 @@ packages:
     dev: false
 
   /fast-deep-equal@2.0.1:
-    resolution: {integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=}
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
     dev: false
 
   /fast-json-stable-stringify@2.0.0:
-    resolution: {integrity: sha1-1RQsDK7msRifh9OnYREGT4bIu/I=}
+    resolution: {integrity: sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==}
     dev: false
 
   /json-schema-traverse@0.4.1:

--- a/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
+++ b/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
@@ -18,11 +18,11 @@ packages:
     dev: false
 
   /any-promise@1.3.0:
-    resolution: {integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=}
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
     dev: false
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.11:
@@ -33,7 +33,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /define-properties@1.1.3:
@@ -64,7 +64,7 @@ packages:
     dev: false
 
   /fs.realpath@1.0.0:
-    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
 
   /function-bind@1.1.1:
@@ -87,7 +87,7 @@ packages:
     dev: false
 
   /has-symbols@1.0.0:
-    resolution: {integrity: sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=}
+    resolution: {integrity: sha512-QfcgWpH8qn5qhNMg3wfXf2FD/rSA4TwNiDDthKqXe7v6oBW0YKWcnfwMAApgWq9Lh+Yu+fQWVhHPohlD/S6uoQ==}
     engines: {node: '>= 0.4'}
     dev: false
 
@@ -99,14 +99,14 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-callable@1.1.4:
@@ -115,12 +115,12 @@ packages:
     dev: false
 
   /is-date-object@1.0.1:
-    resolution: {integrity: sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=}
+    resolution: {integrity: sha512-P5rExV1phPi42ppoMWy7V63N3i173RY921l4JJ7zonMSxK+OWGPj76GD+cUKUb68l4vQXcJp2SsG+r/A4ABVzg==}
     engines: {node: '>= 0.4'}
     dev: false
 
   /is-regex@1.0.4:
-    resolution: {integrity: sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=}
+    resolution: {integrity: sha512-WQgPrEkb1mPCWLSlLFuN1VziADSixANugwSkJfPRR73FNWIQQN+tR/t1zWfyES/Y9oag/XBtVsahFdfBku3Kyw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has: 1.0.3
@@ -145,18 +145,18 @@ packages:
     dev: false
 
   /minimist@0.0.8:
-    resolution: {integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=}
+    resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
     dev: false
 
   /mkdirp-promise@5.0.1:
-    resolution: {integrity: sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=}
+    resolution: {integrity: sha512-Hepn5kb1lJPtVW84RFT40YG1OddBNTOVUZR2bzQUHc+Z03en8/3uX0+060JDhcEzyO08HmipsN9DcnFMxhIL9w==}
     engines: {node: '>=4'}
     dependencies:
       mkdirp: 0.5.1
     dev: false
 
   /mkdirp@0.5.1:
-    resolution: {integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=}
+    resolution: {integrity: sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==}
     hasBin: true
     dependencies:
       minimist: 0.0.8
@@ -171,7 +171,7 @@ packages:
     dev: false
 
   /object-assign@4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -181,7 +181,7 @@ packages:
     dev: false
 
   /object.getownpropertydescriptors@2.0.3:
-    resolution: {integrity: sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=}
+    resolution: {integrity: sha512-NwrpYtu1CSNWdNgcEvLmHOHjhMeglj22YJpg/ezASfIFYqNK4F94iUxKRPnRNbOuOMoQb5JS+6Ebi16xtYZbqQ==}
     engines: {node: '>= 0.8'}
     dependencies:
       define-properties: 1.1.3
@@ -189,13 +189,13 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -230,14 +230,14 @@ packages:
     dev: false
 
   /thenify-all@1.6.0:
-    resolution: {integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=}
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
     dependencies:
       thenify: 3.3.0
     dev: false
 
   /thenify@3.3.0:
-    resolution: {integrity: sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=}
+    resolution: {integrity: sha512-ho5BRit179DQqrTnGIjO+L9vLP/zLyGk6jXn70DLD6MTUYD2FSgR2Y4qWcgca90VD54sQ7GdQ2/C765V6kPcqA==}
     dependencies:
       any-promise: 1.3.0
     dev: false
@@ -250,5 +250,5 @@ packages:
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
@@ -19,6 +19,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
@@ -15,6 +15,6 @@ importers:
 packages:
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
@@ -49,7 +49,7 @@ packages:
     dev: false
 
   /fast-json-stable-stringify@2.0.0:
-    resolution: {integrity: sha1-1RQsDK7msRifh9OnYREGT4bIu/I=}
+    resolution: {integrity: sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==}
     dev: false
 
   /fast-json-stable-stringify@2.1.0:

--- a/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
@@ -19,6 +19,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__utils__/eslint-config/package.json
+++ b/__utils__/eslint-config/package.json
@@ -26,7 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.47.0",
-    "eslint-config-standard-with-typescript": "^37.0.0",
+    "eslint-config-standard-with-typescript": "^39.0.0",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-node": "^11.1.0",

--- a/__utils__/eslint-config/package.json
+++ b/__utils__/eslint-config/package.json
@@ -23,8 +23,8 @@
   "repository": "https://github.com/pnpm/pnpm/blob/master/utils/eslint-config",
   "scripts": {},
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.62.0",
-    "@typescript-eslint/parser": "^5.62.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.47.0",
     "eslint-config-standard-with-typescript": "^37.0.0",
     "eslint-plugin-import": "^2.28.1",

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -361,7 +361,6 @@ function reportAuthError (
   const foundSettings = [] as string[]
   for (const [key, value] of Object.entries(config?.rawConfig ?? {})) {
     if (key.startsWith('@')) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       foundSettings.push(`${key}=${value}`)
       continue
     }

--- a/cli/default-reporter/src/reporterForClient/reportRequestRetry.ts
+++ b/cli/default-reporter/src/reporterForClient/reportRequestRetry.ts
@@ -11,7 +11,6 @@ export function reportRequestRetry (
     map((log) => {
       const retriesLeft = log.maxRetries - log.attempt + 1
       const errorCode = log.error['httpStatusCode'] || log.error['status'] || log.error['errno'] || log.error['code']
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const msg = `${log.method} ${log.url} error (${errorCode}). \
 Will retry in ${prettyMilliseconds(log.timeout, { verbose: true })}. \
 ${retriesLeft} retries left.`

--- a/cli/default-reporter/src/reporterForClient/reportSkippedOptionalDependencies.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSkippedOptionalDependencies.ts
@@ -12,7 +12,6 @@ export function reportSkippedOptionalDependencies (
     filter((log) => Boolean(log['prefix'] === opts.cwd && log.parents && log.parents.length === 0)),
     map((log) => Rx.of({
       msg: `info: ${
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         log.package['id'] || log.package.name && (`${log.package.name}@${log.package.version}`) || log.package['pref']
       } is an optional dependency and failed compatibility check. Excluding it from installation.`,
     }))

--- a/cli/default-reporter/src/reporterForClient/reportStats.ts
+++ b/cli/default-reporter/src/reporterForClient/reportStats.ts
@@ -80,11 +80,9 @@ function statsForCurrentPackage (
 
       let msg = 'Packages:'
       if (stats['added']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         msg += ' ' + chalk.green(`+${stats['added'].toString()}`)
       }
       if (stats['removed']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         msg += ' ' + chalk.red(`-${stats['removed'].toString()}`)
       }
       msg += EOL + printPlusesAndMinuses(opts.width, (stats['added'] || 0), (stats['removed'] || 0))
@@ -134,11 +132,9 @@ function statsForNotCurrentPackage (
       const parts = [] as string[]
 
       if (stats['added']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         parts.push(padStep(chalk.green(`+${stats['added'].toString()}`), 4))
       }
       if (stats['removed']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         parts.push(padStep(chalk.red(`-${stats['removed'].toString()}`), 4))
       }
 

--- a/cli/default-reporter/src/reporterForClient/reportStats.ts
+++ b/cli/default-reporter/src/reporterForClient/reportStats.ts
@@ -112,10 +112,10 @@ function statsForNotCurrentPackage (
             stats[log.prefix] = log
             return { seed: stats, value: null }
           } else if (typeof stats[log.prefix].added === 'number' && typeof log['added'] === 'number') {
-            stats[log.prefix].added += log['added'] // eslint-disable-line
+            stats[log.prefix].added += log['added']
             return { seed: stats, value: null }
           } else if (typeof stats[log.prefix].removed === 'number' && typeof log['removed'] === 'number') {
-            stats[log.prefix].removed += log['removed'] // eslint-disable-line
+            stats[log.prefix].removed += log['removed']
             return { seed: stats, value: null }
           } else {
             const value = { ...stats[log.prefix], ...log }

--- a/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
+++ b/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
@@ -65,7 +65,7 @@ export async function runLifecycleHooksConcurrently (
         }
         let isBuilt = false
         for (const stage of (importerStages ?? stages)) {
-          if ((manifest.scripts == null) || !manifest.scripts[stage]) continue
+          if (!manifest.scripts?.[stage]) continue
           await runLifecycleHook(stage, manifest, runLifecycleHookOpts) // eslint-disable-line no-await-in-loop
           isBuilt = true
         }

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -95,7 +95,7 @@ export async function rebuildSelectedPkgs (
   const opts = await extendRebuildOptions(maybeOpts)
   const ctx = await getContext({ ...opts, allProjects: projects })
 
-  if (!ctx.currentLockfile || (ctx.currentLockfile.packages == null)) return
+  if (ctx.currentLockfile?.packages == null) return
   const packages = ctx.currentLockfile.packages
 
   const searched: PackageSelector[] = pkgSpecs.map((arg) => {

--- a/fetching/git-fetcher/src/index.ts
+++ b/fetching/git-fetcher/src/index.ts
@@ -39,7 +39,7 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions) {
         globalWarn(`The git-hosted package fetched from "${resolution.repo}" has to be built but the build scripts were ignored.`)
       }
     } catch (err: any) { // eslint-disable-line
-      err.message = `Failed to prepare git-hosted package fetched from "${resolution.repo}": ${err.message}` // eslint-disable-line
+      err.message = `Failed to prepare git-hosted package fetched from "${resolution.repo}": ${err.message}`
       throw err
     }
     // removing /.git to make directory integrity calculation faster

--- a/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
@@ -26,7 +26,7 @@ export function createGitHostedTarballFetcher (fetchRemoteTarball: FetchFunction
       }
       return { filesIndex: prepareResult.filesIndex }
     } catch (err: any) { // eslint-disable-line
-      err.message = `Failed to prepare git-hosted package fetched from "${resolution.tarball}": ${err.message}` // eslint-disable-line
+      err.message = `Failed to prepare git-hosted package fetched from "${resolution.tarball}": ${err.message}`
       throw err
     }
   }

--- a/fs/find-packages/src/index.ts
+++ b/fs/find-packages/src/index.ts
@@ -29,7 +29,7 @@ export async function findPackages (root: string, opts?: Options): Promise<Proje
   opts = opts ?? {}
   const globOpts = { ...opts, cwd: root, includeRoot: undefined }
   globOpts.ignore = opts.ignore ?? DEFAULT_IGNORE
-  const patterns = normalizePatterns((opts.patterns != null) ? opts.patterns : ['.', '**'])
+  const patterns = normalizePatterns(opts.patterns ?? ['.', '**'])
   const paths: string[] = await fastGlob(patterns, globOpts)
 
   if (opts.includeRoot) {

--- a/lockfile/lockfile-utils/src/satisfiesPackageManifest.ts
+++ b/lockfile/lockfile-utils/src/satisfiesPackageManifest.ts
@@ -68,14 +68,11 @@ export function satisfiesPackageManifest (
       break
     case 'devDependencies':
       pkgDepNames = Object.keys(pkgDeps)
-        .filter((depName) =>
-          ((pkg.optionalDependencies == null) || !pkg.optionalDependencies[depName]) &&
-            ((pkg.dependencies == null) || !pkg.dependencies[depName])
-        )
+        .filter((depName) => !pkg.optionalDependencies?.[depName] && !pkg.dependencies?.[depName])
       break
     case 'dependencies':
       pkgDepNames = Object.keys(pkgDeps)
-        .filter((depName) => (pkg.optionalDependencies == null) || !pkg.optionalDependencies[depName])
+        .filter((depName) => !pkg.optionalDependencies?.[depName])
       break
     default:
       throw new Error(`Unknown dependency type "${depField as string}"`)

--- a/network/auth-header/src/index.ts
+++ b/network/auth-header/src/index.ts
@@ -27,7 +27,7 @@ function getAuthHeaderByURI (authHeaders: Record<string, string>, maxParts: numb
   const nerfed = nerfDart(uri)
   const parts = nerfed.split('/')
   for (let i = Math.min(parts.length, maxParts) - 1; i >= 3; i--) {
-    const key = `${parts.slice(0, i).join('/')}/` // eslint-disable-line
+    const key = `${parts.slice(0, i).join('/')}/`
     if (authHeaders[key]) return authHeaders[key]
   }
   const urlWithoutPort = removePort(uri)

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "peerDependencyRules": {
       "allowedVersions": {
         "eslint": "*",
-        "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@yarnpkg/core": "*"
       },
       "ignoreMissing": [

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -126,7 +126,7 @@ export function parse (dependencyPath: string) {
     isAbsolute: _isAbsolute,
   }
   const name = parts[0].startsWith('@')
-    ? `${parts.shift()}/${parts.shift()}` // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    ? `${parts.shift()}/${parts.shift()}`
     : parts.shift()
   let version = parts.join('/')
   if (version) {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -278,7 +278,7 @@ export async function mutateModules (
   // @ts-expect-error
   if (global['verifiedFileIntegrity'] > 1000) {
     // @ts-expect-error
-    globalInfo(`The integrity of ${global['verifiedFileIntegrity']} files was checked. This might have caused installation to take longer.`) // eslint-disable-line
+    globalInfo(`The integrity of ${global['verifiedFileIntegrity']} files was checked. This might have caused installation to take longer.`)
   }
   if ((reporter != null) && typeof reporter === 'function') {
     streamParser.removeListener('data', reporter)

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -495,12 +495,10 @@ function fetchToStore (
               !equalOrSemverEqual(pkgFilesIndex.version, opts.expectedPkg.version)
             )
           ) {
-            /* eslint-disable @typescript-eslint/restrict-template-expressions */
             throw new PnpmError('UNEXPECTED_PKG_CONTENT_IN_STORE', `\
 Package name mismatch found while reading ${JSON.stringify(opts.pkg.resolution)} from the store. \
 This means that the lockfile is broken. Expected package: ${opts.expectedPkg.name}@${opts.expectedPkg.version}. \
 Actual package in the store by the given integrity: ${pkgFilesIndex.name}@${pkgFilesIndex.version}.`)
-            /* eslint-enable @typescript-eslint/restrict-template-expressions */
           }
           const verified = await ctx.checkFilesIntegrity(pkgFilesIndex, manifest)
           if (verified) {

--- a/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
@@ -47,7 +47,6 @@ const keyNormalizer = (
       descriptors.push(range.source)
     } else {
       descriptors.push(
-        // eslint-disable-next-line
         `${name}@${protocol}${range.source}${
           range.selector ? '#' + range.selector : ''
         }`

--- a/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
+++ b/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
@@ -53,7 +53,7 @@ exports[`pnpm dedupe updates old resolutions from importers block and removes ol
 -     "/fast-json-stable-stringify@2.0.0": Object {
 -       "dev": false,
 -       "resolution": Object {
--         "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+-         "integrity": "sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==",
         },
       },
       "/fast-json-stable-stringify@2.1.0": Object {

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -68,7 +68,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   if (versionAliasSpecParts != null) {
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const { manifest } = await tryReadProjectManifest(path.join(modulesDir, depName))
-    if ((manifest == null) || !manifest.version) {
+    if (!manifest?.version) {
       throw new PnpmError(
         'CANNOT_RESOLVE_WORKSPACE_PROTOCOL',
         `Cannot resolve workspace protocol of dependency "${depName}" ` +
@@ -84,7 +84,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   }
   if (depSpec.startsWith('workspace:./') || depSpec.startsWith('workspace:../')) {
     const { manifest } = await tryReadProjectManifest(path.join(dir, depSpec.slice(10)))
-    if ((manifest == null) || !manifest.name || !manifest.version) {
+    if (!manifest?.name || !manifest?.version) {
       throw new PnpmError(
         'CANNOT_RESOLVE_WORKSPACE_PROTOCOL',
         `Cannot resolve workspace protocol of dependency "${depName}" ` +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
         specifier: ^8.47.0
         version: 8.47.0
       eslint-config-standard-with-typescript:
-        specifier: ^37.0.0
-        version: 37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^39.0.0
+        version: 39.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
       eslint-plugin-import:
         specifier: ^2.28.1
         version: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
@@ -8785,26 +8785,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4
-      eslint: 8.47.0
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@typescript-eslint/parser@6.5.0(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -8824,14 +8804,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/scope-manager@5.62.0:
-    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
   /@typescript-eslint/scope-manager@6.5.0:
@@ -8862,35 +8834,9 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types@5.62.0:
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
-
   /@typescript-eslint/types@6.5.0:
     resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: false
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@typescript-eslint/typescript-estree@6.5.0(typescript@5.1.6):
@@ -8931,14 +8877,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
-
-  /@typescript-eslint/visitor-keys@5.62.0:
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.3
     dev: false
 
   /@typescript-eslint/visitor-keys@6.5.0:
@@ -10962,10 +10900,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
+  /eslint-config-standard-with-typescript@39.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-CiV2LS4NUeeRmDTDf1ocUMpMxitSyW0g+Y/N7ecElwGj188GahbcQgqfBNyVsIXQxHlZVBlOjkbg3oUI0R3KBg==}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.52.0
+      '@typescript-eslint/eslint-plugin': ^6.4.0
       eslint: '*'
       eslint-plugin-import: ^2.25.2
       eslint-plugin-n: '^15.0.0 || ^16.0.0 '
@@ -10973,7 +10911,7 @@ packages:
       typescript: '*'
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
@@ -16436,16 +16374,6 @@ packages:
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
-
-  /tsutils@3.21.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.6
-    dev: false
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,20 +277,20 @@ importers:
   __utils__/eslint-config:
     dependencies:
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^6.5.0
+        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
-        specifier: ^5.62.0
-        version: 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^6.5.0
+        version: 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       eslint:
         specifier: ^8.47.0
         version: 8.47.0
       eslint-config-standard-with-typescript:
         specifier: ^37.0.0
-        version: 37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
+        version: 37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
       eslint-plugin-import:
         specifier: ^2.28.1
-        version: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+        version: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n:
         specifier: ^16.0.1
         version: 16.0.1(eslint@8.47.0)
@@ -8756,11 +8756,11 @@ packages:
     resolution: {integrity: sha512-kbdQa3J+hVCkqmGQm31fthEwGxszZtepw84p9QGCiJB7TmiPqPAf3/g9eZUnkCeanmiFOaG4pVhiPDyqJxaoaw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
       eslint: '*'
       typescript: '*'
     peerDependenciesMeta:
@@ -8768,17 +8768,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/type-utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4
       eslint: 8.47.0
       graphemer: 1.4.0
       ignore: 5.2.4
-      natural-compare-lite: 1.4.0
+      natural-compare: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -8804,6 +8805,27 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/parser@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4
+      eslint: 8.47.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8812,9 +8834,17 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/scope-manager@6.5.0:
+    resolution: {integrity: sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
+    dev: false
+
+  /@typescript-eslint/type-utils@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '*'
       typescript: '*'
@@ -8822,11 +8852,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.47.0
-      tsutils: 3.21.0(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -8835,6 +8865,11 @@ packages:
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  /@typescript-eslint/types@6.5.0:
+    resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
@@ -8858,20 +8893,40 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/typescript-estree@6.5.0(typescript@5.1.6):
+    resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/utils@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
       eslint: 8.47.0
-      eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -8883,6 +8938,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.3
+    dev: false
+
+  /@typescript-eslint/visitor-keys@6.5.0:
+    resolution: {integrity: sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
       eslint-visitor-keys: 3.4.3
     dev: false
 
@@ -10899,7 +10962,7 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
+  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.52.0
@@ -10909,11 +10972,11 @@ packages:
       eslint-plugin-promise: ^6.0.0
       typescript: '*'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n: 16.0.1(eslint@8.47.0)
       eslint-plugin-promise: 6.1.1(eslint@8.47.0)
       typescript: 5.1.6
@@ -10931,7 +10994,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.47.0
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n: 16.0.1(eslint@8.47.0)
       eslint-plugin-promise: 6.1.1(eslint@8.47.0)
     dev: false
@@ -10946,7 +11009,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10967,7 +11030,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
@@ -10997,7 +11060,7 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0):
+  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11007,7 +11070,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
       array.prototype.flat: 1.3.1
@@ -11016,7 +11079,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -11071,14 +11134,6 @@ packages:
       eslint: '*'
     dependencies:
       eslint: 8.47.0
-    dev: false
-
-  /eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
     dev: false
 
   /eslint-scope@7.2.2:
@@ -11178,11 +11233,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
-
-  /estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: false
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -13923,10 +13973,6 @@ packages:
     dev: false
     optional: true
 
-  /natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: false
-
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -16261,6 +16307,15 @@ packages:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
     dependencies:
       utf8-byte-length: 1.0.4
+    dev: false
+
+  /ts-api-utils@1.0.2(typescript@5.1.6):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.1.6
     dev: false
 
   /ts-jest@29.1.0(@babel/core@7.22.10)(jest@29.6.2)(typescript@5.1.6):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10902,7 +10902,7 @@ packages:
   /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.52.0 || ^5.6.0
+      '@typescript-eslint/eslint-plugin': ^5.52.0
       eslint: '*'
       eslint-plugin-import: ^2.25.2
       eslint-plugin-n: '^15.0.0 || ^16.0.0 '

--- a/pnpm/src/reporter/silentReporter.ts
+++ b/pnpm/src/reporter/silentReporter.ts
@@ -13,7 +13,7 @@ export function silentReporter (
 
     console.log(obj['err']?.message ?? obj['message'])
     if (obj['err']?.stack) {
-      console.log(`\n${obj['err'].stack}`) // eslint-disable-line
+      console.log(`\n${obj['err'].stack}`)
     }
   })
 }

--- a/pnpm/test/cli.ts
+++ b/pnpm/test/cli.ts
@@ -121,7 +121,7 @@ test('pnpx works', () => {
   mkdirSync(global)
 
   const env = {
-    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`, // eslint-disable-line
+    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`,
     PNPM_HOME: pnpmHome,
     XDG_DATA_HOME: global,
   }

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -131,7 +131,7 @@ test('silent dlx prints the output of the child process only', async () => {
   mkdirSync(global)
 
   const env = {
-    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`, // eslint-disable-line
+    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`,
     PNPM_HOME: pnpmHome,
     XDG_DATA_HOME: global,
   }

--- a/store/server/src/createServer.ts
+++ b/store/server/src/createServer.ts
@@ -52,7 +52,7 @@ export function createServer (
     const bodyPromise = new Promise<RequestBody>((resolve, reject) => {
       let body: any = '' // eslint-disable-line
       req.on('data', (data) => {
-        body += data // eslint-disable-line
+        body += data
       })
       req.on('end', async () => {
         try {


### PR DESCRIPTION
## Motivation

I'm hoping to help out with some repository maintenance tasks by upgrading pnpm to TypeScript 5.2. Before that, we'll need to update `@typescript-eslint` to a version that supports TypeScript 5.2.

The TypeScript 5.2 upgrade will be done in a separate PR. https://github.com/pnpm/pnpm/pull/7016

## Changes

This PR follows the typescript-eslint v6 upgrade guide and applies a few fixes to get `pnpm lint:ts` passing.

https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/

## ESLint Config Changes

One of the major changes in typescript-eslint v6 is a [restructuring of the base configs other configs extend from](https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/#reworked-configuration-names).

This doesn't seem to apply to the pnpm repo since it extends the `eslint-config-standard-with-typescript` config instead of `@typescript-eslint/recommended` or `@typescript-eslint/strict`. To sanity check, I compared the rendered config before and after this PR.

```sh
eslint --print-config pnpm/src/pnpm.ts 
```

The changes were very minimal: https://gist.github.com/gluxon/588514a95858a0e0877d85fab3e67825#file-after-before-diff

## Notes for Reviewers

1. Reviewing commit by commit should be easier. I've separated each thematic change into its own commit.
2. The `@typescript-eslint/restrict-template-expressions` and `@typescript-eslint/restrict-plus-operands` rules got relaxed a bit. A few ESLint disable comments were able to be removed as a result. We could alternatively configure these rules to their prior strictness.
3. There are a few runtime changes in this PR as a result of the `prefer-optional-chain` and `prefer-nullish-coalescing` rules becoming smarter. I applied the auto-fixes after convincing myself that they're correct.
