### PR TITLE
chore(deps): update `@typescript-eslint` dependencies to v6

### DIFF
--- a/.changeset/heavy-months-wash.md
+++ b/.changeset/heavy-months-wash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/eslint-config": minor
+---
+
+Update @typescript-eslint dependencies to v6. Version specifiers were changed from `^5.62.0` to `6.5.0`.

--- a/.changeset/little-queens-design.md
+++ b/.changeset/little-queens-design.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/eslint-config": minor
+---
+
+Update `eslint-config-standard-with-typescript` dependency minimum version from 37.0.0 to 39.0.0.

--- a/.changeset/ten-ladybugs-sin.md
+++ b/.changeset/ten-ladybugs-sin.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/exportable-manifest": patch
+"@pnpm/plugin-commands-rebuild": patch
+"@pnpm/lockfile-utils": patch
+"@pnpm/fs.find-packages": patch
+"@pnpm/lifecycle": patch
+"pnpm": patch
+---
+
+Apply fixes from @typescript-eslint v6 for nullish coalescing and optional chains. No behavior changes are expected with this change.

--- a/__utils__/eslint-config/package.json
+++ b/__utils__/eslint-config/package.json
@@ -26,7 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.47.0",
-    "eslint-config-standard-with-typescript": "^37.0.0",
+    "eslint-config-standard-with-typescript": "^39.0.0",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-n": "^16.0.1",
     "eslint-plugin-node": "^11.1.0",

--- a/__utils__/eslint-config/package.json
+++ b/__utils__/eslint-config/package.json
@@ -23,8 +23,8 @@
   "repository": "https://github.com/pnpm/pnpm/blob/master/utils/eslint-config",
   "scripts": {},
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.62.0",
-    "@typescript-eslint/parser": "^5.62.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.47.0",
     "eslint-config-standard-with-typescript": "^37.0.0",
     "eslint-plugin-import": "^2.28.1",

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -361,7 +361,6 @@ function reportAuthError (
   const foundSettings = [] as string[]
   for (const [key, value] of Object.entries(config?.rawConfig ?? {})) {
     if (key.startsWith('@')) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       foundSettings.push(`${key}=${value}`)
       continue
     }

--- a/cli/default-reporter/src/reporterForClient/reportRequestRetry.ts
+++ b/cli/default-reporter/src/reporterForClient/reportRequestRetry.ts
@@ -11,7 +11,6 @@ export function reportRequestRetry (
     map((log) => {
       const retriesLeft = log.maxRetries - log.attempt + 1
       const errorCode = log.error['httpStatusCode'] || log.error['status'] || log.error['errno'] || log.error['code']
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const msg = `${log.method} ${log.url} error (${errorCode}). \
 Will retry in ${prettyMilliseconds(log.timeout, { verbose: true })}. \
 ${retriesLeft} retries left.`

--- a/cli/default-reporter/src/reporterForClient/reportSkippedOptionalDependencies.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSkippedOptionalDependencies.ts
@@ -12,7 +12,6 @@ export function reportSkippedOptionalDependencies (
     filter((log) => Boolean(log['prefix'] === opts.cwd && log.parents && log.parents.length === 0)),
     map((log) => Rx.of({
       msg: `info: ${
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         log.package['id'] || log.package.name && (`${log.package.name}@${log.package.version}`) || log.package['pref']
       } is an optional dependency and failed compatibility check. Excluding it from installation.`,
     }))

--- a/cli/default-reporter/src/reporterForClient/reportStats.ts
+++ b/cli/default-reporter/src/reporterForClient/reportStats.ts
@@ -80,11 +80,9 @@ function statsForCurrentPackage (
 
       let msg = 'Packages:'
       if (stats['added']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         msg += ' ' + chalk.green(`+${stats['added'].toString()}`)
       }
       if (stats['removed']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         msg += ' ' + chalk.red(`-${stats['removed'].toString()}`)
       }
       msg += EOL + printPlusesAndMinuses(opts.width, (stats['added'] || 0), (stats['removed'] || 0))
@@ -134,11 +132,9 @@ function statsForNotCurrentPackage (
       const parts = [] as string[]
 
       if (stats['added']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         parts.push(padStep(chalk.green(`+${stats['added'].toString()}`), 4))
       }
       if (stats['removed']) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         parts.push(padStep(chalk.red(`-${stats['removed'].toString()}`), 4))
       }
 

--- a/cli/default-reporter/src/reporterForClient/reportStats.ts
+++ b/cli/default-reporter/src/reporterForClient/reportStats.ts
@@ -112,10 +112,10 @@ function statsForNotCurrentPackage (
             stats[log.prefix] = log
             return { seed: stats, value: null }
           } else if (typeof stats[log.prefix].added === 'number' && typeof log['added'] === 'number') {
-            stats[log.prefix].added += log['added'] // eslint-disable-line
+            stats[log.prefix].added += log['added']
             return { seed: stats, value: null }
           } else if (typeof stats[log.prefix].removed === 'number' && typeof log['removed'] === 'number') {
-            stats[log.prefix].removed += log['removed'] // eslint-disable-line
+            stats[log.prefix].removed += log['removed']
             return { seed: stats, value: null }
           } else {
             const value = { ...stats[log.prefix], ...log }

--- a/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
+++ b/exec/lifecycle/src/runLifecycleHooksConcurrently.ts
@@ -65,7 +65,7 @@ export async function runLifecycleHooksConcurrently (
         }
         let isBuilt = false
         for (const stage of (importerStages ?? stages)) {
-          if ((manifest.scripts == null) || !manifest.scripts[stage]) continue
+          if (!manifest.scripts?.[stage]) continue
           await runLifecycleHook(stage, manifest, runLifecycleHookOpts) // eslint-disable-line no-await-in-loop
           isBuilt = true
         }

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -95,7 +95,7 @@ export async function rebuildSelectedPkgs (
   const opts = await extendRebuildOptions(maybeOpts)
   const ctx = await getContext({ ...opts, allProjects: projects })
 
-  if (!ctx.currentLockfile || (ctx.currentLockfile.packages == null)) return
+  if (ctx.currentLockfile?.packages == null) return
   const packages = ctx.currentLockfile.packages
 
   const searched: PackageSelector[] = pkgSpecs.map((arg) => {

--- a/fetching/git-fetcher/src/index.ts
+++ b/fetching/git-fetcher/src/index.ts
@@ -39,7 +39,7 @@ export function createGitFetcher (createOpts: CreateGitFetcherOptions) {
         globalWarn(`The git-hosted package fetched from "${resolution.repo}" has to be built but the build scripts were ignored.`)
       }
     } catch (err: any) { // eslint-disable-line
-      err.message = `Failed to prepare git-hosted package fetched from "${resolution.repo}": ${err.message}` // eslint-disable-line
+      err.message = `Failed to prepare git-hosted package fetched from "${resolution.repo}": ${err.message}`
       throw err
     }
     // removing /.git to make directory integrity calculation faster

--- a/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts
@@ -26,7 +26,7 @@ export function createGitHostedTarballFetcher (fetchRemoteTarball: FetchFunction
       }
       return { filesIndex: prepareResult.filesIndex }
     } catch (err: any) { // eslint-disable-line
-      err.message = `Failed to prepare git-hosted package fetched from "${resolution.tarball}": ${err.message}` // eslint-disable-line
+      err.message = `Failed to prepare git-hosted package fetched from "${resolution.tarball}": ${err.message}`
       throw err
     }
   }

--- a/fs/find-packages/src/index.ts
+++ b/fs/find-packages/src/index.ts
@@ -29,7 +29,7 @@ export async function findPackages (root: string, opts?: Options): Promise<Proje
   opts = opts ?? {}
   const globOpts = { ...opts, cwd: root, includeRoot: undefined }
   globOpts.ignore = opts.ignore ?? DEFAULT_IGNORE
-  const patterns = normalizePatterns((opts.patterns != null) ? opts.patterns : ['.', '**'])
+  const patterns = normalizePatterns(opts.patterns ?? ['.', '**'])
   const paths: string[] = await fastGlob(patterns, globOpts)
 
   if (opts.includeRoot) {

--- a/lockfile/lockfile-utils/src/satisfiesPackageManifest.ts
+++ b/lockfile/lockfile-utils/src/satisfiesPackageManifest.ts
@@ -68,14 +68,11 @@ export function satisfiesPackageManifest (
       break
     case 'devDependencies':
       pkgDepNames = Object.keys(pkgDeps)
-        .filter((depName) =>
-          ((pkg.optionalDependencies == null) || !pkg.optionalDependencies[depName]) &&
-            ((pkg.dependencies == null) || !pkg.dependencies[depName])
-        )
+        .filter((depName) => !pkg.optionalDependencies?.[depName] && !pkg.dependencies?.[depName])
       break
     case 'dependencies':
       pkgDepNames = Object.keys(pkgDeps)
-        .filter((depName) => (pkg.optionalDependencies == null) || !pkg.optionalDependencies[depName])
+        .filter((depName) => !pkg.optionalDependencies?.[depName])
       break
     default:
       throw new Error(`Unknown dependency type "${depField as string}"`)

--- a/network/auth-header/src/index.ts
+++ b/network/auth-header/src/index.ts
@@ -27,7 +27,7 @@ function getAuthHeaderByURI (authHeaders: Record<string, string>, maxParts: numb
   const nerfed = nerfDart(uri)
   const parts = nerfed.split('/')
   for (let i = Math.min(parts.length, maxParts) - 1; i >= 3; i--) {
-    const key = `${parts.slice(0, i).join('/')}/` // eslint-disable-line
+    const key = `${parts.slice(0, i).join('/')}/`
     if (authHeaders[key]) return authHeaders[key]
   }
   const urlWithoutPort = removePort(uri)

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
     "peerDependencyRules": {
       "allowedVersions": {
         "eslint": "*",
-        "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@yarnpkg/core": "*"
       },
       "ignoreMissing": [

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -126,7 +126,7 @@ export function parse (dependencyPath: string) {
     isAbsolute: _isAbsolute,
   }
   const name = parts[0].startsWith('@')
-    ? `${parts.shift()}/${parts.shift()}` // eslint-disable-line @typescript-eslint/restrict-template-expressions
+    ? `${parts.shift()}/${parts.shift()}`
     : parts.shift()
   let version = parts.join('/')
   if (version) {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -278,7 +278,7 @@ export async function mutateModules (
   // @ts-expect-error
   if (global['verifiedFileIntegrity'] > 1000) {
     // @ts-expect-error
-    globalInfo(`The integrity of ${global['verifiedFileIntegrity']} files was checked. This might have caused installation to take longer.`) // eslint-disable-line
+    globalInfo(`The integrity of ${global['verifiedFileIntegrity']} files was checked. This might have caused installation to take longer.`)
   }
   if ((reporter != null) && typeof reporter === 'function') {
     streamParser.removeListener('data', reporter)

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -495,12 +495,10 @@ function fetchToStore (
               !equalOrSemverEqual(pkgFilesIndex.version, opts.expectedPkg.version)
             )
           ) {
-            /* eslint-disable @typescript-eslint/restrict-template-expressions */
             throw new PnpmError('UNEXPECTED_PKG_CONTENT_IN_STORE', `\
 Package name mismatch found while reading ${JSON.stringify(opts.pkg.resolution)} from the store. \
 This means that the lockfile is broken. Expected package: ${opts.expectedPkg.name}@${opts.expectedPkg.version}. \
 Actual package in the store by the given integrity: ${pkgFilesIndex.name}@${pkgFilesIndex.version}.`)
-            /* eslint-enable @typescript-eslint/restrict-template-expressions */
           }
           const verified = await ctx.checkFilesIntegrity(pkgFilesIndex, manifest)
           if (verified) {

--- a/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
@@ -47,7 +47,6 @@ const keyNormalizer = (
       descriptors.push(range.source)
     } else {
       descriptors.push(
-        // eslint-disable-next-line
         `${name}@${protocol}${range.source}${
           range.selector ? '#' + range.selector : ''
         }`

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -68,7 +68,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   if (versionAliasSpecParts != null) {
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const { manifest } = await tryReadProjectManifest(path.join(modulesDir, depName))
-    if ((manifest == null) || !manifest.version) {
+    if (!manifest?.version) {
       throw new PnpmError(
         'CANNOT_RESOLVE_WORKSPACE_PROTOCOL',
         `Cannot resolve workspace protocol of dependency "${depName}" ` +
@@ -84,7 +84,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   }
   if (depSpec.startsWith('workspace:./') || depSpec.startsWith('workspace:../')) {
     const { manifest } = await tryReadProjectManifest(path.join(dir, depSpec.slice(10)))
-    if ((manifest == null) || !manifest.name || !manifest.version) {
+    if (!manifest?.name || !manifest?.version) {
       throw new PnpmError(
         'CANNOT_RESOLVE_WORKSPACE_PROTOCOL',
         `Cannot resolve workspace protocol of dependency "${depName}" ` +

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,8 +286,8 @@ importers:
         specifier: ^8.47.0
         version: 8.47.0
       eslint-config-standard-with-typescript:
-        specifier: ^37.0.0
-        version: 37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^39.0.0
+        version: 39.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
       eslint-plugin-import:
         specifier: ^2.28.1
         version: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
@@ -8785,26 +8785,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      debug: 4.3.4
-      eslint: 8.47.0
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@typescript-eslint/parser@6.5.0(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -8824,14 +8804,6 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/scope-manager@5.62.0:
-    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
   /@typescript-eslint/scope-manager@6.5.0:
@@ -8862,35 +8834,9 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types@5.62.0:
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
-
   /@typescript-eslint/types@6.5.0:
     resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
     engines: {node: ^16.0.0 || >=18.0.0}
-    dev: false
-
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@typescript-eslint/typescript-estree@6.5.0(typescript@5.1.6):
@@ -8931,14 +8877,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
-
-  /@typescript-eslint/visitor-keys@5.62.0:
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.3
     dev: false
 
   /@typescript-eslint/visitor-keys@6.5.0:
@@ -10962,10 +10900,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
+  /eslint-config-standard-with-typescript@39.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-CiV2LS4NUeeRmDTDf1ocUMpMxitSyW0g+Y/N7ecElwGj188GahbcQgqfBNyVsIXQxHlZVBlOjkbg3oUI0R3KBg==}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.52.0
+      '@typescript-eslint/eslint-plugin': ^6.4.0
       eslint: '*'
       eslint-plugin-import: ^2.25.2
       eslint-plugin-n: '^15.0.0 || ^16.0.0 '
@@ -10973,7 +10911,7 @@ packages:
       typescript: '*'
     dependencies:
       '@typescript-eslint/eslint-plugin': 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)
       eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
@@ -16436,16 +16374,6 @@ packages:
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
-
-  /tsutils@3.21.0(typescript@5.1.6):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.6
-    dev: false
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,20 +277,20 @@ importers:
   __utils__/eslint-config:
     dependencies:
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.62.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^6.5.0
+        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
-        specifier: ^5.62.0
-        version: 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+        specifier: ^6.5.0
+        version: 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       eslint:
         specifier: ^8.47.0
         version: 8.47.0
       eslint-config-standard-with-typescript:
         specifier: ^37.0.0
-        version: 37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
+        version: 37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6)
       eslint-plugin-import:
         specifier: ^2.28.1
-        version: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+        version: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n:
         specifier: ^16.0.1
         version: 16.0.1(eslint@8.47.0)
@@ -8756,11 +8756,11 @@ packages:
     resolution: {integrity: sha512-kbdQa3J+hVCkqmGQm31fthEwGxszZtepw84p9QGCiJB7TmiPqPAf3/g9eZUnkCeanmiFOaG4pVhiPDyqJxaoaw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
       eslint: '*'
       typescript: '*'
     peerDependenciesMeta:
@@ -8768,17 +8768,18 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/type-utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4
       eslint: 8.47.0
       graphemer: 1.4.0
       ignore: 5.2.4
-      natural-compare-lite: 1.4.0
+      natural-compare: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -8804,6 +8805,27 @@ packages:
       - supports-color
     dev: false
 
+  /@typescript-eslint/parser@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4
+      eslint: 8.47.0
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -8812,9 +8834,17 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/scope-manager@6.5.0:
+    resolution: {integrity: sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
+    dev: false
+
+  /@typescript-eslint/type-utils@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '*'
       typescript: '*'
@@ -8822,11 +8852,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 4.3.4
       eslint: 8.47.0
-      tsutils: 3.21.0(typescript@5.1.6)
+      ts-api-utils: 1.0.2(typescript@5.1.6)
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
@@ -8835,6 +8865,11 @@ packages:
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
+  /@typescript-eslint/types@6.5.0:
+    resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: false
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
@@ -8858,20 +8893,40 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.47.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/typescript-estree@6.5.0(typescript@5.1.6):
+    resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.1.6)
+      typescript: 5.1.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/utils@6.5.0(eslint@8.47.0)(typescript@5.1.6):
+    resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: '*'
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.1.6)
       eslint: 8.47.0
-      eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -8883,6 +8938,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.3
+    dev: false
+
+  /@typescript-eslint/visitor-keys@6.5.0:
+    resolution: {integrity: sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
       eslint-visitor-keys: 3.4.3
     dev: false
 
@@ -10899,7 +10962,7 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
+  /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@6.5.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.52.0
@@ -10909,11 +10972,11 @@ packages:
       eslint-plugin-promise: ^6.0.0
       typescript: '*'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)(typescript@5.1.6)
       '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
       eslint: 8.47.0
       eslint-config-standard: 17.1.0(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n: 16.0.1(eslint@8.47.0)
       eslint-plugin-promise: 6.1.1(eslint@8.47.0)
       typescript: 5.1.6
@@ -10931,7 +10994,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.47.0
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0)
       eslint-plugin-n: 16.0.1(eslint@8.47.0)
       eslint-plugin-promise: 6.1.1(eslint@8.47.0)
     dev: false
@@ -10946,7 +11009,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -10967,7 +11030,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
@@ -10997,7 +11060,7 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@5.62.0)(eslint@8.47.0):
+  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.5.0)(eslint@8.47.0):
     resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -11007,7 +11070,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.47.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.findlastindex: 1.2.2
       array.prototype.flat: 1.3.1
@@ -11016,7 +11079,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.47.0)
       has: 1.0.3
       is-core-module: 2.13.0
       is-glob: 4.0.3
@@ -11071,14 +11134,6 @@ packages:
       eslint: '*'
     dependencies:
       eslint: 8.47.0
-    dev: false
-
-  /eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
     dev: false
 
   /eslint-scope@7.2.2:
@@ -11178,11 +11233,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
-
-  /estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: false
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -13923,10 +13973,6 @@ packages:
     dev: false
     optional: true
 
-  /natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: false
-
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -16261,6 +16307,15 @@ packages:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
     dependencies:
       utf8-byte-length: 1.0.4
+    dev: false
+
+  /ts-api-utils@1.0.2(typescript@5.1.6):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.1.6
     dev: false
 
   /ts-jest@29.1.0(@babel/core@7.22.10)(jest@29.6.2)(typescript@5.1.6):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10902,7 +10902,7 @@ packages:
   /eslint-config-standard-with-typescript@37.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.0.1)(eslint-plugin-promise@6.1.1)(eslint@8.47.0)(typescript@5.1.6):
     resolution: {integrity: sha512-V8I/Q1eFf9tiOuFHkbksUdWO3p1crFmewecfBtRxXdnvb71BCJx+1xAknlIRZMwZioMX3/bPtMVCZsf1+AjjOw==}
     peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.52.0 || ^5.6.0
+      '@typescript-eslint/eslint-plugin': ^5.52.0
       eslint: '*'
       eslint-plugin-import: ^2.25.2
       eslint-plugin-n: '^15.0.0 || ^16.0.0 '

--- a/pnpm/src/reporter/silentReporter.ts
+++ b/pnpm/src/reporter/silentReporter.ts
@@ -13,7 +13,7 @@ export function silentReporter (
 
     console.log(obj['err']?.message ?? obj['message'])
     if (obj['err']?.stack) {
-      console.log(`\n${obj['err'].stack}`) // eslint-disable-line
+      console.log(`\n${obj['err'].stack}`)
     }
   })
 }

--- a/pnpm/test/cli.ts
+++ b/pnpm/test/cli.ts
@@ -121,7 +121,7 @@ test('pnpx works', () => {
   mkdirSync(global)
 
   const env = {
-    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`, // eslint-disable-line
+    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`,
     PNPM_HOME: pnpmHome,
     XDG_DATA_HOME: global,
   }

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -131,7 +131,7 @@ test('silent dlx prints the output of the child process only', async () => {
   mkdirSync(global)
 
   const env = {
-    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`, // eslint-disable-line
+    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`,
     PNPM_HOME: pnpmHome,
     XDG_DATA_HOME: global,
   }

--- a/store/server/src/createServer.ts
+++ b/store/server/src/createServer.ts
@@ -52,7 +52,7 @@ export function createServer (
     const bodyPromise = new Promise<RequestBody>((resolve, reject) => {
       let body: any = '' // eslint-disable-line
       req.on('data', (data) => {
-        body += data // eslint-disable-line
+        body += data
       })
       req.on('end', async () => {
         try {


### PR DESCRIPTION
## Motivation

I'm hoping to help out with some repository maintenance tasks by upgrading pnpm to TypeScript 5.2. Before that, we'll need to update `@typescript-eslint` to a version that supports TypeScript 5.2.

## Changes

This PR follows the typescript-eslint v6 upgrade guide and applies a few fixes to get `pnpm lint:ts` passing.

https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/

## ESLint Config Changes

One of the major changes in typescript-eslint v6 is a [restructuring of the base configs other configs extend from](https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/#reworked-configuration-names).

This doesn't seem to apply to the pnpm repo since it extends the `eslint-config-standard-with-typescript` config instead of `@typescript-eslint/recommended` or `@typescript-eslint/strict`. To sanity check, I compared the rendered config before and after this PR.

```sh
eslint --print-config pnpm/src/pnpm.ts 
```

The changes were very minimal: https://gist.github.com/gluxon/588514a95858a0e0877d85fab3e67825#file-after-before-diff

## Notes for Reviewers

1. Reviewing commit by commit should be easier. I've separated each thematic change into its own commit.
2. The `@typescript-eslint/restrict-template-expressions` and `@typescript-eslint/restrict-plus-operands` rules got relaxed a bit. A few ESLint disable comments were able to be removed as a result. We could alternatively configure these rules to their prior strictness.
3. There are a few runtime changes in this PR as a result of the `prefer-optional-chain` and `prefer-nullish-coalescing` rules becoming smarter. I applied the auto-fixes after convincing myself that they're correct.
