### PR TITLE
test: fix ENOENT break on ci checks by using sha512 integrity in fixtures

### DIFF
--- a/__fixtures__/circular/pnpm-lock.yaml
+++ b/__fixtures__/circular/pnpm-lock.yaml
@@ -8,20 +8,20 @@ dependencies:
 packages:
 
   /d@1.0.0:
-    resolution: {integrity: sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=}
+    resolution: {integrity: sha512-9x1NruMD5YQ7xccKbGEy/bjitRfn5LEIhJIXIOAXC8I1laA5gfezUMVES1/vjLxfGzZjirLLBzEqxMO2/LzGxQ==}
     dependencies:
       es5-ext: 0.10.24
     dev: false
 
   /es5-ext@0.10.24:
-    resolution: {integrity: sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=}
+    resolution: {integrity: sha512-qHKgM1mKhstIAZ1cxefVIOmWREJ2rgQv7aGg9BuCLq9G1vRjkV1K8M4LcSklsYPJwo2dqnOfb3IuNGOp3DxgUw==}
     dependencies:
       es6-iterator: 2.0.1
       es6-symbol: 3.1.1
     dev: false
 
   /es6-iterator@2.0.1:
-    resolution: {integrity: sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=}
+    resolution: {integrity: sha512-6QdxKjEfkAutL86ORbUgbZjfmssn3hfrFZDz5utw2BH9EJWYCVVqn9dN/WvsWSzsZ7Ox/fMrHXexX96fF5vEsw==}
     dependencies:
       d: 1.0.0
       es5-ext: 0.10.24
@@ -29,7 +29,7 @@ packages:
     dev: false
 
   /es6-symbol@3.1.1:
-    resolution: {integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=}
+    resolution: {integrity: sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==}
     dependencies:
       d: 1.0.0
       es5-ext: 0.10.24

--- a/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
@@ -11,6 +11,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixture/pnpm-lock.yaml
+++ b/__fixtures__/fixture/pnpm-lock.yaml
@@ -18,7 +18,7 @@ devDependencies:
 packages:
 
   /detect-indent@5.0.0:
-    resolution: {integrity: sha1-OHHMCmoALow+Wzz38zYmRnXwa50=}
+    resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -27,7 +27,7 @@ packages:
     dev: false
 
   /imurmurhash@0.1.4:
-    resolution: {integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=}
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
@@ -39,12 +39,12 @@ packages:
     optional: true
 
   /is-plain-obj@1.1.0:
-    resolution: {integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=}
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -56,16 +56,16 @@ packages:
     dev: false
 
   /pify@3.0.0:
-    resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
     dev: false
 
   /signal-exit@3.0.2:
-    resolution: {integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=}
+    resolution: {integrity: sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==}
     dev: false
 
   /sort-keys@2.0.0:
-    resolution: {integrity: sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=}
+    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
     engines: {node: '>=4'}
     dependencies:
       is-plain-obj: 1.1.0
@@ -80,7 +80,7 @@ packages:
     dev: false
 
   /write-json-file@2.3.0:
-    resolution: {integrity: sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=}
+    resolution: {integrity: sha512-84+F0igFp2dPD6UpAQjOUX3CdKUOqUzn6oE9sDBNzUXINR5VceJ1rauZltqQB/bcYsx3EpKys4C7/PivKUAiWQ==}
     engines: {node: '>=4'}
     dependencies:
       detect-indent: 5.0.0

--- a/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
@@ -21,7 +21,7 @@ devDependencies:
 packages:
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.11:
@@ -32,11 +32,11 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /glob@6.0.4:
-    resolution: {integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=}
+    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.3
@@ -46,24 +46,24 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-negative@1.0.0:
-    resolution: {integrity: sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=}
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
     engines: {node: '>=0.10.0'}
     dev: false
     optional: true
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -74,23 +74,23 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /rimraf@2.5.1:
-    resolution: {integrity: sha1-UuHpRvP5ubDV2JiLoxkaryotvUM=}
+    resolution: {integrity: sha512-CNymZDrSR9PfkqZnBWaIki7Wlba4c7GzSkSKsHHvjXswXmJA1hM8ZHFrNWIt4L/WcR9kOwvsJZpbxV4fygtXag==}
     hasBin: true
     dependencies:
       glob: 6.0.4
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/general/pnpm-lock.yaml
+++ b/__fixtures__/general/pnpm-lock.yaml
@@ -21,22 +21,22 @@ devDependencies:
 packages:
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.8:
-    resolution: {integrity: sha1-wHshHHyVLsH479Uad+8NHTmQopI=}
+    resolution: {integrity: sha512-Dnfc9ROAPrkkeLIUweEbh7LFT9Mc53tO/bbM044rKjhgAEyIGKvKXg97PM/kRizZIfUHaROZIoeEaWao+Unzfw==}
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /glob@6.0.4:
-    resolution: {integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=}
+    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     dependencies:
       inflight: 1.0.6
       inherits: 2.0.3
@@ -46,14 +46,14 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-negative@1.0.0:
@@ -64,7 +64,7 @@ packages:
     optional: true
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -75,23 +75,23 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /rimraf@2.5.1:
-    resolution: {integrity: sha1-UuHpRvP5ubDV2JiLoxkaryotvUM=}
+    resolution: {integrity: sha512-CNymZDrSR9PfkqZnBWaIki7Wlba4c7GzSkSKsHHvjXswXmJA1hM8ZHFrNWIt4L/WcR9kOwvsJZpbxV4fygtXag==}
     hasBin: true
     dependencies:
       glob: 6.0.4
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
@@ -13,11 +13,11 @@ devDependencies:
 packages:
 
   /is-negative@1.0.1:
-    resolution: {integrity: sha1-3GuHKO69A8db+HYIftzVDpy1aZQ=}
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
@@ -13,11 +13,11 @@ devDependencies:
 packages:
 
   /is-negative@1.0.1:
-    resolution: {integrity: sha1-3GuHKO69A8db+HYIftzVDpy1aZQ=}
+    resolution: {integrity: sha512-gmv+xZIqPGWfqTf195S+I8tw4h/VswI30Eu21e1r8qUVNHIiVdAVtpzoZBGQqrTNC+YjSwCNl33SXU7kuNwMzA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
@@ -9,13 +9,13 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-clmHeoPIAKwxkd17nZ+80PdS1P4=
+      integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==
   /is-positive/2.0.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-sU8GvS24EK5sixJ0HRNr+u8Nh70=
+      integrity: sha512-uJQLtRnc7RP/Xo8tjkK9MJsWdnuKhiD5e8x+idmkUqr2p0R+n/ZdDFG1LEt98WwoRzWhSefhPnyLBleKZhg/Lg==
 specifiers:
   is-negative: 1.0.0
   is-positive: 2.0.0

--- a/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
@@ -6,11 +6,11 @@ packages:
   /is-negative/2.1.0:
     dev: false
     resolution:
-      integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
+      integrity: sha512-+iCKT4ZcvjRnjkHnQjZ8/qfciLLGD8BFKS0GNR5VjDU6jEiwh899R0GSMkaYcuTNd7fEKXb3Qib0webe6HczNw==
   /is-positive/3.1.0:
     dev: false
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==
 specifiers:
   is-negative: ^2.1.0
   is-positive: ^3.1.0

--- a/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
@@ -10,7 +10,7 @@ lockfileVersion: 5
 packages:
   /is-negative/1.1.0:
     resolution:
-      integrity: sha1-8Nhjd6oVpkw0lh84rCqb4rQKEYc=
+      integrity: sha512-+iCKT4ZcvjRnjkHnQjZ8/qfciLLGD8BFKS0GNR5VjDU6jEiwh899R0GSMkaYcuTNd7fEKXb3Qib0webe6HczNw==
   /is-positive/3.1.0:
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==

--- a/__fixtures__/has-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps/pnpm-lock.yaml
@@ -26,6 +26,6 @@ packages:
     dev: false
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: true

--- a/__fixtures__/monorepo/pnpm-lock.yaml
+++ b/__fixtures__/monorepo/pnpm-lock.yaml
@@ -11,4 +11,4 @@ packages:
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=
+      integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==

--- a/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
+++ b/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
@@ -18,7 +18,7 @@ packages:
   /array-flatten/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+      integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
   /body-parser/1.19.0:
     dependencies:
       bytes: 3.1.0
@@ -59,7 +59,7 @@ packages:
   /cookie-signature/1.0.6:
     dev: false
     resolution:
-      integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+      integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
   /cookie/0.4.0:
     dev: false
     engines:
@@ -77,31 +77,31 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+      integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
   /destroy/1.0.4:
     dev: false
     resolution:
-      integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+      integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==
   /ee-first/1.1.1:
     dev: false
     resolution:
-      integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+      integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
   /encodeurl/1.0.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+      integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
   /escape-html/1.0.3:
     dev: false
     resolution:
-      integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+      integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
   /etag/1.8.1:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+      integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
   /express/4.17.1:
     dependencies:
       accepts: 1.3.7
@@ -158,13 +158,13 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+      integrity: sha512-Ua9xNhH0b8pwE3yRbFfXJvfdWF0UHNCdeyb2sbi9Ul/M+r3PTdrz7Cv4SCfZRMjmzEM9PhraqfZFbGTIg3OMyA==
   /fresh/0.5.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+      integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
   /http-errors/1.7.2:
     dependencies:
       depd: 1.1.2
@@ -200,7 +200,7 @@ packages:
   /inherits/2.0.3:
     dev: false
     resolution:
-      integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+      integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
   /inherits/2.0.4:
     dev: false
     resolution:
@@ -216,17 +216,17 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+      integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+      integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
   /methods/1.1.2:
     dev: false
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+      integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
   /mime-db/1.44.0:
     dev: false
     engines:
@@ -251,7 +251,7 @@ packages:
   /ms/2.0.0:
     dev: false
     resolution:
-      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+      integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
   /ms/2.1.1:
     dev: false
     resolution:
@@ -269,7 +269,7 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+      integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==
   /parseurl/1.3.3:
     dev: false
     engines:
@@ -279,7 +279,7 @@ packages:
   /path-to-regexp/0.1.7:
     dev: false
     resolution:
-      integrity: sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+      integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
   /proxy-addr/2.0.6:
     dependencies:
       forwarded: 0.1.2
@@ -360,7 +360,7 @@ packages:
     engines:
       node: '>= 0.6'
     resolution:
-      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+      integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
   /toidentifier/1.0.0:
     dev: false
     engines:
@@ -381,16 +381,16 @@ packages:
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+      integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
   /utils-merge/1.0.1:
     dev: false
     engines:
       node: '>= 0.4.0'
     resolution:
-      integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+      integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
   /vary/1.1.2:
     dev: false
     engines:
       node: '>= 0.8'
     resolution:
-      integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+      integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==

--- a/__fixtures__/with-file-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-file-dep/pnpm-lock.yaml
@@ -11,6 +11,6 @@ dependencies:
 packages:
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/with-peer/pnpm-lock.yaml
+++ b/__fixtures__/with-peer/pnpm-lock.yaml
@@ -28,11 +28,11 @@ packages:
     dev: false
 
   /fast-deep-equal@2.0.1:
-    resolution: {integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=}
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
     dev: false
 
   /fast-json-stable-stringify@2.0.0:
-    resolution: {integrity: sha1-1RQsDK7msRifh9OnYREGT4bIu/I=}
+    resolution: {integrity: sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==}
     dev: false
 
   /json-schema-traverse@0.4.1:

--- a/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
+++ b/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
@@ -18,11 +18,11 @@ packages:
     dev: false
 
   /any-promise@1.3.0:
-    resolution: {integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=}
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
     dev: false
 
   /balanced-match@1.0.0:
-    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
     dev: false
 
   /brace-expansion@1.1.11:
@@ -33,7 +33,7 @@ packages:
     dev: false
 
   /concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /define-properties@1.1.3:
@@ -64,7 +64,7 @@ packages:
     dev: false
 
   /fs.realpath@1.0.0:
-    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
 
   /function-bind@1.1.1:
@@ -87,7 +87,7 @@ packages:
     dev: false
 
   /has-symbols@1.0.0:
-    resolution: {integrity: sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=}
+    resolution: {integrity: sha512-QfcgWpH8qn5qhNMg3wfXf2FD/rSA4TwNiDDthKqXe7v6oBW0YKWcnfwMAApgWq9Lh+Yu+fQWVhHPohlD/S6uoQ==}
     engines: {node: '>= 0.4'}
     dev: false
 
@@ -99,14 +99,14 @@ packages:
     dev: false
 
   /inflight@1.0.6:
-    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
   /inherits@2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /is-callable@1.1.4:
@@ -115,12 +115,12 @@ packages:
     dev: false
 
   /is-date-object@1.0.1:
-    resolution: {integrity: sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=}
+    resolution: {integrity: sha512-P5rExV1phPi42ppoMWy7V63N3i173RY921l4JJ7zonMSxK+OWGPj76GD+cUKUb68l4vQXcJp2SsG+r/A4ABVzg==}
     engines: {node: '>= 0.4'}
     dev: false
 
   /is-regex@1.0.4:
-    resolution: {integrity: sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=}
+    resolution: {integrity: sha512-WQgPrEkb1mPCWLSlLFuN1VziADSixANugwSkJfPRR73FNWIQQN+tR/t1zWfyES/Y9oag/XBtVsahFdfBku3Kyw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has: 1.0.3
@@ -145,18 +145,18 @@ packages:
     dev: false
 
   /minimist@0.0.8:
-    resolution: {integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=}
+    resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
     dev: false
 
   /mkdirp-promise@5.0.1:
-    resolution: {integrity: sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=}
+    resolution: {integrity: sha512-Hepn5kb1lJPtVW84RFT40YG1OddBNTOVUZR2bzQUHc+Z03en8/3uX0+060JDhcEzyO08HmipsN9DcnFMxhIL9w==}
     engines: {node: '>=4'}
     dependencies:
       mkdirp: 0.5.1
     dev: false
 
   /mkdirp@0.5.1:
-    resolution: {integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=}
+    resolution: {integrity: sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==}
     hasBin: true
     dependencies:
       minimist: 0.0.8
@@ -171,7 +171,7 @@ packages:
     dev: false
 
   /object-assign@4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -181,7 +181,7 @@ packages:
     dev: false
 
   /object.getownpropertydescriptors@2.0.3:
-    resolution: {integrity: sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=}
+    resolution: {integrity: sha512-NwrpYtu1CSNWdNgcEvLmHOHjhMeglj22YJpg/ezASfIFYqNK4F94iUxKRPnRNbOuOMoQb5JS+6Ebi16xtYZbqQ==}
     engines: {node: '>= 0.8'}
     dependencies:
       define-properties: 1.1.3
@@ -189,13 +189,13 @@ packages:
     dev: false
 
   /once@1.4.0:
-    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
   /path-is-absolute@1.0.1:
-    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -230,14 +230,14 @@ packages:
     dev: false
 
   /thenify-all@1.6.0:
-    resolution: {integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=}
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
     dependencies:
       thenify: 3.3.0
     dev: false
 
   /thenify@3.3.0:
-    resolution: {integrity: sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=}
+    resolution: {integrity: sha512-ho5BRit179DQqrTnGIjO+L9vLP/zLyGk6jXn70DLD6MTUYD2FSgR2Y4qWcgca90VD54sQ7GdQ2/C765V6kPcqA==}
     dependencies:
       any-promise: 1.3.0
     dev: false
@@ -250,5 +250,5 @@ packages:
     dev: false
 
   /wrappy@1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false

--- a/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
@@ -19,6 +19,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
@@ -15,6 +15,6 @@ importers:
 packages:
 
   /is-positive@3.1.0:
-    resolution: {integrity: sha1-hX21hKG6XRyymAUn/DtsQ103sP0=}
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
@@ -49,7 +49,7 @@ packages:
     dev: false
 
   /fast-json-stable-stringify@2.0.0:
-    resolution: {integrity: sha1-1RQsDK7msRifh9OnYREGT4bIu/I=}
+    resolution: {integrity: sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==}
     dev: false
 
   /fast-json-stable-stringify@2.1.0:

--- a/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
@@ -19,6 +19,6 @@ importers:
 packages:
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false

--- a/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
+++ b/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
@@ -53,7 +53,7 @@ exports[`pnpm dedupe updates old resolutions from importers block and removes ol
 -     "/fast-json-stable-stringify@2.0.0": Object {
 -       "dev": false,
 -       "resolution": Object {
--         "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+-         "integrity": "sha512-eIgZvM9C3P05kg0qxfqaVU6Tma4QedCPIByQOcemV0vju8ot3cS2DpHi4m2G2JvbSMI152rjfLX0p1pkSdyPlQ==",
         },
       },
       "/fast-json-stable-stringify@2.1.0": Object {


### PR DESCRIPTION
## Summary

This PR fixes a CI break. The next person to change `pnpm-lock.yaml` would have hit this error.

## Problem

The CI break in question can be found here: https://github.com/pnpm/pnpm/actions/runs/6032629535/job/16368092501. This is a simple commit that just adds a dummy `pnpm.overrides` entry. https://github.com/pnpm/pnpm/commit/ea6f55266a356b6fa174a3f95d4c059d5c15bde6

<img width="1265" alt="Screenshot 2023-08-31 at 1 01 21 AM" src="https://github.com/pnpm/pnpm/assets/906558/c9bb95b8-1d77-4cef-92e0-ba6970e07560">

Copying the error out for easier viewing:

```
Packages are hard linked from the content-addressable store to the virtual store.
Content-addressable store is at: /home/runner/setup-pnpm/node_modules/.bin/store/v3
Virtual store is at: circular/node_modules/.pnpm

with-peer | Progress: resolved 7, reused 1, downloaded 6, added 7, done
with-non-package-dep | Progress: resolved 1, reused 0, downloaded 1, added 1, done
with-unsaved-deps | Progress: resolved 39, reused 4, downloaded 27, added 39, done
undefined
/home/runner/work/pnpm/pnpm/__fixtures__/with-aliased-dep:
 ENOENT  ENOENT: no such file or directory, open '/home/runner/setup-pnpm/node_modules/.bin/store/v3/files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812c5d8da8a735e94c2a1ccb77b4583808ee8405313951e7146ac83ede3671dc292-index.json'
```

## What caused this?

The `ENOENT` exception thrown is from the `loadJsonFile` call. This is a new code path that started running on CI after a recent PR https://github.com/pnpm/pnpm/pull/7003 set `skipIfHasSideEffectsCache` to `true`.

https://github.com/pnpm/pnpm/blob/5ce333519da3774ecd66a40d6870bbc7a6e765f1/exec/plugin-commands-rebuild/src/implementation/index.ts#L310-L312

## What are the steps to reproduce?

The problem can be consistently reproduced locally by running these commands.

```sh
cd __fixtures__
rm -rf mock-store
node ../pnpm/dist/pnpm.cjs install -rf --frozen-lockfile --no-shared-workspace-lockfile --no-link-workspace-packages --store-dir=mock-store
```

This is roughly the first line of `__fixtures__/package.yaml`, except the `--store-dir=mock-store` argument is added to consistently reproduce the problem.

https://github.com/pnpm/pnpm/blob/19e823beab4bf6b5b8afedecb86359ae675e8755/__fixtures__/package.yaml#L3

## Why is this happening?

It took me a few hours to understand why this broke, but I think I have a pretty good explanation after investigating in a debugger for a few hours.

The throwing `loadJsonFile(filesIndexFile)` call is attempting to find the package manifest for `is-positive@1.0.0`. This manifest is supposed to be written to the store in `packageRequester.ts` before it's read later.

https://github.com/pnpm/pnpm/blob/e6353f964cde3fd93c0c81a6bcab97419995d74d/pkg-manager/package-requester/src/packageRequester.ts#L357-L363

However, the `is-positive@1.0.0` package manifest is only added once, and the package exists in our `__fixtures__` setup multiple times with different `resolution.integrity` fields.

https://github.com/pnpm/pnpm/blob/993044180d70dac72d513c8279dbc9494f7d002d/__fixtures__/with-aliased-dep/pnpm-lock.yaml#L10-L11

https://github.com/pnpm/pnpm/blob/993044180d70dac72d513c8279dbc9494f7d002d/__fixtures__/general/pnpm-lock.yaml#L66-L67

I've verified in a debugger that:

1. The `doFetchToStore` call is storing the manifest using `sha1-iACYVrZKLx632LsBeUGEJK4EUss=`.
   <img width="1501" alt="Screenshot 2023-08-30 at 11 39 56 PM" src="https://github.com/pnpm/pnpm/assets/906558/fea345b1-1f8d-4841-b301-feb1a2da2f94">
2. The failing `loadJsonFile` call is attempting to load using `sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==`.
   <img width="1983" alt="Screenshot 2023-08-30 at 11 40 31 PM" src="https://github.com/pnpm/pnpm/assets/906558/9eda5880-c973-400e-b05a-2994748cd7d0">

## Caching

Another factor that's complicating this issue further is that the `action/setup-node` GitHub action is caching the pnpm store to a version this works against. I believe the currently cached store has a copy of `is-positive@1.0.0` with the sha512 addressed manifest.

```
Run actions/setup-node@v3
Attempting to download 16.14...
Acquiring 16.14.2 - x64 from [https://github.com/actions/node-versions/releases/download/16.14.2-2007501289/node-16.14.2-linux-x64.tar.gz](https://github.com/actions/node-versions/releases/download/16.14.2-2007501289/node-16.14.2-linux-x64.tar.gz)
Extracting ...
/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword -C /home/runner/work/_temp/d1dbff35-4eb4-4f2a-a441-f15ca7595f7a -f /home/runner/work/_temp/478d8381-f057-43db-8f38-3d9c4b0c10d8
Adding to the cache ...
Environment details
/home/runner/setup-pnpm/node_modules/.bin/pnpm store path --silent
/home/runner/setup-pnpm/node_modules/.bin/store/v3
Received 8388608 of 108140430 (7.8%), 8.0 MBs/sec
Received 108140430 of 108140430 (100.0%), 56.8 MBs/sec
Cache Size: ~103 MB (108140430 B)
/usr/bin/tar -xf /home/runner/work/_temp/f87ef397-76e0-48a8-8cd3-04b170ac4b1d/cache.tzst -P -C /home/runner/work/pnpm/pnpm --use-compress-program unzstd
Cache restored successfully
Cache restored from key: node-cache-Linux-pnpm-a2ca78762b7dacf194800f8d1b871636b5a9900905189a87b1e7dd6ff827c3ba
```

Making any change to `pnpm-lock.yaml` will bust the cache and break PRs to the pnpm repo.

See this branch https://github.com/pnpm/pnpm/commits/gluxon/test-pnpm-lock-change for example. As noted above, this simply adds a dummy `pnpm.overrides` entry to bust the cache.

## Workaround

We can work around the problem for now by upgrading all sha1 resolutions in  `__fixtures__` to sha512. I think we would have wanted to do this at some point regardless of whether or not this broke CI.

## Questions

The `__fixtures__` setup is fairly unique. Is it a supported user setup? I believe this bug only happens when there's a recursive install reading multiple `pnpm-lock.yaml` files.

If this is supported, one possible fix in pnpm proper would be to incorporate the `resolution.integrity` value into the `fetchingLocker` key. But this entire problem is an extreme edge case. I could use another person's thoughts on whether properly fixing this is worth the complexity.

https://github.com/pnpm/pnpm/blob/e6353f964cde3fd93c0c81a6bcab97419995d74d/pkg-manager/package-requester/src/packageRequester.ts#L357