### PR TITLE
chore: remove unused logger.info

### DIFF
--- a/.changeset/odd-bears-think.md
+++ b/.changeset/odd-bears-think.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+Remove unused logger.info [#7005](https://github.com/pnpm/pnpm/issues/7005)

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -131,8 +131,6 @@ export async function runRecursive (
           result[prefix].status = 'passed'
           result[prefix].duration = getExecutionDuration(startTime)
         } catch (err: any) { // eslint-disable-line
-          logger.info(err)
-
           result[prefix] = {
             status: 'failure',
             duration: getExecutionDuration(startTime),


### PR DESCRIPTION
close #7005 

[logger.info(err)](https://github.com/pnpm/pnpm/blob/main/exec/plugin-commands-script-runners/src/runRecursive.ts#L134) here looks like doesn't actually do anything, Because we will output error information in `errorHandler`. 

But when the reporter type is `append-only`,  since the [message attribute](https://github.com/pnpm/pnpm/blob/main/cli/default-reporter/src/reporterForClient/reportMisc.ts#L53) is `undefined`, it will also output a unused `undefined`.
> When the reporter type is the default, it looks like `undefined` are [filtered here](https://github.com/pnpm/pnpm/blob/main/cli/default-reporter/src/mergeOutputs.ts#L50), so it doesn't do anything under normal use.