### PR TITLE
test: set logErrorsBeforeRetry to debug failing retries

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,11 @@
-jest.retryTimes(1);
+jest.retryTimes(1, {
+  // Some tests don't clean up their resources completely and cause the retried
+  // run fail. Set logErrorsBeforeRetry to make it more clear that the retried
+  // run was a retry and not the first attempt. Otherwise Jest hides the first
+  // attempt. This makes it easier to distinguish between a test that's truly
+  // broken and one that's not retry-able.
+  logErrorsBeforeRetry: true
+})
 
 afterAll(() => {
   // @ts-expect-error


### PR DESCRIPTION
## Changes

Some tests don't clean up their resources completely and cause the retried run fail. Let's set `logErrorsBeforeRetry` to make it more clear that the retried run was a retry and not the first attempt. Otherwise Jest hides the first attempt. This makes it easier to distinguish between a test that's truly broken and one that's not retry-able.

The main motivation is to debug a test failure that I believe is keeping resources alive and hanging. https://github.com/pnpm/pnpm/pull/7029

It's possible this adds more noise than it helps. Happy to close if we think that's the case.

## Example

Here's an example of a test failure Jest will now print. This is otherwise hidden.

```
LOGGING RETRY ERRORS  should skip store integrity check and resolve manifest if fetchRawManifest is true
RETRY 1 

   thrown: "Exceeded timeout of 240000 ms for a test.
   Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."

     1052 | })
     1053 |
   > 1054 | test('should skip store integrity check and resolve manifest if fetchRawManifest is true', async () => {
          | ^
     1055 |   const storeDir = tempy.directory()
     1056 |   const cafs = createCafsStore(storeDir)
     1057 |

     at Object.<anonymous> (test/index.ts:1054:1)
```