### PR TITLE
fix: report correct errors when using the pnpm server

### DIFF
--- a/.changeset/wet-lies-smoke.md
+++ b/.changeset/wet-lies-smoke.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+pnpm: patch
+---
+
+Fix a bug causing errors to be printed as `Cannot read properties of undefined (reading 'code')` instead of the underlying reason when using the pnpm store server.

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -21,7 +21,7 @@ const colorPath = chalk.gray
 
 export function reportError (logObj: Log, config?: Config) {
   const errorInfo = getErrorInfo(logObj, config)
-  let output = formatErrorSummary(errorInfo.title, logObj['err']['code'])
+  let output = formatErrorSummary(errorInfo.title, (logObj as LogObjWithPossibleError).err?.code)
   if (logObj['pkgsStack'] != null) {
     if (logObj['pkgsStack'].length > 0) {
       output += `\n\n${formatPkgsStack(logObj['pkgsStack'])}`
@@ -33,6 +33,14 @@ export function reportError (logObj: Log, config?: Config) {
     output += `\n\n${errorInfo.body}`
   }
   return output
+
+  /**
+   * A type to assist with introspection of the logObj.
+   * These objects may or may not have an `err` field.
+   */
+  interface LogObjWithPossibleError {
+    readonly err?: { code?: string }
+  }
 }
 
 function getErrorInfo (logObj: Log, config?: Config): {


### PR DESCRIPTION
## Steps to Reproduce

1. Start the pnpm store server.

   ```
   ❯ pnpm server start
   ```

2. Run a command that is expected to error.
   ```
   ❯ pnpm install is-positive@1.0.1
   Cannot read properties of undefined (reading 'code')
   ```
   In this example, we're attempting to install a version that doesn't exist.

## Changes

The actual error is now printed with the fix in this PR.

```
❯ pnpm install is-positive@1.0.1
A store server is running. All store manipulations are delegated to it.
 ERROR  No matching version found for is-positive@1.0.1

This error happened while installing a direct dependency of /Users/gluxon/Developer/test
```

## Explanation

Errors from the pnpm server go through a different reporting code path. It looks like in this case the `err` object is empty for the `log` argument.

https://github.com/pnpm/pnpm/blob/ee61ca4cb7ce6b3cb177f892940edb55b19b9e17/cli/default-reporter/src/reporterForServer.ts#L24