### PR TITLE
fix(server): prevent intermittent hanging when requesting a tarball worker

### DIFF
--- a/.changeset/chilled-ghosts-flow.md
+++ b/.changeset/chilled-ghosts-flow.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-server": patch
+"@pnpm/server": patch
+pnpm: patch
+---
+
+Fix a bug causing the pnpm server to hang if a tarball worker was requested while another worker was exiting.

--- a/store/plugin-commands-server/src/start.ts
+++ b/store/plugin-commands-server/src/start.ts
@@ -64,7 +64,7 @@ export async function start (
     }
     throw new PnpmError('SERVER_MANIFEST_LOCKED', `Canceling startup of server (pid ${process.pid}) because another process got exclusive access to server.json`)
   }
-  let server: null | { close: () => Promise<void> } = null
+  let server: null | ReturnType<typeof createServer> = null
   onExit(() => {
     if (server !== null) {
       // Note that server.close returns a Promise, but we cannot wait for it because we may be
@@ -118,6 +118,11 @@ export async function start (
   // Set fd to null so we only attempt to close it once.
   fd = null
   await close(fdForClose)
+
+  // Intentionally avoid returning control back to the caller until the server
+  // exits. This defers cleanup operations that should not run before the server
+  // finishes.
+  await server.waitForClose
 }
 
 async function getServerOptions (

--- a/store/server/src/createServer.ts
+++ b/store/server/src/createServer.ts
@@ -166,7 +166,11 @@ export function createServer (
     listener = server.listen(opts.port, opts.hostname)
   }
 
-  return { close }
+  const waitForClose = new Promise<void>((resolve) => listener.once('close', () => {
+    resolve()
+  }))
+
+  return { close, waitForClose }
 
   async function close () {
     listener.close()


### PR DESCRIPTION
## Problem

Fixes #7038. When running `pnpm server start`, the tarball fetcher worker pool (introduced in https://github.com/pnpm/pnpm/pull/6850) is immediately marked as "_finishing_" by this statement.

https://github.com/pnpm/pnpm/blob/131c723030ec4016274ca1cef33aadd66eb0e3b9/pnpm/src/main.ts#L300

The server continues running and handles requests after this point, which causes a few problems:

1. It results in a degraded state where the worker pool will think it's exiting and therefore never reuses workers. When the server is asked to do work it'll create a new worker, but immediately discard it.
2. In addition to the degraded state, there's an edge case in the worker pool finishing state's implementation that can cause hanging.

The exact conditions of the hanging were observed in https://github.com/pnpm/pnpm/issues/7038#issuecomment-1704572627. In summary, the hanging happens if a worker is requested in between the time that a different worker has been marked for cleanup, but before the `exit` event for that other worker has fired.

It's a bit surprising to me that the worker pool will accept new work after `finishAsync` is called. I'm not sure if that's intentional.

## Reproducing the hanging

The hanging can be reproduced consistently by forcing some contrived settings:

1. Adding a 10s sleep to `exit` event handler's logic. [`WorkerPool.ts#L209-L214`](https://github.com/microsoft/rushstack/blob/6fd68ae2706a15f6f41f20f76183e368df88167e/libraries/worker-pool/src/WorkerPool.ts#L209-L214)
2. Forcibly setting the worker pool max size to `1`. This is the value CI on this repo evaluates to.
  https://github.com/pnpm/pnpm/blob/494f8754492031f5b5c387f08cdecbdd203510f6/worker/src/index.ts#L22

After performing above, running `pnpm server start` and `pnpm install is-positive@1.0.0` will reproduce the hanging.

Although this is fairly contrived, this was happening very consistently on pnpm's CI jobs.

## Changes

The main idea behind this PR is to delay the `finishAsync` call until the server is exiting through `Ctrl-C` or a `POST /exit` request.

https://github.com/pnpm/pnpm/blob/131c723030ec4016274ca1cef33aadd66eb0e3b9/pnpm/src/main.ts#L300

I'm not sure if this is the best approach. I'd welcome suggestions around an alternative fix.

## Alternatives

We could also set up a check around the `global.finishWorkers?.()` call and avoid running it if the current process is driving a pnpm server. This felt a bit more hacky to me though. To check if the current process is a pnpm server, information needs to be propagated back up the command handler chain or some kind of sideways information passing. In theory there are other situations where we'd want to avoid `global.finishWorkers?.()` from running as well.