### PR TITLE
wip: record server messages in tests

### DIFF
--- a/pnpm/test/utils/ServerTestingFramework.ts
+++ b/pnpm/test/utils/ServerTestingFramework.ts
@@ -1,0 +1,229 @@
+import { type ChildProcess } from 'child_process'
+import chalk from 'chalk'
+import crossSpawn from 'cross-spawn'
+import { createEnv, pnpmBinLocation } from './execPnpm'
+import { retryLoadJsonFile2 } from './retryLoadJsonFile'
+import delay from 'delay'
+
+interface ServerInstanceInfo {
+  readonly connectionOptions: {
+    readonly remotePrefix: string
+  }
+  readonly pid: number
+  readonly pnpmVersion: string
+}
+
+// Polyfilling Symbol.asyncDispose for Jest.
+//
+// Copied with a few changes from https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#using-declarations-and-explicit-resource-management
+if (Symbol.asyncDispose === undefined) {
+  (Symbol as { asyncDispose?: symbol }).asyncDispose = Symbol('Symbol.asyncDispose')
+}
+
+const DEFAULT_EXEC_PNPM_TIMEOUT = 3 * 60 * 1000 // 3 minutes
+const TIMEOUT_FOR_GRACEFUL_EXIT = 10 * 1000 // 10s
+
+export class ServerTestingFramework implements AsyncDisposable {
+  private readonly serverProcess: ChildProcess
+  private serverOutput: string = ''
+
+  constructor (serverStartArgs?: readonly string[]) {
+    const serverProcess = this.spawnPnpm(['server', 'start', ...(serverStartArgs ?? [])])
+    this.serverProcess = serverProcess
+
+    const appendToServerOutput = (data: Buffer) => {
+      this.serverOutput += data.toString()
+    }
+
+    // Intentionally interleaving stdout and stderr to mimic how this would look
+    // in a user's console.
+    this.serverProcess.stdout?.on('data', appendToServerOutput)
+    this.serverProcess.stderr?.on('data', appendToServerOutput)
+  }
+
+  public async startup (serverJsonPath: string) {
+    const { value, abortController } = retryLoadJsonFile2<ServerInstanceInfo>(serverJsonPath)
+
+    return this.performServerAction({
+      // It shouldn't take longer than 10s for the server to start up.
+      timeout: 10_000,
+
+      operation: () => value,
+      cancel: async () => {
+        abortController()
+      },
+      logs: () => '',
+    })
+  }
+
+  public async exec (args: readonly string[], opts?: { timeout?: number }): Promise<void> {
+    const proc = this.spawnPnpm(args)
+
+    let clientOutput: string = ''
+
+    function appendToClientOutput (data: Buffer) {
+      clientOutput += data.toString()
+    }
+
+    proc.stdout?.on('data', appendToClientOutput)
+    proc.stderr?.on('data', appendToClientOutput)
+
+    return this.performServerAction({
+      timeout: opts?.timeout,
+
+      operation: () => {
+        return new Promise((resolve, reject) => {
+          proc.on('error', reject)
+
+          proc.on('close', (code) => {
+            if (code != null && code > 0) {
+              reject(new Error(`Process exited with code ${code}`))
+            } else {
+              resolve()
+            }
+          })
+        })
+      },
+      cancel: async () => {
+        // Ask the process to exit politely and clean up its resources. On Windows
+        // this will likely no-op since there is no SIGINT. The SIGTERM kill below
+        // will stop the process in that case.
+        proc.kill('SIGINT')
+
+        await delay(TIMEOUT_FOR_GRACEFUL_EXIT)
+
+        if (proc.exitCode !== null) {
+          proc.kill()
+        }
+      },
+      logs: () => clientOutput,
+    })
+  }
+
+  private async performServerAction<T> (opts: {
+    operation: () => Promise<T>
+    cancel: () => Promise<void>
+    logs: () => string
+    timeout?: number
+  }) {
+    const timeout = opts.timeout ?? DEFAULT_EXEC_PNPM_TIMEOUT
+
+    const timeoutSymbol = Symbol('timeout')
+    let timeoutId: NodeJS.Timeout | undefined
+    const timeoutPromise = new Promise((resolve) => {
+      timeoutId = setTimeout(() => {
+        resolve(timeoutSymbol)
+      }, timeout)
+    })
+
+    let raceResult: Awaited<T> | typeof timeoutSymbol
+    try {
+      raceResult = await Promise.race([
+        opts.operation(),
+        timeoutPromise,
+      ]) as Awaited<T> | typeof timeoutSymbol
+    } catch (error: unknown) {
+      throw new ServerTestExecError(error as string, this.serverOutput, opts.logs())
+    } finally {
+      clearTimeout(timeoutId)
+    }
+
+    if (raceResult === timeoutSymbol) {
+      await opts.cancel()
+      throw new ServerTestExecTimeoutError(timeout, this.serverOutput, '')
+    }
+
+    return raceResult
+  }
+
+  private spawnPnpm (
+    args: readonly string[],
+    opts?: {
+      env?: Record<string, string>
+      storeDir?: string
+    }
+  ): ChildProcess {
+    return crossSpawn.spawn(process.execPath, [pnpmBinLocation, ...args], {
+      env: {
+        ...createEnv(opts),
+        ...opts?.env,
+      } as NodeJS.ProcessEnv,
+    })
+  }
+
+  public async [Symbol.asyncDispose] (): Promise<void> {
+    await this.exec(['server', 'stop'])
+
+    if (this.serverProcess.exitCode === null) {
+      this.serverProcess.kill('SIGTERM')
+    }
+  }
+}
+
+export class ServerTestExecError extends Error {
+  /**
+   * The entire server's output before the error. This will contain logs from
+   * prior executions. The stdout and stderr streams are interleaved.
+   */
+  readonly serverOutput: string
+
+  /**
+   * The interleaved stdout and stderr of the pnpm exec during a server test.
+   */
+  readonly clientOutput: string
+
+  constructor (message: string, serverOutput: string, clientOutput: string) {
+    super(message)
+    this.serverOutput = serverOutput
+    this.clientOutput = clientOutput
+  }
+}
+
+export class ServerTestExecTimeoutError extends ServerTestExecError {
+  constructor (timeout: number, serverOutput: string, clientOutput: string) {
+    super(`The running command did not exit after ${timeout}ms.`, serverOutput, clientOutput)
+  }
+}
+
+expect.extend({
+  async toBePassingServerTest (received: Promise<unknown>): Promise<jest.CustomMatcherResult> {
+    try {
+      await received
+    } catch (error: unknown) {
+      return {
+        pass: false,
+        message: () => {
+          if (error instanceof ServerTestExecError) {
+            return `\
+${error.message}
+
+${chalk.underline('Client log:')}
+${error.clientOutput}
+
+${chalk.underline('Server log:')}
+${error.serverOutput}
+`
+          } else if (error instanceof Error) {
+            return error.toString()
+          }
+
+          return error as string
+        },
+      }
+    }
+
+    return {
+      pass: true,
+      message: () => 'The client call succeeded.',
+    }
+  },
+})
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toBePassingServerTest: () => Promise<R>
+    }
+  }
+}

--- a/pnpm/test/utils/retryLoadJsonFile.ts
+++ b/pnpm/test/utils/retryLoadJsonFile.ts
@@ -1,7 +1,7 @@
 import loadJsonFile from 'load-json-file'
 import * as retry from '@zkochan/retry'
 
-export async function retryLoadJsonFile<T> (filePath: string): Promise<T> {
+export function retryLoadJsonFile<T> (filePath: string): Promise<T> {
   const operation = retry.operation({})
 
   return new Promise<T>((resolve, reject) => {
@@ -16,4 +16,26 @@ export async function retryLoadJsonFile<T> (filePath: string): Promise<T> {
       }
     })
   })
+}
+
+export function retryLoadJsonFile2<T> (filePath: string): { value: Promise<T>, abortController: () => void } {
+  const operation = retry.operation({})
+
+  return {
+    value: new Promise<T>((resolve, reject) => {
+      operation.attempt(async (currentAttempt) => {
+        try {
+          resolve(await loadJsonFile<T>(filePath))
+        } catch (err: any) { // eslint-disable-line
+          if (operation.retry(err)) {
+            return
+          }
+          reject(err)
+        }
+      })
+    }),
+    abortController: () => {
+      operation.stop()
+    },
+  }
 }


### PR DESCRIPTION
This PR contains a work in progress attempt to get logs from `pnpm server start` if a server test fails. Instead of appearing randomly throughout a test, it'll aggregate logs and only show them on failure.

```
● installation using pnpm server

  The running command did not exit after 180000ms.

  Client log:


  Server log:
  Got request at 1675.9179480000166: /requestPackage
  {
    msgId: '8d899b90-54e0-4658-9a89-3dbc1927dc70',
    options: {
      alwaysTryWorkspacePackages: true,
      currentPkg: {},
      expectedPkg: {},
      defaultTag: 'latest',
      ignoreScripts: false,
      pickLowestVersion: false,
      downloadPriority: 0,
      lockfileDir: '/home/runner/work/pnpm/pnpm_tmp/52a9ab4955bafcfd9d1de0428a9e4550/14/project',
      preferredVersions: {},
      preferWorkspacePackages: false,
      projectDir: '/home/runner/work/pnpm/pnpm_tmp/52a9ab4955bafcfd9d1de0428a9e4550/14/project',
      registry: 'http://localhost:7776/',
      skipFetch: false,
      update: true,
      workspacePackages: {}
    },
    wantedDependency: {
      alias: 'is-positive',
      dev: false,
      optional: false,
      raw: 'is-positive@1.0.0',
      pref: '1.0.0',
      isNew: true,
      updateSpec: true,
      updateDepth: -1
    }
  }
  Responded to request: 1675.9179480000166
  fetching_started localhost+7776/is-positive/1.0.0
  Checking out worker for "extract"
  { max: 1, active: 0, idle: 0, live: 0 }
  WorkerPool: Checking out a new worker
  Finished checking out worker for "extract": 2.909321999992244
  Got request at 1740.640429000021: /rawManifestResponse
  { msgId: '8d899b90-54e0-4658-9a89-3dbc1927dc70' }
  Got request at 1741.2127329999348: /packageFilesResponse
  { msgId: '8d899b90-54e0-4658-9a89-3dbc1927dc70' }
  Worker responded with message for extract
  WorkerPool: Checking in worker
  WorkerPool: The worker pool is finishing.
  Responded to request: 1740.640429000021
  Responded to request: 1741.2127329999348
  Got request at 1857.7302980000386: /importPackage
  {
    opts: {
      filesResponse: { fromStore: false, filesIndex: [Object] },
      force: false,
      requiresBuild: false
    },
    to: '/home/runner/work/pnpm/pnpm_tmp/52a9ab4955bafcfd9d1de0428a9e4550/14/project/node_modules/.pnpm/is-positive@1.0.0/node_modules/is-positive'
  }
  Checking out worker for "link"
  { max: 1, active: 1, idle: 0, live: 1 }
  WorkerPool: Checking out a new worker

    43 |   expect(typeof serverJson.pnpmVersion).toBe('string')
    44 |
  > 45 |   await expect(framework.exec(['install', 'is-positive@1.0.0'])).toBePassingServerTest()
       |                                                                  ^
    46 |
    47 |   expect(project.requireModule('is-positive')).toBeTruthy()
    48 |

    at Object.<anonymous> (test/server.ts:45:66)
```