### PR TITLE
fix(install): delay fetching directory until symlink

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1097,6 +1097,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         dependenciesByProjectId,
         depsStateCache,
         extraNodePaths: ctx.extraNodePaths,
+        finishLockfileUpdates,
         force: opts.force,
         hoistedDependencies: ctx.hoistedDependencies,
         hoistedModulesDir: ctx.hoistedModulesDir,
@@ -1122,7 +1123,6 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       }
     )
     stats = result.stats
-    await finishLockfileUpdates()
     if (opts.enablePnp) {
       const importerNames = Object.fromEntries(
         projects.map(({ manifest, id }) => [id, manifest.name ?? id])

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -48,6 +48,7 @@ export async function linkPackages (
     currentLockfile: Lockfile
     dedupeDirectDeps: boolean
     dependenciesByProjectId: Record<string, Record<string, string>>
+    finishLockfileUpdates: () => Promise<unknown>
     force: boolean
     depsStateCache: DepsStateCache
     extraNodePaths: string[]
@@ -134,31 +135,6 @@ export async function linkPackages (
     failOnMissingDependencies: true,
     skipped: new Set(),
   })
-  const { newDepPaths, added } = await linkNewPackages(
-    filterLockfileByImporters(opts.currentLockfile, projectIds, {
-      ...filterOpts,
-      failOnMissingDependencies: false,
-    }),
-    newCurrentLockfile,
-    depGraph,
-    {
-      force: opts.force,
-      depsStateCache: opts.depsStateCache,
-      ignoreScripts: opts.ignoreScripts,
-      lockfileDir: opts.lockfileDir,
-      optional: opts.include.optionalDependencies,
-      sideEffectsCacheRead: opts.sideEffectsCacheRead,
-      symlink: opts.symlink,
-      skipped: opts.skipped,
-      storeController: opts.storeController,
-      virtualStoreDir: opts.virtualStoreDir,
-    }
-  )
-
-  stageLogger.debug({
-    prefix: opts.lockfileDir,
-    stage: 'importing_done',
-  })
 
   let currentLockfile: Lockfile
   const allImportersIncluded = equals(projectIds.sort(), Object.keys(opts.wantedLockfile.importers).sort())
@@ -201,6 +177,97 @@ export async function linkPackages (
     currentLockfile = newCurrentLockfile
   }
 
+  const filteredLockfile = filterLockfileByImporters(opts.currentLockfile, projectIds, {
+    ...filterOpts,
+    failOnMissingDependencies: false,
+  })
+  const { newDepPaths, wantedRelDepPaths } = await calculateDepPaths({
+    currentLockfile: filteredLockfile,
+    depGraph,
+    force: opts.force,
+    skipped: opts.skipped,
+    wantedLockfile: newCurrentLockfile,
+  })
+
+  let linkedToRoot = 0
+  let dedupeLinkedDirectDeps = async () => {}
+  if (opts.symlink) {
+    const projectsToLink = Object.fromEntries(await Promise.all(
+      projects.map(async ({ id, manifest, modulesDir, rootDir }) => {
+        const deps = opts.dependenciesByProjectId[id]
+        const importerFromLockfile = newCurrentLockfile.importers[id]
+        return [id, {
+          dir: rootDir,
+          modulesDir,
+          dependencies: [
+            ...Object.entries(deps)
+              .filter(([rootAlias]) => importerFromLockfile.specifiers[rootAlias])
+              .map(([rootAlias, depPath]) => ({ rootAlias, depGraphNode: depGraph[depPath] }))
+              .filter(({ depGraphNode }) => depGraphNode)
+              .map(({ rootAlias, depGraphNode }) => {
+                const isDev = Boolean(manifest.devDependencies?.[depGraphNode.name])
+                const isOptional = Boolean(manifest.optionalDependencies?.[depGraphNode.name])
+                return {
+                  alias: rootAlias,
+                  name: depGraphNode.name,
+                  version: depGraphNode.version,
+                  dir: depGraphNode.dir,
+                  id: depGraphNode.id,
+                  dependencyType: (isDev && 'dev' || isOptional && 'optional' || 'prod') as 'dev' | 'optional' | 'prod',
+                  latest: opts.outdatedDependencies[depGraphNode.id],
+                  isExternalLink: false,
+                }
+              }),
+            ...opts.linkedDependenciesByProjectId[id].map((linkedDependency) => {
+              const dir = resolvePath(rootDir, linkedDependency.resolution.directory)
+              return {
+                alias: linkedDependency.alias,
+                name: linkedDependency.name,
+                version: linkedDependency.version,
+                dir,
+                id: linkedDependency.resolution.directory,
+                dependencyType: (linkedDependency.dev && 'dev' || linkedDependency.optional && 'optional' || 'prod') as 'dev' | 'optional' | 'prod',
+                isExternalLink: true,
+              }
+            }),
+          ],
+        }]
+      }))
+    )
+    const dedupe = opts.dedupeDirectDeps
+    const _linkDirectDeps = linkDirectDeps.bind(null, projectsToLink, { dedupe })
+    linkedToRoot = await _linkDirectDeps()
+    if (dedupe) {
+      dedupeLinkedDirectDeps = async () => {
+        await _linkDirectDeps()
+      }
+    }
+  }
+  await opts.finishLockfileUpdates()
+  const { added } = await linkNewPackages(
+    filteredLockfile,
+    newCurrentLockfile,
+    depGraph,
+    {
+      force: opts.force,
+      depsStateCache: opts.depsStateCache,
+      ignoreScripts: opts.ignoreScripts,
+      lockfileDir: opts.lockfileDir,
+      newDepPaths,
+      optional: opts.include.optionalDependencies,
+      sideEffectsCacheRead: opts.sideEffectsCacheRead,
+      symlink: opts.symlink,
+      storeController: opts.storeController,
+      virtualStoreDir: opts.virtualStoreDir,
+      wantedRelDepPaths,
+    }
+  )
+
+  stageLogger.debug({
+    prefix: opts.lockfileDir,
+    stage: 'importing_done',
+  })
+
   let newHoistedDependencies!: HoistedDependencies
   if (opts.hoistPattern == null && opts.publicHoistPattern == null) {
     newHoistedDependencies = {}
@@ -226,52 +293,8 @@ export async function linkPackages (
     newHoistedDependencies = opts.hoistedDependencies
   }
 
-  let linkedToRoot = 0
-  if (opts.symlink) {
-    const projectsToLink = Object.fromEntries(await Promise.all(
-      projects.map(async ({ id, manifest, modulesDir, rootDir }) => {
-        const deps = opts.dependenciesByProjectId[id]
-        const importerFromLockfile = newCurrentLockfile.importers[id]
-        return [id, {
-          dir: rootDir,
-          modulesDir,
-          dependencies: await Promise.all([
-            ...Object.entries(deps)
-              .filter(([rootAlias]) => importerFromLockfile.specifiers[rootAlias])
-              .map(([rootAlias, depPath]) => ({ rootAlias, depGraphNode: depGraph[depPath] }))
-              .filter(({ depGraphNode }) => depGraphNode)
-              .map(async ({ rootAlias, depGraphNode }) => {
-                const isDev = Boolean(manifest.devDependencies?.[depGraphNode.name])
-                const isOptional = Boolean(manifest.optionalDependencies?.[depGraphNode.name])
-                return {
-                  alias: rootAlias,
-                  name: depGraphNode.name,
-                  version: depGraphNode.version,
-                  dir: depGraphNode.dir,
-                  id: depGraphNode.id,
-                  dependencyType: (isDev && 'dev' || isOptional && 'optional' || 'prod') as 'dev' | 'optional' | 'prod',
-                  latest: opts.outdatedDependencies[depGraphNode.id],
-                  isExternalLink: false,
-                }
-              }),
-            ...opts.linkedDependenciesByProjectId[id].map(async (linkedDependency) => {
-              const dir = resolvePath(rootDir, linkedDependency.resolution.directory)
-              return {
-                alias: linkedDependency.alias,
-                name: linkedDependency.name,
-                version: linkedDependency.version,
-                dir,
-                id: linkedDependency.resolution.directory,
-                dependencyType: (linkedDependency.dev && 'dev' || linkedDependency.optional && 'optional' || 'prod') as 'dev' | 'optional' | 'prod',
-                isExternalLink: true,
-              }
-            }),
-          ]),
-        }]
-      }))
-    )
-    linkedToRoot = await linkDirectDeps(projectsToLink, { dedupe: opts.dedupeDirectDeps })
-  }
+  // Possibly dedupe dependencies that were hoisted after local link
+  await dedupeLinkedDirectDeps()
 
   return {
     currentLockfile,
@@ -283,6 +306,36 @@ export async function linkPackages (
       removed: removedDepPaths.size,
       linkedToRoot,
     },
+  }
+}
+
+async function calculateDepPaths (opts: {
+  currentLockfile: Lockfile
+  depGraph: DependenciesGraph
+  force: boolean
+  skipped: Set<string>
+  wantedLockfile: Lockfile
+}): Promise<{
+    newDepPaths: string[]
+    wantedRelDepPaths: string[]
+  }> {
+  const wantedRelDepPaths = difference(Object.keys(opts.wantedLockfile.packages ?? {}), Array.from(opts.skipped))
+
+  let newDepPathsSet: Set<string>
+  if (opts.force) {
+    newDepPathsSet = new Set(
+      wantedRelDepPaths
+      // when installing a new package, not all the nodes are analyzed
+      // just skip the ones that are in the lockfile but were not analyzed
+        .filter((depPath) => opts.depGraph[depPath])
+    )
+  } else {
+    newDepPathsSet = await selectNewFromWantedDeps(wantedRelDepPaths, opts.currentLockfile, opts.depGraph)
+  }
+
+  return {
+    newDepPaths: Array.from(newDepPathsSet),
+    wantedRelDepPaths,
   }
 }
 
@@ -301,29 +354,18 @@ async function linkNewPackages (
   opts: {
     depsStateCache: DepsStateCache
     force: boolean
+    newDepPaths: string[]
     optional: boolean
     ignoreScripts: boolean
     lockfileDir: string
     sideEffectsCacheRead: boolean
     symlink: boolean
-    skipped: Set<string>
     storeController: StoreController
     virtualStoreDir: string
+    wantedRelDepPaths: string[]
   }
-): Promise<{ newDepPaths: string[], added: number }> {
-  const wantedRelDepPaths = difference(Object.keys(wantedLockfile.packages ?? {}), Array.from(opts.skipped))
-
-  let newDepPathsSet: Set<string>
-  if (opts.force) {
-    newDepPathsSet = new Set(
-      wantedRelDepPaths
-        // when installing a new package, not all the nodes are analyzed
-        // just skip the ones that are in the lockfile but were not analyzed
-        .filter((depPath) => depGraph[depPath])
-    )
-  } else {
-    newDepPathsSet = await selectNewFromWantedDeps(wantedRelDepPaths, currentLockfile, depGraph)
-  }
+): Promise<{ added: number }> {
+  const newDepPathsSet = new Set(opts.newDepPaths)
 
   const added = newDepPathsSet.size
   statsLogger.debug({
@@ -335,7 +377,7 @@ async function linkNewPackages (
   if (!opts.force && (currentLockfile.packages != null) && (wantedLockfile.packages != null)) {
     // add subdependencies that have been updated
     // TODO: no need to relink everything. Can be relinked only what was changed
-    for (const depPath of wantedRelDepPaths) {
+    for (const depPath of opts.wantedRelDepPaths) {
       if (currentLockfile.packages[depPath] &&
         (!equals(currentLockfile.packages[depPath].dependencies, wantedLockfile.packages[depPath].dependencies) ||
         !equals(currentLockfile.packages[depPath].optionalDependencies, wantedLockfile.packages[depPath].optionalDependencies))) {
@@ -348,11 +390,9 @@ async function linkNewPackages (
     }
   }
 
-  if (!newDepPathsSet.size && (existingWithUpdatedDeps.length === 0)) return { newDepPaths: [], added }
+  if (!newDepPathsSet.size && (existingWithUpdatedDeps.length === 0)) return { added }
 
-  const newDepPaths = Array.from(newDepPathsSet)
-
-  const newPkgs = props<string, DependenciesGraphNode>(newDepPaths, depGraph)
+  const newPkgs = props<string, DependenciesGraphNode>(opts.newDepPaths, depGraph)
 
   await Promise.all(newPkgs.map(async (depNode) => fs.mkdir(depNode.modules, { recursive: true })))
   await Promise.all([
@@ -372,7 +412,7 @@ async function linkNewPackages (
     }),
   ])
 
-  return { newDepPaths, added }
+  return { added }
 }
 
 async function selectNewFromWantedDeps (

--- a/pkg-manager/plugin-commands-installation/test/install.ts
+++ b/pkg-manager/plugin-commands-installation/test/install.ts
@@ -1,8 +1,9 @@
 import fs from 'fs'
 import delay from 'delay'
 import path from 'path'
+import { readProjects } from '@pnpm/filter-workspace-packages'
 import { add, install } from '@pnpm/plugin-commands-installation'
-import { prepareEmpty } from '@pnpm/prepare'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import rimraf from '@zkochan/rimraf'
 import { DEFAULT_OPTS } from './utils'
 
@@ -51,4 +52,125 @@ test('install with no store integrity validation', async () => {
   })
 
   expect(fs.readFileSync('node_modules/is-positive/readme.md', 'utf8')).toBe('modified')
+})
+
+describe('install injected dependencies', () => {
+  for (const {
+    title,
+    withLockfile,
+  } of [
+      {
+        title: 'with shared lockfile',
+        withLockfile: true,
+      }, {
+        title: 'with individual lockfiles',
+        withLockfile: false,
+      },
+    ]) {
+    test(title, async () => {
+      preparePackages([
+        {
+          location: '.',
+          package: {
+            name: 'root',
+            version: '1.0.0',
+          },
+        },
+        {
+          name: 'project-1',
+          version: '1.0.0',
+          dependencies: {
+            'project-2': 'workspace:*',
+          },
+          devDependencies: {
+            'project-3': 'workspace:*',
+          },
+          dependenciesMeta: {
+            'project-2': {
+              injected: true,
+            },
+          },
+        },
+        {
+          name: 'project-2',
+          version: '1.0.0',
+          devDependencies: {
+            'project-3': 'workspace:*',
+          },
+          publishConfig: {
+            exports: {
+              foo: 'bar',
+            },
+          },
+        },
+        {
+          location: 'nested-packages/project-3',
+          package: {
+            name: 'project-3',
+            version: '1.0.0',
+          },
+        },
+      ])
+
+      const { allProjects, allProjectsGraph, selectedProjectsGraph } = await readProjects(process.cwd(), [])
+
+      const lockfileDir = withLockfile ? process.cwd() : undefined
+
+      await install.handler({
+        ...DEFAULT_OPTS,
+        allProjects,
+        allProjectsGraph,
+        dir: process.cwd(),
+        lockfileDir,
+        selectedProjectsGraph,
+        workspaceDir: process.cwd(),
+      })
+
+      const [
+        originalProject2,
+        injectedProject2,
+      ] = await Promise.all([
+        fs.promises.readFile('project-2/package.json', 'utf8'),
+        fs.promises.readFile('project-1/node_modules/project-2/package.json', 'utf8'),
+      ])
+
+      expect(
+        JSON.parse(originalProject2)
+      ).toEqual({
+        name: 'project-2',
+        version: '1.0.0',
+        devDependencies: {
+          'project-3': 'workspace:*',
+        },
+        publishConfig: {
+          exports: {
+            foo: 'bar',
+          },
+        },
+      })
+
+      expect(
+        JSON.parse(injectedProject2)
+      ).toEqual({
+        name: 'project-2',
+        version: '1.0.0',
+        devDependencies: {
+          'project-3': '1.0.0',
+        },
+        exports: {
+          foo: 'bar',
+        },
+      })
+
+      await install.handler({
+        ...DEFAULT_OPTS,
+        allProjects,
+        allProjectsGraph,
+        dir: process.cwd(),
+        lockfileDir,
+        selectedProjectsGraph,
+        workspaceDir: process.cwd(),
+      })
+    })
+  }
 })

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -21,7 +21,6 @@ import {
   type ProjectManifest,
   type Registries,
 } from '@pnpm/types'
-import promiseShare from 'promise-share'
 import difference from 'ramda/src/difference'
 import zipWith from 'ramda/src/zipWith'
 import isSubdir from 'is-subdir'
@@ -282,10 +281,15 @@ export async function resolveDependencies (
     } catch {}
   }))
 
+  let finishLockfileUpdatesPromise: Promise<unknown> | undefined
+
   return {
     dependenciesByProjectId,
     dependenciesGraph,
-    finishLockfileUpdates: promiseShare(finishLockfileUpdates(dependenciesGraph, pendingRequiresBuilds, newLockfile)),
+    finishLockfileUpdates: () => {
+      finishLockfileUpdatesPromise ??= finishLockfileUpdates(dependenciesGraph, pendingRequiresBuilds, newLockfile)
+      return finishLockfileUpdatesPromise
+    },
     outdatedDependencies,
     linkedDependenciesByProjectId,
     newLockfile,


### PR DESCRIPTION
Ensure that fetches from directory are delayed until the package is synlinked. That will allow the created `exportableManifest` to correctly find it's dependencies.

Resolves: https://github.com/pnpm/pnpm/issues/7040