### PR TITLE
fix: [use-]node-version isn't passed on workspace

### DIFF
--- a/.changeset/selfish-pianos-burn.md
+++ b/.changeset/selfish-pianos-burn.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/filter-workspace-packages": minor
+"pnpm": patch
+---
+
+Fix a bug in which `use-node-version` or `node-version` isn't passed down to `checkEngine` when using pnpm workspace, resulting in an error [#6981](https://github.com/pnpm/pnpm/issues/6981).

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -199,6 +199,7 @@ export async function main (inputArgv: string[]) {
 
     const filterResults = await filterPackagesFromDir(wsDir, filters, {
       engineStrict: config.engineStrict,
+      nodeVersion: config.nodeVersion ?? config.useNodeVersion,
       patterns: cliOptions['workspace-packages'],
       linkWorkspacePackages: !!config.linkWorkspacePackages,
       prefix: process.cwd(),

--- a/workspace/filter-workspace-packages/src/index.ts
+++ b/workspace/filter-workspace-packages/src/index.ts
@@ -70,9 +70,18 @@ export interface FilterPackagesOptions {
 export async function filterPackagesFromDir (
   workspaceDir: string,
   filter: WorkspaceFilter[],
-  opts: FilterPackagesOptions & { engineStrict?: boolean, patterns: string[] }
+  opts: FilterPackagesOptions & {
+    engineStrict?: boolean
+    nodeVersion?: string
+    patterns: string[]
+  }
 ) {
-  const allProjects = await findWorkspacePackages(workspaceDir, { engineStrict: opts?.engineStrict, patterns: opts.patterns, sharedWorkspaceLockfile: opts.sharedWorkspaceLockfile })
+  const allProjects = await findWorkspacePackages(workspaceDir, {
+    engineStrict: opts?.engineStrict,
+    patterns: opts.patterns,
+    sharedWorkspaceLockfile: opts.sharedWorkspaceLockfile,
+    nodeVersion: opts.nodeVersion,
+  })
   return {
     allProjects,
     ...(await filterPackages(allProjects, filter, opts)),


### PR DESCRIPTION
fixes https://github.com/pnpm/pnpm/issues/6981