### PR TITLE
fix: don't run prepublishOnly of git-hosted dependencies

### DIFF
--- a/.changeset/metal-starfishes-decide.md
+++ b/.changeset/metal-starfishes-decide.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/prepare-package": patch
+"pnpm": patch
+---
+
+Don't run the `prepublishOnly` scripts of git-hosted dependencies [#7026](https://github.com/pnpm/pnpm/issues/7026).

--- a/exec/prepare-package/src/index.ts
+++ b/exec/prepare-package/src/index.ts
@@ -7,9 +7,11 @@ import rimraf from '@zkochan/rimraf'
 import preferredPM from 'preferred-pm'
 import omit from 'ramda/src/omit'
 
+// We don't run prepublishOnly to prepare the dependency.
+// This might be counterintuitive as prepublishOnly is where a lot of packages put their build scripts.
+// However, neither npm nor Yarn run prepublishOnly of git-hosted dependencies (checked on npm v10 and Yarn v3).
 const PREPUBLISH_SCRIPTS = [
   'prepublish',
-  'prepublishOnly',
   'prepack',
   'publish',
 ]

--- a/pkg-manager/core/test/install/lifecycleScripts.ts
+++ b/pkg-manager/core/test/install/lifecycleScripts.ts
@@ -278,7 +278,6 @@ test('run prepare script for git-hosted dependencies', async () => {
     'install',
     'postinstall',
     'prepare',
-    'prepublishOnly',
     'preinstall',
     'install',
     'postinstall',


### PR DESCRIPTION
close #7026