### PR TITLE
feat(plugin-commands-config): throw meaningful error for config sub commands

### DIFF
--- a/.changeset/four-carpets-itch.md
+++ b/.changeset/four-carpets-itch.md
@@ -1,0 +1,4 @@
+---
+"@pnpm/plugin-commands-config": patch
+---
+Throw meaningful error for config sub commands.[#7106](https://github.com/pnpm/pnpm/issues/7106)

--- a/.changeset/four-carpets-itch.md
+++ b/.changeset/four-carpets-itch.md
@@ -1,4 +1,6 @@
 ---
 "@pnpm/plugin-commands-config": patch
+"pnpm": patch
 ---
+
 Throw meaningful error for config sub commands.[#7106](https://github.com/pnpm/pnpm/issues/7106)

--- a/config/plugin-commands-config/src/config.ts
+++ b/config/plugin-commands-config/src/config.ts
@@ -87,20 +87,29 @@ export async function handler (opts: ConfigCommandOptions, params: string[]) {
     opts.global = true
   }
   switch (params[0]) {
-  case 'set': {
-    let [key, value] = params.slice(1)
-    if (value == null) {
-      const parts = key.split('=')
-      key = parts.shift()!
-      value = parts.join('=')
+  case 'set':
+  case 'delete': {
+    if (!params[1]) {
+      throw new PnpmError('CONFIG_NO_PARAMS', `\`pnpm config ${params[0]}\` requires the config key`)
     }
-    return configSet(opts, key, value ?? '')
+    if (params[0] === 'set') {
+      let [key, value] = params.slice(1)
+      if (value == null) {
+        const parts = key.split('=')
+        key = parts.shift()!
+        value = parts.join('=')
+      }
+      return configSet(opts, key, value ?? '')
+    } else {
+      return configSet(opts, params[1], null)
+    }
   }
   case 'get': {
-    return configGet(opts, params[1])
-  }
-  case 'delete': {
-    return configSet(opts, params[1], null)
+    if (params[1]) {
+      return configGet(opts, params[1])
+    } else {
+      return configList(opts)
+    }
   }
   case 'list': {
     return configList(opts)

--- a/config/plugin-commands-config/test/configGet.test.ts
+++ b/config/plugin-commands-config/test/configGet.test.ts
@@ -27,3 +27,26 @@ test('config get a boolean should return string format', async () => {
 
   expect(configKey).toEqual('true')
 })
+
+test('config get without key show list all settings ', async () => {
+  const rawConfig = {
+    'store-dir': '~/store',
+    'fetch-retries': '2',
+  }
+  const getOutput = await config.handler({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: true,
+    rawConfig,
+  }, ['get'])
+
+  const listOutput = await config.handler({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    rawConfig,
+  }, ['list'])
+
+  expect(getOutput).toEqual(listOutput)
+})

--- a/config/plugin-commands-config/test/configSet.test.ts
+++ b/config/plugin-commands-config/test/configSet.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { PnpmError } from '@pnpm/error'
 import { tempDir } from '@pnpm/prepare'
 import { config } from '@pnpm/plugin-commands-config'
 import { readIniFileSync } from 'read-ini-file'
@@ -122,4 +123,27 @@ test('config set key=value, when value contains a "="', async () => {
     'store-dir': '~/store',
     foo: 'bar=qar',
   })
+})
+
+test('config set or delete throws missing params error', async () => {
+  const tmp = tempDir()
+  const configDir = path.join(tmp, 'global-config')
+  fs.mkdirSync(configDir, { recursive: true })
+  fs.writeFileSync(path.join(tmp, '.npmrc'), 'store-dir=~/store')
+
+  await expect(config.handler({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir,
+    location: 'project',
+    rawConfig: {},
+  }, ['set'])).rejects.toThrow(new PnpmError('CONFIG_NO_PARAMS', '`pnpm config set` requires the config key'))
+
+  await expect(config.handler({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir,
+    location: 'project',
+    rawConfig: {},
+  }, ['delete'])).rejects.toThrow(new PnpmError('CONFIG_NO_PARAMS', '`pnpm config delete` requires the config key'))
 })


### PR DESCRIPTION
fix #7106 

* Throw `ERR_PNPM_CONFIG_NO_PARAMS` for `pnpm config set` and `pnpm config delete` that missing  config key.
* output all settings when `pnpm config get` doesn't have config key.