### PR TITLE
perf: replace startsWith with ===

### DIFF
--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -368,7 +368,7 @@ function reportAuthError (
 ) {
   const foundSettings = [] as string[]
   for (const [key, value] of Object.entries(config?.rawConfig ?? {})) {
-    if (key.startsWith('@')) {
+    if (key[0] === '@') {
       foundSettings.push(`${key}=${value}`)
       continue
     }

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -532,7 +532,7 @@ export async function getConfig (
     }).filter(key => key.trim() !== '')
     const unknownKeys = []
     for (const key of settingKeys) {
-      if (!rcOptions.includes(key) && !key.startsWith('//') && !(key.startsWith('@') && key.endsWith(':registry'))) {
+      if (!rcOptions.includes(key) && !key.startsWith('//') && !(key[0] === '@' && key.endsWith(':registry'))) {
         unknownKeys.push(key)
       }
     }

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -412,7 +412,7 @@ function binDirsInAllParentDirs (pkgRoot: string, lockfileDir: string): string[]
   const binDirs: string[] = []
   let dir = pkgRoot
   do {
-    if (!path.dirname(dir).startsWith('@')) {
+    if (!(path.dirname(dir)[0] === '@')) {
       binDirs.push(path.join(dir, 'node_modules/.bin'))
     }
     dir = path.dirname(dir)

--- a/exec/plugin-commands-script-runners/src/create.ts
+++ b/exec/plugin-commands-script-runners/src/create.ts
@@ -65,7 +65,7 @@ const CREATE_PREFIX = 'create-'
  * For more info, see https://docs.npmjs.com/cli/v9/commands/npm-init#description
  */
 function convertToCreateName (packageName: string) {
-  if (packageName.startsWith('@')) {
+  if (packageName[0] === '@') {
     const preferredVersionPosition = packageName.indexOf('@', 1)
     let preferredVersion = ''
     if (preferredVersionPosition > -1) {

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -141,7 +141,7 @@ ${binNames.map(name => `pnpm --package=${pkgName} dlx ${name}`).join('\n')}
 }
 
 function scopeless (pkgName: string) {
-  if (pkgName.startsWith('@')) {
+  if (pkgName[0] === '@') {
     return pkgName.split('/')[1]
   }
   return pkgName

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -125,7 +125,7 @@ export function parse (dependencyPath: string) {
     host,
     isAbsolute: _isAbsolute,
   }
-  const name = parts[0].startsWith('@')
+  const name = parts[0][0] === '@'
     ? `${parts.shift()}/${parts.shift()}`
     : parts.shift()
   let version = parts.join('/')
@@ -179,7 +179,7 @@ export function depPathToFilename (depPath: string) {
 
 function depPathToFilenameUnescaped (depPath: string) {
   if (depPath.indexOf('file:') !== 0) {
-    if (depPath.startsWith('/')) {
+    if (depPath[0] === '/') {
       depPath = depPath.substring(1)
     }
     const index = depPath.lastIndexOf('/', depPath.includes('(') ? depPath.indexOf('(') - 1 : depPath.length)

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -135,7 +135,7 @@ async function diffFolders (folderA: string, folderB: string) {
 }
 
 function removeTrailingAndLeadingSlash (p: string) {
-  if (p.startsWith('/') || p.endsWith('/')) {
+  if (p[0] === '/' || p.endsWith('/')) {
     return p.replace(/^\/|\/$/g, '')
   }
   return p

--- a/pkg-manager/package-bins/src/index.ts
+++ b/pkg-manager/package-bins/src/index.ts
@@ -42,7 +42,7 @@ function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string) {
   if (typeof bin === 'string') {
     return [
       {
-        name: pkgName.startsWith('@') ? pkgName.slice(pkgName.indexOf('/') + 1) : pkgName,
+        name: pkgName[0] === '@' ? pkgName.slice(pkgName.indexOf('/') + 1) : pkgName,
         path: path.join(pkgPath, bin),
       },
     ]

--- a/pkg-manager/plugin-commands-installation/src/getOptionsFromRootManifest.ts
+++ b/pkg-manager/plugin-commands-installation/src/getOptionsFromRootManifest.ts
@@ -57,7 +57,7 @@ function createVersionReferencesReplacer (manifest: ProjectManifest) {
 }
 
 function replaceVersionReferences (dep: Record<string, string>, spec: string) {
-  if (!spec.startsWith('$')) return spec
+  if (!(spec[0] === '$')) return spec
   const dependencyName = spec.slice(1)
   const newSpec = dep[dependencyName]
   if (newSpec) return newSpec

--- a/workspace/filter-workspace-packages/src/index.ts
+++ b/workspace/filter-workspace-packages/src/index.ts
@@ -315,7 +315,7 @@ function matchPackages<T> (
 ): string[] {
   const match = createMatcher(pattern)
   const matches = Object.keys(graph).filter((id) => graph[id].package.manifest.name && match(graph[id].package.manifest.name!))
-  if (matches.length === 0 && !pattern.startsWith('@') && !pattern.includes('/')) {
+  if (matches.length === 0 && !(pattern[0] === '@') && !pattern.includes('/')) {
     const scopedMatches = matchPackages(graph, `@*/${pattern}`)
     return scopedMatches.length !== 1 ? [] : scopedMatches
   }


### PR DESCRIPTION

`===` should be faster according to [startsWith source](https://github.com/zloirock/core-js/blob/446aa802ebc37831c14c5f18be17d01189374bd5/packages/core-js/modules/es.string.starts-with.js#L26-L36) in theory

[perf test](https://perf.link/#eyJpZCI6InFmNmVhMmwzMTNnIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSAnYWFhJyIsInRlc3RzIjpbeyJuYW1lIjoiVGVzdCBDYXNlIiwiY29kZSI6ImRhdGEuc3RhcnRzV2l0aCgnYicpIiwicnVucyI6WzM5MzAwMCwxNDI2MDAwLDkwMDAsMjQ1NjAwMCwzNjUyMDAwLDQ1MDQwMDAsNDgzNjAwMCwxODA4MDAwLDMwNDEwMDAsMjE5MjAwMCw0NTU4MDAwLDIyMjgwMDAsMjY0NzAwMCw0MzEwMDAwLDI1MzcwMDAsMTg5NTAwMCw1Mzc5MDAwLDQ5NTMwMDAsMzMyNjAwMCw1MjE5MDAwLDQ4NzIwMDAsMzEwMzAwMCwxNjQ2MDAwLDQwMzcwMDAsNDYwMDAwMCwzNjUxMDAwLDI1MTkwMDAsMTM2OTAwMCw1MjM1MDAwLDIzNTAwMDAsNDc1NDAwMCw1NDI4MDAwLDI3MDAwMDAsNDc0MjAwMCw4MzgzMDAwLDQyMDQwMDAsNDYwMjAwMCwyNjczMDAwLDU1NjAwMCwyNzUyMDAwLDIxNDUwMDAsNTM1MzAwMCw0NDExMDAwLDM1NDAwMDAsNTA0MjAwMCw1NDI4MDAwLDIxODQwMDAsNDA4MjAwMCw1ODcwMDAsMzMxOTAwMCw1MzgxMDAwLDQ1MDcwMDAsMzIwMzAwMCwxODQzMDAwLDIxMTYwMDAsMjkxNjAwMCwyMTM4MDAwLDIxMjAwMDAsMzM2ODAwMCw0MjM4MDAwLDYzMDAwMCwxNDAyMDAwLDQ2MTcwMDAsNjk0MDAwLDQ4MDUwMDAsNjY2OTAwMCwyNjg3MDAwLDI2MjkwMDAsMzcyNzAwMCw1MDE5MDAwLDMzMDIwMDAsNTE1MzAwMCw0MjYwMDAwLDgxNzUwMDAsNDU4OTAwMCw2ODA5MDAwLDQxMjUwMDAsMzAzNDAwMCw1MjEzMDAwLDQ5MjYwMDAsMTQwNTAwMCwzODc0MDAwLDE4NzAwMDAsMzc2MjAwMCwzOTY1MDAwLDM4MzAwMCw0NTUxMDAwLDMzNjcwMDAsMjY3NDAwMCwyOTg3MDAwLDQzODcwMDAsMzgxMjAwMCw1MTEyMDAwLDY3NjcwMDAsMzQyODAwMCwyNjk3MDAwLDQxMTYwMDAsNDI0NzAwMCw3NjE2MDAwLDE1MzEwMDBdLCJvcHMiOjM1ODQ4MjB9LHsibmFtZSI6IlRlc3QgQ2FzZSIsImNvZGUiOiJkYXRhWzBdID09PSAnYiciLCJydW5zIjpbMTM3MzAwMCw0NDY4MDAwLDMxNDIwMDAsMTA5NDAwMCwyNDc3MDAwLDMxMjgwMDAsMTQ1ODAwMCw0OTAzMDAwLDg1NTEwMDAsMjA0MDAwMCwxMzMzMDAwLDg5NDAwMCw1NzczMDAwLDIyMTYwMDAsODYyMDAwLDkxODkwMDAsMjE4NTAwMCw2MTE2MDAwLDc3MDcwMDAsMzI0NTAwMCwzOTg0MDAwLDM2ODAwMCw3NDQ0MDAwLDcwMTAwMCw3NzI2MDAwLDExMTMwMDAsODk2ODAwMCw5NDc1MDAwLDMwMzUwMDAsNzgwNTAwMCwzNjIyMDAwLDg0NTgwMDAsODk3MjAwMCw0MjQ0MDAwLDUxODEwMDAsOTAxOTAwMCwyODA5MDAwLDg1MjAwMDAsODc0MDAwLDQ3MDAwLDkxOTMwMDAsNjQwNTAwMCw0MTQ2MDAwLDIxNDgwMDAsMTA3MjAwMCw0MDQ2MDAwLDg1NTgwMDAsMTc0ODAwMCwyMjYzMDAwLDI3NzQwMDAsMjUyNzAwMCwxMzMwMDAsOTM0NjAwMCwyMjUwMDAsODEyMDAwMCw1NzczMDAwLDg0NzIwMDAsMzQxNTAwMCw4MjIwMDAwLDIxNzIwMDAsMjcyMDAwLDc1NzEwMDAsNjIzOTAwMCw5NzQ4MDAwLDIxNjkwMDAsMzMyNTAwMCw5NzAwMCw0MDAwMDAsMzc2MDAwLDMwOTcwMDAsNDcwMDAsMTgzOTAwMCwxOTQ3MDAwLDQ2MzkwMDAsMTUzODAwMCwzNTMwMDAwLDMyOTcwMDAsNjIzNDAwMCw0MDc5MDAwLDE4MzkwMDAsODYwMzAwMCwyMjMxMDAwLDI4MTAwMCwxNTc4MDAwLDEwNjEwMDAsODcwNjAwMCwyMzA4MDAwLDE1NjQwMDAsNzA1MDAwLDk1NjEwMDAsMjMzMzAwMCwyMDk5MDAwLDE4NTkwMDAsNTIxNDAwMCw2MzgwMDAsOTIxNDAwMCwxNjg0MDAwLDgwMzAwMCw1OTgxMDAwLDg0MzIwMDBdLCJvcHMiOjQwMjQxMzB9XSwidXBkYXRlZCI6IjIwMjMtMDMtMjJUMDY6MzA6MzUuMDQ1WiJ9) data[0] === 'x' wins most of the time