### PR TITLE
fix: honor never/only-built-dependencies in workspace setup

### DIFF
--- a/.changeset/modern-crabs-smile.md
+++ b/.changeset/modern-crabs-smile.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/plugin-commands-rebuild": patch
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Use `neverBuiltDependencies` and `onlyBuiltDependencies` from the root `package.json` of the workspace, when `shared-workspace-lockfile` is set to `false` [#7141](https://github.com/pnpm/pnpm/pull/7141).

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -45,6 +45,7 @@
     "write-yaml-file": "^5.0.0"
   },
   "dependencies": {
+    "@pnpm/builder.policy": "1.0.0",
     "@pnpm/calc-dep-state": "workspace:*",
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/common-cli-options-help": "workspace:*",

--- a/exec/plugin-commands-rebuild/src/implementation/extendRebuildOptions.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/extendRebuildOptions.ts
@@ -45,6 +45,8 @@ export interface StrictRebuildOptions {
   pending: boolean
   shamefullyHoist: boolean
   deployAllFiles: boolean
+  neverBuiltDependencies?: string[]
+  onlyBuiltDependencies?: string[]
 }
 
 export type RebuildOptions = Partial<StrictRebuildOptions> &

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -25,6 +25,7 @@ import { logger, streamParser } from '@pnpm/logger'
 import { writeModulesManifest } from '@pnpm/modules-yaml'
 import { createOrConnectStoreController } from '@pnpm/store-connection-manager'
 import { type ProjectManifest } from '@pnpm/types'
+import { createAllowBuildFunction } from '@pnpm/builder.policy'
 import * as dp from '@pnpm/dependency-path'
 import { hardLinkDir } from '@pnpm/fs.hard-link-dir'
 import loadJsonFile from 'load-json-file'
@@ -283,15 +284,7 @@ async function _rebuild (
     logger.info({ message, prefix: opts.dir })
   }
 
-  const allowBuild = (pkgName: string) => {
-    if (opts.onlyBuiltDependencies) {
-      return opts.onlyBuiltDependencies.includes(pkgName)
-    } else if (opts.neverBuiltDependencies) {
-      return !opts.neverBuiltDependencies.includes(pkgName)
-    } else {
-      return true
-    }
-  }
+  const allowBuild = createAllowBuildFunction(opts) ?? (() => true)
 
   const groups = chunks.map((chunk) => chunk.filter((depPath) => ctx.pkgsToRebuild.has(depPath) && !ctx.skipped.has(depPath)).map((depPath) =>
     async () => {

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -282,6 +282,17 @@ async function _rebuild (
   const warn = (message: string) => {
     logger.info({ message, prefix: opts.dir })
   }
+
+  const allowBuild = (pkgName: string) => {
+    if (opts.onlyBuiltDependencies) {
+      return opts.onlyBuiltDependencies.includes(pkgName)
+    } else if (opts.neverBuiltDependencies) {
+      return !opts.neverBuiltDependencies.includes(pkgName)
+    } else {
+      return true
+    }
+  }
+
   const groups = chunks.map((chunk) => chunk.filter((depPath) => ctx.pkgsToRebuild.has(depPath) && !ctx.skipped.has(depPath)).map((depPath) =>
     async () => {
       const pkgSnapshot = pkgSnapshots[depPath]
@@ -318,7 +329,8 @@ async function _rebuild (
             return
           }
         }
-        const hasSideEffects = await runPostinstallHooks({
+
+        const hasSideEffects = allowBuild(pkgInfo.name) && await runPostinstallHooks({
           depPath,
           extraBinPaths,
           extraEnv: opts.extraEnv,

--- a/exec/plugin-commands-rebuild/src/rebuild.ts
+++ b/exec/plugin-commands-rebuild/src/rebuild.ts
@@ -94,6 +94,8 @@ export async function handler (
     reporter?: (logObj: LogBase) => void
     pending: boolean
     skipIfHasSideEffectsCache?: boolean
+    neverBuiltDependencies?: string[]
+    onlyBuiltDependencies?: string[]
   },
   params: string[]
 ) {

--- a/exec/plugin-commands-rebuild/test/index.ts
+++ b/exec/plugin-commands-rebuild/test/index.ts
@@ -375,3 +375,44 @@ test(`rebuild should not fail on incomplete ${WANTED_LOCKFILE}`, async () => {
     storeDir,
   }, [])
 })
+
+test('never build neverBuiltDependencies', async () => {
+  const project = prepare()
+  const cacheDir = path.resolve('cache')
+  const storeDir = path.resolve('store')
+
+  await execa('node', [
+    pnpmBin,
+    'add',
+    '@pnpm.e2e/install-script-example@1.0.0',
+    '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0',
+    `--registry=${REGISTRY}`,
+    `--store-dir=${storeDir}`,
+    `--cache-dir=${cacheDir}`,
+  ])
+
+  const modulesManifest = await project.readModulesManifest()
+  await rebuild.handler(
+    {
+      ...DEFAULT_OPTS,
+      neverBuiltDependencies: ['@pnpm.e2e/pre-and-postinstall-scripts-example'],
+      cacheDir,
+      dir: process.cwd(),
+      pending: false,
+      registries: modulesManifest!.registries!,
+      storeDir,
+    },
+    []
+  )
+
+  expect(
+    await exists(
+      'node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-prepare.js'
+    )
+  ).toBeFalsy()
+  expect(
+    await exists(
+      'node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js'
+    )
+  ).toBeTruthy()
+})

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@pnpm/build-modules": "workspace:*",
+    "@pnpm/builder.policy": "1.0.0",
     "@pnpm/calc-dep-state": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import path from 'path'
 import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/build-modules'
+import { createAllowBuildFunction } from '@pnpm/builder.policy'
 import {
   LAYOUT_VERSION,
   LOCKFILE_VERSION,
@@ -1362,22 +1363,6 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     })),
     stats,
   }
-}
-
-function createAllowBuildFunction (
-  opts: {
-    neverBuiltDependencies?: string[]
-    onlyBuiltDependencies?: string[]
-  }
-): undefined | ((pkgName: string) => boolean) {
-  if (opts.neverBuiltDependencies != null && opts.neverBuiltDependencies.length > 0) {
-    const neverBuiltDependencies = new Set(opts.neverBuiltDependencies)
-    return (pkgName) => !neverBuiltDependencies.has(pkgName)
-  } else if (opts.onlyBuiltDependencies != null) {
-    const onlyBuiltDependencies = new Set(opts.onlyBuiltDependencies)
-    return (pkgName) => onlyBuiltDependencies.has(pkgName)
-  }
-  return undefined
 }
 
 const installInContext: InstallFunction = async (projects, ctx, opts) => {

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -165,7 +165,7 @@ export async function handler (
   const manifest = await readProjectManifestOnly(opts.dir)
   const installOpts = {
     ...opts,
-    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
+    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
     lockfileOnly: true,
     preferredVersions,
     storeController: store.ctrl,

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -99,6 +99,7 @@ export type ImportCommandOptions = Pick<Config,
 | 'workspaceDir'
 | 'ignoreWorkspaceCycles'
 | 'sharedWorkspaceLockfile'
+| 'rootProjectManifest'
 > & CreateStoreControllerOptions & Omit<InstallOptions, 'storeController' | 'lockfileOnly' | 'preferredVersions'>
 
 export async function handler (
@@ -164,7 +165,7 @@ export async function handler (
   const manifest = await readProjectManifestOnly(opts.dir)
   const installOpts = {
     ...opts,
-    ...getOptionsFromRootManifest(manifest),
+    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
     lockfileOnly: true,
     preferredVersions,
     storeController: store.ctrl,

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -165,7 +165,7 @@ export async function handler (
   const manifest = await readProjectManifestOnly(opts.dir)
   const installOpts = {
     ...opts,
-    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
+    ...getOptionsFromRootManifest({ ...opts.rootProjectManifest, ...manifest }),
     lockfileOnly: true,
     preferredVersions,
     storeController: store.ctrl,

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -214,7 +214,7 @@ when running add/update with the --workspace option')
   const store = await createOrConnectStoreController(opts)
   const installOpts: Omit<MutateModulesOptions, 'allProjects'> = {
     ...opts,
-    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
+    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
     forceHoistPattern,
     forcePublicHoistPattern,
     // In case installation is done in a multi-package repository

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -215,7 +215,7 @@ when running add/update with the --workspace option')
   const store = await createOrConnectStoreController(opts)
   const installOpts: Omit<MutateModulesOptions, 'allProjects'> = {
     ...opts,
-    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
+    ...getOptionsFromRootManifest({ ...opts.rootProjectManifest, ...manifest }),
     forceHoistPattern,
     forcePublicHoistPattern,
     // In case installation is done in a multi-package repository

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -58,6 +58,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'production'
 | 'rawLocalConfig'
 | 'registries'
+| 'rootProjectManifest'
 | 'save'
 | 'saveDev'
 | 'saveExact'
@@ -213,7 +214,7 @@ when running add/update with the --workspace option')
   const store = await createOrConnectStoreController(opts)
   const installOpts: Omit<MutateModulesOptions, 'allProjects'> = {
     ...opts,
-    ...getOptionsFromRootManifest(manifest),
+    ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
     forceHoistPattern,
     forcePublicHoistPattern,
     // In case installation is done in a multi-package repository

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -182,6 +182,7 @@ when running add/update with the --workspace option')
         params,
         {
           ...opts,
+          ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
           forceHoistPattern,
           forcePublicHoistPattern,
           allProjectsGraph,

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -364,7 +364,7 @@ export async function recursive (
           {
             ...installOpts,
             ...localConfig,
-            ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
+            ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,
             hooks,

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -413,6 +413,7 @@ export async function recursive (
   ) {
     await rebuild.handler({
       ...opts,
+      ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
       pending: opts.pending === true,
       skipIfHasSideEffectsCache: true,
     }, [])

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -58,6 +58,7 @@ type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'pnpmfile'
 | 'rawLocalConfig'
 | 'registries'
+| 'rootProjectManifest'
 | 'save'
 | 'saveDev'
 | 'saveExact'
@@ -363,7 +364,7 @@ export async function recursive (
           {
             ...installOpts,
             ...localConfig,
-            ...getOptionsFromRootManifest(manifest),
+            ...getOptionsFromRootManifest(opts.rootProjectManifest ?? {}),
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,
             hooks,

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -364,7 +364,7 @@ export async function recursive (
           {
             ...installOpts,
             ...localConfig,
-            ...getOptionsFromRootManifest(opts.rootProjectManifest ?? manifest),
+            ...getOptionsFromRootManifest({ ...opts.rootProjectManifest, ...manifest }),
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,
             hooks,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,6 +1158,9 @@ importers:
 
   exec/plugin-commands-rebuild:
     dependencies:
+      '@pnpm/builder.policy':
+        specifier: 1.0.0
+        version: 1.0.0
       '@pnpm/calc-dep-state':
         specifier: workspace:*
         version: link:../../packages/calc-dep-state
@@ -2862,6 +2865,9 @@ importers:
       '@pnpm/build-modules':
         specifier: workspace:*
         version: link:../../exec/build-modules
+      '@pnpm/builder.policy':
+        specifier: 1.0.0
+        version: 1.0.0
       '@pnpm/calc-dep-state':
         specifier: workspace:*
         version: link:../../packages/calc-dep-state
@@ -7732,6 +7738,11 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@pnpm/builder.policy@1.0.0:
+    resolution: {integrity: sha512-0BhTu6nZ5DzIjJzuTJWOVbd1cN+0wu8k1aXXSawT+/i9Biq/3vuzqnxiTSt5e7IStZ01n59GTMvCoZ/VRAYQiA==}
+    engines: {node: '>=12.22.0'}
+    dev: false
 
   /@pnpm/byline@1.0.0:
     resolution: {integrity: sha512-61tmh+k7hnKK6b2XbF4GvxmiaF3l2a+xQlZyeoOGBs7mXU3Ie8iCAeAnM0+r70KiqTrgWvBCjMeM+W3JarJqaQ==}


### PR DESCRIPTION
Fix #7135 #5407

In the current implementation there are 2 bugs that prevent `pnpm.neverBuiltDependencies` and `pnpm.onlyBuiltDependencies` to work under a workspace that doesn't share a single lockfile

1. The argument passed to some `getOptionsFromRootManifest` calls are wrong. They were incorrectly passed the project manifest instead of the intended root project manifest.
2. Both `neverBuiltDependencies` and `onlyBuiltDependencies` settings are not implemented in the recursive logic.

This PR provides a fix to the bugs above.