### PR TITLE
feat(graph-sequencer): add package @pnpm/graph-sequencer

### DIFF
--- a/.changeset/proud-oranges-talk.md
+++ b/.changeset/proud-oranges-talk.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/plugin-commands-rebuild": minor
+"@pnpm/deps.graph-sequencer": major
+"@pnpm/sort-packages": minor
+"@pnpm/build-modules": minor
+"@pnpm/core": minor
+"@pnpm-private/typings": minor
+---
+
+add package @pnpm/deps.graph-sequencer for better topological sort

--- a/.changeset/proud-oranges-talk.md
+++ b/.changeset/proud-oranges-talk.md
@@ -1,10 +1,10 @@
 ---
-"@pnpm/plugin-commands-rebuild": minor
+"@pnpm/plugin-commands-rebuild": patch
 "@pnpm/deps.graph-sequencer": major
-"@pnpm/sort-packages": minor
-"@pnpm/build-modules": minor
-"@pnpm/core": minor
-"@pnpm-private/typings": minor
+"@pnpm/sort-packages": patch
+"@pnpm/build-modules": patch
+"@pnpm/core": patch
+"@pnpm-private/typings": patch
 ---
 
-add package @pnpm/deps.graph-sequencer for better topological sort
+Add package @pnpm/deps.graph-sequencer for better topological sort [#7168](https://github.com/pnpm/pnpm/pull/7168).

--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -79,29 +79,6 @@ declare module 'graceful-git' {
   export = anything
 }
 
-declare module '@pnpm/graph-sequencer' {
-  namespace graphSequencer {
-    type Graph<T> = Map<T, T[]>
-    type Groups<T> = T[][]
-
-    interface Options<T> {
-      graph: Graph<T>
-      groups: Groups<T>
-    }
-
-    interface Result<T> {
-      safe: boolean
-      chunks: Groups<T>
-      cycles: Groups<T>
-    }
-
-    type GraphSequencer = <T>(opts: Options<T>) => Result<T>
-  }
-
-  const graphSequencer: graphSequencer.GraphSequencer
-  export = graphSequencer
-}
-
 declare module 'is-inner-link' {
   const anything: any
   export = anything

--- a/deps/graph-sequencer/README.md
+++ b/deps/graph-sequencer/README.md
@@ -1,0 +1,34 @@
+# @pnpm/deps.graph-sequencer
+
+> graph-sequencer
+
+[![npm version](https://img.shields.io/npm/v/@pnpm/deps.graph-sequencer.svg)](https://www.npmjs.com/package/@pnpm/deps.graph-sequencer)
+
+## Installation
+
+```sh
+pnpm add @pnpm/deps.graph-sequencer
+```
+
+
+## Usage
+
+```ts
+  expect(graphSequencer(new Map([
+    [0, [1]],
+    [1, [2]],
+    [2, [3]],
+    [3, [0]],
+  ]), [0, 1, 2, 3])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [[0, 1, 2, 3]],
+      cycles: [[0, 1, 2, 3]],
+    }
+  )
+```
+
+
+## License
+
+MIT

--- a/deps/graph-sequencer/README.md
+++ b/deps/graph-sequencer/README.md
@@ -27,4 +27,4 @@ pnpm add @pnpm/deps.graph-sequencer
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/deps/graph-sequencer/README.md
+++ b/deps/graph-sequencer/README.md
@@ -1,15 +1,12 @@
 # @pnpm/deps.graph-sequencer
 
-> graph-sequencer
+> Sort items in a graph using a topological sort
 
-[![npm version](https://img.shields.io/npm/v/@pnpm/deps.graph-sequencer.svg)](https://www.npmjs.com/package/@pnpm/deps.graph-sequencer)
+## Install
 
-## Installation
-
-```sh
+```
 pnpm add @pnpm/deps.graph-sequencer
 ```
-
 
 ## Usage
 
@@ -27,7 +24,6 @@ pnpm add @pnpm/deps.graph-sequencer
     }
   )
 ```
-
 
 ## License
 

--- a/deps/graph-sequencer/jest.config.js
+++ b/deps/graph-sequencer/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/deps/graph-sequencer/package.json
+++ b/deps/graph-sequencer/package.json
@@ -21,7 +21,8 @@
   "repository": "https://github.com/pnpm/pnpm/blob/main/deps/graph-sequencer",
   "keywords": [
     "pnpm8",
-    "pnpm"
+    "pnpm",
+    "graph"
   ],
   "license": "MIT",
   "bugs": {

--- a/deps/graph-sequencer/package.json
+++ b/deps/graph-sequencer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@pnpm/sort-packages",
-  "version": "5.0.5",
-  "description": "Sort packages",
+  "name": "@pnpm/deps.graph-sequencer",
+  "version": "0.0.0",
+  "description": "Sort items in a graph using a topological sort",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
@@ -12,12 +12,13 @@
     "node": ">=16.14"
   },
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pnpm run compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "_test": "jest",
+    "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },
-  "repository": "https://github.com/pnpm/pnpm/blob/main/workspace/sort-packages",
+  "repository": "https://github.com/pnpm/pnpm/blob/main/deps/graph-sequencer",
   "keywords": [
     "pnpm8",
     "pnpm"
@@ -26,14 +27,12 @@
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },
-  "homepage": "https://github.com/pnpm/pnpm/blob/main/workspace/sort-packages#readme",
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/deps/graph-sequencer#readme",
   "dependencies": {
-    "@pnpm/deps.graph-sequencer": "workspace:*",
-    "@pnpm/types": "workspace:*"
-  },
+    },
   "funding": "https://opencollective.com/pnpm",
   "devDependencies": {
-    "@pnpm/sort-packages": "workspace:*"
+    "@pnpm/deps.graph-sequencer": "workspace:*"
   },
   "exports": {
     ".": "./lib/index.js"

--- a/deps/graph-sequencer/src/index.ts
+++ b/deps/graph-sequencer/src/index.ts
@@ -1,0 +1,118 @@
+export type Graph<T> = Map<T, T[]>
+export type Groups<T> = T[][]
+
+export interface Options<T> {
+  graph: Graph<T>
+  groups: Groups<T>
+}
+
+export interface Result<T> {
+  safe: boolean
+  chunks: Groups<T>
+  cycles: Groups<T>
+}
+
+/**
+ * Performs topological sorting on a graph while supporting node restrictions.
+ *
+ * @param {Graph<T>}  graph - The graph represented as a Map where keys are nodes and values are their outgoing edges.
+ * @param {T[]} includedNodes - An array of nodes that should be included in the sorting process. Other nodes will be ignored.
+ * @returns {Result<T>} An object containing the result of the sorting, including safe, chunks, and cycles.
+ */
+export function graphSequencer<T> (graph: Graph<T>, includedNodes: T[] = [...graph.keys()]): Result<T> {
+  const cycles: T[][] = []
+  const chunks: T[][] = []
+  const visited = new Set<T>()
+  const nodes = new Set<T>(includedNodes)
+  const outDegree = new Map<T, number>()
+  const reverseGraph = new Map<T, T[]>()
+  let safe = true
+  // Function to update the outDegree of a node.
+  const changeDegree = (node: T, v: number) => {
+    const degree = outDegree.get(node) ?? 0
+    outDegree.set(node, degree + v)
+  }
+
+  // Initialize reverseGraph with empty arrays for all nodes.
+  for (const key of graph.keys()) {
+    reverseGraph.set(key, [])
+  }
+
+  // Calculate outDegree and reverseGraph for the included nodes.
+  for (const [from, edges] of graph.entries()) {
+    outDegree.set(from, 0)
+    for (const to of edges) {
+      if (nodes.has(from) && nodes.has(to)) {
+        changeDegree(from, 1)
+        const reverseEdges = reverseGraph.get(to)!
+        reverseGraph.set(to, [...reverseEdges, from])
+      }
+    }
+
+    if (!nodes.has(from)) {
+      visited.add(from)
+    }
+  }
+
+  // Function to remove a node from the graph.
+  const removeNode = (node: T) => {
+    for (const from of reverseGraph.get(node)!) {
+      changeDegree(from, -1)
+    }
+    visited.add(node)
+    nodes.delete(node)
+  }
+
+  const findCycle = (startNode: T): T[] => {
+    const queue: Array<[T, T[]]> = [[startNode, [startNode]]]
+    const cycleVisited = new Set<T>()
+    while (queue.length) {
+      const [id, cycle] = queue.shift()!
+      for (const to of graph.get(id)!) {
+        if (to === startNode) {
+          return cycle
+        }
+        if (visited.has(to) || cycleVisited.has(to)) {
+          continue
+        }
+        cycleVisited.add(to)
+        queue.push([to, [...cycle, to]])
+      }
+    }
+    return []
+  }
+
+  while (nodes.size) {
+    const chunk: T[] = []
+    let minDegree = Number.MAX_SAFE_INTEGER
+    for (const node of nodes) {
+      const degree = outDegree.get(node)!
+      if (degree === 0) {
+        chunk.push(node)
+      }
+      minDegree = Math.min(minDegree, degree)
+    }
+
+    if (minDegree === 0) {
+      chunk.forEach(removeNode)
+      chunks.push(chunk)
+    } else {
+      let cycleNodes: T[] = []
+      for (const node of nodes) {
+        const cycle = findCycle(node)
+        if (cycle.length) {
+          cycles.push(cycle)
+          cycle.forEach(removeNode)
+          cycleNodes = cycleNodes.concat(cycle)
+
+          if (cycle.length > 1) {
+            safe = false
+          }
+        }
+      }
+      chunks.push(cycleNodes)
+    }
+  }
+
+  return { safe, chunks, cycles }
+}

--- a/deps/graph-sequencer/test/index.ts
+++ b/deps/graph-sequencer/test/index.ts
@@ -1,6 +1,6 @@
 import { graphSequencer } from '../src'
 
-test('graph with three independent self cycles', () => {
+test('graph with three independent self-cycles', () => {
   expect(graphSequencer(new Map([
     ['a', ['a']],
     ['b', ['b']],
@@ -17,7 +17,22 @@ test('graph with three independent self cycles', () => {
   )
 })
 
-test('graph with two self cycles and an edge linking them', () => {
+test('graph with self-cycle. Sequencing a subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['a']],
+    ['b', ['b']],
+    ['c', ['c']],
+
+  ]), ['a', 'b'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b']],
+      cycles: [['a'], ['b']],
+    }
+  )
+})
+
+test('graph with two self-cycles and an edge linking them', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c']],
     ['b', ['b']],
@@ -191,7 +206,7 @@ test('graph with two cycles', () => {
   )
 })
 
-test('graph with multiple cycles', () => {
+test('graph with multiple cycles. case 1', () => {
   expect(graphSequencer(new Map([
     ['a', ['c']],
     ['b', ['a', 'd']],
@@ -207,7 +222,7 @@ test('graph with multiple cycles', () => {
   )
 })
 
-test('graph with multiple cycles', () => {
+test('graph with multiple cycles. case 2', () => {
   expect(graphSequencer(new Map([
     ['a', ['b']],
     ['b', ['d']],
@@ -241,7 +256,7 @@ test('graph with fully connected subgraph and additional connected node', () => 
   )
 })
 
-test('graph with fully connected subgraph', () => {
+test('graph with fully connected subgraph. case 1', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c', 'd']],
     ['b', ['a', 'c', 'd']],
@@ -257,7 +272,7 @@ test('graph with fully connected subgraph', () => {
   )
 })
 
-test('graph with fully conn subgraph', () => {
+test('graph with fully connected subgraph. case 2', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c', 'd']],
     ['b', ['a', 'c', 'd']],
@@ -273,37 +288,7 @@ test('graph with fully conn subgraph', () => {
   )
 })
 
-test('graph with self-cycle', () => {
-  expect(graphSequencer(new Map([
-    ['a', ['a']],
-    ['b', ['b']],
-    ['c', ['c']],
-
-  ]))).toStrictEqual(
-    {
-      safe: true,
-      chunks: [['a', 'b', 'c']],
-      cycles: [['a'], ['b'], ['c']],
-    }
-  )
-})
-
-test('graph with self cycle subgraph', () => {
-  expect(graphSequencer(new Map([
-    ['a', ['a']],
-    ['b', ['b']],
-    ['c', ['c']],
-
-  ]), ['a', 'b'])).toStrictEqual(
-    {
-      safe: true,
-      chunks: [['a', 'b']],
-      cycles: [['a'], ['b']],
-    }
-  )
-})
-
-test('graph with two self cycle', () => {
+test('graph with two self-cycles', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c']],
     ['b', ['b']],
@@ -318,7 +303,7 @@ test('graph with two self cycle', () => {
   )
 })
 
-test('graph with two self cycle subgraph', () => {
+test('graph with two self-cycles. Sequencing a subgraph', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c']],
     ['b', ['b']],
@@ -349,7 +334,7 @@ test('graph with many nodes', () => {
   )
 })
 
-test('graph with many nodes and need subgraph', () => {
+test('graph with many nodes. Sequencing a subgraph', () => {
   expect(graphSequencer(new Map([
     ['a', ['b', 'c']],
     ['b', []],

--- a/deps/graph-sequencer/test/index.ts
+++ b/deps/graph-sequencer/test/index.ts
@@ -6,7 +6,7 @@ test('graph with three independent self cycles', () => {
     ['b', ['b']],
     ['c', ['c']],
   ]
-  ), ['a', 'b', 'c'])).toStrictEqual(
+  ))).toStrictEqual(
     {
       safe: true,
       chunks: [['a', 'b', 'c']],
@@ -22,7 +22,7 @@ test('graph with two self cycles and an edge linking them', () => {
     ['a', ['b', 'c']],
     ['b', ['b']],
     ['c', ['b', 'c']]]
-  ), ['a', 'b', 'c'])).toStrictEqual(
+  ))).toStrictEqual(
     {
       safe: true,
       chunks: [['b', 'c'], ['a']],
@@ -38,7 +38,7 @@ test('graph with nodes connected to each other sequentially without forming a cy
     ['a', ['b', 'c']],
     ['b', []],
     ['c', ['b']]]
-  ), ['a', 'b', 'c'])).toStrictEqual(
+  ))).toStrictEqual(
     {
       safe: true,
       chunks: [['b'], ['c'], ['a']],
@@ -69,7 +69,7 @@ test('graph with no edges', () => {
     ['b', []],
     ['c', []],
     ['d', []],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: true,
       chunks: [['a', 'b', 'c', 'd']],
@@ -99,7 +99,7 @@ test('graph with multiple dependencies on one item', () => {
     ['b', ['d']],
     ['c', []],
     ['d', []],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: true,
       chunks: [['c', 'd'], ['a', 'b']],
@@ -114,7 +114,7 @@ test('graph with resolved cycle', () => {
     ['b', ['c']],
     ['c', ['d']],
     ['d', ['a']],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [['a', 'b', 'c', 'd']],
@@ -144,7 +144,7 @@ test('graph with resolved cycle with multiple unblocked deps', () => {
     ['b', ['d']],
     ['c', ['d']],
     ['d', ['a']],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [
@@ -179,7 +179,7 @@ test('graph with two cycles', () => {
     ['b', ['a']],
     ['c', ['d']],
     ['d', ['c']],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [['a', 'b', 'c', 'd']],
@@ -198,7 +198,7 @@ test('graph with multiple cycles', () => {
     ['c', ['b']],
     ['d', ['c', 'e']],
     ['e', []],
-  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [['e'], ['a', 'c', 'b'], ['d']],
@@ -213,7 +213,7 @@ test('graph with multiple cycles', () => {
     ['b', ['d']],
     ['c', []],
     ['d', ['b', 'c']],
-  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [['c'], ['b', 'd'], ['a']],
@@ -229,7 +229,7 @@ test('graph with fully connected subgraph and additional connected node', () => 
     ['c', ['a', 'b', 'd']],
     ['d', ['a', 'b', 'c']],
     ['e', ['b']],
-  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: false,
       chunks: [['a', 'b', 'c', 'd'], ['e']],
@@ -279,7 +279,7 @@ test('graph with self-cycle', () => {
     ['b', ['b']],
     ['c', ['c']],
 
-  ]), ['a', 'b', 'c'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: true,
       chunks: [['a', 'b', 'c']],
@@ -309,7 +309,7 @@ test('graph with two self cycle', () => {
     ['b', ['b']],
     ['c', ['c']],
 
-  ]), ['a', 'b', 'c'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: true,
       chunks: [['b', 'c'], ['a']],
@@ -340,7 +340,7 @@ test('graph with many nodes', () => {
     ['c', []],
     ['d', ['a']],
     ['e', ['a', 'b', 'c']],
-  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+  ]))).toStrictEqual(
     {
       safe: true,
       chunks: [['b', 'c'], ['a'], ['d', 'e']],

--- a/deps/graph-sequencer/test/index.ts
+++ b/deps/graph-sequencer/test/index.ts
@@ -1,0 +1,366 @@
+import { graphSequencer } from '../src'
+
+test('graph with three independent self cycles', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['a']],
+    ['b', ['b']],
+    ['c', ['c']],
+  ]
+  ), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b', 'c']],
+      cycles: [
+        ['a'], ['b'], ['c'],
+      ],
+    }
+  )
+})
+
+test('graph with two self cycles and an edge linking them', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', ['b']],
+    ['c', ['b', 'c']]]
+  ), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b', 'c'], ['a']],
+      cycles: [
+        ['b'], ['c'],
+      ],
+    }
+  )
+})
+
+test('graph with nodes connected to each other sequentially without forming a cycle', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', []],
+    ['c', ['b']]]
+  ), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b'], ['c'], ['a']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph sequencing with a subset of 3 nodes, ignoring 2 nodes, in a 5-node graph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', []],
+    ['c', []],
+    ['d', ['a']],
+    ['e', ['a', 'b', 'c']]]
+  ), ['a', 'd', 'e'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a'], ['d', 'e']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with no edges', () => {
+  expect(graphSequencer(new Map([
+    ['a', []],
+    ['b', []],
+    ['c', []],
+    ['d', []],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b', 'c', 'd']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph of isolated nodes with no edges, sequencing a subgraph of selected nodes', () => {
+  expect(graphSequencer(new Map([
+    ['a', []],
+    ['b', []],
+    ['c', []],
+    ['d', []],
+  ]), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b', 'c']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with multiple dependencies on one item', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['d']],
+    ['b', ['d']],
+    ['c', []],
+    ['d', []],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['c', 'd'], ['a', 'b']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with resolved cycle', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b']],
+    ['b', ['c']],
+    ['c', ['d']],
+    ['d', ['a']],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['a', 'b', 'c', 'd']],
+      cycles: [['a', 'b', 'c', 'd']],
+    }
+  )
+})
+
+test('graph with a cycle, but sequencing a subgraph that avoids the cycle', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b']],
+    ['b', ['c']],
+    ['c', ['d']],
+    ['d', ['a']],
+  ]), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['c'], ['b'], ['a']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with resolved cycle with multiple unblocked deps', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['d']],
+    ['b', ['d']],
+    ['c', ['d']],
+    ['d', ['a']],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [
+        ['a', 'd'],
+        ['b', 'c'],
+      ],
+      cycles: [['a', 'd']],
+    }
+  )
+})
+
+test('graph with resolved cycle with multiple unblocked deps subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['d']],
+    ['b', ['d']],
+    ['c', ['d']],
+    ['d', ['a']],
+  ]), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [
+        ['a', 'b', 'c'],
+      ],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with two cycles', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b']],
+    ['b', ['a']],
+    ['c', ['d']],
+    ['d', ['c']],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['a', 'b', 'c', 'd']],
+      cycles: [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+    }
+  )
+})
+
+test('graph with multiple cycles', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['c']],
+    ['b', ['a', 'd']],
+    ['c', ['b']],
+    ['d', ['c', 'e']],
+    ['e', []],
+  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['e'], ['a', 'c', 'b'], ['d']],
+      cycles: [['a', 'c', 'b']],
+    }
+  )
+})
+
+test('graph with multiple cycles', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b']],
+    ['b', ['d']],
+    ['c', []],
+    ['d', ['b', 'c']],
+  ]), ['a', 'b', 'c', 'd'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['c'], ['b', 'd'], ['a']],
+      cycles: [['b', 'd']],
+    }
+  )
+})
+
+test('graph with fully connected subgraph and additional connected node', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c', 'd']],
+    ['b', ['a', 'c', 'd']],
+    ['c', ['a', 'b', 'd']],
+    ['d', ['a', 'b', 'c']],
+    ['e', ['b']],
+  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['a', 'b', 'c', 'd'], ['e']],
+      cycles: [
+        ['a', 'b'],
+        ['c', 'd'],
+      ],
+    }
+  )
+})
+
+test('graph with fully connected subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c', 'd']],
+    ['b', ['a', 'c', 'd']],
+    ['c', ['a', 'b', 'd']],
+    ['d', ['a', 'b', 'c']],
+    ['e', ['b']],
+  ]), ['b', 'e'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b'], ['e']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with fully conn subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c', 'd']],
+    ['b', ['a', 'c', 'd']],
+    ['c', ['a', 'b', 'd']],
+    ['d', ['a', 'b', 'c']],
+    ['e', ['b']],
+  ]), ['a', 'b', 'e'])).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['a', 'b'], ['e']],
+      cycles: [['a', 'b']],
+    }
+  )
+})
+
+test('graph with self-cycle', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['a']],
+    ['b', ['b']],
+    ['c', ['c']],
+
+  ]), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b', 'c']],
+      cycles: [['a'], ['b'], ['c']],
+    }
+  )
+})
+
+test('graph with self cycle subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['a']],
+    ['b', ['b']],
+    ['c', ['c']],
+
+  ]), ['a', 'b'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a', 'b']],
+      cycles: [['a'], ['b']],
+    }
+  )
+})
+
+test('graph with two self cycle', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', ['b']],
+    ['c', ['c']],
+
+  ]), ['a', 'b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b', 'c'], ['a']],
+      cycles: [['b'], ['c']],
+    }
+  )
+})
+
+test('graph with two self cycle subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', ['b']],
+    ['c', ['c']],
+
+  ]), ['b', 'c'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b', 'c']],
+      cycles: [['b'], ['c']],
+    }
+  )
+})
+
+test('graph with many nodes', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', []],
+    ['c', []],
+    ['d', ['a']],
+    ['e', ['a', 'b', 'c']],
+  ]), ['a', 'b', 'c', 'd', 'e'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['b', 'c'], ['a'], ['d', 'e']],
+      cycles: [],
+    }
+  )
+})
+
+test('graph with many nodes and need subgraph', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b', 'c']],
+    ['b', []],
+    ['c', []],
+    ['d', ['a']],
+    ['e', ['a', 'b', 'c']],
+  ]), ['a', 'd', 'e'])).toStrictEqual(
+    {
+      safe: true,
+      chunks: [['a'], ['d', 'e']],
+      cycles: [],
+    }
+  )
+})

--- a/deps/graph-sequencer/tsconfig.json
+++ b/deps/graph-sequencer/tsconfig.json
@@ -9,12 +9,6 @@
     "../../__typings__/**/*.d.ts"
   ],
   "references": [
-    {
-      "path": "../../deps/graph-sequencer"
-    },
-    {
-      "path": "../../packages/types"
-    }
   ],
   "composite": true
 }

--- a/deps/graph-sequencer/tsconfig.lint.json
+++ b/deps/graph-sequencer/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/exec/build-modules/CHANGELOG.md
+++ b/exec/build-modules/CHANGELOG.md
@@ -169,7 +169,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/graph-sequencer`.
+- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
 - Updated dependencies [64d0f47ff]
   - @pnpm/fs.hard-link-dir@2.0.1
 
@@ -611,7 +611,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
 - Updated dependencies [8fa95fd86]
   - @pnpm/link-bins@7.1.0
   - @pnpm/lifecycle@13.0.1

--- a/exec/build-modules/CHANGELOG.md
+++ b/exec/build-modules/CHANGELOG.md
@@ -169,7 +169,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
+- d43ccc44d: Update `@pnpm/graph-sequencer`.
 - Updated dependencies [64d0f47ff]
   - @pnpm/fs.hard-link-dir@2.0.1
 
@@ -611,7 +611,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
 - Updated dependencies [8fa95fd86]
   - @pnpm/link-bins@7.1.0
   - @pnpm/lifecycle@13.0.1

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -37,7 +37,7 @@
     "@pnpm/calc-dep-state": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/fs.hard-link-dir": "workspace:*",
-    "@pnpm/graph-sequencer": "1.1.1",
+    "@pnpm/deps.graph-sequencer": "workspace:*",
     "@pnpm/lifecycle": "workspace:*",
     "@pnpm/link-bins": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",

--- a/exec/build-modules/src/buildSequence.ts
+++ b/exec/build-modules/src/buildSequence.ts
@@ -1,4 +1,4 @@
-import graphSequencer from '@pnpm/graph-sequencer'
+import { graphSequencer } from '@pnpm/deps.graph-sequencer'
 import { type PackageManifest, type PatchFile } from '@pnpm/types'
 import filter from 'ramda/src/filter'
 
@@ -36,10 +36,7 @@ export function buildSequence (
     nodesToBuildArray
       .map((depPath) => [depPath, onlyFromBuildGraph(Object.values(depGraph[depPath].children))])
   )
-  const graphSequencerResult = graphSequencer({
-    graph,
-    groups: [nodesToBuildArray],
-  })
+  const graphSequencerResult = graphSequencer(graph, nodesToBuildArray)
   const chunks = graphSequencerResult.chunks as string[][]
   return chunks
 }

--- a/exec/build-modules/tsconfig.json
+++ b/exec/build-modules/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../deps/graph-sequencer"
+    },
+    {
       "path": "../../fs/hard-link-dir"
     },
     {

--- a/exec/plugin-commands-rebuild/CHANGELOG.md
+++ b/exec/plugin-commands-rebuild/CHANGELOG.md
@@ -477,7 +477,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
+- d43ccc44d: Update `@pnpm/graph-sequencer`.
 - c0760128d: bump semver to 7.4.0
 - Updated dependencies [64d0f47ff]
 - Updated dependencies [32f8e08c6]
@@ -1776,7 +1776,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
 - Updated dependencies [0a70aedb1]
 - Updated dependencies [8fa95fd86]
 - Updated dependencies [2109f2e8e]

--- a/exec/plugin-commands-rebuild/CHANGELOG.md
+++ b/exec/plugin-commands-rebuild/CHANGELOG.md
@@ -477,7 +477,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/graph-sequencer`.
+- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
 - c0760128d: bump semver to 7.4.0
 - Updated dependencies [64d0f47ff]
 - Updated dependencies [32f8e08c6]
@@ -1776,7 +1776,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
 - Updated dependencies [0a70aedb1]
 - Updated dependencies [8fa95fd86]
 - Updated dependencies [2109f2e8e]

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -56,7 +56,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/fs.hard-link-dir": "workspace:*",
     "@pnpm/get-context": "workspace:*",
-    "@pnpm/graph-sequencer": "1.1.1",
+    "@pnpm/deps.graph-sequencer": "workspace:*",
     "@pnpm/lifecycle": "workspace:*",
     "@pnpm/link-bins": "workspace:*",
     "@pnpm/lockfile-types": "workspace:*",

--- a/exec/plugin-commands-rebuild/src/implementation/index.ts
+++ b/exec/plugin-commands-rebuild/src/implementation/index.ts
@@ -30,7 +30,7 @@ import * as dp from '@pnpm/dependency-path'
 import { hardLinkDir } from '@pnpm/fs.hard-link-dir'
 import loadJsonFile from 'load-json-file'
 import runGroups from 'run-groups'
-import graphSequencer from '@pnpm/graph-sequencer'
+import { graphSequencer } from '@pnpm/deps.graph-sequencer'
 import npa from '@pnpm/npm-package-arg'
 import pLimit from 'p-limit'
 import semver from 'semver'
@@ -275,10 +275,10 @@ async function _rebuild (
       .map(([pkgName, reference]) => dp.refToRelative(reference, pkgName))
       .filter((childRelDepPath) => childRelDepPath && nodesToBuildAndTransitive.has(childRelDepPath)))
   }
-  const graphSequencerResult = graphSequencer({
+  const graphSequencerResult = graphSequencer(
     graph,
-    groups: [nodesToBuildAndTransitiveArray],
-  })
+    nodesToBuildAndTransitiveArray
+  )
   const chunks = graphSequencerResult.chunks as string[][]
   const warn = (message: string) => {
     logger.info({ message, prefix: opts.dir })

--- a/exec/plugin-commands-rebuild/tsconfig.json
+++ b/exec/plugin-commands-rebuild/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../../config/normalize-registries"
     },
     {
+      "path": "../../deps/graph-sequencer"
+    },
+    {
       "path": "../../fs/hard-link-dir"
     },
     {

--- a/pkg-manager/core/CHANGELOG.md
+++ b/pkg-manager/core/CHANGELOG.md
@@ -630,7 +630,7 @@
 ### Patch Changes
 
 - 6706a7d17: Add lockfileCheck option for lockfile only diff installs
-- d43ccc44d: Update `@pnpm/graph-sequencer`.
+- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
 - c0760128d: bump semver to 7.4.0
 - Updated dependencies [8f7e99477]
 - Updated dependencies [d43ccc44d]
@@ -2566,7 +2566,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
 - 88289a42c: peerDependencyRules will no longer cause duplicated peer dependency rules in the lockfile when used in workspaces
 - aecd4acdd: Linked in dependencies should be considered when resolving peer dependencies [#4541](https://github.com/pnpm/pnpm/pull/4541).
 - dbe366990: Peer dependency should be correctly resolved from the workspace, when it is declared using a workspace protocol [#4529](https://github.com/pnpm/pnpm/issues/4529).

--- a/pkg-manager/core/CHANGELOG.md
+++ b/pkg-manager/core/CHANGELOG.md
@@ -630,7 +630,7 @@
 ### Patch Changes
 
 - 6706a7d17: Add lockfileCheck option for lockfile only diff installs
-- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
+- d43ccc44d: Update `@pnpm/graph-sequencer`.
 - c0760128d: bump semver to 7.4.0
 - Updated dependencies [8f7e99477]
 - Updated dependencies [d43ccc44d]
@@ -2566,7 +2566,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
 - 88289a42c: peerDependencyRules will no longer cause duplicated peer dependency rules in the lockfile when used in workspaces
 - aecd4acdd: Linked in dependencies should be considered when resolving peer dependencies [#4541](https://github.com/pnpm/pnpm/pull/4541).
 - dbe366990: Peer dependency should be correctly resolved from the workspace, when it is declared using a workspace protocol [#4529](https://github.com/pnpm/pnpm/issues/4529).

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -26,7 +26,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/filter-lockfile": "workspace:*",
     "@pnpm/get-context": "workspace:*",
-    "@pnpm/graph-sequencer": "1.1.1",
+    "@pnpm/deps.graph-sequencer": "workspace:*",
     "@pnpm/headless": "workspace:*",
     "@pnpm/hoist": "workspace:*",
     "@pnpm/hooks.read-package-hook": "workspace:*",

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../config/normalize-registries"
     },
     {
+      "path": "../../deps/graph-sequencer"
+    },
+    {
       "path": "../../exec/build-modules"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,12 @@ importers:
         specifier: 0.28.20
         version: 0.28.20
 
+  deps/graph-sequencer:
+    devDependencies:
+      '@pnpm/deps.graph-sequencer':
+        specifier: workspace:*
+        version: 'link:'
+
   env/node.fetcher:
     dependencies:
       '@pnpm/create-cafs-store':
@@ -1057,12 +1063,12 @@ importers:
       '@pnpm/core-loggers':
         specifier: workspace:*
         version: link:../../packages/core-loggers
+      '@pnpm/deps.graph-sequencer':
+        specifier: workspace:*
+        version: link:../../deps/graph-sequencer
       '@pnpm/fs.hard-link-dir':
         specifier: workspace:*
         version: link:../../fs/hard-link-dir
-      '@pnpm/graph-sequencer':
-        specifier: 1.1.1
-        version: 1.1.1
       '@pnpm/lifecycle':
         specifier: workspace:*
         version: link:../lifecycle
@@ -1182,6 +1188,9 @@ importers:
       '@pnpm/dependency-path':
         specifier: workspace:*
         version: link:../../packages/dependency-path
+      '@pnpm/deps.graph-sequencer':
+        specifier: workspace:*
+        version: link:../../deps/graph-sequencer
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -1191,9 +1200,6 @@ importers:
       '@pnpm/get-context':
         specifier: workspace:*
         version: link:../../pkg-manager/get-context
-      '@pnpm/graph-sequencer':
-        specifier: 1.1.1
-        version: 1.1.1
       '@pnpm/lifecycle':
         specifier: workspace:*
         version: link:../lifecycle
@@ -2886,6 +2892,9 @@ importers:
       '@pnpm/dependency-path':
         specifier: workspace:*
         version: link:../../packages/dependency-path
+      '@pnpm/deps.graph-sequencer':
+        specifier: workspace:*
+        version: link:../../deps/graph-sequencer
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -2895,9 +2904,6 @@ importers:
       '@pnpm/get-context':
         specifier: workspace:*
         version: link:../get-context
-      '@pnpm/graph-sequencer':
-        specifier: 1.1.1
-        version: 1.1.1
       '@pnpm/headless':
         specifier: workspace:*
         version: link:../headless
@@ -6195,9 +6201,9 @@ importers:
 
   workspace/sort-packages:
     dependencies:
-      '@pnpm/graph-sequencer':
-        specifier: 1.1.1
-        version: 1.1.1
+      '@pnpm/deps.graph-sequencer':
+        specifier: workspace:*
+        version: link:../../deps/graph-sequencer
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -7931,10 +7937,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
     dev: true
-
-  /@pnpm/graph-sequencer@1.1.1:
-    resolution: {integrity: sha512-nlLogZV9i8J2z9vw1cHtKAX8Caj3WeYUw63G1ni2ULLwvb+FfRAhdIfDsuce0gUHdOClF/gsKN+7H28yryNlAw==}
-    dev: false
 
   /@pnpm/hooks.types@1.0.1:
     resolution: {integrity: sha512-Zx2hzwxBKv1RmFzyu4pEVY7QeIGUb54smSSYt8GcJgByn+uMXgwJ7ydv9t2Koc90QTqk8J3P2J+RDrZVIQpVQw==}

--- a/workspace/sort-packages/CHANGELOG.md
+++ b/workspace/sort-packages/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/graph-sequencer`.
+- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
 
 ## 5.0.0
 
@@ -131,7 +131,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
 
 ## 3.0.0
 

--- a/workspace/sort-packages/CHANGELOG.md
+++ b/workspace/sort-packages/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Patch Changes
 
-- d43ccc44d: Update `@pnpm/deps.graph-sequencer`.
+- d43ccc44d: Update `@pnpm/graph-sequencer`.
 
 ## 5.0.0
 
@@ -131,7 +131,7 @@
 
 ### Patch Changes
 
-- 2109f2e8e: Use `@pnpm/deps.graph-sequencer` instead of `graph-sequencer`.
+- 2109f2e8e: Use `@pnpm/graph-sequencer` instead of `graph-sequencer`.
 
 ## 3.0.0
 


### PR DESCRIPTION
## support  Subgraph Sorting for Improved Performance
Faster than https://github.com/jamiebuilds/graph-sequencer
![image](https://github.com/pnpm/pnpm/assets/19884146/a48eb5ce-526a-4fa5-81c1-b95260a7108f)

### Subgraph Sort

In scenarios where we have a large graph but only need to execute commands on a few specific nodes, the `graphSequencer` function now offers enhanced support. The `includeNodes` parameter allows us to limit the result to only the nodes we're interested in.

```javascript
graphSequencer(new Map([
    [0, [1]],
    [1, [2]],
    [2, [3]],
    [3, [0]],
]), [0, 1, 2])
```

For instance, if our graph is a big cycle but our subgraph is a simple linked list, we can now safely execute commands on the selected nodes.

```javascript
{
    safe: true,
    chunks: [[2], [1], [0]],
    cycles: [],
}
```

### Improved Behavior

In the previous behavior of the `graphSequencer` function, there were some peculiarities when handling single-node cycles.

```javascript
graphSequencer({
  graph: new Map([
    ['a', ['a']],
    ['b', ['b']],
    ['c', ['c']],
  ]),
  groups: ['a', 'b', 'c']
})
```

This resulted in issues when dealing with single-node cycles, as demonstrated by the following output:

```javascript
{
  safe: false,
  chunks: [ [ 'a' ], [ 'b' ], [ 'c' ] ],
  cycles: [
    [ 'a' ], [ 'a', 'a' ],
    [ 'b' ], [ 'b', 'b' ],
    [ 'c' ], [ 'c', 'c' ],
    [ 'b' ], [ 'c' ],
    [ 'c' ]
  ]
}
```

Now, with the improved behavior, each single-node cycle is treated independently, ensuring safe parallel execution:

```javascript
{
  safe: true,
  chunks: [ [ 'a', 'b', 'c' ] ],
  cycles: [ [ 'a' ], [ 'b' ], [ 'c' ] ]
}
```
