### PR TITLE
fix(pd): ensure `pd` builds the pnpm worker

### DIFF
--- a/pnpm/dev/pd.js
+++ b/pnpm/dev/pd.js
@@ -37,6 +37,16 @@ const pnpmPackageJson = JSON.parse(fs.readFileSync(pathLib.join(__dirname, 'pack
   }
 
   await esbuild.build({
+    entryPoints: [pathLib.resolve(__dirname, '../../worker/src/worker.ts')],
+    bundle: true,
+    platform: 'node',
+    outfile: pathLib.resolve(__dirname, 'dist/worker.js'),
+    loader: {
+      '.node': 'copy',
+    },
+  })
+
+  await esbuild.build({
     bundle: true,
     platform: 'node',
     target: 'node14',


### PR DESCRIPTION
Trying to develop from a fresh clone of `pnpm`, I noticed that the worker was missing from `./pnpm/pnpm/dev/dist`. This makes it so that esbuild compiles it in addition to the main `pnpm` script.

Without this, `pd install` was failing with:

```
MODULE_NOT_FOUND  Cannot find module '/Users/steven/src/pnpm/pnpm/dev/dist/worker.js'
```
