### PR TITLE
feat: merge manifest `resolutions` and `pnpm.overrides`

### DIFF
--- a/.changeset/twenty-walls-sit.md
+++ b/.changeset/twenty-walls-sit.md
@@ -2,5 +2,4 @@
 "@pnpm/config": major
 ---
 
-Instead of `pnpm.overrides` replacing `resolutions`, the two are now merged. This is intended to make it easier to migrate from Yarn by allowing one to keep
-using `resolutions` for Yarn, but adding additional changes just for pnpm using `pnpm.overrides`.
+Instead of `pnpm.overrides` replacing `resolutions`, the two are now merged. This is intended to make it easier to migrate from Yarn by allowing one to keep using `resolutions` for Yarn, but adding additional changes just for pnpm using `pnpm.overrides`.

--- a/.changeset/twenty-walls-sit.md
+++ b/.changeset/twenty-walls-sit.md
@@ -1,5 +1,6 @@
 ---
-"@pnpm/config": major
+"@pnpm/config": patch
+"pnpm": patch
 ---
 
 Instead of `pnpm.overrides` replacing `resolutions`, the two are now merged. This is intended to make it easier to migrate from Yarn by allowing one to keep using `resolutions` for Yarn, but adding additional changes just for pnpm using `pnpm.overrides`.

--- a/.changeset/twenty-walls-sit.md
+++ b/.changeset/twenty-walls-sit.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+---
+
+Instead of `pnpm.overrides` replacing `resolutions`, the two are now merged. This is intended to make it easier to migrate from Yarn by allowing one to keep
+using `resolutions` for Yarn, but adding additional changes just for pnpm using `pnpm.overrides`.

--- a/config/config/src/getOptionsFromRootManifest.ts
+++ b/config/config/src/getOptionsFromRootManifest.ts
@@ -26,7 +26,10 @@ export function getOptionsFromRootManifest (manifestDir: string, manifest: Proje
   // so we cannot call it resolutions
   const overrides = mapValues(
     createVersionReferencesReplacer(manifest),
-    manifest.pnpm?.overrides ?? manifest.resolutions ?? {}
+    {
+      ...manifest.resolutions,
+      ...manifest.pnpm?.overrides,
+    }
   )
   const neverBuiltDependencies = manifest.pnpm?.neverBuiltDependencies
   const onlyBuiltDependencies = manifest.pnpm?.onlyBuiltDependencies


### PR DESCRIPTION
As someone currently migrating from Yarn, I would find it extremely helpful to be able to give Yarn and pnpm different override instructions.

By merging these two, migration from Yarn is even easier, because you can fix pnpm-specific overrides inside `pnpm.overrides` without affecting the existing Yarn setup.
