### PR TITLE
perf: replace endsWith with ===

### DIFF
--- a/env/plugin-commands-env/src/getNodeMirror.ts
+++ b/env/plugin-commands-env/src/getNodeMirror.ts
@@ -8,5 +8,5 @@ export function getNodeMirror (rawConfig: Config['rawConfig'], releaseChannel: s
 }
 
 function normalizeNodeMirror (nodeMirror: string): string {
-  return nodeMirror.endsWith('/') ? nodeMirror : `${nodeMirror}/`
+  return nodeMirror[nodeMirror.length - 1] === '/' ? nodeMirror : `${nodeMirror}/`
 }

--- a/lockfile/audit/src/index.ts
+++ b/lockfile/audit/src/index.ts
@@ -24,7 +24,7 @@ export async function audit (
   }
 ) {
   const auditTree = await lockfileToAuditTree(lockfile, { include: opts.include, lockfileDir: opts.lockfileDir })
-  const registry = opts.registry.endsWith('/') ? opts.registry : `${opts.registry}/`
+  const registry = opts.registry[opts.registry.length - 1] === '/' ? opts.registry : `${opts.registry}/`
   const auditUrl = `${registry}-/npm/v1/security/audits`
   const authHeaderValue = getAuthHeader(registry)
 

--- a/lockfile/lockfile-utils/src/pkgSnapshotToResolution.ts
+++ b/lockfile/lockfile-utils/src/pkgSnapshotToResolution.ts
@@ -26,7 +26,7 @@ export function pkgSnapshotToResolution (
     tarball = getTarball(registry)
   } else {
     tarball = new url.URL((pkgSnapshot.resolution as TarballResolution).tarball,
-      registry.endsWith('/') ? registry : `${registry}/`
+      registry[registry.length - 1] === '/' ? registry : `${registry}/`
     ).toString()
   }
   return {

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -27,7 +27,7 @@ export function resolve (
 }
 
 export function indexOfPeersSuffix (depPath: string) {
-  if (!depPath.endsWith(')')) return -1
+  if (!(depPath[depPath.length - 1] === ')')) return -1
   let open = true
   for (let i = depPath.length - 2; i >= 0; i--) {
     if (depPath[i] === '(') {
@@ -132,7 +132,7 @@ export function parse (dependencyPath: string) {
   if (version) {
     let peerSepIndex!: number
     let peersSuffix: string | undefined
-    if (version.includes('(') && version.endsWith(')')) {
+    if (version.includes('(') && version[version.length - 1] === ')') {
       peerSepIndex = version.indexOf('(')
       if (peerSepIndex !== -1) {
         peersSuffix = version.substring(peerSepIndex)

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -136,7 +136,7 @@ async function diffFolders (folderA: string, folderB: string) {
 }
 
 function removeTrailingAndLeadingSlash (p: string) {
-  if (p[0] === '/' || p.endsWith('/')) {
+  if (p[0] === '/' || p[p.length - 1] === '/') {
     return p.replace(/^\/|\/$/g, '')
   }
   return p

--- a/pnpm/src/getOptionType.ts
+++ b/pnpm/src/getOptionType.ts
@@ -60,6 +60,6 @@ function isOption (word: string) {
 }
 
 export function currentTypedWordType (completionCtx: CompletionCtx) {
-  if (completionCtx.partial.endsWith(' ')) return null
+  if (completionCtx.partial[completionCtx.partial.length - 1] === ' ') return null
   return completionCtx.lastPartial.startsWith('-') ? 'option' : 'value'
 }

--- a/resolving/npm-resolver/src/fetch.ts
+++ b/resolving/npm-resolver/src/fetch.ts
@@ -106,5 +106,5 @@ function toUri (pkgName: string, registry: string) {
     encodedName = encodeURIComponent(pkgName)
   }
 
-  return new url.URL(encodedName, registry.endsWith('/') ? registry : `${registry}/`).toString()
+  return new url.URL(encodedName, registry[registry.length - 1] === '/' ? registry : `${registry}/`).toString()
 }

--- a/resolving/tarball-resolver/src/index.ts
+++ b/resolving/tarball-resolver/src/index.ts
@@ -26,7 +26,7 @@ const GIT_HOSTERS = new Set([
 ])
 
 function isRepository (pref: string) {
-  if (pref.endsWith('/')) {
+  if (pref[pref.length - 1] === '/') {
     pref = pref.slice(0, -1)
   }
   const parts = pref.split('/')

--- a/workspace/filter-workspace-packages/src/parsePackageSelector.ts
+++ b/workspace/filter-workspace-packages/src/parsePackageSelector.ts
@@ -21,7 +21,7 @@ export function parsePackageSelector (rawSelector: string, prefix: string): Pack
   const includeDependencies = rawSelector.endsWith('...')
   if (includeDependencies) {
     rawSelector = rawSelector.slice(0, -3)
-    if (rawSelector.endsWith('^')) {
+    if (rawSelector[rawSelector.length - 1] === '^') {
       excludeSelf = true
       rawSelector = rawSelector.slice(0, -1)
     }


### PR DESCRIPTION
like #7138 
I guess we can use str[str.length - 1] === 'x' rather than str.endsWith('x') too.
This is a [test](https://perf.link/#eyJpZCI6InFmNmVhMmwzMTNnIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IHN0ciA9ICdhYWF4JyIsInRlc3RzIjpbeyJuYW1lIjoiVGVzdCBDYXNlIiwiY29kZSI6InN0ci5lbmRzV2l0aCgneCcpIiwicnVucyI6WzQ3NTgwMDAsNTgzNjAwMCw1ODc1MDAwLDI1MDAwMDAsMTAwNzAwMCw0MTM1MDAwLDM4MjMwMDAsNDkyMzAwMCwxMzUzMDAwLDQ4NTQwMDAsMTAwMCw5MDAwLDg5NTAwMCw5MDAwLDc0MTIwMDAsMTIzNjAwMCwxMzgxMDAwLDM3ODYwMDAsMjQxNTAwMCw1MDkwMDAsNTE3NDAwMCwxMDAwLDM4MDcwMDAsMTgzMjAwMCw0MjI1MDAwLDMzNDQwMDAsNDIxNTAwMCwxMDM3MDAwLDQyMzEwMDAsMzM1NjAwMCwzNzc0MDAwLDIxNzcwMDAsNDkwNTAwMCwyNDg0MDAwLDY0MDAwMCw5ODAwMCwzNzcxMDAwLDIyMTgwMDAsMjcxMjAwMCw5MDAwLDQ0NzgwMDAsMzE4NDAwMCwxMDAwMCw1MDAxMDAwLDkwMDAsMjIyODAwMCwxNTg5MDAwLDQ3MjEwMDAsNjI2MDAwLDM2MjgwMDAsNjE3MDAwLDUyOTEwMDAsNTU5MzAwMCw4NjkwMDAsNTA5OTAwMCwzNzAwMDAsMzExNTAwMCwyNjgwMDAsNjg1OTAwMCw5MzYwMDAsMTEzNzAwMCw2NjAwMDAsMTAwMDAsMTkwMjAwMCw2OTcwMDAsODU0MDAwLDM3MjAwMCwxMzkwMDAwLDM1NDMwMDAsOTAwMCw1MzkyMDAwLDE2OTIwMDAsMzQxMjAwMCwyODgwMDAsNTEzNTAwMCwxNTQ5MDAwLDU5NzUwMDAsNzM1MDAwLDI1NTAwMCw3ODUwMDAwLDQwODgwMDAsNTU3MTAwMCw0MDQxMDAwLDI2ODUwMDAsOTAwMCw0NTQ1MDAwLDEyNjMwMDAsNDI0MTAwMCwxNTMyMDAwLDQ0MjIwMDAsOTgwMDAsMTg0MDAwLDQ4OTAwMCw0MzYwMDAsMTAwMDAsOTgwMDAsOTgwMDAsOTgwMDAsMTA0OTAwMCw1OTAwMDBdLCJvcHMiOjI0MzYyMjB9LHsibmFtZSI6IlRlc3QgQ2FzZSIsImNvZGUiOiJzdHJbc3RyLmxlbmd0aCAtIDFdID09PSAneCciLCJydW5zIjpbNTYxMjAwMCw2NjMwMDAwLDY3NzAwMDAsMzI0NjAwMCwxMjc5MDAwLDQ5NzAwMDAsNDY0NDAwMCw1NjE4MDAwLDE2NDYwMDAsNDY1MDAwMCwxMDAwLDU3NzgwMDAsMTEzNzAwMCw5MDAwLDgwODQwMDAsMTQ2NTAwMCwxNjQ2MDAwLDQ1NDQwMDAsMzEzOTAwMCw1MjgwMDAsNjA0NTAwMCw0ODg1MDAwLDQ1MjkwMDAsMjI4ODAwMCw1MDQ1MDAwLDQxNjMwMDAsNDg5NDAwMCwxMzA4MDAwLDUwNDMwMDAsMzkzNTAwMCw0MjI5MDAwLDIzMTAwMDAsNTYyNTAwMCwzMTAxMDAwLDc5MjAwMCw1MzUwMDAsNDg1NTAwMCw0MDcwMDAsMzM5OTAwMCw5MDAwLDQ2MTMwMDAsMzg0NjAwMCwxMDAwMCw1NzQ1MDAwLDkwMDAsMjgxNTAwMCwxNTE4MDAwLDU0ODMwMDAsNzg3MDAwLDQzOTYwMDAsNjA0MjAwMCw2MDYwMDAwLDY0MTcwMDAsMTA5MDAwMCw1ODU2MDAwLDQ1MjAwMCwzOTAyMDAwLDMyNTAwMCw2NzY4MDAwLDExOTQwMDAsMjg5MDAwMCw2NzkwMDAsMTAwMDAsMjQ1NjAwMCw4ODIwMDAsMTA2NjAwMCw0NjEwMDAsMTY0NjAwMCw0MzA5MDAwLDkwMDAsNTc3NDAwMCwyMzkxMDAwLDQxNzkwMDAsMzUwMDAwLDU3NjQwMDAsMTg0MDAwMCw2NzUwMDAwLDkwODAwMCwzMDAwMDAsODYxOTAwMCw0NjEwMDAwLDYyNjEwMDAsNDc4NTAwMCwzNDQ3MDAwLDkwMDAsNTIyMDAwMCwxNjE0MDAwLDUzNzgwMDAsMTgzMjAwMCw2Mjg1MDAwLDk4MDAwLDIzMDAwLDU3OTAwMCw2NjY2MDAwLDEwMDAwLDk4MDAwLDk4MDAwLDY0OTEwMDAsMTMzMTAwMCw3MzkwMDBdLCJvcHMiOjMxMjk3ODB9XSwidXBkYXRlZCI6IjIwMjMtMTAtMDhUMTA6NTk6NDcuMjIxWiJ9).