### PR TITLE
fix: avoid empty cloned files

### DIFF
--- a/.changeset/twelve-apricots-scream.md
+++ b/.changeset/twelve-apricots-scream.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fs.indexed-pkg-importer": patch
+"pnpm": patch
+---
+
+Fix file cloning to `node_modules` on Windows Dev Drives [#7186](https://github.com/pnpm/pnpm/issues/7186). This is a fix to a regression that was shipped with v8.9.0.

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -24,7 +24,7 @@
     "p-limit": "^3.1.0",
     "path-exists": "^4.0.0",
     "path-temp": "^2.1.0",
-    "@reflink/reflink": "0.1.8",
+    "@reflink/reflink": "0.1.11",
     "rename-overwrite": "^4.0.3",
     "sanitize-filename": "^1.6.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1707,8 +1707,8 @@ importers:
         specifier: workspace:*
         version: link:../../store/store-controller-types
       '@reflink/reflink':
-        specifier: 0.1.8
-        version: 0.1.8
+        specifier: 0.1.11
+        version: 0.1.11
       '@zkochan/rimraf':
         specifier: ^2.1.3
         version: 2.1.3
@@ -8297,8 +8297,8 @@ packages:
       write-yaml-file: 5.0.0
     dev: true
 
-  /@reflink/reflink-darwin-arm64@0.1.8:
-    resolution: {integrity: sha512-8KYwX+0i/QHMxd65s1d8ed5gbfJnYNk4ldaa8egCiv16fhXa+lFZUcpXE2tMp5jm0BpCAYgv2v5RcJa4TuAUmQ==}
+  /@reflink/reflink-darwin-arm64@0.1.11:
+    resolution: {integrity: sha512-jtGxrj3/00lI+U9ozkNpES+NQ5oJYZXnz2Ab5ijdwaVvprAzeaxWb0IgY4ZSJRBBlP0wocpxsl+ew1jHFq7JzA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -8306,8 +8306,8 @@ packages:
     dev: false
     optional: true
 
-  /@reflink/reflink-darwin-x64@0.1.8:
-    resolution: {integrity: sha512-vi9ArVw5AuEXIC8rGCxy4weSp4j45JO3bGtmWMbhEY2kE5O5/+EMpECGRCsVs1SPXqxOlDOSegNyUcEAZs7gsA==}
+  /@reflink/reflink-darwin-x64@0.1.11:
+    resolution: {integrity: sha512-sEzmYWzAJxVz8PgyIJh9+gizZk2CyK8zskA2XLKHh37NfxrlFEKsfvyI4UuBdhCk+ZDvBOoEGwOOT5ceBSERAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -8315,8 +8315,8 @@ packages:
     dev: false
     optional: true
 
-  /@reflink/reflink-win32-arm64-msvc@0.1.8:
-    resolution: {integrity: sha512-7BDH9H4KrZ2ZC2r3Dmd2bNbMzk0kAy4bUs6L77DkOENJCmOquWpW6iiNNf2h08MXboPRsrYj/gEADXAgaknNCQ==}
+  /@reflink/reflink-win32-arm64-msvc@0.1.11:
+    resolution: {integrity: sha512-WwcCONGpFzZSE4CHcnEtUZgVGmUq6gTdvqaeTIxfX20dMISh7BzlxyMZ1TlhgBGHY2wlW1fM3h7mYQSbPEBUqQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -8324,8 +8324,8 @@ packages:
     dev: false
     optional: true
 
-  /@reflink/reflink-win32-x64-msvc@0.1.8:
-    resolution: {integrity: sha512-mivp08nIaxhLGPili+wkjisafpU4n239QMAoE+7R/i4bXNi/fsPZbA+B42HYmx50SptHEbgzfzyKYQdj5qu+tg==}
+  /@reflink/reflink-win32-x64-msvc@0.1.11:
+    resolution: {integrity: sha512-WOnrjFa/B1nSslUyrVeHnpCGExtwBbOXBSvQstXBU9O6Bu7LnDflWjX7yb2JFQFuQz7gXzaIGPkVtk2oLYIX+A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8333,14 +8333,14 @@ packages:
     dev: false
     optional: true
 
-  /@reflink/reflink@0.1.8:
-    resolution: {integrity: sha512-+sKH6o5byiE1cy+D1Dzw7z0MbK8vikVKS1JMuLSvWNAgJnJfPwyZXCzX9UlBR1IGl+BBXnVVrEFpzI7Wgj9jyw==}
+  /@reflink/reflink@0.1.11:
+    resolution: {integrity: sha512-TDPyKIjTnP+BUMq4ABT9V9RpIsiAXCyFowZ3l8qOvdPqCbqC6R3CiLRP8jVH3MlCRjizbiRl9Fm7EqIysnPogg==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.8
-      '@reflink/reflink-darwin-x64': 0.1.8
-      '@reflink/reflink-win32-arm64-msvc': 0.1.8
-      '@reflink/reflink-win32-x64-msvc': 0.1.8
+      '@reflink/reflink-darwin-arm64': 0.1.11
+      '@reflink/reflink-darwin-x64': 0.1.11
+      '@reflink/reflink-win32-arm64-msvc': 0.1.11
+      '@reflink/reflink-win32-x64-msvc': 0.1.11
     dev: false
 
   /@rushstack/worker-pool@0.3.34(@types/node@16.18.57):
@@ -9066,7 +9066,7 @@ packages:
     resolution: {integrity: sha512-YmG+oTBCyrAoMIx5g2I9CfyurSpHyoan+9SCj7laaFKseOe3lFEyIVKvwRBQMmSt8uzh+eY5RWeQnoyyOs6AbA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      '@yarnpkg/fslib': 3.0.0-rc.45
+      '@yarnpkg/fslib': 3.0.0-rc.25
     dependencies:
       '@types/emscripten': 1.39.8
       '@yarnpkg/fslib': 3.0.0-rc.25
@@ -10039,6 +10039,7 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+    requiresBuild: true
 
   /cli-boxes@2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}


### PR DESCRIPTION
Close: #7186 

In Windows, use `FSCTL_SET_SPARSE` ([FSCTL_SET_SPARSE IOCTL](https://learn.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-fsctl_set_sparse)), to set the destination file as sparse before cloning to it.

Sparse files do not allocate space for null bytes, preventing the cloned file from being filled with them. In short, this ensures that the cloned files are not empty.
