### PR TITLE
fix: error occurs with `patchedDependencies` when running dlx

### DIFF
--- a/.changeset/fair-seahorses-rhyme.md
+++ b/.changeset/fair-seahorses-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Fixed issue where using `patchedDependencies` with `pnpx` or `pnpm dlx` resulted in errors. [#7198](https://github.com/pnpm/pnpm/issues/7198).

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -219,7 +219,7 @@ when running add/update with the --workspace option')
   }
 
   const store = await createOrConnectStoreController(opts)
-  const manifestOpts = opts.rootProjectManifest ? getOptionsFromRootManifest(opts.rootProjectManifestDir!, opts.rootProjectManifest) : {}
+  const manifestOpts = opts.extraEnv.npm_command !== 'dlx' && opts.rootProjectManifest ? getOptionsFromRootManifest(opts.rootProjectManifestDir!, opts.rootProjectManifest) : {}
   const installOpts: Omit<MutateModulesOptions, 'allProjects'> = {
     ...opts,
     ...manifestOpts,


### PR DESCRIPTION
`package.json`:
```json
{
  "pnpm": {
      "patchedDependencies": {
         "~~":"~~"
      }
   }
}
```


```sh
$ pnpx npkill
```

result:
```
ENOENT: no such file or directory, open '/Users/<user>/Library/pnpm/store/v3/tmp/dlx-66214/~~~'
```

This issue only occurred in version 8.9.0
While running with `pnpm dlx` or `pnpx`, a `tmp-${pid}` folder is created. I've observed that when there is a patchedDependencies present in the package.json at the cwd path, it seems to reference that path. 

fix for issue https://github.com/pnpm/pnpm/issues/7198