### PR TITLE
fix: do not run node-gyp rebuild if preinstall lifecycle script is present

### DIFF
--- a/.changeset/swift-ducks-talk.md
+++ b/.changeset/swift-ducks-talk.md
@@ -1,5 +1,6 @@
 ---
-"@pnpm/lifecycle": minor
+"@pnpm/lifecycle": patch
+"pnpm": patch
 ---
 
-fix: Do not run node-gyp rebuild if preinstall lifecycle script is present
+Do not run node-gyp rebuild if `preinstall` lifecycle script is present [#7206](https://github.com/pnpm/pnpm/pull/7206).

--- a/.changeset/swift-ducks-talk.md
+++ b/.changeset/swift-ducks-talk.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lifecycle": minor
+---
+
+fix: Do not run node-gyp rebuild if preinstall lifecycle script is present

--- a/exec/lifecycle/src/index.ts
+++ b/exec/lifecycle/src/index.ts
@@ -27,7 +27,7 @@ export async function runPostinstallHooks (
     pkg.scripts = {}
   }
 
-  if (!pkg.scripts.install) {
+  if (!pkg.scripts.install && !pkg.scripts.preinstall) {
     await checkBindingGyp(opts.pkgRoot, pkg.scripts)
   }
 
@@ -47,8 +47,8 @@ export async function runPostinstallHooks (
 }
 
 /**
- * Run node-gyp when binding.gyp is available. Only do this when there's no
- * `install` script (see `npm help scripts`).
+ * Run node-gyp when binding.gyp is available. Only do this when there are no
+ * `install` and `preinstall` scripts (see `npm help scripts`).
  */
 async function checkBindingGyp (
   root: string,

--- a/exec/lifecycle/test/fixtures/gyp-with-preinstall/binding.gyp
+++ b/exec/lifecycle/test/fixtures/gyp-with-preinstall/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "binding",
+      "sources": [ "binding.cc" ]
+    }
+  ]
+}

--- a/exec/lifecycle/test/fixtures/gyp-with-preinstall/package.json
+++ b/exec/lifecycle/test/fixtures/gyp-with-preinstall/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gyp-with-preinstall",
+  "version": "1.0.0",
+  "scripts": {
+    "preinstall": "node -e \"process.stdout.write('preinstall')\" | json-append output.json"
+  }
+}

--- a/exec/lifecycle/test/index.ts
+++ b/exec/lifecycle/test/index.ts
@@ -84,3 +84,18 @@ test('runLifecycleHook() should throw an error while missing script start or fil
     })
   ).rejects.toThrow(new PnpmError('NO_SCRIPT_OR_SERVER', 'Missing script start or file server.js'))
 })
+
+test('preinstall script does not trigger node-gyp rebuild', async () => {
+  const pkgRoot = f.find('gyp-with-preinstall')
+  await rimraf(path.join(pkgRoot, 'output.json'))
+  await runPostinstallHooks({
+    depPath: '/gyp-with-preinstall/1.0.0',
+    optional: false,
+    pkgRoot,
+    rawConfig: {},
+    rootModulesDir,
+    unsafePerm: true,
+  })
+
+  expect(loadJsonFile.sync(path.join(pkgRoot, 'output.json'))).toStrictEqual(['preinstall'])
+})


### PR DESCRIPTION
According to [npm documentation](https://docs.npmjs.com/cli/v10/using-npm/scripts):

> If there is a binding.gyp file in the root of your package and you haven't defined your own install or preinstall scripts, npm will default the install command to compile using node-gyp via node-gyp rebuild


However, in the case of `pnpm`, this check was only performed if an install script was defined, resulting in a discrepancy between the behavior of npm and pnpm. You can refer to this GitHub issue for more information: https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/78.

This pull request modifies `pnpm` to execute `node-gyp rebuild` only when neither the preinstall nor the install scripts are defined.