### PR TITLE
 fix(plugin-commands-patching): should fetch dependency from tarball url when patching dependency installed from git

### DIFF
--- a/.changeset/proud-trees-develop.md
+++ b/.changeset/proud-trees-develop.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+Should fetch dependency from tarball url when patching dependency installed from git [#7196](https://github.com/pnpm/pnpm/issues/7196)

--- a/.changeset/proud-trees-develop.md
+++ b/.changeset/proud-trees-develop.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-patching": patch
+"pnpm": patch
 ---
 
 Should fetch dependency from tarball url when patching dependency installed from git [#7196](https://github.com/pnpm/pnpm/issues/7196)

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -53,6 +53,7 @@
     "@pnpm/parse-wanted-dependency": "workspace:*",
     "@pnpm/patching.apply-patch": "workspace:*",
     "@pnpm/pick-registry-for-package": "workspace:*",
+    "@pnpm/pick-fetcher": "workspace:*",
     "@pnpm/plugin-commands-installation": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -38,18 +38,18 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
       choices: preferredVersions.map(preferred => ({
         name: preferred.version,
         message: preferred.version,
-        value: preferred.isGitHosted ? preferred.tarball : preferred.version,
-        hint: preferred.isGitHosted ? 'Git Hosted' : undefined,
+        value: preferred.gitTarballUrl ? preferred.gitTarballUrl : preferred.version,
+        hint: preferred.gitTarballUrl ? 'Git Hosted' : undefined,
       })),
       result (selected) {
         const selectedVersion = preferredVersions.find(preferred => preferred.version === selected)!
-        return selectedVersion.isGitHosted ? selectedVersion.tarball : selected
+        return selectedVersion.gitTarballUrl ?? selected
       },
     })
     dep.pref = version
   } else {
     const preferred = preferredVersions[0]
-    dep.pref = preferred.isGitHosted ? preferred.tarball : preferred.version
+    dep.pref = preferred.gitTarballUrl ?? preferred.version
   }
   return dep
 }
@@ -75,8 +75,7 @@ export async function getVersionsFromLockfile (dep: ParseWantedDependencyResult,
       const tarball = (pkgSnapshot.resolution as TarballResolution)?.tarball ?? ''
       return {
         ...nameVerFromPkgSnapshot(depPath, pkgSnapshot),
-        isGitHosted: isGitHostedPkgUrl(tarball ?? ''),
-        tarball,
+        gitTarballUrl: isGitHostedPkgUrl(tarball) ? tarball : undefined,
       }
     })
     .filter(({ name }) => name === pkgName)

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -42,7 +42,8 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
         hint: preferred.isGitHosted ? 'Git Hosted' : undefined,
       })),
       result (selected) {
-        return preferredVersions.find(preferred => preferred.version === selected)!.tarball
+        const selectedVersion = preferredVersions.find(preferred => preferred.version === selected)!
+        return selectedVersion.isGitHosted ? selectedVersion.tarball : selected
       },
     })
     dep.pref = version

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -38,7 +38,7 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
       choices: preferredVersions.map(preferred => ({
         name: preferred.version,
         message: preferred.version,
-        value: preferred.gitTarballUrl ? preferred.gitTarballUrl : preferred.version,
+        value: preferred.gitTarballUrl ?? preferred.version,
         hint: preferred.gitTarballUrl ? 'Git Hosted' : undefined,
       })),
       result (selected) {

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -1,16 +1,17 @@
 import path from 'path'
 import { parseWantedDependency, type ParseWantedDependencyResult } from '@pnpm/parse-wanted-dependency'
 import { prompt } from 'enquirer'
-import { readCurrentLockfile } from '@pnpm/lockfile-file'
+import { readCurrentLockfile, type TarballResolution } from '@pnpm/lockfile-file'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile-utils'
 import { PnpmError } from '@pnpm/error'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { readModulesManifest } from '@pnpm/modules-yaml'
+import { isGitHostedPkgUrl } from '@pnpm/pick-fetcher'
 import realpathMissing from 'realpath-missing'
 import semver from 'semver'
 import { type Config } from '@pnpm/config'
 
-type GetPatchedDependencyOptions = {
+export type GetPatchedDependencyOptions = {
   lockfileDir: string
 } & Pick<Config, 'virtualStoreDir' | 'modulesDir'>
 
@@ -22,7 +23,7 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
   if (!preferredVersions.length) {
     throw new PnpmError(
       'PATCH_VERSION_NOT_FOUND',
-      `Can not find ${rawDependency} in project ${opts.lockfileDir}, ${versions.length ? `you can specify currently installed version: ${versions.join(', ')}.` : `did you forget to install ${rawDependency}?`}`
+      `Can not find ${rawDependency} in project ${opts.lockfileDir}, ${versions.length ? `you can specify currently installed version: ${versions.map(({ version }) => version).join(', ')}.` : `did you forget to install ${rawDependency}?`}`
     )
   }
 
@@ -34,17 +35,25 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
       type: 'select',
       name: 'version',
       message: 'Choose which version to patch',
-      choices: versions,
+      choices: preferredVersions.map(preferred => ({
+        name: preferred.version,
+        message: preferred.version,
+        value: preferred.isGitHosted ? preferred.tarball : preferred.version,
+        hint: preferred.isGitHosted ? 'Git Hosted' : undefined,
+      })),
+      result (selected) {
+        return preferredVersions.find(preferred => preferred.version === selected)!.tarball
+      },
     })
     dep.pref = version
   } else {
-    dep.pref = preferredVersions[0]
+    const preferred = preferredVersions[0]
+    dep.pref = preferred.isGitHosted ? preferred.tarball : preferred.version
   }
-
   return dep
 }
 
-async function getVersionsFromLockfile (dep: ParseWantedDependencyResult, opts: GetPatchedDependencyOptions) {
+export async function getVersionsFromLockfile (dep: ParseWantedDependencyResult, opts: GetPatchedDependencyOptions) {
   const modulesDir = await realpathMissing(path.join(opts.lockfileDir, opts.modulesDir ?? 'node_modules'))
   const modules = await readModulesManifest(modulesDir)
   const lockfile = (modules?.virtualStoreDir && await readCurrentLockfile(modules.virtualStoreDir, {
@@ -61,12 +70,18 @@ async function getVersionsFromLockfile (dep: ParseWantedDependencyResult, opts: 
   const pkgName = dep.alias && dep.pref ? dep.alias : (dep.pref ?? dep.alias)
 
   const versions = Object.entries(lockfile.packages ?? {})
-    .map(([depPath, pkgSnapshot]) => nameVerFromPkgSnapshot(depPath, pkgSnapshot))
+    .map(([depPath, pkgSnapshot]) => {
+      const tarball = (pkgSnapshot.resolution as TarballResolution)?.tarball ?? ''
+      return {
+        ...nameVerFromPkgSnapshot(depPath, pkgSnapshot),
+        isGitHosted: isGitHostedPkgUrl(tarball ?? ''),
+        tarball,
+      }
+    })
     .filter(({ name }) => name === pkgName)
-    .map(({ version }) => version)
 
   return {
     versions,
-    preferredVersions: versions.filter(version => dep.alias && dep.pref ? semver.satisfies(version, dep.pref) : true),
+    preferredVersions: versions.filter(({ version }) => dep.alias && dep.pref ? semver.satisfies(version, dep.pref) : true),
   }
 }

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -51,7 +51,7 @@ export async function handler (opts: install.InstallCommandOptions & Pick<Config
   await fs.promises.mkdir(patchesDir, { recursive: true })
   const patchedPkgManifest = await readPackageJsonFromDir(userDir)
   const pkgNameAndVersion = `${patchedPkgManifest.name}@${patchedPkgManifest.version}`
-  const gitTarballUrl = await getGitTarballUrlFormLockfile({
+  const gitTarballUrl = await getGitTarballUrlFromLockfile({
     alias: patchedPkgManifest.name,
     pref: patchedPkgManifest.version,
   }, {
@@ -183,10 +183,7 @@ async function areAllFilesInPkg (files: string[], basePath: string) {
   return equals(allFiles.sort(), files.sort())
 }
 
-async function getGitTarballUrlFormLockfile (dep: ParseWantedDependencyResult, opts: GetPatchedDependencyOptions) {
+async function getGitTarballUrlFromLockfile (dep: ParseWantedDependencyResult, opts: GetPatchedDependencyOptions) {
   const { preferredVersions } = await getVersionsFromLockfile(dep, opts)
-  if (preferredVersions[0]?.isGitHosted) {
-    return preferredVersions[0].tarball
-  }
-  return undefined
+  return preferredVersions[0]?.gitTarballUrl
 }

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -14,8 +14,9 @@ import escapeStringRegexp from 'escape-string-regexp'
 import renderHelp from 'render-help'
 import tempy from 'tempy'
 import { writePackage } from './writePackage'
-import { parseWantedDependency } from '@pnpm/parse-wanted-dependency'
+import { type ParseWantedDependencyResult, parseWantedDependency } from '@pnpm/parse-wanted-dependency'
 import packlist from 'npm-packlist'
+import { type GetPatchedDependencyOptions, getVersionsFromLockfile } from './getPatchedDependency'
 
 export const rcOptionsTypes = cliOptionsTypes
 
@@ -50,9 +51,16 @@ export async function handler (opts: install.InstallCommandOptions & Pick<Config
   await fs.promises.mkdir(patchesDir, { recursive: true })
   const patchedPkgManifest = await readPackageJsonFromDir(userDir)
   const pkgNameAndVersion = `${patchedPkgManifest.name}@${patchedPkgManifest.version}`
+  const gitTarballUrl = await getGitTarballUrlFormLockfile({
+    alias: patchedPkgManifest.name,
+    pref: patchedPkgManifest.version,
+  }, {
+    lockfileDir,
+    modulesDir: opts.modulesDir,
+    virtualStoreDir: opts.virtualStoreDir,
+  })
   const srcDir = tempy.directory()
-  await writePackage(parseWantedDependency(pkgNameAndVersion), srcDir, opts)
-
+  await writePackage(parseWantedDependency(gitTarballUrl ? `${patchedPkgManifest.name}@${gitTarballUrl}` : pkgNameAndVersion), srcDir, opts)
   const patchedPkgDir = await preparePkgFilesForDiff(userDir)
   const patchContent = await diffFolders(srcDir, patchedPkgDir)
 
@@ -173,4 +181,12 @@ async function areAllFilesInPkg (files: string[], basePath: string) {
     cwd: basePath,
   })
   return equals(allFiles.sort(), files.sort())
+}
+
+async function getGitTarballUrlFormLockfile (dep: ParseWantedDependencyResult, opts: GetPatchedDependencyOptions) {
+  const { preferredVersions } = await getVersionsFromLockfile(dep, opts)
+  if (preferredVersions[0]?.isGitHosted) {
+    return preferredVersions[0].tarball
+  }
+  return undefined
 }

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../config/pick-registry-for-package"
     },
     {
+      "path": "../../fetching/pick-fetcher"
+    },
+    {
       "path": "../../lockfile/lockfile-file"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2758,6 +2758,9 @@ importers:
       '@pnpm/patching.apply-patch':
         specifier: workspace:*
         version: link:../apply-patch
+      '@pnpm/pick-fetcher':
+        specifier: workspace:*
+        version: link:../../fetching/pick-fetcher
       '@pnpm/pick-registry-for-package':
         specifier: workspace:*
         version: link:../../config/pick-registry-for-package


### PR DESCRIPTION
fix #7196

1. When patching dependency that installed from git, download the dependency directly from the tarball url in the lockfile, not from the npm registry (theversion in git may not have been released yet).

2. When prompted to select a version to patch, display a hint as to whether it is from git or not:

```
pnpm patch hi
? Choose which version to patch …
❯ 0.0.0
  1.0.0 Git Hosted
```

