### PR TITLE
fix(lockfile): remove `registry` from tarball resolutions

### DIFF
--- a/.changeset/fifty-kiwis-end.md
+++ b/.changeset/fifty-kiwis-end.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile-utils": patch
+"@pnpm/resolver-base": patch
+---
+
+Tarball resolutions in pnpm-lock.yaml will no longer contain a `registry` field, as it was unused.

--- a/.changeset/fifty-kiwis-end.md
+++ b/.changeset/fifty-kiwis-end.md
@@ -1,6 +1,8 @@
 ---
-"@pnpm/lockfile-utils": patch
-"@pnpm/resolver-base": patch
+"@pnpm/lockfile-utils": major
+"@pnpm/resolver-base": major
+"@pnpm/npm-resolver": major
+"pnpm": patch
 ---
 
-Tarball resolutions in pnpm-lock.yaml will no longer contain a `registry` field, as it was unused.
+(Important) Tarball resolutions in `pnpm-lock.yaml` will no longer contain a `registry` field. This field has been unused for a long time. This change should not cause any issues besides backward compatible modifications to the lockfile [#7262](https://github.com/pnpm/pnpm/pull/7262).

--- a/lockfile/lockfile-utils/src/pkgSnapshotToResolution.ts
+++ b/lockfile/lockfile-utils/src/pkgSnapshotToResolution.ts
@@ -31,7 +31,6 @@ export function pkgSnapshotToResolution (
   }
   return {
     ...pkgSnapshot.resolution,
-    registry,
     tarball,
   } as Resolution
 

--- a/lockfile/lockfile-utils/test/pkgSnapshotToResolution.ts
+++ b/lockfile/lockfile-utils/test/pkgSnapshotToResolution.ts
@@ -7,7 +7,6 @@ test('pkgSnapshotToResolution()', () => {
     },
   }, { default: 'https://registry.npmjs.org/' })).toEqual({
     integrity: 'AAAA',
-    registry: 'https://registry.npmjs.org/',
     tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
   })
 
@@ -18,7 +17,6 @@ test('pkgSnapshotToResolution()', () => {
     },
   }, { default: 'https://registry.npmjs.org/', '@mycompany': 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local/' })).toEqual({
     integrity: 'AAAA',
-    registry: 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local/',
     tarball: 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local/@mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz',
   })
 
@@ -29,7 +27,6 @@ test('pkgSnapshotToResolution()', () => {
     },
   }, { default: 'https://registry.npmjs.org/', '@mycompany': 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local' })).toEqual({
     integrity: 'AAAA',
-    registry: 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local',
     tarball: 'https://mycompany.jfrog.io/mycompany/api/npm/npm-local/@mycompany/mypackage/-/@mycompany/mypackage-2.0.0.tgz',
   })
 })

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -1185,7 +1185,6 @@ test('tarball domain differs from registry domain', async () => {
         name: 'is-positive',
         resolution: {
           integrity: 'sha1-hX21hKG6XRyymAUn/DtsQ103sP0=',
-          registry: 'https://registry.example.com/',
           tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-3.1.0.tgz',
         },
         version: '3.1.0',

--- a/pkg-manager/package-requester/test/index.ts
+++ b/pkg-manager/package-requester/test/index.ts
@@ -62,7 +62,6 @@ test('request package', async () => {
   expect(!pkgResponse.body.normalizedPref).toBeTruthy()
   expect(pkgResponse.body.resolution).toStrictEqual({
     integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
   })
 
@@ -104,7 +103,6 @@ test('request package but skip fetching', async () => {
   expect(!pkgResponse.body.normalizedPref).toBeTruthy()
   expect(pkgResponse.body.resolution).toStrictEqual({
     integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
   })
 
@@ -130,7 +128,6 @@ test('request package but skip fetching, when resolution is already available', 
       id: `localhost+${REGISTRY_MOCK_PORT}/is-positive/1.0.0`,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
         tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
       },
     },
@@ -158,7 +155,6 @@ test('request package but skip fetching, when resolution is already available', 
   expect(!pkgResponse.body.normalizedPref).toBeTruthy()
   expect(pkgResponse.body.resolution).toStrictEqual({
     integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
   })
 
@@ -370,7 +366,6 @@ test('fetchPackageToStore()', async () => {
       id: pkgId,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
         tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
       },
     },
@@ -395,7 +390,6 @@ test('fetchPackageToStore()', async () => {
       id: pkgId,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
         tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
       },
     },
@@ -440,7 +434,6 @@ test('fetchPackageToStore() concurrency check', async () => {
         id: pkgId,
         resolution: {
           integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-          registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
           tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
         },
       },
@@ -454,7 +447,6 @@ test('fetchPackageToStore() concurrency check', async () => {
         id: pkgId,
         resolution: {
           integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-          registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
           tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
         },
       },
@@ -525,7 +517,6 @@ test('fetchPackageToStore() does not cache errors', async () => {
       id: pkgId,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
         tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
       },
     },
@@ -541,7 +532,6 @@ test('fetchPackageToStore() does not cache errors', async () => {
       id: pkgId,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
         tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
       },
     },
@@ -588,7 +578,6 @@ test('always return a package manifest in the response', async () => {
         id: `localhost+${REGISTRY_MOCK_PORT}/is-positive/1.0.0`,
         resolution: {
           integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-          registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
           tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
         },
       },
@@ -632,7 +621,6 @@ test('fetchPackageToStore() fetch raw manifest of cached package', async () => {
 
   const pkgId = `localhost+${REGISTRY_MOCK_PORT}/is-positive/1.0.0`
   const resolution = {
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
   }
   const fetchResults = await Promise.all([
@@ -670,7 +658,6 @@ test('refetch package to store if it has been modified', async () => {
 
   const pkgId = `localhost+${REGISTRY_MOCK_PORT}/magic-hook/2.0.0`
   const resolution = {
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/magic-hook/-/magic-hook-2.0.0.tgz`,
   }
 

--- a/pnpm/test/hooks.ts
+++ b/pnpm/test/hooks.ts
@@ -218,7 +218,6 @@ test('custom fetcher can call default fetcher', async () => {
 
   expect(args.resolution).toEqual({
     integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-    registry: `http://localhost:${REGISTRY_MOCK_PORT}/`,
     tarball: `http://localhost:${REGISTRY_MOCK_PORT}/is-positive/-/is-positive-1.0.0.tgz`,
   })
 

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -222,7 +222,6 @@ async function resolveNpm (
   const id = createPkgId(pickedPackage.dist.tarball, pickedPackage.name, pickedPackage.version)
   const resolution = {
     integrity: getIntegrity(pickedPackage.dist),
-    registry: opts.registry,
     tarball: pickedPackage.dist.tarball,
   }
   return {

--- a/resolving/npm-resolver/test/index.ts
+++ b/resolving/npm-resolver/test/index.ts
@@ -77,7 +77,6 @@ test('resolveFromNpm()', async () => {
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -147,7 +146,6 @@ test('dry run', async () => {
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -920,7 +918,6 @@ test('resolve when tarball URL is requested from the registry', async () => {
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -954,7 +951,6 @@ test('resolve when tarball URL is requested from the registry and alias is not s
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -1076,7 +1072,6 @@ test('do not resolve from local directory when alwaysTryWorkspacePackages is fal
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -1185,7 +1180,6 @@ test('use version from the registry if it is newer than the local one', async ()
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9Qa5b+9n69IEuxk4FiNcavXqkixb9lD03BLtdTeu2bbORnLZQrw+pR/exiSg7SoODeu08yxS47mdZa9ddodNwQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-3.1.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -1709,7 +1703,6 @@ test('resolveFromNpm() should always return the name of the package that is spec
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9Qa5b+9n69IEuxk4FiNcavXqkixb9lD03BLtdTeu2bbORnLZQrw+pR/exiSg7SoODeu08yxS47mdZa9ddodNwQ==',
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-3.1.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -1807,7 +1800,6 @@ test('resolveFromNpm() does not fail if the meta file contains no integrity info
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: undefined,
-    registry,
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-2.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()
@@ -1847,7 +1839,6 @@ test('resolveFromNpm() should normalize the registry', async () => {
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',
-    registry: 'https://reg.com/owner',
     tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
   })
   expect(resolveResult!.manifest).toBeTruthy()

--- a/resolving/resolver-base/src/index.ts
+++ b/resolving/resolver-base/src/index.ts
@@ -7,10 +7,6 @@ export interface TarballResolution {
   type?: undefined
   tarball: string
   integrity?: string
-  // needed in some cases to get the auth token
-  // sometimes the tarball URL is under a different path
-  // and the auth token is specified for the registry only
-  registry?: string
 }
 
 /**

--- a/store/package-store/test/index.ts
+++ b/store/package-store/test/index.ts
@@ -30,7 +30,6 @@ describe('store.importPackage()', () => {
         id: pkgId,
         resolution: {
           integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-          registry: 'https://registry.npmjs.org/',
           tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
         },
       },
@@ -69,7 +68,6 @@ describe('store.importPackage()', () => {
         id: pkgId,
         resolution: {
           integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-          registry: 'https://registry.npmjs.org/',
           tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
         },
       },

--- a/store/server/test/index.ts
+++ b/store/server/test/index.ts
@@ -92,7 +92,6 @@ test('fetchPackage', async () => {
       id: pkgId,
       resolution: {
         integrity: 'sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==',
-        registry: 'https://registry.npmjs.org/',
         tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-1.0.0.tgz',
       },
     },


### PR DESCRIPTION
In some cases, pnpm would add a `registry` field to tarball resolutions in pnpm-lock.yaml. This field is no longer used, so it was removed, which should make lockfiles smaller and their generation more deterministic.

💬 [Discord discussion](https://canary.discord.com/channels/731599538665553971/747905674578624633/1168693156854890506)
