### PR TITLE
test: change jest config worker count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,13 @@ jobs:
         # restore-keys: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-
     - name: run tests (main)
       timeout-minutes: 60
-      # if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main'
       run: pnpm run test-main
       env:
         PNPM_WORKERS: 3
-    # - name: run tests (branch)
-      # timeout-minutes: 60
-      # if: github.ref != 'refs/heads/main'
-      # run: pnpm run test-branch
-      # env:
-        # PNPM_WORKERS: 3
+    - name: run tests (branch)
+      timeout-minutes: 60
+      if: github.ref != 'refs/heads/main'
+      run: pnpm run test-branch
+      env:
+        PNPM_WORKERS: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,13 @@ jobs:
         # restore-keys: ts-jest-${{ matrix.platform }}-${{ matrix.node }}-
     - name: run tests (main)
       timeout-minutes: 60
-      if: github.ref == 'refs/heads/main'
+      # if: github.ref == 'refs/heads/main'
       run: pnpm run test-main
       env:
         PNPM_WORKERS: 3
-    - name: run tests (branch)
-      timeout-minutes: 60
-      if: github.ref != 'refs/heads/main'
-      run: pnpm run test-branch
-      env:
-        PNPM_WORKERS: 3
+    # - name: run tests (branch)
+      # timeout-minutes: 60
+      # if: github.ref != 'refs/heads/main'
+      # run: pnpm run test-branch
+      # env:
+        # PNPM_WORKERS: 3

--- a/jest-with-registry.config.js
+++ b/jest-with-registry.config.js
@@ -2,6 +2,10 @@ const path = require("path");
 
 module.exports = {
   ...require('./jest.config'),
+  // Many tests change the dist tags of packages.
+  // Unfortunately, this means that if two such tests will run at the same time,
+  // they may break each other.
+  maxWorkers: 1,
   globalSetup: path.join(__dirname, 'jest.globalSetup.js'),
   globalTeardown: path.join(__dirname, 'jest.globalTeardown.js'),
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,10 +9,7 @@ const config = {
   testPathIgnorePatterns: ["/fixtures/", "/__fixtures__/", "<rootDir>/test/utils/.+"],
   testTimeout: 4 * 60 * 1000, // 4 minutes
   setupFilesAfterEnv: [path.join(__dirname, "jest.setup.js")],
-  // Many tests change the dist tags of packages.
-  // Unfortunately, this means that if two such tests will run at the same time,
-  // they may break each other.
-  maxWorkers: 1,
+  maxWorkers: "50%",
 }
 
 if (process.env.PNPM_SCRIPT_SRC_DIR) {


### PR DESCRIPTION
This allows concurrency for running the non registry-mock dependent tests