### PR TITLE
Add usage trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ Benchmarks on an app with lots of dependencies:
 
 ## Usage Trend
 
-[Usage Trend of JavaScript Package Manager](https://npm-compare.com/pnpm,npm,yarn/#timeRange=THREE_YEARS)
+[Usage Trend of pnpm](https://npm-compare.com/pnpm/#timeRange=THREE_YEARS)
 
-![image](https://github.com/pnpm/pnpm/assets/3455798/07ee0a9a-b08a-4da5-a41e-a5219ca3b822)
+![image](https://github.com/pnpm/pnpm/assets/3455798/ee2513db-7a98-43dc-8561-7f4d62635912)
 
 ## Backers
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Benchmarks on an app with lots of dependencies:
 
 ![](https://pnpm.io/img/benchmarks/alotta-files.svg)
 
+## Usage Trend
+
+[Usage Trend of JavaScript Package Manager](https://npm-compare.com/pnpm,npm,yarn/#timeRange=THREE_YEARS)
+
+![image](https://github.com/pnpm/pnpm/assets/3455798/07ee0a9a-b08a-4da5-a41e-a5219ca3b822)
+
 ## Backers
 
 Thank you to all our backers! [Become a backer](https://opencollective.com/pnpm#backer)


### PR DESCRIPTION
I am writing to propose an enhancement to the README file of the pnpm project. 

As pnpm serves as an alternative to both npm and yarn, I believe it would be beneficial to include a usage trend link for JavaScript package managers in the project's documentation. It's easy to compare the popularity rates of different package managers.  

Thank you for your time.