### PR TITLE
fix: don't retry fetching missing packages

### DIFF
--- a/.changeset/real-dolls-share.md
+++ b/.changeset/real-dolls-share.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tarball-fetcher": patch
+"pnpm": patch
+---
+
+Don't retry fetching missing packages, since the retries will never work

--- a/.changeset/real-dolls-share.md
+++ b/.changeset/real-dolls-share.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Don't retry fetching missing packages, since the retries will never work
+Don't retry fetching missing packages, since the retries will never work [#7276](https://github.com/pnpm/pnpm/pull/7276).

--- a/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -75,6 +75,7 @@ export function createDownloader (
           if (
             error.response?.status === 401 ||
             error.response?.status === 403 ||
+            error.response?.status === 404 ||
             error.code === 'ERR_PNPM_PREPARE_PKG_FAILURE'
           ) {
             reject(error)

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -340,6 +340,38 @@ test('throw error when accessing private package w/o authorization', async () =>
   expect(scope.isDone()).toBeTruthy()
 })
 
+test('do not retry when package does not exist', async () => {
+  const scope = nock(registry)
+    .get('/foo.tgz')
+    .reply(404)
+
+  process.chdir(tempy.directory())
+
+  const resolution = {
+    integrity: tarballIntegrity,
+    tarball: 'http://example.com/foo.tgz',
+  }
+
+  await expect(
+    fetch.remoteTarball(cafs, resolution, {
+      filesIndexFile,
+      lockfileDir: process.cwd(),
+      pkg: {},
+    })
+  ).rejects.toThrow(
+    new FetchError(
+      {
+        url: resolution.tarball,
+      },
+      {
+        status: 404,
+        statusText: '',
+      }
+    )
+  )
+  expect(scope.isDone()).toBeTruthy()
+})
+
 test('accessing private packages', async () => {
   const scope = nock(
     registry,


### PR DESCRIPTION
If you run pnpm on [this repo](https://github.com/gcuddy/margins), you'll get errors like the following:

```
 WARN  GET https://registry.npmjs.org/@tiptap-pro/extension-mathematics/-/extension-mathematics-2.3.3.tgz error (ERR_PNPM_FETCH_404). Will retry in 10 seconds. 2 retries left.
 WARN  GET https://registry.npmjs.org/@tiptap-pro/extension-mathematics/-/extension-mathematics-2.3.3.tgz error (ERR_PNPM_FETCH_404). Will retry in 1 minute. 1 retries left.
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@tiptap-pro/extension-mathematics/-/extension-mathematics-2.3.3.tgz: Not Found - 404

This error happened while installing a direct dependency of /Users/deivid/code/dependabot/dependabot-core/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency

No authorization header was set for the request.
```

My understanding is that these are permanent errors that don't need to be retried, and can error out immediately.

That's what this PR tries to implement.

After this PR, errors should be like this

```
 ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@tiptap-pro/extension-mathematics/-/extension-mathematics-2.3.3.tgz: Not Found - 404

This error happened while installing a direct dependency of /Users/deivid/code/dependabot/dependabot-core/npm_and_yarn/spec/fixtures/projects/pnpm/nonexistent_locked_dependency

No authorization header was set for the request.
```