### PR TITLE
perf: default network-concurrency to cpu count

### DIFF
--- a/.changeset/small-eels-cry.md
+++ b/.changeset/small-eels-cry.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+(Important) Increased the default amount of allowed concurrent network request on systems that have more than 16 CPUs [#7285](https://github.com/pnpm/pnpm/pull/7285).

--- a/cspell.json
+++ b/cspell.json
@@ -237,6 +237,7 @@
     "testcase",
     "todomvc",
     "tsparticles",
+    "underperformance",
     "undollar",
     "uninstallation",
     "unnest",

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -98,7 +98,7 @@ export function createPackageRequester (
   } {
   opts = opts || {}
 
-  const networkConcurrency = opts.networkConcurrency ?? os.cpus().length
+  const networkConcurrency = opts.networkConcurrency ?? Math.max(os.cpus().length, 16)
   const requestsQueue = new PQueue({
     concurrency: networkConcurrency,
   })

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -98,6 +98,9 @@ export function createPackageRequester (
   } {
   opts = opts || {}
 
+  // A lower bound of 16 is enforced to prevent performance degradation,
+  // especially in CI environments. Tests with a threshold lower than 16
+  // have shown consistent underperformance.
   const networkConcurrency = opts.networkConcurrency ?? Math.max(os.cpus().length, 16)
   const requestsQueue = new PQueue({
     concurrency: networkConcurrency,

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -1,4 +1,5 @@
 import { createReadStream, promises as fs } from 'fs'
+import os from 'os'
 import path from 'path'
 import {
   type FileType,
@@ -97,7 +98,7 @@ export function createPackageRequester (
   } {
   opts = opts || {}
 
-  const networkConcurrency = opts.networkConcurrency ?? 16
+  const networkConcurrency = opts.networkConcurrency ?? os.cpus().length
   const requestsQueue = new PQueue({
     concurrency: networkConcurrency,
   })


### PR DESCRIPTION
It was discovered last week that pnpm is fastest when `network-concurrency` is set to the exact number of available CPU cores.

What do you think, @zkochan?

**NOTE:** I haven't tested this on machine with fewer than 16 cores.
