### PR TITLE
fix: don't try to readd packages on repeat install

### DIFF
--- a/.changeset/three-apricots-wonder.md
+++ b/.changeset/three-apricots-wonder.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.graph-builder": patch
+"pnpm": patch
+---
+
+Fixed a performance regression on running installation on a project with an up to date lockfile [#7297](https://github.com/pnpm/pnpm/issues/7297).

--- a/deps/graph-builder/src/lockfileToDepGraph.ts
+++ b/deps/graph-builder/src/lockfileToDepGraph.ts
@@ -133,8 +133,8 @@ export async function lockfileToDepGraph (
         const depIsPresent = !refIsLocalDirectory(depPath) &&
           currentPackages[depPath] && equals(currentPackages[depPath].dependencies, lockfile.packages![depPath].dependencies)
         if (
-          depIsPresent && isEmpty(currentPackages[depPath].optionalDependencies) &&
-          isEmpty(lockfile.packages![depPath].optionalDependencies)
+          depIsPresent && isEmpty(currentPackages[depPath].optionalDependencies ?? {}) &&
+          isEmpty(lockfile.packages![depPath].optionalDependencies ?? {})
         ) {
           if (await pathExists(dir)) {
             return

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -342,8 +342,8 @@ async function linkNewPackages (
     for (const depPath of wantedRelDepPaths) {
       if (currentLockfile.packages[depPath] &&
         (!equals(currentLockfile.packages[depPath].dependencies, wantedLockfile.packages[depPath].dependencies) ||
-        !isEmpty(currentLockfile.packages[depPath].optionalDependencies) ||
-        !isEmpty(wantedLockfile.packages[depPath].optionalDependencies))
+        !isEmpty(currentLockfile.packages[depPath].optionalDependencies ?? {}) ||
+        !isEmpty(wantedLockfile.packages[depPath].optionalDependencies ?? {}))
       ) {
         // TODO: come up with a test that triggers the usecase of depGraph[depPath] undefined
         // see related issue: https://github.com/pnpm/pnpm/issues/870

--- a/pkg-manager/core/test/install/misc.ts
+++ b/pkg-manager/core/test/install/misc.ts
@@ -145,6 +145,19 @@ test('no dependencies (lodash)', async () => {
   expect(typeof m.clone).toBe('function')
 })
 
+test('only the new packages are added', async () => {
+  prepareEmpty()
+  const manifest = await addDependenciesToPackage({}, ['@pnpm/x'], await testDefaults())
+  const reporter = sinon.spy()
+  await addDependenciesToPackage(manifest, ['@pnpm/y'], await testDefaults({ reporter }))
+
+  expect(reporter.calledWithMatch({
+    added: 1,
+    level: 'debug',
+    name: 'pnpm:stats',
+  } as StatsLog)).toBeTruthy()
+})
+
 test('scoped modules without version spec', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['@zkochan/foo'], await testDefaults())

--- a/pkg-manager/headless/test/index.ts
+++ b/pkg-manager/headless/test/index.ts
@@ -76,6 +76,20 @@ test('installing a simple project', async () => {
     requester: prefix,
     status: 'resolved',
   })).toBeTruthy()
+
+  reporter.resetHistory()
+  await headlessInstall(await testDefaults({
+    lockfileDir: prefix,
+    reporter,
+  }))
+  // On repeat install no new packages should be added
+  // covers https://github.com/pnpm/pnpm/issues/7297
+  expect(reporter.calledWithMatch({
+    added: 0,
+    level: 'debug',
+    name: 'pnpm:stats',
+    prefix,
+  } as StatsLog)).toBeTruthy()
 })
 
 test('installing only prod deps', async () => {


### PR DESCRIPTION
close #7297

TODO:
- [x] fix the same issue with non-up-to-date lockfile