### PR TITLE
fix(workspace.read-manifest): allow null or empty manifest

### DIFF
--- a/.changeset/fifty-rabbits-sleep.md
+++ b/.changeset/fifty-rabbits-sleep.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.read-manifest": patch
+"pnpm": patch
+---
+
+Don't fail on an empty `pnpm-workspace.yaml` file [#7307](https://github.com/pnpm/pnpm/issues/7307).

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -32,13 +32,9 @@ async function readManifestRaw (dir: string): Promise<unknown> {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function validateWorkspaceManifest (manifest: any): manifest is WorkspaceManifest | undefined {
-  if (manifest === undefined) {
-    // Empty manifest is ok
+  if (manifest === undefined || manifest === null) {
+    // Empty or null manifest is ok
     return true
-  }
-
-  if (manifest === null) {
-    throw new InvalidWorkspaceManifestError('Expected object but found - null')
   }
 
   if (typeof manifest !== 'object') {

--- a/workspace/read-manifest/test/index.ts
+++ b/workspace/read-manifest/test/index.ts
@@ -50,3 +50,15 @@ test('readWorkspaceManifest() works when no workspace file is present', async ()
 
   expect(manifest).toBeUndefined()
 })
+
+test('readWorkspaceManifest() works when workspace file is empty', async () => {
+  const manifest = await readWorkspaceManifest(path.join(__dirname, '__fixtures__/empty'))
+
+  expect(manifest).toBeUndefined()
+})
+
+test('readWorkspaceManifest() works when workspace file is null', async () => {
+  const manifest = await readWorkspaceManifest(path.join(__dirname, '__fixtures__/null'))
+
+  expect(manifest).toBeNull()
+})


### PR DESCRIPTION
close #7307