### PR TITLE
fix: use the registry domain in the package ID, not the tarball domain

### DIFF
--- a/.changeset/unlucky-bees-film.md
+++ b/.changeset/unlucky-bees-film.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/npm-resolver": major
+"pnpm": minor
+---
+
+(IMPORTANT) When the package tarballs aren't hosted on the same domain on which the registry (the server with the package metadata) is, the dependency keys in the lockfile should only contain `/<pkg_name>@<pkg_version`, not `<domain>/<pkg_name>@<pkg_version>`.
+
+This change is a fix to avoid the same package from being added to `node_modules/.pnpm` multiple times. The change to the lockfile is backward compatible, so previous versions of pnpm will work with the fixed lockfile.
+
+We recommend that all team members update pnpm in order to avoid repeated changes in the lockfile.
+
+Related PR: [#7318](https://github.com/pnpm/pnpm/pull/7318).

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -1174,20 +1174,18 @@ test('tarball domain differs from registry domain', async () => {
     dependencies: {
       'is-positive': {
         specifier: '^3.1.0',
-        version: 'registry.npmjs.org/is-positive@3.1.0',
+        version: '3.1.0',
       },
     },
     lockfileVersion: LOCKFILE_VERSION,
     packages: {
-      'registry.npmjs.org/is-positive@3.1.0': {
+      '/is-positive@3.1.0': {
         dev: false,
         engines: { node: '>=0.10.0' },
-        name: 'is-positive',
         resolution: {
           integrity: 'sha1-hX21hKG6XRyymAUn/DtsQ103sP0=',
           tarball: 'https://registry.npmjs.org/is-positive/-/is-positive-3.1.0.tgz',
         },
-        version: '3.1.0',
       },
     },
   })

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -219,7 +219,7 @@ async function resolveNpm (
     }
   }
 
-  const id = createPkgId(pickedPackage.dist.tarball, pickedPackage.name, pickedPackage.version)
+  const id = createPkgId(opts.registry, pickedPackage.name, pickedPackage.version)
   const resolution = {
     integrity: getIntegrity(pickedPackage.dist),
     tarball: pickedPackage.dist.tarball,

--- a/resolving/npm-resolver/test/index.ts
+++ b/resolving/npm-resolver/test/index.ts
@@ -1736,7 +1736,7 @@ test('request to metadata is retried if the received JSON is broken', async () =
     registry,
   })!
 
-  expect(resolveResult?.id).toBe('registry.npmjs.org/is-positive/1.0.0')
+  expect(resolveResult?.id).toBe('registry1.com/is-positive/1.0.0')
 })
 
 test('request to a package with unpublished versions', async () => {
@@ -1835,7 +1835,7 @@ test('resolveFromNpm() should normalize the registry', async () => {
   })
 
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
-  expect(resolveResult!.id).toBe('registry.npmjs.org/is-positive/1.0.0')
+  expect(resolveResult!.id).toBe('reg.com/is-positive/1.0.0')
   expect(resolveResult!.latest!.split('.').length).toBe(3)
   expect(resolveResult!.resolution).toStrictEqual({
     integrity: 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ==',


### PR DESCRIPTION
(IMPORTANT) When the package tarballs aren't hosted on the same domain on which the registry (the server with the package metadata) is, the dependency keys in the lockfile should only contain `/<pkg_name>@<pkg_version`, not `<domain>/<pkg_name>@<pkg_version>`.

This change is a fix to avoid the same package from being added to `node_modules/.pnpm` multiple times. The change to the lockfile is backward compatible, so previous versions of pnpm will work with the fixed lockfile.

We recommend that all team members update pnpm in order to avoid repeated changes in the lockfile.