### PR TITLE
Feat/pnpm i module already in dev deps

### DIFF
--- a/.changeset/eleven-kids-exist.md
+++ b/.changeset/eleven-kids-exist.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/default-reporter": patch
+"pnpm": patch
 ---
 
-pnpm i a-module-already-in-dev-deps will show a message to notice the user that the package was not moved to dependencies.
+`pnpm add a-module-already-in-dev-deps` will show a message to notice the user that the package was not moved to "dependencies" [#926](https://github.com/pnpm/pnpm/issues/926).

--- a/.changeset/eleven-kids-exist.md
+++ b/.changeset/eleven-kids-exist.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": patch
+---
+
+pnpm i a-module-already-in-dev-deps will show a message to notice the user that the package was not moved to dependencies.

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -71,6 +71,10 @@ export function reportSummary (
             msg += EOL
             msg += _printDiffs(diffs)
             msg += EOL
+            if (depType === 'dev' && !opts.pnpmConfig?.saveDev) {
+              msg += 'was already in devDependencies but wasn\'t moved automatically to dependencies. Please move it manually if needed. '
+            }
+            msg += EOL
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {
             msg += EOL
             msg += `${chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)} skipped`

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -71,10 +71,11 @@ export function reportSummary (
             msg += EOL
             msg += _printDiffs(diffs)
             msg += EOL
-            if (depType === 'dev' && !opts.pnpmConfig?.saveDev) {
+            if (depType === 'dev' && opts.pnpmConfig?.saveDev === false) {
+              msg += EOL
               msg += 'was already in devDependencies but wasn\'t moved automatically to dependencies. Please move it manually if needed. '
+              msg += EOL
             }
-            msg += EOL
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {
             msg += EOL
             msg += `${chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)} skipped`

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -73,7 +73,7 @@ export function reportSummary (
             msg += EOL
             if (depType === 'dev' && opts.pnpmConfig?.saveDev === false) {
               msg += EOL
-              msg += 'was already in devDependencies but wasn\'t moved automatically to dependencies. Please move it manually if needed. '
+              msg += `The dependency was already listed in devDependencies.${EOL}If you want to make it a prod dependency, then move it manually.`
               msg += EOL
             }
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {


### PR DESCRIPTION
pnpm i a-module-already-in-dev-deps will show a message to notice the user that the package was not moved to dependencies.

Close #926 

![image](https://github.com/pnpm/pnpm/assets/106020312/52362def-62e3-4e44-a198-94b9f458c3c4)