### PR TITLE
feat: use unpkg for file list

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -430,7 +430,6 @@ Note that in CI environments, this setting is enabled by default.`,
     Failure reason:
     ${detailedReason ?? ''}`,
               })
-            /* eslint-enable @typescript-eslint/restrict-template-expressions */
           }
         }
       }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -430,6 +430,7 @@ Note that in CI environments, this setting is enabled by default.`,
     Failure reason:
     ${detailedReason ?? ''}`,
               })
+            /* eslint-enable @typescript-eslint/restrict-template-expressions */
           }
         }
       }


### PR DESCRIPTION
The NPM files index is returning 429s. This uses unpkg instead.

I can rename the endpoints/flags but I wanted to check CI first, and see if anyone else wanted to test it for performance/other issues