### PR TITLE
refactor(read-manifest): improve type safety of manifest validation logic

### DIFF
--- a/.changeset/six-fireants-count.md
+++ b/.changeset/six-fireants-count.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.read-manifest": patch
+---
+
+Minor refactors to improve the type safety of the workspace manifest validation logic in the `readWorkspaceManifest` function.

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -9,11 +9,8 @@ export interface WorkspaceManifest {
 
 export async function readWorkspaceManifest (dir: string): Promise<WorkspaceManifest | undefined> {
   const manifest = await readManifestRaw(dir)
-  if (validateWorkspaceManifest(manifest)) {
-    return manifest
-  }
-
-  return undefined
+  validateWorkspaceManifest(manifest)
+  return manifest
 }
 
 async function readManifestRaw (dir: string): Promise<unknown> {
@@ -30,10 +27,10 @@ async function readManifestRaw (dir: string): Promise<unknown> {
   }
 }
 
-function validateWorkspaceManifest (manifest: unknown): manifest is WorkspaceManifest | undefined {
+function validateWorkspaceManifest (manifest: unknown): asserts manifest is WorkspaceManifest | undefined {
   if (manifest === undefined || manifest === null) {
     // Empty or null manifest is ok
-    return true
+    return
   }
 
   if (typeof manifest !== 'object') {
@@ -46,12 +43,10 @@ function validateWorkspaceManifest (manifest: unknown): manifest is WorkspaceMan
 
   if (Object.keys(manifest).length === 0) {
     // manifest content `{}` is ok
-    return true
+    return
   }
 
   assertValidWorkspaceManifestPackages(manifest)
-
-  return true
 }
 
 function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown }): asserts manifest is { packages: string[] } {

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -30,8 +30,7 @@ async function readManifestRaw (dir: string): Promise<unknown> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function validateWorkspaceManifest (manifest: any): manifest is WorkspaceManifest | undefined {
+function validateWorkspaceManifest (manifest: unknown): manifest is WorkspaceManifest | undefined {
   if (manifest === undefined || manifest === null) {
     // Empty or null manifest is ok
     return true

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -50,6 +50,12 @@ function validateWorkspaceManifest (manifest: any): manifest is WorkspaceManifes
     return true
   }
 
+  assertValidWorkspaceManifestPackages(manifest)
+
+  return true
+}
+
+function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown }): asserts manifest is { packages: string[] } {
   if (!manifest.packages) {
     throw new InvalidWorkspaceManifestError('packages field missing or empty')
   }
@@ -68,8 +74,6 @@ function validateWorkspaceManifest (manifest: any): manifest is WorkspaceManifes
       throw new InvalidWorkspaceManifestError(`Invalid package type - ${type}`)
     }
   }
-
-  return true
 }
 
 class InvalidWorkspaceManifestError extends PnpmError {

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -47,6 +47,7 @@ function validateWorkspaceManifest (manifest: unknown): asserts manifest is Work
   }
 
   assertValidWorkspaceManifestPackages(manifest)
+  checkWorkspaceManifestAssignability(manifest)
 }
 
 function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown }): asserts manifest is { packages: string[] } {
@@ -69,6 +70,14 @@ function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown })
     }
   }
 }
+
+/**
+ * Empty function to ensure TypeScript has narrowed the manifest object to
+ * something assignable to the {@see WorkspaceManifest} interface. This helps
+ * make sure the validation logic in this file is correct as it's refactored in
+ * the future.
+ */
+function checkWorkspaceManifestAssignability (_manifest: WorkspaceManifest) {}
 
 class InvalidWorkspaceManifestError extends PnpmError {
   constructor (message: string) {


### PR DESCRIPTION
Follow up to https://github.com/pnpm/pnpm/pull/7278. I happened to be in this code path while working on #7072 and noticed a few ways the validation logic could be more type safe.

There should be no behavior changes in this PR. Just moving some functions and type annotations around.