### PR TITLE
feat: pnpm i a-module-already-in-dev-deps should show message

### DIFF
--- a/.changeset/gorgeous-seas-listen.md
+++ b/.changeset/gorgeous-seas-listen.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+`pnpm add a-module-already-in-dev-deps` will show a message to notice the user that the package was not moved to "dependencies" [#926](https://github.com/pnpm/pnpm/issues/926) and fix [#7319](https://github.com/pnpm/pnpm/pull/7319)`

--- a/cli/default-reporter/src/reporterForClient/index.ts
+++ b/cli/default-reporter/src/reporterForClient/index.ts
@@ -149,6 +149,7 @@ export function reporterForClient (
 
   if (!opts.isRecursive) {
     outputs.push(reportSummary(log$, {
+      cmd: opts.cmd,
       cwd,
       env: opts.env,
       filterPkgsDiff: opts.filterPkgsDiff,

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -71,6 +71,11 @@ export function reportSummary (
             msg += EOL
             msg += _printDiffs(diffs)
             msg += EOL
+            if (depType === 'dev' && opts.pnpmConfig?.saveDev === false && opts.pnpmConfig?.extraEnv?.npm_command === 'add') {
+              msg += EOL
+              msg += `The dependency was already listed in devDependencies.${EOL}If you want to make it a prod dependency, then move it manually.`
+              msg += EOL
+            }
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {
             msg += EOL
             msg += `${chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)} skipped`

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -35,6 +35,7 @@ export function reportSummary (
     packageManifest: Rx.Observable<PackageManifestLog>
   },
   opts: {
+    cmd: string
     cwd: string
     env: NodeJS.ProcessEnv
     filterPkgsDiff?: FilterPkgsDiff
@@ -44,7 +45,7 @@ export function reportSummary (
   const pkgsDiff$ = getPkgsDiff(log$, { prefix: opts.cwd })
 
   const summaryLog$ = log$.summary.pipe(take(1))
-  const _printDiffs = printDiffs.bind(null, { prefix: opts.cwd })
+  const _printDiffs = printDiffs.bind(null, { cmd: opts.cmd, prefix: opts.cwd, pnpmConfig: opts.pnpmConfig })
 
   return Rx.combineLatest(
     pkgsDiff$,
@@ -69,7 +70,7 @@ export function reportSummary (
               msg += chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)
             }
             msg += EOL
-            msg += _printDiffs(diffs, depType, opts.pnpmConfig)
+            msg += _printDiffs(diffs, depType)
             msg += EOL
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {
             msg += EOL
@@ -89,11 +90,12 @@ export type FilterPkgsDiff = (pkgsDiff: PackageDiff) => boolean
 
 function printDiffs (
   opts: {
+    cmd: string
     prefix: string
+    pnpmConfig?: Config
   },
   pkgsDiff: PackageDiff[],
-  depType: string,
-  pnpmConfig?: Config
+  depType: string
 ) {
   // Sorts by alphabet then by removed/added
   // + ava 0.10.0
@@ -121,7 +123,7 @@ function printDiffs (
     if (pkg.from) {
       result += ` ${chalk.grey(`<- ${pkg.from && path.relative(opts.prefix, pkg.from) || '???'}`)}`
     }
-    if (pkg.added && depType === 'dev' && pnpmConfig?.saveDev === false && pnpmConfig?.extraEnv?.npm_command === 'add') {
+    if (pkg.added && depType === 'dev' && opts.pnpmConfig?.saveDev === false && opts.cmd === 'add') {
       result += `${chalk.yellow(' already in devDependencies, was not moved to dependencies.')}`
     }
     return result

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -122,7 +122,7 @@ function printDiffs (
       result += ` ${chalk.grey(`<- ${pkg.from && path.relative(opts.prefix, pkg.from) || '???'}`)}`
     }
     if (pkg.added && depType === 'dev' && pnpmConfig?.saveDev === false && pnpmConfig?.extraEnv?.npm_command === 'add') {
-      result += `${chalk.yellow(' was already listed in devDependencies, If you want to make it a prod dependency, then move it manually.')}`
+      result += `${chalk.yellow(' already in devDependencies, was not moved to dependencies.')}`
     }
     return result
   }).join(EOL)

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -69,13 +69,8 @@ export function reportSummary (
               msg += chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)
             }
             msg += EOL
-            msg += _printDiffs(diffs)
+            msg += _printDiffs(diffs, depType, opts.pnpmConfig)
             msg += EOL
-            if (depType === 'dev' && opts.pnpmConfig?.saveDev === false && opts.pnpmConfig?.extraEnv?.npm_command === 'add') {
-              msg += EOL
-              msg += `The dependency was already listed in devDependencies.${EOL}If you want to make it a prod dependency, then move it manually.`
-              msg += EOL
-            }
           } else if (opts.pnpmConfig?.[CONFIG_BY_DEP_TYPE[depType]] === false) {
             msg += EOL
             msg += `${chalk.cyanBright(`${propertyByDependencyType[depType] as string}:`)} skipped`
@@ -96,7 +91,9 @@ function printDiffs (
   opts: {
     prefix: string
   },
-  pkgsDiff: PackageDiff[]
+  pkgsDiff: PackageDiff[],
+  depType: string,
+  pnpmConfig?: Config
 ) {
   // Sorts by alphabet then by removed/added
   // + ava 0.10.0
@@ -123,6 +120,9 @@ function printDiffs (
     }
     if (pkg.from) {
       result += ` ${chalk.grey(`<- ${pkg.from && path.relative(opts.prefix, pkg.from) || '???'}`)}`
+    }
+    if (pkg.added === true && depType === 'dev' && pnpmConfig?.saveDev === false && pnpmConfig?.extraEnv?.npm_command === 'add') {
+      result += `${chalk.yellow(` was already listed in devDependencies, If you want to make it a prod dependency, then move it manually.`)}`
     }
     return result
   }).join(EOL)

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -121,8 +121,8 @@ function printDiffs (
     if (pkg.from) {
       result += ` ${chalk.grey(`<- ${pkg.from && path.relative(opts.prefix, pkg.from) || '???'}`)}`
     }
-    if (pkg.added === true && depType === 'dev' && pnpmConfig?.saveDev === false && pnpmConfig?.extraEnv?.npm_command === 'add') {
-      result += `${chalk.yellow(` was already listed in devDependencies, If you want to make it a prod dependency, then move it manually.`)}`
+    if (pkg.added && depType === 'dev' && pnpmConfig?.saveDev === false && pnpmConfig?.extraEnv?.npm_command === 'add') {
+      result += `${chalk.yellow(' was already listed in devDependencies, If you want to make it a prod dependency, then move it manually.')}`
     }
     return result
   }).join(EOL)


### PR DESCRIPTION
Close https://github.com/pnpm/pnpm/issues/926

Fix  [#7319 ](https://github.com/pnpm/pnpm/pull/7319)

Here the result : 

![image](https://github.com/pnpm/pnpm/assets/106020312/f6dda777-cf87-423d-9f66-5ba20e2b2b66)


@brc-dd
Tested on [ vuejs/vitepress](https://github.com/vuejs/vitepress) :
```bash
~/vitepress main*
❯ pd i
Scope: all 4 workspace projects
Packages: +622
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 654, reused 622, downloaded 0, added 622, done

dependencies:
+ @docsearch/css 3.5.2
+ @docsearch/js 3.5.2
+ @types/markdown-it 13.0.7
+ @vitejs/plugin-vue 4.5.0
+ @vue/devtools-api 6.5.1
+ @vueuse/core 10.6.1
+ @vueuse/integrations 10.6.1
+ focus-trap 7.5.4
+ mark.js 8.11.1
+ minisearch 6.3.0
+ mrmime 1.0.1
+ shikiji 0.7.4
+ shikiji-transformers 0.7.4
+ vite 5.0.2
+ vue 3.3.9

devDependencies:
+ @clack/prompts 0.7.0
+ @mdit-vue/plugin-component 1.0.0
+ @mdit-vue/plugin-frontmatter 1.0.0
+ @mdit-vue/plugin-headers 1.0.0
+ @mdit-vue/plugin-sfc 1.0.0
+ @mdit-vue/plugin-title 1.0.0
+ @mdit-vue/plugin-toc 1.0.0
+ @mdit-vue/shared 1.0.0
+ @rollup/plugin-alias 5.1.0
+ @rollup/plugin-commonjs 25.0.7
+ @rollup/plugin-json 6.0.1
+ @rollup/plugin-node-resolve 15.2.3
+ @rollup/plugin-replace 5.0.5
+ @types/compression 1.7.5
+ @types/cross-spawn 6.0.6
+ @types/debug 4.1.12
+ @types/escape-html 1.0.4
+ @types/fs-extra 11.0.4
+ @types/lodash.template 4.5.3
+ @types/mark.js 8.11.12
+ @types/markdown-it-attrs 4.1.3
+ @types/markdown-it-container 2.0.9
+ @types/markdown-it-emoji 2.0.4
+ @types/micromatch 4.0.6
+ @types/minimist 1.2.5
+ @types/node 20.10.0
+ @types/postcss-prefix-selector 1.16.3
+ @types/prompts 2.4.9
+ @vue/shared 3.3.9
+ chokidar 3.5.3
+ compression 1.7.4
+ conventional-changelog-cli 4.1.0
+ cross-spawn 7.0.3
+ debug 4.3.4
+ esbuild 0.19.8
+ escape-html 1.0.3
+ execa 8.0.1
+ fast-glob 3.3.2
+ fs-extra 11.1.1
+ get-port 7.0.0
+ gray-matter 4.0.3
+ lint-staged 15.1.0
+ lodash.template 4.5.0
+ lru-cache 10.1.0
+ markdown-it 13.0.2
+ markdown-it-anchor 8.6.7
+ markdown-it-attrs 4.1.6
+ markdown-it-container 3.0.0
+ markdown-it-emoji 2.0.2
+ markdown-it-mathjax3 4.3.2
+ micromatch 4.0.5
+ minimist 1.2.8
+ nanoid 5.0.3
+ npm-run-all 4.1.5
+ ora 7.0.1
+ path-to-regexp 6.2.1
+ picocolors 1.0.0
+ pkg-dir 8.0.0
+ playwright-chromium 1.40.0
+ polka 1.0.0-next.23
+ postcss-prefix-selector 1.16.0
+ prettier 3.1.0
+ prompts 2.4.2
+ punycode 2.3.1
+ rimraf 5.0.5
+ rollup 4.6.0
+ rollup-plugin-dts 6.1.0
+ rollup-plugin-esbuild 6.1.0
+ semver 7.5.4
+ simple-git-hooks 2.9.0
+ sirv 2.0.3
+ sitemap 7.1.1
+ supports-color 9.4.0
+ typescript 5.3.2
+ vitest 1.0.0-beta.5
+ vue-tsc 1.8.22
+ wait-on 7.2.0

Done in 8.9s
```

@Mister-Hope : tested on [vuepress-theme-hope/vuepress-theme-hope](https://github.com/vuepress-theme-hope/vuepress-theme-hope)

```bash
╰─ pd i
Scope: all 65 workspace projects
 WARN  3 deprecated subdependencies found: @npmcli/move-file@2.0.1, rollup-plugin-terser@7.0.2, sourcemap-codec@1.4.8
Packages: +1833
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1884, reused 1830, downloaded 1, added 1833, done
 WARN  Failed to create bin at /home/yanzi/contribute/vuepress-theme-hope/demo/redirect/node_modules/.bin/vp-redirect. ENOENT: no such file or directory, open '/home/yanzi/contribute/vuepress-theme-hope/packages/redirect/lib/cli/index.js'
 WARN  Failed to create bin at /home/yanzi/contribute/vuepress-theme-hope/docs-shared/node_modules/.bin/vp-redirect. ENOENT: no such file or directory, open '/home/yanzi/contribute/vuepress-theme-hope/packages/redirect/lib/cli/index.js'
. prepare$ husky install
│ husky - Git hooks installed
└─ Done in 32ms
 WARN  Failed to create bin at /home/yanzi/contribute/vuepress-theme-hope/demo/redirect/node_modules/.bin/vp-redirect. ENOENT: no such file or directory, open '/home/yanzi/contribute/vuepress-theme-hope/demo/redirect/node_modules/vuepress-plugin-redirect/lib/cli/index.js'
 WARN  Failed to create bin at /home/yanzi/contribute/vuepress-theme-hope/docs-shared/node_modules/.bin/vp-redirect. ENOENT: no such file or directory, open '/home/yanzi/contribute/vuepress-theme-hope/docs-shared/node_modules/vuepress-plugin-redirect/lib/cli/index.js'

devDependencies:
+ @commitlint/cli 18.4.3
+ @commitlint/config-conventional 18.4.3
+ @rollup/plugin-alias 5.1.0
+ @rollup/plugin-commonjs 25.0.7
+ @rollup/plugin-node-resolve 15.2.3
+ @rollup/plugin-replace 5.0.5
+ @types/inquirer 9.0.7
+ @types/node 20.10.0
+ @typescript-eslint/eslint-plugin 6.12.0 (6.13.0 is available)
+ @typescript-eslint/parser 6.12.0 (6.13.0 is available)
+ @vitest/coverage-v8 0.34.6
+ @vue/eslint-config-typescript 12.0.0
+ bumpp 9.2.0
+ commit-and-tag-version 12.0.0
+ commitizen 4.3.0
+ concurrently 8.2.2
+ cpx2 6.0.1
+ cross-env 7.0.3
+ cz-git 1.7.1
+ esbuild 0.19.8
+ eslint 8.54.0
+ eslint-config-prettier 9.0.0
+ eslint-plugin-import 2.29.0
+ eslint-plugin-prettier 5.0.1
+ eslint-plugin-vue 9.18.1
+ execa 8.0.1
+ gulp 4.0.2
+ http-server 14.1.1
+ husky 8.0.3
+ inquirer 9.2.12
+ magic-string 0.30.5
+ markdownlint-cli 0.37.0
+ nano-staged 0.8.0
+ ora 7.0.1
+ picocolors 1.0.0
+ prettier 3.1.0
+ rimraf 5.0.5
+ rollup 4.6.0
+ rollup-plugin-copy 3.5.0
+ rollup-plugin-dts 6.1.0
+ rollup-plugin-esbuild 6.1.0
+ rollup-plugin-resolve-shebang 1.0.1
+ sort-package-json 2.6.0
+ stylelint 15.11.0
+ stylelint-config-hope 4.1.0
+ through2 4.0.2
+ tslib 2.6.2
+ tsx 4.5.0 (4.5.1 is available)
+ typescript 5.3.2
+ vitest 0.34.6

Done in 35.8s
```
