### PR TITLE
fix(patch-commit): Wrap out patch dir in quotes in the log statement

### DIFF
--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -103,7 +103,7 @@ export async function handler (opts: PatchCommandOptions, params: string[]) {
   }
   return `You can now edit the following folder: ${editDir}
 
-Once you're done with your changes, run "pnpm patch-commit ${editDir}"`
+Once you're done with your changes, run "pnpm patch-commit '${editDir}'"`
 }
 
 function tryPatchWithExistingPatchFile (


### PR DESCRIPTION
When running `pnpm patch-commit C://....` in Windows machine it can't find the file without quotes

> $ pnpm patch-commit C:\Users\A7med\AppData\Local\Temp\d26090b9171e469a1772e17685fc5823
> ENOENT  ENOENT: no such file or directory, open 'C:\UsersA7medAppDataLocalTempd26090b9171e469a1772e17685fc5823\package.json'

After some debugging I found that it must be wrapped with quotes:

> $ pnpm patch-commit 'C:\Users\A7med\AppData\Local\Temp\d26090b9171e469a1772e17685fc5823'
> Packages: -1
> -
> Progress: resolved 1045, reused 1016, downloaded 0, added 1, done