### PR TITLE
test: fix flaking filterProd and monorepo test due to json-append on windows

### DIFF
--- a/pnpm/test/filterProd.test.ts
+++ b/pnpm/test/filterProd.test.ts
@@ -1,57 +1,70 @@
+import fs from 'fs/promises'
 import path from 'path'
 import writeYamlFile from 'write-yaml-file'
 import { execPnpm } from './utils'
 import {
   preparePackages,
 } from '@pnpm/prepare'
+import { type ProjectManifest } from '@pnpm/types'
 
 test.each([
-  { message: '--filter should include devDependencies', filter: '--filter', expected: ['project-1', 'project-3', 'project-4'] },
-  { message: '--filter-prod should not include devDependencies', filter: '--filter-prod', expected: ['project-1', 'project-3'] },
+  { message: '--filter should include devDependencies', filter: '--filter', expected: new Set(['project-1', 'project-3', 'project-4']) },
+  { message: '--filter-prod should not include devDependencies', filter: '--filter-prod', expected: new Set(['project-1', 'project-3']) },
 ])('$message', async ({ filter, expected }) => {
-  preparePackages([
+  // Using backticks in scripts for better readability. Otherwise single quotes need to be escaped.
+  /* eslint-disable @typescript-eslint/quotes */
+  const projects: Array<ProjectManifest & { name: string }> = [
     {
       name: 'project-1',
       version: '1.0.0',
       dependencies: { 'project-2': '1.0.0', 'project-3': '1.0.0' },
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-2',
       version: '1.0.0',
       dependencies: {},
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-3',
       version: '1.0.0',
       dependencies: { 'project-2': '1.0.0' },
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-4',
       version: '1.0.0',
       dependencies: {},
-      devDependencies: { 'json-append': '1', 'project-3': '1.0.0' },
+      devDependencies: { 'project-3': '1.0.0' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-4\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
-  ])
+  ]
+  preparePackages(projects)
 
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
   await execPnpm(['install'])
 
+  // Ensure none of these files exist before the build script runs.
+  await Promise.all(projects.map(async project => {
+    await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
+  }))
+
   await execPnpm(['recursive', 'test', filter, '...project-3'])
-  const { default: output } = await import(path.resolve('output.json'))
-  expect(output.sort()).toStrictEqual(expected)
+
+  await Promise.all(projects.map(async project => {
+    if (expected.has(project.name)) {
+      await expect(fs.access(path.resolve(project.name, 'output.txt'))).resolves.not.toThrow()
+    } else {
+      await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
+    }
+  }))
 })

--- a/pnpm/test/filterProd.test.ts
+++ b/pnpm/test/filterProd.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises'
+import fs from 'fs'
 import path from 'path'
 import writeYamlFile from 'write-yaml-file'
 import { execPnpm } from './utils'
@@ -54,17 +54,17 @@ test.each([
   await execPnpm(['install'])
 
   // Ensure none of these files exist before the build script runs.
-  await Promise.all(projects.map(async project => {
-    await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
-  }))
+  for (const project of projects) {
+    expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeFalsy()
+  }
 
   await execPnpm(['recursive', 'test', filter, '...project-3'])
 
-  await Promise.all(projects.map(async project => {
+  for (const project of projects) {
     if (expected.has(project.name)) {
-      await expect(fs.access(path.resolve(project.name, 'output.txt'))).resolves.not.toThrow()
+      expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeTruthy()
     } else {
-      await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
+      expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeFalsy()
     }
-  }))
+  }
 })

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -21,6 +21,7 @@ import symlink from 'symlink-dir'
 import writeYamlFile from 'write-yaml-file'
 import { execPnpm, execPnpmSync } from '../utils'
 import { addDistTag } from '@pnpm/registry-mock'
+import { type ProjectManifest } from '@pnpm/types'
 
 test('no projects matched the filters', async () => {
   preparePackages([
@@ -340,46 +341,46 @@ test('topological order of packages with self-dependencies in monorepo is correc
 })
 
 test('test-pattern is respected by the test script', async () => {
+  // Using backticks in scripts for better readability. Otherwise single quotes need to be escaped.
+  /* eslint-disable @typescript-eslint/quotes */
+
   const remote = tempy.directory()
 
-  preparePackages([
+  const projects: Array<ProjectManifest & { name: string }> = [
     {
       name: 'project-1',
       version: '1.0.0',
       dependencies: { 'project-2': 'workspace:*', 'project-3': 'workspace:*' },
-      devDependencies: { 'json-append': '1.1.1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-2',
       version: '1.0.0',
       dependencies: {},
-      devDependencies: { 'json-append': '1.1.1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-3',
       version: '1.0.0',
       dependencies: { 'project-2': 'workspace:*' },
-      devDependencies: { 'json-append': '1.1.1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
     {
       name: 'project-4',
       version: '1.0.0',
       dependencies: {},
-      devDependencies: { 'json-append': '1.1.1' },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-4\')" | json-append ../output.json',
+        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
       },
     },
-  ])
+  ]
+  preparePackages(projects)
 
   await execa('git', ['init', '--initial-branch=main'])
   await execa('git', ['config', 'user.email', 'x@y.z'])
@@ -398,14 +399,25 @@ test('test-pattern is respected by the test script', async () => {
   await execa('git', ['add', '.'])
   await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'])
 
-  process.chdir('project-1')
-
   await execPnpm(['install'])
+
+  // Ensure none of these files exist before the test script runs.
+  await Promise.all(projects.map(async project => {
+    await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
+  }))
 
   await execPnpm(['recursive', 'test', '--filter', '...[origin/main]'])
 
-  const { default: output } = await import(path.resolve('..', 'output.json'))
-  expect(output.sort()).toStrictEqual(['project-2', 'project-4'])
+  // Expecting only project-2 and project-4 to run since they were changed above.
+  const expected = new Set(['project-2', 'project-4'])
+
+  await Promise.all(projects.map(async project => {
+    if (expected.has(project.name)) {
+      await expect(fs.access(path.resolve(project.name, 'output.txt'))).resolves.not.toThrow()
+    } else {
+      await expect(fs.access(path.resolve(project.name, 'output.txt'))).rejects.toThrow()
+    }
+  }))
 })
 
 test('changed-files-ignore-pattern is respected', async () => {


### PR DESCRIPTION
## Problem

Similar to https://github.com/pnpm/pnpm/pull/7346, I'm seeing this test in `test/filterProd.test.ts` flake on Windows.

```
2023-12-19T18:45:03.5114961Z FAIL test/filterProd.test.ts (6.17 s)
2023-12-19T18:45:03.5117704Z   ● --filter should include devDependencies
2023-12-19T18:45:03.5118205Z 
2023-12-19T18:45:03.5120054Z     expect(received).toStrictEqual(expected) // deep equality
2023-12-19T18:45:03.5120621Z 
2023-12-19T18:45:03.5120898Z     - Expected  - 1
2023-12-19T18:45:03.5121295Z     + Received  + 0
2023-12-19T18:45:03.5121553Z 
2023-12-19T18:45:03.5121686Z       Array [
2023-12-19T18:45:03.5123124Z         "project-1",
2023-12-19T18:45:03.5123926Z         "project-3",
2023-12-19T18:45:03.5124769Z     -   "project-4",
2023-12-19T18:45:03.5125159Z       ]
2023-12-19T18:45:03.5125351Z 
2023-12-19T18:45:03.5129028Z       54 |   await execPnpm(['recursive', 'test', filter, '...project-3'])
2023-12-19T18:45:03.5132391Z       55 |   const { default: output } = await import(path.resolve('output.json'))
2023-12-19T18:45:03.5134315Z     > 56 |   expect(output.sort()).toStrictEqual(expected)
2023-12-19T18:45:03.5135327Z          |                         ^
2023-12-19T18:45:03.5136097Z       57 | })
2023-12-19T18:45:03.5136621Z 
2023-12-19T18:45:03.5138194Z       at test/filterProd.test.ts:56:25
```

## Changes

Using the approach in https://github.com/pnpm/pnpm/pull/7346, let's write to separate files for testing to avoid race conditions when writing to the same file.