### PR TITLE
Fix `--update-interactive` for light theme

### DIFF
--- a/.changeset/great-comics-clap.md
+++ b/.changeset/great-comics-clap.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+Better support for light themed terminals by the `pnpm update --interactive` command [#7439](https://github.com/pnpm/pnpm/issues/7439).

--- a/pkg-manager/plugin-commands-installation/src/update/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/index.ts
@@ -238,9 +238,9 @@ async function interactiveUpdate (
       return this.styles.primary(this.selected.name)
     },
     styles: {
-      dark: chalk.white,
+      dark: chalk.gray,
       em: chalk.bgBlack.whiteBright,
-      success: chalk.white,
+      success: chalk.gray,
     },
     type: 'multiselect',
     validate (value: string[]) {

--- a/pkg-manager/plugin-commands-installation/src/update/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/index.ts
@@ -238,9 +238,9 @@ async function interactiveUpdate (
       return this.styles.primary(this.selected.name)
     },
     styles: {
-      dark: chalk.gray,
+      dark: chalk.reset,
       em: chalk.bgBlack.whiteBright,
-      success: chalk.gray,
+      success: chalk.reset,
     },
     type: 'multiselect',
     validate (value: string[]) {


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/7439

According to `enquirer` [sources](https://github.com/enquirer/enquirer/blob/70bdb0fedc3ed355d9d8fe4f00ac9b3874f94f61/lib/prompt.js#L327) it uses `styles.success` or `styles.dark`.

According to my tests with chalk, `chalk.white()` is invisible in light terminal theme. So I suggest using `gray` (any other ideas are welcome).

![Screenshot from 2023-12-23 19-50-51](https://github.com/pnpm/pnpm/assets/19343/49c4ad93-eacb-4455-a1d8-f65865153807)
![Screenshot from 2023-12-23 19-51-00](https://github.com/pnpm/pnpm/assets/19343/1bd5b3af-8f11-4091-9fc0-60e4ce72661b)
