### PR TITLE
fix: --global related error messages

### DIFF
--- a/.changeset/friendly-owls-smell.md
+++ b/.changeset/friendly-owls-smell.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-env": patch
+"pnpm": patch
 ---
 
-fix: --global related error messages
+Fix error message texts in the `pnpm env` commands [#7456](https://github.com/pnpm/pnpm/pull/7456).

--- a/.changeset/friendly-owls-smell.md
+++ b/.changeset/friendly-owls-smell.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-env": patch
+---
+
+fix: --global related error messages

--- a/env/plugin-commands-env/src/envAdd.ts
+++ b/env/plugin-commands-env/src/envAdd.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-await-in-loop */
 import { PnpmError } from '@pnpm/error'
-import { type NvmNodeCommandOptions } from './node'
 import { downloadNodeVersion } from './downloadNodeVersion'
+import { type NvmNodeCommandOptions } from './node'
 
 export async function envAdd (opts: NvmNodeCommandOptions, params: string[]) {
   if (!opts.global) {
-    throw new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env use <version>" can only be used with the "--global" option currently')
+    throw new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env add <version>" can only be used with the "--global" option currently')
   }
   const failed: string[] = []
   for (const envSpecifier of params) {

--- a/env/plugin-commands-env/src/envRemove.ts
+++ b/env/plugin-commands-env/src/envRemove.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-await-in-loop */
-import { existsSync } from 'fs'
-import path from 'path'
 import { PnpmError } from '@pnpm/error'
-import { logger, globalInfo } from '@pnpm/logger'
+import { globalInfo, logger } from '@pnpm/logger'
 import { removeBin } from '@pnpm/remove-bins'
 import rimraf from '@zkochan/rimraf'
-import { getNodeExecPathAndTargetDir } from './utils'
-import { getNodeVersionsBaseDir, type NvmNodeCommandOptions } from './node'
+import { existsSync } from 'fs'
+import path from 'path'
 import { getNodeVersion } from './downloadNodeVersion'
+import { getNodeVersionsBaseDir, type NvmNodeCommandOptions } from './node'
+import { getNodeExecPathAndTargetDir } from './utils'
 
 export async function envRemove (opts: NvmNodeCommandOptions, params: string[]) {
   if (!opts.global) {
-    throw new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env use <version>" can only be used with the "--global" option currently')
+    throw new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env remove <version>" can only be used with the "--global" option currently')
   }
 
   let failed = false

--- a/env/plugin-commands-env/test/env.test.ts
+++ b/env/plugin-commands-env/test/env.test.ts
@@ -1,10 +1,10 @@
-import fs from 'fs'
-import path from 'path'
 import { PnpmError } from '@pnpm/error'
-import { tempDir } from '@pnpm/prepare'
 import { env } from '@pnpm/plugin-commands-env'
+import { tempDir } from '@pnpm/prepare'
 import * as execa from 'execa'
+import fs from 'fs'
 import nock from 'nock'
+import path from 'path'
 import PATH from 'path-name'
 import semver from 'semver'
 
@@ -147,7 +147,7 @@ describe('env add/remove', () => {
         pnpmHomeDir: process.cwd(),
         rawConfig: {},
       }, ['remove', 'lts'])
-    ).rejects.toEqual(new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env use <version>" can only be used with the "--global" option currently'))
+    ).rejects.toEqual(new PnpmError('NOT_IMPLEMENTED_YET', '"pnpm env remove <version>" can only be used with the "--global" option currently'))
   })
 
   test('fail if can not resolve Node.js version', async () => {


### PR DESCRIPTION
Fix incorrect error messages.

```shell
pnpm env rm 21.5.0
# ERR_PNPM_NOT_IMPLEMENTED_YET  "pnpm env use <version>" can only be used with the "--global" option currently

pnpm env rm 21.5.0 --global
# Node.js 21.5.0 was removed
```

```diff
- pnpm env use
+ pnpm env remove
```