### PR TITLE
test: fix file system race conditions in tests by switching to an IPC server

### DIFF
--- a/__utils__/test-ipc-server/README.md
+++ b/__utils__/test-ipc-server/README.md
@@ -1,0 +1,53 @@
+# @pnpm/test-ipc-server
+
+The `TestIpcServer` is a simple Inter-Process Communication (IPC) server written specifically for usage in pnpm tests.
+
+It's a simple wrapper around Node.js's builtin [_IPC support_](https://nodejs.org/api/net.html#ipc-support). Messages sent to the server are saved to a buffer that can be retrieved for assertions.
+
+## Rationale
+
+In the past, many pnpm tests contained scripts that wrote output to the same file. Writing to the same file concurrently causes race conditions resulting in flaky CI tests. The race conditions occur due to multiple processes reading a file, appending data, and writing the file back out. If two processes start at the same time and read the same input, one of the process's output would be overwritten by the other.
+
+At the time of writing (December 2023), there's no great cross-platform way to append to a file atomically. From https://www.man7.org/linux/man-pages/man2/open.2.html
+
+> `O_APPEND` may lead to corrupted files on NFS filesystems if more than one process appends data to a file at once. This is because NFS does not support appending to a file, so the client kernel has to simulate it, which can't be done without a race condition.
+
+The `TestIpcServer` doesn't drop messages the same way since it's using Node.js's IPC mechanism that is specifically designed to handle multiple clients.
+
+## Example
+
+A common testing pattern in the pnpm repo is to ensure package scripts runs as expected or in particular orders.
+
+```json
+{
+  "name": "@pnpm/example-test-fixture",
+  "private": true,
+  "scripts": {
+    "build": "echo 'This script should run'"
+  }
+}
+```
+
+This can be tested through the `TestIpcServer`,
+
+```ts
+import { prepare } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
+
+test('example test', async () => {
+  await using server = await createTestIpcServer()
+  prepare({
+    scripts: {
+      build: server.sendLineScript('this is a built script that should run'),
+    },
+  })
+
+  await execa('node', [pnpmBin, 'run', 'build'])
+
+  expect(server.getLines()).toStrictEqual(['this is a built script that should run'])
+})
+```
+
+## License
+
+MIT

--- a/__utils__/test-ipc-server/bin/test-ipc-server-client.js
+++ b/__utils__/test-ipc-server/bin/test-ipc-server-client.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/clientBin')

--- a/__utils__/test-ipc-server/jest.config.js
+++ b/__utils__/test-ipc-server/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config')

--- a/__utils__/test-ipc-server/package.json
+++ b/__utils__/test-ipc-server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pnpm/test-ipc-server",
+  "version": "0.0.0",
+  "private": true,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "bin": {
+    "test-ipc-server-client": "./bin/test-ipc-server-client.js"
+  },
+  "devDependencies": {
+    "@pnpm/prepare": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
+    "@types/node": "^18.14.6",
+    "execa": "npm:safe-execa@0.1.2"
+  },
+  "scripts": {
+    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
+    "test": "pnpm run compile && jest"
+  }
+}

--- a/__utils__/test-ipc-server/src/TestIpcServer.ts
+++ b/__utils__/test-ipc-server/src/TestIpcServer.ts
@@ -1,0 +1,105 @@
+import net from 'node:net'
+import { promisify } from 'node:util'
+import { computeHandlePath } from './computeHandlePath'
+
+// Polyfilling Symbol.asyncDispose for Jest.
+//
+// Copied with a few changes from https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#using-declarations-and-explicit-resource-management
+if (Symbol.asyncDispose === undefined) {
+  (Symbol as { asyncDispose?: symbol }).asyncDispose = Symbol('Symbol.asyncDispose')
+}
+if (Symbol.dispose === undefined) {
+  (Symbol as { dispose?: symbol }).dispose = Symbol('Symbol.dispose')
+}
+
+/**
+ * A simple Inter-Process Communication (IPC) server written specifically for
+ * usage in pnpm tests.
+ *
+ * It's a simple wrapper around Node.js's builtin IPC support. Messages sent to
+ * the server are saved to a buffer that can be retrieved for assertions.
+ */
+export class TestIpcServer implements AsyncDisposable {
+  private readonly server: net.Server
+  private buffer = ''
+
+  public readonly listenPath: string
+
+  constructor (server: net.Server, listenPath: string) {
+    this.server = server
+    this.listenPath = listenPath
+
+    server.on('connection', (client) => {
+      client.on('data', data => {
+        this.buffer += data.toString()
+      })
+    })
+  }
+
+  /**
+   * Creates a new IPC server.
+   *
+   * The handle is expected to be a file system path. On Linux and macOS, a unix
+   * socket is created at this path. On Windows, a named pipe is created using
+   * the path as the name.
+   */
+  public static async listen (handle?: string): Promise<TestIpcServer> {
+    const listenPath = computeHandlePath(handle)
+    const server = net.createServer()
+    const testIpcServer = new TestIpcServer(server, listenPath)
+
+    return new Promise((resolve, reject) => {
+      server.once('error', reject)
+
+      server.listen(listenPath, () => {
+        resolve(testIpcServer)
+      })
+    })
+  }
+
+  /**
+   * Return the buffer of received messages.
+   */
+  public getBuffer (): string {
+    return this.buffer
+  }
+
+  /**
+   * Return the buffer as an array of strings split by the new line character.
+   */
+  public getLines (): string[] {
+    return this.buffer === ''
+      ? []
+      : this.buffer.trim().split('\n')
+  }
+
+  /**
+   * Reset the buffer to an empty string.
+   */
+  public clear () {
+    this.buffer = ''
+  }
+
+  /**
+   * Generates a shell script that can used as a package manifest "scripts"
+   * entry. Exits after sending the message.
+   */
+  public sendLineScript (message: string) {
+    return `node -e "const c = require('net').connect('${JSON.stringify(this.listenPath).slice(1, -1)}', () => { c.write('${message}\\n'); c.end(); })"`
+  }
+
+  /**
+   * Generates a shell script that can used as a package manifest "scripts"
+   * entry. This script consumes its stdin and sends it to the server.
+   */
+  public generateSendStdinScript () {
+    return `node -e "const c = require('net').connect('${JSON.stringify(this.listenPath).slice(1, -1)}', () => { process.stdin.pipe(c).on('end', () => { c.destroy(); }); })"`
+  }
+
+  public [Symbol.asyncDispose] = async () => {
+    const close = promisify(this.server.close).bind(this.server)
+    await close()
+  }
+}
+
+export const createTestIpcServer = TestIpcServer.listen

--- a/__utils__/test-ipc-server/src/clientBin.ts
+++ b/__utils__/test-ipc-server/src/clientBin.ts
@@ -1,0 +1,9 @@
+import net from 'node:net'
+import { computeHandlePath } from './computeHandlePath'
+
+const [handle] = process.argv.slice(2)
+const connectPath = computeHandlePath(handle)
+
+const client = net.connect(connectPath, () => {
+  process.stdin.pipe(client).on('end', () => client.destroy())
+})

--- a/__utils__/test-ipc-server/src/computeHandlePath.ts
+++ b/__utils__/test-ipc-server/src/computeHandlePath.ts
@@ -1,0 +1,19 @@
+import crypto from 'node:crypto'
+import os from 'node:os'
+import path from 'node:path'
+
+export function computeHandlePath (handle?: string) {
+  const handleFilePath = handle != null
+    ? path.resolve(handle)
+    : path.join(os.tmpdir(), `${crypto.randomUUID()}.sock`)
+
+  // Node.js and libuv do not yet support unix sockets on Windows.
+  // https://github.com/libuv/libuv/issues/2537
+  //
+  // Until then, the best IPC alternative on Windows is a "named pipe", which
+  // needs to be prefixed with '\\<server-name>\pipe'.
+  // https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections
+  return os.platform() === 'win32'
+    ? path.join('\\\\.\\pipe', 'pnpm-test-ipc-server', handleFilePath)
+    : handleFilePath
+}

--- a/__utils__/test-ipc-server/src/index.ts
+++ b/__utils__/test-ipc-server/src/index.ts
@@ -1,0 +1,1 @@
+export { createTestIpcServer, TestIpcServer } from './TestIpcServer'

--- a/__utils__/test-ipc-server/test/TestIpcServer.test.ts
+++ b/__utils__/test-ipc-server/test/TestIpcServer.test.ts
@@ -1,0 +1,145 @@
+/// <reference lib="esnext.disposable" />
+import execa from 'execa'
+import fs from 'fs'
+import net from 'net'
+import path from 'path'
+import { setTimeout } from 'timers/promises'
+import { promisify } from 'util'
+import { prepare } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
+
+const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
+
+describe('TestEchoServer', () => {
+  describe('lifecycle', () => {
+    it('cleans up through Symbol.asyncDispose', async () => {
+      let listenPath: string
+
+      // eslint-disable-next-line no-lone-blocks
+      {
+        await using server = await createTestIpcServer()
+        listenPath = server.listenPath
+        await expect(fs.promises.access(server.listenPath)).resolves.not.toThrow()
+      }
+
+      // The Symbol.asyncDispose method should have been called by this point and
+      // removed the listening file.
+      await expect(fs.promises.access(listenPath)).rejects.toThrow('ENOENT')
+    })
+
+    it('throws if another server is listening on same socket', async () => {
+      await using server = await createTestIpcServer()
+      await expect(createTestIpcServer(server.listenPath)).rejects.toThrow('EADDRINUSE')
+    })
+  })
+
+  describe('message handling', () => {
+    it('receives messages', async () => {
+      await using server = await createTestIpcServer()
+      await using client = await createClient(server.listenPath)
+      await client.sendLine('hello')
+      await client.sendLine('world')
+
+      // Wait a short amount of time for the server to handle incoming messages.
+      await setTimeout(50)
+      expect(server.getBuffer()).toStrictEqual('hello\nworld\n')
+      expect(server.getLines()).toStrictEqual(['hello', 'world'])
+    })
+
+    it('clears messages', async () => {
+      await using server = await createTestIpcServer()
+      await using client = await createClient(server.listenPath)
+      await client.sendLine('hello')
+      await client.sendLine('world')
+
+      // Wait a short amount of time for the server to handle incoming messages.
+      await setTimeout(50)
+      expect(server.getLines()).toStrictEqual(['hello', 'world'])
+
+      server.clear()
+
+      expect(server.getLines()).toStrictEqual([])
+    })
+  })
+
+  describe('generated scripts', () => {
+    it('generates working send message script', async () => {
+      await using server = await createTestIpcServer()
+
+      prepare({
+        scripts: {
+          build: server.sendLineScript('build script'),
+        },
+      })
+
+      await execa('node', [pnpmBin, 'run', 'build'])
+
+      expect(server.getLines()).toStrictEqual(['build script'])
+    })
+
+    it('send message script works with &&', async () => {
+      await using server = await createTestIpcServer()
+
+      prepare({
+        scripts: {
+          build: `${server.sendLineScript('message1')} && ${server.sendLineScript('message2')}`,
+        },
+      })
+
+      await execa('node', [pnpmBin, 'run', 'build'])
+
+      expect(server.getLines()).toStrictEqual(['message1', 'message2'])
+    })
+
+    it('generates working stdin script', async () => {
+      await using server = await createTestIpcServer()
+
+      prepare({
+        scripts: {
+          build: `node -e "process.stdout.write('build script')" | ${server.generateSendStdinScript()}`,
+        },
+      })
+
+      await execa('node', [pnpmBin, 'run', 'build'])
+
+      expect(server.getLines()).toStrictEqual(['build script'])
+    })
+  })
+
+  it('has working client binary', async () => {
+    const project = prepare({
+      scripts: {
+        build: "node -e \"process.stdout.write('build script')\" | test-ipc-server-client ./test.sock",
+      },
+    })
+
+    await using server = await createTestIpcServer(path.join(project.dir(), './test.sock'))
+
+    await execa('node', [pnpmBin, 'run', 'build'])
+
+    expect(server.getLines()).toStrictEqual(['build script'])
+  })
+})
+
+interface TestClient extends AsyncDisposable {
+  sendLine: (message: string) => Promise<void>
+}
+
+function createClient (handle: string): Promise<TestClient> {
+  const client = net.connect(handle)
+
+  const write = promisify(client.write).bind(client)
+  const destroy = promisify(client.destroy).bind(client)
+
+  return new Promise((resolve, reject) => {
+    client.once('error', reject)
+    client.once('ready', () => {
+      resolve({
+        sendLine: (message: string) => write(message + '\n'),
+        [Symbol.asyncDispose]: async () => {
+          await destroy(undefined)
+        },
+      })
+    })
+  })
+}

--- a/__utils__/test-ipc-server/tsconfig.json
+++ b/__utils__/test-ipc-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "lib": ["ESNext.Disposable"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../prepare"
+    }
+  ],
+  "composite": true
+}

--- a/__utils__/test-ipc-server/tsconfig.lint.json
+++ b/__utils__/test-ipc-server/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -49,9 +49,9 @@
   "devDependencies": {
     "@pnpm/lifecycle": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/rimraf": "^3.0.2",
     "@zkochan/rimraf": "^2.1.3",
-    "json-append": "1.1.1",
     "load-json-file": "^6.2.0"
   },
   "funding": "https://opencollective.com/pnpm",

--- a/exec/lifecycle/test/fixtures/.gitignore
+++ b/exec/lifecycle/test/fixtures/.gitignore
@@ -1,1 +1,2 @@
 output.json
+test.sock

--- a/exec/lifecycle/test/fixtures/gyp-with-preinstall/package.json
+++ b/exec/lifecycle/test/fixtures/gyp-with-preinstall/package.json
@@ -2,6 +2,6 @@
   "name": "gyp-with-preinstall",
   "version": "1.0.0",
   "scripts": {
-    "preinstall": "node -e \"process.stdout.write('preinstall')\" | json-append output.json"
+    "preinstall": "node -e \"process.stdout.write('preinstall')\" | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/lifecycle/test/fixtures/inspect-frozen-lockfile/package.json
+++ b/exec/lifecycle/test/fixtures/inspect-frozen-lockfile/package.json
@@ -2,6 +2,6 @@
   "name": "inspect-frozen-lockfile",
   "version": "1.0.0",
   "scripts": {
-    "postinstall": "rimraf output.json && node postinstall.js | json-append output.json"
+    "postinstall": "node postinstall.js | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/lifecycle/test/fixtures/simple/package.json
+++ b/exec/lifecycle/test/fixtures/simple/package.json
@@ -2,6 +2,6 @@
   "name": "simple",
   "version": "1.0.0",
   "scripts": {
-    "postinstall": "rimraf output.json && node -e \"process.stdout.write('install')\" | json-append output.json"
+    "postinstall": "node -e \"process.stdout.write('install')\" | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/lifecycle/test/fixtures/with-many-scripts/package.json
+++ b/exec/lifecycle/test/fixtures/with-many-scripts/package.json
@@ -2,9 +2,9 @@
   "name": "with-many-scripts",
   "version": "1.0.0",
   "scripts": {
-    "prepare": "node -e \"process.stdout.write('prepare')\" | json-append output.json",
-    "preinstall": "node -e \"process.stdout.write('preinstall')\" | json-append output.json",
-    "install": "node -e \"process.stdout.write('install')\" | json-append output.json",
-    "postinstall": "node -e \"process.stdout.write('postinstall')\" | json-append output.json"
+    "prepare": "node -e \"console.log('prepare')\" | test-ipc-server-client ./test.sock",
+    "preinstall": "node -e \"console.log('preinstall')\" | test-ipc-server-client ./test.sock",
+    "install": "node -e \"console.log('install')\" | test-ipc-server-client ./test.sock",
+    "postinstall": "node -e \"console.log('postinstall')\" | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/lifecycle/tsconfig.json
+++ b/exec/lifecycle/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../fetching/directory-fetcher"
     },
     {

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -36,6 +36,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.17.1",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/ramda": "0.28.20",
     "@types/semver": "7.5.3",
     "@types/sinon": "^10.0.20",

--- a/exec/plugin-commands-rebuild/test/recursive.ts
+++ b/exec/plugin-commands-rebuild/test/recursive.ts
@@ -148,12 +148,11 @@ test('pnpm recursive rebuild with hoisted node linker', async () => {
   await projects['project-4'].has('@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')
 })
 
-// TODO: make this test pass
-test.skip('rebuild multiple packages in correct order', async () => {
+test('rebuild multiple packages in correct order', async () => {
   await using server1 = await createTestIpcServer()
   await using server2 = await createTestIpcServer()
 
-  const pkgs = [
+  const pkgs: Array<PackageManifest & { name: string }> = [
     {
       name: 'project-1',
       version: '1.0.0',
@@ -190,9 +189,9 @@ test.skip('rebuild multiple packages in correct order', async () => {
 
       dependencies: {},
     },
-  ] as PackageManifest[]
+  ]
   preparePackages(pkgs)
-  await writeYamlFile('pnpm-workspace.yaml', { packages: ['project-1'] })
+  await writeYamlFile('pnpm-workspace.yaml', { packages: pkgs.map(pkg => pkg.name) })
 
   const { allProjects, selectedProjectsGraph } = await readProjects(process.cwd(), [])
   await execa('node', [

--- a/exec/plugin-commands-rebuild/tsconfig.json
+++ b/exec/plugin-commands-rebuild/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -35,6 +35,7 @@
     "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.17.1",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/is-windows": "^1.0.2",
     "@types/ramda": "0.28.20",
     "@types/which": "^2.0.2",

--- a/exec/plugin-commands-script-runners/test/index.ts
+++ b/exec/plugin-commands-script-runners/test/index.ts
@@ -9,6 +9,7 @@ import {
   test as testCommand,
 } from '@pnpm/plugin-commands-script-runners'
 import { prepare, preparePackages } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import execa from 'execa'
 import isWindows from 'is-windows'
 import writeYamlFile from 'write-yaml-file'
@@ -179,23 +180,24 @@ test('run stop: pass the args to the command that is specified in the build scri
 })
 
 test('restart: run stop, restart and start', async () => {
+  await using server = await createTestIpcServer()
+
   prepare({
     scripts: {
-      poststop: 'node -e "process.stdout.write(\'poststop\')" | json-append ./output.json',
-      prestop: 'node -e "process.stdout.write(\'prestop\')" | json-append ./output.json',
-      stop: 'node -e "process.stdout.write(\'stop\')" | json-append ./output.json',
+      poststop: server.sendLineScript('poststop'),
+      prestop: server.sendLineScript('prestop'),
+      stop: server.sendLineScript('stop'),
 
-      postrestart: 'node -e "process.stdout.write(\'postrestart\')" | json-append ./output.json',
-      prerestart: 'node -e "process.stdout.write(\'prerestart\')" | json-append ./output.json',
-      restart: 'node -e "process.stdout.write(\'restart\')" | json-append ./output.json',
+      postrestart: server.sendLineScript('postrestart'),
+      prerestart: server.sendLineScript('prerestart'),
+      restart: server.sendLineScript('restart'),
 
-      poststart: 'node -e "process.stdout.write(\'poststart\')" | json-append ./output.json',
-      prestart: 'node -e "process.stdout.write(\'prestart\')" | json-append ./output.json',
-      start: 'node -e "process.stdout.write(\'start\')" | json-append ./output.json',
+      poststart: server.sendLineScript('poststart'),
+      prestart: server.sendLineScript('prestart'),
+      start: server.sendLineScript('start'),
     },
   })
 
-  await execa('pnpm', ['add', 'json-append@1'])
   await restart.handler({
     dir: process.cwd(),
     extraBinPaths: [],
@@ -203,8 +205,7 @@ test('restart: run stop, restart and start', async () => {
     rawConfig: {},
   }, [])
 
-  const { default: scriptsRan } = await import(path.resolve('output.json'))
-  expect(scriptsRan).toStrictEqual([
+  expect(server.getLines()).toStrictEqual([
     'stop',
     'restart',
     'start',
@@ -212,23 +213,24 @@ test('restart: run stop, restart and start', async () => {
 })
 
 test('restart: run stop, restart and start and all the pre/post scripts', async () => {
+  await using server = await createTestIpcServer()
+
   prepare({
     scripts: {
-      poststop: 'node -e "process.stdout.write(\'poststop\')" | json-append ./output.json',
-      prestop: 'node -e "process.stdout.write(\'prestop\')" | json-append ./output.json',
-      stop: 'pnpm prestop && node -e "process.stdout.write(\'stop\')" | json-append ./output.json && pnpm poststop',
+      poststop: server.sendLineScript('poststop'),
+      prestop: server.sendLineScript('prestop'),
+      stop: `${server.sendLineScript('stop')} && pnpm poststop`,
 
-      postrestart: 'node -e "process.stdout.write(\'postrestart\')" | json-append ./output.json',
-      prerestart: 'node -e "process.stdout.write(\'prerestart\')" | json-append ./output.json',
-      restart: 'node -e "process.stdout.write(\'restart\')" | json-append ./output.json',
+      postrestart: server.sendLineScript('postrestart'),
+      prerestart: server.sendLineScript('prerestart'),
+      restart: server.sendLineScript('restart'),
 
-      poststart: 'node -e "process.stdout.write(\'poststart\')" | json-append ./output.json',
-      prestart: 'node -e "process.stdout.write(\'prestart\')" | json-append ./output.json',
-      start: 'node -e "process.stdout.write(\'start\')" | json-append ./output.json',
+      poststart: server.sendLineScript('poststart'),
+      prestart: server.sendLineScript('prestart'),
+      start: server.sendLineScript('start'),
     },
   })
 
-  await execa('pnpm', ['add', 'json-append@1'])
   await restart.handler({
     dir: process.cwd(),
     enablePrePostScripts: true,
@@ -237,8 +239,7 @@ test('restart: run stop, restart and start and all the pre/post scripts', async 
     rawConfig: {},
   }, [])
 
-  const { default: scriptsRan } = await import(path.resolve('output.json'))
-  expect(scriptsRan).toStrictEqual([
+  expect(server.getLines()).toStrictEqual([
     'prestop',
     'stop',
     'poststop',
@@ -281,9 +282,6 @@ test('"pnpm run" prints the list of available commands, including commands of th
     {
       location: '.',
       package: {
-        dependencies: {
-          'json-append': '1',
-        },
         scripts: {
           build: 'echo root',
           test: 'test-all',
@@ -372,11 +370,8 @@ test('if a script is not found but is present in the root, print an info message
     {
       location: '.',
       package: {
-        dependencies: {
-          'json-append': '1',
-        },
         scripts: {
-          build: 'node -e "process.stdout.write(\'root\')" | json-append ./output.json',
+          build: 'node -e "process.stdout.write(\'root\')"',
         },
       },
     },
@@ -517,14 +512,15 @@ test('pnpm run with RegExp script selector should work also for pre/post script'
 })
 
 test('pnpm run with RegExp script selector should work parallel as a default behavior (parallel execution limits number is four)', async () => {
+  await using serverA = await createTestIpcServer()
+  await using serverB = await createTestIpcServer()
+
   prepare({
     scripts: {
-      'build:a': 'node -e "let i = 20;setInterval(() => {if (!--i) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-a.json\');},50)"',
-      'build:b': 'node -e "let i = 40;setInterval(() => {if (!--i) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-b.json\');},25)"',
+      'build:a': `node -e "let i = 20;setInterval(() => {if (!--i) process.exit(0); console.log(Date.now());},50)" | ${serverA.generateSendStdinScript()}`,
+      'build:b': `node -e "let i = 40;setInterval(() => {if (!--i) process.exit(0); console.log(Date.now());},25)" | ${serverB.generateSendStdinScript()}`,
     },
   })
-
-  await execa('pnpm', ['add', 'json-append@1'])
 
   await run.handler({
     dir: process.cwd(),
@@ -533,21 +529,22 @@ test('pnpm run with RegExp script selector should work parallel as a default beh
     rawConfig: {},
   }, ['/build:.*/'])
 
-  const { default: outputsA } = await import(path.resolve('output-a.json'))
-  const { default: outputsB } = await import(path.resolve('output-b.json'))
+  const outputsA = serverA.getLines().map(x => Number.parseInt(x))
+  const outputsB = serverB.getLines().map(x => Number.parseInt(x))
 
   expect(Math.max(outputsA[0], outputsB[0]) < Math.min(outputsA[outputsA.length - 1], outputsB[outputsB.length - 1])).toBeTruthy()
 })
 
 test('pnpm run with RegExp script selector should work sequentially with --workspace-concurrency=1', async () => {
+  await using serverA = await createTestIpcServer()
+  await using serverB = await createTestIpcServer()
+
   prepare({
     scripts: {
-      'build:a': 'node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-a.json\');},16)"',
-      'build:b': 'node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-b.json\');},16)"',
+      'build:a': `node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); console.log(Date.now()); },16)" | ${serverA.generateSendStdinScript()}`,
+      'build:b': `node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); console.log(Date.now()); },16)" | ${serverB.generateSendStdinScript()}`,
     },
   })
-
-  await execa('pnpm', ['add', 'json-append@1'])
 
   await run.handler({
     dir: process.cwd(),
@@ -557,17 +554,20 @@ test('pnpm run with RegExp script selector should work sequentially with --works
     workspaceConcurrency: 1,
   }, ['/build:.*/'])
 
-  const { default: outputsA } = await import(path.resolve('output-a.json'))
-  const { default: outputsB } = await import(path.resolve('output-b.json'))
+  const outputsA = serverA.getLines().map(x => Number.parseInt(x))
+  const outputsB = serverB.getLines().map(x => Number.parseInt(x))
 
   expect(outputsA[0] < outputsB[0] && outputsA[1] < outputsB[1]).toBeTruthy()
 })
 
 test('pnpm run with RegExp script selector with flag should throw error', async () => {
+  await using serverA = await createTestIpcServer()
+  await using serverB = await createTestIpcServer()
+
   prepare({
     scripts: {
-      'build:a': 'node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-a.json\');},16)"',
-      'build:b': 'node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); require(\'json-append\').append(Date.now(),\'./output-b.json\');},16)"',
+      'build:a': `node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); console.log(Date.now()); },16)" | ${serverA.generateSendStdinScript()}`,
+      'build:b': `node -e "let i = 2;setInterval(() => {if (!i--) process.exit(0); console.log(Date.now()); },16)" | ${serverB.generateSendStdinScript()}`,
     },
   })
 

--- a/exec/plugin-commands-script-runners/test/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/runRecursive.ts
@@ -581,7 +581,8 @@ test('testing the bail config with "pnpm recursive run"', async () => {
       recursive: true,
       selectedProjectsGraph,
       workspaceDir: process.cwd(),
-    }, ['build', '--no-bail'])
+      bail: false,
+    }, ['build'])
   } catch (_err: any) { // eslint-disable-line
     err1 = _err
   }

--- a/exec/plugin-commands-script-runners/test/testRecursive.ts
+++ b/exec/plugin-commands-script-runners/test/testRecursive.ts
@@ -2,22 +2,23 @@ import path from 'path'
 import { filterPkgsBySelectorObjects, readProjects } from '@pnpm/filter-workspace-packages'
 import { test as testCommand } from '@pnpm/plugin-commands-script-runners'
 import { preparePackages } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import execa from 'execa'
 import { DEFAULT_OPTS, REGISTRY_URL } from './utils'
 
 const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
 
 test('pnpm recursive test', async () => {
+  await using server1 = await createTestIpcServer()
+  await using server2 = await createTestIpcServer()
+
   preparePackages([
     {
       name: 'project-1',
       version: '1.0.0',
 
-      dependencies: {
-        'json-append': '1',
-      },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output1.json && node -e "process.stdout.write(\'project-1\')" | json-append ../output2.json',
+        test: `${server1.sendLineScript('project-1')} && ${server2.sendLineScript('project-1')}`,
       },
     },
     {
@@ -25,11 +26,10 @@ test('pnpm recursive test', async () => {
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-1': '1',
       },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output1.json',
+        test: server1.sendLineScript('project-2'),
       },
     },
     {
@@ -37,11 +37,10 @@ test('pnpm recursive test', async () => {
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-1': '1',
       },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output2.json',
+        test: server2.sendLineScript('project-3'),
       },
     },
     {
@@ -71,11 +70,8 @@ test('pnpm recursive test', async () => {
     workspaceDir: process.cwd(),
   })
 
-  const { default: outputs1 } = await import(path.resolve('output1.json'))
-  const { default: outputs2 } = await import(path.resolve('output2.json'))
-
-  expect(outputs1).toStrictEqual(['project-1', 'project-2'])
-  expect(outputs2).toStrictEqual(['project-1', 'project-3'])
+  expect(server1.getLines()).toStrictEqual(['project-1', 'project-2'])
+  expect(server2.getLines()).toStrictEqual(['project-1', 'project-3'])
 })
 
 test('`pnpm recursive test` does not fail if none of the packages has a test command', async () => {
@@ -130,16 +126,15 @@ test('`pnpm recursive test` does not fail if none of the packages has a test com
 })
 
 test('pnpm recursive test with filtering', async () => {
+  await using server = await createTestIpcServer()
+
   preparePackages([
     {
       name: 'project-1',
       version: '1.0.0',
 
-      dependencies: {
-        'json-append': '1',
-      },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
+        test: server.sendLineScript('project-1'),
       },
     },
     {
@@ -147,11 +142,10 @@ test('pnpm recursive test with filtering', async () => {
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-1': '1',
       },
       scripts: {
-        test: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output.json',
+        test: server.sendLineScript('project-2'),
       },
     },
   ])
@@ -180,7 +174,5 @@ test('pnpm recursive test with filtering', async () => {
     workspaceDir: process.cwd(),
   })
 
-  const { default: outputs } = await import(path.resolve('output.json'))
-
-  expect(outputs).toStrictEqual(['project-1'])
+  expect(server.getLines()).toStrictEqual(['project-1'])
 })

--- a/exec/plugin-commands-script-runners/tsconfig.json
+++ b/exec/plugin-commands-script-runners/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -42,6 +42,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/prepare-package": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/ramda": "0.28.20",
     "load-json-file": "^6.2.0"
   },

--- a/exec/prepare-package/test/__fixtures__/has-prepublish-script-and-main-file/package.json
+++ b/exec/prepare-package/test/__fixtures__/has-prepublish-script-and-main-file/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "file": "main.js",
   "scripts": {
-    "prepublish": "node -e \"process.stdout.write('prepublish')\" | json-append output.json"
-  },
-  "devDependencies": {
-    "json-append": "1.1.1"
+    "prepublish": "node -e \"console.log('prepublish')\" | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/prepare-package/test/__fixtures__/has-prepublish-script/package.json
+++ b/exec/prepare-package/test/__fixtures__/has-prepublish-script/package.json
@@ -2,10 +2,7 @@
   "name": "has-prepublish-script",
   "version": "1.0.0",
   "scripts": {
-    "prepublish": "node -e \"process.stdout.write('prepublish')\" | json-append output.json",
-    "postpublish": "node -e \"process.stdout.write('postpublish')\" | json-append output.json"
-  },
-  "devDependencies": {
-    "json-append": "1.1.1"
+    "prepublish": "node -e \"console.log('prepublish')\" | test-ipc-server-client ./test.sock",
+    "postpublish": "node -e \"console.log('postpublish')\" | test-ipc-server-client ./test.sock"
   }
 }

--- a/exec/prepare-package/test/index.ts
+++ b/exec/prepare-package/test/index.ts
@@ -1,25 +1,27 @@
 import path from 'path'
 import { preparePackage } from '@pnpm/prepare-package'
 import { tempDir } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { fixtures } from '@pnpm/test-fixtures'
-import { sync as loadJsonFile } from 'load-json-file'
 
 const f = fixtures(__dirname)
 
 test('prepare package runs the prepublish script', async () => {
   const tmp = tempDir()
+  await using server = await createTestIpcServer(path.join(tmp, 'test.sock'))
   f.copy('has-prepublish-script', tmp)
   await preparePackage({ rawConfig: {} }, tmp)
-  expect(loadJsonFile(path.join(tmp, 'output.json'))).toStrictEqual([
+  expect(server.getLines()).toStrictEqual([
     'prepublish',
   ])
 })
 
 test('prepare package does not run the prepublish script if the main file is present', async () => {
   const tmp = tempDir()
+  await using server = await createTestIpcServer(path.join(tmp, 'test.sock'))
   f.copy('has-prepublish-script-and-main-file', tmp)
   await preparePackage({ rawConfig: {} }, tmp)
-  expect(loadJsonFile(path.join(tmp, 'output.json'))).toStrictEqual([
+  expect(server.getLines()).toStrictEqual([
     'prepublish',
   ])
 })

--- a/exec/prepare-package/tsconfig.json
+++ b/exec/prepare-package/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../packages/types"
     },
     {

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -84,6 +84,7 @@
     "@pnpm/registry-mock": "3.17.1",
     "@pnpm/store-path": "workspace:*",
     "@pnpm/store.cafs": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/fs-extra": "^9.0.13",
     "@types/is-windows": "^1.0.2",

--- a/pkg-manager/core/test/install/lifecycleScripts.ts
+++ b/pkg-manager/core/test/install/lifecycleScripts.ts
@@ -10,6 +10,7 @@ import {
   type MutatedProject,
   mutateModules,
 } from '@pnpm/core'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { restartWorkerPool } from '@pnpm/worker'
 import rimraf from '@zkochan/rimraf'
 import isWindows from 'is-windows'
@@ -98,38 +99,47 @@ test('run install scripts', async () => {
 })
 
 test('run install scripts in the current project', async () => {
+  await using server = await createTestIpcServer()
+  await using serverForDevPreinstall = await createTestIpcServer()
   prepareEmpty()
   const manifest = await addDependenciesToPackage({
     scripts: {
-      'pnpm:devPreinstall': 'node -e "require(\'fs\').writeFileSync(\'test.txt\', \'\', \'utf-8\')"',
-      install: 'node -e "process.stdout.write(\'install\')" | json-append output.json',
-      postinstall: 'node -e "process.stdout.write(\'postinstall\')" | json-append output.json',
-      preinstall: 'node -e "process.stdout.write(\'preinstall\')" | json-append output.json',
+      'pnpm:devPreinstall': `node -e "console.log('pnpm:devPreinstall-' + process.cwd())" | ${serverForDevPreinstall.generateSendStdinScript()}`,
+      install: `node -e "console.log('install-' + process.cwd())" | ${server.generateSendStdinScript()}`,
+      postinstall: `node -e "console.log('postinstall-' + process.cwd())" | ${server.generateSendStdinScript()}`,
+      preinstall: `node -e "console.log('preinstall-' + process.cwd())" | ${server.generateSendStdinScript()}`,
     },
-  }, ['json-append@1.1.1'], await testDefaults({ fastUnpack: false }))
+  }, [], await testDefaults({ fastUnpack: false }))
   await install(manifest, await testDefaults({ fastUnpack: false }))
 
-  const output = await loadJsonFile<string[]>('output.json')
-
-  expect(output).toStrictEqual(['preinstall', 'install', 'postinstall'])
-  expect(await exists('test.txt')).toBeTruthy()
+  expect(server.getLines()).toStrictEqual([`preinstall-${process.cwd()}`, `install-${process.cwd()}`, `postinstall-${process.cwd()}`])
+  expect(serverForDevPreinstall.getLines()).toStrictEqual([
+    // The pnpm:devPreinstall script runs twice in this test. Once for the
+    // initial "addDependenciesToPackage" test setup stage and again for the
+    // dedicated install afterwards.
+    `pnpm:devPreinstall-${process.cwd()}`,
+    `pnpm:devPreinstall-${process.cwd()}`,
+  ])
 })
 
 test('run install scripts in the current project when its name is different than its directory', async () => {
+  await using server = await createTestIpcServer()
   prepareEmpty()
   const manifest = await addDependenciesToPackage({
     name: 'different-name',
     scripts: {
-      install: 'node -e "process.stdout.write(\'install\')" | json-append output.json',
-      postinstall: 'node -e "process.stdout.write(\'postinstall\')" | json-append output.json',
-      preinstall: 'node -e "process.stdout.write(\'preinstall\')" | json-append output.json',
+      install: `node -e "console.log('install-' + process.cwd())" | ${server.generateSendStdinScript()}`,
+      postinstall: `node -e "console.log('postinstall-' + process.cwd())" | ${server.generateSendStdinScript()}`,
+      preinstall: `node -e "console.log('preinstall-' + process.cwd())" | ${server.generateSendStdinScript()}`,
     },
-  }, ['json-append@1.1.1'], await testDefaults({ fastUnpack: false }))
+  }, [], await testDefaults({ fastUnpack: false }))
   await install(manifest, await testDefaults({ fastUnpack: false }))
 
-  const output = await loadJsonFile('output.json')
-
-  expect(output).toStrictEqual(['preinstall', 'install', 'postinstall'])
+  expect(server.getLines()).toStrictEqual([
+    `preinstall-${process.cwd()}`,
+    `install-${process.cwd()}`,
+    `postinstall-${process.cwd()}`,
+  ])
 })
 
 test('installation fails if lifecycle script fails', async () => {
@@ -153,11 +163,10 @@ test('INIT_CWD is always set to lockfile directory', async () => {
     mutation: 'install',
     manifest: {
       dependencies: {
-        'json-append': '1.1.1',
         '@pnpm.e2e/write-lifecycle-env': '1.0.0',
       },
       scripts: {
-        install: 'node -e "process.stdout.write(process.env.INIT_CWD)" | json-append output.json',
+        install: 'node -e "fs.writeFileSync(\'output.json\', JSON.stringify(process.env.INIT_CWD))"',
       },
     },
     rootDir,
@@ -170,7 +179,7 @@ test('INIT_CWD is always set to lockfile directory', async () => {
   expect(childEnv.INIT_CWD).toBe(rootDir)
 
   const output = await loadJsonFile(path.join(rootDir, 'output.json'))
-  expect(output).toStrictEqual([process.cwd()])
+  expect(output).toStrictEqual(process.cwd())
 })
 
 // TODO: duplicate this test to @pnpm/lifecycle
@@ -619,41 +628,36 @@ test('lifecycle scripts run after linking root dependencies', async () => {
 })
 
 test('ignore-dep-scripts', async () => {
+  await using server1 = await createTestEchoServer()
+  await using server2 = await createTestEchoServer()
   prepareEmpty()
   const manifest = {
     scripts: {
-      'pnpm:devPreinstall': 'node -e "require(\'fs\').writeFileSync(\'test.txt\', \'\', \'utf-8\')"',
-      install: 'node -e "process.stdout.write(\'install\')" | json-append output.json',
-      postinstall: 'node -e "process.stdout.write(\'postinstall\')" | json-append output.json',
-      preinstall: 'node -e "process.stdout.write(\'preinstall\')" | json-append output.json',
+      'pnpm:devPreinstall': server2.sendLineScript('pnpm:devPreinstall'),
+      install: server1.sendLineScript('install'),
+      postinstall: server1.sendLineScript('postinstall'),
+      preinstall: server1.sendLineScript('preinstall'),
     },
     dependencies: {
-      'json-append': '1.1.1',
       '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
     },
   }
   await install(manifest, await testDefaults({ fastUnpack: false, ignoreDepScripts: true }))
 
-  {
-    const output = await loadJsonFile<string[]>('output.json')
+  expect(server1.getLines()).toStrictEqual(['preinstall', 'install', 'postinstall'])
+  expect(server2.getLines()).toStrictEqual(['pnpm:devPreinstall'])
 
-    expect(output).toStrictEqual(['preinstall', 'install', 'postinstall'])
-    expect(await exists('test.txt')).toBeTruthy()
-
-    expect(await exists('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeFalsy()
-  }
+  expect(await exists('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeFalsy()
 
   await rimraf('node_modules')
-  await rimraf('output.json')
+  server1.clear()
+  server2.clear()
   await install(manifest, await testDefaults({ fastUnpack: false, ignoreDepScripts: true }))
-  {
-    const output = await loadJsonFile<string[]>('output.json')
 
-    expect(output).toStrictEqual(['preinstall', 'install', 'postinstall'])
-    expect(await exists('test.txt')).toBeTruthy()
+  expect(server1.getLines()).toStrictEqual(['preinstall', 'install', 'postinstall'])
+  expect(server2.getLines()).toStrictEqual(['pnpm:devPreinstall'])
 
-    expect(await exists('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeFalsy()
-  }
+  expect(await exists('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeFalsy()
 })
 
 test('run pre/postinstall scripts in a workspace that uses node-linker=hoisted', async () => {

--- a/pkg-manager/core/test/install/lifecycleScripts.ts
+++ b/pkg-manager/core/test/install/lifecycleScripts.ts
@@ -628,8 +628,8 @@ test('lifecycle scripts run after linking root dependencies', async () => {
 })
 
 test('ignore-dep-scripts', async () => {
-  await using server1 = await createTestEchoServer()
-  await using server2 = await createTestEchoServer()
+  await using server1 = await createTestIpcServer()
+  await using server2 = await createTestIpcServer()
   prepareEmpty()
   const manifest = {
     scripts: {

--- a/pkg-manager/core/test/install/setExtraNodePath.ts
+++ b/pkg-manager/core/test/install/setExtraNodePath.ts
@@ -7,7 +7,6 @@ import {
   mutateModules,
   install,
 } from '@pnpm/core'
-import { sync as loadJsonFile } from 'load-json-file'
 import { testDefaults } from '../utils'
 
 const f = fixtures(__dirname)
@@ -40,12 +39,11 @@ test('jest CLI should print the right version when multiple instances of jest ar
         name: 'project-1',
         version: '1.0.0',
         scripts: {
-          postinstall: 'jest --version | json-append output.json',
+          postinstall: 'jest --version > output.json',
         },
 
         dependencies: {
           jest: '27.5.1',
-          'json-append': '1.1.1',
         },
       },
       rootDir: path.resolve('project-1'),
@@ -56,12 +54,11 @@ test('jest CLI should print the right version when multiple instances of jest ar
         name: 'project-2',
         version: '1.0.0',
         scripts: {
-          postinstall: 'jest --version | json-append output.json',
+          postinstall: 'jest --version > output.json',
         },
 
         dependencies: {
           jest: '24.9.0',
-          'json-append': '1.1.1',
         },
       },
       rootDir: path.resolve('project-2'),
@@ -75,11 +72,11 @@ test('jest CLI should print the right version when multiple instances of jest ar
   }))
 
   {
-    const [jestVersion] = loadJsonFile<string[]>('project-1/output.json')
+    const jestVersion = fs.readFileSync('project-1/output.json').toString()
     expect(jestVersion.trim()).toStrictEqual('27.5.1')
   }
   {
-    const [jestVersion] = loadJsonFile<string[]>('project-2/output.json')
+    const jestVersion = fs.readFileSync('project-2/output.json').toString()
     expect(jestVersion.trim()).toStrictEqual('24.9.0')
   }
 })

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../config/matcher"
     },
     {

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -26,6 +26,7 @@
     "@pnpm/store-path": "workspace:*",
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/fs-extra": "^9.0.13",
     "@types/ramda": "0.28.20",
     "@types/rimraf": "^3.0.2",

--- a/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/.gitignore
+++ b/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/.gitignore
@@ -1,1 +1,1 @@
-output.json
+test.sock

--- a/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/package.json
+++ b/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/package.json
@@ -1,10 +1,9 @@
 {
   "scripts": {
-    "install": "node -e \"process.stdout.write('install')\" | json-append output.json",
-    "postinstall": "node -e \"process.stdout.write('postinstall')\" | json-append output.json"
+    "install": "node -e \"console.log('install')\" | test-ipc-server-client ./test.sock",
+    "postinstall": "node -e \"console.log('postinstall')\" | test-ipc-server-client ./test.sock"
   },
   "dependencies": {
-    "json-append": "1.1.1",
     "@pnpm.e2e/pre-and-postinstall-scripts-example": "*"
   }
 }

--- a/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   '@pnpm.e2e/pre-and-postinstall-scripts-example':
     specifier: '*'
     version: 2.0.0
-  json-append:
-    specifier: 1.1.1
-    version: 1.1.1
 
 packages:
 
@@ -24,71 +21,4 @@ packages:
     requiresBuild: true
     dependencies:
       '@pnpm.e2e/hello-world-js-bin': 1.0.0
-    dev: false
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: false
-
-  /concat-stream@1.6.2:
-    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
-    engines: {'0': node >= 0.8}
-    dependencies:
-      buffer-from: 1.1.2
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      typedarray: 0.0.6
-    dev: false
-
-  /core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: false
-
-  /inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: false
-
-  /isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: false
-
-  /json-append@1.1.1:
-    resolution: {integrity: sha512-UiS6F4XN66/WfXnyhlMUtcYMfcEo1CfoOWITo+4NJODqbaoEWvKDk85heyxJd0IQuVt5MhSndpdurY/A1VamyA==}
-    hasBin: true
-    dependencies:
-      concat-stream: 1.6.2
-    dev: false
-
-  /process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-    dev: false
-
-  /readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-    dev: false
-
-  /safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: false
-
-  /string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
-    dependencies:
-      safe-buffer: 5.1.2
-    dev: false
-
-  /typedarray@0.0.6:
-    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-    dev: false
-
-  /util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: false

--- a/pkg-manager/headless/tsconfig.json
+++ b/pkg-manager/headless/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../config/package-is-installable"
     },
     {

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -36,6 +36,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.17.1",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/proxyquire": "^1.3.31",
     "@types/ramda": "0.28.20",
     "@types/sinon": "^10.0.20",

--- a/pkg-manager/plugin-commands-installation/test/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/test/dedupe.ts
@@ -6,6 +6,7 @@ import { type Lockfile } from '@pnpm/lockfile-types'
 import { dedupe, install } from '@pnpm/plugin-commands-installation'
 import { prepare } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { diff } from 'jest-diff'
 import readYamlFile from 'read-yaml-file'
 import { DEFAULT_OPTS } from './utils'
@@ -75,19 +76,17 @@ describe('pnpm dedupe', () => {
   })
 
   test('dedupe: ignores all the lifecycle scripts when --ignore-scripts is used', async () => {
+    await using server = await createTestIpcServer()
+
     const project = prepare({
       name: 'test-dedupe-with-ignore-scripts',
       version: '0.0.0',
 
-      dependencies: {
-        'json-append': '1.1.1',
-      },
-
       scripts: {
         // eslint-disable:object-literal-sort-keys
-        preinstall: 'node -e "process.stdout.write(\'preinstall\')" | json-append output.json',
-        prepare: 'node -e "process.stdout.write(\'prepare\')" | json-append output.json',
-        postinstall: 'node -e "process.stdout.write(\'postinstall\')" | json-append output.json',
+        preinstall: server.sendLineScript('preinstall'),
+        prepare: server.sendLineScript('prepare'),
+        postinstall: server.sendLineScript('postinstall'),
         // eslint-enable:object-literal-sort-keys
       },
     })
@@ -106,7 +105,7 @@ describe('pnpm dedupe', () => {
     await dedupe.handler(opts)
 
     expect(fs.existsSync('package.json')).toBeTruthy()
-    expect(fs.existsSync('output.json')).toBeFalsy()
+    expect(server.getLines()).toStrictEqual([])
   })
 })
 

--- a/pkg-manager/plugin-commands-installation/tsconfig.json
+++ b/pkg-manager/plugin-commands-installation/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3407,6 +3407,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/fs-extra':
         specifier: ^9.0.13
         version: 9.0.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1427,6 +1427,9 @@ importers:
       '@pnpm/registry-mock':
         specifier: 3.17.1
         version: 3.17.1(typanion@3.14.0)
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/is-windows':
         specifier: ^1.0.2
         version: 1.0.2
@@ -3122,6 +3125,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/fs-extra':
         specifier: ^9.0.13
         version: 9.0.13
@@ -4499,6 +4505,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../__utils__/test-ipc-server
       '@pnpm/types':
         specifier: workspace:*
         version: link:../packages/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1312,6 +1312,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20
@@ -3945,6 +3948,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/proxyquire':
         specifier: ^1.3.31
         version: 1.3.31
@@ -4853,6 +4859,9 @@ importers:
       '@pnpm/registry-mock':
         specifier: 3.17.1
         version: 3.17.1(typanion@3.14.0)
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/cross-spawn':
         specifier: ^6.0.5
         version: 6.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,21 @@ importers:
         specifier: ^9.0.13
         version: 9.0.13
 
+  __utils__/test-ipc-server:
+    devDependencies:
+      '@pnpm/prepare':
+        specifier: workspace:*
+        version: link:../prepare
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: 'link:'
+      '@types/node':
+        specifier: ^18.14.6
+        version: 18.14.6
+      execa:
+        specifier: npm:safe-execa@0.1.2
+        version: /safe-execa@0.1.2
+
   __utils__/tsconfig:
     devDependencies:
       '@pnpm/tsconfig':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,15 +1176,15 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2
       '@zkochan/rimraf':
         specifier: ^2.1.3
         version: 2.1.3
-      json-append:
-        specifier: 1.1.1
-        version: 1.1.1
       load-json-file:
         specifier: ^6.2.0
         version: 6.2.0
@@ -13786,13 +13786,6 @@ packages:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
-
-  /json-append@1.1.1:
-    resolution: {integrity: sha512-UiS6F4XN66/WfXnyhlMUtcYMfcEo1CfoOWITo+4NJODqbaoEWvKDk85heyxJd0IQuVt5MhSndpdurY/A1VamyA==}
-    hasBin: true
-    dependencies:
-      concat-stream: 1.6.2
     dev: true
 
   /json-buffer@3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1482,6 +1482,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@pnpm/test-ipc-server':
+        specifier: workspace:*
+        version: link:../../__utils__/test-ipc-server
       '@types/ramda':
         specifier: 0.28.20
         version: 0.28.20

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -67,6 +67,7 @@
     "@pnpm/run-npm": "workspace:*",
     "@pnpm/tabtab": "^0.1.2",
     "@pnpm/test-fixtures": "workspace:*",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/worker": "workspace:*",
     "@pnpm/workspace.find-packages": "workspace:*",

--- a/pnpm/test/filterProd.test.ts
+++ b/pnpm/test/filterProd.test.ts
@@ -1,25 +1,24 @@
-import fs from 'fs'
-import path from 'path'
 import writeYamlFile from 'write-yaml-file'
 import { execPnpm } from './utils'
 import {
   preparePackages,
 } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { type ProjectManifest } from '@pnpm/types'
 
 test.each([
-  { message: '--filter should include devDependencies', filter: '--filter', expected: new Set(['project-1', 'project-3', 'project-4']) },
-  { message: '--filter-prod should not include devDependencies', filter: '--filter-prod', expected: new Set(['project-1', 'project-3']) },
+  { message: '--filter should include devDependencies', filter: '--filter', expected: ['project-1', 'project-3', 'project-4'] },
+  { message: '--filter-prod should not include devDependencies', filter: '--filter-prod', expected: ['project-1', 'project-3'] },
 ])('$message', async ({ filter, expected }) => {
-  // Using backticks in scripts for better readability. Otherwise single quotes need to be escaped.
-  /* eslint-disable @typescript-eslint/quotes */
+  await using server = await createTestIpcServer()
+
   const projects: Array<ProjectManifest & { name: string }> = [
     {
       name: 'project-1',
       version: '1.0.0',
       dependencies: { 'project-2': '1.0.0', 'project-3': '1.0.0' },
       scripts: {
-        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
+        test: server.sendLineScript('project-1'),
       },
     },
     {
@@ -27,7 +26,7 @@ test.each([
       version: '1.0.0',
       dependencies: {},
       scripts: {
-        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
+        test: server.sendLineScript('project-2'),
       },
     },
     {
@@ -35,7 +34,7 @@ test.each([
       version: '1.0.0',
       dependencies: { 'project-2': '1.0.0' },
       scripts: {
-        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
+        test: server.sendLineScript('project-3'),
       },
     },
     {
@@ -44,7 +43,7 @@ test.each([
       dependencies: {},
       devDependencies: { 'project-3': '1.0.0' },
       scripts: {
-        test: `node -e "require('fs').writeFileSync('./output.txt', '')"`,
+        test: server.sendLineScript('project-4'),
       },
     },
   ]
@@ -53,18 +52,7 @@ test.each([
   await writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
   await execPnpm(['install'])
 
-  // Ensure none of these files exist before the build script runs.
-  for (const project of projects) {
-    expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeFalsy()
-  }
-
   await execPnpm(['recursive', 'test', filter, '...project-3'])
 
-  for (const project of projects) {
-    if (expected.has(project.name)) {
-      expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeTruthy()
-    } else {
-      expect(fs.existsSync(path.resolve(project.name, 'output.txt'))).toBeFalsy()
-    }
-  }
+  expect(server.getLines().sort()).toEqual(expected)
 })

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -209,13 +209,14 @@ test('linking a package inside a monorepo with --link-workspace-packages when in
 })
 
 test('linking a package inside a monorepo with --link-workspace-packages', async () => {
+  await using server = await createTestIpcServer()
+
   const projects = preparePackages([
     {
       name: 'project-1',
       version: '1.0.0',
 
       dependencies: {
-        'json-append': '1',
         'project-2': '2.0.0',
       },
       devDependencies: {
@@ -225,18 +226,15 @@ test('linking a package inside a monorepo with --link-workspace-packages', async
         'is-positive': '1.0.0',
       },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
+        install: server.sendLineScript('project-1'),
       },
     },
     {
       name: 'project-2',
       version: '2.0.0',
 
-      dependencies: {
-        'json-append': '1',
-      },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output.json',
+        install: server.sendLineScript('project-2'),
       },
     },
     {
@@ -260,8 +258,7 @@ save-workspace-protocol=false
 
   await execPnpm(['install'])
 
-  const { default: outputs } = await import(path.resolve('..', 'output.json'))
-  expect(outputs).toStrictEqual(['project-2', 'project-1'])
+  expect(server.getLines()).toStrictEqual(['project-2', 'project-1'])
 
   await projects['project-1'].has('project-2')
   await projects['project-1'].has('is-negative')
@@ -295,16 +292,18 @@ save-workspace-protocol=false
 })
 
 test('topological order of packages with self-dependencies in monorepo is correct', async () => {
+  await using server1 = await createTestIpcServer()
+  await using server2 = await createTestIpcServer()
+
   preparePackages([
     {
       name: 'project-1',
       version: '1.0.0',
 
       dependencies: { 'project-2': '1.0.0', 'project-3': '1.0.0' },
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
-        test: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output2.json',
+        install: server1.sendLineScript('project-1'),
+        test: server2.sendLineScript('project-1'),
       },
     },
     {
@@ -312,10 +311,9 @@ test('topological order of packages with self-dependencies in monorepo is correc
       version: '1.0.0',
 
       dependencies: { 'project-2': '1.0.0' },
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output.json',
-        test: 'node -e "process.stdout.write(\'project-2\')" | json-append ../output2.json',
+        install: server1.sendLineScript('project-2'),
+        test: server2.sendLineScript('project-2'),
       },
     },
     {
@@ -323,10 +321,9 @@ test('topological order of packages with self-dependencies in monorepo is correc
       version: '1.0.0',
 
       dependencies: { 'project-2': '1.0.0', 'project-3': '1.0.0' },
-      devDependencies: { 'json-append': '1' },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output.json',
-        test: 'node -e "process.stdout.write(\'project-3\')" | json-append ../output2.json',
+        install: server1.sendLineScript('project-3'),
+        test: server2.sendLineScript('project-3'),
       },
     },
   ])
@@ -337,13 +334,11 @@ test('topological order of packages with self-dependencies in monorepo is correc
 
   await execPnpm(['install'])
 
-  const { default: outputs } = await import(path.resolve('..', 'output.json'))
-  expect(outputs).toStrictEqual(['project-2', 'project-3', 'project-1'])
+  expect(server1.getLines()).toStrictEqual(['project-2', 'project-3', 'project-1'])
 
   await execPnpm(['recursive', 'test'])
 
-  const { default: outputs2 } = await import(path.resolve('..', 'output2.json'))
-  expect(outputs2).toStrictEqual(['project-2', 'project-3', 'project-1'])
+  expect(server2.getLines()).toStrictEqual(['project-2', 'project-3', 'project-1'])
 })
 
 test('test-pattern is respected by the test script', async () => {
@@ -665,6 +660,7 @@ test('shared-workspace-lockfile: installation with --link-workspace-packages lin
 })
 
 test('recursive install with link-workspace-packages and shared-workspace-lockfile', async () => {
+  await using server = await createTestIpcServer()
   await addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
   const projects = preparePackages([
     {
@@ -673,10 +669,9 @@ test('recursive install with link-workspace-packages and shared-workspace-lockfi
 
       dependencies: {
         'is-negative': '1.0.0',
-        'json-append': '1',
       },
       scripts: {
-        install: 'node -e "process.stdout.write(\'is-positive\')" | json-append ../output.json',
+        install: server.sendLineScript('is-positive'),
       },
     },
     // This empty package is added to the workspace only to verify
@@ -691,10 +686,9 @@ test('recursive install with link-workspace-packages and shared-workspace-lockfi
 
       devDependencies: {
         'is-positive': '1.0.0',
-        'json-append': '1',
       },
       scripts: {
-        install: 'node -e "process.stdout.write(\'project-1\')" | json-append ../output.json',
+        install: server.sendLineScript('project-1'),
       },
     },
   ])
@@ -719,8 +713,7 @@ test('recursive install with link-workspace-packages and shared-workspace-lockfi
   const sharedLockfile = await readYamlFile<Lockfile>(WANTED_LOCKFILE)
   expect(sharedLockfile.importers['project-1']!.devDependencies!['is-positive'].version).toBe('link:../is-positive')
 
-  const { default: outputs } = await import(path.resolve('output.json'))
-  expect(outputs).toStrictEqual(['is-positive', 'project-1'])
+  expect(server.getLines()).toStrictEqual(['is-positive', 'project-1'])
 
   await execPnpm(['recursive', 'install', '@pnpm.e2e/pkg-with-1-dep', '--link-workspace-packages', '--shared-workspace-lockfile=true', '--store-dir', 'store'])
 
@@ -741,20 +734,19 @@ test('recursive install with link-workspace-packages and shared-workspace-lockfi
 })
 
 test('recursive install with shared-workspace-lockfile builds workspace projects in correct order', async () => {
-  const jsonAppend = (append: string, target: string) => `node -e "process.stdout.write('${append}')" | json-append ${target}`
+  await using server1 = await createTestIpcServer()
+  await using server2 = await createTestIpcServer()
+
   preparePackages([
     {
       name: 'project-999',
       version: '1.0.0',
 
-      dependencies: {
-        'json-append': '1',
-      },
       scripts: {
-        install: `${jsonAppend('project-999-install', '../output1.json')} && ${jsonAppend('project-999-install', '../output2.json')}`,
-        postinstall: `${jsonAppend('project-999-postinstall', '../output1.json')} && ${jsonAppend('project-999-postinstall', '../output2.json')}`,
-        prepare: `${jsonAppend('project-999-prepare', '../output1.json')} && ${jsonAppend('project-999-prepare', '../output2.json')}`,
-        prepublish: `${jsonAppend('project-999-prepublish', '../output1.json')} && ${jsonAppend('project-999-prepublish', '../output2.json')}`,
+        install: `${server1.sendLineScript('project-999-install')} && ${server2.sendLineScript('project-999-install')}`,
+        postinstall: `${server1.sendLineScript('project-999-postinstall')} && ${server2.sendLineScript('project-999-postinstall')}`,
+        prepare: `${server1.sendLineScript('project-999-prepare')} && ${server2.sendLineScript('project-999-prepare')}`,
+        prepublish: `${server1.sendLineScript('project-999-prepublish')} && ${server2.sendLineScript('project-999-prepublish')}`,
       },
     },
     {
@@ -762,14 +754,13 @@ test('recursive install with shared-workspace-lockfile builds workspace projects
       version: '1.0.0',
 
       devDependencies: {
-        'json-append': '1',
         'project-999': '1.0.0',
       },
       scripts: {
-        install: jsonAppend('project-1-install', '../output1.json'),
-        postinstall: jsonAppend('project-1-postinstall', '../output1.json'),
-        prepare: jsonAppend('project-1-prepare', '../output1.json'),
-        prepublish: jsonAppend('project-1-prepublish', '../output1.json'),
+        install: server1.sendLineScript('project-1-install'),
+        postinstall: server1.sendLineScript('project-1-postinstall'),
+        prepare: server1.sendLineScript('project-1-prepare'),
+        prepublish: server1.sendLineScript('project-1-prepublish'),
       },
     },
     {
@@ -777,14 +768,13 @@ test('recursive install with shared-workspace-lockfile builds workspace projects
       version: '1.0.0',
 
       devDependencies: {
-        'json-append': '1',
         'project-999': '1.0.0',
       },
       scripts: {
-        install: jsonAppend('project-2-install', '../output2.json'),
-        postinstall: jsonAppend('project-2-postinstall', '../output2.json'),
-        prepare: jsonAppend('project-2-prepare', '../output2.json'),
-        prepublish: jsonAppend('project-2-prepublish', '../output2.json'),
+        install: server2.sendLineScript('project-2-install'),
+        postinstall: server2.sendLineScript('project-2-postinstall'),
+        prepare: server2.sendLineScript('project-2-prepare'),
+        prepublish: server2.sendLineScript('project-2-prepublish'),
       },
     },
   ], { manifestFormat: 'YAML' })
@@ -793,56 +783,48 @@ test('recursive install with shared-workspace-lockfile builds workspace projects
 
   await execPnpm(['recursive', 'install', '--link-workspace-packages', '--shared-workspace-lockfile=true', '--store-dir', 'store'])
 
-  {
-    const { default: outputs1 } = await import(path.resolve('output1.json'))
-    expect(outputs1).toStrictEqual([
-      'project-999-install',
-      'project-999-postinstall',
-      'project-999-prepare',
-      'project-1-install',
-      'project-1-postinstall',
-      'project-1-prepare',
-    ])
+  expect(server1.getLines()).toStrictEqual([
+    'project-999-install',
+    'project-999-postinstall',
+    'project-999-prepare',
+    'project-1-install',
+    'project-1-postinstall',
+    'project-1-prepare',
+  ])
 
-    const { default: outputs2 } = await import(path.resolve('output2.json'))
-    expect(outputs2).toStrictEqual([
-      'project-999-install',
-      'project-999-postinstall',
-      'project-999-prepare',
-      'project-2-install',
-      'project-2-postinstall',
-      'project-2-prepare',
-    ])
-  }
+  expect(server2.getLines()).toStrictEqual([
+    'project-999-install',
+    'project-999-postinstall',
+    'project-999-prepare',
+    'project-2-install',
+    'project-2-postinstall',
+    'project-2-prepare',
+  ])
 
   await rimraf('node_modules')
-  await rimraf('output1.json')
-  await rimraf('output2.json')
+  server1.clear()
+  server2.clear()
 
   // TODO: duplicate this test in @pnpm/headless
   await execPnpm(['recursive', 'install', '--frozen-lockfile', '--link-workspace-packages', '--shared-workspace-lockfile=true'])
 
-  {
-    const { default: outputs1 } = await import(path.resolve('output1.json'))
-    expect(outputs1).toStrictEqual([
-      'project-999-install',
-      'project-999-postinstall',
-      'project-999-prepare',
-      'project-1-install',
-      'project-1-postinstall',
-      'project-1-prepare',
-    ])
+  expect(server1.getLines()).toStrictEqual([
+    'project-999-install',
+    'project-999-postinstall',
+    'project-999-prepare',
+    'project-1-install',
+    'project-1-postinstall',
+    'project-1-prepare',
+  ])
 
-    const { default: outputs2 } = await import(path.resolve('output2.json'))
-    expect(outputs2).toStrictEqual([
-      'project-999-install',
-      'project-999-postinstall',
-      'project-999-prepare',
-      'project-2-install',
-      'project-2-postinstall',
-      'project-2-prepare',
-    ])
-  }
+  expect(server2.getLines()).toStrictEqual([
+    'project-999-install',
+    'project-999-postinstall',
+    'project-999-prepare',
+    'project-2-install',
+    'project-2-postinstall',
+    'project-2-prepare',
+  ])
 })
 
 test('recursive installation with shared-workspace-lockfile and a readPackage hook', async () => {

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -98,18 +98,15 @@ test('start: run "node server.js" by default', async () => {
 
 test('install-test: install dependencies and runs tests', async () => {
   prepare({
-    dependencies: {
-      'json-append': '1',
-    },
     scripts: {
-      test: 'node -e "process.stdout.write(\'test\')" | json-append ./output.json',
+      test: 'node -e "process.stdout.write(\'test\')" > ./output.txt',
     },
   }, { manifestFormat: 'JSON5' })
 
   await execPnpm(['install-test'])
 
-  const { default: scriptsRan } = await import(path.resolve('output.json'))
-  expect(scriptsRan).toStrictEqual(['test'])
+  const scriptsRan = (await fs.readFile('output.txt')).toString()
+  expect(scriptsRan.trim()).toStrictEqual('test')
 })
 
 test('silent run only prints the output of the child process', async () => {

--- a/pnpm/tsconfig.json
+++ b/pnpm/tsconfig.json
@@ -23,6 +23,9 @@
       "path": "../__utils__/test-fixtures"
     },
     {
+      "path": "../__utils__/test-ipc-server"
+    },
+    {
       "path": "../cli/cli-meta"
     },
     {

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -36,6 +36,7 @@
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "3.17.1",
+    "@pnpm/test-ipc-server": "workspace:*",
     "@types/cross-spawn": "^6.0.5",
     "@types/is-windows": "^1.0.2",
     "@types/proxyquire": "^1.3.31",

--- a/releasing/plugin-commands-publishing/tsconfig.json
+++ b/releasing/plugin-commands-publishing/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {


### PR DESCRIPTION
## Problem

I've noticed tests that use `json-append` regularly flake on Windows. Here's one example flake:

```
FAIL test/filterProd.test.ts (6.17 s)
  ● --filter should include devDependencies

    expect(received).toStrictEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 0

      Array [
        "project-1",
        "project-3",
    -   "project-4",
      ]

      54 |   await execPnpm(['recursive', 'test', filter, '...project-3'])
      55 |   const { default: output } = await import(path.resolve('output.json'))
    > 56 |   expect(output.sort()).toStrictEqual(expected)
         |                         ^
      57 | })

      at test/filterProd.test.ts:56:25
```

In the past, I attempted to fix this writing to multiple files instead of a single `output.json` file. The first PR contains a description of why `json-append` on a single file can cause this problem.

- https://github.com/pnpm/pnpm/pull/7346
- https://github.com/pnpm/pnpm/pull/7445

Writing to a single file concurrently from multiple processes (which many tests in the pnpm repo do) has inherent race conditions that can't be fixed. Even opening a file with [`O_APPEND`](https://www.man7.org/linux/man-pages/man2/open.2.html) can still result in writes to be dropped.

## Changes

This PR replaces all tests that use `json-append` with a drop-in replacement backed by Node.js's builtin  IPC. This IPC can receive messages without dropping them.

This is a bit more complicated than writing to a file, but I believe it's the simplest mechanism that matches the requirements of this problem. It allows multiple processes to write data to the same place safely.

Overall, I think this is a huge improvement.

## FAQ

I'm anticipating a few questions on the PR that I can try to answer early.

#### Will the tests fixed here flake afterwards this PR merges?

Likely yes. This PR fixes a race condition that causes appended data to be dropped. I've noticed many of these tests still have ordering problems where scripts from two packages can run at the same time and result in data appended in different orders. These tests are fundamentally broken and need a different fix if they continue flaking. It should be easier to identify these tests when they flake since messages will no longer be dropped though.

#### Aren't some tests that use `json-append` fine?

There are some tests that check for a specific script execution order. These tests aren't subject to file write race conditions since one script is expected to completely finish before the next script starts. In theory these tests can continue using `json-append` without problems.

I opted to replace `json-append` completely with the new IPC server regardless.

- This makes it easier for new contributors of pnpm in the future to copy a test that won't have unexpected foot guns.
- It also makes the code base more consistent. Using both `json-append` and the IPC server causes tests to become more fragmented and confusing.
- The IPC server is much faster. See below.

#### Any performance differences?

Using an IPC server avoids having to install `json-append` and read/write from the file system. This makes several tests much faster. I grabbed some numbers for a one-off run of a few tests.

|Test File|Test Name|Before|After|
|-|-|-|-|
|`test/install/lifecycleScripts.ts`|run install scripts in the current project|2515 ms|263 ms|
|`test/testRecursive.ts`|pnpm recursive test|2386 ms|415 ms|