### PR TITLE
fix(lockfile-types): remove specifiers from ProjectSnapshotV6

### DIFF
--- a/.changeset/strange-queens-notice.md
+++ b/.changeset/strange-queens-notice.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lockfile-types": patch
+---
+
+Remove `specifiers` field from `ProjectSnapshotV6`. This is a typing fix. The field is not present on the v6 lockfile.

--- a/lockfile/lockfile-types/src/index.ts
+++ b/lockfile/lockfile-types/src/index.ts
@@ -43,7 +43,6 @@ export interface LockfileV6 {
 }
 
 export interface ProjectSnapshotV6 {
-  specifiers: ResolvedDependenciesOfImporters
   dependencies?: ResolvedDependenciesOfImporters
   optionalDependencies?: ResolvedDependenciesOfImporters
   devDependencies?: ResolvedDependenciesOfImporters


### PR DESCRIPTION
## Changes

Fixes a minor extra field I noticed in `ProjectSnapshotV6`. The v6 lockfile format no longer has a `specifiers` field.

## Questions

I noticed there's a separate PR to remove the older format #7267. If it's easier to incorporate this fix into the other PR, I can close this PR.