### PR TITLE
fix: skip automatic download/install of Node.js versions in WebContainer

### DIFF
--- a/.changeset/late-seals-brake.md
+++ b/.changeset/late-seals-brake.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Don't install Node.js when use-node-version is set in a WebContainer [#7478](https://github.com/pnpm/pnpm/pull/7478).

--- a/cspell.json
+++ b/cspell.json
@@ -251,11 +251,12 @@
     "uuidv",
     "valign",
     "vuln",
+    "webcontainer",
     "winst",
     "wrappy",
     "xmarw",
     "zkochan",
     "zoli",
-    "zoltan" 
+    "zoltan"
   ]
 }

--- a/env/node.fetcher/src/index.ts
+++ b/env/node.fetcher/src/index.ts
@@ -22,10 +22,6 @@ export interface FetchNodeOptions {
 }
 
 export async function fetchNode (fetch: FetchFromRegistry, version: string, targetDir: string, opts: FetchNodeOptions) {
-  if ('webcontainer' in process.versions) {
-    console.warn('Automatic installation of different Node.js versions is not supported in WebContainer')
-    return
-  }
   if (await isNonGlibcLinux()) {
     throw new PnpmError('MUSL', 'The current system uses the "MUSL" C standard library. Node.js currently has prebuilt artifacts only for the "glibc" libc, so we can install Node.js only for glibc')
   }

--- a/env/node.fetcher/src/index.ts
+++ b/env/node.fetcher/src/index.ts
@@ -22,6 +22,10 @@ export interface FetchNodeOptions {
 }
 
 export async function fetchNode (fetch: FetchFromRegistry, version: string, targetDir: string, opts: FetchNodeOptions) {
+  if ('webcontainer' in process.versions) {
+    console.warn('Automatic installation of different Node.js versions is not supported in WebContainer')
+    return
+  }
   if (await isNonGlibcLinux()) {
     throw new PnpmError('MUSL', 'The current system uses the "MUSL" C standard library. Node.js currently has prebuilt artifacts only for the "glibc" libc, so we can install Node.js only for glibc')
   }

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -10,7 +10,7 @@ import {
 } from '@pnpm/config'
 import { executionTimeLogger, scopeLogger } from '@pnpm/core-loggers'
 import { filterPackagesFromDir } from '@pnpm/filter-workspace-packages'
-import { logger } from '@pnpm/logger'
+import { globalWarn, logger } from '@pnpm/logger'
 import { type ParsedCliArgs } from '@pnpm/parse-cli-args'
 import { node } from '@pnpm/plugin-commands-env'
 import { finishWorkers } from '@pnpm/worker'
@@ -271,9 +271,13 @@ export async function main (inputArgv: string[]) {
     })
 
     if (config.useNodeVersion != null) {
-      const nodePath = await node.getNodeBinDir(config)
-      config.extraBinPaths.push(nodePath)
-      config.nodeVersion = config.useNodeVersion
+      if ('webcontainer' in process.versions) {
+        globalWarn('Automatic installation of different Node.js versions is not supported in WebContainer')
+      } else {
+        const nodePath = await node.getNodeBinDir(config)
+        config.extraBinPaths.push(nodePath)
+        config.nodeVersion = config.useNodeVersion
+      }
     }
     let result = pnpmCmds[cmd ?? 'help'](
       // TypeScript doesn't currently infer that the type of config


### PR DESCRIPTION
The automatic install feature causes PNPM to throw and fail in WebContainer as downloading different versions is not supported on that target.

This skips the download/install in WebContainer and allows PNPM to continue functioning with a warning.