### PR TITLE
fix: use real path for module root dir (#6524)

### DIFF
--- a/.changeset/real-knives-bathe.md
+++ b/.changeset/real-knives-bathe.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Fetches the local module real path

--- a/.changeset/real-knives-bathe.md
+++ b/.changeset/real-knives-bathe.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/plugin-commands-installation": patch
+"@pnpm/config": patch
 ---
 
-Fetches the local module real path
+Fixes the local package real path

--- a/.changeset/real-knives-bathe.md
+++ b/.changeset/real-knives-bathe.md
@@ -1,5 +1,7 @@
 ---
 "@pnpm/config": patch
+"pnpm": patch
 ---
 
-Fixes the local package real path
+Resolve the current working directory to its real location before doing any operations [#6524](https://github.com/pnpm/pnpm/issues/6524).
+

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -291,7 +291,7 @@ export async function getConfig (
     ...rcOptions.map((configKey) => [camelcase(configKey), npmConfig.get(configKey)]) as any, // eslint-disable-line
     ...Object.entries(cliOptions).filter(([name, value]) => typeof value !== 'undefined').map(([name, value]) => [camelcase(name), value]),
   ]) as unknown as ConfigWithDeprecatedSettings
-  const cwd = await fs.promises.realpath(betterPathResolve(cliOptions.dir ?? npmConfig.localPrefix))
+  const cwd = fs.realpathSync(betterPathResolve(cliOptions.dir ?? npmConfig.localPrefix))
 
   pnpmConfig.maxSockets = npmConfig.maxsockets
   // @ts-expect-error

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -291,7 +291,7 @@ export async function getConfig (
     ...rcOptions.map((configKey) => [camelcase(configKey), npmConfig.get(configKey)]) as any, // eslint-disable-line
     ...Object.entries(cliOptions).filter(([name, value]) => typeof value !== 'undefined').map(([name, value]) => [camelcase(name), value]),
   ]) as unknown as ConfigWithDeprecatedSettings
-  const cwd = betterPathResolve(cliOptions.dir ?? npmConfig.localPrefix)
+  const cwd = await fs.promises.realpath(betterPathResolve(cliOptions.dir ?? npmConfig.localPrefix))
 
   pnpmConfig.maxSockets = npmConfig.maxsockets
   // @ts-expect-error

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -291,6 +291,8 @@ export async function getConfig (
     ...rcOptions.map((configKey) => [camelcase(configKey), npmConfig.get(configKey)]) as any, // eslint-disable-line
     ...Object.entries(cliOptions).filter(([name, value]) => typeof value !== 'undefined').map(([name, value]) => [camelcase(name), value]),
   ]) as unknown as ConfigWithDeprecatedSettings
+  // Resolving the current working directory to its actual location is crucial.
+  // This prevents potential inconsistencies in the future, especially when processing or mapping subdirectories.
   const cwd = fs.realpathSync(betterPathResolve(cliOptions.dir ?? npmConfig.localPrefix))
 
   pnpmConfig.maxSockets = npmConfig.maxsockets

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -170,6 +170,7 @@ export async function recursive (
     const calculatedRepositoryRoot = await fs.realpath(calculateRepositoryRoot(opts.workspaceDir, importers.map(x => x.rootDir)))
     const isFromWorkspace = isSubdir.bind(null, calculatedRepositoryRoot)
     importers = await pFilter(importers, async ({ rootDir }: { rootDir: string }) => isFromWorkspace(await fs.realpath(rootDir)))
+    importers = await Promise.all(importers.map(async ({ rootDir, ...rest }) => ({ rootDir: await fs.realpath(rootDir), ...rest })))
     if (importers.length === 0) return true
     let mutation!: string
     switch (cmdFullName) {

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -170,7 +170,6 @@ export async function recursive (
     const calculatedRepositoryRoot = await fs.realpath(calculateRepositoryRoot(opts.workspaceDir, importers.map(x => x.rootDir)))
     const isFromWorkspace = isSubdir.bind(null, calculatedRepositoryRoot)
     importers = await pFilter(importers, async ({ rootDir }: { rootDir: string }) => isFromWorkspace(await fs.realpath(rootDir)))
-    importers = await Promise.all(importers.map(async ({ rootDir, ...rest }) => ({ rootDir: await fs.realpath(rootDir), ...rest })))
     if (importers.length === 0) return true
     let mutation!: string
     switch (cmdFullName) {


### PR DESCRIPTION
Resolves #6524 

# Intro

I was not able to verify the fix with [the mentioned `pd` command](https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md?plain=1#L22). I applied the same changes to this repository as I did on my local installation of `pnpm` for the issue to be fixed.

**I might not have fixed the original issue** so I'll describe here the issue I faced and how I fixed it.

# How to reproduce constantly the issue

* This issue only concerns systems that are NOT case sensitive in their file path (basically Windows).
* Place yourself in a folder where to create a test project, make sure the `parent` folder is either not existent or not important
* Run the following commands (I'm using gitbash but equivalents in powershell or cmd behave the same) :
  ```bash
  [ ! -e parent ] || rm -rf parent
  mkdir -p parent/workspaces
  (
    cd Parent # Bad casing is INTENTIONAL and part of why the bug happen
    echo -e '{\n  "name": "parent",\n  "private": true\n}' > package.json
    echo -e 'packages:\n  - "workspaces/*"' > pnpm-workspace.yaml
    pnpm add -P rxjs
  )
  ```
# My analysis

At some point in a `pnpm add` command, There is a mismatch [when fetching the manifest of an `importer`](https://github.com/pnpm/pnpm/blob/c0182b429ff9c1161706211e6fe6dd1c56cc556d/pkg-manager/plugin-commands-installation/src/recursive.ts#L191) because their `rootDir` uses the bad `Parent` folder name instead of the `parent` real folder name.

I threw some logs right before that call ( `console.log([Object.keys(manifestsByPath), rootDir])` ) and I got the following log :

```
[
  [ 'E:\\code\\parent' ],
  'E:\\code\\Parent'
]
```

I saw that [you fetch the real path earlier](https://github.com/pnpm/pnpm/blob/c0182b429ff9c1161706211e6fe6dd1c56cc556d/pkg-manager/plugin-commands-installation/src/recursive.ts#L172) in the function to check either or not the folder is part of the workspaces so I added the same and it worked !
Of course my local change was different as I acted on the compiled output and here is what I did :

*(Change is at line 190518 of `pnpm.cjs`)*
```diff
          const isFromWorkspace = is_subdir_1.default.bind(null, calculatedRepositoryRoot);
          importers = await (0, p_filter_1.default)(importers, async ({ rootDir }) => isFromWorkspace(await fs_1.promises.realpath(rootDir)));
+         importers = await Promise.all(importers.map(async ({ rootDir, ...rest }) => ({ rootDir: await fs_1.promises.realpath(rootDir), ...rest })));
          if (importers.length === 0)
            return true;
```

# Notes

If you have better knowledge of where this `rootDir` is from, you may want to update to the `realpath` earlier and save other unidentified bugs related to it.