### PR TITLE
fix(install-help): add ignore-workspace

### DIFF
--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -184,6 +184,10 @@ by any dependencies, so it is an emulation of a flat node_modules',
             name: '--ignore-pnpmfile',
           },
           {
+            description: 'Ignore pnpm-workspace.yaml if exists in the parent directory, and treat the installation as normal non-workspace installation.',
+            name: '--ignore-workspace',
+          },
+          {
             description: "If false, doesn't check whether packages in the store were mutated",
             name: '--[no-]verify-store-integrity',
           },


### PR DESCRIPTION
Adding `--ignore-workspace` to the `pnpm install --help` section. 

This is an undocumented feature that is quite useful in monorepos where we have a directory that contains a `package.json` file and it is not part of the workspace.