### PR TITLE
fix: registry configuration from previous install should not override the current one

### DIFF
--- a/.changeset/funny-snails-turn.md
+++ b/.changeset/funny-snails-turn.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/get-context": patch
+"pnpm": patch
+---
+
+Registry configuration from previous installation should not override current settings [#7507](https://github.com/pnpm/pnpm/issues/7507).

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -172,10 +172,7 @@ export async function getContext (
     pendingBuilds: importersContext.pendingBuilds,
     projects: Object.fromEntries(importersContext.projects.map((project) => [project.rootDir, project])),
     publicHoistPattern: importersContext.currentPublicHoistPattern ?? opts.publicHoistPattern,
-    registries: {
-      ...opts.registries,
-      ...importersContext.registries,
-    },
+    registries: opts.registries,
     rootModulesDir: importersContext.rootModulesDir,
     skipped: importersContext.skipped,
     storeDir: opts.storeDir,


### PR DESCRIPTION
close #7507