### PR TITLE
fix(plugin-commands-publishing): should pack main file or bin files defined in publishConfig

### DIFF
--- a/.changeset/smooth-buckets-drop.md
+++ b/.changeset/smooth-buckets-drop.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"@pnpm-private/typings": patch
+"@pnpm/fs.packlist": patch
+---
+
+Should pack main file or bin files defined in publishConfig [#4195](https://github.com/pnpm/pnpm/issues/4195).

--- a/.changeset/smooth-buckets-drop.md
+++ b/.changeset/smooth-buckets-drop.md
@@ -2,6 +2,7 @@
 "@pnpm/plugin-commands-publishing": patch
 "@pnpm-private/typings": patch
 "@pnpm/fs.packlist": patch
+"pnpm": patch
 ---
 
-Should pack main file or bin files defined in publishConfig [#4195](https://github.com/pnpm/pnpm/issues/4195).
+`pnpm publish` should pack "main" file or "bin" files defined in "publishConfig" [#4195](https://github.com/pnpm/pnpm/issues/4195).

--- a/__typings__/typed.d.ts
+++ b/__typings__/typed.d.ts
@@ -214,6 +214,6 @@ declare module '@pnpm/npm-conf/lib/types' {
 }
 
 declare module 'npm-packlist' {
-  function npmPacklist (opts: { path: string }): Promise<string[]>
+  function npmPacklist (opts: { path: string, packageJsonCache?: Map<string, Record<string, unknown>> }): Promise<string[]>
   export = npmPacklist
 }

--- a/fs/packlist/src/index.ts
+++ b/fs/packlist/src/index.ts
@@ -1,7 +1,12 @@
 import npmPacklist from 'npm-packlist'
 
-export async function packlist (pkgDir: string): Promise<string[]> {
-  const files = await npmPacklist({ path: pkgDir })
+export async function packlist (pkgDir: string, opts?: {
+  packageJsonCache?: Record<string, Record<string, unknown>>
+}): Promise<string[]> {
+  const packageJsonCacheMap = opts?.packageJsonCache
+    ? new Map(Object.entries(opts.packageJsonCache))
+    : undefined
+  const files = await npmPacklist({ path: pkgDir, packageJsonCache: packageJsonCacheMap })
   // There's a bug in the npm-packlist version that we use,
   // it sometimes returns duplicates.
   // Related issue: https://github.com/pnpm/pnpm/issues/6997

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -340,7 +340,7 @@ test('pack: should resolve correct files from publishConfig', async () => {
   await tar.x({ file: 'custom-publish-dir-0.0.0.tgz' })
 
   expect(await exists('./package/bin.js')).toBeFalsy()
-  expect(await exists('./package/index.js')).toBeFalsy()
+  expect(await exists('./package/index.ts')).toBeFalsy()
   expect(await exists('./package/package.json')).toBeTruthy()
   expect(await exists('./package/a.js')).toBeTruthy()
   expect(await exists('./package/dist-index.js')).toBeTruthy()

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -309,3 +309,40 @@ test('pack: custom pack-gzip-level', async () => {
   const tgz2 = fs.statSync(path.resolve('../big/test-publish-package.json-0.0.0.tgz'))
   expect(tgz1.size).not.toEqual(tgz2.size)
 })
+
+test('pack: should resolve correct files from publishConfig', async () => {
+  prepare({
+    name: 'custom-publish-dir',
+    version: '0.0.0',
+    main: './index.ts',
+    bin: './bin.js',
+    files: [
+      './a.js',
+    ],
+    publishConfig: {
+      main: './dist-index.js',
+      bin: './dist-bin.js',
+    },
+  })
+  fs.writeFileSync('./a.js', 'a', 'utf8')
+  fs.writeFileSync('./index.ts', 'src-index', 'utf8')
+  fs.writeFileSync('./bin.js', 'src-bin-src', 'utf8')
+  fs.writeFileSync('./dist-index.js', 'dist-index', 'utf8')
+  fs.writeFileSync('./dist-bin.js', 'dist-bin', 'utf8')
+
+  await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    packDestination: process.cwd(),
+  })
+  await tar.x({ file: 'custom-publish-dir-0.0.0.tgz' })
+
+  expect(await exists('./package/bin.js')).toBeFalsy()
+  expect(await exists('./package/index.js')).toBeFalsy()
+  expect(await exists('./package/package.json')).toBeTruthy()
+  expect(await exists('./package/a.js')).toBeTruthy()
+  expect(await exists('./package/dist-index.js')).toBeTruthy()
+  expect(await exists('./package/dist-bin.js')).toBeTruthy()
+})


### PR DESCRIPTION
fix #4195 

Following @popeindustries's  suggestion,  we can create publishManifest before pack tarball, and then use the [`packageJsonCache` option in npm-packlist](https://github.com/npm/npm-packlist/blob/v5.1.3/lib/index.js#L211) to avoid loading pacakge.json from the local filesystem, which should ensure that the final list of files in packed tarball is the one that needs to be published.