### PR TITLE
fix: package with unsupported platform should return false to skip download

### DIFF
--- a/config/package-is-installable/src/index.ts
+++ b/config/package-is-installable/src/index.ts
@@ -44,9 +44,7 @@ export function packageIsInstallable (
     prefix: options.lockfileDir,
   })
 
-  if (warn instanceof UnsupportedPlatformError) return false
-
-  if (options.optional) {
+  if (options.optional || warn instanceof UnsupportedPlatformError) {
     skippedOptionalDependencyLogger.debug({
       details: warn.toString(),
       package: {

--- a/config/package-is-installable/src/index.ts
+++ b/config/package-is-installable/src/index.ts
@@ -44,7 +44,7 @@ export function packageIsInstallable (
     prefix: options.lockfileDir,
   })
 
-  if (options.optional || warn instanceof UnsupportedPlatformError) {
+  if (options.optional) {
     skippedOptionalDependencyLogger.debug({
       details: warn.toString(),
       package: {

--- a/config/package-is-installable/src/index.ts
+++ b/config/package-is-installable/src/index.ts
@@ -2,7 +2,11 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
-import { checkEngine, UnsupportedEngineError, type WantedEngine } from './checkEngine'
+import {
+  checkEngine,
+  UnsupportedEngineError,
+  type WantedEngine,
+} from './checkEngine'
 import { checkPlatform, UnsupportedPlatformError } from './checkPlatform'
 import { getSystemNodeVersion } from './getSystemNodeVersion'
 import { type SupportedArchitectures } from '@pnpm/types'
@@ -10,11 +14,7 @@ import { type SupportedArchitectures } from '@pnpm/types'
 export type { Engine } from './checkEngine'
 export type { Platform, WantedPlatform } from './checkPlatform'
 
-export {
-  UnsupportedEngineError,
-  UnsupportedPlatformError,
-  type WantedEngine,
-}
+export { UnsupportedEngineError, UnsupportedPlatformError, type WantedEngine }
 
 export function packageIsInstallable (
   pkgId: string,
@@ -44,6 +44,8 @@ export function packageIsInstallable (
     prefix: options.lockfileDir,
   })
 
+  if (warn instanceof UnsupportedPlatformError) return false
+
   if (options.optional) {
     skippedOptionalDependencyLogger.debug({
       details: warn.toString(),
@@ -53,7 +55,10 @@ export function packageIsInstallable (
         version: pkg.version,
       },
       prefix: options.lockfileDir,
-      reason: warn.code === 'ERR_PNPM_UNSUPPORTED_ENGINE' ? 'unsupported_engine' : 'unsupported_platform',
+      reason:
+        warn.code === 'ERR_PNPM_UNSUPPORTED_ENGINE'
+          ? 'unsupported_engine'
+          : 'unsupported_platform',
     })
 
     return false
@@ -78,16 +83,21 @@ export function checkPackage (
     supportedArchitectures?: SupportedArchitectures
   }
 ): null | UnsupportedEngineError | UnsupportedPlatformError {
-  return checkPlatform(pkgId, {
-    cpu: manifest.cpu ?? ['any'],
-    os: manifest.os ?? ['any'],
-    libc: manifest.libc ?? ['any'],
-  }, options.supportedArchitectures) ?? (
-    (manifest.engines == null)
+  return (
+    checkPlatform(
+      pkgId,
+      {
+        cpu: manifest.cpu ?? ['any'],
+        os: manifest.os ?? ['any'],
+        libc: manifest.libc ?? ['any'],
+      },
+      options.supportedArchitectures
+    ) ??
+    (manifest.engines == null
       ? null
       : checkEngine(pkgId, manifest.engines, {
         node: options.nodeVersion ?? getSystemNodeVersion(),
         pnpm: options.pnpmVersion,
-      })
+      }))
   )
 }

--- a/config/package-is-installable/src/index.ts
+++ b/config/package-is-installable/src/index.ts
@@ -2,11 +2,7 @@ import {
   installCheckLogger,
   skippedOptionalDependencyLogger,
 } from '@pnpm/core-loggers'
-import {
-  checkEngine,
-  UnsupportedEngineError,
-  type WantedEngine,
-} from './checkEngine'
+import { checkEngine, UnsupportedEngineError, type WantedEngine } from './checkEngine'
 import { checkPlatform, UnsupportedPlatformError } from './checkPlatform'
 import { getSystemNodeVersion } from './getSystemNodeVersion'
 import { type SupportedArchitectures } from '@pnpm/types'
@@ -14,7 +10,11 @@ import { type SupportedArchitectures } from '@pnpm/types'
 export type { Engine } from './checkEngine'
 export type { Platform, WantedPlatform } from './checkPlatform'
 
-export { UnsupportedEngineError, UnsupportedPlatformError, type WantedEngine }
+export {
+  UnsupportedEngineError,
+  UnsupportedPlatformError,
+  type WantedEngine,
+}
 
 export function packageIsInstallable (
   pkgId: string,
@@ -55,10 +55,7 @@ export function packageIsInstallable (
         version: pkg.version,
       },
       prefix: options.lockfileDir,
-      reason:
-        warn.code === 'ERR_PNPM_UNSUPPORTED_ENGINE'
-          ? 'unsupported_engine'
-          : 'unsupported_platform',
+      reason: warn.code === 'ERR_PNPM_UNSUPPORTED_ENGINE' ? 'unsupported_engine' : 'unsupported_platform',
     })
 
     return false
@@ -83,21 +80,16 @@ export function checkPackage (
     supportedArchitectures?: SupportedArchitectures
   }
 ): null | UnsupportedEngineError | UnsupportedPlatformError {
-  return (
-    checkPlatform(
-      pkgId,
-      {
-        cpu: manifest.cpu ?? ['any'],
-        os: manifest.os ?? ['any'],
-        libc: manifest.libc ?? ['any'],
-      },
-      options.supportedArchitectures
-    ) ??
-    (manifest.engines == null
+  return checkPlatform(pkgId, {
+    cpu: manifest.cpu ?? ['any'],
+    os: manifest.os ?? ['any'],
+    libc: manifest.libc ?? ['any'],
+  }, options.supportedArchitectures) ?? (
+    (manifest.engines == null)
       ? null
       : checkEngine(pkgId, manifest.engines, {
         node: options.nodeVersion ?? getSystemNodeVersion(),
         pnpm: options.pnpmVersion,
-      }))
+      })
   )
 }

--- a/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
+++ b/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
@@ -59,7 +59,7 @@ export async function lockfileToHoistedDepGraph (
   if (currentLockfile?.packages != null) {
     prevGraph = (await _lockfileToHoistedDepGraph(currentLockfile, {
       ...opts,
-      force: true,
+      // force: true,
       skipped: new Set(),
     })).graph
   } else {


### PR DESCRIPTION
## How to reproduce?

```sh
git clone https://github.com/ts-monorepo/basic
cd basic 
pnpm install 
```
First time install will be ok;

Install again will show the unnecessary download details

```sh
pnpm install
```

![image](https://github.com/pnpm/pnpm/assets/6512574/fa55bd94-8112-4fa3-8c56-527c032b1be7)

After fix, Now:

<img width="536" alt="image" src="https://github.com/pnpm/pnpm/assets/6512574/af2bbf0b-6bb4-403f-bc11-9783691b6f68">

