### PR TITLE
fix(pack): "pnpm pack" should work as expected when prepack modifies the manifest

### DIFF
--- a/.changeset/afraid-news-cheat.md
+++ b/.changeset/afraid-news-cheat.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-"pnpm pack" should work as expected when prepack modifies the manifest.
+`pnpm pack` should work as expected when "prepack" modifies the manifest [#7558](https://github.com/pnpm/pnpm/pull/7558).

--- a/.changeset/afraid-news-cheat.md
+++ b/.changeset/afraid-news-cheat.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"pnpm": patch
+---
+
+"pnpm pack" should work as expected when prepack modifies the manifest.

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -88,7 +88,7 @@ export async function handler (
     ? path.join(opts.dir, entryManifest.publishConfig.directory)
     : opts.dir
   // always read the latest manifest, as "prepack" or "prepare" script may modify package manifest.
-  const manifest = (await readProjectManifest(dir, opts)).manifest
+  const { manifest } = await readProjectManifest(dir, opts)
   if (!manifest.name) {
     throw new PnpmError('PACKAGE_NAME_NOT_FOUND', `Package name is not defined in the ${manifestFileName}.`)
   }

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -87,7 +87,8 @@ export async function handler (
   const dir = entryManifest.publishConfig?.directory
     ? path.join(opts.dir, entryManifest.publishConfig.directory)
     : opts.dir
-  const manifest = (opts.dir !== dir) ? (await readProjectManifest(dir, opts)).manifest : entryManifest
+  // always read the latest manifest, as "prepack" or "prepare" script may modify package manifest.
+  const manifest = (await readProjectManifest(dir, opts)).manifest
   if (!manifest.name) {
     throw new PnpmError('PACKAGE_NAME_NOT_FOUND', `Package name is not defined in the ${manifestFileName}.`)
   }


### PR DESCRIPTION
 As discussed in https://github.com/pnpm/pnpm/pull/7538#issuecomment-1905025493.
 
 `prepack` script may modifes `package.json`, so we should reread the manifest after executing the `prepack`script.