### PR TITLE
feat: set default import method in Win to hardlink

### DIFF
--- a/.changeset/pretty-apples-dance.md
+++ b/.changeset/pretty-apples-dance.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fs.indexed-pkg-importer": patch
+"pnpm": patch
+---
+
+Prefer hard links over reflinks on Windows as they perform better [#7564](https://github.com/pnpm/pnpm/pull/7564).

--- a/fs/indexed-pkg-importer/src/index.ts
+++ b/fs/indexed-pkg-importer/src/index.ts
@@ -27,12 +27,6 @@ function createImportPackage (packageImportMethod?: 'auto' | 'hardlink' | 'copy'
     packageImportMethodLogger.debug({ method: 'hardlink' })
     return hardlinkPkg.bind(null, linkOrCopy)
   case 'auto': {
-    // Set default import method to hardlinking on Windows
-    if (process.platform === 'win32') {
-      packageImportMethodLogger.debug({ method: 'hardlink' })
-      return hardlinkPkg.bind(null, linkOrCopy)
-    }
-
     return createAutoImporter()
   }
   case 'clone-or-copy':
@@ -54,14 +48,16 @@ function createAutoImporter (): ImportIndexedPackage {
     to: string,
     opts: ImportOptions
   ): string | undefined {
-    try {
-      const _clonePkg = clonePkg.bind(null, createCloneFunction())
-      if (!_clonePkg(to, opts)) return undefined
-      packageImportMethodLogger.debug({ method: 'clone' })
-      auto = _clonePkg
-      return 'clone'
-    } catch (err: any) { // eslint-disable-line
-      // ignore
+    if (process.platform !== 'win32') {
+      try {
+        const _clonePkg = clonePkg.bind(null, createCloneFunction())
+        if (!_clonePkg(to, opts)) return undefined
+        packageImportMethodLogger.debug({ method: 'clone' })
+        auto = _clonePkg
+        return 'clone'
+      } catch (err: any) { // eslint-disable-line
+        // ignore
+      }
     }
     try {
       if (!hardlinkPkg(fs.linkSync, to, opts)) return undefined

--- a/fs/indexed-pkg-importer/src/index.ts
+++ b/fs/indexed-pkg-importer/src/index.ts
@@ -48,6 +48,9 @@ function createAutoImporter (): ImportIndexedPackage {
     to: string,
     opts: ImportOptions
   ): string | undefined {
+    // Although reflinks are supported on Windows Dev Drives,
+    // they are 10x slower than hard links.
+    // Hence, we prefer reflinks by default only on Linux and macOS.
     if (process.platform !== 'win32') {
       try {
         const _clonePkg = clonePkg.bind(null, createCloneFunction())


### PR DESCRIPTION
Set default `package-import-method` to hardlinks in Windows to avoid performance errors in systems without Dev Drives.

Close #7524 
Close #7547 
Close #7492