### PR TITLE
chore(pd): make esbuild find `js-yaml` correctly

### DIFF
--- a/pnpm/dev/pd.js
+++ b/pnpm/dev/pd.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const esbuild = require('esbuild')
 const pathLib = require('path')
-const {createRequire} = require('module')
+const { createRequire } = require('module')
 const { findWorkspacePackagesNoCheck } = require('@pnpm/workspace.find-packages')
 const { findWorkspaceDir } = require('@pnpm/find-workspace-dir')
 

--- a/pnpm/dev/pd.js
+++ b/pnpm/dev/pd.js
@@ -2,6 +2,7 @@
 const fs = require('fs')
 const esbuild = require('esbuild')
 const pathLib = require('path')
+const {createRequire} = require('module')
 const { findWorkspacePackagesNoCheck } = require('@pnpm/workspace.find-packages')
 const { findWorkspaceDir } = require('@pnpm/find-workspace-dir')
 
@@ -31,6 +32,18 @@ const pnpmPackageJson = JSON.parse(fs.readFileSync(pathLib.join(__dirname, 'pack
         const newPath = pathLib.resolve(dirByPackageName[path], 'src', 'index.ts')
         return {
           path: newPath
+        }
+      })
+
+      build.onResolve({filter: /js-yaml/}, ({ path, resolveDir, ...rest }) => {
+        if (path === 'js-yaml' && resolveDir.includes('lockfile/lockfile-file')) {
+          // Force esbuild to use the resolved js-yaml from within lockfile-file,
+          // since it seems to pick the wrong one otherwise.
+          const lockfileFileProject = pathLib.resolve(__dirname, '../../lockfile/lockfile-file/index.js')
+          const resolvedJsYaml = createRequire(lockfileFileProject).resolve('js-yaml')
+          return {
+            path: resolvedJsYaml
+          }
         }
       })
     }


### PR DESCRIPTION
For some reason, esbuild uses the upstream version of `js-yaml` rather than the @zkochan fork. This throws a little plugin into esbuild's resolution to resolve `js-yaml` using Node's resolvers instead, which seems to find the correct version.

There may be a better way to do this, especially considering esbuild does fine in the normal build of pnpm as far as I can tell... though that may be because `tsc` does the first pass.
