### PR TITLE
fix(resolve-dependencies): packages are deduplicated when it is direc…

### DIFF
--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -182,7 +182,7 @@ function deduplicateDepPaths<T extends PartialResolvedPackage> (
       const nextDepPaths = []
       while (currentDepPaths.length) {
         const depPath2 = currentDepPaths.pop()!
-        if (isCompatibleAndHasMoreDeps(depGraph, depPath1, depPath2)) {
+        if (isCompatibleAndHasMoreDeps(depGraph, depPath1, depPath2) || isDirectDependence(depGraph, depPath1) || isDirectDependence(depGraph, depPath2)) {
           depPathsMap[depPath2] = depPath1
           unresolvedDepPaths.delete(depPath1)
           unresolvedDepPaths.delete(depPath2)
@@ -221,6 +221,13 @@ function isCompatibleAndHasMoreDeps<T extends PartialResolvedPackage> (
     if (!node1.resolvedPeerNames.has(depPath)) return false
   }
   return true
+}
+
+function isDirectDependence<T extends PartialResolvedPackage> (
+  depGraph: GenericDependenciesGraph<T>,
+  depPath: string
+) {
+  return depGraph[depPath].depth === 0
 }
 
 function getRootPkgsByName<T extends PartialResolvedPackage> (dependenciesTree: DependenciesTree<T>, projects: ProjectToResolve[]) {

--- a/pkg-manager/resolve-dependencies/test/dedupeDepPaths.test.ts
+++ b/pkg-manager/resolve-dependencies/test/dedupeDepPaths.test.ts
@@ -1,7 +1,7 @@
 import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers'
 import { type DependenciesTreeNode } from '../lib/resolveDependencies'
 
-test('packages are not deduplicated when versions do not match', () => {
+test('packages are deduplicated when it is direct dependencies', () => {
   const fooPkg: PartialResolvedPackage = {
     name: 'foo',
     version: '1.0.0',
@@ -100,6 +100,6 @@ test('packages are not deduplicated when versions do not match', () => {
   })
 
   expect(dependenciesByProjectId.project1.foo).toEqual(dependenciesByProjectId.project2.foo)
-  expect(dependenciesByProjectId.project1.foo).not.toEqual(dependenciesByProjectId.project3.foo)
+  expect(dependenciesByProjectId.project1.foo).toEqual(dependenciesByProjectId.project3.foo)
   expect(dependenciesByProjectId.project3.foo).toEqual(dependenciesByProjectId.project4.foo)
 })


### PR DESCRIPTION
I met a same problem like #7600.
I try to fix it follow your comment.
If the pr is merged, pnpm will deduplicate the same package when it it direct depdencies.