### PR TITLE
fix: linking globally a package with no name in package.json

### DIFF
--- a/.changeset/thin-pumpkins-mate.md
+++ b/.changeset/thin-pumpkins-mate.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+Link globally the command of a package that has no name in `package.json` [#4761](https://github.com/pnpm/pnpm/issues/4761).

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1156,7 +1156,7 @@ async function resolveDependency (
       throw new PnpmError('MISSING_PACKAGE_JSON', `Can't install ${wantedDependency.pref}: Missing package.json file`)
     }
     return {
-      alias: wantedDependency.alias || manifest.name,
+      alias: wantedDependency.alias || manifest.name || path.basename(pkgResponse.body.resolution.directory),
       depPath: pkgResponse.body.id,
       dev: wantedDependency.dev,
       isLinkedDependency: true,

--- a/pnpm/test/link.ts
+++ b/pnpm/test/link.ts
@@ -1,0 +1,31 @@
+import path from 'path'
+import PATH_NAME from 'path-name'
+import fs from 'fs'
+import { isExecutable } from '@pnpm/assert-project'
+import { LAYOUT_VERSION } from '@pnpm/constants'
+import { prepare } from '@pnpm/prepare'
+import { execPnpm } from './utils'
+
+test('link globally the command of a package that has no name in package.json', async () => {
+  prepare()
+  fs.mkdirSync('cmd')
+  process.chdir('cmd')
+  fs.writeFileSync('package.json', JSON.stringify({ bin: { cmd: 'bin.js' } }), 'utf8')
+  fs.writeFileSync('bin.js', `#!/usr/bin/env node
+console.log("hello world");`, 'utf8')
+
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(global)
+
+  const env = { [PATH_NAME]: pnpmHome, PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  await execPnpm(['link', '--global'], { env })
+
+  const globalPrefix = path.join(global, `pnpm/global/${LAYOUT_VERSION}`)
+  expect(fs.existsSync(path.join(globalPrefix, 'node_modules/cmd'))).toBeTruthy()
+  const ok = (value: any) => { // eslint-disable-line
+    expect(value).toBeTruthy()
+  }
+  await isExecutable(ok, path.join(pnpmHome, 'cmd'))
+})


### PR DESCRIPTION
close #4761
close #4793
close #7511
close #7560
