### PR TITLE
fix(get-context): avoid excess purge prompts

### DIFF
--- a/.changeset/lemon-windows-tickle.md
+++ b/.changeset/lemon-windows-tickle.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/get-context": patch
+"pnpm": patch
 ---
 
 When purging multiple node_modules folders, pnpm will no longer print multiple prompts simultaneously.

--- a/.changeset/lemon-windows-tickle.md
+++ b/.changeset/lemon-windows-tickle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/get-context": patch
+---
+
+When purging multiple node_modules folders, pnpm will no longer print multiple prompts simultaneously.

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -316,10 +316,7 @@ async function purgeModulesDirsOfImporters (
     confirmModulesPurge?: boolean
     virtualStoreDir: string
   },
-  importers: Array<{
-    modulesDir: string
-    rootDir: string
-  }>
+  importers: ImporterToPurge[]
 ) {
   if (opts.confirmModulesPurge ?? true) {
     const confirmed = await enquirer.prompt({

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -294,11 +294,12 @@ async function validateModules (
     })
   }
 
-  if (importersToPurge.length > 0) {
+  const purged = importersToPurge.length > 0
+  if (purged) {
     await purgeModulesDirsOfImporters(opts, importersToPurge)
   }
 
-  return { purged: importersToPurge.length > 0 }
+  return { purged }
 }
 
 async function purgeModulesDirsOfImporter (

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -101,6 +101,10 @@ export interface GetContextOptions {
   forcePublicHoistPattern?: boolean
   global?: boolean
 }
+interface ImporterToPurge {
+  modulesDir: string
+  rootDir: string
+}
 
 export async function getContext (
   opts: GetContextOptions
@@ -243,7 +247,9 @@ async function validateModules (
       ' Run "pnpm install" to recreate the modules directory.'
     )
   }
-  let purged = false
+
+  const importersToPurge: ImporterToPurge[] = []
+
   if (opts.forceHoistPattern && (rootProject != null)) {
     try {
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -256,11 +262,10 @@ async function validateModules (
       }
     } catch (err: any) { // eslint-disable-line
       if (!opts.forceNewModules) throw err
-      await purgeModulesDirsOfImporter(opts, rootProject)
-      purged = true
+      importersToPurge.push(rootProject)
     }
   }
-  await Promise.all(projects.map(async (project) => {
+  for (const project of projects) {
     try {
       checkCompatibility(modules, {
         modulesDir: project.modulesDir,
@@ -279,17 +284,21 @@ async function validateModules (
       }
     } catch (err: any) { // eslint-disable-line
       if (!opts.forceNewModules) throw err
-      await purgeModulesDirsOfImporter(opts, project)
-      purged = true
+      importersToPurge.push(project)
     }
-  }))
-  if (purged && (rootProject == null)) {
-    await purgeModulesDirsOfImporter(opts, {
+  }
+  if (importersToPurge.length > 0 && (rootProject == null)) {
+    importersToPurge.push({
       modulesDir: path.join(opts.lockfileDir, opts.modulesDir),
       rootDir: opts.lockfileDir,
     })
   }
-  return { purged }
+
+  if (importersToPurge.length > 0) {
+    await purgeModulesDirsOfImporters(opts, importersToPurge)
+  }
+
+  return { purged: importersToPurge.length > 0 }
 }
 
 async function purgeModulesDirsOfImporter (
@@ -297,10 +306,7 @@ async function purgeModulesDirsOfImporter (
     confirmModulesPurge?: boolean
     virtualStoreDir: string
   },
-  importer: {
-    modulesDir: string
-    rootDir: string
-  }
+  importer: ImporterToPurge
 ) {
   return purgeModulesDirsOfImporters(opts, [importer])
 }


### PR DESCRIPTION
pnpm sometimes needs to purge modules folders (node_modules) when certain configuration changes (in other words, when it needs to start from scratch).

This prompt, problematically, was getting triggered asynchronously for each importer in the workspace that needed a purge, which would sometimes lead to gargantuan prompts instead of one consolidated prompt.

The fix is to queue up which importers need a purge, then fire the prompter all at once.

Closes #7320

## Before

<img width="1000" alt="" src="https://github.com/pnpm/pnpm/assets/1724000/e16c0f75-5b69-488b-9522-1515206018f7">

## After

<img width="931" alt="" src="https://github.com/pnpm/pnpm/assets/1724000/20c12a46-c362-4fb7-af3b-c922ed654a60">

