### PR TITLE
fix: do not fail when the same package with peer dependency is installed via different aliases

### DIFF
--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1774,3 +1774,15 @@ test('resolves complex circular deps', async () => {
   }))
   // it doesn't hang
 })
+
+test('do not fail when the same package with peer dependency is installed via different aliases', async () => {
+  const project = prepareEmpty()
+  await addDependenciesToPackage({}, [
+    '@pnpm.e2e/has-y-peer@1.0.0',
+    'has-y-peer@npm:@pnpm.e2e/has-y-peer@1.0.0',
+  ], await testDefaults({
+    autoInstallPeers: true,
+  }))
+  const lockfile = await project.readLockfile()
+  expect(Object.keys(lockfile.packages).length).toBe(2)
+})

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -589,9 +589,9 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
   // Partition children based on whether they're repeated in parentPkgs.
   // This impacts the efficiency of graph traversal and prevents potential out-of-memory errors.mes can even lead to out-of-memory exceptions.
   const [repeated, notRepeated] = partition(([alias]) => parentPkgs[alias] != null, Object.entries(children))
-  const nodeIds = [...notRepeated, ...repeated]
+  const nodeIds = Array.from(new Set([...notRepeated, ...repeated].map(([, nodeId]) => nodeId)))
 
-  for (const [,nodeId] of nodeIds) {
+  for (const nodeId of nodeIds) {
     if (!ctx.pathsByNodeIdPromises.has(nodeId)) {
       ctx.pathsByNodeIdPromises.set(nodeId, pDefer())
     }
@@ -601,7 +601,7 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
   const calculateDepPaths: CalculateDepPath[] = []
   const graph = []
   const finishingList: FinishingResolutionPromise[] = []
-  for (const [, childNodeId] of nodeIds) {
+  for (const childNodeId of nodeIds) {
     const {
       resolvedPeers,
       missingPeers,


### PR DESCRIPTION
This issue is only on v9

related: https://github.com/pnpm/pnpm/pull/7606