### PR TITLE
chore!: enable minification

### DIFF
--- a/pnpm/bundle.ts
+++ b/pnpm/bundle.ts
@@ -10,6 +10,7 @@ import { build } from 'esbuild'
     await build({
       entryPoints: ['lib/pnpm.js'],
       bundle: true,
+      minify: true,
       platform: 'node',
       outfile: 'dist/pnpm.cjs',
       external: ['node-gyp'],
@@ -29,6 +30,7 @@ import { build } from 'esbuild'
     await build({
       entryPoints: ['../worker/lib/worker.js'],
       bundle: true,
+      minify: true,
       platform: 'node',
       outfile: 'dist/worker.js',
       loader: {


### PR DESCRIPTION
The PR enables the modification of the `pnpm.cjs` file and the `worker.js` file.

-----

I use pnpm through the corepack. When a requested version of pnpm is not available locally, corepack automatically downloads and caches pnpm locally. Currently, I have 20 copies of pnpm on my disk, each taking up about 15-20 MiB:

<img width="540" alt="image" src="https://github.com/pnpm/pnpm/assets/40715044/2d360ebf-3652-4d94-b6b3-6e9ffaef111e">

By enabling minification, the size of the `pnpm.cjs` file can be reduced from 8.1 MiB to 3.7 MiB, achieving a 53% reduction.

Yarn also ships a minified version of a single `yarn.js` bundle, which has a size of 2.7 MiB (https://repo.yarnpkg.com/4.0.0/packages/yarnpkg-cli/bin/yarn.js).

There are a few downsides though:

- Patching pnpm itself becomes impossible (hence the breaking change)
- The stack of the crash error might be messed up, so it could be hard to debug




