### PR TITLE
[DRAFT,EXPERIMENTAL] feat: add --publish-tag option

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,6 +4,7 @@ git-checks = false
 hoist-pattern[] = jest-runner
 shared-workspace-lockfile = true
 publish-branch = main
+publish-tag=
 pnpmfile = .pnpmfile.cjs
 node-version = 18.12.0
 engine-strict = true

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -151,6 +151,7 @@ export interface Config {
   npmPath?: string
   gitChecks?: boolean
   publishBranch?: string
+  publishTag?: string
   recursiveInstall?: boolean
   symlink: boolean
   enablePnp?: boolean

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -111,6 +111,7 @@ export const types = Object.assign({
   production: [null, true],
   'public-hoist-pattern': Array,
   'publish-branch': String,
+  'publish-tag': String,
   'recursive-install': Boolean,
   reporter: String,
   'resolution-mode': ['highest', 'time-based', 'lowest-direct'],

--- a/packages/git-utils/src/index.ts
+++ b/packages/git-utils/src/index.ts
@@ -11,6 +11,15 @@ export async function isGitRepo () {
   return true
 }
 
+export async function getCurrentHead () {
+  try {
+    const { stdout } = await execa('git', ['rev-parse', 'HEAD'])
+    return stdout.trim()
+  } catch (_: any) { // eslint-disable-line
+    return null
+  }
+}
+
 export async function getCurrentBranch () {
   try {
     const { stdout } = await execa('git', ['symbolic-ref', '--short', 'HEAD'])
@@ -18,6 +27,25 @@ export async function getCurrentBranch () {
   } catch (_: any) {  // eslint-disable-line
     // Command will fail with code 1 if the HEAD is detached.
     return null
+  }
+}
+
+export async function getCurrentTags () {
+  try {
+    const currentHead = await getCurrentHead()
+    if (!currentHead) {
+      return []
+    }
+
+    const { stdout } = await execa('git', ['show-ref', '--tags', '-d']).pipeStdout(execa(
+      'grep', [currentHead]
+    )).pipeStdout(execa(
+      'sed', ['-e', 's,.* refs/tags/,,', '-e', 's/\^{}//']
+    ))
+
+    return stdout.trim().split(/\s+/)
+  } catch (_: any) {  // eslint-disable-line
+    return []
   }
 }
 

--- a/releasing/plugin-commands-publishing/test/gitChecks.ts
+++ b/releasing/plugin-commands-publishing/test/gitChecks.ts
@@ -72,6 +72,7 @@ test('publish: fails git check if branch is not on specified branch', async () =
       argv: { original: ['publish', ...CREDENTIALS] },
       dir: process.cwd(),
       publishBranch: 'latest',
+      publishTag: undefined,
     }, [])
   ).rejects.toThrow(
     new PnpmError('GIT_NOT_CORRECT_BRANCH', "Branch is not on 'latest'.")

--- a/releasing/plugin-commands-publishing/test/publish.ts
+++ b/releasing/plugin-commands-publishing/test/publish.ts
@@ -701,6 +701,7 @@ test('publish: with specified publish branch name', async () => {
     argv: { original: ['publish', '--publish-branch', branch, ...CREDENTIALS] },
     dir: process.cwd(),
     publishBranch: branch,
+    publishTag: undefined,
   }, [])
 })
 


### PR DESCRIPTION
**IMPORTANT:** I'm sure this is not finished. I didn't manage to run the tests locally because of the constraint on PNPM's version to be >= 9 (still not sure how to deal with that without messing with my working environment configuration).

This PR intends to introduce a new option for PNPM, so we can dynamically configure from which branch do we want to publish.

The aim of this change is to make it easier to automate package publishing from Github Actions triggered from "release" events.