### PR TITLE
feat!: bump lockfile to v7

### DIFF
--- a/__fixtures__/circular/pnpm-lock.yaml
+++ b/__fixtures__/circular/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   es6-iterator:

--- a/__fixtures__/custom-modules-dir/pnpm-lock.yaml
+++ b/__fixtures__/custom-modules-dir/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/empty/pnpm-lock.yaml
+++ b/__fixtures__/empty/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   write-json-file:

--- a/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   write-json-file:

--- a/__fixtures__/fixture/pnpm-lock.yaml
+++ b/__fixtures__/fixture/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   write-json-file:

--- a/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   minimatch:

--- a/__fixtures__/fixtureWithLinks/with-links-only/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/with-links-only/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   general:

--- a/__fixtures__/general/pnpm-lock.yaml
+++ b/__fixtures__/general/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   minimatch:

--- a/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-negative:

--- a/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-negative:

--- a/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-negative:

--- a/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 dependencies:
   is-negative:
     version: 2.1.0

--- a/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 importers:
   pkg:
     dependencies:

--- a/__fixtures__/has-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   '@pnpm.e2e/deprecated':

--- a/__fixtures__/local-pkg/pnpm-lock.yaml
+++ b/__fixtures__/local-pkg/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/local-scoped-pkg/pnpm-lock.yaml
+++ b/__fixtures__/local-scoped-pkg/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/multiple-scripts-error-exit/pnpm-lock.yaml
+++ b/__fixtures__/multiple-scripts-error-exit/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
+++ b/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/pnpm-lock.yaml
+++ b/__fixtures__/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/tar-pkg/pnpm-lock.yaml
+++ b/__fixtures__/tar-pkg/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/with-aliased-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-aliased-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   positive:

--- a/__fixtures__/with-file-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-file-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   general:

--- a/__fixtures__/with-git-protocol-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-git-protocol-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-non-package-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-non-package-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   camelcase:

--- a/__fixtures__/with-peer/pnpm-lock.yaml
+++ b/__fixtures__/with-peer/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   ajv:

--- a/__fixtures__/with-pnpm-update-ignore/pnpm-lock.yaml
+++ b/__fixtures__/with-pnpm-update-ignore/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-negative:

--- a/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
+++ b/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   symlink-dir:

--- a/__fixtures__/workspace-external-depends-deep/pnpm-lock.yaml
+++ b/__fixtures__/workspace-external-depends-deep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/workspace-has-shared-npm-shrinkwrap-json/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-npm-shrinkwrap-json/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/workspace-has-shared-package-lock-json/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-package-lock-json/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/workspace-has-shared-yarn-lock/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-yarn-lock/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'

--- a/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/workspace-with-lockfile-subdep-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-subdep-dupes/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/__utils__/assert-store/test/fixture/project/pnpm-lock.yaml
+++ b/__utils__/assert-store/test/fixture/project/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/test/__snapshots__/write.test.ts.snap
+++ b/lockfile/lockfile-file/test/__snapshots__/write.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`writeLockfiles() 1`] = `
-"lockfileVersion: '6.1'
+"lockfileVersion: '7.0'
 
 dependencies:
   is-negative:

--- a/lockfile/lockfile-file/test/fixtures/2/pnpm-lock.yaml
+++ b/lockfile/lockfile-file/test/fixtures/2/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 dependencies:
   foo:
     version: '1.0.0'

--- a/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.branch.yaml
+++ b/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.branch.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.yaml
+++ b/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/test/lockfileV6Converters.test.ts
+++ b/lockfile/lockfile-file/test/lockfileV6Converters.test.ts
@@ -2,7 +2,7 @@ import { convertToLockfileFile, convertToLockfileObject } from '../lib/lockfileF
 
 test('convertToLockfileFile()', () => {
   const lockfileV5 = {
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     importers: {
       project1: {
         specifiers: {
@@ -39,7 +39,7 @@ test('convertToLockfileFile()', () => {
     },
   }
   const lockfileV6 = {
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     importers: {
       project1: {
         dependencies: {
@@ -87,7 +87,7 @@ test('convertToLockfileFile()', () => {
 
 test('convertToLockfileFile() with lockfile v6', () => {
   const lockfileV5 = {
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     importers: {
       project1: {
         specifiers: {
@@ -124,7 +124,7 @@ test('convertToLockfileFile() with lockfile v6', () => {
     },
   }
   const lockfileV6 = {
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     importers: {
       project1: {
         dependencies: {

--- a/lockfile/lockfile-file/test/read.test.ts
+++ b/lockfile/lockfile-file/test/read.test.ts
@@ -18,7 +18,7 @@ test('readWantedLockfile()', async () => {
     const lockfile = await readWantedLockfile(path.join('fixtures', '2'), {
       ignoreIncompatible: false,
     })
-    expect(lockfile?.lockfileVersion).toEqual('6.0')
+    expect(lockfile?.lockfileVersion).toEqual('7.0')
     expect(lockfile?.importers).toStrictEqual({
       '.': {
         dependencies: {

--- a/lockfile/lockfile-file/test/read.test.ts
+++ b/lockfile/lockfile-file/test/read.test.ts
@@ -88,7 +88,7 @@ test('writeWantedLockfile()', async () => {
         },
       },
     },
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     packages: {
       '/is-negative@1.0.0': {
         dependencies: {
@@ -131,7 +131,7 @@ test('writeCurrentLockfile()', async () => {
         },
       },
     },
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     packages: {
       '/is-negative@1.0.0': {
         dependencies: {

--- a/lockfile/plugin-commands-audit/test/fixtures/has-vulnerabilities/pnpm-lock.yaml
+++ b/lockfile/plugin-commands-audit/test/fixtures/has-vulnerabilities/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   karma:

--- a/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
+++ b/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   '@zkochan/git-config':

--- a/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
+++ b/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
@@ -1,26 +1,38 @@
-lockfileVersion: '7.0'
+lockfileVersion: '6.0'
 
-dependencies:
-  '@zkochan/git-config':
-    specifier: 0.1.0
-    version: 0.1.0
-  is-positive:
-    specifier: 1.0.0
-    version: 1.0.0
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@zkochan/git-config':
+        specifier: 0.1.0
+        version: 0.1.0
+      is-positive:
+        specifier: 1.0.0
+        version: 1.0.0
 
 packages:
 
   /@zkochan/git-config@0.1.0:
-    resolution: {integrity: sha1-lHdoOUuwyBsfrnA+/pjQDYyXl+A=}
+    resolution: {integrity: sha512-JBrmOelc6E+T2pbyLItPnVhY/hBVKE8K4TpdVK0ymlL1OvYj/VJYJszuAoOP2Q+Sw2QIZHvngURNYChk1TbhvA==}
     dependencies:
-      ini: 1.3.8
+      ini: 1.3.4
     dev: false
 
-  /ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+  /ini@1.3.4:
+    resolution: {integrity: sha512-VUA7WAWNCWfm6/8f9kAb8Y6iGBWnmCfgFS5dTrv2C38LLm1KUmpY388mCVCJCsMKQomvOQ1oW8/edXdChd9ZXQ==}
+    deprecated: Please update to ini >=1.3.6 to avoid a prototype pollution issue
     dev: false
 
   /is-positive@1.0.0:
-    resolution: {integrity: sha1-iACYVrZKLx632LsBeUGEJK4EUss=}
+    resolution: {integrity: sha512-xxzPGZ4P2uN6rROUa5N9Z7zTX6ERuE0hs6GUOc/cKBLF2NqKc16UwqHMt3tFg4CO6EBTE5UecUasg+3jZx3Ckg==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+time:
+  /@zkochan/git-config@0.1.0: '2016-04-06T16:35:39.401Z'
+  /is-positive@1.0.0: '2015-06-02T12:03:51.069Z'

--- a/modules-mounter/daemon/test/__snapshots__/makeVirtualNodeModules.test.ts.snap
+++ b/modules-mounter/daemon/test/__snapshots__/makeVirtualNodeModules.test.ts.snap
@@ -20,7 +20,7 @@ exports[`makeVirtualNodeModules 1`] = `
                 },
                 "ini": {
                   "entryType": "symlink",
-                  "target": "../../ini@1.3.8/node_modules/ini",
+                  "target": "../../ini@1.3.4/node_modules/ini",
                 },
               },
               "entryType": "directory",
@@ -28,12 +28,12 @@ exports[`makeVirtualNodeModules 1`] = `
           },
           "entryType": "directory",
         },
-        "ini@1.3.8": {
+        "ini@1.3.4": {
           "entries": {
             "node_modules": {
               "entries": {
                 "ini": {
-                  "depPath": "/ini@1.3.8",
+                  "depPath": "/ini@1.3.4",
                   "entryType": "index",
                 },
               },

--- a/modules-mounter/daemon/test/createFuseHandlers.test.ts
+++ b/modules-mounter/daemon/test/createFuseHandlers.test.ts
@@ -27,7 +27,7 @@ describe('FUSE handlers', () => {
       expect(returnCode).toBe(0)
       expect(files!.sort()).toStrictEqual([
         '@zkochan+git-config@0.1.0',
-        'ini@1.3.8',
+        'ini@1.3.4',
         'is-positive@1.0.0',
       ].sort())
     })

--- a/packages/calc-dep-state/test/lockfileToDepGraph.test.ts
+++ b/packages/calc-dep-state/test/lockfileToDepGraph.test.ts
@@ -2,7 +2,7 @@ import { lockfileToDepGraph } from '@pnpm/calc-dep-state'
 
 test('lockfileToDepGraph', () => {
   expect(lockfileToDepGraph({
-    lockfileVersion: '6.0',
+    lockfileVersion: '7.0',
     importers: {},
     packages: {
       '/foo@1.0.0': {

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,6 @@
 export const WANTED_LOCKFILE = 'pnpm-lock.yaml'
-export const LOCKFILE_VERSION = '6.1'
+export const LOCKFILE_VERSION = '7.0'
+export const LOCKFILE_VERSION_V6 = '6.0'
 
 export const ENGINE_NAME = `${process.platform}-${process.arch}-node-${process.version.split('.')[0]}`
 export const LAYOUT_VERSION = 5

--- a/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
+++ b/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -350,7 +350,7 @@ export async function mutateModules (
     }
     let needsFullResolution = outdatedLockfileSettings ||
       opts.fixLockfile ||
-      !ctx.wantedLockfile.lockfileVersion.toString().startsWith('6.') ||
+      !ctx.wantedLockfile.lockfileVersion.toString().startsWith('7.') ||
       opts.forceFullResolution
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -5,6 +5,7 @@ import { createAllowBuildFunction } from '@pnpm/builder.policy'
 import {
   LAYOUT_VERSION,
   LOCKFILE_VERSION,
+  LOCKFILE_VERSION_V6,
   WANTED_LOCKFILE,
 } from '@pnpm/constants'
 import {
@@ -381,6 +382,7 @@ export async function mutateModules (
         ctx.existsNonEmptyWantedLockfile &&
         (
           ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION ||
+          ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION_V6 ||
           ctx.wantedLockfile.lockfileVersion === '6.1'
         ) &&
         await allProjectsAreUpToDate(Object.values(ctx.projects), {

--- a/pkg-manager/core/test/lockfile.ts
+++ b/pkg-manager/core/test/lockfile.ts
@@ -1035,7 +1035,7 @@ test('existing dependencies are preserved when updating a lockfile to a newer fo
   const manifest = await addDependenciesToPackage({}, ['@pnpm.e2e/pkg-with-1-dep'], testDefaults())
 
   const initialLockfile = project.readLockfile()
-  writeYamlFile(WANTED_LOCKFILE, { ...initialLockfile, lockfileVersion: 5.01 }, { lineWidth: 1000 })
+  writeYamlFile(WANTED_LOCKFILE, { ...initialLockfile, lockfileVersion: '6.0' }, { lineWidth: 1000 })
 
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
 

--- a/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-glob-and-rimraf/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-glob-and-rimraf/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-glob/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-glob/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-incompatible-optional-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-incompatible-optional-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dep/pkg/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dep/pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dir-dep/example/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dir-dep/example/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dir-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dir-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-nonexistent-optional-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-nonexistent-optional-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-several-versions-of-same-pkg/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-several-versions-of-same-pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/ignore-package-manifest/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/ignore-package-manifest/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/pkg-manager/headless/test/fixtures/prod-dep-is-dev-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/prod-dep-is-dev-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/reinstall-peer-deps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/reinstall-peer-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true
@@ -7,11 +7,11 @@ settings:
 devDependencies:
   '@pnpm.e2e/abc':
     specifier: 1.0.0
-    version: 1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.1)
+    version: 1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)
 
 packages:
 
-  /@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.1):
+  /@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0):
     resolution: {integrity: sha512-pXCDz60zZZ33NeZpkHZtikJBbyAHjK42Nv33wgxGXV/bNDhLfXQ9yQTsVXfR1xOwJ55n2nV+Zkx/W0Lo5YL8ag==}
     peerDependencies:
       '@pnpm.e2e/peer-a': ^1.0.0
@@ -21,7 +21,7 @@ packages:
       '@pnpm.e2e/dep-of-pkg-with-1-dep': 100.0.0
       '@pnpm.e2e/peer-a': 1.0.1
       '@pnpm.e2e/peer-b': 1.0.0
-      '@pnpm.e2e/peer-c': 1.0.1
+      '@pnpm.e2e/peer-c': 1.0.0
     dev: true
 
   /@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0:
@@ -36,6 +36,6 @@ packages:
     resolution: {integrity: sha512-/xEON+6CnPFjT8WUWdDI+ZaK+/foZqWhqhzEslQvjaRUZZPD9ClSa1VQqrRLK7DctB9X01rYorCDfRrCCgNU4w==}
     dev: true
 
-  /@pnpm.e2e/peer-c@1.0.1:
-    resolution: {integrity: sha512-lggiyZeagLoAxKSvbMBMZaoQaDO2a0Kev28fUpgEVR/9eHpvB9SQe5relsbWQq3AIt+5Yi/ZL7PmiKY8qC0vhg==}
+  /@pnpm.e2e/peer-c@1.0.0:
+    resolution: {integrity: sha512-mIxp7K4B8IeXU/fuEP/llay2xDR+hyyhwlqL9D+/3NewrXTyvJUjp8cNagIuEOjA/1VZCDcNQfI947LjsSe3qQ==}
     dev: true

--- a/pkg-manager/headless/test/fixtures/resolved-peer-deps-in-subdeps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/resolved-peer-deps-in-subdeps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: false
@@ -109,22 +109,34 @@ packages:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
     dev: false
 
-  /define-data-property@1.1.1:
-    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+  /define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.2
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
       gopd: 1.0.1
-      has-property-descriptors: 1.0.1
     dev: false
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.1
-      has-property-descriptors: 1.0.1
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+    dev: false
+
+  /es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.4
+    dev: false
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
     dev: false
 
   /escape-string-regexp@1.0.5:
@@ -136,13 +148,15 @@ packages:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
     dev: false
 
-  /get-intrinsic@1.2.2:
-    resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
+  /get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
     dependencies:
+      es-errors: 1.3.0
       function-bind: 1.1.2
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      hasown: 2.0.0
+      hasown: 2.0.1
     dev: false
 
   /get-source@1.0.42:
@@ -162,7 +176,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.2
+      get-intrinsic: 1.2.4
     dev: false
 
   /has-flag@3.0.0:
@@ -170,10 +184,10 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /has-property-descriptors@1.0.1:
-    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
+  /has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
-      get-intrinsic: 1.2.2
+      es-define-property: 1.0.0
     dev: false
 
   /has-proto@1.0.1:
@@ -186,8 +200,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /hasown@2.0.0:
-    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+  /hasown@2.0.1:
+    resolution: {integrity: sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2

--- a/pkg-manager/headless/test/fixtures/side-effects-of-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/side-effects-of-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/side-effects/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/side-effects/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/simple-shamefully-flatten/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-shamefully-flatten/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: false

--- a/pkg-manager/headless/test/fixtures/simple-with-more-deps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-with-more-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true
@@ -16,14 +16,14 @@ optionalDependencies:
 
 packages:
 
-  /@pnpm.e2e/dep-of-pkg-with-1-dep@101.0.0:
-    resolution: {integrity: sha512-KS9eCiX1F0DF+YHrpQDGkUkIPcZFhz6NhOh5amLnTUpR0Dcd6Mv96YOf01PBw1pINWs+Jo5KhXYp0L58mebTgw==}
+  /@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0:
+    resolution: {integrity: sha512-60+yiZtuRbojMieLzg4UxzBs5fxSVfRtTRNKvdfTaLTb/2XLZTZORTSWkz8ttCGmNbMv5Li2gP4TNgVFMbnYgw==}
     dev: false
 
   /@pnpm.e2e/pkg-with-good-optional@1.0.0:
     resolution: {integrity: sha512-KfshZeGJiii1oEMjabBfxZ/rB14oJfE7wtFIRHmElIIZZHZlDtP1u4m8nBYrFKs4b8Dku4BCMV6pO0uMIVwHpQ==}
     dependencies:
-      '@pnpm.e2e/dep-of-pkg-with-1-dep': 101.0.0
+      '@pnpm.e2e/dep-of-pkg-with-1-dep': 100.1.0
     optionalDependencies:
       is-positive: 1.0.0
     dev: false

--- a/pkg-manager/headless/test/fixtures/simple/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/with-1-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/with-1-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/workspace/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/workspace/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/pkg-manager/headless/test/fixtures/workspace2/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/workspace2/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 importers:
 

--- a/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
+++ b/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
@@ -15,7 +15,7 @@ exports[`pnpm dedupe updates old resolutions from importers block and removes ol
       },
 @@ -20,18 +20,6 @@
     },
-    "lockfileVersion": "6.1",
+    "lockfileVersion": "7.0",
     "packages": Object {
 -     "/ajv@6.10.2": Object {
 -       "dependencies": Object {
@@ -98,7 +98,7 @@ exports[`pnpm dedupe updates old resolutions from package block 1`] = `
 
 @@ -20,15 +20,6 @@
     },
-    "lockfileVersion": "6.1",
+    "lockfileVersion": "7.0",
     "packages": Object {
 -     "/punycode@2.1.1": Object {
 -       "dev": false,

--- a/pkg-manager/plugin-commands-installation/test/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/test/dedupe.ts
@@ -8,7 +8,7 @@ import { prepare } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
 import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { diff } from 'jest-diff'
-import readYamlFile from 'read-yaml-file'
+import { sync as readYamlFile } from 'read-yaml-file'
 import { DEFAULT_OPTS } from './utils'
 
 const f = fixtures(__dirname)
@@ -159,12 +159,12 @@ async function testFixture (fixtureName: string) {
 
   const readProjectLockfile = () => readYamlFile<Lockfile>(path.join(project.dir(), './pnpm-lock.yaml'))
 
-  const originalLockfile = await readProjectLockfile()
+  const originalLockfile = readProjectLockfile()
 
   // Sanity check that this test is set up correctly by ensuring the lockfile is
   // unmodified after a regular install.
   await install.handler(opts)
-  expect(await readProjectLockfile()).toEqual(originalLockfile)
+  expect(readProjectLockfile()).toEqual(originalLockfile)
 
   let dedupeCheckError: DedupeCheckIssuesError | undefined
   try {
@@ -174,7 +174,7 @@ async function testFixture (fixtureName: string) {
     dedupeCheckError = err as DedupeCheckIssuesError
   } finally {
     // The dedupe check option should never change the lockfile.
-    expect(await readProjectLockfile()).toEqual(originalLockfile)
+    expect(readProjectLockfile()).toEqual(originalLockfile)
   }
 
   if (dedupeCheckError == null) {
@@ -185,7 +185,7 @@ async function testFixture (fixtureName: string) {
   // re-resolving versions.
   await dedupe.handler(opts)
 
-  const dedupedLockfile = await readProjectLockfile()
+  const dedupedLockfile = readProjectLockfile()
 
   // It should be possible to remove packages from the fixture lockfile.
   const originalLockfilePackageNames = Object.keys(originalLockfile.packages ?? {})
@@ -200,7 +200,7 @@ async function testFixture (fixtureName: string) {
   // state. If so, the "pnpm install" command should pass successfully and not
   // make any further edits to the lockfile.
   await install.handler(opts)
-  expect(await readProjectLockfile()).toEqual(dedupedLockfile)
+  expect(readProjectLockfile()).toEqual(dedupedLockfile)
 
   return { originalLockfile, dedupedLockfile, dedupeCheckError }
 }

--- a/reviewing/plugin-commands-licenses/test/fixtures/complex-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/complex-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   react:

--- a/reviewing/plugin-commands-licenses/test/fixtures/file-mode-test/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/file-mode-test/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   svgicons2svgfont:

--- a/reviewing/plugin-commands-licenses/test/fixtures/simple-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/simple-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-dev-dependency/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-dev-dependency/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 dependencies:
   is-positive:

--- a/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
Due to the changes to peer dependencies resolution, we need to bump the lockfile version: https://github.com/pnpm/pnpm/pull/7606

Lockfile v6 will automatically be converted to lockfile v7.