### PR TITLE
fix: unpacking tarballs that appear to be not USTAR or GNU TAR

### DIFF
--- a/.changeset/forty-turtles-rhyme.md
+++ b/.changeset/forty-turtles-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/store.cafs": patch
+"pnpm": patch
+---
+
+Don't fail on a tarball that appears to be not a USTAR or GNU TAR archive. Still try to unpack the tarball [#7120](https://github.com/pnpm/pnpm/issues/7120).

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 * text eol=lf
-
-*.tgz binary
+*.tgz filter=lfs diff=lfs merge=lfs -text

--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "deburr",
     "denolib",
     "deptype",
+    "devextreme",
     "dgimuys",
     "didyoumean",
     "dirtyforms",

--- a/store/cafs/src/parseTarball.ts
+++ b/store/cafs/src/parseTarball.ts
@@ -22,13 +22,10 @@ const FILE_TYPE_PAX_HEADER: number = 'x'.charCodeAt(0)
 const FILE_TYPE_PAX_GLOBAL_HEADER: number = 'g'.charCodeAt(0)
 const FILE_TYPE_LONGLINK: number = 'L'.charCodeAt(0)
 
-const USTAR_MAGIC: Buffer = Buffer.from('ustar', 'latin1')
-
 const MODE_OFFSET: 100 = 100
 const FILE_SIZE_OFFSET: 124 = 124
 const CHECKSUM_OFFSET: 148 = 148
 const FILE_TYPE_OFFSET: 156 = 156
-const MAGIC_OFFSET: 257 = 257
 const PREFIX_OFFSET: 345 = 345
 
 // See TAR specification here: https://www.gnu.org/software/tar/manual/html_node/Standard.html
@@ -73,24 +70,6 @@ export function parseTarball (buffer: Buffer): IParseResult {
     if (expectedCheckSum !== actualCheckSum) {
       throw new Error(
         `Invalid checksum for TAR header at offset ${blockStart}. Expected ${expectedCheckSum}, got ${actualCheckSum}`
-      )
-    }
-
-    if (
-      buffer.compare(
-        USTAR_MAGIC,
-        0,
-        USTAR_MAGIC.byteLength,
-        blockStart + MAGIC_OFFSET,
-        blockStart + MAGIC_OFFSET + USTAR_MAGIC.byteLength
-      ) !== 0
-    ) {
-      throw new Error(
-        `This parser only supports USTAR or GNU TAR archives. Found magic and version: ${buffer.toString(
-          'latin1',
-          blockStart + MAGIC_OFFSET,
-          blockStart + MAGIC_OFFSET + 8
-        )}`
       )
     }
 

--- a/store/cafs/test/index.ts
+++ b/store/cafs/test/index.ts
@@ -122,3 +122,13 @@ test('unpack a tarball that contains hard links', () => {
   )
   expect(Object.keys(filesIndex).length).toBeGreaterThan(0)
 })
+
+// Related issue: https://github.com/pnpm/pnpm/issues/7120
+test('unpack should not fail when the tarball format seems to be not USTAR or GNU TAR', () => {
+  const dest = tempy.directory()
+  const cafs = createCafs(dest)
+  const { filesIndex } = cafs.addFilesFromTarball(
+    fs.readFileSync(path.join(__dirname, '../__fixtures__/devextreme-17.1.6.tgz'))
+  )
+  expect(Object.keys(filesIndex).length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
close #7120