### PR TITLE
feat(exec): allow scripts to call the right pnpm

### DIFF
--- a/.changeset/tricky-ways-unite.md
+++ b/.changeset/tricky-ways-unite.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": minor
+"pnpm": minor
+---
+
+Prepend pnpm's installation folder to `PATH`, allowing scripts to invoke the right version of pnpm.

--- a/exec/plugin-commands-script-runners/src/exec.ts
+++ b/exec/plugin-commands-script-runners/src/exec.ts
@@ -184,6 +184,9 @@ export async function handler (
     './node_modules/.bin',
     ...opts.extraBinPaths,
   ]
+  if (require.main?.filename) {
+    prependPaths.unshift(path.dirname(require.main.filename))
+  }
   for (const chunk of chunks) {
     // eslint-disable-next-line no-await-in-loop
     await Promise.all(chunk.map(async (prefix: string) =>


### PR DESCRIPTION
When there are multiple pnpm versions installed in different places (such as `corepack`, distro specific package manager, or combination of different methods), calling `pnpm` from within a script (in `package.json#scripts`) often leads to wrong version of pnpm.

By adding the installation directory to the start of `PATH`, this problem should be resolved.