### PR TITLE
fix(licenses): use correct lockfileDir

### DIFF
--- a/.changeset/quick-students-hope.md
+++ b/.changeset/quick-students-hope.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+---
+
+Fix `pnpm licenses list --json` command not returning correct paths when run on workspace members

--- a/reviewing/plugin-commands-licenses/src/licensesList.ts
+++ b/reviewing/plugin-commands-licenses/src/licensesList.ts
@@ -62,7 +62,7 @@ export async function licensesList (opts: LicensesCommandOptions) {
 
   const licensePackages = await findDependencyLicenses({
     include,
-    lockfileDir: opts.dir,
+    lockfileDir: opts.lockfileDir ?? opts.dir,
     storeDir,
     virtualStoreDir: opts.virtualStoreDir ?? '.',
     modulesDir: opts.modulesDir,

--- a/reviewing/plugin-commands-licenses/test/index.ts
+++ b/reviewing/plugin-commands-licenses/test/index.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts" />
 import path from 'path'
+import fs from 'fs'
 import { licenses } from '@pnpm/plugin-commands-licenses'
 import { install } from '@pnpm/plugin-commands-installation'
 import { tempDir } from '@pnpm/prepare'
@@ -115,6 +116,56 @@ test('pnpm licenses: output as json', async () => {
     'homepage',
     'description',
   ])
+})
+
+test('pnpm licenses: path should be correct for workspaces', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-licenses', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await readProjects(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const barPackageDir = path.join(workspaceDir, 'bar')
+  for (const packageDir of [workspaceDir, barPackageDir]) {
+    // eslint-disable-next-line no-await-in-loop
+    const { output, exitCode } = await licenses.handler({
+      ...DEFAULT_OPTS,
+      dir: packageDir,
+      lockfileDir: workspaceDir,
+      pnpmHomeDir: '',
+      long: false,
+      json: true,
+      storeDir: path.resolve(storeDir, 'v3'),
+    }, ['list'])
+
+    expect(exitCode).toBe(0)
+
+    const parsedOutput = JSON.parse(output)
+    for (const license in parsedOutput) {
+      const packages = parsedOutput[license]
+      for (const pkg of packages) {
+        const pkgRoots = pkg['paths']
+        expect(pkgRoots).not.toHaveLength(0)
+        for (const pkgRoot of pkgRoots) {
+          const packageJsonPath = path.join(pkgRoot, 'package.json')
+          expect(fs.existsSync(packageJsonPath)).toBeTruthy()
+        }
+      }
+    }
+  }
 })
 
 test('pnpm licenses: filter outputs', async () => {

--- a/reviewing/plugin-commands-licenses/test/utils/index.ts
+++ b/reviewing/plugin-commands-licenses/test/utils/index.ts
@@ -45,5 +45,6 @@ export const DEFAULT_OPTS = {
   userConfig: {},
   useRunningStoreServer: false,
   useStoreServer: false,
+  virtualStoreDir: 'node_modules/.pnpm',
   workspaceConcurrency: 4,
 }


### PR DESCRIPTION
Fixes #7725

This PR fixes a bug where calling `pnpm licenses list --json` in a workspace member package returns incorrect `"paths"`. I also added a test case to make sure `paths` was correct.