### PR TITLE
fix: packageManager field can contain various values

### DIFF
--- a/cli/cli-utils/src/packageIsInstallable.ts
+++ b/cli/cli-utils/src/packageIsInstallable.ts
@@ -24,7 +24,8 @@ export function packageIsInstallable (
     ? packageManager.version
     : undefined
   if (pkg.packageManager) {
-    const [pmName, pmVersion] = pkg.packageManager.split('@')
+    const [pmName, pmReference] = pkg.packageManager.split('@')
+    const [pmVersion] = pmReference.split('+')
     if (pmName && pmName !== 'pnpm') {
       const msg = `This project is configured to use ${pmName}`
       if (opts.packageManagerStrict) {

--- a/cli/cli-utils/src/packageIsInstallable.ts
+++ b/cli/cli-utils/src/packageIsInstallable.ts
@@ -25,7 +25,6 @@ export function packageIsInstallable (
     : undefined
   if (pkg.packageManager) {
     const [pmName, pmReference] = pkg.packageManager.split('@')
-    const [pmVersion] = pmReference.split('+')
     if (pmName && pmName !== 'pnpm') {
       const msg = `This project is configured to use ${pmName}`
       if (opts.packageManagerStrict) {
@@ -33,12 +32,16 @@ export function packageIsInstallable (
       } else {
         globalWarn(msg)
       }
-    } else if (pmVersion && pnpmVersion && pmVersion !== pnpmVersion) {
-      const msg = `This project is configured to use v${pmVersion} of pnpm. Your current pnpm is v${pnpmVersion}`
-      if (opts.packageManagerStrict) {
-        throw new PnpmError('BAD_PM_VERSION', msg)
-      } else {
-        globalWarn(msg)
+    } else if (!pmReference.includes(':')) {
+      // pmReference is semantic versioning, not URL
+      const [pmVersion] = pmReference.split('+')
+      if (pmVersion && pnpmVersion && pmVersion !== pnpmVersion) {
+        const msg = `This project is configured to use v${pmVersion} of pnpm. Your current pnpm is v${pnpmVersion}`
+        if (opts.packageManagerStrict) {
+          throw new PnpmError('BAD_PM_VERSION', msg)
+        } else {
+          globalWarn(msg)
+        }
       }
     }
   }

--- a/cli/cli-utils/src/packageIsInstallable.ts
+++ b/cli/cli-utils/src/packageIsInstallable.ts
@@ -21,7 +21,7 @@ export function packageIsInstallable (
   }
 ) {
   const pnpmVersion = packageManager.name === 'pnpm'
-    ? packageManager.stableVersion
+    ? packageManager.version
     : undefined
   if (pkg.packageManager) {
     const [pmName, pmVersion] = pkg.packageManager.split('@')

--- a/config/package-is-installable/test/checkEngine.ts
+++ b/config/package-is-installable/test/checkEngine.ts
@@ -22,7 +22,7 @@ test('pnpm version too old', () => {
   expect(err?.wanted.pnpm).toBe('^1.4.6')
 })
 
-test('pnpm is a prereleased version', () => {
+test('pnpm is a prerelease version', () => {
   expect(checkEngine(packageId, { pnpm: '9' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBe(null)
   expect(checkEngine(packageId, { pnpm: '>=9' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBe(null)
   expect(checkEngine(packageId, { pnpm: '>=9.0.0' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBeDefined()

--- a/config/package-is-installable/test/checkEngine.ts
+++ b/config/package-is-installable/test/checkEngine.ts
@@ -22,6 +22,12 @@ test('pnpm version too old', () => {
   expect(err?.wanted.pnpm).toBe('^1.4.6')
 })
 
+test('pnpm is a prereleased version', () => {
+  expect(checkEngine(packageId, { pnpm: '9' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBe(null)
+  expect(checkEngine(packageId, { pnpm: '>=9' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBe(null)
+  expect(checkEngine(packageId, { pnpm: '>=9.0.0' }, { pnpm: '9.0.0-alpha.1', node: '0.2.1' })).toBeDefined()
+})
+
 test('engine is supported', () => {
   expect(checkEngine(packageId, { pnpm: '1', node: '10' }, { pnpm: '1.3.2', node: '10.2.1' })).toBe(null)
 })

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -311,6 +311,18 @@ test('install should not fail for packageManager field with hash', async () => {
   expect(status).toBe(0)
 })
 
+test('install should not fail for packageManager field with url', async () => {
+  prepare({
+    name: 'project',
+    version: '1.0.0',
+
+    packageManager: 'pnpm@https://github.com/pnpm/pnpm',
+  })
+
+  const { status } = execPnpmSync(['install'])
+  expect(status).toBe(0)
+})
+
 test('engine-strict=false: install should not fail if the used Node version does not satisfy the Node version specified in engines', async () => {
   prepare({
     name: 'project',

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -296,6 +296,21 @@ test('install should fail if the project requires a different package manager', 
   expect(execPnpmSync(['install', '--config.package-manager-strict=false']).status).toBe(0)
 })
 
+test('install should not fail for packageManager field with hash', async () => {
+  const versionProcess = execPnpmSync(['--version'])
+  const pnpmVersion = versionProcess.stdout.toString().trim()
+
+  prepare({
+    name: 'project',
+    version: '1.0.0',
+
+    packageManager: `pnpm@${pnpmVersion}+sha256.123456789`,
+  })
+
+  const { status } = execPnpmSync(['install'])
+  expect(status).toBe(0)
+})
+
 test('engine-strict=false: install should not fail if the used Node version does not satisfy the Node version specified in engines', async () => {
   prepare({
     name: 'project',


### PR DESCRIPTION
Fixes #7733

`"packageManager"` field in `package.json` may contain semver with pre-release (e.g. `8.0.0-dev`) or build identifiers (e.g. `8.0.0+sha256.hash...`), or URL.

`"packageManager"` is determined if it's a URL by checking for the existance of character ':' in the value. This works because ':' must appear on all URLs, while the character may not appear on semvers. `URL.canParse()` is not used because the function is not implemented in all node versions pnpm currently supports (>= 18.12).

If it is a semver, build values are stripped, and it is compared with pnpm version including the pre-release identifiers.

URLs are ignored as there is no way to check that running pnpm version is the same as the build at URL.

