### PR TITLE
fix: link overrides should be able to use absolute path

### DIFF
--- a/.changeset/hungry-mirrors-thank.md
+++ b/.changeset/hungry-mirrors-thank.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/hooks.read-package-hook": patch
+"pnpm": patch
 ---
 
-fix: link overrides should be able to use absolute path
+Link overrides should be able to use absolute path [#7749](https://github.com/pnpm/pnpm/pull/7749).

--- a/.changeset/hungry-mirrors-thank.md
+++ b/.changeset/hungry-mirrors-thank.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+---
+
+fix: link overrides should be able to use absolute path

--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -17,7 +17,8 @@ export function createVersionsOverrider (
       .map((override) => {
         let linkTarget: string | undefined
         if (override.newPref.startsWith('link:')) {
-          linkTarget = path.join(rootDir, override.newPref.substring(5))
+          const pkgPath = override.newPref.substring(5)
+          linkTarget = path.isAbsolute(pkgPath) ? pkgPath : path.join(rootDir, pkgPath)
         }
         let linkFileTarget: string | undefined
         if (override.newPref.startsWith('file:')) {

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -148,6 +148,27 @@ test('createVersionsOverrider() overrides dependencies with links', () => {
   })
 })
 
+test('createVersionsOverrider() overrides dependencies with absolute links', () => {
+  const qarAbsolutePath = path.resolve(process.cwd(), './qar')
+  const overrider = createVersionsOverrider({
+    qar: `link:${qarAbsolutePath}`,
+  }, process.cwd())
+
+  expect(overrider({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: '3.0.0',
+    },
+  }, path.resolve('pkg'))).toStrictEqual({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: `link:${path.relative(path.resolve('pkg'), qarAbsolutePath)}`,
+    },
+  })
+})
+
 test('createVersionsOverrider() overrides dependency of pkg matched by name and version', () => {
   const overrider = createVersionsOverrider({
     'yargs@^7.1.0>yargs-parser': '^20.0.0',

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { createVersionsOverrider } from '../lib/createVersionsOverrider'
+import normalizePath from 'normalize-path'
 
 test('createVersionsOverrider() matches sub-ranges', () => {
   const overrider = createVersionsOverrider({
@@ -164,7 +165,7 @@ test('createVersionsOverrider() overrides dependencies with absolute links', () 
     name: 'foo',
     version: '1.2.0',
     dependencies: {
-      qar: `link:${path.relative(path.resolve('pkg'), qarAbsolutePath)}`,
+      qar: `link:${normalizePath(path.relative(path.resolve('pkg'), qarAbsolutePath))}`,
     },
   })
 })


### PR DESCRIPTION
pnpm will install a wrong dependency when link override is an absolute path
```
"pnpm": {
    "overrides": {
      "test": "link:/absolute-path//test"
    }
  }
```