### PR TITLE
Update README.md: Update badge image of @pnpm/fs.find-packages

### DIFF
--- a/fs/find-packages/README.md
+++ b/fs/find-packages/README.md
@@ -3,7 +3,7 @@
 > Find all packages inside a directory
 
 <!--@shields('npm')-->
-[![npm version](https://img.shields.io/npm/v/find-packages.svg)](https://www.npmjs.com/package/@pnpm/fs.find-packages)
+[![npm version](https://img.shields.io/npm/v/@pnpm/fs.find-packages.svg)](https://www.npmjs.com/package/@pnpm/fs.find-packages)
 <!--/@-->
 
 ## Installation


### PR DESCRIPTION
The package used to be named "find-packages" but it's moved to "@pnpm/fs.find-packages", but the badge image src wasn't updated