### PR TITLE
feat(dlx): cache

### DIFF
--- a/__utils__/prepare/package.json
+++ b/__utils__/prepare/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@pnpm/assert-project": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "unique-string": "^2.0.0",
     "write-json5-file": "^3.1.0",
     "write-pkg": "4.0.0",
     "write-yaml-file": "^5.0.0"

--- a/__utils__/prepare/src/index.ts
+++ b/__utils__/prepare/src/index.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import path from 'path'
 import { assertProject, type Modules, type Project } from '@pnpm/assert-project'
 import { type ProjectManifest } from '@pnpm/types'
-import uniqueString from 'unique-string'
 import { sync as writeJson5File } from 'write-json5-file'
 import { sync as writeYamlFile } from 'write-yaml-file'
 import writePkg from 'write-pkg'
@@ -12,7 +11,17 @@ export type ManifestFormat = 'JSON' | 'JSON5' | 'YAML'
 
 // The testing folder should be outside of the project to avoid lookup in the project's node_modules
 // Not using the OS temp directory due to issues on Windows CI.
-const tmpPath = path.join(__dirname, `../../../../pnpm_tmp/${uniqueString()}`)
+const tmpBaseDir = path.join(__dirname, '../../../../pnpm_tmp')
+
+function getFilesCountInDir (dir: string): number {
+  try {
+    return fs.readdirSync(dir).length
+  } catch {
+    return 0
+  }
+}
+
+const tmpPath = path.join(tmpBaseDir, `${getFilesCountInDir(tmpBaseDir).toString()}_${process.pid.toString()}`)
 
 let dirNumber = 0
 

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -239,7 +239,7 @@ export async function getConfig (
     'link-workspace-packages': false,
     'lockfile-include-tarball-url': false,
     'modules-cache-max-age': 7 * 24 * 60, // 7 days
-    'dlx-cache-max-age': 5, // 5 minutes
+    'dlx-cache-max-age': 24 * 60, // 1 day
     'node-linker': 'isolated',
     'package-lock': npmDefaults['package-lock'],
     pending: false,

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -67,6 +67,7 @@
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "realpath-missing": "^1.1.0",
     "render-help": "^1.0.3",
+    "symlink-dir": "^5.2.1",
     "which": "npm:@pnpm/which@^3.0.1",
     "write-json-file": "^4.3.0"
   },

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -72,7 +72,7 @@ export async function handler (
 ) {
   const pkgs = opts.package ?? [command]
   const now = new Date()
-  const { storeDir, dlxCacheDir, cacheName, cachePath } = await getInfo({
+  const { storeDir, cachePath } = await getInfo({
     dir: opts.dir,
     pnpmHomeDir: opts.pnpmHomeDir,
     storeDir: opts.storeDir,

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -278,6 +278,6 @@ function acquireCacheLock (opts: {
     }
   }
   const cacheFullyInstalled = linkAlreadyExists && fs.existsSync(path.join(linkName, 'node_modules', '.modules.yaml'))
-  const cacheUpToDate = cacheFullyInstalled && fs.statSync(linkName).mtime.getTime() + dlxCacheMaxAge * 60_000 <= now.getTime()
+  const cacheUpToDate = cacheFullyInstalled && fs.statSync(linkName).mtime.getTime() + dlxCacheMaxAge * 60_000 > now.getTime()
   return { linkAlreadyExists, cacheFullyInstalled, cacheUpToDate }
 }

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -167,8 +167,8 @@ function findCache (pkgs: string[], opts: {
 function createDlxCommandCacheDir (cacheDir: string, pkgs: string[]) {
   const dlxCacheDir = path.resolve(cacheDir, 'dlx')
   const hashStr = pkgs.join('\n') // '\n' is not a URL-friendly character, and therefore not a valid package name, which can be used as separator
-  const cacheName = createBase32Hash(hashStr)
-  const cachePath = path.join(dlxCacheDir, cacheName)
+  const cacheKey = createBase32Hash(hashStr)
+  const cachePath = path.join(dlxCacheDir, cacheKey)
   fs.mkdirSync(cachePath, { recursive: true })
   return cachePath
 }

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -71,10 +71,9 @@ export async function handler (
   [command, ...args]: string[]
 ) {
   const pkgs = opts.package ?? [command]
-  const { cacheLink, prepareDir } = getLocations({
+  const { cacheLink, prepareDir } = findCache(pkgs, {
     dlxCacheMaxAge: opts.dlxCacheMaxAge,
     cacheDir: opts.cacheDir,
-    pkgs,
   })
   if (prepareDir) {
     fs.mkdirSync(prepareDir, { recursive: true })
@@ -154,12 +153,11 @@ function scopeless (pkgName: string) {
   return pkgName
 }
 
-function getLocations (opts: {
+function findCache (pkgs: string[], opts: {
   cacheDir: string
-  pkgs: string[]
   dlxCacheMaxAge: number
 }) {
-  const dlxCommandCacheDir = createDlxCommandCacheDir(opts.cacheDir, opts.pkgs)
+  const dlxCommandCacheDir = createDlxCommandCacheDir(opts.cacheDir, pkgs)
   const cacheLink = path.join(dlxCommandCacheDir, 'link')
   const valid = isCacheValid(cacheLink, opts.dlxCacheMaxAge)
   const prepareDir = valid ? null : getPrepareDir(dlxCommandCacheDir)

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -15,6 +15,7 @@ import execa from 'execa'
 import omit from 'ramda/src/omit'
 import pick from 'ramda/src/pick'
 import renderHelp from 'render-help'
+import symlinkDir from 'symlink-dir'
 import { makeEnv } from './makeEnv'
 
 export const commandNames = ['dlx']
@@ -106,20 +107,7 @@ export async function handler (
       saveOptional: false,
       savePeer: false,
     }, pkgs)
-    try {
-      await fs.unlink(cacheLink)
-    } catch (err) {
-      if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) {
-        throw err
-      }
-    }
-    try {
-      await fs.symlink(newPrefix, cacheLink, 'junction')
-    } catch (err) {
-      if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) {
-        throw err
-      }
-    }
+    await symlinkDir(newPrefix, cacheLink, { overwrite: true })
   }
   const binName = opts.package
     ? command

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -64,34 +64,55 @@ export function help () {
 export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
-} & Pick<Config, 'reporter' | 'userAgent' | 'cacheDir' > & add.AddCommandOptions
+} & Pick<Config, 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' > & add.AddCommandOptions
 
 export async function handler (
   opts: DlxCommandOptions,
   [command, ...args]: string[]
 ) {
   const pkgs = opts.package ?? [command]
-  const { storeDir, tempDir, cachePath } = await getInfo({
+  const now = new Date()
+  const { storeDir, contentDir, linkName } = await getInfo({
+    pid: process.pid,
     dir: opts.dir,
     pnpmHomeDir: opts.pnpmHomeDir,
     storeDir: opts.storeDir,
     cacheDir: opts.cacheDir,
     pkgs,
+    now,
   })
-  const tempPath = path.join(tempDir, `dlx-${process.pid.toString()}`)
   let prefix: string
   let shouldInstall: boolean
-  const { cacheOccupied, cacheFullyInstalled } = acquireCacheLock(cachePath)
-  if (cacheFullyInstalled) {
-    prefix = cachePath
+  let shouldRenewLink: boolean
+  let shouldDeleteContent: boolean
+  const { linkAlreadyExists, cacheFullyInstalled, cacheUpToDate } = acquireCacheLock({
+    dlxCacheMaxAge: opts.dlxCacheMaxAge,
+    contentDir,
+    linkName,
+    now,
+  })
+  if (cacheUpToDate) {
+    prefix = linkName
     shouldInstall = false
-  } else if (cacheOccupied) {
-    prefix = tempPath
+    shouldRenewLink = false
+    shouldDeleteContent = false
+  } else if (cacheFullyInstalled) {
+    prefix = contentDir
     shouldInstall = true
-    fs.mkdirSync(tempPath, { recursive: true })
+    fs.mkdirSync(contentDir, { recursive: true })
+    shouldRenewLink = true
+    shouldDeleteContent = false
+  } else if (linkAlreadyExists) {
+    prefix = contentDir
+    shouldInstall = true
+    fs.mkdirSync(contentDir, { recursive: true })
+    shouldRenewLink = false
+    shouldDeleteContent = true
   } else {
-    prefix = cachePath
+    prefix = linkName
     shouldInstall = true
+    shouldRenewLink = true
+    shouldDeleteContent = false
   }
   const modulesDir = path.join(prefix, 'node_modules')
   const binsDir = path.join(modulesDir, '.bin')
@@ -129,6 +150,26 @@ export async function handler (
       }
     }
     throw err
+  } finally {
+    if (shouldRenewLink) {
+      try {
+        fs.unlinkSync(linkName)
+      } catch (err) {
+        if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) throw err
+      }
+
+      try {
+        fs.symlinkSync(contentDir, linkName, 'junction')
+      } catch (err) {
+        if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
+      }
+    }
+
+    if (shouldDeleteContent) {
+      try {
+        fs.rmSync(contentDir, { recursive: true })
+      } catch { }
+    }
   }
   return { exitCode: 0 }
 }
@@ -176,43 +217,73 @@ async function getInfo (opts: {
   cacheDir: string
   pnpmHomeDir: string
   pkgs: string[]
+  now: Date
+  pid: number
 }) {
   const storeDir = await getStorePath({
     pkgRoot: opts.dir,
     storePath: opts.storeDir,
     pnpmHomeDir: opts.pnpmHomeDir,
   })
-  const tempDir = path.join(storeDir, 'tmp')
   const cacheDir = path.resolve(opts.cacheDir, 'dlx')
-  const cacheInfo = getCacheInfo(cacheDir, opts.pkgs)
+  const cacheInfo = getCacheInfo({
+    cacheDir,
+    now: opts.now,
+    pkgs: opts.pkgs,
+    pid: opts.pid,
+  })
   return {
     storeDir,
-    tempDir,
     cacheDir,
     ...cacheInfo,
   }
 }
 
-function getCacheInfo (cacheDir: string, pkgs: string[]) {
+function getCacheInfo (opts: {
+  cacheDir: string
+  pkgs: string[]
+  now: Date
+  pid: number
+}) {
+  const { cacheDir, pkgs, now, pid } = opts
   const hashStr = pkgs.join('\n') // '\n' is not a URL-friendly character, and therefore not a valid package name, which can be used as separator
   const cacheName = createBase32Hash(hashStr)
-  const cachePath = path.join(cacheDir, cacheName)
-  return { cacheName, cachePath }
+  const linkName = path.join(cacheDir, cacheName)
+  const contentDir = getContentDir({ cacheDir, cacheName, now, pid })
+  return { cacheName, linkName, contentDir }
 }
 
-function acquireCacheLock (cachePath: string) {
-  fs.mkdirSync(path.dirname(cachePath), { recursive: true })
-  let cacheOccupied: boolean
+function getContentDir (opts: {
+  cacheDir: string
+  cacheName: string
+  now: Date
+  pid: number
+}) {
+  const { cacheDir, cacheName, now, pid } = opts
+  const name = `${cacheName}-${now.getTime().toString(16)}-${pid.toString(16)}`
+  return path.join(cacheDir, name)
+}
+
+function acquireCacheLock (opts: {
+  linkName: string
+  contentDir: string
+  now: Date
+  dlxCacheMaxAge: number
+}) {
+  const { linkName, contentDir, now, dlxCacheMaxAge } = opts
+  fs.mkdirSync(path.dirname(linkName), { recursive: true })
+  let linkAlreadyExists: boolean
   try {
-    fs.mkdirSync(cachePath)
-    cacheOccupied = false
+    fs.symlinkSync(contentDir, linkName, 'junction')
+    linkAlreadyExists = false
   } catch (err) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST') {
-      cacheOccupied = true
+      linkAlreadyExists = true
     } else {
       throw err
     }
   }
-  const cacheFullyInstalled = cacheOccupied && fs.existsSync(path.join(cachePath, 'node_modules', '.modules.yaml'))
-  return { cacheOccupied, cacheFullyInstalled }
+  const cacheFullyInstalled = linkAlreadyExists && fs.existsSync(path.join(linkName, 'node_modules', '.modules.yaml'))
+  const cacheUpToDate = cacheFullyInstalled && fs.statSync(linkName).mtime.getTime() + dlxCacheMaxAge * 60_000 <= now.getTime()
+  return { linkAlreadyExists, cacheFullyInstalled, cacheUpToDate }
 }

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -154,15 +154,8 @@ export async function handler (
     if (shouldRenewLink) {
       try {
         fs.unlinkSync(linkName)
-      } catch (err) {
-        if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) throw err
-      }
-
-      try {
         fs.symlinkSync(contentDir, linkName, 'junction')
-      } catch (err) {
-        if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
-      }
+      } catch { }
     }
 
     if (shouldDeleteContent) {

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -158,7 +158,7 @@ function findCache (pkgs: string[], opts: {
   dlxCacheMaxAge: number
 }) {
   const dlxCommandCacheDir = createDlxCommandCacheDir(opts.cacheDir, pkgs)
-  const cacheLink = path.join(dlxCommandCacheDir, 'link')
+  const cacheLink = path.join(dlxCommandCacheDir, 'pkg')
   const valid = isCacheValid(cacheLink, opts.dlxCacheMaxAge)
   const prepareDir = valid ? null : getPrepareDir(dlxCommandCacheDir)
   return { cacheLink, prepareDir }

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -71,7 +71,7 @@ export async function handler (
   [command, ...args]: string[]
 ) {
   const pkgs = opts.package ?? [command]
-  const { storeDir, tempDir, cachePathExists, cachePath, cacheFullyInstalled } = await getInfo({
+  const { storeDir, tempDir, cacheOccupied, cachePath, cacheFullyInstalled } = await getInfo({
     dir: opts.dir,
     pnpmHomeDir: opts.pnpmHomeDir,
     storeDir: opts.storeDir,
@@ -84,7 +84,7 @@ export async function handler (
   if (cacheFullyInstalled) {
     prefix = cachePath
     shouldInstall = false
-  } else if (cachePathExists) {
+  } else if (cacheOccupied) {
     prefix = tempPath
     shouldInstall = true
     fs.mkdirSync(tempPath, { recursive: true })
@@ -197,17 +197,17 @@ function getCacheInfo (cacheDir: string, pkgs: string[]) {
   const cacheName = createBase32Hash(hashStr)
   const cachePath = path.join(cacheDir, cacheName)
   fs.mkdirSync(cacheDir, { recursive: true })
-  let cachePathExists: boolean
+  let cacheOccupied: boolean
   try {
     fs.mkdirSync(cachePath)
-    cachePathExists = false
+    cacheOccupied = false
   } catch (err) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST') {
-      cachePathExists = true
+      cacheOccupied = true
     } else {
       throw err
     }
   }
-  const cacheFullyInstalled = cachePathExists && fs.existsSync(path.join(cachePath, 'node_modules', '.modules.yaml'))
-  return { cacheName, cachePath, cachePathExists, cacheFullyInstalled }
+  const cacheFullyInstalled = cacheOccupied && fs.existsSync(path.join(cachePath, 'node_modules', '.modules.yaml'))
+  return { cacheName, cachePath, cacheOccupied, cacheFullyInstalled }
 }

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -109,8 +109,9 @@ export async function handler (
     shouldRenewLink = false
     shouldDeleteContent = true
   } else {
-    prefix = linkName
+    prefix = contentDir
     shouldInstall = true
+    fs.mkdirSync(contentDir, { recursive: true })
     shouldRenewLink = true
     shouldDeleteContent = false
   }

--- a/exec/plugin-commands-script-runners/test/create.ts
+++ b/exec/plugin-commands-script-runners/test/create.ts
@@ -10,6 +10,7 @@ it('throws an error if called without arguments', async () => {
   await expect(create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
+    dlxCacheMaxAge: Infinity,
   }, [])).rejects.toThrow(PnpmError)
   expect(dlx.handler).not.toHaveBeenCalled()
 })
@@ -20,12 +21,14 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['create_no_dash'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-create_no_dash'])
   }
@@ -37,12 +40,14 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['create-some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['create-'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-'])
   }
@@ -54,12 +59,14 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/create_no_dash'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-create_no_dash'])
   }
@@ -71,12 +78,14 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-'])
   }
@@ -86,6 +95,7 @@ it('infers a package name from a plain scope', async () => {
   await create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
+    dlxCacheMaxAge: Infinity,
   }, ['@scope'])
   expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create'])
 })
@@ -94,6 +104,7 @@ it('passes the remaining arguments to `dlx`', async () => {
   await create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
+    dlxCacheMaxAge: Infinity,
   }, ['some-app', 'directory/', '--silent'])
   expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app', 'directory/', '--silent'])
 })
@@ -104,35 +115,41 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['foo@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@2.0.0'])
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['foo@latest'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@latest'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@2.0.0'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope@next'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@next'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/foo@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-foo@2.0.0'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
+      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-a@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-a@2.0.0'])
   }

--- a/exec/plugin-commands-script-runners/test/create.ts
+++ b/exec/plugin-commands-script-runners/test/create.ts
@@ -10,7 +10,6 @@ it('throws an error if called without arguments', async () => {
   await expect(create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
-    dlxCacheMaxAge: Infinity,
   }, [])).rejects.toThrow(PnpmError)
   expect(dlx.handler).not.toHaveBeenCalled()
 })
@@ -21,14 +20,12 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['create_no_dash'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-create_no_dash'])
   }
@@ -40,14 +37,12 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['create-some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['create-'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-'])
   }
@@ -59,14 +54,12 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/create_no_dash'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-create_no_dash'])
   }
@@ -78,14 +71,12 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-some-app'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-'])
   }
@@ -95,7 +86,6 @@ it('infers a package name from a plain scope', async () => {
   await create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
-    dlxCacheMaxAge: Infinity,
   }, ['@scope'])
   expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create'])
 })
@@ -104,7 +94,6 @@ it('passes the remaining arguments to `dlx`', async () => {
   await create.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
-    dlxCacheMaxAge: Infinity,
   }, ['some-app', 'directory/', '--silent'])
   expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app', 'directory/', '--silent'])
 })
@@ -115,41 +104,35 @@ it(
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['foo@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@2.0.0'])
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['foo@latest'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@latest'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@2.0.0'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope@next'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@next'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/foo@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-foo@2.0.0'])
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
-      dlxCacheMaxAge: Infinity,
     }, ['@scope/create-a@2.0.0'])
     expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-a@2.0.0'])
   }

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -69,11 +69,12 @@ test('dlx', async () => {
 test('dlx install from git', async () => {
   prepareEmpty()
 
-  const pkg = 'shelljs/shx#61aca968cd7afc712ca61a4fc4ec3201e3770dc7'
+  const pkg = 'shelljs/shx#0dcbb9d1022037268959f8b706e0f06a6fd43fde'
 
   await dlx.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
+    storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
     dlxCacheMaxAge: Infinity,
   }, [pkg, 'touch', 'foo'])

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -189,3 +189,20 @@ test('dlx with cache', async () => {
 
   spy.mockRestore()
 })
+
+test('dlx still saves cache even if execution fails', async () => {
+  prepareEmpty()
+
+  fs.writeFileSync(path.resolve('not-a-dir'), 'to make `shx mkdir` fails')
+
+  await dlx.handler({
+    ...DEFAULT_OPTS,
+    dir: path.resolve('project'),
+    storeDir: path.resolve('store'),
+    cacheDir: path.resolve('cache'),
+  }, ['shx', 'mkdir', path.resolve('not-a-dir')])
+
+  expect(fs.readFileSync(path.resolve('not-a-dir'), 'utf-8')).toEqual(expect.anything())
+  expect(fs.readdirSync(path.resolve('cache', 'dlx'))).toStrictEqual([createBase32Hash('shx')])
+  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+})

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -59,45 +59,35 @@ test('dlx', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
-    dlxCacheMaxAge: Infinity,
   }, ['shx', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
-  verifyDlxCache(createBase32Hash('shx'))
 })
 
 test('dlx install from git', async () => {
   prepareEmpty()
-
-  const pkg = 'shelljs/shx#0dcbb9d1022037268959f8b706e0f06a6fd43fde'
 
   await dlx.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
-    dlxCacheMaxAge: Infinity,
-  }, [pkg, 'touch', 'foo'])
+  }, ['shelljs/shx#0dcbb9d1022037268959f8b706e0f06a6fd43fde', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
-  verifyDlxCache(createBase32Hash(pkg))
 })
 
 test('dlx should work when the package name differs from the bin name', async () => {
   prepareEmpty()
-
-  const pkg = '@pnpm.e2e/touch-file-one-bin'
 
   await dlx.handler({
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
-    dlxCacheMaxAge: Infinity,
-  }, [pkg])
+  }, ['@pnpm.e2e/touch-file-one-bin'])
 
   expect(fs.existsSync('touch.txt')).toBeTruthy()
-  verifyDlxCache(createBase32Hash(pkg))
 })
 
 test('dlx should fail when the installed package has many commands and none equals the package name', async () => {
@@ -108,7 +98,6 @@ test('dlx should fail when the installed package has many commands and none equa
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       storeDir: path.resolve('store'),
-      dlxCacheMaxAge: Infinity,
     }, ['@pnpm.e2e/touch-file-many-bins'])
   ).rejects.toThrow('Could not determine executable to run. @pnpm.e2e/touch-file-many-bins has multiple binaries: t, tt')
 })
@@ -120,7 +109,6 @@ test('dlx should not fail when the installed package has many commands and one e
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
-    dlxCacheMaxAge: Infinity,
   }, ['@pnpm.e2e/touch-file-good-bin-name'])
 
   expect(fs.existsSync('touch.txt')).toBeTruthy()
@@ -129,22 +117,16 @@ test('dlx should not fail when the installed package has many commands and one e
 test('dlx --package <pkg1> [--package <pkg2>]', async () => {
   prepareEmpty()
 
-  const pkgs = [
-    'zkochan/for-testing-pnpm-dlx',
-    'is-positive',
-  ]
-
   await dlx.handler({
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
-    package: pkgs,
-    dlxCacheMaxAge: Infinity,
+    package: [
+      'zkochan/for-testing-pnpm-dlx',
+      'is-positive',
+    ],
   }, ['foo'])
-
-  const hash = createBase32Hash(pkgs.join('\n'))
-  verifyDlxCache(hash)
 
   expect(fs.existsSync('foo')).toBeTruthy()
 })
@@ -157,7 +139,6 @@ test('dlx should fail when the package has no bins', async () => {
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       storeDir: path.resolve('store'),
-      dlxCacheMaxAge: Infinity,
     }, ['is-positive'])
   ).rejects.toThrow(/No binaries found in is-positive/)
 })
@@ -173,7 +154,6 @@ test('dlx should work in shell mode', async () => {
       'is-positive',
     ],
     shellMode: true,
-    dlxCacheMaxAge: Infinity,
   }, ['echo "some text" > foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
@@ -189,7 +169,6 @@ test('dlx should return a non-zero exit code when the underlying script fails', 
     package: [
       'touch@3.1.0',
     ],
-    dlxCacheMaxAge: Infinity,
   }, ['nodetouch', '--bad-option'])
 
   expect(exitCode).toBe(1)
@@ -202,7 +181,6 @@ testOnWindowsOnly('dlx should work when running in the root of a Windows Drive',
     ...DEFAULT_OPTS,
     dir: 'C:\\',
     storeDir: path.resolve('store'),
-    dlxCacheMaxAge: Infinity,
   }, ['cowsay', 'hello'])
 })
 

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -8,6 +8,10 @@ import { DLX_DEFAULT_OPTS as DEFAULT_OPTS } from './utils'
 
 const testOnWindowsOnly = process.platform === 'win32' ? test : test.skip
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 test('dlx', async () => {
   prepareEmpty()
 

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -10,7 +10,6 @@ const testOnWindowsOnly = process.platform === 'win32' ? test : test.skip
 
 function sanitizeDlxCacheName (cacheName: string): string {
   const segments = cacheName.split('-')
-  if (segments.length === 1) return cacheName
   if (segments.length !== 3) {
     throw new Error(`Unexpected name: ${cacheName}`)
   }

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -25,6 +25,15 @@ function createSanitizedDlxCacheName (linkName: string): string {
   return [linkName, '*'.repeat(11), '*'.repeat(5)].join('-')
 }
 
+function readSubdirsStartWith (parentPath: string, subdirNamePrefix: string): string[][] {
+  return fs.readdirSync(parentPath, 'utf-8')
+    .filter(subdirName => subdirName.startsWith(subdirNamePrefix))
+    .sort()
+    .map(subdirName => path.join(parentPath, subdirName))
+    .map(subdirPath => fs.readdirSync(subdirPath, 'utf-8'))
+    .map(subdirChildren => subdirChildren.sort())
+}
+
 afterEach(() => {
   jest.restoreAllMocks()
 })
@@ -46,10 +55,9 @@ test('dlx', async () => {
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash('shx'),
     createSanitizedDlxCacheName(createBase32Hash('shx')),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash('shx'))).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
 })
 
 test('dlx install from git', async () => {
@@ -70,10 +78,9 @@ test('dlx install from git', async () => {
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash(pkg),
     createSanitizedDlxCacheName(createBase32Hash(pkg)),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash(pkg))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash(pkg))).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
 })
 
 test('dlx should work when the package name differs from the bin name', async () => {
@@ -95,10 +102,9 @@ test('dlx should work when the package name differs from the bin name', async ()
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash(pkg),
     createSanitizedDlxCacheName(createBase32Hash(pkg)),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash(pkg))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash(pkg))).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
 })
 
 test('dlx should fail when the installed package has many commands and none equals the package name', async () => {
@@ -144,16 +150,15 @@ test('dlx --package <pkg1> [--package <pkg2>]', async () => {
     dlxCacheMaxAge: Infinity,
   }, ['foo'])
 
-  const linkName = createBase32Hash(pkgs.join('\n'))
+  const hash = createBase32Hash(pkgs.join('\n'))
   expect(
     fs.readdirSync(path.resolve('cache', 'dlx'))
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    linkName,
-    createSanitizedDlxCacheName(linkName),
+    createSanitizedDlxCacheName(hash),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', linkName)).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), hash)).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
 
   expect(fs.existsSync('foo')).toBeTruthy()
 })
@@ -234,10 +239,9 @@ test('dlx with cache', async () => {
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash('shx'),
     createSanitizedDlxCacheName(createBase32Hash('shx')),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash('shx'))).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
   expect(spy).toHaveBeenCalled()
 
   spy.mockReset()
@@ -256,10 +260,9 @@ test('dlx with cache', async () => {
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash('shx'),
     createSanitizedDlxCacheName(createBase32Hash('shx')),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash('shx'))).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
   expect(spy).not.toHaveBeenCalled()
 
   spy.mockRestore()
@@ -284,8 +287,7 @@ test('dlx still saves cache even if execution fails', async () => {
       .map(sanitizeDlxCacheName)
       .sort()
   ).toStrictEqual([
-    createBase32Hash('shx'),
     createSanitizedDlxCacheName(createBase32Hash('shx')),
   ].sort())
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+  expect(readSubdirsStartWith(path.resolve('cache', 'dlx'), createBase32Hash('shx')).sort()).toStrictEqual([['node_modules', 'package.json', 'pnpm-lock.yaml']])
 })

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -206,3 +206,20 @@ test('dlx still saves cache even if execution fails', async () => {
   expect(fs.readdirSync(path.resolve('cache', 'dlx'))).toStrictEqual([createBase32Hash('shx')])
   expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
 })
+
+test('dlx installs and runs multiple instances of the same package in parallel', async () => {
+  prepareEmpty()
+
+  await Promise.all(['foo', 'bar', 'baz'].map(
+    name => dlx.handler({
+      ...DEFAULT_OPTS,
+      dir: path.resolve('project'),
+      storeDir: path.resolve('store'),
+      cacheDir: path.resolve('cache'),
+    }, ['shx', 'touch', name])
+  ))
+
+  expect(['foo', 'bar', 'baz'].filter(name => fs.existsSync(name))).toStrictEqual(['foo', 'bar', 'baz'])
+  expect(fs.readdirSync(path.resolve('cache', 'dlx'))).toStrictEqual([createBase32Hash('shx')])
+  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
+})

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -9,7 +9,7 @@ import { DLX_DEFAULT_OPTS as DEFAULT_OPTS } from './utils'
 const testOnWindowsOnly = process.platform === 'win32' ? test : test.skip
 
 function sanitizeDlxCacheComponent (cacheName: string): string {
-  if (cacheName === 'link') return cacheName
+  if (cacheName === 'pkg') return cacheName
   const segments = cacheName.split('-')
   if (segments.length !== 2) {
     throw new Error(`Unexpected name: ${cacheName}`)
@@ -27,7 +27,7 @@ function verifyDlxCache (cacheName: string): void {
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
-    'link',
+    'pkg',
     '***********-*****',
   ].sort())
   verifyDlxCacheLink(cacheName)
@@ -35,7 +35,7 @@ function verifyDlxCache (cacheName: string): void {
 
 function verifyDlxCacheLink (cacheName: string): void {
   expect(
-    fs.readdirSync(path.resolve('cache', 'dlx', cacheName, 'link'))
+    fs.readdirSync(path.resolve('cache', 'dlx', cacheName, 'pkg'))
       .sort()
   ).toStrictEqual([
     'node_modules',
@@ -43,7 +43,7 @@ function verifyDlxCacheLink (cacheName: string): void {
     'pnpm-lock.yaml',
   ].sort())
   expect(
-    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', cacheName, 'link')))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', cacheName, 'pkg')))
   ).toBe(path.resolve('cache', 'dlx', cacheName))
 }
 
@@ -257,7 +257,7 @@ test('dlx does not reuse expired cache', async () => {
 
   // change the date attributes of the cache to 30 minutes older than now
   const newDate = new Date(now.getTime() - 30 * 60_000)
-  fs.lutimesSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'), newDate, newDate)
+  fs.lutimesSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg'), newDate, newDate)
 
   const spy = jest.spyOn(add, 'handler')
 
@@ -280,7 +280,7 @@ test('dlx does not reuse expired cache', async () => {
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
-    'link',
+    'pkg',
     '***********-*****',
     '***********-*****',
   ].sort())

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -20,6 +20,7 @@ test('dlx', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, ['shx', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
@@ -36,6 +37,7 @@ test('dlx install from git', async () => {
     ...DEFAULT_OPTS,
     dir: process.cwd(),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, [pkg, 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
@@ -53,6 +55,7 @@ test('dlx should work when the package name differs from the bin name', async ()
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, [pkg])
 
   expect(fs.existsSync('touch.txt')).toBeTruthy()
@@ -68,6 +71,7 @@ test('dlx should fail when the installed package has many commands and none equa
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       storeDir: path.resolve('store'),
+      dlxCacheMaxAge: Infinity,
     }, ['@pnpm.e2e/touch-file-many-bins'])
   ).rejects.toThrow('Could not determine executable to run. @pnpm.e2e/touch-file-many-bins has multiple binaries: t, tt')
 })
@@ -79,6 +83,7 @@ test('dlx should not fail when the installed package has many commands and one e
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
+    dlxCacheMaxAge: Infinity,
   }, ['@pnpm.e2e/touch-file-good-bin-name'])
 
   expect(fs.existsSync('touch.txt')).toBeTruthy()
@@ -98,6 +103,7 @@ test('dlx --package <pkg1> [--package <pkg2>]', async () => {
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
     package: pkgs,
+    dlxCacheMaxAge: Infinity,
   }, ['foo'])
 
   const cacheName = createBase32Hash(pkgs.join('\n'))
@@ -115,6 +121,7 @@ test('dlx should fail when the package has no bins', async () => {
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       storeDir: path.resolve('store'),
+      dlxCacheMaxAge: Infinity,
     }, ['is-positive'])
   ).rejects.toThrow(/No binaries found in is-positive/)
 })
@@ -130,6 +137,7 @@ test('dlx should work in shell mode', async () => {
       'is-positive',
     ],
     shellMode: true,
+    dlxCacheMaxAge: Infinity,
   }, ['echo "some text" > foo'])
 
   expect(fs.existsSync('foo')).toBeTruthy()
@@ -145,6 +153,7 @@ test('dlx should return a non-zero exit code when the underlying script fails', 
     package: [
       'touch@3.1.0',
     ],
+    dlxCacheMaxAge: Infinity,
   }, ['nodetouch', '--bad-option'])
 
   expect(exitCode).toBe(1)
@@ -157,6 +166,7 @@ testOnWindowsOnly('dlx should work when running in the root of a Windows Drive',
     ...DEFAULT_OPTS,
     dir: 'C:\\',
     storeDir: path.resolve('store'),
+    dlxCacheMaxAge: Infinity,
   }, ['cowsay', 'hello'])
 })
 
@@ -170,6 +180,7 @@ test('dlx with cache', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, ['shx', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBe(true)
@@ -184,6 +195,7 @@ test('dlx with cache', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, ['shx', 'touch', 'bar'])
 
   expect(fs.existsSync('bar')).toBe(true)
@@ -204,6 +216,7 @@ test('dlx still saves cache even if execution fails', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
   }, ['shx', 'mkdir', path.resolve('not-a-dir')])
 
   expect(fs.readFileSync(path.resolve('not-a-dir'), 'utf-8')).toEqual(expect.anything())
@@ -220,6 +233,7 @@ test('dlx installs and runs multiple instances of the same package in parallel',
       dir: path.resolve('project'),
       storeDir: path.resolve('store'),
       cacheDir: path.resolve('cache'),
+      dlxCacheMaxAge: Infinity,
     }, ['shx', 'touch', name])
   ))
 

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -289,28 +289,3 @@ test('dlx still saves cache even if execution fails', async () => {
   ].sort())
   expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
 })
-
-test('dlx installs and runs multiple instances of the same package in parallel', async () => {
-  prepareEmpty()
-
-  await Promise.all(['foo', 'bar', 'baz'].map(
-    name => dlx.handler({
-      ...DEFAULT_OPTS,
-      dir: path.resolve('project'),
-      storeDir: path.resolve('store'),
-      cacheDir: path.resolve('cache'),
-      dlxCacheMaxAge: Infinity,
-    }, ['shx', 'touch', name])
-  ))
-
-  expect(['foo', 'bar', 'baz'].filter(name => fs.existsSync(name))).toStrictEqual(['foo', 'bar', 'baz'])
-  expect(
-    fs.readdirSync(path.resolve('cache', 'dlx'))
-      .map(sanitizeDlxCacheName)
-      .sort()
-  ).toStrictEqual([
-    createBase32Hash('shx'),
-    createSanitizedDlxCacheName(createBase32Hash('shx')),
-  ])
-  expect(fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'))).sort()).toStrictEqual(['node_modules', 'package.json', 'pnpm-lock.yaml'])
-})

--- a/exec/plugin-commands-script-runners/test/dlx.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.ts
@@ -17,7 +17,6 @@ test('dlx should work with scoped packages', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     userAgent,
-    dlxCacheMaxAge: Infinity,
   }, ['@foo/touch-file-one-bin'])
 
   expect(execa).toHaveBeenCalledWith('touch-file-one-bin', [], expect.objectContaining({
@@ -34,7 +33,6 @@ test('dlx should work with versioned packages', async () => {
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
-    dlxCacheMaxAge: Infinity,
   }, ['@foo/touch-file-one-bin@latest'])
 
   expect(execa).toHaveBeenCalledWith('touch-file-one-bin', [], expect.anything())

--- a/exec/plugin-commands-script-runners/test/dlx.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.ts
@@ -17,6 +17,7 @@ test('dlx should work with scoped packages', async () => {
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
     userAgent,
+    dlxCacheMaxAge: Infinity,
   }, ['@foo/touch-file-one-bin'])
 
   expect(execa).toHaveBeenCalledWith('touch-file-one-bin', [], expect.objectContaining({
@@ -33,6 +34,7 @@ test('dlx should work with versioned packages', async () => {
     ...DEFAULT_OPTS,
     dir: path.resolve('project'),
     storeDir: path.resolve('store'),
+    dlxCacheMaxAge: Infinity,
   }, ['@foo/touch-file-one-bin@latest'])
 
   expect(execa).toHaveBeenCalledWith('touch-file-one-bin', [], expect.anything())

--- a/exec/plugin-commands-script-runners/test/utils/index.ts
+++ b/exec/plugin-commands-script-runners/test/utils/index.ts
@@ -66,6 +66,7 @@ export const DLX_DEFAULT_OPTS = {
   cacheDir: path.join(tmp, 'cache'),
   extraEnv: {},
   cliOptions: {},
+  dlxCacheMaxAge: Infinity,
   include: {
     dependencies: true,
     devDependencies: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,6 +1444,9 @@ importers:
       render-help:
         specifier: ^1.0.3
         version: 1.0.3
+      symlink-dir:
+        specifier: ^5.2.1
+        version: 5.2.1
       which:
         specifier: npm:@pnpm/which@^3.0.1
         version: '@pnpm/which@3.0.1'
@@ -6366,7 +6369,7 @@ importers:
         version: link:../fs/symlink-dependency
       '@rushstack/worker-pool':
         specifier: 0.4.9
-        version: 0.4.9(@types/node@20.11.30)
+        version: 0.4.9(@types/node@18.19.26)
       load-json-file:
         specifier: ^6.2.0
         version: 6.2.0
@@ -7896,9 +7899,6 @@ packages:
 
   '@types/node@18.19.26':
     resolution: {integrity: sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==}
-
-  '@types/node@20.11.30':
-    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
 
   '@types/node@20.5.1':
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
@@ -14481,9 +14481,9 @@ snapshots:
       '@reflink/reflink-win32-arm64-msvc': 0.1.16
       '@reflink/reflink-win32-x64-msvc': 0.1.16
 
-  '@rushstack/worker-pool@0.4.9(@types/node@20.11.30)':
+  '@rushstack/worker-pool@0.4.9(@types/node@18.19.26)':
     dependencies:
-      '@types/node': 20.11.30
+      '@types/node': 18.19.26
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -14666,10 +14666,6 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/node@18.19.26':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.11.30':
     dependencies:
       undici-types: 5.26.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6061,6 +6061,9 @@ importers:
       '@pnpm/assert-store':
         specifier: workspace:*
         version: link:../../__utils__/assert-store
+      '@pnpm/crypto.base32-hash':
+        specifier: workspace:*
+        version: link:../../packages/crypto.base32-hash
       '@pnpm/lockfile-file':
         specifier: workspace:*
         version: link:../../lockfile/lockfile-file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,9 +298,6 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
-      unique-string:
-        specifier: ^2.0.0
-        version: 2.0.0
       write-json5-file:
         specifier: ^3.1.0
         version: 3.1.0

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -11,7 +11,6 @@ const testOnPosix = isWindows() ? test.skip : test
 
 function sanitizeDlxCacheName (cacheName: string): string {
   const segments = cacheName.split('-')
-  if (segments.length === 1) return cacheName
   if (segments.length !== 3) {
     throw new Error(`Unexpected name: ${cacheName}`)
   }

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -334,7 +334,7 @@ test('parallel dlx calls of the same package', async () => {
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 })
 
-test('dlx creates cache and store prune clean cache', async () => {
+test('dlx creates cache and store prune cleans cache', async () => {
   prepareEmpty()
 
   fs.writeFileSync('.npmrc', [

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -10,7 +10,7 @@ const RECORD_ARGS_FILE = 'require(\'fs\').writeFileSync(\'args.json\', JSON.stri
 const testOnPosix = isWindows() ? test.skip : test
 
 function sanitizeDlxCacheComponent (cacheName: string): string {
-  if (cacheName === 'link') return cacheName
+  if (cacheName === 'pkg') return cacheName
   const segments = cacheName.split('-')
   if (segments.length !== 2) {
     throw new Error(`Unexpected name: ${cacheName}`)
@@ -317,20 +317,20 @@ test('parallel dlx calls of the same package', async () => {
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
-    'link',
+    'pkg',
     '***********-*****',
     '***********-*****',
     '***********-*****',
   ].sort())
   expect(
-    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))
+    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg'))
   ).toStrictEqual([
     'node_modules',
     'package.json',
     'pnpm-lock.yaml',
   ])
   expect(
-    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 
   // parallel dlx calls with cache
@@ -344,20 +344,20 @@ test('parallel dlx calls of the same package', async () => {
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
-    'link',
+    'pkg',
     '***********-*****',
     '***********-*****',
     '***********-*****',
   ].sort())
   expect(
-    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))
+    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg'))
   ).toStrictEqual([
     'node_modules',
     'package.json',
     'pnpm-lock.yaml',
   ])
   expect(
-    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 
   // parallel dlx calls with expired cache
@@ -375,7 +375,7 @@ test('parallel dlx calls of the same package', async () => {
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
-    'link',
+    'pkg',
     '***********-*****',
     '***********-*****',
     '***********-*****',
@@ -384,14 +384,14 @@ test('parallel dlx calls of the same package', async () => {
     '***********-*****',
   ].sort())
   expect(
-    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))
+    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg'))
   ).toStrictEqual([
     'node_modules',
     'package.json',
     'pnpm-lock.yaml',
   ])
   expect(
-    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 })
 
@@ -435,7 +435,7 @@ test('dlx creates cache and store prune cleans cache', async () => {
     Object.fromEntries(
       Object.keys(commands).map(cmd => [
         cmd,
-        ['link', '***********-*****'].sort(),
+        ['pkg', '***********-*****'].sort(),
       ])
     )
   )
@@ -450,7 +450,7 @@ test('dlx creates cache and store prune cleans cache', async () => {
   const now = new Date()
   await Promise.all(Object.entries(ageTable).map(async ([cmd, age]) => {
     const newDate = new Date(now.getTime() - age * 60_000)
-    const dlxCacheLink = path.resolve('cache', 'dlx', createBase32Hash(cmd), 'link')
+    const dlxCacheLink = path.resolve('cache', 'dlx', createBase32Hash(cmd), 'pkg')
     await fs.promises.lutimes(dlxCacheLink, newDate, newDate)
   }))
 
@@ -478,7 +478,7 @@ test('dlx creates cache and store prune cleans cache', async () => {
     Object.fromEntries(
       ['shx', '@pnpm.e2e/touch-file-good-bin-name'].map(cmd => [
         cmd,
-        ['link', '***********-*****'].sort(),
+        ['pkg', '***********-*****'].sort(),
       ])
     )
   )

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -332,7 +332,7 @@ test('parallel dlx calls of the same package', async () => {
     'pnpm-lock.yaml',
   ])
   expect(
-    path.resolve(path.dirname(fs.readlinkSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 
   // parallel dlx calls with cache
@@ -359,7 +359,7 @@ test('parallel dlx calls of the same package', async () => {
     'pnpm-lock.yaml',
   ])
   expect(
-    path.resolve(path.dirname(fs.readlinkSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 
   // set dlx-cache-max-age to 0
@@ -396,7 +396,7 @@ test('parallel dlx calls of the same package', async () => {
     'pnpm-lock.yaml',
   ])
   expect(
-    path.resolve(path.dirname(fs.readlinkSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link'))))
+    path.dirname(fs.realpathSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'link')))
   ).toBe(path.resolve('cache', 'dlx', createBase32Hash('shx')))
 })
 

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/store/plugin-commands-store#readme",
   "devDependencies": {
     "@pnpm/assert-store": "workspace:*",
+    "@pnpm/crypto.base32-hash": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",

--- a/store/plugin-commands-store/src/cleanExpiredCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.test.ts
@@ -1,39 +1,80 @@
 import fs from 'fs'
 import path from 'path'
+import util from 'util'
 import { createBase32Hash } from '@pnpm/crypto.base32-hash'
 import { prepareEmpty } from '@pnpm/prepare'
 import { cleanExpiredCache } from './cleanExpiredCache'
+
+function readDlxCachePath (cachePath: string): string[] | 'ENOENT' {
+  let names: string[]
+  try {
+    names = fs.readdirSync(cachePath, 'utf-8')
+  } catch (err) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return 'ENOENT'
+    }
+    throw err
+  }
+  return names
+    .map(sanitizeDlxCacheComponent)
+    .sort()
+}
+
+function sanitizeDlxCacheComponent (cacheName: string): string {
+  if (cacheName === 'link') return cacheName
+  const segments = cacheName.split('-')
+  if (segments.length !== 2) {
+    throw new Error(`Unexpected name: ${cacheName}`)
+  }
+  const [date, pid] = segments
+  if (!/[0-9a-f]+/.test(date) && !/[0-9a-f]+/.test(pid)) {
+    throw new Error(`Name ${cacheName} doesn't end with 2 hex numbers`)
+  }
+  return '***********-*****'
+}
+
+function createSampleDlxCacheLinkTarget (dirPath: string): void {
+  fs.mkdirSync(path.join(dirPath, 'node_modules', '.pnpm'), { recursive: true })
+  fs.mkdirSync(path.join(dirPath, 'node_modules', '.bin'), { recursive: true })
+  fs.writeFileSync(path.join(dirPath, 'node_modules', '.modules.yaml'), '')
+  fs.writeFileSync(path.join(dirPath, 'package.json'), '')
+  fs.writeFileSync(path.join(dirPath, 'pnpm-lock.yaml'), '')
+}
+
+function createSampleDlxCacheFsTree (cacheDir: string, now: Date, ageTable: Record<string, number>): void {
+  for (const [key, age] of Object.entries(ageTable)) {
+    const hash = createBase32Hash(key)
+    const newDate = new Date(now.getTime() - age * 60_000)
+    const timeError = 432 // just an arbitrary amount, nothing is special about this number
+    const pid = 71014 // just an arbitrary number to represent pid
+    const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
+    const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
+    const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
+    createSampleDlxCacheLinkTarget(linkTarget)
+    fs.symlinkSync(linkTarget, linkPath, 'junction')
+    fs.lutimesSync(linkPath, newDate, newDate)
+  }
+}
 
 afterEach(() => {
   jest.restoreAllMocks()
 })
 
-test('cleanExpiredCache removes directories that outlive dlxCacheMaxAge', async () => {
+test('cleanExpiredCache removes items that outlive dlxCacheMaxAge', async () => {
   prepareEmpty()
 
   const cacheDir = path.resolve('cache')
   const dlxCacheMaxAge = 7
   const now = new Date()
 
-  const timeTable = {
-    foo: 12,
-    bar: 1,
-    baz: -20,
-  }
-
-  for (const [key, minuteDelta] of Object.entries(timeTable)) {
-    const dirName = createBase32Hash(key)
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
-    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
-    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
-  }
+  createSampleDlxCacheFsTree(cacheDir, now, {
+    foo: 1,
+    bar: 5,
+    baz: 20,
+  })
 
   const readdirSpy = jest.spyOn(fs.promises, 'readdir')
-  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
   await cleanExpiredCache({
@@ -42,23 +83,35 @@ test('cleanExpiredCache removes directories that outlive dlxCacheMaxAge', async 
     now,
   })
 
-  expect(
-    fs.readdirSync(path.join(cacheDir, 'dlx'))
-      .sort()
-  ).toStrictEqual(
-    ['foo', 'bar']
-      .map(createBase32Hash)
-      .sort()
-  )
+  expect({
+    foo: readDlxCachePath(path.join(cacheDir, 'dlx', createBase32Hash('foo'))),
+    bar: readDlxCachePath(path.join(cacheDir, 'dlx', createBase32Hash('bar'))),
+    baz: readDlxCachePath(path.join(cacheDir, 'dlx', createBase32Hash('baz'))),
+  }).toStrictEqual({
+    foo: ['link', '***********-*****'].sort(),
+    bar: ['link', '***********-*****'].sort(),
+    baz: 'ENOENT',
+  })
 
   expect(readdirSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx'), expect.anything())
   for (const key of ['foo', 'bar', 'baz']) {
-    expect(statSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash(key)))
+    expect(lstatSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash(key), 'link'))
   }
-  expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash('baz')), { recursive: true })
+  expect(rmSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('foo'))),
+    expect.anything(),
+  )
+  expect(rmSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('bar'))),
+    expect.anything(),
+  )
+  expect(rmSpy).toHaveBeenCalledWith(
+    expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('baz'))),
+    { recursive: true },
+  )
 
   readdirSpy.mockRestore()
-  statSpy.mockRestore()
+  lstatSpy.mockRestore()
   rmSpy.mockRestore()
 })
 
@@ -69,25 +122,14 @@ test('cleanExpiredCache removes all directories without checking stat if dlxCach
   const dlxCacheMaxAge = 0
   const now = new Date()
 
-  const timeTable = {
-    foo: 12,
-    bar: 1,
-    baz: -20,
-  }
-
-  for (const [key, minuteDelta] of Object.entries(timeTable)) {
-    const dirName = createBase32Hash(key)
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
-    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
-    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
-  }
+  createSampleDlxCacheFsTree(cacheDir, now, {
+    foo: 1,
+    bar: 5,
+    baz: 20,
+  })
 
   const readdirSpy = jest.spyOn(fs.promises, 'readdir')
-  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
   await cleanExpiredCache({
@@ -102,13 +144,13 @@ test('cleanExpiredCache removes all directories without checking stat if dlxCach
   ).toStrictEqual([])
 
   expect(readdirSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx'), expect.anything())
-  expect(statSpy).not.toHaveBeenCalled()
+  expect(lstatSpy).not.toHaveBeenCalled()
   for (const key of ['foo', 'bar', 'baz']) {
     expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash(key)), { recursive: true })
   }
 
   readdirSpy.mockRestore()
-  statSpy.mockRestore()
+  lstatSpy.mockRestore()
   rmSpy.mockRestore()
 })
 
@@ -119,25 +161,14 @@ test('cleanExpiredCache does nothing if dlxCacheMaxAge is Infinity', async () =>
   const dlxCacheMaxAge = Infinity
   const now = new Date()
 
-  const timeTable = {
-    foo: 12,
-    bar: 1,
-    baz: -20,
-  }
-
-  for (const [key, minuteDelta] of Object.entries(timeTable)) {
-    const dirName = createBase32Hash(key)
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
-    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
-    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
-    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
-    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
-  }
+  createSampleDlxCacheFsTree(cacheDir, now, {
+    foo: 1,
+    bar: 5,
+    baz: 20,
+  })
 
   const readdirSpy = jest.spyOn(fs.promises, 'readdir')
-  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
   await cleanExpiredCache({
@@ -155,11 +186,28 @@ test('cleanExpiredCache does nothing if dlxCacheMaxAge is Infinity', async () =>
       .sort()
   )
 
+  expect(
+    Object.fromEntries(
+      fs.readdirSync(path.join(cacheDir, 'dlx'))
+        .sort()
+        .map(dlxCacheName => [
+          dlxCacheName,
+          fs.readdirSync(path.join(cacheDir, 'dlx', dlxCacheName))
+            .map(sanitizeDlxCacheComponent)
+            .sort(),
+        ])
+    )
+  ).toStrictEqual({
+    [createBase32Hash('foo')]: ['link', '***********-*****'].sort(),
+    [createBase32Hash('bar')]: ['link', '***********-*****'].sort(),
+    [createBase32Hash('baz')]: ['link', '***********-*****'].sort(),
+  })
+
   expect(readdirSpy).not.toHaveBeenCalled()
-  expect(statSpy).not.toHaveBeenCalled()
+  expect(lstatSpy).not.toHaveBeenCalled()
   expect(rmSpy).not.toHaveBeenCalled()
 
   readdirSpy.mockRestore()
-  statSpy.mockRestore()
+  lstatSpy.mockRestore()
   rmSpy.mockRestore()
 })

--- a/store/plugin-commands-store/src/cleanExpiredCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.test.ts
@@ -1,0 +1,165 @@
+import fs from 'fs'
+import path from 'path'
+import { createBase32Hash } from '@pnpm/crypto.base32-hash'
+import { prepareEmpty } from '@pnpm/prepare'
+import { cleanExpiredCache } from './cleanExpiredCache'
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('cleanExpiredCache removes directories that outlive dlxCacheMaxAge', async () => {
+  prepareEmpty()
+
+  const cacheDir = path.resolve('cache')
+  const dlxCacheMaxAge = 7
+  const now = new Date()
+
+  const timeTable = {
+    foo: 12,
+    bar: 1,
+    baz: -20,
+  }
+
+  for (const [key, minuteDelta] of Object.entries(timeTable)) {
+    const dirName = createBase32Hash(key)
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
+    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
+    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
+  }
+
+  const readdirSpy = jest.spyOn(fs.promises, 'readdir')
+  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const rmSpy = jest.spyOn(fs.promises, 'rm')
+
+  await cleanExpiredCache({
+    cacheDir,
+    dlxCacheMaxAge,
+    now,
+  })
+
+  expect(
+    fs.readdirSync(path.join(cacheDir, 'dlx'))
+      .sort()
+  ).toStrictEqual(
+    ['foo', 'bar']
+      .map(createBase32Hash)
+      .sort()
+  )
+
+  expect(readdirSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx'), expect.anything())
+  for (const key of ['foo', 'bar', 'baz']) {
+    expect(statSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash(key)))
+  }
+  expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash('baz')), { recursive: true })
+
+  readdirSpy.mockRestore()
+  statSpy.mockRestore()
+  rmSpy.mockRestore()
+})
+
+test('cleanExpiredCache removes all directories without checking stat if dlxCacheMaxAge is 0', async () => {
+  prepareEmpty()
+
+  const cacheDir = path.resolve('cache')
+  const dlxCacheMaxAge = 0
+  const now = new Date()
+
+  const timeTable = {
+    foo: 12,
+    bar: 1,
+    baz: -20,
+  }
+
+  for (const [key, minuteDelta] of Object.entries(timeTable)) {
+    const dirName = createBase32Hash(key)
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
+    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
+    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
+  }
+
+  const readdirSpy = jest.spyOn(fs.promises, 'readdir')
+  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const rmSpy = jest.spyOn(fs.promises, 'rm')
+
+  await cleanExpiredCache({
+    cacheDir,
+    dlxCacheMaxAge,
+    now,
+  })
+
+  expect(
+    fs.readdirSync(path.join(cacheDir, 'dlx'))
+      .sort()
+  ).toStrictEqual([])
+
+  expect(readdirSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx'), expect.anything())
+  expect(statSpy).not.toHaveBeenCalled()
+  for (const key of ['foo', 'bar', 'baz']) {
+    expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createBase32Hash(key)), { recursive: true })
+  }
+
+  readdirSpy.mockRestore()
+  statSpy.mockRestore()
+  rmSpy.mockRestore()
+})
+
+test('cleanExpiredCache does nothing if dlxCacheMaxAge is Infinity', async () => {
+  prepareEmpty()
+
+  const cacheDir = path.resolve('cache')
+  const dlxCacheMaxAge = Infinity
+  const now = new Date()
+
+  const timeTable = {
+    foo: 12,
+    bar: 1,
+    baz: -20,
+  }
+
+  for (const [key, minuteDelta] of Object.entries(timeTable)) {
+    const dirName = createBase32Hash(key)
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.pnpm'), { recursive: true })
+    fs.mkdirSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.bin'), { recursive: true })
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'node_modules', '.modules.yaml'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'package.json'), '')
+    fs.writeFileSync(path.join(cacheDir, 'dlx', dirName, 'pnpm-lock.yaml'), '')
+    const newDate = new Date(now.getTime() + minuteDelta * 60_000)
+    fs.utimesSync(path.join(cacheDir, 'dlx', dirName), newDate, newDate)
+  }
+
+  const readdirSpy = jest.spyOn(fs.promises, 'readdir')
+  const statSpy = jest.spyOn(fs.promises, 'stat')
+  const rmSpy = jest.spyOn(fs.promises, 'rm')
+
+  await cleanExpiredCache({
+    cacheDir,
+    dlxCacheMaxAge,
+    now,
+  })
+
+  expect(
+    fs.readdirSync(path.join(cacheDir, 'dlx'))
+      .sort()
+  ).toStrictEqual(
+    ['foo', 'bar', 'baz']
+      .map(createBase32Hash)
+      .sort()
+  )
+
+  expect(readdirSpy).not.toHaveBeenCalled()
+  expect(statSpy).not.toHaveBeenCalled()
+  expect(rmSpy).not.toHaveBeenCalled()
+
+  readdirSpy.mockRestore()
+  statSpy.mockRestore()
+  rmSpy.mockRestore()
+})

--- a/store/plugin-commands-store/src/cleanExpiredCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.ts
@@ -19,8 +19,14 @@ export async function cleanExpiredCache (opts: {
   await Promise.all(dlxCacheNames.map(async (dlxCacheName) => {
     const dlxCachePath = path.join(dlxCacheDir, dlxCacheName)
     const dlxCacheLink = path.join(dlxCachePath, 'link')
-    const dlxCacheLinkStats = await getStats(dlxCacheLink)
-    if (dlxCacheLinkStats !== 'ENOENT' && isOutdated(dlxCacheLinkStats, dlxCacheMaxAge, now)) {
+    let shouldClean: boolean
+    if (dlxCacheMaxAge <= 0) {
+      shouldClean = true
+    } else {
+      const dlxCacheLinkStats = await getStats(dlxCacheLink)
+      shouldClean = dlxCacheLinkStats !== 'ENOENT' && isOutdated(dlxCacheLinkStats, dlxCacheMaxAge, now)
+    }
+    if (shouldClean) {
       // delete the symlink, the symlink's target, and orphans (if any)
       await fs.rm(dlxCachePath, { recursive: true })
     }

--- a/store/plugin-commands-store/src/cleanExpiredCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.ts
@@ -1,0 +1,37 @@
+import fs from 'fs/promises'
+import path from 'path'
+import util from 'util'
+
+export async function cleanExpiredCache (opts: {
+  cacheDir: string
+  dlxCacheMaxAge: number
+  now: Date
+}): Promise<void> {
+  const { cacheDir, dlxCacheMaxAge, now } = opts
+  const dlxCacheDir = path.join(cacheDir, 'dlx')
+
+  if (dlxCacheMaxAge === Infinity) return
+
+  let cacheNames: string[]
+  try {
+    cacheNames = await fs.readdir(dlxCacheDir, { encoding: 'utf-8' })
+  } catch (err) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return
+    throw err
+  }
+  await Promise.all(cacheNames.map(async (name) => {
+    const dlxCachePath = path.join(dlxCacheDir, name)
+    let shouldClean: boolean
+    if (dlxCacheMaxAge <= 0) {
+      shouldClean = true
+    } else {
+      const cacheStats = await fs.stat(dlxCachePath)
+      shouldClean = cacheStats.mtime.getTime() + dlxCacheMaxAge * 60000 <= now.getTime()
+    }
+    if (shouldClean) {
+      try {
+        await fs.rm(dlxCachePath, { recursive: true })
+      } catch { }
+    }
+  }))
+}

--- a/store/plugin-commands-store/src/cleanExpiredCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.ts
@@ -9,10 +9,10 @@ export async function cleanExpiredCache (opts: {
   now: Date
 }): Promise<void> {
   const { cacheDir, dlxCacheMaxAge, now } = opts
-  const dlxCacheDir = path.join(cacheDir, 'dlx')
 
   if (dlxCacheMaxAge === Infinity) return
 
+  const dlxCacheDir = path.join(cacheDir, 'dlx')
   const dlxCacheNames = await readOptDir(dlxCacheDir)
   if (!dlxCacheNames) return
 

--- a/store/plugin-commands-store/src/cleanExpiredCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.ts
@@ -28,13 +28,8 @@ export async function cleanExpiredCache (opts: {
     const dlxCacheLink = path.join(dlxCachePath, 'link')
     const dlxCacheLinkStats = await getStats(dlxCacheLink)
     if (dlxCacheLinkStats !== 'ENOENT' && isOutdated(dlxCacheLinkStats, dlxCacheMaxAge, now)) {
-      const dlxCacheLinkTarget = await getRealPath(dlxCacheLink)
-      await Promise.all([
-        fs.unlink(dlxCacheLink),
-        dlxCacheLinkTarget && path.dirname(dlxCacheLinkTarget) === dlxCachePath
-          ? fs.rm(dlxCacheLinkTarget, { recursive: true })
-          : Promise.resolve(),
-      ])
+      // delete the symlink, the symlink's target, and orphans (if any)
+      await fs.rm(dlxCachePath, { recursive: true })
     }
   }))
 

--- a/store/plugin-commands-store/src/cleanExpiredCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredCache.ts
@@ -73,7 +73,7 @@ async function cleanOrphans (opts: {
       }
       throw err
     }
-    if (currentRealPath.startsWith(dlxCacheDir)) {
+    if (path.dirname(currentRealPath) === dlxCacheDir) {
       realPaths.push(currentRealPath)
     }
   }))

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
@@ -41,18 +41,22 @@ function createSampleDlxCacheLinkTarget (dirPath: string): void {
   fs.writeFileSync(path.join(dirPath, 'pnpm-lock.yaml'), '')
 }
 
+function createSampleDlxCacheItem (cacheDir: string, cmd: string, now: Date, age: number): void {
+  const hash = createBase32Hash(cmd)
+  const newDate = new Date(now.getTime() - age * 60_000)
+  const timeError = 432 // just an arbitrary amount, nothing is special about this number
+  const pid = 71014 // just an arbitrary number to represent pid
+  const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
+  const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
+  const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
+  createSampleDlxCacheLinkTarget(linkTarget)
+  fs.symlinkSync(linkTarget, linkPath, 'junction')
+  fs.lutimesSync(linkPath, newDate, newDate)
+}
+
 function createSampleDlxCacheFsTree (cacheDir: string, now: Date, ageTable: Record<string, number>): void {
-  for (const [key, age] of Object.entries(ageTable)) {
-    const hash = createBase32Hash(key)
-    const newDate = new Date(now.getTime() - age * 60_000)
-    const timeError = 432 // just an arbitrary amount, nothing is special about this number
-    const pid = 71014 // just an arbitrary number to represent pid
-    const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
-    const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
-    const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
-    createSampleDlxCacheLinkTarget(linkTarget)
-    fs.symlinkSync(linkTarget, linkPath, 'junction')
-    fs.lutimesSync(linkPath, newDate, newDate)
+  for (const [cmd, age] of Object.entries(ageTable)) {
+    createSampleDlxCacheItem(cacheDir, cmd, now, age)
   }
 }
 

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
@@ -99,15 +99,15 @@ test('cleanExpiredCache removes items that outlive dlxCacheMaxAge', async () => 
   }
   expect(rmSpy).not.toHaveBeenCalledWith(
     expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('foo'))),
-    expect.anything(),
+    expect.anything()
   )
   expect(rmSpy).not.toHaveBeenCalledWith(
     expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('bar'))),
-    expect.anything(),
+    expect.anything()
   )
   expect(rmSpy).toHaveBeenCalledWith(
     expect.stringContaining(path.join(cacheDir, 'dlx', createBase32Hash('baz'))),
-    { recursive: true },
+    { recursive: true }
   )
 
   readdirSpy.mockRestore()

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
@@ -20,15 +20,15 @@ function readDlxCachePath (cachePath: string): string[] | 'ENOENT' {
     .sort()
 }
 
-function sanitizeDlxCacheComponent (cacheName: string): string {
-  if (cacheName === 'pkg') return cacheName
-  const segments = cacheName.split('-')
+function sanitizeDlxCacheComponent (cacheEntry: string): string {
+  if (cacheEntry === 'pkg') return cacheEntry
+  const segments = cacheEntry.split('-')
   if (segments.length !== 2) {
-    throw new Error(`Unexpected name: ${cacheName}`)
+    throw new Error(`Unexpected name: ${cacheEntry}`)
   }
   const [date, pid] = segments
   if (!/[0-9a-f]+/.test(date) && !/[0-9a-f]+/.test(pid)) {
-    throw new Error(`Name ${cacheName} doesn't end with 2 hex numbers`)
+    throw new Error(`Name ${cacheEntry} doesn't end with 2 hex numbers`)
   }
   return '***********-*****'
 }

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import util from 'util'
 import { createBase32Hash } from '@pnpm/crypto.base32-hash'
 import { prepareEmpty } from '@pnpm/prepare'
-import { cleanExpiredCache } from './cleanExpiredCache'
+import { cleanExpiredDlxCache } from './cleanExpiredDlxCache'
 
 function readDlxCachePath (cachePath: string): string[] | 'ENOENT' {
   let names: string[]
@@ -77,7 +77,7 @@ test('cleanExpiredCache removes items that outlive dlxCacheMaxAge', async () => 
   const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
-  await cleanExpiredCache({
+  await cleanExpiredDlxCache({
     cacheDir,
     dlxCacheMaxAge,
     now,
@@ -132,7 +132,7 @@ test('cleanExpiredCache removes all directories without checking stat if dlxCach
   const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
-  await cleanExpiredCache({
+  await cleanExpiredDlxCache({
     cacheDir,
     dlxCacheMaxAge,
     now,
@@ -171,7 +171,7 @@ test('cleanExpiredCache does nothing if dlxCacheMaxAge is Infinity', async () =>
   const lstatSpy = jest.spyOn(fs.promises, 'lstat')
   const rmSpy = jest.spyOn(fs.promises, 'rm')
 
-  await cleanExpiredCache({
+  await cleanExpiredDlxCache({
     cacheDir,
     dlxCacheMaxAge,
     now,

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import util from 'util'
 
-export async function cleanExpiredCache (opts: {
+export async function cleanExpiredDlxCache (opts: {
   cacheDir: string
   dlxCacheMaxAge: number
   now: Date

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
@@ -35,7 +35,7 @@ export async function cleanExpiredDlxCache (opts: {
   await cleanOrphans(dlxCacheDir)
 }
 
-async function cleanOrphans (dlxCacheDir: string): Promise<void> {
+export async function cleanOrphans (dlxCacheDir: string): Promise<void> {
   const dlxCacheNames = await readOptDir(dlxCacheDir)
   if (!dlxCacheNames) return
   await Promise.all(dlxCacheNames.map(async dlxCacheName => {

--- a/store/plugin-commands-store/src/storePrune.ts
+++ b/store/plugin-commands-store/src/storePrune.ts
@@ -38,28 +38,29 @@ export async function cleanExpiredCache (opts: {
   now: Date
 }): Promise<void> {
   const { cacheDir, dlxCacheMaxAge, now } = opts
+  const dlxCacheDir = path.join(cacheDir, 'dlx')
 
   if (dlxCacheMaxAge === Infinity) return
 
   let cacheNames: string[]
   try {
-    cacheNames = await fs.readdir(cacheDir, { encoding: 'utf-8' })
+    cacheNames = await fs.readdir(dlxCacheDir, { encoding: 'utf-8' })
   } catch (err) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return
     throw err
   }
   await Promise.all(cacheNames.map(async name => {
-    const cachePath = path.join(cacheDir, name)
+    const dlxCachePath = path.join(dlxCacheDir, name)
     let shouldClean: boolean
     if (dlxCacheMaxAge <= 0) {
       shouldClean = true
     } else {
-      const cacheStats = await fs.stat(cachePath)
+      const cacheStats = await fs.stat(dlxCachePath)
       shouldClean = cacheStats.mtime.getTime() + dlxCacheMaxAge * 60_000 <= now.getTime()
     }
     if (shouldClean) {
       try {
-        await fs.rm(cachePath, { recursive: true })
+        await fs.rm(dlxCachePath, { recursive: true })
       } catch {}
     }
   }))

--- a/store/plugin-commands-store/src/storePrune.ts
+++ b/store/plugin-commands-store/src/storePrune.ts
@@ -1,7 +1,7 @@
 import { streamParser } from '@pnpm/logger'
 import { type StoreController } from '@pnpm/store-controller-types'
 import { type ReporterFunction } from './types'
-import { cleanExpiredCache } from './cleanExpiredCache'
+import { cleanExpiredDlxCache } from './cleanExpiredDlxCache'
 
 export async function storePrune (
   opts: {
@@ -19,7 +19,7 @@ export async function storePrune (
   await opts.storeController.prune(opts.removeAlienFiles)
   await opts.storeController.close()
 
-  await cleanExpiredCache({
+  await cleanExpiredDlxCache({
     cacheDir: opts.cacheDir,
     dlxCacheMaxAge: opts.dlxCacheMaxAge,
     now: new Date(),

--- a/store/plugin-commands-store/src/storePrune.ts
+++ b/store/plugin-commands-store/src/storePrune.ts
@@ -1,9 +1,7 @@
-import fs from 'fs/promises'
-import path from 'path'
-import util from 'util'
 import { streamParser } from '@pnpm/logger'
 import { type StoreController } from '@pnpm/store-controller-types'
 import { type ReporterFunction } from './types'
+import { cleanExpiredCache } from './cleanExpiredCache'
 
 export async function storePrune (
   opts: {
@@ -30,38 +28,4 @@ export async function storePrune (
   if ((reporter != null) && typeof reporter === 'function') {
     streamParser.removeListener('data', reporter)
   }
-}
-
-export async function cleanExpiredCache (opts: {
-  cacheDir: string
-  dlxCacheMaxAge: number
-  now: Date
-}): Promise<void> {
-  const { cacheDir, dlxCacheMaxAge, now } = opts
-  const dlxCacheDir = path.join(cacheDir, 'dlx')
-
-  if (dlxCacheMaxAge === Infinity) return
-
-  let cacheNames: string[]
-  try {
-    cacheNames = await fs.readdir(dlxCacheDir, { encoding: 'utf-8' })
-  } catch (err) {
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return
-    throw err
-  }
-  await Promise.all(cacheNames.map(async name => {
-    const dlxCachePath = path.join(dlxCacheDir, name)
-    let shouldClean: boolean
-    if (dlxCacheMaxAge <= 0) {
-      shouldClean = true
-    } else {
-      const cacheStats = await fs.stat(dlxCachePath)
-      shouldClean = cacheStats.mtime.getTime() + dlxCacheMaxAge * 60_000 <= now.getTime()
-    }
-    if (shouldClean) {
-      try {
-        await fs.rm(dlxCachePath, { recursive: true })
-      } catch {}
-    }
-  }))
 }

--- a/store/plugin-commands-store/test/storeAdd.ts
+++ b/store/plugin-commands-store/test/storeAdd.ts
@@ -23,6 +23,7 @@ test('pnpm store add express@4.16.3', async () => {
     registries: { default: `http://localhost:${REGISTRY_MOCK_PORT}/` },
     storeDir,
     userConfig: {},
+    dlxCacheMaxAge: 0,
   }, ['add', 'express@4.16.3'])
 
   const { cafsHas } = assertStore(path.join(storeDir, STORE_VERSION))
@@ -48,6 +49,7 @@ test('pnpm store add scoped package that uses not the standard registry', async 
     },
     storeDir,
     userConfig: {},
+    dlxCacheMaxAge: 0,
   }, ['add', '@foo/no-deps@1.0.0'])
 
   const { cafsHas } = assertStore(path.join(storeDir, STORE_VERSION))
@@ -76,6 +78,7 @@ test('should fail if some packages can not be added', async () => {
       },
       storeDir,
       userConfig: {},
+      dlxCacheMaxAge: 0,
     }, ['add', '@pnpm/this-does-not-exist'])
   } catch (e: any) { // eslint-disable-line
     thrown = true

--- a/store/plugin-commands-store/test/storePath.ts
+++ b/store/plugin-commands-store/test/storePath.ts
@@ -19,6 +19,7 @@ test('CLI prints the current store path', async () => {
     registries: { default: REGISTRY },
     storeDir: '/home/example/.pnpm-store',
     userConfig: {},
+    dlxCacheMaxAge: 0,
   }, ['path'])
 
   const expectedStorePath = os.platform() === 'win32'

--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -279,18 +279,22 @@ function createSampleDlxCacheLinkTarget (dirPath: string): void {
   fs.writeFileSync(path.join(dirPath, 'pnpm-lock.yaml'), '')
 }
 
+function createSampleDlxCacheItem (cacheDir: string, cmd: string, now: Date, age: number): void {
+  const hash = createBase32Hash(cmd)
+  const newDate = new Date(now.getTime() - age * 60_000)
+  const timeError = 432 // just an arbitrary amount, nothing is special about this number
+  const pid = 71014 // just an arbitrary number to represent pid
+  const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
+  const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
+  const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
+  createSampleDlxCacheLinkTarget(linkTarget)
+  fs.symlinkSync(linkTarget, linkPath, 'junction')
+  fs.lutimesSync(linkPath, newDate, newDate)
+}
+
 function createSampleDlxCacheFsTree (cacheDir: string, now: Date, ageTable: Record<string, number>): void {
-  for (const [key, age] of Object.entries(ageTable)) {
-    const hash = createBase32Hash(key)
-    const newDate = new Date(now.getTime() - age * 60_000)
-    const timeError = 432 // just an arbitrary amount, nothing is special about this number
-    const pid = 71014 // just an arbitrary number to represent pid
-    const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
-    const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
-    const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
-    createSampleDlxCacheLinkTarget(linkTarget)
-    fs.symlinkSync(linkTarget, linkPath, 'junction')
-    fs.lutimesSync(linkPath, newDate, newDate)
+  for (const [cmd, age] of Object.entries(ageTable)) {
+    createSampleDlxCacheItem(cacheDir, cmd, now, age)
   }
 }
 

--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -286,7 +286,7 @@ function createSampleDlxCacheItem (cacheDir: string, cmd: string, now: Date, age
   const pid = 71014 // just an arbitrary number to represent pid
   const targetName = `${(newDate.getTime() - timeError).toString(16)}-${pid.toString(16)}`
   const linkTarget = path.join(cacheDir, 'dlx', hash, targetName)
-  const linkPath = path.join(cacheDir, 'dlx', hash, 'link')
+  const linkPath = path.join(cacheDir, 'dlx', hash, 'pkg')
   createSampleDlxCacheLinkTarget(linkTarget)
   fs.symlinkSync(linkTarget, linkPath, 'junction')
   fs.lutimesSync(linkPath, newDate, newDate)

--- a/store/plugin-commands-store/test/storeStatus.ts
+++ b/store/plugin-commands-store/test/storeStatus.ts
@@ -40,6 +40,7 @@ test('CLI fails when store status finds modified packages', async () => {
       registries: modulesState!.registries!,
       storeDir,
       userConfig: {},
+      dlxCacheMaxAge: 0,
     }, ['status'])
   } catch (_err: any) { // eslint-disable-line
     err = _err
@@ -91,5 +92,6 @@ test('CLI does not fail when store status does not find modified packages', asyn
     registries: modulesState!.registries!,
     storeDir,
     userConfig: {},
+    dlxCacheMaxAge: 0,
   }, ['status'])
 })

--- a/store/plugin-commands-store/tsconfig.json
+++ b/store/plugin-commands-store/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../../lockfile/lockfile-utils"
     },
     {
+      "path": "../../packages/crypto.base32-hash"
+    },
+    {
       "path": "../../packages/dependency-path"
     },
     {


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/5277

---

**TODO:**
* [x] Group the cache directories by id.
* [x] Fix tests in `dlx.e2e.ts` and `run.ts`.
* [x] Fix `cleanExpiredCache.ts`.
* [x] Fix `cleanExpiredCache.test.ts`.
* [x] Refactor: Rename `cleanExpiredCache` to `cleanExpiredDlxCache`.
* [x] Fix tests for `storePrune.ts`.
* [x] Proper tests for pruning dlx cache must be placed in `run.ts` (as a CLI invoker).
* [x] Test removing orphans.
* [x] Test running `dlx` with cache that is expired but still exist.
* [x] Test running multiple `dlx` in parallel with cache that is expired but still exist.
* [x] Refactor `dlx.ts`: async fs methods.