### PR TITLE
revert: use the same directories on macOS as on Linux

### DIFF
--- a/.changeset/fresh-boats-press.md
+++ b/.changeset/fresh-boats-press.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+"pnpm": major
+---
+
+Use the same directory for state files on macOS as on Linux (`~/.local/state/pnpm`).

--- a/.changeset/plenty-humans-exist.md
+++ b/.changeset/plenty-humans-exist.md
@@ -1,6 +1,0 @@
----
-"@pnpm/config": major
-"pnpm": major
----
-
-Revert a change in v9.0.0-alpha.0 to use the same directories on macOS as on Linux. [#7321](https://github.com/pnpm/pnpm/issues/7321). The directories inside `~/Library` will be used again on macOS. [#7732](https://github.com/pnpm/pnpm/issues/7732)

--- a/.changeset/plenty-humans-exist.md
+++ b/.changeset/plenty-humans-exist.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+"pnpm": major
+---
+
+Revert a change in v9.0.0-alpha.0 to use the same directories on macOS as on Linux. [#7321](https://github.com/pnpm/pnpm/issues/7321). The directories inside `~/Library` will be used again on macOS. [#7732](https://github.com/pnpm/pnpm/issues/7732)

--- a/.changeset/silly-moles-rhyme.md
+++ b/.changeset/silly-moles-rhyme.md
@@ -1,6 +1,0 @@
----
-"@pnpm/config": major
-"pnpm": major
----
-
-Use the same directories on macOS as on Linux. Don't use directories inside `~/Library` on macOS [#7321](https://github.com/pnpm/pnpm/issues/7321).

--- a/config/config/src/dirs.ts
+++ b/config/config/src/dirs.ts
@@ -31,7 +31,7 @@ export function getStateDir (
   if (opts.env.XDG_STATE_HOME) {
     return path.join(opts.env.XDG_STATE_HOME, 'pnpm')
   }
-  if (opts.platform !== 'win32' && opts.platform !== 'darwin') {
+  if (opts.platform !== 'win32') {
     return path.join(os.homedir(), '.local/state/pnpm')
   }
   if (opts.env.LOCALAPPDATA) {

--- a/config/config/src/dirs.ts
+++ b/config/config/src/dirs.ts
@@ -10,6 +10,9 @@ export function getCacheDir (
   if (opts.env.XDG_CACHE_HOME) {
     return path.join(opts.env.XDG_CACHE_HOME, 'pnpm')
   }
+  if (opts.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library/Caches/pnpm')
+  }
   if (opts.platform !== 'win32') {
     return path.join(os.homedir(), '.cache/pnpm')
   }
@@ -28,7 +31,7 @@ export function getStateDir (
   if (opts.env.XDG_STATE_HOME) {
     return path.join(opts.env.XDG_STATE_HOME, 'pnpm')
   }
-  if (opts.platform !== 'win32') {
+  if (opts.platform !== 'win32' && opts.platform !== 'darwin') {
     return path.join(os.homedir(), '.local/state/pnpm')
   }
   if (opts.env.LOCALAPPDATA) {
@@ -49,6 +52,9 @@ export function getDataDir (
   if (opts.env.XDG_DATA_HOME) {
     return path.join(opts.env.XDG_DATA_HOME, 'pnpm')
   }
+  if (opts.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library/pnpm')
+  }
   if (opts.platform !== 'win32') {
     return path.join(os.homedir(), '.local/share/pnpm')
   }
@@ -66,6 +72,9 @@ export function getConfigDir (
 ) {
   if (opts.env.XDG_CONFIG_HOME) {
     return path.join(opts.env.XDG_CONFIG_HOME, 'pnpm')
+  }
+  if (opts.platform === 'darwin') {
+    return path.join(os.homedir(), 'Library/Preferences/pnpm')
   }
   if (opts.platform !== 'win32') {
     return path.join(os.homedir(), '.config/pnpm')

--- a/config/config/test/dirs.test.ts
+++ b/config/config/test/dirs.test.ts
@@ -43,7 +43,7 @@ test('getStateDir()', () => {
   expect(getStateDir({
     env: {},
     platform: 'darwin',
-  })).toBe(path.join(os.homedir(), '.pnpm-state'))
+  })).toBe(path.join(os.homedir(), '.local/state/pnpm'))
   expect(getStateDir({
     env: {
       LOCALAPPDATA: '/localappdata',

--- a/config/config/test/dirs.test.ts
+++ b/config/config/test/dirs.test.ts
@@ -16,7 +16,7 @@ test('getCacheDir()', () => {
   expect(getCacheDir({
     env: {},
     platform: 'darwin',
-  })).toBe(path.join(os.homedir(), '.cache/pnpm'))
+  })).toBe(path.join(os.homedir(), 'Library/Caches/pnpm'))
   expect(getCacheDir({
     env: {
       LOCALAPPDATA: '/localappdata',
@@ -43,7 +43,7 @@ test('getStateDir()', () => {
   expect(getStateDir({
     env: {},
     platform: 'darwin',
-  })).toBe(path.join(os.homedir(), '.local/state/pnpm'))
+  })).toBe(path.join(os.homedir(), '.pnpm-state'))
   expect(getStateDir({
     env: {
       LOCALAPPDATA: '/localappdata',
@@ -76,7 +76,7 @@ test('getDataDir()', () => {
   expect(getDataDir({
     env: {},
     platform: 'darwin',
-  })).toBe(path.join(os.homedir(), '.local/share/pnpm'))
+  })).toBe(path.join(os.homedir(), 'Library/pnpm'))
   expect(getDataDir({
     env: {
       LOCALAPPDATA: '/localappdata',
@@ -103,7 +103,7 @@ test('getConfigDir()', () => {
   expect(getConfigDir({
     env: {},
     platform: 'darwin',
-  })).toBe(path.join(os.homedir(), '.config/pnpm'))
+  })).toBe(path.join(os.homedir(), 'Library/Preferences/pnpm'))
   expect(getConfigDir({
     env: {
       LOCALAPPDATA: '/localappdata',

--- a/pnpm/CHANGELOG.md
+++ b/pnpm/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Support for lockfile v5 is dropped. Use pnpm v8 to convert lockfile v5 to lockfile v6 [#7470](https://github.com/pnpm/pnpm/pull/7470).
 - The [`dedupe-injected-deps`](https://pnpm.io/npmrc#dedupe-injected-deps) setting is `true` by default.
 - The default value of the `link-workspace-packages` setting changed from `true` to `false`. This means that by default, dependencies will be linked from workspace packages only when they are specified using the [workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace).
-- Use the same directories on macOS as on Linux. Don't use directories inside `~/Library` on macOS [#7321](https://github.com/pnpm/pnpm/issues/7321).
 - The default value of the [hoist-workspace-packages](https://pnpm.io/npmrc#hoist-workspace-packages) is `true`.
 - `pnpm licenses list` prints license information of all versions of the same package in case different versions use different licenses. The format of the `pnpm licenses list --json` output has been changed [#7528](https://github.com/pnpm/pnpm/pull/7528).
 - A new command added for printing completion code to the console: `pnpm completion [shell]`. The old command that modified the user's shell dotfiles has been removed [#3083](https://github.com/pnpm/pnpm/issues/3083).


### PR DESCRIPTION
## Changes

This reverts commit b970d965517ac1e78d2bb9d572a6a2b5e310378a.

## Rationale

As mentioned by @arcc1845 in https://github.com/pnpm/pnpm/issues/7732, the original premise of this change doesn't seem correct. The `$HOME/Library` directory is not protected by macOS System Integrity Protection (SIP).

I think we should go back to `$HOME/Library` on macOS. I personally don't have a preference on `$HOME/Library` versus `~/.config`, but would prefer to have less changes on the unreleased v9 branch. I think we'll see more users confused by the current behavior on the alpha branch when v9 releases if we don't revert.
