### PR TITLE
refactor: bump lockfile version to v9 instead of v7

### DIFF
--- a/__fixtures__/circular/pnpm-lock.yaml
+++ b/__fixtures__/circular/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/custom-modules-dir/pnpm-lock.yaml
+++ b/__fixtures__/custom-modules-dir/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/empty/pnpm-lock.yaml
+++ b/__fixtures__/empty/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-external-shrinkwrap/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-name-and-no-version/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
+++ b/__fixtures__/fixture-with-no-pkg-version/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/fixture/pnpm-lock.yaml
+++ b/__fixtures__/fixture/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/general/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   minimatch:

--- a/__fixtures__/fixtureWithLinks/with-links-only/pnpm-lock.yaml
+++ b/__fixtures__/fixtureWithLinks/with-links-only/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   general:

--- a/__fixtures__/general/pnpm-lock.yaml
+++ b/__fixtures__/general/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/node_modules/.pnpm/lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-2-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-major-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   is-negative:

--- a/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-not-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-and-external-shrinkwrap/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
   pkg:

--- a/__fixtures__/has-outdated-deps/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/local-pkg/pnpm-lock.yaml
+++ b/__fixtures__/local-pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/local-scoped-pkg/pnpm-lock.yaml
+++ b/__fixtures__/local-scoped-pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/monorepo/pnpm-lock.yaml
+++ b/__fixtures__/monorepo/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
   package:

--- a/__fixtures__/multiple-scripts-error-exit/pnpm-lock.yaml
+++ b/__fixtures__/multiple-scripts-error-exit/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
+++ b/__fixtures__/pkg-with-external-lockfile/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/pnpm-lock.yaml
+++ b/__fixtures__/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/tar-pkg/pnpm-lock.yaml
+++ b/__fixtures__/tar-pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-aliased-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-aliased-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-file-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-file-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-git-protocol-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-git-protocol-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-non-package-dep/pnpm-lock.yaml
+++ b/__fixtures__/with-non-package-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-peer/pnpm-lock.yaml
+++ b/__fixtures__/with-peer/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-pnpm-update-ignore/pnpm-lock.yaml
+++ b/__fixtures__/with-pnpm-update-ignore/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
+++ b/__fixtures__/with-unsaved-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/workspace-external-depends-deep/pnpm-lock.yaml
+++ b/__fixtures__/workspace-external-depends-deep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/workspace-has-shared-npm-shrinkwrap-json/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-npm-shrinkwrap-json/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'

--- a/__fixtures__/workspace-has-shared-package-lock-json/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-package-lock-json/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'

--- a/__fixtures__/workspace-has-shared-yarn-lock/pnpm-lock.yaml
+++ b/__fixtures__/workspace-has-shared-yarn-lock/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'

--- a/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-2-pkgs/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-different-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-dupes/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/workspace-with-lockfile-subdep-dupes/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-lockfile-subdep-dupes/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-nested-workspace-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
+++ b/__fixtures__/workspace-with-private-pkgs/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/__utils__/assert-store/test/fixture/project/pnpm-lock.yaml
+++ b/__utils__/assert-store/test/fixture/project/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/src/lockfileFormatConverters.ts
+++ b/lockfile/lockfile-file/src/lockfileFormatConverters.ts
@@ -186,7 +186,7 @@ function convertFromLockfileFileMutable (lockfileFile: LockfileFile): InlineSpec
 
 export function convertToLockfileObject (lockfile: LockfileFile | LockfileFileV7): Lockfile {
   if ((lockfile as LockfileFileV7).snapshots) {
-    return convertLockfileV7ToLockfileObject(lockfile as LockfileFileV7)
+    return convertLockfileV9ToLockfileObject(lockfile as LockfileFileV7)
   }
   convertPkgIds(lockfile)
   const { importers, ...rest } = convertFromLockfileFileMutable(lockfile)
@@ -268,7 +268,7 @@ function convertPkgIds (lockfile: LockfileFile) {
   }
 }
 
-export function convertLockfileV7ToLockfileObject (lockfile: LockfileFileV7): Lockfile {
+export function convertLockfileV9ToLockfileObject (lockfile: LockfileFileV7): Lockfile {
   const { importers, ...rest } = convertFromLockfileFileMutable(lockfile)
 
   const packages: PackageSnapshots = {}

--- a/lockfile/lockfile-file/test/__snapshots__/write.test.ts.snap
+++ b/lockfile/lockfile-file/test/__snapshots__/write.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`writeLockfiles() 1`] = `
-"lockfileVersion: '7.0'
+"lockfileVersion: '9.0'
 
 importers:
 

--- a/lockfile/lockfile-file/test/fixtures/2/pnpm-lock.yaml
+++ b/lockfile/lockfile-file/test/fixtures/2/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 dependencies:
   foo:
     version: '1.0.0'

--- a/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.branch.yaml
+++ b/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.branch.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.yaml
+++ b/lockfile/lockfile-file/test/fixtures/6/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   is-positive:

--- a/lockfile/lockfile-file/test/lockfileV6Converters.test.ts
+++ b/lockfile/lockfile-file/test/lockfileV6Converters.test.ts
@@ -2,7 +2,7 @@ import { convertToLockfileFile, convertToLockfileObject } from '../lib/lockfileF
 
 test('convertToLockfileFile()', () => {
   const lockfileV5 = {
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     importers: {
       project1: {
         specifiers: {
@@ -39,7 +39,7 @@ test('convertToLockfileFile()', () => {
     },
   }
   const lockfileV6 = {
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     importers: {
       project1: {
         dependencies: {
@@ -93,7 +93,7 @@ test('convertToLockfileFile()', () => {
 
 test('convertToLockfileFile() with lockfile v6', () => {
   const lockfileV5 = {
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     importers: {
       project1: {
         specifiers: {
@@ -130,7 +130,7 @@ test('convertToLockfileFile() with lockfile v6', () => {
     },
   }
   const lockfileV6 = {
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     importers: {
       project1: {
         dependencies: {

--- a/lockfile/lockfile-file/test/read.test.ts
+++ b/lockfile/lockfile-file/test/read.test.ts
@@ -18,7 +18,7 @@ test('readWantedLockfile()', async () => {
     const lockfile = await readWantedLockfile(path.join('fixtures', '2'), {
       ignoreIncompatible: false,
     })
-    expect(lockfile?.lockfileVersion).toEqual('7.0')
+    expect(lockfile?.lockfileVersion).toEqual('9.0')
     expect(lockfile?.importers).toStrictEqual({
       '.': {
         dependencies: {
@@ -88,7 +88,7 @@ test('writeWantedLockfile()', async () => {
         },
       },
     },
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     packages: {
       'is-negative@1.0.0': {
         dependencies: {
@@ -131,7 +131,7 @@ test('writeCurrentLockfile()', async () => {
         },
       },
     },
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     packages: {
       'is-negative@1.0.0': {
         dependencies: {

--- a/lockfile/lockfile-types/src/index.ts
+++ b/lockfile/lockfile-types/src/index.ts
@@ -22,7 +22,7 @@ export interface Lockfile {
   settings?: LockfileSettings
 }
 
-export interface LockfileV7 {
+export interface LockfileV9 {
   importers: Record<string, ProjectSnapshot>
   lockfileVersion: number | string
   time?: Record<string, string>

--- a/lockfile/plugin-commands-audit/test/fixtures/has-vulnerabilities/pnpm-lock.yaml
+++ b/lockfile/plugin-commands-audit/test/fixtures/has-vulnerabilities/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 dependencies:
   karma:

--- a/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
+++ b/modules-mounter/daemon/test/__fixtures__/simple/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/packages/calc-dep-state/test/lockfileToDepGraph.test.ts
+++ b/packages/calc-dep-state/test/lockfileToDepGraph.test.ts
@@ -2,7 +2,7 @@ import { lockfileToDepGraph } from '@pnpm/calc-dep-state'
 
 test('lockfileToDepGraph', () => {
   expect(lockfileToDepGraph({
-    lockfileVersion: '7.0',
+    lockfileVersion: '9.0',
     importers: {},
     packages: {
       'foo@1.0.0': {

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,5 @@
 export const WANTED_LOCKFILE = 'pnpm-lock.yaml'
-export const LOCKFILE_VERSION = '7.0'
+export const LOCKFILE_VERSION = '9.0'
 export const LOCKFILE_VERSION_V6 = '6.0'
 
 export const ENGINE_NAME = `${process.platform}-${process.arch}-node-${process.version.split('.')[0]}`

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -1,5 +1,6 @@
 export const WANTED_LOCKFILE = 'pnpm-lock.yaml'
-export const LOCKFILE_VERSION = '9.0'
+export const LOCKFILE_MAJOR_VERSION = '9'
+export const LOCKFILE_VERSION = `${LOCKFILE_MAJOR_VERSION}.0`
 export const LOCKFILE_VERSION_V6 = '6.0'
 
 export const ENGINE_NAME = `${process.platform}-${process.arch}-node-${process.version.split('.')[0]}`

--- a/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
+++ b/packages/make-dedicated-lockfile/test/fixtures/fixture/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -5,6 +5,7 @@ import { createAllowBuildFunction } from '@pnpm/builder.policy'
 import {
   LAYOUT_VERSION,
   LOCKFILE_VERSION,
+  LOCKFILE_MAJOR_VERSION,
   LOCKFILE_VERSION_V6,
   WANTED_LOCKFILE,
 } from '@pnpm/constants'
@@ -351,7 +352,7 @@ export async function mutateModules (
     }
     let needsFullResolution = outdatedLockfileSettings ||
       opts.fixLockfile ||
-      !ctx.wantedLockfile.lockfileVersion.toString().startsWith('7.') ||
+      !ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`) ||
       opts.forceFullResolution
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {

--- a/pkg-manager/core/test/install/fixLockfile.ts
+++ b/pkg-manager/core/test/install/fixLockfile.ts
@@ -4,7 +4,7 @@ import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { install, type MutatedProject, mutateModules } from '@pnpm/core'
 import { sync as writeYamlFile } from 'write-yaml-file'
 import { sync as readYamlFile } from 'read-yaml-file'
-import { type LockfileV7 as Lockfile, type PackageSnapshots } from '@pnpm/lockfile-file'
+import { type LockfileV9 as Lockfile, type PackageSnapshots } from '@pnpm/lockfile-file'
 import { testDefaults } from '../utils'
 
 test('fix broken lockfile with --fix-lockfile', async () => {

--- a/pkg-manager/core/test/install/local.ts
+++ b/pkg-manager/core/test/install/local.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-file'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-file'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/registry-mock'
 import { fixtures } from '@pnpm/test-fixtures'

--- a/pkg-manager/core/test/install/optionalDependencies.ts
+++ b/pkg-manager/core/test/install/optionalDependencies.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-file'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-file'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import deepRequireCwd from 'deep-require-cwd'
 import { sync as readYamlFile } from 'read-yaml-file'

--- a/pkg-manager/core/test/install/peerDependencies.ts
+++ b/pkg-manager/core/test/install/peerDependencies.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-file'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-file'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag, REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import { fixtures } from '@pnpm/test-fixtures'

--- a/pkg-manager/core/test/install/update.ts
+++ b/pkg-manager/core/test/install/update.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-file'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-file'
 import { prepareEmpty } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/registry-mock'
 import { sync as readYamlFile } from 'read-yaml-file'

--- a/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/deps-have-lifecycle-scripts/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-glob-and-rimraf/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-glob-and-rimraf/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-glob/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-glob/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-incompatible-optional-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-incompatible-optional-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dep/pkg/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dep/pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dir-dep/example/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dir-dep/example/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-local-dir-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-local-dir-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-nonexistent-optional-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-nonexistent-optional-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/has-several-versions-of-same-pkg/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-several-versions-of-same-pkg/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/ignore-package-manifest/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/ignore-package-manifest/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/prod-dep-is-dev-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/prod-dep-is-dev-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/reinstall-peer-deps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/reinstall-peer-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/resolved-peer-deps-in-subdeps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/resolved-peer-deps-in-subdeps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: false

--- a/pkg-manager/headless/test/fixtures/side-effects-of-subdep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/side-effects-of-subdep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/side-effects/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/side-effects/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/simple-shamefully-flatten/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-shamefully-flatten/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: false

--- a/pkg-manager/headless/test/fixtures/simple-with-more-deps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-with-more-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple-with-optional-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/simple/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/simple/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/with-1-dep/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/with-1-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/headless/test/fixtures/workspace/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/workspace/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 importers:
 

--- a/pkg-manager/headless/test/fixtures/workspace2/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/workspace2/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
+++ b/pkg-manager/plugin-commands-installation/test/__snapshots__/dedupe.ts.snap
@@ -15,7 +15,7 @@ exports[`pnpm dedupe updates old resolutions from importers block and removes ol
       },
 @@ -20,31 +20,16 @@
     },
-    "lockfileVersion": "7.0",
+    "lockfileVersion": "9.0",
     "packages": Object {
 -     "ajv@6.10.2": Object {
 -       "resolution": Object {
@@ -116,7 +116,7 @@ exports[`pnpm dedupe updates old resolutions from package block 1`] = `
 
 @@ -20,14 +20,6 @@
     },
-    "lockfileVersion": "7.0",
+    "lockfileVersion": "9.0",
     "packages": Object {
 -     "punycode@2.1.1": Object {
 -       "engines": Object {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '9.0'
+lockfileVersion: '7.0'
 
 settings:
   autoInstallPeers: true
@@ -6360,7 +6360,7 @@ importers:
         version: link:../fs/symlink-dependency
       '@rushstack/worker-pool':
         specifier: 0.4.9
-        version: 0.4.9(@types/node@20.11.30)
+        version: 0.4.9(@types/node@18.19.26)
       load-json-file:
         specifier: ^6.2.0
         version: 6.2.0
@@ -7890,9 +7890,6 @@ packages:
 
   '@types/node@18.19.26':
     resolution: {integrity: sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==}
-
-  '@types/node@20.11.30':
-    resolution: {integrity: sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==}
 
   '@types/node@20.5.1':
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
@@ -14475,9 +14472,9 @@ snapshots:
       '@reflink/reflink-win32-arm64-msvc': 0.1.16
       '@reflink/reflink-win32-x64-msvc': 0.1.16
 
-  '@rushstack/worker-pool@0.4.9(@types/node@20.11.30)':
+  '@rushstack/worker-pool@0.4.9(@types/node@18.19.26)':
     dependencies:
-      '@types/node': 20.11.30
+      '@types/node': 18.19.26
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -14660,10 +14657,6 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/node@18.19.26':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@20.11.30':
     dependencies:
       undici-types: 5.26.5
 

--- a/pnpm/CHANGELOG.md
+++ b/pnpm/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Major Changes
 
 - Node.js v16 support dropped. Use at least Node.js v18.12.
-- Lockfile version bumped to v7.
+- Lockfile version bumped to v9.
 - Support for lockfile v5 is dropped. Use pnpm v8 to convert lockfile v5 to lockfile v6 [#7470](https://github.com/pnpm/pnpm/pull/7470).
 - The [`dedupe-injected-deps`](https://pnpm.io/npmrc#dedupe-injected-deps) setting is `true` by default.
 - The default value of the `link-workspace-packages` setting changed from `true` to `false`. This means that by default, dependencies will be linked from workspace packages only when they are specified using the [workspace protocol](https://pnpm.io/workspaces#workspace-protocol-workspace).

--- a/pnpm/test/install/hooks.ts
+++ b/pnpm/test/install/hooks.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-types'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-types'
 import { prepare, preparePackages } from '@pnpm/prepare'
 import { sync as readYamlFile } from 'read-yaml-file'
 import loadJsonFile from 'load-json-file'

--- a/pnpm/test/monorepo/dedupePeers.test.ts
+++ b/pnpm/test/monorepo/dedupePeers.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-types'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-types'
 import { preparePackages } from '@pnpm/prepare'
 import { addDistTag } from '@pnpm/registry-mock'
 import { sync as readYamlFile } from 'read-yaml-file'

--- a/pnpm/test/monorepo/peerDependencies.ts
+++ b/pnpm/test/monorepo/peerDependencies.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-types'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-types'
 import { preparePackages } from '@pnpm/prepare'
 import { sync as readYamlFile } from 'read-yaml-file'
 import { sync as writeYamlFile } from 'write-yaml-file'

--- a/pnpm/test/recursive/misc.ts
+++ b/pnpm/test/recursive/misc.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { prepare, preparePackages } from '@pnpm/prepare'
-import { type LockfileV7 as Lockfile } from '@pnpm/lockfile-types'
+import { type LockfileV9 as Lockfile } from '@pnpm/lockfile-types'
 import { sync as readYamlFile } from 'read-yaml-file'
 import { isCI } from 'ci-info'
 import isWindows from 'is-windows'

--- a/reviewing/plugin-commands-licenses/test/fixtures/complex-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/complex-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/file-mode-test/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/file-mode-test/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/simple-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/simple-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-dev-dependency/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-dev-dependency/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/sub-dep/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-file-protocol/sub-dep/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-caps/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-caps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-git-protocol-patched-deps/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/bar/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/bar/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/foo/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/foo/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true

--- a/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/workspace-licenses/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '7.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
In order to align the lockfile version with pnpm version that ships it.