### PR TITLE
fix: wrong tag stated in `pnpm publish`

### DIFF
--- a/.changeset/hungry-eyes-reply.md
+++ b/.changeset/hungry-eyes-reply.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"pnpm": patch
+---
+
+It should be possible to publish a tarball with custom dist-tag [#7845](https://github.com/pnpm/pnpm/issues/7845).

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -183,8 +183,11 @@ Do you want to continue?`,
     })
     return { exitCode }
   }
+
+  let args = opts.argv.original.slice(1)
+
   if ((params.length > 0) && params[0].endsWith('.tgz')) {
-    const { status } = runNpm(opts.npmPath, ['publish', ...params])
+    const { status } = runNpm(opts.npmPath, ['publish', ...args])
     return { exitCode: status ?? 0 }
   }
   const dirInParams = (params.length > 0) && params[0]
@@ -202,7 +205,6 @@ Do you want to continue?`,
   })
   const { manifest } = await readProjectManifest(dir, opts)
   // Unfortunately, we cannot support postpack at the moment
-  let args = opts.argv.original.slice(1)
   if (dirInParams) {
     args = args.filter(arg => arg !== params[0])
   }

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -185,26 +185,7 @@ Do you want to continue?`,
   }
 
   let args = opts.argv.original.slice(1)
-
-  if ((params.length > 0) && params[0].endsWith('.tgz')) {
-    const { status } = runNpm(opts.npmPath, ['publish', ...args])
-    return { exitCode: status ?? 0 }
-  }
-  const dirInParams = (params.length > 0) && params[0]
-  const dir = dirInParams || opts.dir || process.cwd()
-
-  const _runScriptsIfPresent = runScriptsIfPresent.bind(null, {
-    depPath: dir,
-    extraBinPaths: opts.extraBinPaths,
-    extraEnv: opts.extraEnv,
-    pkgRoot: dir,
-    rawConfig: opts.rawConfig,
-    rootModulesDir: await realpathMissing(path.join(dir, 'node_modules')),
-    stdio: 'inherit',
-    unsafePerm: true, // when running scripts explicitly, assume that they're trusted.
-  })
-  const { manifest } = await readProjectManifest(dir, opts)
-  // Unfortunately, we cannot support postpack at the moment
+  const dirInParams = (params.length > 0) ? params[0] : undefined
   if (dirInParams) {
     args = args.filter(arg => arg !== params[0])
   }
@@ -218,6 +199,25 @@ Do you want to continue?`,
       args.splice(index, 2)
     }
   }
+
+  if (dirInParams?.endsWith('.tgz')) {
+    const { status } = runNpm(opts.npmPath, ['publish', ...args])
+    return { exitCode: status ?? 0 }
+  }
+  const dir = dirInParams ?? opts.dir ?? process.cwd()
+
+  const _runScriptsIfPresent = runScriptsIfPresent.bind(null, {
+    depPath: dir,
+    extraBinPaths: opts.extraBinPaths,
+    extraEnv: opts.extraEnv,
+    pkgRoot: dir,
+    rawConfig: opts.rawConfig,
+    rootModulesDir: await realpathMissing(path.join(dir, 'node_modules')),
+    stdio: 'inherit',
+    unsafePerm: true, // when running scripts explicitly, assume that they're trusted.
+  })
+  const { manifest } = await readProjectManifest(dir, opts)
+  // Unfortunately, we cannot support postpack at the moment
   if (!opts.ignoreScripts) {
     await _runScriptsIfPresent([
       'prepublishOnly',


### PR DESCRIPTION
Closes #7845 

Prior to this PR, pnpm publishes a package when we run `pnpm publish package-1.0.1.tgz --access public --no-git-checks --tag exp --ignore-scripts`, but ignores `--tag`, `--access` and all options.
Because pnpm only passes the tarball name to params in releasing/plugin-commands-publishing/src/publish.ts.

After this PR we can use pnpm with any options.

I've just started learning about pnpm, so apologies if I'm wrong. The original code ignored processing for args, such as the `--publish-branch` option, because the processing for the tarball was done first, but I am not confident that this is correct.
