### PR TITLE
chore: output options to descriptionLists of pnpm import

### DIFF
--- a/.changeset/shy-cherries-pay.md
+++ b/.changeset/shy-cherries-pay.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+The pnpm import help must show the description of the reporter options, because it accepts them.

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@pnpm/store-connection-manager'
 import gfs from '@pnpm/graceful-fs'
 import { install, type InstallOptions } from '@pnpm/core'
-import { type Config, getOptionsFromRootManifest } from '@pnpm/config'
+import { type Config, getOptionsFromRootManifest, types as allTypes } from '@pnpm/config'
 import { findWorkspacePackages } from '@pnpm/workspace.find-packages'
 import { type Project } from '@pnpm/types'
 import { logger } from '@pnpm/logger'
@@ -24,6 +24,8 @@ import { parseSyml } from '@yarnpkg/parsers'
 import exists from 'path-exists'
 import { recursive } from '../recursive'
 import { yarnLockFileKeyNormalizer } from './yarnUtil'
+import pick from 'ramda/src/pick'
+import { OUTPUT_OPTIONS } from '@pnpm/common-cli-options-help'
 
 interface NpmPackageLock {
   dependencies: LockedPackagesMap
@@ -73,15 +75,22 @@ interface YarnLock2Struct {
   object: YarnPackageLock
 }
 
-export const rcOptionsTypes = cliOptionsTypes
+export function rcOptionsTypes () {
+  return pick([
+    'reporter',
+  ], allTypes)
+}
 
 export function cliOptionsTypes () {
-  return {}
+  return rcOptionsTypes()
 }
 
 export function help () {
   return renderHelp({
     description: `Generates ${WANTED_LOCKFILE} from an npm package-lock.json (or npm-shrinkwrap.json, yarn.lock) file.`,
+    descriptionLists: [
+      OUTPUT_OPTIONS,
+    ],
     url: docsUrl('import'),
     usages: [
       'pnpm import',


### PR DESCRIPTION
close #7829 

Prior to this PR, `pnpm help import` doesn't show the description of the reporter options, even though it accepts them.

```sh
❯ ./pnpm/bin/pnpm.cjs help import 
Version 9.0.0-beta.3
Usage: pnpm import

Generates pnpm-lock.yaml from an npm package-lock.json (or npm-shrinkwrap.json, yarn.lock) file.

Visit https://pnpm.io/9.x/cli/import for documentation about this command.
```

After this PR we can check the use of the reporter options.

```sh
❯ ./pnpm/bin/pnpm.cjs help import 
Version 9.0.0-beta.3
Usage: pnpm import

Generates pnpm-lock.yaml from an npm package-lock.json (or npm-shrinkwrap.json, yarn.lock) file.

Output:
      --reporter append-only       The output is always appended to the end. No cursor manipulations are performed
      --reporter default           The default reporter when the stdout is TTY
      --reporter ndjson            The most verbose reporter. Prints all logs in ndjson format
  -s, --silent, --reporter silent  No output is logged to the console, except fatal errors

Visit https://pnpm.io/9.x/cli/import for documentation about this command.
```

