### PR TITLE
refactor: return type for dependency-path

### DIFF
--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -2,11 +2,11 @@ import { createBase32Hash } from '@pnpm/crypto.base32-hash'
 import { type Registries } from '@pnpm/types'
 import semver from 'semver'
 
-export function isAbsolute (dependencyPath: string) {
+export function isAbsolute (dependencyPath: string): boolean {
   return dependencyPath[0] !== '/'
 }
 
-export function indexOfPeersSuffix (depPath: string) {
+export function indexOfPeersSuffix (depPath: string): number {
   if (!depPath.endsWith(')')) return -1
   let open = 1
   for (let i = depPath.length - 2; i >= 0; i--) {
@@ -21,7 +21,12 @@ export function indexOfPeersSuffix (depPath: string) {
   return -1
 }
 
-export function parseDepPath (relDepPath: string) {
+export interface ParsedDepPath {
+  id: string
+  peersSuffix: string
+}
+
+export function parseDepPath (relDepPath: string): ParsedDepPath {
   const sepIndex = indexOfPeersSuffix(relDepPath)
   if (sepIndex !== -1) {
     return {
@@ -35,7 +40,7 @@ export function parseDepPath (relDepPath: string) {
   }
 }
 
-export function removePeersSuffix (relDepPath: string) {
+export function removePeersSuffix (relDepPath: string): string {
   const sepIndex = indexOfPeersSuffix(relDepPath)
   if (sepIndex !== -1) {
     return relDepPath.substring(0, sepIndex)
@@ -43,7 +48,7 @@ export function removePeersSuffix (relDepPath: string) {
   return relDepPath
 }
 
-export function tryGetPackageId (relDepPath: string) {
+export function tryGetPackageId (relDepPath: string): string {
   const sepIndex = indexOfPeersSuffix(relDepPath)
   if (sepIndex !== -1) {
     relDepPath = relDepPath.substring(0, sepIndex)
@@ -54,7 +59,7 @@ export function tryGetPackageId (relDepPath: string) {
   return relDepPath
 }
 
-export function getRegistryByPackageName (registries: Registries, packageName: string) {
+export function getRegistryByPackageName (registries: Registries, packageName: string): string {
   if (packageName[0] !== '@') return registries.default
   const scope = packageName.substring(0, packageName.indexOf('/'))
   return registries[scope] || registries.default
@@ -76,7 +81,14 @@ export function refToRelative (
   return `${pkgName}@${reference}`
 }
 
-export function parse (dependencyPath: string) {
+export interface DependencyPath {
+  name?: string
+  peersSuffix?: string
+  version?: string
+  nonSemverVersion?: string
+}
+
+export function parse (dependencyPath: string): DependencyPath {
   // eslint-disable-next-line: strict-type-predicates
   if (typeof dependencyPath !== 'string') {
     throw new TypeError(`Expected \`dependencyPath\` to be of type \`string\`, got \`${
@@ -113,13 +125,12 @@ export function parse (dependencyPath: string) {
       peersSuffix,
     }
   }
-  return {
-  }
+  return {}
 }
 
 const MAX_LENGTH_WITHOUT_HASH = 120 - 26 - 1
 
-export function depPathToFilename (depPath: string) {
+export function depPathToFilename (depPath: string): string {
   let filename = depPathToFilenameUnescaped(depPath).replace(/[\\/:*?"<>|]/g, '+')
   if (filename.includes('(')) {
     filename = filename
@@ -132,7 +143,7 @@ export function depPathToFilename (depPath: string) {
   return filename
 }
 
-function depPathToFilenameUnescaped (depPath: string) {
+function depPathToFilenameUnescaped (depPath: string): string {
   if (depPath.indexOf('file:') !== 0) {
     if (depPath[0] === '/') {
       depPath = depPath.substring(1)


### PR DESCRIPTION
I want to improve type checker performance as recommended by https://github.com/microsoft/TypeScript/wiki/Performance#using-type-annotations.

In order to prevent merge conflict, I will do it one module at a time.