### PR TITLE
fix: error when `script-shell` is configured to a `.bat` or `.cmd` file

### DIFF
--- a/.changeset/shiny-zoos-love.md
+++ b/.changeset/shiny-zoos-love.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lifecycle": patch
+pnpm: patch
+---
+
+If the `script-shell` option is configured to a `.bat`/`.cmd` file on Windows, pnpm will now error with `ERR_PNPM_INVALID_SCRIPT_SHELL_WINDOWS`. Newer [versions of Node.js released in April 2024](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2) do not support executing these files directly without behavior differences. If the `script-shell` option is necessary for your use-case, please set a `.exe` file instead.

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -43,6 +43,7 @@
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/store-controller-types": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "is-windows": "^1.0.2",
     "path-exists": "^4.0.0",
     "run-groups": "^3.0.1"
   },
@@ -50,6 +51,7 @@
     "@pnpm/lifecycle": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@pnpm/test-ipc-server": "workspace:*",
+    "@types/is-windows": "^1.0.2",
     "@types/rimraf": "^3.0.2",
     "@zkochan/rimraf": "^2.1.3",
     "load-json-file": "^6.2.0"

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -167,5 +167,5 @@ function isWindowsBatchFile (scriptShell: string) {
   //
   // https://github.com/nodejs/node/commit/6627222409#diff-1e725bfa950eda4d4b5c0c00a2bb6be3e5b83d819872a1adf2ef87c658273903
   const scriptShellLower = scriptShell.toLowerCase()
-  return (scriptShellLower.endsWith('.cmd') || scriptShellLower.endsWith('.bat')) && isWindows()
+  return isWindows() && (scriptShellLower.endsWith('.cmd') || scriptShellLower.endsWith('.bat'))
 }

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -4,6 +4,7 @@ import lifecycle from '@pnpm/npm-lifecycle'
 import { type DependencyManifest, type ProjectManifest } from '@pnpm/types'
 import { PnpmError } from '@pnpm/error'
 import { existsSync } from 'fs'
+import isWindows from 'is-windows'
 
 function noop () {} // eslint-disable-line:no-empty
 
@@ -31,6 +32,39 @@ export async function runLifecycleHook (
   opts: RunLifecycleHookOptions
 ): Promise<void> {
   const optional = opts.optional === true
+
+  // To remediate CVE_2024_27980, Node.js does not allow .bat or .cmd files to
+  // be spawned without the "shell: true" option.
+  //
+  // https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
+  //
+  // Unfortunately, setting spawn's shell option also causes arguments to be
+  // evaluated before they're passed to the shell, resulting in a surprising
+  // behavior difference only with .bat/.cmd files.
+  //
+  // Instead of showing a "spawn EINVAL" error, let's throw a clearer error that
+  // this isn't supported.
+  //
+  // If this behavior needs to be supported in the future, the arguments would
+  // need to be escaped before they're passed to the .bat/.cmd file. For
+  // example, scripts such as "echo %PATH%" should be passed verbatim rather
+  // than expanded. This is difficult to do correctly. Other open source tools
+  // (e.g. Rust) attempted and introduced bugs. The Rust blog has a good
+  // high-level explanation of the same security vulnerability Node.js patched.
+  //
+  // https://blog.rust-lang.org/2024/04/09/cve-2024-24576.html#overview
+  //
+  // Note that npm (as of version 10.5.0) doesn't support setting script-shell
+  // to a .bat or .cmd file either.
+  if (opts.scriptShell != null && isWindowsBatchFile(opts.scriptShell)) {
+    throw new PnpmError('ERR_PNPM_INVALID_SCRIPT_SHELL_WINDOWS', 'Cannot spawn .bat or .cmd as a script shell.', {
+      hint: `\
+The .npmrc script-shell option was configured to a .bat or .cmd file. These cannot be used as a script shell reliably.
+
+Please unset the script-shell option, or configure it to a .exe instead.
+`,
+    })
+  }
 
   const m = { _id: getId(manifest), ...manifest }
   m.scripts = { ...m.scripts }
@@ -125,4 +159,13 @@ export async function runLifecycleHook (
 
 function getId (manifest: ProjectManifest | DependencyManifest): string {
   return `${manifest.name ?? ''}@${manifest.version ?? ''}`
+}
+
+function isWindowsBatchFile (scriptShell: string) {
+  // Node.js performs a similar check to determine whether it should throw
+  // EINVAL when spawning a .cmd/.bat file.
+  //
+  // https://github.com/nodejs/node/commit/6627222409#diff-1e725bfa950eda4d4b5c0c00a2bb6be3e5b83d819872a1adf2ef87c658273903
+  const scriptShellLower = scriptShell.toLowerCase()
+  return (scriptShellLower.endsWith('.cmd') || scriptShellLower.endsWith('.bat')) && isWindows()
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,6 +1177,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      is-windows:
+        specifier: ^1.0.2
+        version: 1.0.2
       path-exists:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1193,6 +1196,9 @@ importers:
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
+      '@types/is-windows':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@types/rimraf':
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
## Problem

Configuring [`script-shell` in `.npmrc`](https://pnpm.io/cli/run#script-shell) on Windows to a `.bat` or `.cmd` file,

```ini
# .npmrc
script-shell = node_modules/.bin/shell-mock.cmd
```

will result in:

```
spawn EINVAL

  at spawn (../../node_modules/.pnpm/@pnpm+npm-lifecycle@3.0.2_typanion@3.14.0/node_modules/@pnpm/npm-lifecycle/lib/spawn.js:36:15)
```

This previously worked, but changed after the [Node.js security release on April 10th, 2024](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2).

## Prior Attempt

Yesterday, I attempted to update `@pnpm/npm-lifecycle` to support `.bat`/`.cmd` files, but this change was reverted after discovering behavior differences with arguments passed to these `.bat`/`.cmd` files.

https://github.com/pnpm/npm-lifecycle/pull/42

## What does npm do?

As of version 10.5.0, npm doesn't handle `.cmd` files for `script-shell` either on Node.js 21.7.3.

<img width="1470" alt="Screenshot 2024-04-16 at 10 45 18 PM" src="https://github.com/pnpm/pnpm/assets/906558/c3556083-5728-4a7b-918e-dbda9b31eb8a">

## Proposal

Let's show an error if `.bat`/`.cmd` files are set as the `script-shell` for now.

I think there's several strong reasons for this:

1. We would have to implement a Windows-specific argument escaping function to maintain expected behavior under this configuration.
2. npm doesn't support this configuration.
3. This behavior is currently broken when pnpm runs on newer versions of Node.js anyway, so this change just makes the existing error more clear. We can always try a different approach later if users provide a valid use-case.

To elaborate on the first point, I haven't found an easy way to support `.bat`/`.cmd` files as shells on newer versions of Node.js without making `.bat` or `.cmd` files behave differently than `.exe` files or shells on Linux or macOS. Arguments are parsed regardless of `spawn`, `exec`, `execFile`, or `windowsVerbatimArguments` options. I believe the correct behavior would involve manually escaping variables like `%PATH%` so they're passed verbatim to the `script-shell`. The Rust team attempted to do something similar so arguments are passed verbatim, but [their implementation was incorrect](https://blog.rust-lang.org/2024/04/09/cve-2024-24576.html#overview). I don't think we should try to do the same given that. From their blog post (emphasis mine):

> On Windows, the implementation of this is more complex than other platforms, because the Windows API only provides a single string containing all the arguments to the spawned process, and it's up to the spawned process to split them. Most programs use the standard C run-time argv, which in practice results in a mostly consistent way arguments are splitted.
>
> One exception though is `cmd.exe` (used among other things to execute batch files), which has its own argument splitting logic. That forces the standard library to implement custom escaping for arguments passed to batch files. **Unfortunately it was reported that our escaping logic was not thorough enough, and it was possible to pass malicious arguments that would result in arbitrary shell execution.**

## Changes

Here's a screenshot of the new error users will see under this unsupported configuration.

<img width="1470" alt="Screenshot 2024-04-16 at 11 06 50 PM" src="https://github.com/pnpm/pnpm/assets/906558/ff44b1b5-d117-472a-a504-71548220da87">
