### PR TITLE
refactor(resolve-dependencies): annotate linkedDep as ResolvedDirectDependency

### DIFF
--- a/pkg-manager/resolve-dependencies/src/dedupeInjectedDeps.ts
+++ b/pkg-manager/resolve-dependencies/src/dedupeInjectedDeps.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import normalize from 'normalize-path'
-import { type ResolvedImporters } from './resolveDependencyTree'
+import { type ResolvedDirectDependency, type ResolvedImporters } from './resolveDependencyTree'
 import { type LinkedDependency } from './resolveDependencies'
 import {
   type DependenciesByProjectId,
@@ -79,7 +79,7 @@ function applyDedupeMap<T extends PartialResolvedPackage> (
       const index = opts.resolvedImporters[id].directDependencies.findIndex((dep) => dep.alias === alias)
       const prev = opts.resolvedImporters[id].directDependencies[index]
       const depPath = `link:${normalize(path.relative(id, dedupedProjectId))}`
-      const linkedDep: LinkedDependency = {
+      const linkedDep: LinkedDependency & ResolvedDirectDependency = {
         ...prev,
         isLinkedDependency: true,
         depPath,


### PR DESCRIPTION
Very small change to improve type checking.

The `linkedDep` constant is pushed to `opts.resolvedImporters[id].directDependencies`, which requires its entries to satisfy the `ResolvedDirectDependency` interface. Making the type annotation on `linkedDep` more accurate so errors are clearer if someone changes `ResolvedDirectDependency` in the future.

<img width="834" alt="Screenshot 2024-04-21 at 8 39 14 PM" src="https://github.com/pnpm/pnpm/assets/906558/86b5eed4-41fe-482b-9474-d4719613fbfc">