### PR TITLE
fix: don't upgrade the lockfile format during frozen lockfile install

### DIFF
--- a/.changeset/quick-walls-report.md
+++ b/.changeset/quick-walls-report.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Don't upgrade the lockfile format on `pnpm install --frozen-lockfile` [#7991](https://github.com/pnpm/pnpm/issues/7991).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -471,7 +471,10 @@ Note that in CI environments, this setting is enabled by default.`,
             wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
             useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
           })
-          if (opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles || !upToDateLockfileMajorVersion) {
+          if (
+            opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
+            !upToDateLockfileMajorVersion && !opts.frozenLockfile
+          ) {
             await writeLockfiles({
               currentLockfile: ctx.currentLockfile,
               currentLockfileDir: ctx.virtualStoreDir,


### PR DESCRIPTION
close #7991