### PR TITLE
DRAFT: Test on macOS Intel X64 and ARM64 Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,11 @@ jobs:
           - '20'
           - '21'
         platform:
-          - ubuntu-latest
-          - windows-latest
+          # - ubuntu-latest
+          # - windows-latest
+          # macos-13 is Intel X64, macos-14 is ARM64 Apple Silicon
+          - macos-13
+          - macos-14
 
     name: '${{matrix.platform}} / Node.js ${{ matrix.node }}'
     runs-on: ${{matrix.platform}}


### PR DESCRIPTION
# Just an experiment...

Will `pnpm` on `npm@v7` work on Apple Silicon?

GitHub Actions blog:
> Over the next 12 weeks, jobs using the `macos-latest` runner label will migrate from macOS 12 (Monterey) to macOS 14 (Sonoma).

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image