### PR TITLE
feat: implement catalog protocol reads (feature flagged)

### DIFF
--- a/catalogs/protocol-parser/CHANGELOG.md
+++ b/catalogs/protocol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.protocol-parser
+
+## 0.1.0
+
+Initial release

--- a/catalogs/protocol-parser/README.md
+++ b/catalogs/protocol-parser/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.protocol-parser
+
+> Parse catalog protocol specifiers and return the catalog name.

--- a/catalogs/protocol-parser/jest.config.js
+++ b/catalogs/protocol-parser/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/catalogs/protocol-parser/package.json
+++ b/catalogs/protocol-parser/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pnpm/catalogs.protocol-parser",
+  "version": "0.1.0",
+  "description": "Parse catalog protocol specifiers and return the catalog name.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/protocol-parser",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/protocol-parser#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile && pnpm run _test",
+    "_test": "jest"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:*"
+  }
+}

--- a/catalogs/protocol-parser/src/index.ts
+++ b/catalogs/protocol-parser/src/index.ts
@@ -1,0 +1,1 @@
+export { parseCatalogProtocol } from './parseCatalogProtocol'

--- a/catalogs/protocol-parser/src/parseCatalogProtocol.ts
+++ b/catalogs/protocol-parser/src/parseCatalogProtocol.ts
@@ -1,0 +1,18 @@
+const CATALOG_PROTOCOL = 'catalog:'
+
+/**
+ * Parse a package.json dependency specifier using the catalog: protocol.
+ * Returns null if the given specifier does not start with 'catalog:'.
+ */
+export function parseCatalogProtocol (pref: string): string | 'default' | null {
+  if (!pref.startsWith(CATALOG_PROTOCOL)) {
+    return null
+  }
+
+  const catalogNameRaw = pref.slice(CATALOG_PROTOCOL.length).trim()
+
+  // Allow a specifier of 'catalog:' to be a short-hand for 'catalog:default'.
+  const catalogNameNormalized = catalogNameRaw === '' ? 'default' : catalogNameRaw
+
+  return catalogNameNormalized
+}

--- a/catalogs/protocol-parser/test/parseCatalogProtocol.test.ts
+++ b/catalogs/protocol-parser/test/parseCatalogProtocol.test.ts
@@ -1,0 +1,20 @@
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+
+test('parses named catalog', () => {
+  expect(parseCatalogProtocol('catalog:foo')).toBe('foo')
+  expect(parseCatalogProtocol('catalog:bar')).toBe('bar')
+})
+
+test('returns null for specifier not using catalog protocol', () => {
+  expect(parseCatalogProtocol('^1.0.0')).toBe(null)
+})
+
+describe('default catalog', () => {
+  test('parses explicit default catalog', () => {
+    expect(parseCatalogProtocol('catalog:default')).toBe('default')
+  })
+
+  test('parses implicit catalog', () => {
+    expect(parseCatalogProtocol('catalog:')).toBe('default')
+  })
+})

--- a/catalogs/protocol-parser/tsconfig.json
+++ b/catalogs/protocol-parser/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": []
+}

--- a/catalogs/protocol-parser/tsconfig.lint.json
+++ b/catalogs/protocol-parser/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/catalogs/types/CHANGELOG.md
+++ b/catalogs/types/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.types
+
+## 0.1.0
+
+Initial release

--- a/catalogs/types/README.md
+++ b/catalogs/types/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.types
+
+> Types related to the pnpm catalogs feature.

--- a/catalogs/types/package.json
+++ b/catalogs/types/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pnpm/catalogs.types",
+  "version": "0.1.0",
+  "description": "Types related to the pnpm catalogs feature.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/types",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/types#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.types": "workspace:*"
+  }
+}

--- a/catalogs/types/src/index.ts
+++ b/catalogs/types/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Catalogs parsed from the pnpm-workspace.yaml file.
+ *
+ * https://github.com/pnpm/rfcs/pull/1
+ */
+export interface Catalogs {
+  /**
+   * The default catalog.
+   *
+   * The default catalog can be defined in 2 ways.
+   *
+   *   1. Users can specify a top-level "catalog" field or,
+   *   2. An explicitly named "default" catalog under the "catalogs" map.
+   *
+   * This field contains either definition. Note that it's an error to define
+   * the default catalog using both options. The parser will fail when reading
+   * the workspace manifest.
+   */
+  readonly default?: Catalog
+
+  /**
+   * Named catalogs.
+   */
+  readonly [catalogName: string]: Catalog | undefined
+}
+
+export interface Catalog {
+  readonly [dependencyName: string]: string | undefined
+}

--- a/catalogs/types/tsconfig.json
+++ b/catalogs/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": []
+}

--- a/catalogs/types/tsconfig.lint.json
+++ b/catalogs/types/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/lockfile/lockfile-file/src/lockfileFormatConverters.ts
+++ b/lockfile/lockfile-file/src/lockfileFormatConverters.ts
@@ -113,6 +113,9 @@ function normalizeLockfile (lockfile: InlineSpecifiersLockfile, opts: NormalizeL
   if (lockfileToSave.time) {
     lockfileToSave.time = pruneTimeInLockfileV6(lockfileToSave.time, lockfile.importers ?? {})
   }
+  if ((lockfileToSave.catalogs != null) && isEmpty(lockfileToSave.catalogs)) {
+    delete lockfileToSave.catalogs
+  }
   if ((lockfileToSave.overrides != null) && isEmpty(lockfileToSave.overrides)) {
     delete lockfileToSave.overrides
   }

--- a/lockfile/lockfile-file/src/sortLockfileKeys.ts
+++ b/lockfile/lockfile-file/src/sortLockfileKeys.ts
@@ -35,6 +35,7 @@ type RootKey = keyof LockfileFile
 const ROOT_KEYS: readonly RootKey[] = [
   'lockfileVersion',
   'settings',
+  'catalogs',
   'overrides',
   'packageExtensionsChecksum',
   'pnpmfileChecksum',
@@ -82,6 +83,15 @@ export function sortLockfileKeys (lockfile: LockfileFileV9): LockfileFileV9 {
     for (const [pkgId, pkg] of Object.entries(lockfile.snapshots)) {
       lockfile.snapshots[pkgId] = sortKeys(pkg, {
         compare: compareWithPriority.bind(null, ORDERED_KEYS),
+        deep: true,
+      })
+    }
+  }
+  if (lockfile.catalogs != null) {
+    lockfile.catalogs = sortKeys(lockfile.catalogs)
+    for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
+      lockfile.catalogs[catalogName] = sortKeys(catalog, {
+        compare: lexCompare,
         deep: true,
       })
     }

--- a/lockfile/lockfile-types/src/index.ts
+++ b/lockfile/lockfile-types/src/index.ts
@@ -13,6 +13,7 @@ export interface Lockfile {
   importers: Record<string, ProjectSnapshot>
   lockfileVersion: string
   time?: Record<string, string>
+  catalogs?: CatalogSnapshots
   packages?: PackageSnapshots
   overrides?: Record<string, string>
   packageExtensionsChecksum?: string
@@ -135,3 +136,24 @@ export type PackageBin = string | { [name: string]: string }
  * }
  */
 export type ResolvedDependencies = Record<string, string>
+
+export interface CatalogSnapshots {
+  [catalogName: string]: { [dependencyName: string]: ResolvedCatalogEntry }
+}
+
+export interface ResolvedCatalogEntry {
+  /**
+   * The real specifier that should be used for this dependency's catalog entry.
+   * This would be the ^1.2.3 portion of:
+   *
+   * @example
+   * catalog:
+   *   foo: ^1.2.3
+   */
+  readonly specifier: string
+
+  /**
+   * The concrete version that the requested specifier resolved to. Ex: 1.2.3
+   */
+  readonly version: string
+}

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -19,6 +19,8 @@
     "@pnpm/build-modules": "workspace:*",
     "@pnpm/builder.policy": "3.0.0",
     "@pnpm/calc-dep-state": "workspace:*",
+    "@pnpm/catalogs.protocol-parser": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/crypto.base32-hash": "workspace:*",

--- a/pkg-manager/core/src/getPeerDependencyIssues.ts
+++ b/pkg-manager/core/src/getPeerDependencyIssues.ts
@@ -55,6 +55,7 @@ export async function getPeerDependencyIssues (
   } = await resolveDependencies(
     projectsToResolve,
     {
+      catalogs: ctx.catalogs,
       currentLockfile: ctx.currentLockfile,
       allowedDeprecatedVersions: {},
       allowNonAppliedPatches: false,

--- a/pkg-manager/core/src/install/allCatalogsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allCatalogsAreUpToDate.ts
@@ -1,0 +1,11 @@
+import { type CatalogSnapshots } from '@pnpm/lockfile-file'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+export function allCatalogsAreUpToDate (
+  catalogsConfig: Catalogs,
+  snapshot: CatalogSnapshots | undefined
+): boolean {
+  return Object.entries(snapshot ?? {})
+    .every(([catalogName, catalog]) => Object.entries(catalog ?? {})
+      .every(([alias, entry]) => entry.specifier === catalogsConfig[catalogName]?.[alias]))
+}

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -144,6 +144,8 @@ export interface StrictInstallOptions {
 
   supportedArchitectures?: SupportedArchitectures
   hoistWorkspacePackages?: boolean
+
+  useBetaCatalogsFeat?: boolean
 }
 
 export type InstallOptions =

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1024,6 +1024,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       autoInstallPeers: opts.autoInstallPeers,
       autoInstallPeersFromHighestMatch: opts.autoInstallPeersFromHighestMatch,
       catalogs: ctx.catalogs,
+      useBetaCatalogsFeat: opts.useBetaCatalogsFeat,
       currentLockfile: ctx.currentLockfile,
       defaultUpdateDepth: opts.depth,
       dedupeDirectDeps: opts.dedupeDirectDeps,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1023,6 +1023,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       allowNonAppliedPatches: opts.allowNonAppliedPatches,
       autoInstallPeers: opts.autoInstallPeers,
       autoInstallPeersFromHighestMatch: opts.autoInstallPeersFromHighestMatch,
+      catalogs: ctx.catalogs,
       currentLockfile: ctx.currentLockfile,
       defaultUpdateDepth: opts.depth,
       dedupeDirectDeps: opts.dedupeDirectDeps,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -624,6 +624,10 @@ Note that in CI environments, this setting is enabled by default.`,
     }
     /* eslint-enable no-await-in-loop */
 
+    function isWantedDepPrefSame (_alias: string, prevPref: string | undefined, nextPref: string): boolean {
+      return prevPref !== nextPref
+    }
+
     async function installCase (project: any) { // eslint-disable-line
       const wantedDependencies = getWantedDependencies(project.manifest, {
         autoInstallPeers: opts.autoInstallPeers,
@@ -634,7 +638,7 @@ Note that in CI environments, this setting is enabled by default.`,
         .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
 
       if (ctx.wantedLockfile?.importers) {
-        forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies)
+        forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, isWantedDepPrefSame)
       }
       if (opts.ignoreScripts && project.manifest?.scripts &&
         (project.manifest.scripts.preinstall ||
@@ -796,13 +800,17 @@ function pkgHasDependencies (manifest: ProjectManifest): boolean {
 
 // If the specifier is new, the old resolution probably does not satisfy it anymore.
 // By removing these resolutions we ensure that they are resolved again using the new specs.
-function forgetResolutionsOfPrevWantedDeps (importer: ProjectSnapshot, wantedDeps: WantedDependency[]): void {
+function forgetResolutionsOfPrevWantedDeps (
+  importer: ProjectSnapshot,
+  wantedDeps: WantedDependency[],
+  isWantedDepPrefSame: (alias: string, prevPref: string | undefined, nextPref: string) => boolean
+): void {
   if (!importer.specifiers) return
   importer.dependencies = importer.dependencies ?? {}
   importer.devDependencies = importer.devDependencies ?? {}
   importer.optionalDependencies = importer.optionalDependencies ?? {}
   for (const { alias, pref } of wantedDeps) {
-    if (alias && importer.specifiers[alias] !== pref) {
+    if (alias && !isWantedDepPrefSame(alias, importer.specifiers[alias], pref)) {
       if (!importer.dependencies[alias]?.startsWith('link:')) {
         delete importer.dependencies[alias]
       }

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -25,6 +25,12 @@
       "path": "../../__utils__/test-ipc-server"
     },
     {
+      "path": "../../catalogs/protocol-parser"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../config/matcher"
     },
     {

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -37,6 +37,7 @@
     "@pnpm/logger": "^5.0.0"
   },
   "dependencies": {
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/error": "workspace:*",
@@ -44,6 +45,7 @@
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/read-projects-context": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*",
     "@zkochan/rimraf": "^2.1.3",
     "ci-info": "^3.9.0",
     "enquirer": "^2.4.1",

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -99,6 +99,15 @@ export interface GetContextOptions {
   publicHoistPattern?: string[] | undefined
   forcePublicHoistPattern?: boolean
   global?: boolean
+
+  /**
+   * A temporary feature flag that determines whether or not pnpm catalogs
+   * should be used. This will default to true and be removed when catalogs
+   * development has finished.
+   *
+   * @default false
+   */
+  useBetaCatalogsFeat?: boolean
 }
 interface ImporterToPurge {
   modulesDir: string

--- a/pkg-manager/get-context/src/readCatalogsFromWorkspaceManifest.ts
+++ b/pkg-manager/get-context/src/readCatalogsFromWorkspaceManifest.ts
@@ -1,0 +1,25 @@
+import { type Catalogs } from '@pnpm/catalogs.types'
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest'
+
+export async function readCatalogsFromWorkspaceManifest (
+  workspaceDir: string,
+  isCatalogsFeatureFlagEnabled: boolean
+): Promise<Catalogs> {
+  const workspaceManifest = await readWorkspaceManifest(workspaceDir, { catalogs: isCatalogsFeatureFlagEnabled })
+
+  if (workspaceManifest?.catalog == null && workspaceManifest?.catalogs == null) {
+    return {}
+  }
+
+  return {
+    // The readWorkspaceManifest function validates that the default catalog is
+    // specified using only the "catalog" field or as a named catalog under the
+    // catalogs block, but not both.
+    //
+    // If workspaceManifest.catalog is undefined, intentionally allow the spread
+    // below to overwrite it.
+    default: workspaceManifest.catalog,
+
+    ...workspaceManifest.catalogs,
+  }
+}

--- a/pkg-manager/get-context/tsconfig.json
+++ b/pkg-manager/get-context/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../lockfile/lockfile-file"
     },
     {
@@ -23,6 +26,9 @@
     },
     {
       "path": "../../packages/types"
+    },
+    {
+      "path": "../../workspace/read-manifest"
     },
     {
       "path": "../modules-yaml"

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -313,6 +313,14 @@ export type InstallCommandOptions = Pick<Config,
   workspace?: boolean
   includeOnlyPackageFiles?: boolean
   confirmModulesPurge?: boolean
+  /**
+   * A temporary feature flag that determines whether or not pnpm catalogs
+   * should be used. This will default to true and be removed when catalogs
+   * development has finished.
+   *
+   * @default false
+   */
+  useBetaCatalogsFeat?: boolean
 } & Partial<Pick<Config, 'modulesCacheMaxAge' | 'pnpmHomeDir' | 'preferWorkspacePackages'>>
 
 export async function handler (opts: InstallCommandOptions): Promise<void> {

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -113,6 +113,7 @@ export type InstallDepsOptions = Pick<Config,
   dedupe?: boolean
   workspace?: boolean
   includeOnlyPackageFiles?: boolean
+  useBetaCatalogsFeat?: boolean
 } & Partial<Pick<Config, 'pnpmHomeDir'>>
 
 export async function installDeps (

--- a/pkg-manager/plugin-commands-installation/test/catalog.ts
+++ b/pkg-manager/plugin-commands-installation/test/catalog.ts
@@ -1,0 +1,324 @@
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { type Lockfile } from '@pnpm/lockfile-types'
+import { type ProjectManifest } from '@pnpm/types'
+import { readProjects } from '@pnpm/filter-workspace-packages'
+import { preparePackages } from '@pnpm/prepare'
+import { install } from '@pnpm/plugin-commands-installation'
+import { DEFAULT_OPTS } from './utils'
+import path from 'path'
+import readYamlFile from 'read-yaml-file'
+import writeYamlFile from 'write-yaml-file'
+
+/**
+ * A utility to make writing catalog tests easier by reducing boilerplate.
+ */
+class CatalogTestsController {
+  private readonly workspaceDir: string
+
+  constructor (readonly pkgs: Array<{ location: string, package: ProjectManifest }>) {
+    preparePackages(pkgs)
+    this.workspaceDir = process.cwd()
+  }
+
+  async writeWorkspaceYml (data: unknown) {
+    await writeYamlFile(path.join(this.workspaceDir, 'pnpm-workspace.yaml'), data)
+  }
+
+  async install (opts?: { frozenLockfile?: boolean, filter?: readonly string[] }) {
+    const { allProjects, selectedProjectsGraph } = await readProjects(this.workspaceDir, opts?.filter?.map(parentDir => ({ parentDir })) ?? [])
+    await install.handler({
+      ...DEFAULT_OPTS,
+      allProjects,
+      dir: this.workspaceDir,
+      lockfileDir: this.workspaceDir,
+      recursive: true,
+      selectedProjectsGraph,
+      workspaceDir: this.workspaceDir,
+      useBetaCatalogsFeat: true,
+
+      rawLocalConfig: {
+        ...DEFAULT_OPTS.rawLocalConfig,
+        // Many tests check if the pnpm-lock.yaml is updated after a
+        // package.json or pnpm-workspace.yaml change. Setting frozen-lockfile
+        // to false is necessary for these tests to pass on CI since this
+        // defaults to true on CI.
+        'frozen-lockfile': opts?.frozenLockfile ?? true,
+      },
+    })
+  }
+
+  async lockfile (): Promise<Lockfile> {
+    return readYamlFile(path.join(this.workspaceDir, WANTED_LOCKFILE))
+  }
+
+  async updateProjectManifest (location: string, manifest: ProjectManifest): Promise<void> {
+    const { selectedProjectsGraph } = await readProjects(this.workspaceDir, [{ parentDir: location }])
+    await selectedProjectsGraph[path.join(this.workspaceDir, location)].package.writeProjectManifest(manifest)
+  }
+}
+
+test('installing with "catalog:" should work', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+    // Empty second project to create a multi-package workspace.
+    {
+      location: 'packages/project2',
+      package: {},
+    },
+  ])
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: { 'is-positive': '1.0.0' },
+  })
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.importers['packages/project1']).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+})
+
+test('importer to importer dependency with "catalog:" should work', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        name: 'project1',
+        dependencies: {
+          project2: 'workspace:*',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        name: 'project2',
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: { 'is-positive': '1.0.0' },
+  })
+
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.importers['packages/project2']).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+})
+
+test('lockfile contains catalog snapshots', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        dependencies: {
+          'is-negative': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '^1.0.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.catalogs).toStrictEqual({
+    default: {
+      'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+    },
+  })
+})
+
+test('lockfile is updated if catalog config changes', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: { 'is-positive': '=1.0.0' },
+  })
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).importers['packages/project1']).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '=3.1.0',
+    },
+  })
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).importers['packages/project1']).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '3.1.0',
+      },
+    },
+  })
+})
+
+test('lockfile catalog snapshots retain existing entries on --filter', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-negative': 'catalog:',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '^1.0.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).catalogs).toStrictEqual({
+    default: {
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+      'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+    },
+  })
+
+  // Update catalog definitions so pnpm triggers a rerun.
+  await ctrl.writeWorkspaceYml({
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '=3.1.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+  await ctrl.install({ filter: ['packages/project2'] })
+
+  expect((await ctrl.lockfile()).catalogs).toStrictEqual({
+    default: {
+      // The is-negative snapshot should be carried from the previous install,
+      // despite the current filtered install not using it.
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+
+      'is-positive': { specifier: '=3.1.0', version: '3.1.0' },
+    },
+  })
+})
+
+test('lockfile catalog snapshots should keep unused entries', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  await writeYamlFile('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '=1.0.0',
+    },
+  })
+
+  {
+    await ctrl.install()
+    const lockfile = await ctrl.lockfile()
+    expect(lockfile.importers['packages/project1']?.dependencies?.['is-positive']).toEqual({
+      specifier: 'catalog:',
+      version: '1.0.0',
+    })
+    expect(lockfile.catalogs?.default).toStrictEqual({
+      'is-positive': { specifier: '=1.0.0', version: '1.0.0' },
+    })
+  }
+
+  await ctrl.updateProjectManifest('packages/project1', { dependencies: { 'is-positive': '=1.0.0' } })
+  await ctrl.install()
+
+  {
+    const lockfile = await ctrl.lockfile()
+    expect(lockfile.importers['packages/project1']).toEqual({
+      dependencies: {
+        'is-positive': {
+          specifier: '=1.0.0',
+          version: '1.0.0',
+        },
+      },
+    })
+    expect(lockfile.catalogs?.default).toStrictEqual({
+      'is-positive': { specifier: '=1.0.0', version: '1.0.0' },
+    })
+  }
+})

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -29,6 +29,7 @@
     "_test": "jest"
   },
   "dependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -29,6 +29,7 @@
     "_test": "jest"
   },
   "dependencies": {
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",

--- a/pkg-manager/resolve-dependencies/src/getCatalogResolver.ts
+++ b/pkg-manager/resolve-dependencies/src/getCatalogResolver.ts
@@ -1,0 +1,55 @@
+import { PnpmError } from '@pnpm/error'
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+export interface WantedDependency {
+  readonly pref: string
+  readonly alias: string
+}
+
+/**
+ * Dereferences a wanted dependency using the catalog protocol and returns the
+ * configured version.
+ *
+ * Example: catalog:default -> ^1.2.3
+ *
+ * @returns The catalog entry or undefined if the wanted dependency does not use
+ * the catalog protocol.
+ *
+ * @throws {@link PnpmError} if the catalog entry does not exist.
+ */
+export type CatalogResolver = (wantedDependency: WantedDependency) => CatalogResolution | undefined
+
+export interface CatalogResolution {
+  /**
+   * The name of the catalog the resolved specifier was defined in.
+   */
+  readonly catalogName: string
+
+  /**
+   * The specifier that should be used for the wanted dependency.
+   */
+  readonly entrySpecifier: string
+}
+
+export function getCatalogResolver (catalogs: Catalogs): CatalogResolver {
+  return function resolveFromCatalog (wantedDependency: WantedDependency): CatalogResolution | undefined {
+    const catalogName = parseCatalogProtocol(wantedDependency.pref)
+
+    if (catalogName == null) {
+      return undefined
+    }
+
+    const catalogLookup = catalogs[catalogName]?.[wantedDependency.alias]
+    if (catalogLookup == null) {
+      throw new PnpmError(
+        'CATALOG_ENTRY_NOT_FOUND_FOR_SPEC',
+        `No catalog entry was found for catalog ${catalogName} and ${wantedDependency.alias}.`)
+    }
+
+    return {
+      catalogName,
+      entrySpecifier: catalogLookup,
+    }
+  }
+}

--- a/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
+++ b/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
@@ -1,0 +1,66 @@
+import { type CatalogSnapshots } from '@pnpm/lockfile-types'
+import { type ResolvedDirectDependency } from './resolveDependencyTree'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+export function getCatalogSnapshots (
+  resolvedDirectDeps: readonly ResolvedDirectDependency[],
+  catalogsConfig: Catalogs,
+  prevSnapshots: CatalogSnapshots = {}
+): CatalogSnapshots {
+  const nextSnapshots: CatalogSnapshots = {}
+
+  // Note that "snapshotUpdates" only contains the catalog lookups relevant to a
+  // filtered install. This is by design.
+  //
+  // To avoid wiping away previous catalog snapshots that weren't involved in a
+  // filtered install, we'll need to merge these updates in with the
+  // "prevSnapshots" from the existing wanted lockfile.
+  const snapshotUpdates = getCatalogSnapshotsForResolvedDeps(resolvedDirectDeps)
+
+  const catalogNames = [...Object.keys(prevSnapshots), ...Object.keys(snapshotUpdates)]
+    // Avoid persisting catalog lockfile snapshots that are no longer in the
+    // catalog config. This has a strange interaction with filtered installs and
+    // may need to be improved. Stale catalog references may linger for an
+    // importer if the catalog entry was removed but we're running a filtered
+    // installed that does not include that importer.
+    .filter(catalogName => catalogsConfig[catalogName] != null)
+
+  for (const catalogName of catalogNames) {
+    const prevAliases = Object.keys(prevSnapshots[catalogName] ?? {})
+    const usedAliases = Object.keys(snapshotUpdates[catalogName] ?? {})
+
+    const aliases = [...prevAliases, ...usedAliases]
+      // Similar to the above, avoid persisting lockfile catalog snapshot
+      // entries that are no longer part of the pnpm-workspace.yaml catalogs
+      // config.
+      .filter(alias => catalogsConfig[catalogName]?.[alias] != null)
+
+    for (const alias of aliases) {
+      const entry = snapshotUpdates[catalogName]?.[alias] ?? prevSnapshots[catalogName]?.[alias]
+      if (entry != null) {
+        (nextSnapshots[catalogName] ??= {})[alias] ??= entry
+      }
+    }
+  }
+
+  return nextSnapshots
+}
+
+export function getCatalogSnapshotsForResolvedDeps (resolvedDirectDeps: readonly ResolvedDirectDependency[]): CatalogSnapshots {
+  const catalogSnapshots: CatalogSnapshots = {}
+  const catalogedDeps = resolvedDirectDeps.filter(isCatalogedDep)
+
+  for (const dep of catalogedDeps) {
+    const snapshotForSingleCatalog = (catalogSnapshots[dep.catalogLookup.catalogName] ??= {})
+    snapshotForSingleCatalog[dep.alias] = {
+      specifier: dep.catalogLookup.entrySpecifier,
+      version: dep.version,
+    }
+  }
+
+  return catalogSnapshots
+}
+
+function isCatalogedDep (dep: ResolvedDirectDependency): dep is ResolvedDirectDependency & { catalogLookup: Required<ResolvedDirectDependency>['catalogLookup'] } {
+  return dep.catalogLookup != null
+}

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -44,6 +44,7 @@ import {
 import { toResolveImporter } from './toResolveImporter'
 import { updateLockfile } from './updateLockfile'
 import { updateProjectManifest } from './updateProjectManifest'
+import { getCatalogSnapshots } from './getCatalogSnapshots'
 
 export type DependenciesGraph = GenericDependenciesGraph<ResolvedPackage>
 
@@ -295,6 +296,11 @@ export async function resolveDependencies (
       ...time,
     }
   }
+
+  newLockfile.catalogs = getCatalogSnapshots(
+    Object.values(resolvedImporters).flatMap(x => x.directDependencies),
+    opts.catalogs,
+    opts.wantedLockfile.catalogs)
 
   // waiting till package requests are finished
   async function waitTillAllFetchingsFinish (): Promise<void> {

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { type Catalogs } from '@pnpm/catalogs.types'
 import {
   deprecationLogger,
   progressLogger,
@@ -50,6 +49,7 @@ import omit from 'ramda/src/omit'
 import zipWith from 'ramda/src/zipWith'
 import semver from 'semver'
 import { encodePkgId } from './encodePkgId'
+import { type CatalogResolver } from './getCatalogResolver'
 import { getNonDevWantedDependencies, type WantedDependency } from './getNonDevWantedDependencies'
 import { safeIntersect } from './mergePeers'
 import {
@@ -139,6 +139,7 @@ export interface ResolutionContext {
   allPreferredVersions?: PreferredVersions
   appliedPatches: Set<string>
   updatedSet: Set<string>
+  catalogResolver: CatalogResolver
   defaultTag: string
   dryRun: boolean
   forceFullResolution: boolean
@@ -1124,7 +1125,13 @@ async function resolveDependency (
       optional: true,
     }
   }
+
+  const catalogLookup = ctx.catalogResolver(wantedDependency)
+
   try {
+    if (catalogLookup != null) {
+      wantedDependency.pref = catalogLookup.entrySpecifier
+    }
     if (!options.update && currentPkg.version && currentPkg.pkgId?.endsWith(`@${currentPkg.version}`)) {
       wantedDependency.pref = replaceVersionInPref(wantedDependency.pref, currentPkg.version)
     }

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -59,6 +59,7 @@ import {
   splitNodeId,
 } from './nodeIdUtils'
 import { hoistPeers } from './hoistPeers'
+import { type CatalogLookupMetadata } from './resolveDependencyTree'
 import { wantedDepIsLocallyAvailable } from './wantedDepIsLocallyAvailable'
 import { replaceVersionInPref } from './replaceVersionInPref'
 
@@ -114,6 +115,7 @@ export interface LinkedDependency {
   name: string
   normalizedPref?: string
   alias: string
+  catalogLookup?: CatalogLookupMetadata
 }
 
 export interface PendingNode {
@@ -199,6 +201,7 @@ export type PkgAddress = {
   missingPeers: MissingPeers
   missingPeersOfChildren?: MissingPeersOfChildren
   publishedAt?: string
+  catalogLookup?: CatalogLookupMetadata
   optional: boolean
 } & ({
   isLinkedDependency: true
@@ -1224,6 +1227,7 @@ async function resolveDependency (
     }
     return {
       alias: wantedDependency.alias || pkgResponse.body.manifest.name || path.basename(pkgResponse.body.resolution.directory),
+      catalogLookup,
       depPath: pkgResponse.body.id,
       dev: wantedDependency.dev,
       isLinkedDependency: true,
@@ -1433,6 +1437,7 @@ async function resolveDependency (
   }
   return {
     alias: wantedDependency.alias || pkg.name,
+    catalogLookup,
     depIsLinked,
     depPath,
     isNew: isNew || resolveChildren,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import {
   deprecationLogger,
   progressLogger,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -53,6 +53,16 @@ export interface ResolvedDirectDependency {
   version: string
   name: string
   normalizedPref?: string
+  catalogLookup?: CatalogLookupMetadata
+}
+
+/**
+ * Information related to the catalog entry for this dependency if it was
+ * requested through the catalog protocol.
+ */
+export interface CatalogLookupMetadata {
+  readonly catalogName: string
+  readonly entrySpecifier: string
 }
 
 export interface Importer<WantedDepExtraProps> {
@@ -239,6 +249,7 @@ export async function resolveDependencyTree<T> (
           const resolvedPackage = ctx.dependenciesTree.get(dep.nodeId)!.resolvedPackage as ResolvedPackage
           return {
             alias: dep.alias,
+            catalogLookup: dep.catalogLookup,
             dev: resolvedPackage.dev,
             name: resolvedPackage.name,
             normalizedPref: dep.normalizedPref,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -29,6 +29,7 @@ import {
   type ResolvedPackagesByDepPath,
   type ResolutionContext,
 } from './resolveDependencies'
+import { getCatalogResolver } from './getCatalogResolver'
 
 export * from './nodeIdUtils'
 export type { LinkedDependency, ResolvedPackage, DependenciesTree, DependenciesTreeNode } from './resolveDependencies'
@@ -105,6 +106,14 @@ export interface ResolveDependenciesOptions {
   workspacePackages: WorkspacePackages
   supportedArchitectures?: SupportedArchitectures
   updateToLatest?: boolean
+  /**
+   * A temporary feature flag that determines whether or not pnpm catalogs
+   * should be used. This will default to true and be removed when catalogs
+   * development has finished.
+   *
+   * @default false
+   */
+  useBetaCatalogsFeat?: boolean
 }
 
 export interface ResolveDependencyTreeResult {
@@ -130,6 +139,10 @@ export async function resolveDependencyTree<T> (
     autoInstallPeersFromHighestMatch: opts.autoInstallPeersFromHighestMatch === true,
     allowBuild: opts.allowBuild,
     allowedDeprecatedVersions: opts.allowedDeprecatedVersions,
+    // Use a no-op catalog resolver if the temporary feature flag is off.
+    catalogResolver: opts.useBetaCatalogsFeat
+      ? getCatalogResolver(opts.catalogs)
+      : () => undefined,
     childrenByParentDepPath: {} as ChildrenByParentDepPath,
     currentLockfile: opts.currentLockfile,
     defaultTag: opts.tag,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -1,3 +1,4 @@
+import { type Catalogs } from '@pnpm/catalogs.types'
 import { type Lockfile, type PatchFile } from '@pnpm/lockfile-types'
 import { type PreferredVersions, type Resolution, type WorkspacePackages } from '@pnpm/resolver-base'
 import { type StoreController } from '@pnpm/store-controller-types'
@@ -76,6 +77,7 @@ export interface ResolveDependenciesOptions {
   allowBuild?: (pkgName: string) => boolean
   allowedDeprecatedVersions: AllowedDeprecatedVersions
   allowNonAppliedPatches: boolean
+  catalogs: Catalogs
   currentLockfile: Lockfile
   dedupePeerDependents?: boolean
   dryRun: boolean

--- a/pkg-manager/resolve-dependencies/tsconfig.json
+++ b/pkg-manager/resolve-dependencies/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../config/pick-registry-for-package"
     },
     {

--- a/pkg-manager/resolve-dependencies/tsconfig.json
+++ b/pkg-manager/resolve-dependencies/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/protocol-parser"
+    },
+    {
       "path": "../../catalogs/types"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,12 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/types:
+    devDependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: 'link:'
+
   cli/cli-meta:
     dependencies:
       '@pnpm/types':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,12 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/protocol-parser:
+    devDependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: 'link:'
+
   cli/cli-meta:
     dependencies:
       '@pnpm/types':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3377,6 +3377,9 @@ importers:
 
   pkg-manager/get-context:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -3401,6 +3404,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../../workspace/read-manifest
       '@zkochan/rimraf':
         specifier: ^2.1.3
         version: 2.1.3
@@ -4247,6 +4253,9 @@ importers:
 
   pkg-manager/resolve-dependencies:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4253,6 +4253,9 @@ importers:
 
   pkg-manager/resolve-dependencies:
     dependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: link:../../catalogs/protocol-parser
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3075,6 +3075,12 @@ importers:
       '@pnpm/calc-dep-state':
         specifier: workspace:*
         version: link:../../packages/calc-dep-state
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: link:../../catalogs/protocol-parser
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - __typings__
   - __utils__/*
   - "!__utils__/build-artifacts"
+  - catalogs/*
   - cli/*
   - completion/*
   - config/*


### PR DESCRIPTION
## Changes

This implements the following items from the tracking issue https://github.com/pnpm/pnpm/issues/7072.

- [x] Support the `catalog:` and `catalog:default` specifiers.
- [x] Support `catalog:<name>` specifiers.
- [x] Changing a catalog entry in pnpm-workspace.yaml causes the lock file to not be up to date.

I've organized this PR into different commits that make sense by themselves. **This PR should be easier to review commit by commit rather than all files changed at once.**

## When should we transform the catalog protocol?

The hardest part of this PR was determining the right place for the `catalog:` → `^1.2.3` translation internally.

- We could model this as a [read package hook](https://github.com/pnpm/pnpm/blob/aa33269f9f9fc0c3505ae1c59264d1706923a971/hooks/read-package-hook/src/createReadPackageHook.ts#L14), which would be similar to how `pnpm.overrides` and `packageExtensions` work. I think this is **too early** of a place for the protocol to be resolved since it means the `pnpm-lock.yaml` file won't have the original `catalog:` specifier that was declared in `package.json`.
- We could rewrite it at the [`@pnpm/default-resolver` level](https://github.com/pnpm/pnpm/blob/ee61ca4cb7ce6b3cb177f892940edb55b19b9e17/resolving/default-resolver/src/index.ts#L22), but I think that's **too deep**. It means the default resolver would need to understand catalogs, which leaks the catalogs abstraction and makes the resolvers more complicated.

I settled on performing the `catalog:` protocol replacement right before we request dependencies from the store. I think that strikes the right balance.

https://github.com/pnpm/pnpm/blob/ade62a991a8f542b647d24f5ee4637c51cf72d8d/pkg-manager/resolve-dependencies/src/resolveDependencies.ts#L1135-L1141