### PR TITLE
feat: create new `@pnpm/catalogs.types` package

### DIFF
--- a/catalogs/types/CHANGELOG.md
+++ b/catalogs/types/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.types
+
+## 0.1.0
+
+Initial release

--- a/catalogs/types/README.md
+++ b/catalogs/types/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.types
+
+> Types related to the pnpm catalogs feature.

--- a/catalogs/types/package.json
+++ b/catalogs/types/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@pnpm/catalogs.types",
+  "version": "0.1.0",
+  "description": "Types related to the pnpm catalogs feature.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/types",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/types#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.types": "workspace:*"
+  }
+}

--- a/catalogs/types/src/index.ts
+++ b/catalogs/types/src/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Catalogs parsed from the pnpm-workspace.yaml file.
+ *
+ * https://github.com/pnpm/rfcs/pull/1
+ */
+export interface Catalogs {
+  /**
+   * The default catalog.
+   *
+   * The default catalog can be defined in 2 ways.
+   *
+   *   1. Users can specify a top-level "catalog" field or,
+   *   2. An explicitly named "default" catalog under the "catalogs" map.
+   *
+   * This field contains either definition. Note that it's an error to define
+   * the default catalog using both options. The parser will fail when reading
+   * the workspace manifest.
+   */
+  readonly default?: Catalog
+
+  /**
+   * Named catalogs.
+   */
+  readonly [catalogName: string]: Catalog | undefined
+}
+
+export interface Catalog {
+  readonly [dependencyName: string]: string | undefined
+}

--- a/catalogs/types/tsconfig.json
+++ b/catalogs/types/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": []
+}

--- a/catalogs/types/tsconfig.lint.json
+++ b/catalogs/types/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,12 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/types:
+    devDependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: 'link:'
+
   cli/cli-meta:
     dependencies:
       '@pnpm/types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - __typings__
   - __utils__/*
   - "!__utils__/build-artifacts"
+  - catalogs/*
   - cli/*
   - completion/*
   - config/*


### PR DESCRIPTION
## Changes

Cherry picking the commit that creates a new `@pnpm/catalogs.types` package from a different draft PR https://github.com/pnpm/pnpm/pull/8020 so we can merge the catalogs feature into `main` more incrementally. This also makes the more complicated draft PR smaller and easier to review.

Sounds like a new `@pnpm/catalogs.types` package is okay: https://github.com/pnpm/pnpm/pull/8020#discussion_r1581501808