### PR TITLE
feat: create new @pnpm/catalogs.protocol-parser package for parsing catalog specifiers

### DIFF
--- a/catalogs/protocol-parser/CHANGELOG.md
+++ b/catalogs/protocol-parser/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.protocol-parser
+
+## 0.1.0
+
+Initial release

--- a/catalogs/protocol-parser/README.md
+++ b/catalogs/protocol-parser/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.protocol-parser
+
+> Parse catalog protocol specifiers and return the catalog name.

--- a/catalogs/protocol-parser/jest.config.js
+++ b/catalogs/protocol-parser/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/catalogs/protocol-parser/package.json
+++ b/catalogs/protocol-parser/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pnpm/catalogs.protocol-parser",
+  "version": "0.1.0",
+  "description": "Parse catalog protocol specifiers and return the catalog name.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/protocol-parser",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/protocol-parser#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile && pnpm run _test",
+    "_test": "jest"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:*"
+  }
+}

--- a/catalogs/protocol-parser/src/index.ts
+++ b/catalogs/protocol-parser/src/index.ts
@@ -1,0 +1,1 @@
+export { parseCatalogProtocol } from './parseCatalogProtocol'

--- a/catalogs/protocol-parser/src/parseCatalogProtocol.ts
+++ b/catalogs/protocol-parser/src/parseCatalogProtocol.ts
@@ -1,0 +1,18 @@
+const CATALOG_PROTOCOL = 'catalog:'
+
+/**
+ * Parse a package.json dependency specifier using the catalog: protocol.
+ * Returns null if the given specifier does not start with 'catalog:'.
+ */
+export function parseCatalogProtocol (pref: string): string | 'default' | null {
+  if (!pref.startsWith(CATALOG_PROTOCOL)) {
+    return null
+  }
+
+  const catalogNameRaw = pref.slice(CATALOG_PROTOCOL.length).trim()
+
+  // Allow a specifier of 'catalog:' to be a short-hand for 'catalog:default'.
+  const catalogNameNormalized = catalogNameRaw === '' ? 'default' : catalogNameRaw
+
+  return catalogNameNormalized
+}

--- a/catalogs/protocol-parser/test/parseCatalogProtocol.test.ts
+++ b/catalogs/protocol-parser/test/parseCatalogProtocol.test.ts
@@ -1,0 +1,20 @@
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+
+test('parses named catalog', () => {
+  expect(parseCatalogProtocol('catalog:foo')).toBe('foo')
+  expect(parseCatalogProtocol('catalog:bar')).toBe('bar')
+})
+
+test('returns null for specifier not using catalog protocol', () => {
+  expect(parseCatalogProtocol('^1.0.0')).toBe(null)
+})
+
+describe('default catalog', () => {
+  test('parses explicit default catalog', () => {
+    expect(parseCatalogProtocol('catalog:default')).toBe('default')
+  })
+
+  test('parses implicit catalog', () => {
+    expect(parseCatalogProtocol('catalog:')).toBe('default')
+  })
+})

--- a/catalogs/protocol-parser/tsconfig.json
+++ b/catalogs/protocol-parser/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": []
+}

--- a/catalogs/protocol-parser/tsconfig.lint.json
+++ b/catalogs/protocol-parser/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,12 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/protocol-parser:
+    devDependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: 'link:'
+
   cli/cli-meta:
     dependencies:
       '@pnpm/types':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - __typings__
   - __utils__/*
   - "!__utils__/build-artifacts"
+  - catalogs/*
   - cli/*
   - completion/*
   - config/*


### PR DESCRIPTION
## Changes

Cherry picking the commit that creates a new `@pnpm/catalogs.protocol-parser` package from a different draft PR https://github.com/pnpm/pnpm/pull/8020 so we can merge the catalogs feature into `main` more incrementally. This also makes the more complicated draft PR smaller and easier to review.

This package will be unused until #8020 merges.