### PR TITLE
fix: only automatically resolve optional peers with versions that satisfy the ranges

### DIFF
--- a/.changeset/curly-actors-repeat.md
+++ b/.changeset/curly-actors-repeat.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+A dependency is hoisted to resolve an optional peer dependency only if it satisfied the range provided for the optional peer dependency [#8028](https://github.com/pnpm/pnpm/pull/8028).

--- a/.changeset/curly-actors-repeat.md
+++ b/.changeset/curly-actors-repeat.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-A dependency is hoisted to resolve an optional peer dependency only if it satisfied the range provided for the optional peer dependency [#8028](https://github.com/pnpm/pnpm/pull/8028).
+A dependency is hoisted to resolve an optional peer dependency only if it satisfies the range provided for the optional peer dependency [#8028](https://github.com/pnpm/pnpm/pull/8028).

--- a/cspell.json
+++ b/cspell.json
@@ -87,6 +87,7 @@
     "hashbang",
     "highmaps",
     "hikljmi",
+    "hoistable",
     "homepath",
     "hosters",
     "hyperdrive",

--- a/pkg-manager/resolve-dependencies/src/hoistPeers.ts
+++ b/pkg-manager/resolve-dependencies/src/hoistPeers.ts
@@ -28,7 +28,7 @@ export function hoistPeers (
   return dependencies
 }
 
-export function hoistOptionalPeers (
+export function getHoistableOptionalPeers (
   allMissingOptionalPeers: Record<string, string[]>,
   allPreferredVersions: PreferredVersions
 ): Record<string, string> {

--- a/pkg-manager/resolve-dependencies/src/hoistPeers.ts
+++ b/pkg-manager/resolve-dependencies/src/hoistPeers.ts
@@ -27,3 +27,20 @@ export function hoistPeers (
   }
   return dependencies
 }
+
+export function hoistOptionalPeers (
+  allMissingOptionalPeers: Record<string, string[]>,
+  allPreferredVersions: PreferredVersions
+): Record<string, string> {
+  const optionalDependencies: Record<string, string> = {}
+  for (const [missingOptionalPeerName, ranges] of Object.entries(allMissingOptionalPeers)) {
+    if (allPreferredVersions?.[missingOptionalPeerName] == null) continue
+    const optionalPeerVersionThatSatisfyAll = Object.entries(allPreferredVersions[missingOptionalPeerName])
+      .filter(([_, specType]) => specType === 'version')
+      .find(([version]) => ranges.every((range) => semver.satisfies(version, range)))
+    if (optionalPeerVersionThatSatisfyAll) {
+      optionalDependencies[missingOptionalPeerName] = optionalPeerVersionThatSatisfyAll[0]
+    }
+  }
+  return optionalDependencies
+}

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -57,7 +57,7 @@ import {
   nodeIdContains,
   splitNodeId,
 } from './nodeIdUtils'
-import { hoistPeers, hoistOptionalPeers } from './hoistPeers'
+import { hoistPeers, getHoistableOptionalPeers } from './hoistPeers'
 import { wantedDepIsLocallyAvailable } from './wantedDepIsLocallyAvailable'
 import { replaceVersionInPref } from './replaceVersionInPref'
 
@@ -348,7 +348,7 @@ export async function resolveRootDependencies (
       pkgAddresses.push(...importerResolutionResult.pkgAddresses)
     }
     if (Object.keys(allMissingOptionalPeers).length && ctx.allPreferredVersions) {
-      const optionalDependencies = hoistOptionalPeers(allMissingOptionalPeers, ctx.allPreferredVersions)
+      const optionalDependencies = getHoistableOptionalPeers(allMissingOptionalPeers, ctx.allPreferredVersions)
       if (Object.keys(optionalDependencies).length) {
         const wantedDependencies = getNonDevWantedDependencies({ optionalDependencies })
         const resolveDependenciesResult = await resolveDependencies(ctx, preferredVersions, wantedDependencies, {

--- a/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
+++ b/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
@@ -1,4 +1,4 @@
-import { hoistPeers } from '../lib/hoistPeers'
+import { hoistPeers, hoistOptionalPeers } from '../lib/hoistPeers'
 
 test('hoistPeers picks an already available prerelease version', () => {
   expect(hoistPeers([['foo', { range: '*' }]], {
@@ -10,5 +10,20 @@ test('hoistPeers picks an already available prerelease version', () => {
     },
   })).toStrictEqual({
     foo: '1.0.0-beta.0',
+  })
+})
+
+test('hoistOptionalPeers only picks a version that satisfies all optional ranges', () => {
+  expect(hoistOptionalPeers({
+    foo: ['2', '2.1'],
+  }, {
+    foo: {
+      '1.0.0': 'version',
+      '2.0.0': 'version',
+      '2.1.0': 'version',
+      '3.0.0': 'version',
+    },
+  })).toStrictEqual({
+    foo: '2.1.0',
   })
 })

--- a/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
+++ b/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
@@ -1,4 +1,4 @@
-import { hoistPeers, hoistOptionalPeers } from '../lib/hoistPeers'
+import { hoistPeers, getHoistableOptionalPeers } from '../lib/hoistPeers'
 
 test('hoistPeers picks an already available prerelease version', () => {
   expect(hoistPeers([['foo', { range: '*' }]], {
@@ -13,8 +13,8 @@ test('hoistPeers picks an already available prerelease version', () => {
   })
 })
 
-test('hoistOptionalPeers only picks a version that satisfies all optional ranges', () => {
-  expect(hoistOptionalPeers({
+test('getHoistableOptionalPeers only picks a version that satisfies all optional ranges', () => {
+  expect(getHoistableOptionalPeers({
     foo: ['2', '2.1'],
   }, {
     foo: {

--- a/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
+++ b/pkg-manager/resolve-dependencies/test/hoistPeers.test.ts
@@ -27,3 +27,16 @@ test('getHoistableOptionalPeers only picks a version that satisfies all optional
     foo: '2.1.0',
   })
 })
+
+test('getHoistableOptionalPeers picks the highest version that satisfies all the optional ranges', () => {
+  expect(getHoistableOptionalPeers({
+    foo: ['2', '2.1'],
+  }, {
+    foo: {
+      '2.1.0': 'version',
+      '2.1.1': 'version',
+    },
+  })).toStrictEqual({
+    foo: '2.1.1',
+  })
+})


### PR DESCRIPTION
close #7985