### PR TITLE
fix: run devPreinstall even shared-workspace-lockfile=false

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -310,7 +310,12 @@ export async function mutateModules (
       unsafePerm: opts.unsafePerm || false,
     }
 
-    if (!opts.ignoreScripts && !opts.ignorePackageManifest && rootProjectManifest?.scripts?.[DEV_PREINSTALL]) {
+    if (
+      // NOTE: takes ignore-scripts from rawConfig instead of opts to avoid false positive when shared-workspace-lockfile=false is set, which will set opts.ignoreScripts to true
+      !opts.rawConfig['ignore-scripts'] &&
+      !opts.ignorePackageManifest &&
+      rootProjectManifest?.scripts?.[DEV_PREINSTALL]
+    ) {
       await runLifecycleHook(
         DEV_PREINSTALL,
         rootProjectManifest,


### PR DESCRIPTION
When `shared-workspace-lockfile` is false, opts.ignoreScripts is set to true since packages are rebuild after recursive install.
However, it will cause `pnpm:devPreinstall` to be skipped as well since it's not part of the rebuild process.

This fix fixes the issue by checking whether the --ignore-scripts flag is set from the source instead

fix #4503

For the context, it's this line that causes the issue:
https://github.com/pnpm/pnpm/blob/9719a42d0e83a61fd44879d52a52f95632521dc5/pkg-manager/plugin-commands-installation/src/recursive.ts#L359