### PR TITLE
fix: `outdated` output table information is misplaced

### DIFF
--- a/.changeset/flat-poets-worry.md
+++ b/.changeset/flat-poets-worry.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+"@pnpm/plugin-commands-outdated": patch
+"pnpm": patch
+---
+
+Details in the `pnpm outdated` output are wrapped correctly [#8037](https://github.com/pnpm/pnpm/pull/8037).

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
         "strip-bom",
         "tempy",
         "unique-string",
-        "wrap-ansi",
         "write-json-file",
         "write-pkg"
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5601,9 +5601,6 @@ importers:
       '@types/semver':
         specifier: 7.5.3
         version: 7.5.3
-      '@types/wrap-ansi':
-        specifier: 8.0.2
-        version: 8.0.2
       '@types/zkochan__table':
         specifier: npm:@types/table@6.0.0
         version: '@types/table@6.0.0'
@@ -5731,9 +5728,6 @@ importers:
       strip-ansi:
         specifier: ^6.0.1
         version: 6.0.1
-      wrap-ansi:
-        specifier: ^7.0.0
-        version: 7.0.0
     devDependencies:
       '@pnpm/constants':
         specifier: workspace:*
@@ -5759,9 +5753,6 @@ importers:
       '@types/ramda':
         specifier: 0.29.12
         version: 0.29.12
-      '@types/wrap-ansi':
-        specifier: 8.0.2
-        version: 8.0.2
       '@types/zkochan__table':
         specifier: npm:@types/table@6.0.0
         version: '@types/table@6.0.0'
@@ -8003,9 +7994,6 @@ packages:
 
   '@types/which@2.0.2':
     resolution: {integrity: sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==}
-
-  '@types/wrap-ansi@8.0.2':
-    resolution: {integrity: sha512-mdaFibQzYYqJF8Sc9By84eBLtDQD9Hnko0yXuezHBU5f5KdtQk+j5hPRQc1j4ayzdqGddKON6PjeuzxD5U1hPg==}
 
   '@types/write-file-atomic@4.0.3':
     resolution: {integrity: sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==}
@@ -14764,8 +14752,6 @@ snapshots:
   '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/which@2.0.2': {}
-
-  '@types/wrap-ansi@8.0.2': {}
 
   '@types/write-file-atomic@4.0.3':
     dependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -116,10 +116,6 @@
       "allowedVersions": "^6.0.0"
     },
     {
-      "packageNames": ["wrap-ansi"],
-      "allowedVersions": "^7.0.0"
-    },
-    {
       "packageNames": ["escape-string-regexp"],
       "allowedVersions": "^4.0.0"
     },

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -40,7 +40,6 @@
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.29.12",
     "@types/semver": "7.5.3",
-    "@types/wrap-ansi": "8.0.2",
     "@types/zkochan__table": "npm:@types/table@6.0.0",
     "strip-ansi": "^6.0.1"
   },

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -38,7 +38,6 @@
     "@pnpm/registry-mock": "3.30.0",
     "@pnpm/test-fixtures": "workspace:*",
     "@types/ramda": "0.29.12",
-    "@types/wrap-ansi": "8.0.2",
     "@types/zkochan__table": "npm:@types/table@6.0.0"
   },
   "dependencies": {
@@ -60,8 +59,7 @@
     "chalk": "^4.1.2",
     "ramda": "npm:@pnpm/ramda@0.28.1",
     "render-help": "^1.0.3",
-    "strip-ansi": "^6.0.1",
-    "wrap-ansi": "^7.0.0"
+    "strip-ansi": "^6.0.1"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/reviewing/plugin-commands-outdated/src/outdated.ts
+++ b/reviewing/plugin-commands-outdated/src/outdated.ts
@@ -243,10 +243,13 @@ function renderOutdatedTable (outdatedPackages: readonly OutdatedPackage[], opts
     ...sortOutdatedPackages(outdatedPackages)
       .map((outdatedPkg) => columnFns.map((fn) => fn(outdatedPkg))),
   ]
-  const detailsColumnMaxWidth = data.filter(row => !row[2].includes('Deprecated')).reduce((maxWidth, row) => {
-    const cellWidth = row[3].length
-    return Math.max(maxWidth, cellWidth)
-  }, 0)
+  let detailsColumnMaxWidth = 40
+  if (opts.long) {
+    detailsColumnMaxWidth = outdatedPackages.filter(pkg => pkg.latestManifest && !pkg.latestManifest.deprecated).reduce((maxWidth, pkg) => {
+      const cellWidth = pkg.latestManifest?.homepage?.length ?? 0
+      return Math.max(maxWidth, cellWidth)
+    }, 0)
+  }
 
   return table(data, {
     ...TABLE_OPTIONS,

--- a/reviewing/plugin-commands-outdated/test/index.ts
+++ b/reviewing/plugin-commands-outdated/test/index.ts
@@ -175,9 +175,7 @@ is-positive (dev)
     expect(exitCode).toBe(1)
     expect(stripAnsi(output)).toBe(`@pnpm.e2e/deprecated
 1.0.0 => Deprecated
-This package is deprecated. Lorem ipsum
-dolor sit amet, consectetur adipiscing
-elit.
+This package is deprecated. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 https://foo.bar/qar
 
 is-negative


### PR DESCRIPTION
When I run `pnpm outdated --long` under the pnpm repository, the printed information is as follows.
<img width="1056" alt="image" src="https://github.com/pnpm/pnpm/assets/24516654/0d5b1d8a-265d-44d7-a6cd-a4059f8a9293">

After modification, it is as follows:

<img width="1041" alt="image" src="https://github.com/pnpm/pnpm/assets/24516654/0d037fb7-bfa3-41e8-aa90-e2980ec30340">

