### PR TITLE
feat(graph-sequencer): Topological ordering will look for the longest circle

### DIFF
--- a/.changeset/kind-carrots-fry.md
+++ b/.changeset/kind-carrots-fry.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/deps.graph-sequencer": patch
+---
+
+Topological ordering will look for the longest circle

--- a/deps/graph-sequencer/src/index.ts
+++ b/deps/graph-sequencer/src/index.ts
@@ -98,11 +98,15 @@ export function graphSequencer<T> (graph: Graph<T>, includedNodes: T[] = [...gra
   function findCycle (startNode: T): T[] {
     const queue: Array<[T, T[]]> = [[startNode, [startNode]]]
     const cycleVisited = new Set<T>()
+    const cycles: T[][] = []
+
     while (queue.length) {
       const [id, cycle] = queue.shift()!
       for (const to of graph.get(id)!) {
         if (to === startNode) {
-          return cycle
+          cycleVisited.add(to)
+          cycles.push([...cycle])
+          continue
         }
         if (visited.has(to) || cycleVisited.has(to)) {
           continue
@@ -111,6 +115,11 @@ export function graphSequencer<T> (graph: Graph<T>, includedNodes: T[] = [...gra
         queue.push([to, [...cycle, to]])
       }
     }
-    return []
+
+    if (!cycles.length) {
+      return []
+    }
+    cycles.sort((a, b) => b.length - a.length)
+    return cycles[0]
   }
 }

--- a/deps/graph-sequencer/test/index.ts
+++ b/deps/graph-sequencer/test/index.ts
@@ -350,8 +350,7 @@ test('graph with many nodes. Sequencing a subgraph', () => {
   )
 })
 
-// TODO: fix this test
-test.skip('graph with big cycle', () => {
+test('graph with big cycle', () => {
   expect(graphSequencer(new Map([
     ['a', ['b']],
     ['b', ['a', 'c']],
@@ -361,6 +360,23 @@ test.skip('graph with big cycle', () => {
       safe: false,
       chunks: [['a', 'b', 'c']],
       cycles: [['a', 'b', 'c']],
+    }
+  )
+})
+
+test('graph with three cycles', () => {
+  expect(graphSequencer(new Map([
+    ['a', ['b']],
+    ['b', ['a', 'c']],
+    ['c', ['a', 'b']],
+    ['e', ['f']],
+    ['f', ['e']],
+    ['g', ['g']],
+  ]))).toStrictEqual(
+    {
+      safe: false,
+      chunks: [['a', 'b', 'c', 'e', 'f', 'g']],
+      cycles: [['a', 'b', 'c'], ['e', 'f'], ['g']],
     }
   )
 })


### PR DESCRIPTION
Earlier implementations would return after finding the first circle, which in some scenarios found the smallest circle, see the test file for specific scenarios.