### PR TITLE
fix: `licenses` output table misplaced

### DIFF
--- a/.changeset/real-glasses-pull.md
+++ b/.changeset/real-glasses-pull.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+"pnpm": patch
+---
+
+Details in the `pnpm licenses` output are misplaced [#8071](https://github.com/pnpm/pnpm/pull/8071).

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -121,18 +121,17 @@ function renderLicensesTable (
   let packageColumnMaxWidth = 0
   let licenseColumnMaxWidth = 0
   if (opts.long) {
-    detailsColumnMaxWidth = data.slice(1).reduce((maxWidth, row) => {
+    // Use the package link to determine the width of the details column
+    detailsColumnMaxWidth = licensePackages.reduce((max, pkg) => Math.max(max, pkg.homepage?.length ?? 0), 0)
+    for (let i = 1; i < data.length; i++) {
+      const row = data[i]
       const texts = row[2].split('\n')
-      const link = texts.find((line) => line.startsWith('https'))
-      // Use the package link to determine the width of the details column
-      const detailMaxWidth = link ? link.length : 0
       const repeatCount = Math.max(0, texts.length - 1)
-      row[0] = `${row[0]}${'\n '.repeat(repeatCount)}` // Add extra lines to the package column
-      row[1] = `${row[1]}${'\n '.repeat(repeatCount)}` // Add extra lines to the license column
+      row[0] += '\n '.repeat(repeatCount) // Add extra spaces to the package column
+      row[1] += '\n '.repeat(repeatCount) // Add extra spaces to the license column
       packageColumnMaxWidth = Math.max(packageColumnMaxWidth, row[0].length)
       licenseColumnMaxWidth = Math.max(licenseColumnMaxWidth, row[1].length)
-      return Math.max(maxWidth, detailMaxWidth)
-    }, 0)
+    }
     const remainColumnWidth = process.stdout.columns - packageColumnMaxWidth - licenseColumnMaxWidth - 20
     if (detailsColumnMaxWidth > remainColumnWidth) {
       detailsColumnMaxWidth = remainColumnWidth

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -126,9 +126,9 @@ function renderLicensesTable (
     for (let i = 1; i < data.length; i++) {
       const row = data[i]
       const texts = row[2].split('\n')
-      const repeatCount = Math.max(0, texts.length - 1)
-      row[0] += '\n '.repeat(repeatCount) // Add extra spaces to the package column
-      row[1] += '\n '.repeat(repeatCount) // Add extra spaces to the license column
+      const linesNumber = Math.max(0, texts.length - 1)
+      row[0] += '\n '.repeat(linesNumber) // Add extra spaces to the package column
+      row[1] += '\n '.repeat(linesNumber) // Add extra spaces to the license column
       packageColumnMaxWidth = Math.max(packageColumnMaxWidth, row[0].length)
       licenseColumnMaxWidth = Math.max(licenseColumnMaxWidth, row[1].length)
     }

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -138,20 +138,27 @@ function renderLicensesTable (
     }
     detailsColumnMaxWidth = Math.max(detailsColumnMaxWidth, 40)
   }
-
-  return table(
-    data,
-    {
-      ...TABLE_OPTIONS,
-      columns: {
-        ...TABLE_OPTIONS.columns,
-        2: {
-          width: detailsColumnMaxWidth,
-          wrapWord: true,
+  try {
+    return table(
+      data,
+      {
+        ...TABLE_OPTIONS,
+        columns: {
+          ...TABLE_OPTIONS.columns,
+          2: {
+            width: detailsColumnMaxWidth,
+            wrapWord: true,
+          },
         },
-      },
-    }
-  )
+      }
+    )
+  } catch {
+    // Fallback to the default table if the details column width is too large, avoiding the error
+    return table(
+      data,
+      TABLE_OPTIONS
+    )
+  }
 }
 
 function deduplicateLicensesPackages (licensePackages: LicensePackage[]): LicensePackage[] {

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -125,8 +125,8 @@ function renderLicensesTable (
     detailsColumnMaxWidth = licensePackages.reduce((max, pkg) => Math.max(max, pkg.homepage?.length ?? 0), 0)
     for (let i = 1; i < data.length; i++) {
       const row = data[i]
-      const texts = row[2].split('\n')
-      const linesNumber = Math.max(0, texts.length - 1)
+      const detailsLineCount = row[2].split('\n').length
+      const linesNumber = Math.max(0, detailsLineCount - 1)
       row[0] += '\n '.repeat(linesNumber) // Add extra spaces to the package column
       row[1] += '\n '.repeat(linesNumber) // Add extra spaces to the license column
       packageColumnMaxWidth = Math.max(packageColumnMaxWidth, row[0].length)

--- a/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
+++ b/reviewing/plugin-commands-licenses/test/__snapshots__/index.ts.snap
@@ -21,69 +21,76 @@ exports[`pnpm licenses: filter outputs: show-packages 1`] = `
 `;
 
 exports[`pnpm licenses: should correctly read LICENSE file with executable file mode: show-packages-details 1`] = `
-"┌──────────────────────────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Package                      │ License │ Details                                                                                                │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ inherits                     │ ISC     │ Browser-friendly inheritance fully compatible with standard node.js inherits()                         │
-│                              │         │ https://github.com/isaacs/inherits#readme                                                              │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ sax                          │ ISC     │ Isaac Z. Schlueter                                                                                     │
-│                              │         │ An evented streaming XML parser in JavaScript                                                          │
-│                              │         │ https://github.com/isaacs/sax-js#readme                                                                │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ commander                    │ MIT     │ TJ Holowaychuk                                                                                         │
-│                              │         │ the complete solution for node.js command-line programs                                                │
-│                              │         │ https://github.com/tj/commander.js#readme                                                              │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ core-util-is                 │ MIT     │ Isaac Z. Schlueter                                                                                     │
-│                              │         │ The \`util.is*\` functions introduced in Node v0.12.                                                     │
-│                              │         │ https://github.com/isaacs/core-util-is#readme                                                          │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ isarray                      │ MIT     │ Julian Gruber                                                                                          │
-│                              │         │ Array#isArray for older browsers                                                                       │
-│                              │         │ https://github.com/juliangruber/isarray                                                                │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ neatequal                    │ MIT     │ Nicolas Froidure                                                                                       │
-│                              │         │ Neat deep equal.                                                                                       │
-│                              │         │ https://github.com/nfroidure/neatequal                                                                 │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ process-nextick-args         │ MIT     │ process.nextTick but always with args                                                                  │
-│                              │         │ https://github.com/calvinmetcalf/process-nextick-args                                                  │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ readable-stream              │ MIT     │ Streams3, a user-land copy of the stream library from Node.js                                          │
-│                              │         │ https://github.com/nodejs/readable-stream#readme                                                       │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ safe-buffer                  │ MIT     │ Feross Aboukhadijeh                                                                                    │
-│                              │         │ Safer Node.js Buffer API                                                                               │
-│                              │         │ https://github.com/feross/safe-buffer                                                                  │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ string_decoder               │ MIT     │ The string_decoder module from Node core                                                               │
-│                              │         │ https://github.com/nodejs/string_decoder                                                               │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ string.fromcodepoint         │ MIT     │ Mathias Bynens                                                                                         │
-│                              │         │ A robust & optimized \`String.fromCodePoint\` polyfill, based on the ECMAScript 6 specification.         │
-│                              │         │ http://mths.be/fromcodepoint                                                                           │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ string.prototype.codepointat │ MIT     │ Mathias Bynens                                                                                         │
-│                              │         │ A robust & optimized \`String.prototype.codePointAt\` polyfill, based on the ECMAScript 6 specification. │
-│                              │         │ https://mths.be/codepointat                                                                            │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ svg-pathdata                 │ MIT     │ Nicolas Froidure                                                                                       │
-│                              │         │ Parse, transform and encode SVG Path Data.                                                             │
-│                              │         │ https://github.com/nfroidure/SVGPathData#readme                                                        │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ svgicons2svgfont             │ MIT     │ Nicolas Froidure                                                                                       │
-│                              │         │ Read a set of SVG icons and ouput a SVG font                                                           │
-│                              │         │ https://github.com/nfroidure/svgicons2svgfont                                                          │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ util-deprecate               │ MIT     │ Nathan Rajlich                                                                                         │
-│                              │         │ The Node.js \`util.deprecate()\` function with browser support                                           │
-│                              │         │ https://github.com/TooTallNate/util-deprecate                                                          │
-├──────────────────────────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ varstream                    │ MIT     │ Nicolas Froidure                                                                                       │
-│                              │         │ Stream variables beetween 2 JavaScript threads (client/server, ipc, worker/main thread).               │
-│                              │         │ https://github.com/nfroidure/VarStream#readme                                                          │
-└──────────────────────────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+"┌──────────────────────────────┬─────────┬───────────────────────────────────────────────────────┐
+│ Package                      │ License │ Details                                               │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ inherits                     │ ISC     │ Browser-friendly inheritance fully compatible with    │
+│                              │         │ standard node.js inherits()                           │
+│                              │         │ https://github.com/isaacs/inherits#readme             │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ sax                          │ ISC     │ Isaac Z. Schlueter                                    │
+│                              │         │ An evented streaming XML parser in JavaScript         │
+│                              │         │ https://github.com/isaacs/sax-js#readme               │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ commander                    │ MIT     │ TJ Holowaychuk                                        │
+│                              │         │ the complete solution for node.js command-line        │
+│                              │         │ programs                                              │
+│                              │         │ https://github.com/tj/commander.js#readme             │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ core-util-is                 │ MIT     │ Isaac Z. Schlueter                                    │
+│                              │         │ The \`util.is*\` functions introduced in Node v0.12.    │
+│                              │         │ https://github.com/isaacs/core-util-is#readme         │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ isarray                      │ MIT     │ Julian Gruber                                         │
+│                              │         │ Array#isArray for older browsers                      │
+│                              │         │ https://github.com/juliangruber/isarray               │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ neatequal                    │ MIT     │ Nicolas Froidure                                      │
+│                              │         │ Neat deep equal.                                      │
+│                              │         │ https://github.com/nfroidure/neatequal                │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ process-nextick-args         │ MIT     │ process.nextTick but always with args                 │
+│                              │         │ https://github.com/calvinmetcalf/process-nextick-args │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ readable-stream              │ MIT     │ Streams3, a user-land copy of the stream library from │
+│                              │         │ Node.js                                               │
+│                              │         │ https://github.com/nodejs/readable-stream#readme      │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ safe-buffer                  │ MIT     │ Feross Aboukhadijeh                                   │
+│                              │         │ Safer Node.js Buffer API                              │
+│                              │         │ https://github.com/feross/safe-buffer                 │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ string_decoder               │ MIT     │ The string_decoder module from Node core              │
+│                              │         │ https://github.com/nodejs/string_decoder              │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ string.fromcodepoint         │ MIT     │ Mathias Bynens                                        │
+│                              │         │ A robust & optimized \`String.fromCodePoint\` polyfill, │
+│                              │         │ based on the ECMAScript 6 specification.              │
+│                              │         │ http://mths.be/fromcodepoint                          │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ string.prototype.codepointat │ MIT     │ Mathias Bynens                                        │
+│                              │         │ A robust & optimized \`String.prototype.codePointAt\`   │
+│                              │         │ polyfill, based on the ECMAScript 6 specification.    │
+│                              │         │ https://mths.be/codepointat                           │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ svg-pathdata                 │ MIT     │ Nicolas Froidure                                      │
+│                              │         │ Parse, transform and encode SVG Path Data.            │
+│                              │         │ https://github.com/nfroidure/SVGPathData#readme       │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ svgicons2svgfont             │ MIT     │ Nicolas Froidure                                      │
+│                              │         │ Read a set of SVG icons and ouput a SVG font          │
+│                              │         │ https://github.com/nfroidure/svgicons2svgfont         │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ util-deprecate               │ MIT     │ Nathan Rajlich                                        │
+│                              │         │ The Node.js \`util.deprecate()\` function with browser  │
+│                              │         │ support                                               │
+│                              │         │ https://github.com/TooTallNate/util-deprecate         │
+├──────────────────────────────┼─────────┼───────────────────────────────────────────────────────┤
+│ varstream                    │ MIT     │ Nicolas Froidure                                      │
+│                              │         │ Stream variables beetween 2 JavaScript threads        │
+│                              │         │ (client/server, ipc, worker/main thread).             │
+│                              │         │ https://github.com/nfroidure/VarStream#readme         │
+└──────────────────────────────┴─────────┴───────────────────────────────────────────────────────┘
 "
 `;
 


### PR DESCRIPTION
When I run `pnpm licenses ls --long` under the repository, the printed information as follows.

<img width="1463" alt="image" src="https://github.com/pnpm/pnpm/assets/24516654/ddb33560-11ab-4170-bdae-eda973839734">

After modification, it is as follows:

<img width="1304" alt="image" src="https://github.com/pnpm/pnpm/assets/24516654/5cff6dd0-27e5-4fce-89c8-a4385a716987">
