### PR TITLE
chore(deps): deduplicate semver 7.6.0 onto 7.6.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,7 +495,7 @@ importers:
         version: 7.8.1
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       stacktracey:
         specifier: ^2.1.8
         version: 2.1.8
@@ -738,7 +738,7 @@ importers:
         version: 8.1.1
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/package-is-installable':
         specifier: workspace:*
@@ -984,7 +984,7 @@ importers:
         version: link:../node.fetcher
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       version-selector-type:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1048,7 +1048,7 @@ importers:
         version: 1.0.3
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       symlink-dir:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1319,7 +1319,7 @@ importers:
         version: 3.0.1
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/assert-project':
         specifier: workspace:*
@@ -1959,7 +1959,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/hooks.read-package-hook':
         specifier: workspace:*
@@ -2168,7 +2168,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       sort-keys:
         specifier: ^4.2.0
         version: 4.2.0
@@ -2332,7 +2332,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/merge-lockfile-changes':
         specifier: workspace:*
@@ -2644,7 +2644,7 @@ importers:
         version: link:../types
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/dependency-path':
         specifier: workspace:*
@@ -2844,7 +2844,7 @@ importers:
         version: 4.0.0
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/render-peer-issues':
         specifier: workspace:*
@@ -2973,7 +2973,7 @@ importers:
         version: 0.1.4
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       tempy:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3218,7 +3218,7 @@ importers:
         version: 3.0.1
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       sort-keys:
         specifier: ^4.2.0
         version: 4.2.0
@@ -3875,7 +3875,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       ssri:
         specifier: 10.0.5
         version: 10.0.5
@@ -4330,7 +4330,7 @@ importers:
         version: 1.0.1
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       semver-range-intersect:
         specifier: ^0.3.1
         version: 0.3.1
@@ -4776,7 +4776,7 @@ importers:
         version: 1.0.3
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       split-cmd:
         specifier: ^1.1.0
         version: 1.1.0
@@ -5110,7 +5110,7 @@ importers:
         version: '@pnpm/hosted-git-info@1.0.0'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/git-resolver':
         specifier: workspace:*
@@ -5229,7 +5229,7 @@ importers:
         version: 5.0.0
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
       ssri:
         specifier: 10.0.5
         version: 10.0.5
@@ -5334,7 +5334,7 @@ importers:
         version: 2.0.0
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/constants':
         specifier: workspace:*
@@ -5407,7 +5407,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/constants':
         specifier: workspace:*
@@ -5514,7 +5514,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/outdated':
         specifier: workspace:*
@@ -5572,7 +5572,7 @@ importers:
         version: 1.0.3
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/filter-workspace-packages':
         specifier: workspace:*
@@ -6531,7 +6531,7 @@ importers:
     dependencies:
       semver:
         specifier: ^7.6.0
-        version: 7.6.0
+        version: 7.6.2
     devDependencies:
       '@pnpm/resolve-workspace-range':
         specifier: workspace:*
@@ -11963,11 +11963,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.0:
-    resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
     engines: {node: '>=10'}
@@ -13006,7 +13001,7 @@ snapshots:
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13033,7 +13028,7 @@ snapshots:
       '@babel/helper-validator-option': 7.23.5
       browserslist: 4.23.0
       lru-cache: 5.1.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@babel/helper-create-class-features-plugin@7.24.5(@babel/core@7.24.5)':
     dependencies:
@@ -13046,7 +13041,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@babel/helper-environment-visitor@7.22.20': {}
 
@@ -13290,7 +13285,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/assemble-release-plan@6.0.0':
     dependencies:
@@ -13299,7 +13294,7 @@ snapshots:
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -13335,7 +13330,7 @@ snapshots:
       p-limit: 2.3.0
       preferred-pm: 3.1.3
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.3
@@ -13360,7 +13355,7 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/get-release-plan@4.0.0':
     dependencies:
@@ -14084,7 +14079,7 @@ snapshots:
 
   '@npmcli/fs@3.1.0':
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14185,7 +14180,7 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       right-pad: 1.0.1
       rxjs: 7.8.1
-      semver: 7.6.0
+      semver: 7.6.2
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -14364,7 +14359,7 @@ snapshots:
   '@pnpm/npm-package-arg@1.0.0':
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-name: 4.0.0
 
   '@pnpm/os.env.path-extender-posix@2.0.0':
@@ -14391,7 +14386,7 @@ snapshots:
       detect-libc: 2.0.3
       execa: safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@pnpm/patch-package@0.0.0':
     dependencies:
@@ -14405,7 +14400,7 @@ snapshots:
       minimist: 1.2.8
       open: 7.4.2
       rimraf: 2.7.1
-      semver: 7.6.0
+      semver: 7.6.2
       slash: 2.0.0
       tmp: 0.0.33
       yaml: 2.4.2
@@ -14822,7 +14817,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
@@ -14869,7 +14864,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
@@ -14885,7 +14880,7 @@ snapshots:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.4.5)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14921,7 +14916,7 @@ snapshots:
       http-errors: 1.8.1
       http-status-codes: 2.2.0
       process-warning: 1.0.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@verdaccio/file-locking@10.3.0':
     dependencies:
@@ -14968,7 +14963,7 @@ snapshots:
       '@verdaccio/core': 6.0.0-6-next.55
       lodash: 4.17.21
       minimatch: 3.1.2
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@yarnpkg/core@4.0.3(typanion@3.14.0)':
     dependencies:
@@ -14991,7 +14986,7 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.6.0
+      semver: 7.6.2
       strip-ansi: 6.0.1
       tar: 6.2.1
       tinylogic: 2.0.0
@@ -15022,7 +15017,7 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.6.0
+      semver: 7.6.2
       strip-ansi: 6.0.1
       tar: 6.2.1
       tinylogic: 2.0.0
@@ -15563,7 +15558,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   bytes@3.0.0: {}
 
@@ -16049,7 +16044,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       file-entry-cache: 7.0.2
       get-stdin: 9.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       strip-ansi: 7.1.0
       vscode-uri: 3.0.8
     transitivePeerDependencies:
@@ -16417,7 +16412,7 @@ snapshots:
   eslint-compat-utils@0.5.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   eslint-config-standard-with-typescript@39.1.1(@typescript-eslint/eslint-plugin@6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.18.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
@@ -16488,7 +16483,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.0
-      semver: 7.6.0
+      semver: 7.6.2
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 6.18.1(eslint@8.57.0)(typescript@5.4.5)
@@ -16510,7 +16505,7 @@ snapshots:
       is-core-module: 2.13.1
       minimatch: 3.1.2
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.6.2
 
   eslint-plugin-node@11.1.0(eslint@8.57.0):
     dependencies:
@@ -16520,7 +16515,7 @@ snapshots:
       ignore: 5.3.1
       minimatch: 3.1.2
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.6.2
 
   eslint-plugin-promise@6.1.1(eslint@8.57.0):
     dependencies:
@@ -17588,7 +17583,7 @@ snapshots:
       '@babel/parser': 7.24.5(@babel/types@7.24.5)
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - '@babel/types'
       - supports-color
@@ -17886,7 +17881,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17985,7 +17980,7 @@ snapshots:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.6.0
+      semver: 7.6.2
 
   jsprim@1.4.2:
     dependencies:
@@ -18178,11 +18173,11 @@ snapshots:
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   make-dir@3.1.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   make-dir@4.0.0:
     dependencies:
@@ -18516,7 +18511,7 @@ snapshots:
 
   node-abi@3.62.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   node-fetch@2.6.8(encoding@0.1.13):
     dependencies:
@@ -18542,7 +18537,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 3.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -18566,21 +18561,21 @@ snapshots:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@3.0.3:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@5.0.0:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.13.1
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -18835,7 +18830,7 @@ snapshots:
 
   parse-npm-tarball-url@3.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   parseurl@1.3.3: {}
 
@@ -18911,7 +18906,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       progress: 2.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tar-fs: 2.1.1
       yargs: 16.2.0
     transitivePeerDependencies:
@@ -19441,15 +19436,11 @@ snapshots:
   semver-range-intersect@0.3.1:
     dependencies:
       '@types/semver': 6.2.7
-      semver: 7.6.0
+      semver: 7.6.2
 
   semver-utils@1.1.4: {}
 
   semver@7.5.4:
-    dependencies:
-      lru-cache: 6.0.0
-
-  semver@7.6.0:
     dependencies:
       lru-cache: 6.0.0
 
@@ -19870,7 +19861,7 @@ snapshots:
       glob: 8.1.0
       minimatch: 6.1.6
       read-yaml-file: 2.1.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   table@6.8.2:
     dependencies:
@@ -20013,7 +20004,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.0
+      semver: 7.6.2
       typescript: 5.4.5
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -20364,7 +20355,7 @@ snapshots:
 
   version-selector-type@3.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   vfile-message@2.0.4:
     dependencies:


### PR DESCRIPTION
Running `pnpm install` on one of my PRs, I'm noticing `pnpm-lock.yaml` changes where `semver` dependencies on `^7.6.0` are switching between `7.6.0` and `7.6.2`.

This PR deduplicates the `semver` dependency and removes `7.6.0`.