### PR TITLE
fix: reduce memory usage during peers resolution

### DIFF
--- a/.changeset/ninety-kids-push.md
+++ b/.changeset/ninety-kids-push.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+Reduce memory usage by peer dependencies resolution [#8072](https://github.com/pnpm/pnpm/issues/8072).

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -738,9 +738,10 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
   const allMissingPeers = new Set<string>()
 
   // Partition children based on whether they're repeated in parentPkgs.
-  // This impacts the efficiency of graph traversal and prevents potential out-of-memory errors.mes can even lead to out-of-memory exceptions.
+  // This impacts the efficiency of graph traversal and prevents potential out-of-memory errors.
+  // We check repeated first as the peers resolution of those probably are cached already.
   const [repeated, notRepeated] = partition(([alias]) => parentPkgs[alias] != null, Object.entries(children))
-  const nodeIds = Array.from(new Set([...notRepeated, ...repeated].map(([, nodeId]) => nodeId)))
+  const nodeIds = Array.from(new Set([...repeated, ...notRepeated].map(([, nodeId]) => nodeId)))
 
   for (const nodeId of nodeIds) {
     if (!ctx.pathsByNodeIdPromises.has(nodeId)) {


### PR DESCRIPTION
ref #8072

My tests show that with these changes pnpm v9 uses not more memory than v8.