### PR TITLE
feat(plugin-commands-init): add init configs and flags w/ npm compat

### DIFF
--- a/__typings__/typed.d.ts
+++ b/__typings__/typed.d.ts
@@ -129,9 +129,9 @@ declare module '@pnpm/npm-conf/lib/types' {
       'init-author-name': StringConstructor
       'init-author-email': StringConstructor
       // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-      'init-author-url': Array<string | typeof import('url')>
+      'init-author-url': StringConstructor | typeof import('url')
       'init-license': StringConstructor
-      'init-version': () => void
+      'init-version': StringConstructor
       json: BooleanConstructor
       key: Array<StringConstructor | null>
       'legacy-bundling': BooleanConstructor

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/plugin-commands-init",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "description": "Create a package.json file",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -34,15 +34,27 @@
     "@pnpm/plugin-commands-init": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@types/ramda": "0.29.12",
+    "@types/semver": "7.5.8",
+    "type-fest": "^4.18.2",
     "load-json-file": "^6.2.0"
   },
   "dependencies": {
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/config": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*",
+    "@pnpm/find-workspace-dir": "workspace:*",
     "@pnpm/write-project-manifest": "workspace:*",
-    "camelcase-keys": "^6.2.2",
-    "render-help": "^1.0.3"
+    "ramda": "npm:@pnpm/ramda@0.28.1",
+    "camelcase": "^8.0.0",
+    "camelcase-keys": "^9.1.3",
+    "enquirer": "^2.4.1",
+    "render-help": "^1.0.3",
+    "semver": "^7.6.2"
+  },
+  "peerDependencies": {
+    "@pnpm/logger": "^5.0.0"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/packages/plugin-commands-init/src/apply-prompt.ts
+++ b/packages/plugin-commands-init/src/apply-prompt.ts
@@ -1,0 +1,203 @@
+import { prompt } from 'enquirer'
+import { type PkgJsonType, AskLevel, packageNameValidator } from './utils.js'
+import type { ValueOf } from 'type-fest'
+import semverValid from 'semver/functions/valid'
+import { globalInfo } from '@pnpm/logger'
+
+type _PromptOptions = Extract<Parameters<typeof prompt>[0], {
+  name: string | (() => string)
+  type: string | (() => string)
+}>
+type PromptOptions = _PromptOptions & {
+  result?: (value: string) => unknown
+  choices?: Array<{
+    initial?: string
+    name: string
+  }>
+  template?: string
+}
+
+const promptUrlValidator = (value: string) => {
+  if (!value) return true
+  try {
+    new URL(value).toString()
+    return true
+  } catch {
+    return 'Invalid URL'
+  }
+}
+
+export async function applyPrompt (opts: {
+  force: boolean
+  silent: boolean
+  askLevel: ValueOf<typeof AskLevel>
+  packageJson: PkgJsonType
+}): Promise<void> {
+  const {
+    askLevel,
+    packageJson,
+  } = opts
+  const promptBase = {
+    type: 'input',
+    prefix: '>',
+    required: false,
+    format: (value) => typeof value === 'string' ? String.prototype.trim.call(value) : '',
+  } satisfies Partial<PromptOptions>
+  const prompts: PromptOptions[] = []
+  const firstPrompts = [
+    {
+      name: 'name',
+      message: 'package name',
+      initial: packageJson.name,
+      required: true,
+      validate: packageNameValidator,
+    },
+    {
+      name: 'version',
+      message: 'version',
+      initial: packageJson.version,
+      validate: (value) => typeof value === 'string' ? semverValid(value) !== null : false,
+    },
+    {
+      name: 'description',
+      message: 'description',
+      initial: packageJson.description,
+    },
+    {
+      name: 'main',
+      message: 'entry point',
+      initial: packageJson.main,
+    },
+    {
+      name: 'scripts',
+      message: 'test command',
+      initial: packageJson.scripts?.test,
+    },
+    {
+      name: 'repository',
+      message: 'git repository',
+      initial: typeof packageJson.repository === 'string' ? packageJson.repository : packageJson?.repository?.url,
+      validate: promptUrlValidator,
+    },
+    {
+      type: 'list',
+      name: 'keywords',
+      message: 'keywords',
+      initial: packageJson.keywords?.join(', '),
+    },
+    {
+      name: 'author',
+      message: 'author',
+      initial: packageJson.author,
+    },
+    {
+      name: 'license',
+      message: 'license',
+      initial: packageJson.license,
+    }] satisfies Array<Partial<PromptOptions>>
+
+  if (askLevel === AskLevel.npm) {
+    // Limited prompts
+    prompts.push(...(firstPrompts.map((p) => ({ ...promptBase, ...p }))))
+  } else {
+    if (askLevel > AskLevel.npm) {
+      const morePrompts = [
+        {
+          name: 'bugs',
+          message: 'Bugs URL',
+          initial: typeof packageJson.bugs === 'string' ? packageJson.bugs : packageJson?.bugs?.url,
+        },
+        {
+          name: 'homepage',
+          message: 'Homepage',
+          initial: packageJson.homepage,
+          validate: promptUrlValidator,
+        },
+        {
+          type: 'list',
+          name: 'funding',
+          message: 'Funding',
+          initial: typeof packageJson.funding === 'string' ? packageJson.funding : packageJson.funding?.join(', '),
+          validate: promptUrlValidator,
+        },
+      ] satisfies Array<Partial<PromptOptions>>
+      // Form prompts
+      prompts.push({
+        name: '_form',
+        type: 'form',
+        message: 'package.json',
+        choices: [
+          ...firstPrompts,
+          ...morePrompts,
+        ],
+      }, {
+        name: 'private',
+        type: 'confirm',
+        message: 'Make the package private',
+        initial: packageJson.private,
+      }, {
+        name: 'type',
+        type: 'select',
+        message: 'Module type',
+        initial: packageJson.type ?? 'module',
+        choices: [
+          { name: 'module' },
+          { name: 'commonjs' },
+        ],
+      })
+    }
+  }
+  const answers = await prompt(prompts.map((p) => ({
+    ...promptBase,
+    onCancel () {
+      // By default, canceling the prompt via Ctrl+c throws an empty string.
+      // The custom cancel function prevents that behavior.
+      // Otherwise, pnpm CLI would print an error and confuse users.
+      // See related issue: https://github.com/enquirer/enquirer/issues/225
+      globalInfo('Package.json Init canceled')
+      process.exit(0)
+    },
+    ...p,
+  }))) as Record<string, unknown>
+  const notMeta = <T extends string>(key: T): key is Exclude<T, `_${string}`> => key[0] !== '_'
+  const tryApply = (key: string, value: unknown) => {
+    if (key === 'keywords') {
+      return typeof value === 'string' ? value.split(',').map((k) => k?.trim()) : undefined
+    } else if (key === 'scripts' && typeof value === 'string') {
+      return { test: value }
+    }
+    return value
+  }
+
+  const cleanPkgJson = (key: string) => {
+    const pkgValue = (packageJson as Record<string, unknown>)[key]
+    if (pkgValue === '' ||
+    (Array.isArray(pkgValue) && (
+      pkgValue.length === 0 || pkgValue.every((v) => v === '')
+    )) ||
+    (typeof pkgValue === 'object' && pkgValue !== null && (
+      Object.keys(pkgValue).length === 0 || Object.values(pkgValue).every((v) => !v)
+    ))
+    ) {
+      delete (packageJson as Record<string, unknown>)[key]
+    }
+  }
+
+  for (const key of Object.keys(answers) as Array<keyof PkgJsonType | '_form'>) {
+    if (key === '_form') {
+      for (const [k, v] of Object.entries(answers[key] as Record<string, unknown>)) {
+        const value = tryApply(k, v)
+        if (value) {
+          (packageJson as Record<string, unknown>)[k] = value
+        }
+        cleanPkgJson(k)
+      }
+    } else {
+      const v = tryApply(key, answers[key])
+      if (v && notMeta(key))
+        (packageJson as Record<string, unknown>)[key] = v
+
+      cleanPkgJson(key)
+    }
+  }
+}

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -1,62 +1,84 @@
 import fs from 'fs'
 import path from 'path'
-import { docsUrl } from '@pnpm/cli-utils'
 import { type UniversalOptions } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
 import { writeProjectManifest } from '@pnpm/write-project-manifest'
-import renderHelp from 'render-help'
-import { parseRawConfig } from './utils'
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest'
+import { logger } from '@pnpm/logger'
+import { getMetaOptions, parseRawConfig } from './utils'
+import type { OptionsRaw } from './options'
+export { help, rcOptionsTypes, cliOptionsTypes } from './options'
 
-export const rcOptionsTypes = cliOptionsTypes
+export const commandNames = ['init', 'innit']
 
-export function cliOptionsTypes (): Record<string, unknown> {
-  return {}
-}
-
-export const commandNames = ['init']
-
-export function help (): string {
-  return renderHelp({
-    description: 'Create a package.json file',
-    descriptionLists: [],
-    url: docsUrl('init'),
-    usages: ['pnpm init'],
-  })
-}
+const getManifestDefaults = () => ({
+  name: path.basename(process.cwd()),
+  version: '1.0.0',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo "Error: no test specified" && exit 1',
+  },
+  keywords: [],
+  author: '',
+  license: 'ISC',
+})
+export type ManifestDefaults = ReturnType<typeof getManifestDefaults>
 
 export async function handler (
-  opts: Pick<UniversalOptions, 'rawConfig'>,
+  opts: Pick<UniversalOptions, 'rawConfig'> & {
+    rawConfig: OptionsRaw
+  },
   params?: string[]
 ): Promise<string> {
+  const { silent, force, initAsk, workspaceUpdate } = getMetaOptions(opts.rawConfig)
   if (params?.length) {
-    throw new PnpmError('INIT_ARG', 'init command does not accept any arguments', {
+    if (force) !silent || logger.warn({
+      message: 'Ignoring invalid arguments because --force is used',
+      prefix: process.cwd(),
+    })
+    else throw new PnpmError('INIT_ARG', 'init command does not accept any arguments', {
       hint: `Maybe you wanted to run "pnpm create ${params.join(' ')}"`,
     })
   }
   // Using cwd instead of the dir option because the dir option
   // is set to the first parent directory that has a package.json file.
   const manifestPath = path.join(process.cwd(), 'package.json')
-  if (fs.existsSync(manifestPath)) {
-    throw new PnpmError('PACKAGE_JSON_EXISTS', 'package.json already exists')
+  if (fs.existsSync(manifestPath) && !force) {
+    if (force) !silent || logger.warn({
+      message: 'Overwriting existing package.json because --force is used',
+      prefix: process.cwd(),
+    })
+    else throw new PnpmError('PACKAGE_JSON_EXISTS', 'package.json already exists')
   }
-  const manifest = {
-    name: path.basename(process.cwd()),
-    version: '1.0.0',
-    description: '',
-    main: 'index.js',
-    scripts: {
-      test: 'echo "Error: no test specified" && exit 1',
-    },
-    keywords: [],
-    author: '',
-    license: 'ISC',
-  }
-  const config = await parseRawConfig(opts.rawConfig)
-  const packageJson = { ...manifest, ...config }
+  const manifest = getManifestDefaults()
+  const config = await parseRawConfig(opts.rawConfig, manifest)
+  const packageJson = { ...(initAsk ? {} : manifest), ...config }
   await writeProjectManifest(manifestPath, packageJson, {
     indent: 2,
   })
-  return `Wrote to ${manifestPath}
+
+  let addedToWorkspace: string | false = false
+  if (workspaceUpdate) {
+    const workspaceDir = await findWorkspaceDir(process.cwd())
+    const workspaceManifestPath = workspaceDir && path.join(workspaceDir, 'pnpm-workspace.yaml')
+    const workspaceManifest = workspaceManifestPath && await readWorkspaceManifest(workspaceDir)
+    const relativeWorkspacePath = workspaceManifestPath && path.relative(path.resolve(workspaceDir), path.resolve()).split(path.sep).join('/')
+    if (workspaceManifest && workspaceManifest.packages && relativeWorkspacePath) {
+      if (!workspaceManifest.packages.includes(relativeWorkspacePath)) {
+        workspaceManifest.packages.push(relativeWorkspacePath)
+        await fs.promises.writeFile(workspaceManifestPath, `packages:\n${workspaceManifest.packages.map((pkgPath) => `  - ${pkgPath}`).join('\n')}\n`)
+        addedToWorkspace = workspaceManifestPath
+      }
+    }
+  }
+  const workspaceMessage = !addedToWorkspace
+    ? ''
+    : `Added to workspace at ${addedToWorkspace}
+
+`
+  return `${workspaceMessage}Wrote to ${manifestPath}
 
 ${JSON.stringify(packageJson, null, 2)}`
 }

--- a/packages/plugin-commands-init/src/options.ts
+++ b/packages/plugin-commands-init/src/options.ts
@@ -1,0 +1,138 @@
+import { URL } from 'url'
+import { types as allTypes } from '@pnpm/config'
+import { docsUrl } from '@pnpm/cli-utils'
+import renderHelp from 'render-help'
+import omit from 'ramda/src/omit'
+import pick from 'ramda/src/pick'
+
+export type PkgManagerFieldSpec = `${
+  'npm' | 'pnpm' | 'yarn'
+}@${number}.${number}.${number}${
+  '' | `-${string}`
+}`
+export const pkgManagerFieldValid = (s: string): s is PkgManagerFieldSpec =>
+  /^npm|pnpm|yarn@[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9-]+)?$/.test(s)
+
+export type OptionsRaw = Readonly<{
+  loglevel?: 'silent' | 'error' | 'warn' | 'info' | 'debug'
+  scope?: string
+  force?: true
+  'workspace-update'?: string
+  'init-type'?: 'module' | 'commonjs'
+  'init-package-manager'?: PkgManagerFieldSpec
+  'init-private'?: true
+  'init-ask'?: true | 'extended' | 'npm' | 'none'
+  'init-contributors'?: string | string[]
+  'init-funding'?: string | string[]
+  'init-name'?: string
+  'init-homepage'?: string
+  'init-bugs-url'?: string
+  'init-bugs-email'?: string
+  'init-author'?: string
+  'init-publish-config'?: string
+  'init-author-email'?: string
+  'init-author-name'?: string
+  'init-author-url'?: string
+  'init-license'?: string
+  'init-module'?: string
+  'init-version'?: string
+  'init-description'?: string
+  'init-main'?: string
+  'init-script-test'?: string
+  'init-repository'?: string | { type: string, url: string }
+  'init-keywords'?: string[]
+}>
+
+const getOptionTypes = () => ({
+  ...pick([
+    'scope',
+    'force',
+    'loglevel',
+    'init-author-email',
+    'init-author-name',
+    'init-author-url',
+    'init-license',
+    'init-version',
+    'init-module',
+  ], allTypes),
+  'init-type': ['module', 'commonjs'],
+  'init-package-manager': String,
+  'init-private': [null, true],
+  'init-ask': [null, true, 'extended', 'npm', 'none'],
+  'init-contributors': [String, Array],
+  'init-funding': [URL, Array],
+  'init-name': String,
+  'init-homepage': [String, URL],
+  'init-bugs-url': [String, URL],
+  'init-bugs-email': String,
+  'init-author': String,
+  'init-publish-config': String,
+  'workspace-update': Boolean,
+  'init-author-email': String,
+  'init-author-name': String,
+  'init-author-url': String,
+  'init-license': String,
+  'init-module': String,
+  'init-version': String,
+  'init-description': String,
+  'init-main': String,
+  'init-script-test': String,
+  'init-repository': String,
+  'init-keywords': [String, Array],
+} satisfies Record<keyof OptionsRaw, unknown>)
+
+export function cliOptionsTypes (): Record<string, unknown> {
+  return getOptionTypes()
+}
+export function rcOptionsTypes (): Record<string, unknown> {
+  return omit([
+    'force',
+    'loglevel',
+    'init-name',
+  ], getOptionTypes())
+}
+
+export const optionsInfo = {
+  '--scope': 'Prepend the scope to package name in package.json',
+  '--force': 'Create a package.json file even if one already exists',
+  '--loglevel': 'Set to silent to suppress output entirely, to warn to show only warnings and errors, or to info or debug to show all logs.',
+  '--workspace-update': 'Add this package to a workspace root configuration if one exists',
+  '--init-ask': 'Set to true or "npm" to ask only the the same questions as npm, or "extended" to ask all questions relevant via cli.',
+  '--init-author-email': 'The value that should be used by default for the package author\'s email.',
+  '--init-author-name': 'The value that should be used by default for the package author\'s name.',
+  '--init-author-url': 'The value that should be used by default for the package author\'s website/homepage.',
+  '--init-license': 'The value that should be used by default for the package license.',
+  '--init-module': 'A module that will be loaded by the pnpm init command. See the documentation for the init-package-json module for more information',
+  '--init-version': 'The value that should be used by default for the package version number, if not already set in package.json',
+  '--init-homepage': 'The URL to the project homepage.',
+  '--init-bugs-url': 'The URL to your project\'s issue tracker or where issues should be submitted.',
+  '--init-bugs-email': 'The email address to which issues should be reported (the value of the bugs field in package.json will be made an object instead of a string to accommodate).',
+  '--init-author': 'In place of individual author fields, you can also set the author field to a string of the form "Name <email> (url)".',
+  '--init-contributors': 'Provide as many contributors as you like with the format "Name <email> (url)".',
+  '--init-funding': 'Provide as many funding URLs as you like.',
+  '--init-private': 'Set the package to private, making it not publishable to the registry.',
+  '--init-publish-config': 'Provide stringified JSON to be used as the publishConfig field in the package.json file.',
+  '--init-type': 'Set the type of the package to be initialized. Can be either "module" or "commonjs".',
+  '--init-package-manager': 'The package manager to be used for the project. Can be either "npm", "pnpm" or "yarn", followed by an "@" sign and the exact version number.',
+  '--init-name': 'Set the name of the package.',
+  '--init-description': 'Set the description of the package.',
+  '--init-main': 'Set the entry point of the package.',
+  '--init-script-test': 'Set the test command of the package.',
+  '--init-repository': 'Set the repository field of the package.json file.',
+  '--init-keywords': 'Set the keywords of the package. Provide as many keywords as you like.',
+} satisfies {
+  [key in `--${keyof OptionsRaw}`]: string
+}
+export function help (): string {
+  return renderHelp({
+    description: 'Create a package.json file',
+    descriptionLists: [
+      {
+        title: 'Options',
+        list: Object.entries(optionsInfo).map(([name, description]) => ({ name, description })),
+      },
+    ],
+    url: docsUrl('init'),
+    usages: ['pnpm init [options]'],
+  })
+}

--- a/packages/plugin-commands-init/src/utils.ts
+++ b/packages/plugin-commands-init/src/utils.ts
@@ -1,7 +1,20 @@
 import path from 'path'
-import { spawnSync } from 'child_process'
-import camelcaseKeys from 'camelcase-keys'
 import fs from 'fs'
+import { spawnSync } from 'child_process'
+import { logger } from '@pnpm/logger'
+import { PnpmError } from '@pnpm/error'
+import camelcaseKeys, { type CamelCaseKeys } from 'camelcase-keys'
+import _camelcase, { type Options as CamelcaseOptions } from 'camelcase'
+import semverValid from 'semver/functions/valid'
+import type { CamelCase, Entries, ValueOf } from 'type-fest'
+import { pkgManagerFieldValid, type OptionsRaw } from './options'
+import { toUpper } from 'ramda'
+import { applyPrompt } from './apply-prompt.js'
+import type { ManifestDefaults } from './init.js'
+
+function camelcase<T extends string> (input: T, options?: CamelcaseOptions): CamelCase<T> {
+  return _camelcase(input, options) as CamelCase<T>
+}
 
 export interface Person {
   name?: string
@@ -20,10 +33,12 @@ export function personToString (person: Person): string {
   return name + email + url
 }
 
-export function workWithInitModule (localConfig: Record<string, string>): Record<string, string> {
+type CamelInitOptions = CamelCaseKeys<OptionsRaw>
+type CamelInitOptionsFiltered = Omit<CamelInitOptions, 'initModule'>
+export function workWithInitModule (localConfig: Record<string, string> & CamelInitOptions): CamelInitOptionsFiltered {
   const { initModule, ...restConfig } = localConfig
   if (initModule) {
-    const filePath = path.resolve(localConfig.initModule)
+    const filePath = path.resolve(initModule)
     const isFileExist = fs.existsSync(filePath)
     if (['.js', '.cjs'].includes(path.extname(filePath)) && isFileExist) {
       spawnSync('node', [filePath], {
@@ -34,30 +49,300 @@ export function workWithInitModule (localConfig: Record<string, string>): Record
   return restConfig
 }
 
-export function workWithInitConfig (localConfig: Record<string, string>): Record<string, string> {
-  const packageJson: Record<string, string> = {}
-  const authorInfo: Record<string, string> = {}
-  for (const localConfigKey in localConfig) {
-    if (localConfigKey.startsWith('init')) {
-      const pureKey = localConfigKey.replace('init', '')
-      const value = localConfig[localConfigKey]
-      if (pureKey.startsWith('Author')) {
-        authorInfo[pureKey.replace('Author', '')] = value
-      } else {
-        packageJson[pureKey] = value
+type LocalConfigKeys = Array<(keyof CamelInitOptionsFiltered & string)>
+type UnPrefixed<T extends string, Prefix extends string> = T extends `${Prefix}${infer P}` ? P : never
+
+type PureKey = UnPrefixed<(LocalConfigKeys[number] & `init${string}`), 'init'>
+type PureCamelKey = CamelCase<PureKey>
+/** Re-assert the type of the value for the given key once the key has been filtered down */
+type OptType<K extends PureCamelKey> = Required<CamelInitOptionsFiltered>[`init${Capitalize<K>}`]
+
+// if key is prefixed, ASSERT that it is prefixed and filter out the rest
+const isPrefix = <KeyKind extends string, Prefix extends string, Filter = `${Prefix}${string}`>(
+  key: KeyKind, prefix: Prefix
+): key is Extract<KeyKind, Filter> => key.startsWith(prefix)
+const minusPrefix = <KeyKind extends string, Prefix extends string>(
+  key: KeyKind, prefix: Prefix
+): UnPrefixed<KeyKind, Prefix> => String.prototype.slice.call(key, prefix.length) as UnPrefixed<KeyKind, Prefix>
+
+type PurePackageKeys = Exclude<CamelCase<PureKey>,
+`author${string}` |
+`bugs${string}` |
+'ask' |
+'scriptTest'
+>
+export type PkgJsonType = {
+  [K in PurePackageKeys]?: CamelInitOptionsFiltered[`init${Capitalize<K>}`]
+} & {
+  author?: string
+  bugs?: string | { url?: string, email?: string }
+  publishConfig?: Record<string, unknown>
+  contributors?: string[]
+  funding?: string | string[]
+  scripts?: Record<string, string>
+}
+
+export const getMetaOptions = (opts: {
+  loglevel?: 'silent' | 'error' | 'warn' | 'info' | 'debug'
+  force?: true
+  'workspace-update'?: string
+  'init-ask'?: boolean | 'extended' | 'npm' | 'none'
+}): { silent: boolean, force: boolean, initAsk: boolean | 'extended' | 'npm' | 'none', workspaceUpdate: boolean } => ({
+  silent: ['silent', 'error'].includes(opts.loglevel ?? ''),
+  force: !!opts.force,
+  initAsk: opts['init-ask'] ?? false,
+  workspaceUpdate: !!opts['workspace-update'],
+})
+
+export const packageNameValidator = (value: string): string | true => {
+  const maxLength = 214
+  const isScoped = value.startsWith('@')
+  const hasInvalidCharacters = /[^a-zA-Z0-9-_]/.test(value)
+  const hasUppercaseLetters = /[A-Z]/.test(value)
+
+  if (value.length > maxLength) {
+    return `The name must be less than or equal to ${maxLength} characters.`
+  }
+
+  if (isScoped && !value.includes('/')) {
+    return 'Scoped packages must include a scoped name (e.g., @scope/package-name).'
+  }
+
+  if (!isScoped && (value.startsWith('.') || value.startsWith('_'))) {
+    return 'Only scoped packages can begin with a dot or an underscore.'
+  }
+
+  if (hasInvalidCharacters) {
+    return 'The name contains non-URL-safe characters.'
+  }
+
+  if (hasUppercaseLetters) {
+    return 'New packages must not have uppercase letters in the name.'
+  }
+
+  return true
+}
+
+export const AskLevel = {
+  none: 0,
+  npm: 1,
+  extended: 2,
+} as const
+const getAskLevel = (ask: boolean | 'extended' | 'npm' | 'none' | undefined): ValueOf<typeof AskLevel> => {
+  if (ask === 'extended') return AskLevel.extended
+  if (ask === 'npm' || ask === true) return AskLevel.npm
+  return AskLevel.none
+}
+
+export async function workWithInitConfig (localConfig: CamelInitOptionsFiltered, manifestDefaults?: ManifestDefaults): Promise<PkgJsonType> {
+  const { initAsk, loglevel, force: _force, ...lConfig } = localConfig
+  const askLevel = getAskLevel(initAsk)
+  const { silent, force } = getMetaOptions({ loglevel, force: _force })
+
+  const packageJson: PkgJsonType = manifestDefaults ? Object.assign({}, manifestDefaults) : {}
+  let authorInfo: {
+    name?: string
+    email?: string
+    url?: string
+  } | string = {}
+  const bugs = {
+    url: '',
+    email: '',
+  }
+
+  for (const [lKey, lValue] of Object.entries(lConfig) as Entries<typeof lConfig>) {
+    // Init keys
+    if (isPrefix(lKey, 'init')) {
+      const initKey = minusPrefix(lKey, 'init')
+      const pureKey = camelcase(initKey)
+      if (lValue === undefined || lValue === null) continue
+
+      const urlValidator = (value: string) => {
+        try {
+          return new URL(value).toString()
+        } catch (_error) {
+          const message = `Invalid URL string for ${pureKey}: ${value}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError(`INIT_${toUpper(pureKey)}_PARSE`, message)
+          return undefined
+        }
       }
+
+      // Author info
+      if (isPrefix(pureKey, 'author')) {
+        if (typeof authorInfo === 'string') continue
+        const v = lValue as OptType<typeof pureKey>
+        const authorKey = camelcase(minusPrefix(pureKey, 'author'))
+        if (authorKey !== '') {
+          if (authorKey === 'url') authorInfo[authorKey] = urlValidator(v)
+          else authorInfo[authorKey] = v
+        } else {
+          authorInfo = v
+        }
+        continue
+      }
+
+      // Bugs info
+      if (isPrefix(pureKey, 'bugs')) {
+        const k = camelcase(minusPrefix(pureKey, 'bugs'))
+        const v = lValue as OptType<typeof pureKey>
+        if (k === 'url') {
+          const validated = urlValidator(v)
+          if (validated) bugs.url = validated
+        } else bugs[k] = v
+        continue
+      }
+
+      // Validated URLs
+      if (pureKey === 'funding') {
+        const v = lValue as OptType<typeof pureKey>
+        if (typeof v === 'string') {
+          packageJson[pureKey] = urlValidator(v)
+        } else {
+          const funding = v
+            .map(urlValidator)
+            .filter((v): v is string => v !== undefined)
+          packageJson[pureKey] = funding
+        }
+        continue
+      }
+      if (pureKey === 'homepage') {
+        const v = lValue as OptType<typeof pureKey>
+        const validated = urlValidator(v)
+        if (validated) packageJson[pureKey] = validated
+        continue
+      }
+
+      // Uniquely validated keys
+      if (pureKey === 'private') {
+        const v = lValue as OptType<typeof pureKey>
+        if (typeof v === 'boolean' && v) packageJson[pureKey] = v
+        else {
+          const message = `Invalid boolean flag for ${pureKey}: ${v as string}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError(`INIT_${toUpper(pureKey)}_PARSE`, message)
+        }
+        continue
+      }
+      if (pureKey === 'type') {
+        const v = lValue as OptType<typeof pureKey>
+        if (v === 'module' || v === 'commonjs') packageJson[pureKey] = v
+        else {
+          const message = `Invalid boolean flag for ${pureKey}: ${v as string}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError(`INIT_${toUpper(pureKey)}_PARSE`, message)
+        }
+        continue
+      }
+      if (pureKey === 'version') {
+        const v = lValue as OptType<typeof pureKey>
+        const validated = semverValid(v)
+        if (validated) packageJson[pureKey] = validated
+        else {
+          const message = `Invalid version string for ${pureKey} flag: ${v}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError(`INIT_${toUpper(pureKey)}_PARSE`, message)
+        }
+        continue
+      }
+      if (pureKey === 'packageManager') {
+        const v = lValue as OptType<typeof pureKey>
+        if (pkgManagerFieldValid(v)) packageJson[pureKey] = v
+        else {
+          const message = `Invalid package manager (w/version) string for ${pureKey} flag: ${v as string}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError('INIT_PKG_MANAGER_PARSE', message)
+        }
+        continue
+      }
+      if (pureKey === 'name') {
+        const v = lValue as OptType<typeof pureKey>
+        const validated = packageNameValidator(v)
+        if (validated === true) packageJson[pureKey] = v
+        else {
+          const message = `Invalid package name string for ${pureKey} flag: ${validated}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError('INIT_PKG_MANAGER_PARSE', message)
+        }
+        continue
+      }
+
+      // Structured transforms
+      if (pureKey === 'publishConfig') {
+        const v = lValue as OptType<typeof pureKey>
+        try {
+          const parsed = JSON.parse(v)
+          packageJson[pureKey] = parsed
+        } catch (_error) {
+          const message = `Invalid JSON string for publishConfig: ${v}`
+          if (force) !silent || logger.warn({ message, prefix: process.cwd() })
+          else throw new PnpmError('INIT_PUBLISH_CFG_PARSE', message)
+        }
+        continue
+      }
+      if (pureKey === 'scriptTest') {
+        const v = lValue as OptType<typeof pureKey>
+        packageJson.scripts = { test: v }
+        continue
+      }
+
+      // All remaining keys (hover over `pureKey` to see the inferred type of the remaining keys to compare)
+      if (pureKey === 'contributors') {
+        const v = lValue as OptType<typeof pureKey>
+        if (typeof v === 'string') {
+          packageJson[pureKey] = [v]
+        } else {
+          packageJson[pureKey] = v
+        }
+        continue
+      }
+      if (pureKey === 'keywords') {
+        const v = lValue as OptType<typeof pureKey>
+        if (typeof v === 'string') {
+          packageJson[pureKey] = [v]
+        } else {
+          packageJson[pureKey] = v
+        }
+        continue
+      }
+      if (pureKey === 'license') packageJson[pureKey] = lValue as OptType<typeof pureKey>
+      else if (pureKey === 'description') packageJson[pureKey] = lValue as OptType<typeof pureKey>
+      else if (pureKey === 'main') packageJson[pureKey] = lValue as OptType<typeof pureKey>
+      else if (pureKey === 'repository') packageJson[pureKey] = lValue as OptType<typeof pureKey>
     }
   }
 
-  const author = personToString(camelcaseKeys(authorInfo))
-  if (author) {
+  if (lConfig.scope) {
+    const atSign = packageJson.name?.startsWith('@') ? '' : '@'
+    if (packageJson.name) packageJson.name = `${atSign}${lConfig.scope}/${packageJson.name}`
+    else packageJson.name = `${atSign}${lConfig.scope}/${path.basename(process.cwd())}`
+  }
+
+  const author = typeof authorInfo === 'string'
+    ? authorInfo
+    : personToString(camelcaseKeys(authorInfo))
+  if (author !== '') {
     packageJson.author = author
   }
-  return camelcaseKeys(packageJson)
+  if (bugs.email !== '' || bugs.url !== '') {
+    if (bugs.email === '') packageJson.bugs = bugs.url
+    else packageJson.bugs = bugs
+  }
+
+  if (askLevel > AskLevel.none)
+    await applyPrompt({
+      force,
+      silent,
+      askLevel,
+      packageJson,
+    })
+
+  return packageJson
 }
 
-export async function parseRawConfig (rawConfig: Record<string, string>): Promise<Record<string, string>> {
+export async function parseRawConfig (rawConfig: Record<string, string> & OptionsRaw, manifestDefaults?: ManifestDefaults): Promise<PkgJsonType> {
   return workWithInitConfig(
-    workWithInitModule(camelcaseKeys(rawConfig))
+    workWithInitModule(camelcaseKeys(rawConfig)),
+    manifestDefaults
   )
 }

--- a/packages/plugin-commands-init/test/init.test.ts
+++ b/packages/plugin-commands-init/test/init.test.ts
@@ -18,6 +18,14 @@ test('throws an error if a package.json exists in the current directory', async 
   ).rejects.toThrow('package.json already exists')
 })
 
+test('doesn\'t throw an error if a package.json exists with force option', async () => {
+  prepare({})
+
+  await init.handler({ rawConfig: { force: true } })
+  const manifest = loadJsonFile(path.resolve('package.json'))
+  expect(manifest).toBeTruthy()
+})
+
 test('init a new package.json with npmrc', async () => {
   const rawConfig = {
     'init-author-email': 'xxxxxx@pnpm.com',

--- a/packages/plugin-commands-init/tsconfig.json
+++ b/packages/plugin-commands-init/tsconfig.json
@@ -25,6 +25,12 @@
       "path": "../../pkg-manifest/write-project-manifest"
     },
     {
+      "path": "../../workspace/find-workspace-dir"
+    },
+    {
+      "path": "../../workspace/read-manifest"
+    },
+    {
       "path": "../error"
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2771,15 +2771,36 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../error
+      '@pnpm/find-workspace-dir':
+        specifier: workspace:*
+        version: link:../../workspace/find-workspace-dir
+      '@pnpm/logger':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../../workspace/read-manifest
       '@pnpm/write-project-manifest':
         specifier: workspace:*
         version: link:../../pkg-manifest/write-project-manifest
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       camelcase-keys:
-        specifier: ^6.2.2
-        version: 6.2.2
+        specifier: ^9.1.3
+        version: 9.1.3
+      enquirer:
+        specifier: ^2.4.1
+        version: 2.4.1
+      ramda:
+        specifier: npm:@pnpm/ramda@0.28.1
+        version: '@pnpm/ramda@0.28.1'
       render-help:
         specifier: ^1.0.3
         version: 1.0.3
+      semver:
+        specifier: ^7.6.2
+        version: 7.6.2
     devDependencies:
       '@pnpm/plugin-commands-init':
         specifier: workspace:*
@@ -2790,9 +2811,18 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@types/ramda':
+        specifier: 0.29.12
+        version: 0.29.12
+      '@types/semver':
+        specifier: 7.5.8
+        version: 7.5.8
       load-json-file:
         specifier: ^6.2.0
         version: 6.2.0
+      type-fest:
+        specifier: ^4.18.2
+        version: 4.18.2
 
   packages/plugin-commands-setup:
     dependencies:
@@ -8597,6 +8627,10 @@ packages:
     resolution: {integrity: sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==}
     engines: {node: '>=12'}
 
+  camelcase-keys@9.1.3:
+    resolution: {integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==}
+    engines: {node: '>=16'}
+
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -8604,6 +8638,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   can-link@2.0.0:
     resolution: {integrity: sha512-2W2yAdkQQrrL0WM6BrGqkrLkWlVon8riZch0EBNklid2CZsOzZnqR5HE7W3Q3BrMWUop+9I2dpjyZqhSOYh6Yg==}
@@ -10818,6 +10856,10 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  map-obj@5.0.0:
+    resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
 
@@ -11659,6 +11701,10 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
 
   ramda@0.29.1:
     resolution: {integrity: sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==}
@@ -12556,6 +12602,10 @@ packages:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
 
+  type-fest@4.18.2:
+    resolution: {integrity: sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -13006,7 +13056,7 @@ snapshots:
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13033,7 +13083,7 @@ snapshots:
       '@babel/helper-validator-option': 7.23.5
       browserslist: 4.23.0
       lru-cache: 5.1.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@babel/helper-create-class-features-plugin@7.24.5(@babel/core@7.24.5)':
     dependencies:
@@ -13046,7 +13096,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@babel/helper-environment-visitor@7.22.20': {}
 
@@ -13290,7 +13340,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/assemble-release-plan@6.0.0':
     dependencies:
@@ -13299,7 +13349,7 @@ snapshots:
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -13335,7 +13385,7 @@ snapshots:
       p-limit: 2.3.0
       preferred-pm: 3.1.3
       resolve-from: 5.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       spawndamnit: 2.0.0
       term-size: 2.2.1
       tty-table: 4.2.3
@@ -13360,7 +13410,7 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       chalk: 2.4.2
       fs-extra: 7.0.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@changesets/get-release-plan@4.0.0':
     dependencies:
@@ -14084,7 +14134,7 @@ snapshots:
 
   '@npmcli/fs@3.1.0':
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -14185,7 +14235,7 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       right-pad: 1.0.1
       rxjs: 7.8.1
-      semver: 7.6.0
+      semver: 7.6.2
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -14391,7 +14441,7 @@ snapshots:
       detect-libc: 2.0.3
       execa: safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@pnpm/patch-package@0.0.0':
     dependencies:
@@ -14405,7 +14455,7 @@ snapshots:
       minimist: 1.2.8
       open: 7.4.2
       rimraf: 2.7.1
-      semver: 7.6.0
+      semver: 7.6.2
       slash: 2.0.0
       tmp: 0.0.33
       yaml: 2.4.2
@@ -14869,7 +14919,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
       typescript: 5.4.5
@@ -14885,7 +14935,7 @@ snapshots:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.4.5)
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -14921,7 +14971,7 @@ snapshots:
       http-errors: 1.8.1
       http-status-codes: 2.2.0
       process-warning: 1.0.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@verdaccio/file-locking@10.3.0':
     dependencies:
@@ -14968,7 +15018,7 @@ snapshots:
       '@verdaccio/core': 6.0.0-6-next.55
       lodash: 4.17.21
       minimatch: 3.1.2
-      semver: 7.6.0
+      semver: 7.6.2
 
   '@yarnpkg/core@4.0.3(typanion@3.14.0)':
     dependencies:
@@ -15022,7 +15072,7 @@ snapshots:
       lodash: 4.17.21
       micromatch: 4.0.5
       p-limit: 2.3.0
-      semver: 7.6.0
+      semver: 7.6.2
       strip-ansi: 6.0.1
       tar: 6.2.1
       tinylogic: 2.0.0
@@ -15563,7 +15613,7 @@ snapshots:
 
   builtins@5.1.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   bytes@3.0.0: {}
 
@@ -15634,9 +15684,18 @@ snapshots:
       quick-lru: 5.1.1
       type-fest: 1.4.0
 
+  camelcase-keys@9.1.3:
+    dependencies:
+      camelcase: 8.0.0
+      map-obj: 5.0.0
+      quick-lru: 6.1.2
+      type-fest: 4.18.2
+
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@8.0.0: {}
 
   can-link@2.0.0: {}
 
@@ -16049,7 +16108,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       file-entry-cache: 7.0.2
       get-stdin: 9.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       strip-ansi: 7.1.0
       vscode-uri: 3.0.8
     transitivePeerDependencies:
@@ -16417,7 +16476,7 @@ snapshots:
   eslint-compat-utils@0.5.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   eslint-config-standard-with-typescript@39.1.1(@typescript-eslint/eslint-plugin@6.18.1(@typescript-eslint/parser@6.18.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.18.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
@@ -17588,7 +17647,7 @@ snapshots:
       '@babel/parser': 7.24.5(@babel/types@7.24.5)
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - '@babel/types'
       - supports-color
@@ -17886,7 +17945,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.0
+      semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17985,7 +18044,7 @@ snapshots:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.6.0
+      semver: 7.6.2
 
   jsprim@1.4.2:
     dependencies:
@@ -18178,11 +18237,11 @@ snapshots:
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
-      semver: 7.6.0
+      semver: 7.6.2
 
   make-dir@3.1.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   make-dir@4.0.0:
     dependencies:
@@ -18224,6 +18283,8 @@ snapshots:
   map-obj@1.0.1: {}
 
   map-obj@4.3.0: {}
+
+  map-obj@5.0.0: {}
 
   mdast-util-from-markdown@0.8.5:
     dependencies:
@@ -18516,7 +18577,7 @@ snapshots:
 
   node-abi@3.62.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   node-fetch@2.6.8(encoding@0.1.13):
     dependencies:
@@ -18542,7 +18603,7 @@ snapshots:
       make-fetch-happen: 13.0.1
       nopt: 7.2.1
       proc-log: 3.0.0
-      semver: 7.6.0
+      semver: 7.6.2
       tar: 6.2.1
       which: 4.0.0
     transitivePeerDependencies:
@@ -18566,21 +18627,21 @@ snapshots:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@3.0.3:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@5.0.0:
     dependencies:
       hosted-git-info: 6.1.1
       is-core-module: 2.13.1
-      semver: 7.6.0
+      semver: 7.6.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -18835,7 +18896,7 @@ snapshots:
 
   parse-npm-tarball-url@3.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.6.2
 
   parseurl@1.3.3: {}
 
@@ -18911,7 +18972,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       progress: 2.0.3
-      semver: 7.6.0
+      semver: 7.6.2
       tar-fs: 2.1.1
       yargs: 16.2.0
     transitivePeerDependencies:
@@ -19098,6 +19159,8 @@ snapshots:
   quick-lru@4.0.1: {}
 
   quick-lru@5.1.1: {}
+
+  quick-lru@6.1.2: {}
 
   ramda@0.29.1: {}
 
@@ -19441,7 +19504,7 @@ snapshots:
   semver-range-intersect@0.3.1:
     dependencies:
       '@types/semver': 6.2.7
-      semver: 7.6.0
+      semver: 7.6.2
 
   semver-utils@1.1.4: {}
 
@@ -19870,7 +19933,7 @@ snapshots:
       glob: 8.1.0
       minimatch: 6.1.6
       read-yaml-file: 2.1.0
-      semver: 7.6.0
+      semver: 7.6.2
 
   table@6.8.2:
     dependencies:
@@ -20013,7 +20076,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.6.0
+      semver: 7.6.2
       typescript: 5.4.5
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -20115,6 +20178,8 @@ snapshots:
   type-fest@0.8.1: {}
 
   type-fest@1.4.0: {}
+
+  type-fest@4.18.2: {}
 
   type-is@1.6.18:
     dependencies:


### PR DESCRIPTION
closes #7711

Still working on adding the documentation and tests, but wanted to get some feedback in the meantime.
Added all the settings npm exposes from npmrc and cli flags, as well as adding the interactive prompts behind a flag, so the default behavior should not have changed, but can in a future major version if people want it to.

I did add a few more settings that npm wasn't exposing that would make sense to control from npmrc settings, like using the global npmrc to set a policy of `"type":"module"` for new projects