### PR TITLE
fix: update corepack install command for outdated version

### DIFF
--- a/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -54,7 +54,7 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
   if (opts.env.COREPACK_ROOT) {
-    return `corepack prepare pnpm@${opts.latestVersion} --activate`
+    return `corepack install -g pnpm@${opts.latestVersion}`
   }
   const pkgName = opts.currentPkgIsExecutable ? '@pnpm/exe' : 'pnpm'
   return `pnpm add -g ${pkgName}`

--- a/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -6,7 +6,7 @@ exports[`print update notification for Corepack if the latest version is greater
    │                                                                  │
    │                Update available! 10.0.0 → 11.0.0.                │
    │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v11.0.0   │
-   │     Run "corepack prepare pnpm@11.0.0 --activate" to update.     │
+   │     Run "corepack install -g pnpm@11.0.0" to update.             │
    │                                                                  │
    │      Follow @pnpmjs for updates: https://twitter.com/pnpmjs      │
    │                                                                  │

--- a/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -6,7 +6,7 @@ exports[`print update notification for Corepack if the latest version is greater
    │                                                                  │
    │                Update available! 10.0.0 → 11.0.0.                │
    │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v11.0.0   │
-   │     Run "corepack install -g pnpm@11.0.0" to update.             │
+   │         Run "corepack install -g pnpm@11.0.0" to update.         │
    │                                                                  │
    │      Follow @pnpmjs for updates: https://twitter.com/pnpmjs      │
    │                                                                  │


### PR DESCRIPTION
The Corepack CLI was refactored to add much more intuitive commands in PR https://github.com/nodejs/corepack/pull/291

This landed in `corepack@0.20.0` https://github.com/nodejs/corepack/releases/tag/v0.20.0

Which landed in `node@18.19.0` https://github.com/nodejs/node/pull/49464

This has been available since last year https://nodejs.org/en/blog/release/v18.19.0