### PR TITLE
feat: read catalog configs from workspace manifest

### DIFF
--- a/.changeset/unlucky-chefs-learn.md
+++ b/.changeset/unlucky-chefs-learn.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.read-manifest": minor
+---
+
+The `readWorkspaceManifest` function now parses and validates [pnpm catalogs](https://github.com/pnpm/rfcs/pull/1) configs if present.

--- a/workspace/read-manifest/src/catalogs.ts
+++ b/workspace/read-manifest/src/catalogs.ts
@@ -1,0 +1,65 @@
+import { InvalidWorkspaceManifestError } from './errors/InvalidWorkspaceManifestError'
+
+export interface WorkspaceNamedCatalogs {
+  readonly [catalogName: string]: WorkspaceCatalog
+}
+
+export interface WorkspaceCatalog {
+  readonly [dependencyName: string]: string
+}
+
+export function assertValidWorkspaceManifestCatalog (manifest: { packages?: readonly string[], catalog?: unknown }): asserts manifest is { catalog?: WorkspaceCatalog } {
+  if (manifest.catalog == null) {
+    return
+  }
+
+  if (Array.isArray(manifest.catalog)) {
+    throw new InvalidWorkspaceManifestError('Expected catalog field to be an object, but found - array')
+  }
+
+  if (typeof manifest.catalog !== 'object') {
+    throw new InvalidWorkspaceManifestError(`Expected catalog field to be an object, but found - ${typeof manifest.catalog}`)
+  }
+
+  for (const [alias, specifier] of Object.entries(manifest.catalog)) {
+    if (typeof specifier !== 'string') {
+      throw new InvalidWorkspaceManifestError(`Invalid catalog entry for ${alias}. Expected string, but found: ${typeof specifier}`)
+    }
+  }
+}
+
+export function assertValidWorkspaceManifestCatalogs (manifest: { packages?: readonly string[], catalogs?: unknown }): asserts manifest is { catalogs?: WorkspaceNamedCatalogs } {
+  if (manifest.catalogs == null) {
+    return
+  }
+
+  if (Array.isArray(manifest.catalogs)) {
+    throw new InvalidWorkspaceManifestError('Expected catalogs field to be an object, but found - array')
+  }
+
+  if (typeof manifest.catalogs !== 'object') {
+    throw new InvalidWorkspaceManifestError(`Expected catalogs field to be an object, but found - ${typeof manifest.catalogs}`)
+  }
+
+  for (const [catalogName, catalog] of Object.entries(manifest.catalogs)) {
+    if (Array.isArray(catalog)) {
+      throw new InvalidWorkspaceManifestError(`Expected named catalog ${catalogName} to be an object, but found - array`)
+    }
+
+    if (typeof catalog !== 'object') {
+      throw new InvalidWorkspaceManifestError(`Expected named catalog ${catalogName} to be an object, but found - ${typeof catalog}`)
+    }
+
+    for (const [alias, specifier] of Object.entries(catalog)) {
+      if (typeof specifier !== 'string') {
+        throw new InvalidWorkspaceManifestError(`Catalog '${catalogName}' has invalid entry '${alias}'. Expected string specifier, but found: ${typeof specifier}`)
+      }
+    }
+  }
+}
+
+export function checkDefaultCatalogIsDefinedOnce (manifest: { catalog?: WorkspaceCatalog, catalogs?: WorkspaceNamedCatalogs }): void {
+  if (manifest.catalog != null && manifest.catalogs?.default != null) {
+    throw new InvalidWorkspaceManifestError('The \'default\' catalog was defined multiple times. Use the \'catalog\' field or \'catalogs.default\', but not both')
+  }
+}

--- a/workspace/read-manifest/src/errors/InvalidWorkspaceManifestError.ts
+++ b/workspace/read-manifest/src/errors/InvalidWorkspaceManifestError.ts
@@ -1,0 +1,7 @@
+import { PnpmError } from '@pnpm/error'
+
+export class InvalidWorkspaceManifestError extends PnpmError {
+  constructor (message: string) {
+    super('INVALID_WORKSPACE_CONFIGURATION', message)
+  }
+}

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -1,8 +1,8 @@
 import util from 'util'
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
-import { PnpmError } from '@pnpm/error'
 import path from 'node:path'
 import readYamlFile from 'read-yaml-file'
+import { InvalidWorkspaceManifestError } from './errors/InvalidWorkspaceManifestError'
 
 export interface WorkspaceManifest {
   packages?: string[]
@@ -79,9 +79,3 @@ function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown })
  * the future.
  */
 function checkWorkspaceManifestAssignability (_manifest: WorkspaceManifest): void {}
-
-class InvalidWorkspaceManifestError extends PnpmError {
-  constructor (message: string) {
-    super('INVALID_WORKSPACE_CONFIGURATION', message)
-  }
-}

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -2,10 +2,30 @@ import util from 'util'
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import path from 'node:path'
 import readYamlFile from 'read-yaml-file'
+import {
+  assertValidWorkspaceManifestCatalog,
+  assertValidWorkspaceManifestCatalogs,
+  checkDefaultCatalogIsDefinedOnce,
+  type WorkspaceCatalog,
+  type WorkspaceNamedCatalogs,
+} from './catalogs'
 import { InvalidWorkspaceManifestError } from './errors/InvalidWorkspaceManifestError'
 
 export interface WorkspaceManifest {
   packages?: string[]
+
+  /**
+   * The default catalog. Package manifests may refer to dependencies in this
+   * definition through the `catalog:default` specifier or the `catalog:`
+   * shorthand.
+   */
+  catalog?: WorkspaceCatalog
+
+  /**
+   * A dictionary of named catalogs. Package manifests may refer to dependencies
+   * in this definition through the `catalog:<name>` specifier.
+   */
+  catalogs?: WorkspaceNamedCatalogs
 }
 
 export async function readWorkspaceManifest (dir: string): Promise<WorkspaceManifest | undefined> {
@@ -48,6 +68,10 @@ function validateWorkspaceManifest (manifest: unknown): asserts manifest is Work
   }
 
   assertValidWorkspaceManifestPackages(manifest)
+  assertValidWorkspaceManifestCatalog(manifest)
+  assertValidWorkspaceManifestCatalogs(manifest)
+  checkDefaultCatalogIsDefinedOnce(manifest)
+
   checkWorkspaceManifestAssignability(manifest)
 }
 

--- a/workspace/read-manifest/test/__fixtures__/catalog-invalid-array/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalog-invalid-array/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog:
+  - test

--- a/workspace/read-manifest/test/__fixtures__/catalog-invalid-object/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalog-invalid-object/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog: 5

--- a/workspace/read-manifest/test/__fixtures__/catalog-invalid-specifier/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalog-invalid-specifier/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog:
+  foo: {}

--- a/workspace/read-manifest/test/__fixtures__/catalog-ok/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalog-ok/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog:
+  foo: ^1.0.0

--- a/workspace/read-manifest/test/__fixtures__/catalogs-conflicting-defaults/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-conflicting-defaults/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog:
+  foo: ^1.0.0
+
+catalogs:
+  default:
+    bar: ^2.0.0

--- a/workspace/read-manifest/test/__fixtures__/catalogs-invalid-array/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-invalid-array/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs:
+  - foo

--- a/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-array/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-array/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs:
+  foo:
+    - bar

--- a/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-object/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-object/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs:
+  foo: 92

--- a/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-specifier/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-invalid-named-catalog-specifier/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs:
+  foo:
+    bar: {}

--- a/workspace/read-manifest/test/__fixtures__/catalogs-invalid-object/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-invalid-object/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs: 5

--- a/workspace/read-manifest/test/__fixtures__/catalogs-ok/pnpm-workspace.yaml
+++ b/workspace/read-manifest/test/__fixtures__/catalogs-ok/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalog:
+  bar: ^1.0.0
+
+catalogs:
+  foo:
+    bar: ^2.0.0

--- a/workspace/read-manifest/test/index.ts
+++ b/workspace/read-manifest/test/index.ts
@@ -62,3 +62,100 @@ test('readWorkspaceManifest() works when workspace file is null', async () => {
 
   expect(manifest).toBeNull()
 })
+
+describe('readWorkspaceManifest() catalog field', () => {
+  test('works on simple catalog', async () => {
+    await expect(readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalog-ok'))).resolves.toEqual({
+      packages: ['packages/**', 'types'],
+      catalog: {
+        foo: '^1.0.0',
+      },
+    })
+  })
+
+  test('throws on invalid array', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalog-invalid-array'))
+    ).rejects.toThrow('Expected catalog field to be an object, but found - array')
+  })
+
+  test('throws on invalid object', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalog-invalid-object'))
+    ).rejects.toThrow('Expected catalog field to be an object, but found - number')
+  })
+
+  test('throws on invalid specifier', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalog-invalid-specifier'))
+    ).rejects.toThrow('Invalid catalog entry for foo. Expected string, but found: object')
+  })
+})
+
+describe('readWorkspaceManifest() catalogs field', () => {
+  test('works with simple named catalogs', async () => {
+    await expect(readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-ok'))).resolves.toEqual({
+      packages: ['packages/**', 'types'],
+      catalog: {
+        bar: '^1.0.0',
+      },
+      catalogs: {
+        foo: {
+          bar: '^2.0.0',
+        },
+      },
+    })
+  })
+
+  test('throws on invalid array', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-invalid-array'))
+    ).rejects.toThrow('Expected catalogs field to be an object, but found - array')
+  })
+
+  test('throws on invalid value', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-invalid-object'))
+    ).rejects.toThrow('Expected catalogs field to be an object, but found - number')
+  })
+
+  test('throws on invalid named catalog array', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-invalid-named-catalog-array'))
+    ).rejects.toThrow('Expected named catalog foo to be an object, but found - array')
+  })
+
+  test('throws on invalid named catalog object', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-invalid-named-catalog-object'))
+    ).rejects.toThrow('Expected named catalog foo to be an object, but found - number')
+  })
+
+  test('throws on invalid named catalog specifier', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-invalid-named-catalog-specifier'))
+    ).rejects.toThrow('Catalog \'foo\' has invalid entry \'bar\'. Expected string specifier, but found: object')
+  })
+})
+
+describe('readWorkspaceManifest() reads default catalog defined alongside named catalogs', () => {
+  test('works when implicit default catalog is configured alongside named catalogs', async () => {
+    await expect(readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-ok'))).resolves.toEqual({
+      packages: ['packages/**', 'types'],
+      catalog: {
+        bar: '^1.0.0',
+      },
+      catalogs: {
+        foo: {
+          bar: '^2.0.0',
+        },
+      },
+    })
+  })
+
+  test('throws if both catalog and catalogs.default are defined', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-conflicting-defaults'))
+    ).rejects.toThrow('The \'default\' catalog was defined multiple times. Use the \'catalog\' field or \'catalogs.default\', but not both')
+  })
+})


### PR DESCRIPTION
## Context

This is a repeat of https://github.com/pnpm/pnpm/pull/8019, which was reverted on the `main` branch. We're now switching to a feature branch approach for landing the catalogs feature.

## Changes

Compared to the original PR https://github.com/pnpm/pnpm/pull/8019, this removes the feature flag commit since we're merging into a `catalogs` feature branch.

- https://github.com/pnpm/pnpm/pull/8019/commits/b44e2ceded3a18ea1012687a6f7980e1ad991149 feat: disable catalogs config reads by default 