### PR TITLE
chore: configure TypeScript project references for tests

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -87,7 +87,7 @@ async function updateTSConfig (
     ...importer.dependencies,
     ...importer.devDependencies,
   }
-  const references = [] as Array<{ path: string }>
+  const linkValues: string[] = []
   for (const [depName, spec] of Object.entries(deps)) {
     if (!spec.startsWith('link:') || spec.length === 5) continue
     const relativePath = spec.slice(5)
@@ -105,8 +105,10 @@ async function updateTSConfig (
       // This is to avoid a circular graph (which TypeScript references do not support.
       continue
     }
-    references.push({ path: relativePath })
+    linkValues.push(relativePath)
   }
+  linkValues.sort((a, b) => a.localeCompare(b))
+
   await writeJsonFile(path.join(dir, 'tsconfig.lint.json'), {
     extends: './tsconfig.json',
     include: [
@@ -123,7 +125,7 @@ async function updateTSConfig (
       ...(tsConfig as any)['compilerOptions'],
       rootDir: 'src',
     },
-    references: references.sort((r1, r2) => r1.path.localeCompare(r2.path)),
+    references: linkValues.map(path => ({ path })),
   }
 }
 

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -109,14 +109,80 @@ async function updateTSConfig (
   }
   linkValues.sort()
 
-  await writeJsonFile(path.join(dir, 'tsconfig.lint.json'), {
-    extends: './tsconfig.json',
-    include: [
-      'src/**/*.ts',
-      'test/**/*.ts',
-      '../../__typings__/**/*.d.ts',
-    ],
-  }, { indent: 2 })
+  async function writeTestTsconfig () {
+    const testDir = path.join(dir, 'test')
+    if (!await exists(testDir)) {
+      return
+    }
+
+    await writeJsonFile(path.join(dir, 'test/tsconfig.json'), {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        // The composite flag allows projects to be specified as references in
+        // other projects. Test projects should not be dependencies of other
+        // files and don't need composite set.
+        //
+        // Some tests perform a relative import into the "src" directory to test
+        // non-publicly exported idenfiers.
+        //
+        //   import { foo } from "../src/foo"
+        //
+        // Instead of:
+        //
+        //   import { foo } from "@pnpm/example"
+        //
+        // The relative "../src" imports would error if composite is enabled
+        // since composite would require files in "src" to be part of the test
+        // project.
+        composite: false,
+        noEmit: true,
+
+        rootDir: '.'
+      },
+      include: [
+        '**/*.ts',
+        '../../../__typings__/**/*.d.ts',
+      ],
+      references: (tsConfig as any)?.compilerOptions?.composite === false
+        // If composite is explicitly set to false, we can't add the main
+        // tsconfig.json as a project reference. Only composite enabled projects
+        // can be referenced by definition. Instead, we have to add all the
+        // project references directly. Note that this check is approximate. The
+        // main tsconfig.json could inherit another conifg that sets composite
+        // to be false.
+        //
+        // The link values are relative to the current packages root. We'll need
+        // to re-compute them based off of the "test" directory, which is one
+        // directory deeper. In practice the path.relative(...) call below just
+        // prepends another "../" to the relPath, but let's use the correct
+        // methods to be defensive against future changes to testDir, dir, or
+        // relPath.
+        ? linkValues.map(relPath => ({
+          path: path.relative(testDir, path.join(dir, relPath))
+        }))
+
+        // If the main project is composite (the more common case), we can
+        // simply reference that. The main project will have more project
+        // references that will apply to the tests too.
+        //
+        // The project reference allows editor features like Go to Definition
+        // jump to files in src for imports using the current package's name
+        // (ex: @pnpm/config).
+        : [{ path: ".." }]
+    }, { indent: 2 })
+  }
+
+  await Promise.all([
+    writeTestTsconfig(),
+    writeJsonFile(path.join(dir, 'tsconfig.lint.json'), {
+      extends: './tsconfig.json',
+      include: [
+        'src/**/*.ts',
+        'test/**/*.ts',
+        '../../__typings__/**/*.d.ts',
+      ],
+    }, { indent: 2 })
+  ])
   return {
     ...tsConfig,
     extends: '@pnpm/tsconfig',

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -107,7 +107,7 @@ async function updateTSConfig (
     }
     linkValues.push(relativePath)
   }
-  linkValues.sort((a, b) => a.localeCompare(b))
+  linkValues.sort()
 
   await writeJsonFile(path.join(dir, 'tsconfig.lint.json'), {
     extends: './tsconfig.json',

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -141,7 +141,7 @@ async function updateTSConfig (
       },
       include: [
         '**/*.ts',
-        '../../../__typings__/**/*.d.ts',
+        path.relative(testDir, path.join(context.workspaceDir, '__typings__/**/*.d.ts')),
       ],
       references: (tsConfig as any)?.compilerOptions?.composite === false
         // If composite is explicitly set to false, we can't add the main
@@ -179,7 +179,7 @@ async function updateTSConfig (
       include: [
         'src/**/*.ts',
         'test/**/*.ts',
-        '../../__typings__/**/*.d.ts',
+        path.relative(dir, path.join(context.workspaceDir, '__typings__/**/*.d.ts')),
       ],
     }, { indent: 2 })
   ])

--- a/.meta-updater/tsconfig.lint.json
+++ b/.meta-updater/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    "../../__typings__/**/*.d.ts"
+    "../__typings__/**/*.d.ts"
   ]
 }

--- a/__utils__/assert-project/test/tsconfig.json
+++ b/__utils__/assert-project/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/__utils__/assert-store/test/tsconfig.json
+++ b/__utils__/assert-store/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/__utils__/test-ipc-server/test/tsconfig.json
+++ b/__utils__/test-ipc-server/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/cli/cli-utils/test/tsconfig.json
+++ b/cli/cli-utils/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/cli/default-reporter/test/tsconfig.json
+++ b/cli/default-reporter/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/cli/parse-cli-args/test/tsconfig.json
+++ b/cli/parse-cli-args/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/completion/plugin-commands-completion/test/tsconfig.json
+++ b/completion/plugin-commands-completion/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/config/test/tsconfig.json
+++ b/config/config/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/matcher/test/tsconfig.json
+++ b/config/matcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/package-is-installable/test/tsconfig.json
+++ b/config/package-is-installable/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/parse-overrides/test/tsconfig.json
+++ b/config/parse-overrides/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/pick-registry-for-package/test/tsconfig.json
+++ b/config/pick-registry-for-package/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/config/plugin-commands-config/test/tsconfig.json
+++ b/config/plugin-commands-config/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/crypto/object-hasher/test/tsconfig.json
+++ b/crypto/object-hasher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/dedupe/check/test/tsconfig.json
+++ b/dedupe/check/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/dedupe/issues-renderer/test/tsconfig.json
+++ b/dedupe/issues-renderer/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/deps/graph-sequencer/test/tsconfig.json
+++ b/deps/graph-sequencer/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/env/node.fetcher/test/tsconfig.json
+++ b/env/node.fetcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/env/node.resolver/test/tsconfig.json
+++ b/env/node.resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/env/plugin-commands-env/test/tsconfig.json
+++ b/env/plugin-commands-env/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/exec/build-modules/test/tsconfig.json
+++ b/exec/build-modules/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/exec/lifecycle/test/tsconfig.json
+++ b/exec/lifecycle/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/exec/plugin-commands-rebuild/test/tsconfig.json
+++ b/exec/plugin-commands-rebuild/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/exec/plugin-commands-script-runners/test/tsconfig.json
+++ b/exec/plugin-commands-script-runners/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/exec/prepare-package/test/tsconfig.json
+++ b/exec/prepare-package/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fetching/directory-fetcher/test/tsconfig.json
+++ b/fetching/directory-fetcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fetching/git-fetcher/test/tsconfig.json
+++ b/fetching/git-fetcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fetching/pick-fetcher/test/tsconfig.json
+++ b/fetching/pick-fetcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fetching/tarball-fetcher/test/tsconfig.json
+++ b/fetching/tarball-fetcher/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fs/find-packages/test/tsconfig.json
+++ b/fs/find-packages/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fs/hard-link-dir/test/tsconfig.json
+++ b/fs/hard-link-dir/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fs/indexed-pkg-importer/test/tsconfig.json
+++ b/fs/indexed-pkg-importer/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fs/is-empty-dir-or-nothing/test/tsconfig.json
+++ b/fs/is-empty-dir-or-nothing/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/fs/symlink-dependency/test/tsconfig.json
+++ b/fs/symlink-dependency/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/hooks/pnpmfile/test/tsconfig.json
+++ b/hooks/pnpmfile/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/hooks/read-package-hook/test/tsconfig.json
+++ b/hooks/read-package-hook/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,14 @@ const path = require("path")
 
 const config = {
   preset: "ts-jest",
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      // For most projects, the tsconfig.json and test/tsconfig.json are almost
+      // exactly the same. But it's more correct to point to test/tsconfig.json
+      // to prevent surprises in the future.
+      tsconfig: 'test/tsconfig.json'
+    }]
+  },
   testMatch: ["**/test/**/*.[jt]s?(x)", "**/src/**/*.test.ts"],
   testEnvironment: "node",
   collectCoverage: true,

--- a/lockfile/audit/test/tsconfig.json
+++ b/lockfile/audit/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/filter-lockfile/test/tsconfig.json
+++ b/lockfile/filter-lockfile/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/lockfile-file/test/tsconfig.json
+++ b/lockfile/lockfile-file/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/lockfile-to-pnp/test/tsconfig.json
+++ b/lockfile/lockfile-to-pnp/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/lockfile-utils/test/tsconfig.json
+++ b/lockfile/lockfile-utils/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/merge-lockfile-changes/test/tsconfig.json
+++ b/lockfile/merge-lockfile-changes/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/plugin-commands-audit/test/tsconfig.json
+++ b/lockfile/plugin-commands-audit/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/lockfile/prune-lockfile/test/tsconfig.json
+++ b/lockfile/prune-lockfile/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/modules-mounter/daemon/test/tsconfig.json
+++ b/modules-mounter/daemon/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/network/auth-header/test/tsconfig.json
+++ b/network/auth-header/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/network/fetch/test/tsconfig.json
+++ b/network/fetch/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/calc-dep-state/test/tsconfig.json
+++ b/packages/calc-dep-state/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/crypto.base32-hash/test/tsconfig.json
+++ b/packages/crypto.base32-hash/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/dependency-path/test/tsconfig.json
+++ b/packages/dependency-path/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/error/test/tsconfig.json
+++ b/packages/error/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/git-utils/test/tsconfig.json
+++ b/packages/git-utils/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/make-dedicated-lockfile/test/tsconfig.json
+++ b/packages/make-dedicated-lockfile/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/plugin-commands-doctor/test/tsconfig.json
+++ b/packages/plugin-commands-doctor/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/plugin-commands-init/test/tsconfig.json
+++ b/packages/plugin-commands-init/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/plugin-commands-setup/test/tsconfig.json
+++ b/packages/plugin-commands-setup/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/render-peer-issues/test/tsconfig.json
+++ b/packages/render-peer-issues/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/packages/which-version-is-pinned/test/tsconfig.json
+++ b/packages/which-version-is-pinned/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/patching/apply-patch/test/tsconfig.json
+++ b/patching/apply-patch/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/patching/plugin-commands-patching/test/tsconfig.json
+++ b/patching/plugin-commands-patching/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/client/test/tsconfig.json
+++ b/pkg-manager/client/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/core/test/tsconfig.json
+++ b/pkg-manager/core/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/get-context/test/tsconfig.json
+++ b/pkg-manager/get-context/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/headless/test/tsconfig.json
+++ b/pkg-manager/headless/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/link-bins/test/tsconfig.json
+++ b/pkg-manager/link-bins/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/modules-yaml/test/tsconfig.json
+++ b/pkg-manager/modules-yaml/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/package-bins/test/tsconfig.json
+++ b/pkg-manager/package-bins/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/package-requester/test/tsconfig.json
+++ b/pkg-manager/package-requester/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/plugin-commands-installation/test/tsconfig.json
+++ b/pkg-manager/plugin-commands-installation/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/real-hoist/test/tsconfig.json
+++ b/pkg-manager/real-hoist/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manager/resolve-dependencies/test/tsconfig.json
+++ b/pkg-manager/resolve-dependencies/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manifest/exportable-manifest/test/tsconfig.json
+++ b/pkg-manifest/exportable-manifest/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manifest/manifest-utils/test/tsconfig.json
+++ b/pkg-manifest/manifest-utils/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manifest/read-package-json/test/tsconfig.json
+++ b/pkg-manifest/read-package-json/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manifest/read-project-manifest/test/tsconfig.json
+++ b/pkg-manifest/read-project-manifest/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pkg-manifest/write-project-manifest/test/tsconfig.json
+++ b/pkg-manifest/write-project-manifest/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpm/test/tsconfig.json
+++ b/pnpm/test/tsconfig.json
@@ -1,0 +1,158 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../__utils__/assert-project"
+    },
+    {
+      "path": "../../__utils__/prepare"
+    },
+    {
+      "path": "../../__utils__/test-fixtures"
+    },
+    {
+      "path": "../../__utils__/test-ipc-server"
+    },
+    {
+      "path": "../../cli/cli-meta"
+    },
+    {
+      "path": "../../cli/cli-utils"
+    },
+    {
+      "path": "../../cli/command"
+    },
+    {
+      "path": "../../cli/common-cli-options-help"
+    },
+    {
+      "path": "../../cli/default-reporter"
+    },
+    {
+      "path": "../../cli/parse-cli-args"
+    },
+    {
+      "path": "../../completion/plugin-commands-completion"
+    },
+    {
+      "path": "../../config/config"
+    },
+    {
+      "path": "../../config/pick-registry-for-package"
+    },
+    {
+      "path": "../../config/plugin-commands-config"
+    },
+    {
+      "path": "../../env/plugin-commands-env"
+    },
+    {
+      "path": "../../exec/plugin-commands-rebuild"
+    },
+    {
+      "path": "../../exec/plugin-commands-script-runners"
+    },
+    {
+      "path": "../../exec/run-npm"
+    },
+    {
+      "path": "../../lockfile/lockfile-types"
+    },
+    {
+      "path": "../../lockfile/plugin-commands-audit"
+    },
+    {
+      "path": "../../packages/constants"
+    },
+    {
+      "path": "../../packages/core-loggers"
+    },
+    {
+      "path": "../../packages/crypto.base32-hash"
+    },
+    {
+      "path": "../../packages/dependency-path"
+    },
+    {
+      "path": "../../packages/plugin-commands-doctor"
+    },
+    {
+      "path": "../../packages/plugin-commands-init"
+    },
+    {
+      "path": "../../packages/plugin-commands-setup"
+    },
+    {
+      "path": "../../packages/types"
+    },
+    {
+      "path": "../../patching/plugin-commands-patching"
+    },
+    {
+      "path": "../../pkg-manager/client"
+    },
+    {
+      "path": "../../pkg-manager/modules-yaml"
+    },
+    {
+      "path": "../../pkg-manager/plugin-commands-installation"
+    },
+    {
+      "path": "../../pkg-manifest/read-package-json"
+    },
+    {
+      "path": "../../pkg-manifest/read-project-manifest"
+    },
+    {
+      "path": "../../pkg-manifest/write-project-manifest"
+    },
+    {
+      "path": "../../releasing/plugin-commands-deploy"
+    },
+    {
+      "path": "../../releasing/plugin-commands-publishing"
+    },
+    {
+      "path": "../../reviewing/plugin-commands-licenses"
+    },
+    {
+      "path": "../../reviewing/plugin-commands-listing"
+    },
+    {
+      "path": "../../reviewing/plugin-commands-outdated"
+    },
+    {
+      "path": "../../store/plugin-commands-server"
+    },
+    {
+      "path": "../../store/plugin-commands-store"
+    },
+    {
+      "path": "../../store/plugin-commands-store-inspecting"
+    },
+    {
+      "path": "../../worker"
+    },
+    {
+      "path": "../../workspace/filter-workspace-packages"
+    },
+    {
+      "path": "../../workspace/find-packages"
+    },
+    {
+      "path": "../../workspace/find-workspace-dir"
+    },
+    {
+      "path": "../../workspace/pkgs-graph"
+    }
+  ]
+}

--- a/pnpm/tsconfig.lint.json
+++ b/pnpm/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    "../../__typings__/**/*.d.ts"
+    "../__typings__/**/*.d.ts"
   ]
 }

--- a/releasing/plugin-commands-deploy/test/tsconfig.json
+++ b/releasing/plugin-commands-deploy/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/releasing/plugin-commands-publishing/test/tsconfig.json
+++ b/releasing/plugin-commands-publishing/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/resolving/default-resolver/test/tsconfig.json
+++ b/resolving/default-resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/resolving/git-resolver/test/tsconfig.json
+++ b/resolving/git-resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/resolving/local-resolver/test/tsconfig.json
+++ b/resolving/local-resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/resolving/npm-resolver/test/tsconfig.json
+++ b/resolving/npm-resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/resolving/tarball-resolver/test/tsconfig.json
+++ b/resolving/tarball-resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/dependencies-hierarchy/test/tsconfig.json
+++ b/reviewing/dependencies-hierarchy/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/license-scanner/test/tsconfig.json
+++ b/reviewing/license-scanner/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/list/test/tsconfig.json
+++ b/reviewing/list/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/outdated/test/tsconfig.json
+++ b/reviewing/outdated/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/plugin-commands-licenses/test/tsconfig.json
+++ b/reviewing/plugin-commands-licenses/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/plugin-commands-listing/test/tsconfig.json
+++ b/reviewing/plugin-commands-listing/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/reviewing/plugin-commands-outdated/test/tsconfig.json
+++ b/reviewing/plugin-commands-outdated/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/cafs/test/tsconfig.json
+++ b/store/cafs/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/package-store/test/tsconfig.json
+++ b/store/package-store/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/plugin-commands-store-inspecting/test/tsconfig.json
+++ b/store/plugin-commands-store-inspecting/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/plugin-commands-store/test/tsconfig.json
+++ b/store/plugin-commands-store/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/server/test/tsconfig.json
+++ b/store/server/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/store/store-path/test/tsconfig.json
+++ b/store/store-path/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/text/comments-parser/test/tsconfig.json
+++ b/text/comments-parser/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/worker/tsconfig.lint.json
+++ b/worker/tsconfig.lint.json
@@ -3,6 +3,6 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    "../../__typings__/**/*.d.ts"
+    "../__typings__/**/*.d.ts"
   ]
 }

--- a/workspace/filter-workspace-packages/test/tsconfig.json
+++ b/workspace/filter-workspace-packages/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/workspace/find-packages/test/tsconfig.json
+++ b/workspace/find-packages/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/workspace/find-workspace-dir/test/tsconfig.json
+++ b/workspace/find-workspace-dir/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/workspace/pkgs-graph/test/tsconfig.json
+++ b/workspace/pkgs-graph/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/workspace/read-manifest/test/tsconfig.json
+++ b/workspace/read-manifest/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/workspace/spec-parser/test/tsconfig.json
+++ b/workspace/spec-parser/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

This improves the editor experience for developers working on the pnpm codebase.

### Before

Before this change, editor features like "_Go to Definition_" didn't work in tests.

For example, clicking on `getConfig` in `config/config/test/index.ts` brings you to `lib/index.d.ts`, which isn't that useful.

https://github.com/pnpm/pnpm/assets/906558/7c6cb86b-458e-4025-bc63-fbd38d10952e

### After

This PR updates `meta-updater` to generate a `test/tsconfig.json` file with a project reference to the main `tsconfig.json` file at the root of the package. The project reference enables us to take advantage of a TypeScript feature called ["_Build-Free Editing_"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#build-free-editing-with-project-references)

Note that the same click now brings you to `src/index.ts` instead of `lib/index.d.ts`.

This works for imports of other workspace packages since the main `tsconfig.json` file contains `references` for those, which are picked up by the test project.

https://github.com/pnpm/pnpm/assets/906558/90336307-dec9-4fcc-b9bc-18dffa44a9c5
