### PR TITLE
chore: remove top-level `composite` property from `tsconfig.json` files

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -118,7 +118,6 @@ async function updateTSConfig (
   return {
     ...tsConfig,
     extends: '@pnpm/tsconfig',
-    composite: true,
     compilerOptions: {
       ...(tsConfig as any)['compilerOptions'],
       rootDir: 'src',

--- a/.meta-updater/tsconfig.json
+++ b/.meta-updater/tsconfig.json
@@ -16,6 +16,5 @@
     {
       "path": "../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/__utils__/assert-project/tsconfig.json
+++ b/__utils__/assert-project/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../assert-store"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/__utils__/assert-store/tsconfig.json
+++ b/__utils__/assert-store/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../store/cafs"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/__utils__/get-release-text/tsconfig.json
+++ b/__utils__/get-release-text/tsconfig.json
@@ -9,6 +9,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/__utils__/prepare/tsconfig.json
+++ b/__utils__/prepare/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../assert-project"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/__utils__/test-fixtures/tsconfig.json
+++ b/__utils__/test-fixtures/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../prepare"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/__utils__/test-ipc-server/tsconfig.json
+++ b/__utils__/test-ipc-server/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "lib": ["ESNext.Disposable"]
+    "lib": [
+      "ESNext.Disposable"
+    ]
   },
   "include": [
     "src/**/*.ts",
@@ -13,6 +15,5 @@
     {
       "path": "../prepare"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/cli/cli-meta/tsconfig.json
+++ b/cli/cli-meta/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/cli/cli-utils/tsconfig.json
+++ b/cli/cli-utils/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../default-reporter"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/cli/command/tsconfig.json
+++ b/cli/command/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/cli/common-cli-options-help/tsconfig.json
+++ b/cli/common-cli-options-help/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/cli/default-reporter/tsconfig.json
+++ b/cli/default-reporter/tsconfig.json
@@ -32,6 +32,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/cli/parse-cli-args/tsconfig.json
+++ b/cli/parse-cli-args/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../workspace/find-workspace-dir"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/completion/plugin-commands-completion/tsconfig.json
+++ b/completion/plugin-commands-completion/tsconfig.json
@@ -27,6 +27,5 @@
     {
       "path": "../../workspace/find-workspace-dir"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/config/tsconfig.json
+++ b/config/config/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../matcher"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/matcher/tsconfig.json
+++ b/config/matcher/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/config/normalize-registries/tsconfig.json
+++ b/config/normalize-registries/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/package-is-installable/tsconfig.json
+++ b/config/package-is-installable/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/parse-overrides/tsconfig.json
+++ b/config/parse-overrides/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../packages/parse-wanted-dependency"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/pick-registry-for-package/tsconfig.json
+++ b/config/pick-registry-for-package/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/config/plugin-commands-config/tsconfig.json
+++ b/config/plugin-commands-config/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../config"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/crypto/object-hasher/tsconfig.json
+++ b/crypto/object-hasher/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/dedupe/check/tsconfig.json
+++ b/dedupe/check/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/dedupe/issues-renderer/tsconfig.json
+++ b/dedupe/issues-renderer/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/dedupe/types/tsconfig.json
+++ b/dedupe/types/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/deps/graph-builder/tsconfig.json
+++ b/deps/graph-builder/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../../store/store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/deps/graph-sequencer/tsconfig.json
+++ b/deps/graph-sequencer/tsconfig.json
@@ -8,7 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [
-  ],
-  "composite": true
+  "references": []
 }

--- a/env/node.fetcher/tsconfig.json
+++ b/env/node.fetcher/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../../store/create-cafs-store"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/env/node.resolver/tsconfig.json
+++ b/env/node.resolver/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../node.fetcher"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/env/plugin-commands-env/tsconfig.json
+++ b/env/plugin-commands-env/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../node.resolver"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/build-modules/tsconfig.json
+++ b/exec/build-modules/tsconfig.json
@@ -42,6 +42,5 @@
     {
       "path": "../lifecycle"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/lifecycle/tsconfig.json
+++ b/exec/lifecycle/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../../store/store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/pkg-requires-build/tsconfig.json
+++ b/exec/pkg-requires-build/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/plugin-commands-rebuild/tsconfig.json
+++ b/exec/plugin-commands-rebuild/tsconfig.json
@@ -99,6 +99,5 @@
     {
       "path": "../lifecycle"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/plugin-commands-script-runners/tsconfig.json
+++ b/exec/plugin-commands-script-runners/tsconfig.json
@@ -60,6 +60,5 @@
     {
       "path": "../lifecycle"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/prepare-package/tsconfig.json
+++ b/exec/prepare-package/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../lifecycle"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/exec/run-npm/tsconfig.json
+++ b/exec/run-npm/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/fetching/directory-fetcher/tsconfig.json
+++ b/fetching/directory-fetcher/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../fetcher-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fetching/fetcher-base/tsconfig.json
+++ b/fetching/fetcher-base/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../store/cafs-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fetching/git-fetcher/tsconfig.json
+++ b/fetching/git-fetcher/tsconfig.json
@@ -27,6 +27,5 @@
     {
       "path": "../fetcher-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fetching/pick-fetcher/tsconfig.json
+++ b/fetching/pick-fetcher/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../fetcher-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fetching/tarball-fetcher/tsconfig.json
+++ b/fetching/tarball-fetcher/tsconfig.json
@@ -45,6 +45,5 @@
     {
       "path": "../fetcher-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fs/find-packages/tsconfig.json
+++ b/fs/find-packages/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../pkg-manifest/read-project-manifest"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fs/graceful-fs/tsconfig.json
+++ b/fs/graceful-fs/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/fs/hard-link-dir/tsconfig.json
+++ b/fs/hard-link-dir/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../__utils__/prepare"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fs/indexed-pkg-importer/tsconfig.json
+++ b/fs/indexed-pkg-importer/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../graceful-fs"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/fs/is-empty-dir-or-nothing/tsconfig.json
+++ b/fs/is-empty-dir-or-nothing/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/fs/packlist/tsconfig.json
+++ b/fs/packlist/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/fs/read-modules-dir/tsconfig.json
+++ b/fs/read-modules-dir/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/fs/symlink-dependency/tsconfig.json
+++ b/fs/symlink-dependency/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/hooks/pnpmfile/tsconfig.json
+++ b/hooks/pnpmfile/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/hooks/read-package-hook/tsconfig.json
+++ b/hooks/read-package-hook/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/hooks/types/tsconfig.json
+++ b/hooks/types/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/audit/tsconfig.json
+++ b/lockfile/audit/tsconfig.json
@@ -48,6 +48,5 @@
     {
       "path": "../lockfile-walker"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/detect-dep-types/tsconfig.json
+++ b/lockfile/detect-dep-types/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../lockfile-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/filter-lockfile/tsconfig.json
+++ b/lockfile/filter-lockfile/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../lockfile-walker"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/lockfile-file/tsconfig.json
+++ b/lockfile/lockfile-file/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../merge-lockfile-changes"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/lockfile-to-pnp/tsconfig.json
+++ b/lockfile/lockfile-to-pnp/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../lockfile-utils"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/lockfile-types/tsconfig.json
+++ b/lockfile/lockfile-types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "@pnpm/tsconfig",
-  "composite": true,
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src"

--- a/lockfile/lockfile-utils/tsconfig.json
+++ b/lockfile/lockfile-utils/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../lockfile-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/lockfile-walker/tsconfig.json
+++ b/lockfile/lockfile-walker/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../lockfile-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/merge-lockfile-changes/tsconfig.json
+++ b/lockfile/merge-lockfile-changes/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../lockfile-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/plugin-commands-audit/tsconfig.json
+++ b/lockfile/plugin-commands-audit/tsconfig.json
@@ -44,6 +44,5 @@
     {
       "path": "../lockfile-file"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/preferred-versions/tsconfig.json
+++ b/lockfile/preferred-versions/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../lockfile-utils"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/lockfile/prune-lockfile/tsconfig.json
+++ b/lockfile/prune-lockfile/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../lockfile-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/modules-mounter/daemon/tsconfig.json
+++ b/modules-mounter/daemon/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../../store/store-path"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/network/auth-header/tsconfig.json
+++ b/network/auth-header/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/network/fetch/tsconfig.json
+++ b/network/fetch/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../fetching-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/network/fetching-types/tsconfig.json
+++ b/network/fetching-types/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/packages/calc-dep-state/tsconfig.json
+++ b/packages/calc-dep-state/tsconfig.json
@@ -27,6 +27,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/constants/tsconfig.json
+++ b/packages/constants/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "@pnpm/tsconfig",
-  "composite": true,
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src"

--- a/packages/core-loggers/tsconfig.json
+++ b/packages/core-loggers/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/crypto.base32-hash/tsconfig.json
+++ b/packages/crypto.base32-hash/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../__utils__/prepare"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/dependency-path/tsconfig.json
+++ b/packages/dependency-path/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/error/tsconfig.json
+++ b/packages/error/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../constants"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/git-utils/tsconfig.json
+++ b/packages/git-utils/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/packages/make-dedicated-lockfile/tsconfig.json
+++ b/packages/make-dedicated-lockfile/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/parse-wanted-dependency/tsconfig.json
+++ b/packages/parse-wanted-dependency/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/packages/plugin-commands-doctor/tsconfig.json
+++ b/packages/plugin-commands-doctor/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../config/config"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/plugin-commands-init/tsconfig.json
+++ b/packages/plugin-commands-init/tsconfig.json
@@ -27,6 +27,5 @@
     {
       "path": "../error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/plugin-commands-setup/tsconfig.json
+++ b/packages/plugin-commands-setup/tsconfig.json
@@ -19,6 +19,5 @@
     {
       "path": "../error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/render-peer-issues/tsconfig.json
+++ b/packages/render-peer-issues/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "@pnpm/tsconfig",
-  "composite": true,
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src"

--- a/packages/which-version-is-pinned/tsconfig.json
+++ b/packages/which-version-is-pinned/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/patching/apply-patch/tsconfig.json
+++ b/patching/apply-patch/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/patching/plugin-commands-patching/tsconfig.json
+++ b/patching/plugin-commands-patching/tsconfig.json
@@ -66,6 +66,5 @@
     {
       "path": "../apply-patch"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/client/tsconfig.json
+++ b/pkg-manager/client/tsconfig.json
@@ -39,6 +39,5 @@
     {
       "path": "../../resolving/resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -168,6 +168,5 @@
     {
       "path": "../resolve-dependencies"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/direct-dep-linker/tsconfig.json
+++ b/pkg-manager/direct-dep-linker/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../packages/core-loggers"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/get-context/tsconfig.json
+++ b/pkg-manager/get-context/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../read-projects-context"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/headless/tsconfig.json
+++ b/pkg-manager/headless/tsconfig.json
@@ -117,6 +117,5 @@
     {
       "path": "../real-hoist"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/hoist/tsconfig.json
+++ b/pkg-manager/hoist/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../link-bins"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/link-bins/tsconfig.json
+++ b/pkg-manager/link-bins/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../package-bins"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/modules-cleaner/tsconfig.json
+++ b/pkg-manager/modules-cleaner/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../remove-bins"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/modules-yaml/tsconfig.json
+++ b/pkg-manager/modules-yaml/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/package-bins/tsconfig.json
+++ b/pkg-manager/package-bins/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/package-requester/tsconfig.json
+++ b/pkg-manager/package-requester/tsconfig.json
@@ -60,6 +60,5 @@
     {
       "path": "../client"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/plugin-commands-installation/tsconfig.json
+++ b/pkg-manager/plugin-commands-installation/tsconfig.json
@@ -102,6 +102,5 @@
     {
       "path": "../modules-yaml"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/read-projects-context/tsconfig.json
+++ b/pkg-manager/read-projects-context/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../modules-yaml"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/real-hoist/tsconfig.json
+++ b/pkg-manager/real-hoist/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/remove-bins/tsconfig.json
+++ b/pkg-manager/remove-bins/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../package-bins"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manager/resolve-dependencies/tsconfig.json
+++ b/pkg-manager/resolve-dependencies/tsconfig.json
@@ -63,6 +63,5 @@
     {
       "path": "../../workspace/spec-parser"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manifest/exportable-manifest/tsconfig.json
+++ b/pkg-manifest/exportable-manifest/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../read-project-manifest"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manifest/manifest-utils/tsconfig.json
+++ b/pkg-manifest/manifest-utils/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manifest/read-package-json/tsconfig.json
+++ b/pkg-manifest/read-package-json/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manifest/read-project-manifest/tsconfig.json
+++ b/pkg-manifest/read-project-manifest/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../write-project-manifest"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pkg-manifest/write-project-manifest/tsconfig.json
+++ b/pkg-manifest/write-project-manifest/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../text/comments-parser"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/pnpm/tsconfig.json
+++ b/pnpm/tsconfig.json
@@ -157,6 +157,5 @@
     {
       "path": "../workspace/pkgs-graph"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/releasing/plugin-commands-deploy/tsconfig.json
+++ b/releasing/plugin-commands-deploy/tsconfig.json
@@ -45,6 +45,5 @@
     {
       "path": "../../workspace/filter-workspace-packages"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/releasing/plugin-commands-publishing/tsconfig.json
+++ b/releasing/plugin-commands-publishing/tsconfig.json
@@ -66,6 +66,5 @@
     {
       "path": "../../workspace/sort-packages"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/default-resolver/tsconfig.json
+++ b/resolving/default-resolver/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../tarball-resolver"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/git-resolver/tsconfig.json
+++ b/resolving/git-resolver/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/local-resolver/tsconfig.json
+++ b/resolving/local-resolver/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/npm-resolver/tsconfig.json
+++ b/resolving/npm-resolver/tsconfig.json
@@ -39,6 +39,5 @@
     {
       "path": "../resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/resolver-base/tsconfig.json
+++ b/resolving/resolver-base/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/resolving/tarball-resolver/tsconfig.json
+++ b/resolving/tarball-resolver/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/dependencies-hierarchy/tsconfig.json
+++ b/reviewing/dependencies-hierarchy/tsconfig.json
@@ -45,6 +45,5 @@
     {
       "path": "../../pkg-manifest/read-package-json"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/license-scanner/tsconfig.json
+++ b/reviewing/license-scanner/tsconfig.json
@@ -48,6 +48,5 @@
     {
       "path": "../../store/cafs"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/list/tsconfig.json
+++ b/reviewing/list/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../dependencies-hierarchy"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/outdated/tsconfig.json
+++ b/reviewing/outdated/tsconfig.json
@@ -51,6 +51,5 @@
     {
       "path": "../../resolving/resolver-base"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/plugin-commands-licenses/tsconfig.json
+++ b/reviewing/plugin-commands-licenses/tsconfig.json
@@ -51,6 +51,5 @@
     {
       "path": "../license-scanner"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/plugin-commands-listing/tsconfig.json
+++ b/reviewing/plugin-commands-listing/tsconfig.json
@@ -39,6 +39,5 @@
     {
       "path": "../list"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/reviewing/plugin-commands-outdated/tsconfig.json
+++ b/reviewing/plugin-commands-outdated/tsconfig.json
@@ -60,6 +60,5 @@
     {
       "path": "../outdated"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/cafs-types/tsconfig.json
+++ b/store/cafs-types/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/cafs/tsconfig.json
+++ b/store/cafs/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/create-cafs-store/tsconfig.json
+++ b/store/create-cafs-store/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/package-store/tsconfig.json
+++ b/store/package-store/tsconfig.json
@@ -39,6 +39,5 @@
     {
       "path": "../store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/plugin-commands-server/tsconfig.json
+++ b/store/plugin-commands-server/tsconfig.json
@@ -33,6 +33,5 @@
     {
       "path": "../store-path"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/plugin-commands-store-inspecting/tsconfig.json
+++ b/store/plugin-commands-store-inspecting/tsconfig.json
@@ -4,9 +4,14 @@
     "outDir": "lib",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts", "../../__typings__/**/*.d.ts"],
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
   "references": [
-    { "path": "../../__utils__/prepare" },
+    {
+      "path": "../../__utils__/prepare"
+    },
     {
       "path": "../../config/config"
     },
@@ -19,7 +24,6 @@
     {
       "path": "../../lockfile/lockfile-types"
     },
-
     {
       "path": "../../packages/error"
     },
@@ -38,6 +42,5 @@
     {
       "path": "../store-path"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/plugin-commands-store/tsconfig.json
+++ b/store/plugin-commands-store/tsconfig.json
@@ -63,6 +63,5 @@
     {
       "path": "../store-path"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/server/tsconfig.json
+++ b/store/server/tsconfig.json
@@ -27,6 +27,5 @@
     {
       "path": "../store-controller-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/store-connection-manager/tsconfig.json
+++ b/store/store-connection-manager/tsconfig.json
@@ -30,6 +30,5 @@
     {
       "path": "../store-path"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/store-controller-types/tsconfig.json
+++ b/store/store-controller-types/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../cafs-types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/store/store-path/tsconfig.json
+++ b/store/store-path/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/text/comments-parser/tsconfig.json
+++ b/text/comments-parser/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -36,6 +36,5 @@
     {
       "path": "../store/create-cafs-store"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/filter-workspace-packages/tsconfig.json
+++ b/workspace/filter-workspace-packages/tsconfig.json
@@ -24,6 +24,5 @@
     {
       "path": "../pkgs-graph"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/find-packages/tsconfig.json
+++ b/workspace/find-packages/tsconfig.json
@@ -21,6 +21,5 @@
     {
       "path": "../read-manifest"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/find-workspace-dir/tsconfig.json
+++ b/workspace/find-workspace-dir/tsconfig.json
@@ -12,6 +12,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/pkgs-graph/tsconfig.json
+++ b/workspace/pkgs-graph/tsconfig.json
@@ -18,6 +18,5 @@
     {
       "path": "../resolve-workspace-range"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/read-manifest/tsconfig.json
+++ b/workspace/read-manifest/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../packages/error"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/resolve-workspace-range/tsconfig.json
+++ b/workspace/resolve-workspace-range/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }

--- a/workspace/sort-packages/tsconfig.json
+++ b/workspace/sort-packages/tsconfig.json
@@ -15,6 +15,5 @@
     {
       "path": "../../packages/types"
     }
-  ],
-  "composite": true
+  ]
 }

--- a/workspace/spec-parser/tsconfig.json
+++ b/workspace/spec-parser/tsconfig.json
@@ -8,6 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [],
-  "composite": true
+  "references": []
 }


### PR DESCRIPTION
## Problem

It looks like `.meta-updater/src/index.ts` is incorrectly applying `composite` as a top-level key of `tsconfig.json` by mistake.

From https://www.typescriptlang.org/tsconfig/, the only top-level options are `files`, `extends`, `include`, `exclude` and `references`.

<img width="850" alt="Screenshot 2024-05-24 at 5 38 28 PM" src="https://github.com/pnpm/pnpm/assets/906558/ddbc2cbd-df98-43e1-8517-5d741afc781c">

## Changes

I think we can simply remove this from `tsconfig.json` files. Everything extends `@pnpm/tsconfig`, which has this correctly defined.

https://github.com/pnpm/pnpm/blob/65e3af8a090e6a627270f94c56baaca2a0e20738/__utils__/tsconfig/tsconfig.json#L2-L4