### PR TITLE
fix: use more specific devDependencies pattern for eslint import check

### DIFF
--- a/__utils__/eslint-config/eslint.json
+++ b/__utils__/eslint-config/eslint.json
@@ -10,7 +10,7 @@
       "error",
       {
         "devDependencies": [
-          "**/pnpm/**",
+          "**/pnpm/src/**",
           "**/test/**"
         ]
       }

--- a/__utils__/eslint-config/eslint.json
+++ b/__utils__/eslint-config/eslint.json
@@ -11,7 +11,8 @@
       {
         "devDependencies": [
           "**/pnpm/src/**",
-          "**/test/**"
+          "**/test/**",
+          "**/src/**/*.test.ts"
         ]
       }
     ],


### PR DESCRIPTION
## Problem

While working on a different PR, I noticed after adding `@pnpm/dependency-path` to the `devDependencies` of a package for tests, it was no longer flagged as an "_extraneous dependency_" when imported into a `src`.

This worried me since someone in the future might add an import to `@pnpm/dependency-path` in `src` for this package, but not move the dep from `devDependencies` to `dependencies`. This would cause an error in dependent projects after publishing libs.

I think the `devDependencies` pattern here should be `**/pnpm/src/**` rather than just `**/pnpm/**`.

```diff
diff --git a/__utils__/eslint-config/eslint.json b/__utils__/eslint-config/eslint.json
index bcc7cb5a5fe..a902774ef27 100644
--- a/__utils__/eslint-config/eslint.json
+++ b/__utils__/eslint-config/eslint.json
@@ -10,7 +10,7 @@
       "error",
       {
         "devDependencies": [
-          "**/pnpm/**",
+          "**/pnpm/src/**",
           "**/test/**"
         ]
       }
```

 The later matches all files in the repo since:

1. On CI, the repo is cloned to the `/home/runner/work/pnpm` dir, which contains `pnpm`.
2. Locally, I have the repo cloned to `~/Developer/pnpm`.

## Changes

Updating our `import/no-extraneous-dependencies` patterns to be more specific to prevent the problem described above.