### PR TITLE
fix: don't fail if the pnpm version doesn't match the one in the packageManager field

### DIFF
--- a/.changeset/unlucky-avocados-talk.md
+++ b/.changeset/unlucky-avocados-talk.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli-utils": patch
+"pnpm": patch
+---
+
+pnpm doesn't fail if its version doesn't match the one specified in the "packageManager" field of `package.json` [#8087](https://github.com/pnpm/pnpm/issues/8087).

--- a/.changeset/young-carpets-stare.md
+++ b/.changeset/young-carpets-stare.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/workspace.find-packages": minor
+"@pnpm/cli-utils": minor
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+If `package-manager-strict-version` is set to `true` pnpm will fail if its version will not exactly match the version in the `packageManager` field of `package.json`.

--- a/cli/cli-utils/src/packageIsInstallable.ts
+++ b/cli/cli-utils/src/packageIsInstallable.ts
@@ -24,26 +24,13 @@ export function packageIsInstallable (
     ? packageManager.version
     : undefined
   if (pkg.packageManager && !process.env.COREPACK_ROOT) {
-    const [pmName, pmReference] = pkg.packageManager.split('@')
+    const [pmName] = pkg.packageManager.split('@')
     if (pmName && pmName !== 'pnpm') {
       const msg = `This project is configured to use ${pmName}`
       if (opts.packageManagerStrict) {
         throw new PnpmError('OTHER_PM_EXPECTED', msg)
       } else {
         globalWarn(msg)
-      }
-    } else if (!pmReference.includes(':')) {
-      // pmReference is semantic versioning, not URL
-      const [pmVersion] = pmReference.split('+')
-      if (pmVersion && pnpmVersion && pmVersion !== pnpmVersion) {
-        const msg = `This project is configured to use v${pmVersion} of pnpm. Your current pnpm is v${pnpmVersion}`
-        if (opts.packageManagerStrict) {
-          throw new PnpmError('BAD_PM_VERSION', msg, {
-            hint: 'If you want to bypass this version check, you can set the "package-manager-strict" configuration to "false" or set the "COREPACK_ENABLE_STRICT" environment variable to "0"',
-          })
-        } else {
-          globalWarn(msg)
-        }
       }
     }
   }

--- a/cli/cli-utils/src/readProjectManifest.ts
+++ b/cli/cli-utils/src/readProjectManifest.ts
@@ -5,6 +5,7 @@ import { packageIsInstallable } from './packageIsInstallable'
 export interface ReadProjectManifestOpts {
   engineStrict?: boolean
   packageManagerStrict?: boolean
+  packageManagerStrictVersion?: boolean
   nodeVersion?: string
   supportedArchitectures?: SupportedArchitectures
 }

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -192,6 +192,7 @@ export interface Config {
   dedupeInjectedDeps?: boolean
   nodeOptions?: string
   packageManagerStrict?: boolean
+  packageManagerStrictVersion?: boolean
   virtualStoreDirMaxLength: number
 }
 

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -245,6 +245,7 @@ export async function getConfig (
     'package-lock': npmDefaults['package-lock'],
     pending: false,
     'package-manager-strict': process.env.COREPACK_ENABLE_STRICT !== '0',
+    'package-manager-strict-version': false,
     'prefer-workspace-packages': false,
     'public-hoist-pattern': [
       '*eslint*',

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -267,9 +267,12 @@ test('install should not fail if the used pnpm version does not satisfy the pnpm
     packageManager: 'pnpm@0.0.0',
   })
 
-  const { status } = execPnpmSync(['install'])
+  expect(execPnpmSync(['install']).status).toBe(0)
 
-  expect(status).toBe(0)
+  const { status, stdout } = execPnpmSync(['install', '--config.package-manager-strict-version=true'])
+
+  expect(status).toBe(1)
+  expect(stdout.toString()).toContain('This project is configured to use v0.0.0 of pnpm. Your current pnpm is')
 })
 
 test('install should fail if the project requires a different package manager', async () => {

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -259,7 +259,7 @@ test('install should fail if the used pnpm version does not satisfy the pnpm ver
   expect(stdout.toString()).toContain('Your pnpm version is incompatible with')
 })
 
-test('install should fail if the used pnpm version does not satisfy the pnpm version specified in packageManager', async () => {
+test('install should not fail if the used pnpm version does not satisfy the pnpm version specified in packageManager', async () => {
   prepare({
     name: 'project',
     version: '1.0.0',
@@ -267,17 +267,9 @@ test('install should fail if the used pnpm version does not satisfy the pnpm ver
     packageManager: 'pnpm@0.0.0',
   })
 
-  const { status, stdout } = execPnpmSync(['install'])
+  const { status } = execPnpmSync(['install'])
 
-  expect(status).toBe(1)
-  expect(stdout.toString()).toContain('This project is configured to use v0.0.0 of pnpm. Your current pnpm is')
-
-  expect(execPnpmSync(['install', '--config.package-manager-strict=false']).status).toBe(0)
-  expect(execPnpmSync(['install'], {
-    env: {
-      COREPACK_ENABLE_STRICT: '0',
-    },
-  }).status).toBe(0)
+  expect(status).toBe(0)
 })
 
 test('install should fail if the project requires a different package manager', async () => {

--- a/workspace/find-packages/src/index.ts
+++ b/workspace/find-packages/src/index.ts
@@ -12,6 +12,7 @@ export async function findWorkspacePackages (
   opts?: {
     engineStrict?: boolean
     packageManagerStrict?: boolean
+    packageManagerStrictVersion?: boolean
     nodeVersion?: string
     patterns?: string[]
     sharedWorkspaceLockfile?: boolean


### PR DESCRIPTION
close #8087

I considered printing a warning or info message instead. However, this would get printed on all commands and probably break some tools that parse the output of pnpm. So, safer just to not print anything (and faster to implement).