### PR TITLE
feat: disallow external diff drivers

### DIFF
--- a/.changeset/hungry-pears-allow.md
+++ b/.changeset/hungry-pears-allow.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+add `--no-ext-diff` disallow external diff drivers to prevent incorrect diff file formats

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -111,7 +111,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,


### PR DESCRIPTION
The generated diff file will be wrong format if users install an expanded diff tool like [difftastic](https://github.com/Wilfred/difftastic).