### PR TITLE
fix(config): use locale while parsing variables as camelcase

### DIFF
--- a/.changeset/brown-apes-compare.md
+++ b/.changeset/brown-apes-compare.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": minor
+---
+
+fix parsing of config variables in Turkish locale. Example: recursive-install parameter has problems on parsing.

--- a/.changeset/brown-apes-compare.md
+++ b/.changeset/brown-apes-compare.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/config": minor
+"@pnpm/config": patch
 ---
 
 fix parsing of config variables in Turkish locale. Example: recursive-install parameter has problems on parsing.

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -298,8 +298,8 @@ export async function getConfig (
   const rcOptions = Object.keys(rcOptionsTypes)
 
   const pnpmConfig: ConfigWithDeprecatedSettings = Object.fromEntries([
-    ...rcOptions.map((configKey) => [camelcase(configKey), npmConfig.get(configKey)]) as any, // eslint-disable-line
-    ...Object.entries(cliOptions).filter(([name, value]) => typeof value !== 'undefined').map(([name, value]) => [camelcase(name), value]),
+    ...rcOptions.map((configKey) => [camelcase(configKey, { locale: 'en-US' }), npmConfig.get(configKey)]) as any, // eslint-disable-line
+    ...Object.entries(cliOptions).filter(([name, value]) => typeof value !== 'undefined').map(([name, value]) => [camelcase(name, { locale: 'en-US' }), value]),
   ]) as unknown as ConfigWithDeprecatedSettings
   // Resolving the current working directory to its actual location is crucial.
   // This prevents potential inconsistencies in the future, especially when processing or mapping subdirectories.


### PR DESCRIPTION
fixes #8188 

Basically, in a Turkish locale computer; config variables has issues on parsing if they have a "i" character because of camelcase function gets current computer's locale by default. and i become "İ" on Turkish locale. It could probably happen in other languages too.
As a result of this, config variables (even default ones) could have problems like following after config parse operation,
Expected:
<img width="299" alt="Screenshot 2024-06-10 at 16 16 31" src="https://github.com/pnpm/pnpm/assets/6469914/ce88bae9-ba95-4ec6-9582-b542441ab81e">
Actual:
<img width="412" alt="Screenshot 2024-06-10 at 16 16 27" src="https://github.com/pnpm/pnpm/assets/6469914/d715e497-4f7c-4014-87fe-07b756699b6d">

So as the final result even a simple pnpm install command acts with a default filter. Probably this can create other causes too.
<img width="679" alt="Screenshot 2024-06-10 at 16 44 44" src="https://github.com/pnpm/pnpm/assets/6469914/7bee484e-16c5-4af5-929f-c2a1473d0098">

I know this update is in the core of the pnpm, please let me know if you need further information or testing effort.

Thank you for great project and your efforts!

