### PR TITLE
fix: update WorkspaceManifest packages field type to be non-null

### DIFF
--- a/.changeset/metal-panthers-grow.md
+++ b/.changeset/metal-panthers-grow.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.read-manifest": minor
+---
+
+The type definition for the `packages` field of the `WorkspaceManifest` is now non-null. The `readWorkspaceManifest` function expects this field to be present and throws an error otherwise.

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import readYamlFile from 'read-yaml-file'
 
 export interface WorkspaceManifest {
-  packages?: string[]
+  packages: string[]
 }
 
 export async function readWorkspaceManifest (dir: string): Promise<WorkspaceManifest | undefined> {


### PR DESCRIPTION
## Changes

The `packages` field of `WorkspaceManifest` is currently defined as nullable, but I believe this won't ever be the case since we're verifying that it's always present in `readWorkspaceManifest`.

https://github.com/pnpm/pnpm/blob/6ccdfff08cf1a7d481cb5c547757f72b72c8bbc5/workspace/read-manifest/test/index.ts#L24-L28

Let's remove the nullable type annotation to make it easier for code using `WorkspaceManifest` to read `packages`.

## Motivation

This will be useful for https://github.com/pnpm/pnpm/pull/8120#issuecomment-2146312263.

It'd be good to use the compiler to rely on `patterns` never being `undefined`, which would be the case if `packages` from `WorkspaceManifest` also can't be `undefined`.