### PR TITLE
feat(dlx): read auth from local `.npmrc`

### DIFF
--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -26,6 +26,7 @@ export function rcOptionsTypes (): Record<string, unknown> {
   return {
     ...pick([
       'use-node-version',
+      'registry',
     ], types),
     'shell-mode': Boolean,
   }
@@ -64,7 +65,7 @@ export function help (): string {
 export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
-} & Pick<Config, 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' > & add.AddCommandOptions
+} & Pick<Config, 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'registry' > & add.AddCommandOptions
 
 export async function handler (
   opts: DlxCommandOptions,

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -91,13 +91,27 @@ export async function main (inputArgv: string[]): Promise<void> {
     // we don't need the write permission to it. Related issue: #2700
     const globalDirShouldAllowWrite = cmd !== 'root'
     const isDlxCommand = cmd === 'dlx'
-    config = await getConfig(isDlxCommand ? { ...cliOptions, dir: os.homedir() } : cliOptions, {
+    const currentDirConfig = await getConfig(cliOptions, {
       excludeReporter: false,
       globalDirShouldAllowWrite,
       rcOptionsTypes,
       workspaceDir,
       checkUnknownSetting: false,
     }) as typeof config
+    if (isDlxCommand) {
+      config = await getConfig({ ...cliOptions, dir: os.homedir() }, {
+        excludeReporter: false,
+        globalDirShouldAllowWrite,
+        rcOptionsTypes,
+        workspaceDir,
+        checkUnknownSetting: false,
+      }) as typeof config
+      if (currentDirConfig.registry) {
+        config.registry = currentDirConfig.registry
+      }
+    } else {
+      config = currentDirConfig
+    }
     if (isDlxCommand) {
       config.useStderr = true
     }


### PR DESCRIPTION
Resolves https://github.com/pnpm/pnpm/issues/7996

---

**TODO:**
- [ ] Test
- [ ] Include auth info in cache key (is this even necessary though?)
- [ ] Remove non-auth from `rcOptionsTypes` (move them to `cliOptionsTypes`)