### PR TITLE
refactor: store workspace manifest in `@pnpm/config` for reuse

### DIFF
--- a/.changeset/thirty-seals-study.md
+++ b/.changeset/thirty-seals-study.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/config": minor
+"pnpm": patch
+---
+
+The `getConfig` function from `@pnpm/config` now reads the `pnpm-workspace.yaml` file and stores `workspacePackagePatterns` in the `Config` object. An internal refactor was made in pnpm to reuse this value instead of re-reading `pnpm-workspace.yaml` multiple times.

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -41,6 +41,7 @@
     "@pnpm/pnpmfile": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*",
     "better-path-resolve": "1.0.0",
     "camelcase": "^6.3.0",
     "camelcase-keys": "^6.2.2",

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -133,6 +133,7 @@ export interface Config {
   useRunningStoreServer?: boolean
   workspaceConcurrency: number
   workspaceDir?: string
+  workspacePackagePatterns?: string[]
   reporter?: string
   aggregateOutput: boolean
   linkWorkspacePackages: boolean | 'deep'

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -24,6 +24,7 @@ import {
   type UniversalOptions,
 } from './Config'
 import { getWorkspaceConcurrency } from './concurrency'
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest'
 
 export { getOptionsFromRootManifest, type OptionsFromRootManifest } from './getOptionsFromRootManifest'
 export * from './readLocalConfig'
@@ -578,6 +579,11 @@ export async function getConfig (
   pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir) ?? undefined
   if (pnpmConfig.rootProjectManifest?.workspaces?.length && !pnpmConfig.workspaceDir) {
     warnings.push('The "workspaces" field in package.json is not supported by pnpm. Create a "pnpm-workspace.yaml" file instead.')
+  }
+
+  if (pnpmConfig.workspaceDir != null) {
+    const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
+    pnpmConfig.workspacePackagePatterns = workspaceManifest?.packages
   }
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig

--- a/config/config/test/fixtures/pkg-with-valid-workspace-yaml/pnpm-workspace.yaml
+++ b/config/config/test/fixtures/pkg-with-valid-workspace-yaml/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -601,6 +601,21 @@ test('local prefix search stops on pnpm-workspace.yaml', async () => {
   expect(config.dir).toEqual(workspaceDir)
 })
 
+test('reads workspacePackagePatterns', async () => {
+  const workspaceDir = path.join(__dirname, 'fixtures/pkg-with-valid-workspace-yaml')
+  process.chdir(workspaceDir)
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir,
+  })
+
+  expect(config.workspacePackagePatterns).toEqual(['packages/*'])
+})
+
 test('respects test-pattern', async () => {
   {
     const { config } = await getConfig({

--- a/config/config/tsconfig.json
+++ b/config/config/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../../pkg-manifest/read-project-manifest"
     },
     {
+      "path": "../../workspace/read-manifest"
+    },
+    {
       "path": "../matcher"
     }
   ]

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -99,6 +99,7 @@ export type ImportCommandOptions = Pick<Config,
 | 'ignoreWorkspaceCycles'
 | 'disallowWorkspaceCycles'
 | 'sharedWorkspaceLockfile'
+| 'workspacePackagePatterns'
 | 'rootProjectManifest'
 | 'rootProjectManifestDir'
 > & CreateStoreControllerOptions & Omit<InstallOptions, 'storeController' | 'lockfileOnly' | 'preferredVersions'>
@@ -132,7 +133,10 @@ export async function handler (
 
   // For a workspace with shared lockfile
   if (opts.workspaceDir) {
-    const allProjects = opts.allProjects ?? await findWorkspacePackages(opts.workspaceDir, opts)
+    const allProjects = opts.allProjects ?? await findWorkspacePackages(opts.workspaceDir, {
+      ...opts,
+      patterns: opts.workspacePackagePatterns,
+    })
     const selectedProjectsGraph = opts.selectedProjectsGraph ?? selectProjectByDir(allProjects, opts.dir)
     if (selectedProjectsGraph != null) {
       const sequencedGraph = sequenceGraph(selectedProjectsGraph)

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -80,6 +80,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'optional'
 | 'workspaceConcurrency'
 | 'workspaceDir'
+| 'workspacePackagePatterns'
 | 'extraEnv'
 | 'ignoreWorkspaceCycles'
 | 'disallowWorkspaceCycles'
@@ -149,7 +150,9 @@ when running add/update with the --workspace option')
   const forcePublicHoistPattern = typeof opts.rawLocalConfig['shamefully-hoist'] !== 'undefined' ||
     typeof opts.rawLocalConfig['public-hoist-pattern'] !== 'undefined'
   const allProjects = opts.allProjects ?? (
-    opts.workspaceDir ? await findWorkspacePackages(opts.workspaceDir, opts) : []
+    opts.workspaceDir
+      ? await findWorkspacePackages(opts.workspaceDir, { ...opts, patterns: opts.workspacePackagePatterns })
+      : []
   )
   if (opts.workspaceDir) {
     const selectedProjectsGraph = opts.selectedProjectsGraph ?? selectProjectByDir(allProjects, opts.dir)

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -43,6 +43,7 @@ type LinkOpts = CreateStoreControllerOptions & Pick<Config,
 | 'saveOptional'
 | 'saveProd'
 | 'workspaceDir'
+| 'workspacePackagePatterns'
 | 'sharedWorkspaceLockfile'
 > & Partial<Pick<Config, 'linkWorkspacePackages'>>
 
@@ -124,7 +125,10 @@ export async function handler (
   let workspacePackagesArr
   let workspacePackages!: WorkspacePackages
   if (opts.workspaceDir) {
-    workspacePackagesArr = await findWorkspacePackages(opts.workspaceDir, opts)
+    workspacePackagesArr = await findWorkspacePackages(opts.workspaceDir, {
+      ...opts,
+      patterns: opts.workspacePackagePatterns,
+    })
     workspacePackages = arrayOfWorkspacePackagesToMap(workspacePackagesArr) as WorkspacePackages
   } else {
     workspacePackages = {}
@@ -191,7 +195,10 @@ export async function handler (
   if (pkgNames.length > 0) {
     let globalPkgNames!: string[]
     if (opts.workspaceDir) {
-      workspacePackagesArr = await findWorkspacePackages(opts.workspaceDir, opts)
+      workspacePackagesArr = await findWorkspacePackages(opts.workspaceDir, {
+        ...opts,
+        patterns: opts.workspacePackagePatterns,
+      })
 
       const pkgsFoundInWorkspace = workspacePackagesArr
         .filter(({ manifest }) => manifest.name && pkgNames.includes(manifest.name))

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -147,6 +147,7 @@ export async function handler (
   | 'saveProd'
   | 'selectedProjectsGraph'
   | 'workspaceDir'
+  | 'workspacePackagePatterns'
   | 'sharedWorkspaceLockfile'
   > & {
     recursive?: boolean
@@ -178,7 +179,7 @@ export async function handler (
   })
   // @ts-expect-error
   removeOpts['workspacePackages'] = opts.workspaceDir
-    ? arrayOfWorkspacePackagesToMap(await findWorkspacePackages(opts.workspaceDir, opts))
+    ? arrayOfWorkspacePackagesToMap(await findWorkspacePackages(opts.workspaceDir, { ...opts, patterns: opts.workspacePackagePatterns }))
     : undefined
   const targetDependenciesField = getSaveType(opts)
   const {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../../workspace/read-manifest
       better-path-resolve:
         specifier: 1.0.0
         version: 1.0.0

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -200,7 +200,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     const filterResults = await filterPackagesFromDir(wsDir, filters, {
       engineStrict: config.engineStrict,
       nodeVersion: config.nodeVersion ?? config.useNodeVersion,
-      patterns: cliOptions['workspace-packages'],
+      patterns: cliOptions['workspace-packages'] ?? config.workspacePackagePatterns,
       linkWorkspacePackages: !!config.linkWorkspacePackages,
       prefix: process.cwd(),
       workspaceDir: wsDir,


### PR DESCRIPTION
## PR Stack

- https://github.com/pnpm/pnpm/pull/8213
- https://github.com/pnpm/pnpm/pull/8214

## Changes

The `pnpm-workspace.yaml` file is currently read whenever `findWorkspacePackages` is called and then discarded.

Following recent discussions in other PRs, let's store `pnpm-workspace.yaml` in `@pnpm/config` for longer-term reuse and pass the `packages` field to `findWorkspacePackages` when possible.

> approach 1 is the right one. Maybe we can read it in @pnpm/config. We already read the root manifest there too. https://github.com/pnpm/pnpm/pull/8020#discussion_r1584486789

> This sounds good to me. I guess you could put patterns to the options. https://github.com/pnpm/pnpm/pull/8120#issuecomment-2146312263

This makes it easier to reuse the contents of `pnpm-workspace.yaml` for pnpm catalogs.

## Risks

This PR is mostly a no-op refactor, but it does change the timing of when `pnpm-workspace.yaml` is read to be a bit earlier than it was before.