### PR TITLE
feat: create new `@pnpm/catalogs.resolver` package

### DIFF
--- a/catalogs/resolver/CHANGELOG.md
+++ b/catalogs/resolver/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.resolver
+
+## 0.1.0
+
+Initial release

--- a/catalogs/resolver/README.md
+++ b/catalogs/resolver/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.resolver
+
+> Dereferences `catalog:` protocol specifiers into usable specifiers.

--- a/catalogs/resolver/jest.config.js
+++ b/catalogs/resolver/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/catalogs/resolver/package.json
+++ b/catalogs/resolver/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pnpm/catalogs.resolver",
+  "version": "0.1.0",
+  "description": "Dereferences catalog protocol specifiers into usable specifiers.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/resolver",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/resolver#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile && pnpm run _test",
+    "_test": "jest"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "dependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:^",
+    "@pnpm/error": "workspace:^"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.resolver": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*"
+  }
+}

--- a/catalogs/resolver/package.json
+++ b/catalogs/resolver/package.json
@@ -27,7 +27,8 @@
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
-    "_test": "jest"
+    "pretest": "pnpm run compile",
+    "_test": "pnpm pretest && jest"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/catalogs/resolver/src/index.ts
+++ b/catalogs/resolver/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  resolveFromCatalog,
+  type CatalogResolution,
+  type CatalogResolutionFound,
+  type CatalogResolutionMisconfiguration,
+  type CatalogResolutionUnused as CatalogResolutionNotUsed,
+  type CatalogResolutionResult,
+  type CatalogResolver,
+  type WantedDependency,
+} from './resolveFromCatalog'
+export { type CatalogResultMatcher, matchCatalogResolveResult } from './matchCatalogResolveResult'

--- a/catalogs/resolver/src/matchCatalogResolveResult.ts
+++ b/catalogs/resolver/src/matchCatalogResolveResult.ts
@@ -1,0 +1,18 @@
+import { type CatalogResolutionUnused, type CatalogResolutionResult, type CatalogResolutionFound, type CatalogResolutionMisconfiguration } from './resolveFromCatalog'
+
+export interface CatalogResultMatcher<T> {
+  readonly found: (found: CatalogResolutionFound) => T
+  readonly misconfiguration: (misconfiguration: CatalogResolutionMisconfiguration) => T
+  readonly unused: (unused: CatalogResolutionUnused) => T
+}
+
+export function matchCatalogResolveResult<T> (
+  result: CatalogResolutionResult,
+  matcher: CatalogResultMatcher<T>
+): T {
+  switch (result.type) {
+  case 'found': return matcher.found(result)
+  case 'misconfiguration': return matcher.misconfiguration(result)
+  case 'unused': return matcher.unused(result)
+  }
+}

--- a/catalogs/resolver/src/resolveFromCatalog.ts
+++ b/catalogs/resolver/src/resolveFromCatalog.ts
@@ -1,0 +1,95 @@
+import { PnpmError } from '@pnpm/error'
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+export interface WantedDependency {
+  readonly pref: string
+  readonly alias: string
+}
+
+/**
+ * Dereferences a wanted dependency using the catalog protocol and returns the
+ * configured version.
+ *
+ * Example: catalog:default -> ^1.2.3
+ */
+export type CatalogResolver = (wantedDependency: WantedDependency) => CatalogResolutionResult
+
+export type CatalogResolutionResult = CatalogResolutionFound | CatalogResolutionMisconfiguration | CatalogResolutionUnused
+
+export interface CatalogResolutionFound {
+  readonly type: 'found'
+  readonly resolution: CatalogResolution
+}
+
+export interface CatalogResolution {
+  /**
+   * The name of the catalog the resolved specifier was defined in.
+   */
+  readonly catalogName: string
+
+  /**
+   * The specifier that should be used for the wanted dependency. This is a
+   * usable version that replaces the catalog protocol with the relevant user
+   * defined specifier.
+   */
+  readonly specifier: string
+}
+
+/**
+ * The user misconfigured a catalog entry. The entry could be missing or
+ * invalid.
+ */
+export interface CatalogResolutionMisconfiguration {
+  readonly type: 'misconfiguration'
+
+  /**
+   * Convenience error to rethrow.
+   */
+  readonly error: PnpmError
+  readonly catalogName: string
+}
+
+/**
+ * The wanted dependency does not use the catalog protocol.
+ */
+export interface CatalogResolutionUnused {
+  readonly type: 'unused'
+}
+
+export function resolveFromCatalog (catalogs: Catalogs, wantedDependency: WantedDependency): CatalogResolutionResult {
+  const catalogName = parseCatalogProtocol(wantedDependency.pref)
+
+  if (catalogName == null) {
+    return { type: 'unused' }
+  }
+
+  const catalogLookup = catalogs[catalogName]?.[wantedDependency.alias]
+  if (catalogLookup == null) {
+    return {
+      type: 'misconfiguration',
+      catalogName,
+      error: new PnpmError(
+        'CATALOG_ENTRY_NOT_FOUND_FOR_SPEC',
+        `No catalog entry '${wantedDependency.alias}' was found for catalog '${catalogName}'.`),
+    }
+  }
+
+  if (parseCatalogProtocol(catalogLookup) != null) {
+    return {
+      type: 'misconfiguration',
+      catalogName,
+      error: new PnpmError(
+        'CATALOG_ENTRY_INVALID_RECURSIVE_DEFINITION',
+        `Found invalid catalog entry using the catalog protocol recursively. The entry for '${wantedDependency.alias}' in catalog '${catalogName}' is invalid.`),
+    }
+  }
+
+  return {
+    type: 'found',
+    resolution: {
+      catalogName,
+      specifier: catalogLookup,
+    },
+  }
+}

--- a/catalogs/resolver/test/resolveFromCatalog.test.ts
+++ b/catalogs/resolver/test/resolveFromCatalog.test.ts
@@ -1,0 +1,77 @@
+import { type WantedDependency, resolveFromCatalog } from '@pnpm/catalogs.resolver'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+describe('default catalog', () => {
+  const catalogs = {
+    default: {
+      foo: '1.0.0',
+    },
+  }
+
+  test('resolves using implicit name', () => {
+    expect(resolveFromCatalog(catalogs, { alias: 'foo', pref: 'catalog:' }))
+      .toEqual({ type: 'found', resolution: { catalogName: 'default', specifier: '1.0.0' } })
+  })
+
+  test('resolves using explicit name', () => {
+    expect(resolveFromCatalog(catalogs, { alias: 'foo', pref: 'catalog:default' }))
+      .toEqual({ type: 'found', resolution: { catalogName: 'default', specifier: '1.0.0' } })
+  })
+})
+
+test('resolves named catalog', () => {
+  const catalogs = {
+    foo: {
+      bar: '1.0.0',
+    },
+  }
+
+  expect(resolveFromCatalog(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
+    .toEqual({ type: 'found', resolution: { catalogName: 'foo', specifier: '1.0.0' } })
+})
+
+test('returns unused for specifier not using catalog protocol', () => {
+  const catalogs = {
+    foo: {
+      bar: '1.0.0',
+    },
+  }
+
+  expect(resolveFromCatalog(catalogs, { alias: 'bar', pref: '^2.0.0' })).toEqual({ type: 'unused' })
+})
+
+describe('misconfiguration', () => {
+  function resolveFromCatalogOrThrow (catalogs: Catalogs, wantedDependency: WantedDependency) {
+    const result = resolveFromCatalog(catalogs, wantedDependency)
+    if (result.type === 'misconfiguration') {
+      throw result.error
+    }
+    return result
+  }
+
+  test('returns error for missing unresolved catalog', () => {
+    const catalogs = {
+      foo: {
+        bar: '1.0.0',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:' }))
+      .toThrow("No catalog entry 'bar' was found for catalog 'default'.")
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:baz' }))
+      .toThrow("No catalog entry 'bar' was found for catalog 'baz'.")
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'foo', pref: 'catalog:foo' }))
+      .toThrow("No catalog entry 'foo' was found for catalog 'foo'.")
+  })
+
+  test('returns error for recursive catalog', () => {
+    const catalogs = {
+      foo: {
+        bar: 'catalog:foo',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
+      .toThrow("Found invalid catalog entry using the catalog protocol recursively. The entry for 'bar' in catalog 'foo' is invalid.")
+  })
+})

--- a/catalogs/resolver/test/tsconfig.json
+++ b/catalogs/resolver/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/catalogs/resolver/tsconfig.json
+++ b/catalogs/resolver/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../packages/error"
+    },
+    {
+      "path": "../protocol-parser"
+    },
+    {
+      "path": "../types"
+    }
+  ]
+}

--- a/catalogs/resolver/tsconfig.lint.json
+++ b/catalogs/resolver/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,22 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/resolver:
+    dependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:^
+        version: link:../protocol-parser
+      '@pnpm/error':
+        specifier: workspace:^
+        version: link:../../packages/error
+    devDependencies:
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: 'link:'
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../types
+
   catalogs/types:
     devDependencies:
       '@pnpm/catalogs.types':


### PR DESCRIPTION
## Changes

Creating a new `@pnpm/catalogs.resolver` package.

This is a fairly straightforward local resolver that just takes a catalog protocol specifier (e.g. `catalog:foo`) and resolves it using the `Catalogs` config object from `pnpm-workspace.yaml`.

## Usage

In future PRs, this will be used in

- `pkg-manager/resolve-dependencies/src/resolveDependencies.ts` to replace `catalog:` protocol specifiers on `pnpm install`.
- `pkg-manifest/exportable-manifest/src/index.ts` to replace `catalog:` protocol specifiers on `publish`.