### PR TITLE
feat: create new `@pnpm/catalogs.config` package

### DIFF
--- a/catalogs/config/CHANGELOG.md
+++ b/catalogs/config/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pnpm/catalogs.config
+
+## 0.1.0
+
+Initial release

--- a/catalogs/config/README.md
+++ b/catalogs/config/README.md
@@ -1,0 +1,3 @@
+# @pnpm/catalogs.config
+
+> Create a normalized catalogs config from `pnpm-workspace.yaml` contents.

--- a/catalogs/config/jest.config.js
+++ b/catalogs/config/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config.js')

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pnpm/catalogs.config",
+  "version": "0.1.0",
+  "description": "Create a normalized catalogs config from pnpm-workspace.yaml contents.",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "engines": {
+    "node": ">=18.12"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "repository": "https://github.com/pnpm/pnpm/blob/main/catalogs/config",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "types"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/catalogs/config#readme",
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "compile": "tsc --build && pnpm run lint --fix",
+    "prepublishOnly": "pnpm run compile",
+    "test": "pnpm run compile && pnpm run _test",
+    "_test": "jest"
+  },
+  "funding": "https://opencollective.com/pnpm",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "dependencies": {
+    "@pnpm/error": "workspace:*"
+  },
+  "devDependencies": {
+    "@pnpm/catalogs.config": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*"
+  }
+}

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -27,7 +27,8 @@
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
-    "_test": "jest"
+    "pretest": "pnpm run compile",
+    "_test": "pnpm pretest && jest"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/catalogs/config/src/getCatalogsFromWorkspaceManifest.ts
+++ b/catalogs/config/src/getCatalogsFromWorkspaceManifest.ts
@@ -1,0 +1,36 @@
+import { PnpmError } from '@pnpm/error'
+import { type Catalogs } from '@pnpm/catalogs.types'
+import { type WorkspaceManifest } from '@pnpm/workspace.read-manifest'
+
+export function getCatalogsFromWorkspaceManifest (
+  workspaceManifest: Pick<WorkspaceManifest, 'catalog' | 'catalogs'> | undefined
+): Catalogs {
+  // If the pnpm-workspace.yaml file doesn't exist, no catalogs are defined.
+  //
+  // In some cases, it makes sense for callers to handle null/undefined checks
+  // of this form. In this case, let's explicitly handle not found
+  // pnpm-workspace.yaml files by returning an empty catalog to make consuming
+  // logic easier.
+  if (workspaceManifest == null) {
+    return {}
+  }
+
+  checkDefaultCatalogIsDefinedOnce(workspaceManifest)
+
+  return {
+    // If workspaceManifest.catalog is undefined, intentionally allow the spread
+    // below to overwrite it. The check above ensures only one or the either is
+    // defined.
+    default: workspaceManifest.catalog,
+
+    ...workspaceManifest.catalogs,
+  }
+}
+
+export function checkDefaultCatalogIsDefinedOnce (manifest: Pick<WorkspaceManifest, 'catalog' | 'catalogs'>): void {
+  if (manifest.catalog != null && manifest.catalogs?.default != null) {
+    throw new PnpmError(
+      'INVALID_CATALOGS_CONFIGURATION',
+      'The \'default\' catalog was defined multiple times. Use the \'catalog\' field or \'catalogs.default\', but not both.')
+  }
+}

--- a/catalogs/config/src/index.ts
+++ b/catalogs/config/src/index.ts
@@ -1,0 +1,1 @@
+export { getCatalogsFromWorkspaceManifest } from './getCatalogsFromWorkspaceManifest'

--- a/catalogs/config/test/getCatalogsFromWorkspaceManifest.test.ts
+++ b/catalogs/config/test/getCatalogsFromWorkspaceManifest.test.ts
@@ -1,0 +1,54 @@
+import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
+
+test('combines implicit default and named catalogs', () => {
+  expect(getCatalogsFromWorkspaceManifest({
+    catalog: {
+      foo: '^1.0.0',
+    },
+    catalogs: {
+      bar: {
+        baz: '^2.0.0',
+      },
+    },
+  })).toEqual({
+    default: {
+      foo: '^1.0.0',
+    },
+    bar: {
+      baz: '^2.0.0',
+    },
+  })
+})
+
+test('combines explicit default and named catalogs', () => {
+  expect(getCatalogsFromWorkspaceManifest({
+    catalogs: {
+      default: {
+        foo: '^1.0.0',
+      },
+      bar: {
+        baz: '^2.0.0',
+      },
+    },
+  })).toEqual({
+    default: {
+      foo: '^1.0.0',
+    },
+    bar: {
+      baz: '^2.0.0',
+    },
+  })
+})
+
+test('throws if default catalog is defined multiple times', () => {
+  expect(() => getCatalogsFromWorkspaceManifest({
+    catalog: {
+      bar: '^2.0.0',
+    },
+    catalogs: {
+      default: {
+        foo: '^1.0.0',
+      },
+    },
+  })).toThrow(/The 'default' catalog was defined multiple times/)
+})

--- a/catalogs/config/test/tsconfig.json
+++ b/catalogs/config/test/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/catalogs/config/tsconfig.json
+++ b/catalogs/config/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "composite": true,
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../packages/error"
+    },
+    {
+      "path": "../../workspace/read-manifest"
+    },
+    {
+      "path": "../types"
+    }
+  ]
+}

--- a/catalogs/config/tsconfig.lint.json
+++ b/catalogs/config/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,22 @@ importers:
         specifier: workspace:*
         version: 'link:'
 
+  catalogs/config:
+    dependencies:
+      '@pnpm/error':
+        specifier: workspace:*
+        version: link:../../packages/error
+    devDependencies:
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: 'link:'
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../types
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../../workspace/read-manifest
+
   catalogs/protocol-parser:
     devDependencies:
       '@pnpm/catalogs.protocol-parser':

--- a/workspace/read-manifest/src/catalogs.ts
+++ b/workspace/read-manifest/src/catalogs.ts
@@ -57,9 +57,3 @@ export function assertValidWorkspaceManifestCatalogs (manifest: { packages?: rea
     }
   }
 }
-
-export function checkDefaultCatalogIsDefinedOnce (manifest: { catalog?: WorkspaceCatalog, catalogs?: WorkspaceNamedCatalogs }): void {
-  if (manifest.catalog != null && manifest.catalogs?.default != null) {
-    throw new InvalidWorkspaceManifestError('The \'default\' catalog was defined multiple times. Use the \'catalog\' field or \'catalogs.default\', but not both')
-  }
-}

--- a/workspace/read-manifest/src/index.ts
+++ b/workspace/read-manifest/src/index.ts
@@ -5,7 +5,6 @@ import readYamlFile from 'read-yaml-file'
 import {
   assertValidWorkspaceManifestCatalog,
   assertValidWorkspaceManifestCatalogs,
-  checkDefaultCatalogIsDefinedOnce,
   type WorkspaceCatalog,
   type WorkspaceNamedCatalogs,
 } from './catalogs'
@@ -70,7 +69,6 @@ function validateWorkspaceManifest (manifest: unknown): asserts manifest is Work
   assertValidWorkspaceManifestPackages(manifest)
   assertValidWorkspaceManifestCatalog(manifest)
   assertValidWorkspaceManifestCatalogs(manifest)
-  checkDefaultCatalogIsDefinedOnce(manifest)
 
   checkWorkspaceManifestAssignability(manifest)
 }

--- a/workspace/read-manifest/test/index.ts
+++ b/workspace/read-manifest/test/index.ts
@@ -152,10 +152,4 @@ describe('readWorkspaceManifest() reads default catalog defined alongside named 
       },
     })
   })
-
-  test('throws if both catalog and catalogs.default are defined', async () => {
-    await expect(
-      readWorkspaceManifest(path.join(__dirname, '__fixtures__/catalogs-conflicting-defaults'))
-    ).rejects.toThrow('The \'default\' catalog was defined multiple times. Use the \'catalog\' field or \'catalogs.default\', but not both')
-  })
 })


### PR DESCRIPTION
## Changes

Adding a new `@pnpm/catalogs.config` package that merges the `catalog` and `catalogs` fields from `pnpm-workspace.yaml`.

## Usage

This will be used in `@pnpm/config` in a future PR. https://github.com/pnpm/pnpm/pull/8221/commits/fbd0197711bf1499c609f7791ebe259b120f4275

https://github.com/pnpm/pnpm/blob/fbd0197711bf1499c609f7791ebe259b120f4275/config/config/src/index.ts#L587-L592