### PR TITLE
feat: implement catalog protocol for install

### DIFF
--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -27,8 +27,7 @@
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
-    "pretest": "pnpm run compile",
-    "_test": "pnpm pretest && jest"
+    "_test": "jest"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/catalogs/protocol-parser/package.json
+++ b/catalogs/protocol-parser/package.json
@@ -27,8 +27,7 @@
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
-    "pretest": "pnpm run compile",
-    "_test": "pnpm pretest && jest"
+    "_test": "jest"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/catalogs/resolver/package.json
+++ b/catalogs/resolver/package.json
@@ -27,8 +27,7 @@
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
-    "pretest": "pnpm run compile",
-    "_test": "pnpm pretest && jest"
+    "_test": "jest"
   },
   "funding": "https://opencollective.com/pnpm",
   "exports": {

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -32,6 +32,8 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/config/config#readme",
   "dependencies": {
+    "@pnpm/catalogs.config": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/config.env-replace": "3.0.0",
     "@pnpm/constants": "workspace:*",
     "@pnpm/error": "workspace:*",

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -1,3 +1,4 @@
+import type { Catalogs } from '@pnpm/catalogs.types'
 import {
   type Project,
   type ProjectManifest,
@@ -134,6 +135,7 @@ export interface Config {
   workspaceConcurrency: number
   workspaceDir?: string
   workspacePackagePatterns?: string[]
+  catalogs?: Catalogs
   reporter?: string
   aggregateOutput: boolean
   linkWorkspacePackages: boolean | 'deep'

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
 import { LAYOUT_VERSION } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
 import loadNpmConf from '@pnpm/npm-conf'
@@ -584,12 +585,10 @@ export async function getConfig (
   }
 
   if (pnpmConfig.workspaceDir != null) {
-    if (cliOptions['workspace-packages']) {
-      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[]
-    } else {
-      const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
-      pnpmConfig.workspacePackagePatterns = workspaceManifest?.packages
-    }
+    const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
+
+    pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages
+    pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
   }
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig

--- a/config/config/tsconfig.json
+++ b/config/config/tsconfig.json
@@ -16,6 +16,12 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../hooks/pnpmfile"
     },
     {

--- a/lockfile/lockfile-file/src/lockfileFormatConverters.ts
+++ b/lockfile/lockfile-file/src/lockfileFormatConverters.ts
@@ -116,6 +116,9 @@ function normalizeLockfile (lockfile: InlineSpecifiersLockfile, opts: NormalizeL
   if (lockfileToSave.time) {
     lockfileToSave.time = pruneTimeInLockfileV6(lockfileToSave.time, lockfile.importers ?? {})
   }
+  if ((lockfileToSave.catalogs != null) && isEmpty(lockfileToSave.catalogs)) {
+    delete lockfileToSave.catalogs
+  }
   if ((lockfileToSave.overrides != null) && isEmpty(lockfileToSave.overrides)) {
     delete lockfileToSave.overrides
   }

--- a/lockfile/lockfile-file/src/sortLockfileKeys.ts
+++ b/lockfile/lockfile-file/src/sortLockfileKeys.ts
@@ -35,6 +35,7 @@ type RootKey = keyof LockfileFile
 const ROOT_KEYS: readonly RootKey[] = [
   'lockfileVersion',
   'settings',
+  'catalogs',
   'overrides',
   'packageExtensionsChecksum',
   'pnpmfileChecksum',
@@ -82,6 +83,15 @@ export function sortLockfileKeys (lockfile: LockfileFileV9): LockfileFileV9 {
     for (const [pkgId, pkg] of Object.entries(lockfile.snapshots)) {
       lockfile.snapshots[pkgId] = sortKeys(pkg, {
         compare: compareWithPriority.bind(null, ORDERED_KEYS),
+        deep: true,
+      })
+    }
+  }
+  if (lockfile.catalogs != null) {
+    lockfile.catalogs = sortKeys(lockfile.catalogs)
+    for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
+      lockfile.catalogs[catalogName] = sortKeys(catalog, {
+        compare: lexCompare,
         deep: true,
       })
     }

--- a/lockfile/lockfile-types/src/index.ts
+++ b/lockfile/lockfile-types/src/index.ts
@@ -14,6 +14,7 @@ export interface Lockfile {
   importers: Record<ProjectId, ProjectSnapshot>
   lockfileVersion: string
   time?: Record<string, string>
+  catalogs?: CatalogSnapshots
   packages?: PackageSnapshots
   overrides?: Record<string, string>
   packageExtensionsChecksum?: string
@@ -136,3 +137,24 @@ export type PackageBin = string | { [name: string]: string }
  * }
  */
 export type ResolvedDependencies = Record<string, string>
+
+export interface CatalogSnapshots {
+  [catalogName: string]: { [dependencyName: string]: ResolvedCatalogEntry }
+}
+
+export interface ResolvedCatalogEntry {
+  /**
+   * The real specifier that should be used for this dependency's catalog entry.
+   * This would be the ^1.2.3 portion of:
+   *
+   * @example
+   * catalog:
+   *   foo: ^1.2.3
+   */
+  readonly specifier: string
+
+  /**
+   * The concrete version that the requested specifier resolved to. Ex: 1.2.3
+   */
+  readonly version: string
+}

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -91,6 +91,8 @@
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
     "@pnpm/test-ipc-server": "workspace:*",
+    "@pnpm/workspace.find-packages": "workspace:*",
+    "@pnpm/workspace.filter-packages-from-dir": "workspace:*",
     "@types/fs-extra": "^9.0.13",
     "@types/is-windows": "^1.0.2",
     "@types/normalize-path": "^3.0.2",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -19,6 +19,7 @@
     "@pnpm/build-modules": "workspace:*",
     "@pnpm/builder.policy": "3.0.0",
     "@pnpm/calc-dep-state": "workspace:*",
+    "@pnpm/catalogs.protocol-parser": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -19,6 +19,7 @@
     "@pnpm/build-modules": "workspace:*",
     "@pnpm/builder.policy": "3.0.0",
     "@pnpm/calc-dep-state": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/crypto.base32-hash": "workspace:*",

--- a/pkg-manager/core/src/getPeerDependencyIssues.ts
+++ b/pkg-manager/core/src/getPeerDependencyIssues.ts
@@ -8,6 +8,7 @@ import { DEFAULT_REGISTRIES } from '@pnpm/normalize-registries'
 
 export type ListMissingPeersOptions = Partial<GetContextOptions>
 & Pick<InstallOptions, 'hooks'
+| 'catalogs'
 | 'dedupePeerDependents'
 | 'ignoreCompatibilityDb'
 | 'linkWorkspacePackagesDepth'
@@ -60,6 +61,7 @@ export async function getPeerDependencyIssues (
       currentLockfile: ctx.currentLockfile,
       allowedDeprecatedVersions: {},
       allowNonAppliedPatches: false,
+      catalogs: opts.catalogs,
       defaultUpdateDepth: -1,
       dedupePeerDependents: opts.dedupePeerDependents,
       dryRun: true,

--- a/pkg-manager/core/src/install/allCatalogsAreUpToDate.ts
+++ b/pkg-manager/core/src/install/allCatalogsAreUpToDate.ts
@@ -1,0 +1,11 @@
+import { type CatalogSnapshots } from '@pnpm/lockfile-file'
+import { type Catalogs } from '@pnpm/catalogs.types'
+
+export function allCatalogsAreUpToDate (
+  catalogsConfig: Catalogs,
+  snapshot: CatalogSnapshots | undefined
+): boolean {
+  return Object.entries(snapshot ?? {})
+    .every(([catalogName, catalog]) => Object.entries(catalog ?? {})
+      .every(([alias, entry]) => entry.specifier === catalogsConfig[catalogName]?.[alias]))
+}

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -1,4 +1,5 @@
 import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import { PnpmError } from '@pnpm/error'
 import { type ProjectOptions } from '@pnpm/get-context'
 import { type HoistingLimits } from '@pnpm/headless'
@@ -22,6 +23,7 @@ import { type PreResolutionHookContext } from '@pnpm/hooks.types'
 export interface StrictInstallOptions {
   autoInstallPeers: boolean
   autoInstallPeersFromHighestMatch: boolean
+  catalogs: Catalogs
   frozenLockfile: boolean
   frozenLockfileIfExists: boolean
   enablePnp: boolean

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import path from 'path'
 import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/build-modules'
 import { createAllowBuildFunction } from '@pnpm/builder.policy'
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import {
   LAYOUT_VERSION,
   LOCKFILE_VERSION,
@@ -395,6 +396,7 @@ export async function mutateModules (
           ctx.wantedLockfile.lockfileVersion === '6.1'
         ) &&
         await allProjectsAreUpToDate(Object.values(ctx.projects), {
+          catalogs: opts.catalogs,
           autoInstallPeers: opts.autoInstallPeers,
           excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
           linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
@@ -629,8 +631,26 @@ Note that in CI environments, this setting is enabled by default.`,
     }
     /* eslint-enable no-await-in-loop */
 
-    function isWantedDepPrefSame (_alias: string, prevPref: string | undefined, nextPref: string): boolean {
-      return prevPref === nextPref
+    function isWantedDepPrefSame (alias: string, prevPref: string | undefined, nextPref: string): boolean {
+      if (prevPref !== nextPref) {
+        return false
+      }
+
+      // When pnpm catalogs are used, the specifiers can be the same (e.g.
+      // "catalog:default"), but the wanted versions for the dependency can be
+      // different after resolution if the catalog config was just edited.
+      const catalogName = parseCatalogProtocol(prevPref)
+
+      // If there's no catalog name, the catalog protocol was not used and we
+      // can assume the pref is the same since prevPref and nextPref match.
+      if (catalogName === null) {
+        return true
+      }
+
+      const prevCatalogEntrySpec = ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]?.specifier
+      const nextCatalogEntrySpec = opts.catalogs[catalogName]?.[alias]
+
+      return prevCatalogEntrySpec === nextCatalogEntrySpec
     }
 
     async function installCase (project: any) { // eslint-disable-line
@@ -1421,6 +1441,7 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
       if (allProjectsLocatedInsideWorkspace.length > projects.length) {
         if (
           await allProjectsAreUpToDate(allProjectsLocatedInsideWorkspace, {
+            catalogs: opts.catalogs,
             autoInstallPeers: opts.autoInstallPeers,
             excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
             linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1043,6 +1043,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       allowNonAppliedPatches: opts.allowNonAppliedPatches,
       autoInstallPeers: opts.autoInstallPeers,
       autoInstallPeersFromHighestMatch: opts.autoInstallPeersFromHighestMatch,
+      catalogs: opts.catalogs,
       currentLockfile: ctx.currentLockfile,
       defaultUpdateDepth: opts.depth,
       dedupeDirectDeps: opts.dedupeDirectDeps,

--- a/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
+++ b/pkg-manager/core/test/allProjectsAreUpToDate.test.ts
@@ -36,6 +36,7 @@ test('allProjectsAreUpToDate(): works with packages linked through the workspace
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -77,6 +78,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies', async ()
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -118,6 +120,7 @@ test('allProjectsAreUpToDate(): works with aliased local dependencies that speci
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -159,6 +162,7 @@ test('allProjectsAreUpToDate(): returns false if the aliased dependency version 
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -230,6 +234,7 @@ test('allProjectsAreUpToDate(): use link and registry version if linkWorkspacePa
       ],
       {
         autoInstallPeers: false,
+        catalogs: {},
         excludeLinksFromLockfile: false,
         linkWorkspacePackages: false,
         wantedLockfile: {
@@ -296,6 +301,7 @@ test('allProjectsAreUpToDate(): returns false if dependenciesMeta differs', asyn
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -342,6 +348,7 @@ test('allProjectsAreUpToDate(): returns true if dependenciesMeta matches', async
     },
   ], {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -400,6 +407,7 @@ describe('local file dependency', () => {
   ]
   const options = {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {
@@ -499,6 +507,7 @@ test('allProjectsAreUpToDate(): returns true if workspace dependency\'s version 
   ]
   const options = {
     autoInstallPeers: false,
+    catalogs: {},
     excludeLinksFromLockfile: false,
     linkWorkspacePackages: true,
     wantedLockfile: {

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -1,0 +1,396 @@
+import { type Catalogs } from '@pnpm/catalogs.types'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { createPeersDirSuffix } from '@pnpm/dependency-path'
+import { type Lockfile } from '@pnpm/lockfile-types'
+import { type ProjectId, type ProjectManifest } from '@pnpm/types'
+import { preparePackages } from '@pnpm/prepare'
+import { type MutatedProject, mutateModules, type ProjectOptions } from '@pnpm/core'
+import { getLockfileImporterId } from '@pnpm/lockfile-file'
+import { filterPackagesFromDir } from '@pnpm/workspace.filter-packages-from-dir'
+import { arrayOfWorkspacePackagesToMap } from '@pnpm/workspace.find-packages'
+import readYamlFile from 'read-yaml-file'
+import path from 'path'
+import { testDefaults } from './utils'
+
+/**
+ * A utility to make writing catalog tests easier by reducing boilerplate.
+ */
+class CatalogTestsController {
+  private readonly workspaceDir: string
+  private catalogs: Catalogs = {}
+
+  constructor (readonly pkgs: Array<{ location: string, package: ProjectManifest }>) {
+    preparePackages(pkgs)
+    this.workspaceDir = process.cwd()
+  }
+
+  setCatalogs (catalogs: Catalogs) {
+    this.catalogs = catalogs
+  }
+
+  async install (opts?: { frozenLockfile?: boolean, filter?: readonly string[] }) {
+    const { allProjects } = await filterPackagesFromDir(
+      this.workspaceDir,
+      opts?.filter?.map(parentDir => ({ parentDir })) ?? [])
+
+    const importers: MutatedProject[] = allProjects.map(project => ({
+      mutation: 'install',
+      id: getLockfileImporterId(this.workspaceDir, project.dir),
+      manifest: project.manifest,
+      rootDir: project.dirRealPath,
+    }))
+
+    // The mutateModules function expects a different interface (ProjectOptions)
+    // than the filterPackages returns (Project). Adding a few required fields
+    // to get tests to pass.
+    const mutateModulesAllProjects: ProjectOptions[] = allProjects.map(project => ({
+      ...project,
+      buildIndex: 0,
+      rootDir: project.dirRealPath,
+    }))
+
+    await mutateModules(importers, testDefaults({
+      allProjects: mutateModulesAllProjects,
+      lockfileOnly: true,
+      catalogs: this.catalogs,
+      workspacePackages: arrayOfWorkspacePackagesToMap(mutateModulesAllProjects),
+    }))
+  }
+
+  async lockfile (): Promise<Lockfile> {
+    return readYamlFile(path.join(this.workspaceDir, WANTED_LOCKFILE))
+  }
+
+  async updateProjectManifest (location: string, manifest: ProjectManifest): Promise<void> {
+    const { selectedProjectsGraph } = await filterPackagesFromDir(this.workspaceDir, [{ parentDir: location }])
+    await selectedProjectsGraph[path.join(this.workspaceDir, location)].package.writeProjectManifest(manifest)
+  }
+}
+
+test('installing with "catalog:" should work', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+    // Empty second project to create a multi-package workspace.
+    {
+      location: 'packages/project2',
+      package: {},
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: { 'is-positive': '1.0.0' },
+  })
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.importers['packages/project1' as ProjectId]).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+})
+
+test('importer to importer dependency with "catalog:" should work', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        name: 'project1',
+        dependencies: {
+          project2: 'workspace:*',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        name: 'project2',
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: { 'is-positive': '1.0.0' },
+  })
+
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.importers['packages/project2' as ProjectId]).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+})
+
+test('importer with different peers uses correct peer', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          '@pnpm.e2e/has-foo100-peer': 'catalog:',
+          // Define a peer with an exact version to ensure the dep above uses
+          // this peer.
+          '@pnpm.e2e/foo': '100.0.0',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        dependencies: {
+          '@pnpm.e2e/has-foo100-peer': 'catalog:',
+          // Note that this peer is intentionally different than the one above
+          // for project 1. (100.1.0 instead of 100.0.0).
+          //
+          // We want to ensure project2 resolves to the same catalog version for
+          // @pnpm.e2e/has-foo100-peer, but uses a different peers suffix.
+          //
+          // Catalogs allow versions to be reused, but this test ensures we
+          // don't reuse versions too aggressively.
+          '@pnpm.e2e/foo': '100.1.0',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: {
+      '@pnpm.e2e/has-foo100-peer': '^1.0.0',
+    },
+  })
+
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
+    specifier: 'catalog:',
+    version: `1.0.0${createPeersDirSuffix([{ name: '@pnpm.e2e/foo', version: '100.0.0' }])}`,
+  })
+  expect(lockfile.importers['packages/project2' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
+    specifier: 'catalog:',
+    //              This version is intentionally different from the one above    ꜜ
+    version: `1.0.0${createPeersDirSuffix([{ name: '@pnpm.e2e/foo', version: '100.1.0' }])}`,
+  })
+})
+
+test('lockfile contains catalog snapshots', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        dependencies: {
+          'is-negative': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: {
+      'is-positive': '^1.0.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+
+  await ctrl.install()
+  const lockfile = await ctrl.lockfile()
+
+  expect(lockfile.catalogs).toStrictEqual({
+    default: {
+      'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+    },
+  })
+})
+
+test('lockfile is updated if catalog config changes', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: { 'is-positive': '=1.0.0' },
+  })
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).importers['packages/project1' as ProjectId]).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '1.0.0',
+      },
+    },
+  })
+
+  ctrl.setCatalogs({
+    default: {
+      'is-positive': '=3.1.0',
+    },
+  })
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).importers['packages/project1' as ProjectId]).toEqual({
+    dependencies: {
+      'is-positive': {
+        specifier: 'catalog:',
+        version: '3.1.0',
+      },
+    },
+  })
+})
+
+test('lockfile catalog snapshots retain existing entries on --filter', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-negative': 'catalog:',
+        },
+      },
+    },
+    {
+      location: 'packages/project2',
+      package: {
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: {
+      'is-positive': '^1.0.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+
+  await ctrl.install()
+
+  expect((await ctrl.lockfile()).catalogs).toStrictEqual({
+    default: {
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+      'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+    },
+  })
+
+  // Update catalog definitions so pnpm triggers a rerun.
+  ctrl.setCatalogs({
+    default: {
+      'is-positive': '=3.1.0',
+      'is-negative': '^1.0.0',
+    },
+  })
+  await ctrl.install({ filter: ['packages/project2'] })
+
+  expect((await ctrl.lockfile()).catalogs).toStrictEqual({
+    default: {
+      // The is-negative snapshot should be carried from the previous install,
+      // despite the current filtered install not using it.
+      'is-negative': { specifier: '^1.0.0', version: '1.0.0' },
+
+      'is-positive': { specifier: '=3.1.0', version: '3.1.0' },
+    },
+  })
+})
+
+// If a catalog specifier was used in one or more package.json files and all
+// usages were removed later, we should remove the catalog snapshot from
+// pnpm-lock.yaml. This should happen even if the dependency is still defined in
+// a catalog under pnpm-workspace.yaml.
+//
+// Note that this behavior may not be desirable in all cases. If someone removes
+// the last usage of a catalog entry, and another person adds it back later,
+// that dependency will be re-resolved to a newer version. This is probably
+// desirable most of the time, but there could be a good argument to cache the
+// older unused resolution. For now we'll remove the unused entries since that's
+// what would happen anyway if catalogs aren't used.
+test('lockfile catalog snapshots should remove unused entries', async () => {
+  const ctrl = new CatalogTestsController([
+    {
+      location: 'packages/project1',
+      package: {
+        dependencies: {
+          'is-negative': 'catalog:',
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  ctrl.setCatalogs({
+    default: {
+      'is-negative': '=1.0.0',
+      'is-positive': '=1.0.0',
+    },
+  })
+
+  {
+    await ctrl.install()
+    const lockfile = await ctrl.lockfile()
+    expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies).toEqual({
+      'is-negative': { specifier: 'catalog:', version: '1.0.0' },
+      'is-positive': { specifier: 'catalog:', version: '1.0.0' },
+    })
+    expect(lockfile.catalogs?.default).toStrictEqual({
+      'is-negative': { specifier: '=1.0.0', version: '1.0.0' },
+      'is-positive': { specifier: '=1.0.0', version: '1.0.0' },
+    })
+  }
+
+  // Update package.json to no longer depend on is-positive.
+  await ctrl.updateProjectManifest('packages/project1', {
+    dependencies: {
+      'is-negative': 'catalog:',
+    },
+  })
+  await ctrl.install()
+
+  {
+    const lockfile = await ctrl.lockfile()
+    expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies).toEqual({
+      'is-negative': { specifier: 'catalog:', version: '1.0.0' },
+    })
+    // Only "is-negative" should be in the catalogs section of the lockfile
+    // since all packages in the workspace no longer use is-positive. Note that
+    // this should be the case even if pnpm-workspace.yaml still has
+    // "is-positive" configured.
+    expect(lockfile.catalogs?.default).toStrictEqual({
+      'is-negative': { specifier: '=1.0.0', version: '1.0.0' },
+    })
+  }
+})

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../__utils__/test-ipc-server"
     },
     {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../config/matcher"
     },
     {

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -142,6 +142,12 @@
       "path": "../../worker"
     },
     {
+      "path": "../../workspace/filter-packages-from-dir"
+    },
+    {
+      "path": "../../workspace/find-packages"
+    },
+    {
       "path": "../client"
     },
     {

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../__utils__/test-ipc-server"
     },
     {
+      "path": "../../catalogs/protocol-parser"
+    },
+    {
       "path": "../../catalogs/types"
     },
     {

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -29,6 +29,8 @@
     "_test": "jest"
   },
   "dependencies": {
+    "@pnpm/catalogs.resolver": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",

--- a/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
+++ b/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
@@ -1,0 +1,21 @@
+import { type CatalogSnapshots } from '@pnpm/lockfile-types'
+import { type ResolvedDirectDependency } from './resolveDependencyTree'
+
+export function getCatalogSnapshots (resolvedDirectDeps: readonly ResolvedDirectDependency[]): CatalogSnapshots {
+  const catalogSnapshots: CatalogSnapshots = {}
+  const catalogedDeps = resolvedDirectDeps.filter(isCatalogedDep)
+
+  for (const dep of catalogedDeps) {
+    const snapshotForSingleCatalog = (catalogSnapshots[dep.catalogLookup.catalogName] ??= {})
+    snapshotForSingleCatalog[dep.alias] = {
+      specifier: dep.catalogLookup.specifier,
+      version: dep.version,
+    }
+  }
+
+  return catalogSnapshots
+}
+
+function isCatalogedDep (dep: ResolvedDirectDependency): dep is ResolvedDirectDependency & { catalogLookup: Required<ResolvedDirectDependency>['catalogLookup'] } {
+  return dep.catalogLookup != null
+}

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -46,6 +46,7 @@ import {
 import { toResolveImporter } from './toResolveImporter'
 import { updateLockfile } from './updateLockfile'
 import { updateProjectManifest } from './updateProjectManifest'
+import { getCatalogSnapshots } from './getCatalogSnapshots'
 
 export type DependenciesGraph = GenericDependenciesGraphWithResolvedChildren<ResolvedPackage>
 
@@ -303,6 +304,8 @@ export async function resolveDependencies (
       ...time,
     }
   }
+
+  newLockfile.catalogs = getCatalogSnapshots(Object.values(resolvedImporters).flatMap(({ directDependencies }) => directDependencies))
 
   // waiting till package requests are finished
   async function waitTillAllFetchingsFinish (): Promise<void> {

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -1,3 +1,5 @@
+import { resolveFromCatalog } from '@pnpm/catalogs.resolver'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import { type Lockfile, type PatchFile } from '@pnpm/lockfile-types'
 import { type PreferredVersions, type Resolution, type WorkspacePackages } from '@pnpm/resolver-base'
 import { type StoreController } from '@pnpm/store-controller-types'
@@ -74,6 +76,7 @@ export interface ResolveDependenciesOptions {
   allowBuild?: (pkgName: string) => boolean
   allowedDeprecatedVersions: AllowedDeprecatedVersions
   allowNonAppliedPatches: boolean
+  catalogs?: Catalogs
   currentLockfile: Lockfile
   dedupePeerDependents?: boolean
   dryRun: boolean
@@ -129,6 +132,7 @@ export async function resolveDependencyTree<T> (
     autoInstallPeersFromHighestMatch: opts.autoInstallPeersFromHighestMatch === true,
     allowBuild: opts.allowBuild,
     allowedDeprecatedVersions: opts.allowedDeprecatedVersions,
+    catalogResolver: resolveFromCatalog.bind(null, opts.catalogs ?? {}),
     childrenByParentId: {} as ChildrenByParentId,
     currentLockfile: opts.currentLockfile,
     defaultTag: opts.tag,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -51,6 +51,16 @@ export interface ResolvedDirectDependency {
   version: string
   name: string
   normalizedPref?: string
+  catalogLookup?: CatalogLookupMetadata
+}
+
+/**
+ * Information related to the catalog entry for this dependency if it was
+ * requested through the catalog protocol.
+ */
+export interface CatalogLookupMetadata {
+  readonly catalogName: string
+  readonly specifier: string
 }
 
 export interface Importer<WantedDepExtraProps> {
@@ -233,6 +243,7 @@ export async function resolveDependencyTree<T> (
           const resolvedPackage = ctx.dependenciesTree.get(dep.nodeId)!.resolvedPackage as ResolvedPackage
           return {
             alias: dep.alias,
+            catalogLookup: dep.catalogLookup,
             dev: resolvedPackage.dev,
             name: resolvedPackage.name,
             normalizedPref: dep.normalizedPref,

--- a/pkg-manager/resolve-dependencies/tsconfig.json
+++ b/pkg-manager/resolve-dependencies/tsconfig.json
@@ -10,6 +10,12 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/resolver"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../config/pick-registry-for-package"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3134,6 +3134,9 @@ importers:
       '@pnpm/calc-dep-state':
         specifier: workspace:*
         version: link:../../packages/calc-dep-state
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: link:../../catalogs/protocol-parser
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,6 +642,12 @@ importers:
 
   config/config:
     dependencies:
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/config.env-replace':
         specifier: 3.0.0
         version: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3351,6 +3351,12 @@ importers:
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
+      '@pnpm/workspace.filter-packages-from-dir':
+        specifier: workspace:*
+        version: link:../../workspace/filter-packages-from-dir
+      '@pnpm/workspace.find-packages':
+        specifier: workspace:*
+        version: link:../../workspace/find-packages
       '@types/fs-extra':
         specifier: ^9.0.13
         version: 9.0.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3134,6 +3134,9 @@ importers:
       '@pnpm/calc-dep-state':
         specifier: workspace:*
         version: link:../../packages/calc-dep-state
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants
@@ -4321,6 +4324,12 @@ importers:
 
   pkg-manager/resolve-dependencies:
     dependencies:
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: link:../../catalogs/resolver
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants


### PR DESCRIPTION
## Changes

This implements the following items from the tracking issue https://github.com/pnpm/pnpm/issues/7072.

- [x] Support the `catalog:` and `catalog:default` specifiers.
- [x] Support `catalog:<name>` specifiers.
- [x] Changing a catalog entry in pnpm-workspace.yaml causes the lock file to not be up to date.

I've organized this PR into different commits that make sense by themselves. **This PR should be easier to review commit by commit rather than all files changed at once.**

## When should we transform the catalog protocol?

The hardest part of this PR was determining the right place for the `catalog:` → `^1.2.3` translation internally.

- We could model this as a [read package hook](https://github.com/pnpm/pnpm/blob/aa33269f9f9fc0c3505ae1c59264d1706923a971/hooks/read-package-hook/src/createReadPackageHook.ts#L14), which would be similar to how `pnpm.overrides` and `packageExtensions` work. I think this is **too early** of a place for the protocol to be resolved since it means the `pnpm-lock.yaml` file won't have the original `catalog:` specifier that was declared in `package.json`.
- We could rewrite it at the [`@pnpm/default-resolver` level](https://github.com/pnpm/pnpm/blob/ee61ca4cb7ce6b3cb177f892940edb55b19b9e17/resolving/default-resolver/src/index.ts#L22), but I think that's **too deep**. It means the default resolver would need to understand catalogs, which leaks the catalogs abstraction and makes the resolvers more complicated.

I settled on performing the `catalog:` protocol replacement right before we request dependencies from the store. I think that strikes the right balance.

https://github.com/pnpm/pnpm/blob/ade62a991a8f542b647d24f5ee4637c51cf72d8d/pkg-manager/resolve-dependencies/src/resolveDependencies.ts#L1135-L1141

**Edit**: We pivoted to `resolveDependenciesOfImporters` (which is still somewhere in the middle) after the discussion below. https://github.com/pnpm/pnpm/pull/8221#issuecomment-2174317193

## Changes from Previous PR

This PR was previously open at https://github.com/pnpm/pnpm/pull/8020. A few things have changed since the last PR.

- @zkochan changed `--filter` to update the `pnpm-lock.yaml` file first, which eliminates potential problems with the `catalog:` protocol resolving to stale values in `pnpm-lock.yaml`.
- Reading the `pnpm-workspace.yaml` for catalogs is now done in `@pnpm/config` instead of `@pnpm/context`. https://github.com/pnpm/pnpm/pull/8020#discussion_r1581902036