### PR TITLE
feat: implement catalog protocol for publish

### DIFF
--- a/.changeset/chilly-eels-study.md
+++ b/.changeset/chilly-eels-study.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/exportable-manifest": major
+---
+
+Creating an exportable manifest now requires a `Catalog` object to be passed to `createExportableManifest` in order to replace `catalog:` protocol specifiers.

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -32,6 +32,8 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/config/config#readme",
   "dependencies": {
+    "@pnpm/catalogs.config": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/config.env-replace": "3.0.0",
     "@pnpm/constants": "workspace:*",
     "@pnpm/error": "workspace:*",

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -1,3 +1,4 @@
+import type { Catalogs } from '@pnpm/catalogs.types'
 import {
   type Project,
   type ProjectManifest,
@@ -134,6 +135,7 @@ export interface Config {
   workspaceConcurrency: number
   workspaceDir?: string
   workspacePackagePatterns?: string[]
+  catalogs?: Catalogs
   reporter?: string
   aggregateOutput: boolean
   linkWorkspacePackages: boolean | 'deep'

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
 import { LAYOUT_VERSION } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
 import loadNpmConf from '@pnpm/npm-conf'
@@ -584,12 +585,10 @@ export async function getConfig (
   }
 
   if (pnpmConfig.workspaceDir != null) {
-    if (cliOptions['workspace-packages']) {
-      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[]
-    } else {
-      const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
-      pnpmConfig.workspacePackagePatterns = workspaceManifest?.packages
-    }
+    const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
+
+    pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages
+    pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
   }
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig

--- a/config/config/tsconfig.json
+++ b/config/config/tsconfig.json
@@ -16,6 +16,12 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../hooks/pnpmfile"
     },
     {

--- a/packages/make-dedicated-lockfile/src/index.ts
+++ b/packages/make-dedicated-lockfile/src/index.ts
@@ -36,7 +36,12 @@ export async function makeDedicatedLockfile (lockfileDir: string, projectDir: st
   await writeWantedLockfile(projectDir, dedicatedLockfile)
 
   const { manifest, writeProjectManifest } = await readProjectManifest(projectDir)
-  const publishManifest = await createExportableManifest(projectDir, manifest)
+  const publishManifest = await createExportableManifest(projectDir, manifest, {
+    // Since @pnpm/make-dedicated-lockfile is deprecated, avoid supporting new
+    // features like pnpm catalogs. Passing in an empty catalog object
+    // intentionally.
+    catalogs: {},
+  })
   await writeProjectManifest(publishManifest)
 
   const modulesDir = path.join(projectDir, 'node_modules')

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -29,6 +29,8 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/pkg-manifest/exportable-manifest#readme",
   "devDependencies": {
+    "@pnpm/catalogs.config": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/exportable-manifest": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@types/cross-spawn": "^6.0.6",
@@ -39,6 +41,7 @@
   "dependencies": {
     "@pnpm/error": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
+    "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/types": "workspace:*",
     "p-map-values": "^1.0.0",
     "ramda": "npm:@pnpm/ramda@0.28.1"

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -1,4 +1,6 @@
 import path from 'path'
+import { type CatalogResolver, resolveFromCatalog } from '@pnpm/catalogs.resolver'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import { PnpmError } from '@pnpm/error'
 import { tryReadProjectManifest } from '@pnpm/read-project-manifest'
 import { type Dependencies, type ProjectManifest } from '@pnpm/types'
@@ -16,6 +18,7 @@ const PREPUBLISH_SCRIPTS = [
 ]
 
 export interface MakePublishManifestOptions {
+  catalogs: Catalogs
   modulesDir?: string
   readmeFile?: string
 }
@@ -23,14 +26,22 @@ export interface MakePublishManifestOptions {
 export async function createExportableManifest (
   dir: string,
   originalManifest: ProjectManifest,
-  opts?: MakePublishManifestOptions
+  opts: MakePublishManifestOptions
 ): Promise<ProjectManifest> {
   const publishManifest: ProjectManifest = omit(['pnpm', 'scripts', 'packageManager'], originalManifest)
   if (originalManifest.scripts != null) {
     publishManifest.scripts = omit(PREPUBLISH_SCRIPTS, originalManifest.scripts)
   }
+
+  const catalogResolver = resolveFromCatalog.bind(null, opts.catalogs)
+  const replaceCatalogProtocol = resolveCatalogProtocol.bind(null, catalogResolver)
+
+  const convertDependencyForPublish = combineConverters(replaceWorkspaceProtocol, replaceCatalogProtocol)
   await Promise.all((['dependencies', 'devDependencies', 'optionalDependencies'] as const).map(async (depsField) => {
-    const deps = await makePublishDependencies(dir, originalManifest[depsField], { modulesDir: opts?.modulesDir })
+    const deps = await makePublishDependencies(dir, originalManifest[depsField], {
+      modulesDir: opts?.modulesDir,
+      convertDependencyForPublish,
+    })
     if (deps != null) {
       publishManifest[depsField] = deps
     }
@@ -38,9 +49,10 @@ export async function createExportableManifest (
 
   const peerDependencies = originalManifest.peerDependencies
   if (peerDependencies) {
+    const convertPeersForPublish = combineConverters(replaceWorkspaceProtocolPeerDependency, replaceCatalogProtocol)
     publishManifest.peerDependencies = await makePublishDependencies(dir, peerDependencies, {
       modulesDir: opts?.modulesDir,
-      convertDependencyForPublish: replaceWorkspaceProtocolPeerDependency,
+      convertDependencyForPublish: convertPeersForPublish,
     })
   }
 
@@ -53,19 +65,37 @@ export async function createExportableManifest (
   return publishManifest
 }
 
+export type PublishDependencyConverter = (
+  depName: string,
+  depSpec: string,
+  dir: string,
+  modulesDir?: string
+) => Promise<string> | string
+
+function combineConverters (...converters: readonly PublishDependencyConverter[]): PublishDependencyConverter {
+  return async (depName, depSpec, dir, modulesDir) => {
+    let pref = depSpec
+    for (const converter of converters) {
+      // eslint-disable-next-line no-await-in-loop
+      pref = await converter(depName, pref, dir, modulesDir)
+    }
+    return pref
+  }
+}
+
 export interface MakePublishDependenciesOpts {
   readonly modulesDir?: string
-  readonly convertDependencyForPublish?: (depName: string, depSpec: string, dir: string, modulesDir?: string) => Promise<string>
+  readonly convertDependencyForPublish: PublishDependencyConverter
 }
 
 async function makePublishDependencies (
   dir: string,
   dependencies: Dependencies | undefined,
-  { modulesDir, convertDependencyForPublish = replaceWorkspaceProtocol }: MakePublishDependenciesOpts
+  { modulesDir, convertDependencyForPublish }: MakePublishDependenciesOpts
 ): Promise<Dependencies | undefined> {
   if (dependencies == null) return dependencies
   const publishDependencies = await pMapValues(
-    (depSpec, depName) => convertDependencyForPublish(depName, depSpec, dir, modulesDir),
+    async (depSpec, depName) => convertDependencyForPublish(depName, depSpec, dir, modulesDir),
     dependencies
   )
   return publishDependencies
@@ -82,6 +112,16 @@ async function resolveManifest (depName: string, modulesDir: string): Promise<Pr
   }
 
   return manifest
+}
+
+function resolveCatalogProtocol (catalogResolver: CatalogResolver, alias: string, pref: string): string {
+  const result = catalogResolver({ alias, pref })
+
+  switch (result.type) {
+  case 'found': return result.resolution.specifier
+  case 'unused': return pref
+  case 'misconfiguration': throw result.error
+  }
 }
 
 async function replaceWorkspaceProtocol (depName: string, depSpec: string, dir: string, modulesDir?: string): Promise<string> {

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -38,7 +38,10 @@ export async function createExportableManifest (
 
   const peerDependencies = originalManifest.peerDependencies
   if (peerDependencies) {
-    publishManifest.peerDependencies = await makePublishDependencies(dir, peerDependencies, { modulesDir: opts?.modulesDir, convertDependencyForPublish: makePublishPeerDependency })
+    publishManifest.peerDependencies = await makePublishDependencies(dir, peerDependencies, {
+      modulesDir: opts?.modulesDir,
+      convertDependencyForPublish: replaceWorkspaceProtocolPeerDependency,
+    })
   }
 
   overridePublishConfig(publishManifest)
@@ -58,7 +61,7 @@ export interface MakePublishDependenciesOpts {
 async function makePublishDependencies (
   dir: string,
   dependencies: Dependencies | undefined,
-  { modulesDir, convertDependencyForPublish = makePublishDependency }: MakePublishDependenciesOpts
+  { modulesDir, convertDependencyForPublish = replaceWorkspaceProtocol }: MakePublishDependenciesOpts
 ): Promise<Dependencies | undefined> {
   if (dependencies == null) return dependencies
   const publishDependencies = await pMapValues(
@@ -81,7 +84,7 @@ async function resolveManifest (depName: string, modulesDir: string): Promise<Pr
   return manifest
 }
 
-async function makePublishDependency (depName: string, depSpec: string, dir: string, modulesDir?: string): Promise<string> {
+async function replaceWorkspaceProtocol (depName: string, depSpec: string, dir: string, modulesDir?: string): Promise<string> {
   if (!depSpec.startsWith('workspace:')) {
     return depSpec
   }
@@ -111,7 +114,7 @@ async function makePublishDependency (depName: string, depSpec: string, dir: str
   return depSpec
 }
 
-async function makePublishPeerDependency (depName: string, depSpec: string, dir: string, modulesDir?: string) {
+async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec: string, dir: string, modulesDir?: string) {
   if (!depSpec.includes('workspace:')) {
     return depSpec
   }

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -50,13 +50,15 @@ export async function createExportableManifest (
   return publishManifest
 }
 
+export interface MakePublishDependenciesOpts {
+  readonly modulesDir?: string
+  readonly convertDependencyForPublish?: (depName: string, depSpec: string, dir: string, modulesDir?: string) => Promise<string>
+}
+
 async function makePublishDependencies (
   dir: string,
   dependencies: Dependencies | undefined,
-  { modulesDir, convertDependencyForPublish = makePublishDependency }: {
-    modulesDir?: string
-    convertDependencyForPublish?: (depName: string, depSpec: string, dir: string, modulesDir?: string) => Promise<string>
-  } = {}
+  { modulesDir, convertDependencyForPublish = makePublishDependency }: MakePublishDependenciesOpts
 ): Promise<Dependencies | undefined> {
   if (dependencies == null) return dependencies
   const publishDependencies = await pMapValues(

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
-import { createExportableManifest } from '@pnpm/exportable-manifest'
+import { getCatalogsFromWorkspaceManifest } from '@pnpm/catalogs.config'
+import { type MakePublishManifestOptions, createExportableManifest } from '@pnpm/exportable-manifest'
 import { preparePackages } from '@pnpm/prepare'
 import { sync as writeYamlFile } from 'write-yaml-file'
 import { type ProjectManifest } from '@pnpm/types'
@@ -7,6 +8,10 @@ import crossSpawn from 'cross-spawn'
 import path from 'path'
 
 const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
+
+const defaultOpts: MakePublishManifestOptions = {
+  catalogs: {},
+}
 
 test('the pnpm options are removed', async () => {
   expect(await createExportableManifest(process.cwd(), {
@@ -20,7 +25,7 @@ test('the pnpm options are removed', async () => {
         bar: '1',
       },
     },
-  })).toStrictEqual({
+  }, defaultOpts)).toStrictEqual({
     name: 'foo',
     version: '1.0.0',
     dependencies: {
@@ -37,7 +42,7 @@ test('the packageManager field is removed', async () => {
       qar: '2',
     },
     packageManager: 'pnpm@8.0.0',
-  })).toStrictEqual({
+  }, defaultOpts)).toStrictEqual({
     name: 'foo',
     version: '1.0.0',
     dependencies: {
@@ -60,7 +65,7 @@ test('publish lifecycle scripts are removed', async () => {
       postinstall: 'echo',
       test: 'echo',
     },
-  })).toStrictEqual({
+  }, defaultOpts)).toStrictEqual({
     name: 'foo',
     version: '1.0.0',
     scripts: {
@@ -74,7 +79,7 @@ test('readme added to published manifest', async () => {
   expect(await createExportableManifest(process.cwd(), {
     name: 'foo',
     version: '1.0.0',
-  }, { readmeFile: 'readme content' })).toStrictEqual({
+  }, { ...defaultOpts, readmeFile: 'readme content' })).toStrictEqual({
     name: 'foo',
     version: '1.0.0',
     readme: 'readme content',
@@ -119,7 +124,7 @@ test('workspace deps are replaced', async () => {
 
   process.chdir('workspace-protocol-package')
 
-  expect(await createExportableManifest(process.cwd(), workspaceProtocolPackageManifest)).toStrictEqual({
+  expect(await createExportableManifest(process.cwd(), workspaceProtocolPackageManifest, defaultOpts)).toStrictEqual({
     name: 'workspace-protocol-package',
     version: '1.0.0',
     dependencies: {
@@ -130,6 +135,60 @@ test('workspace deps are replaced', async () => {
     peerDependencies: {
       baz: '^1.0.0 || >1.2.3',
       foo: '>=4.5.6 || ^3.9.0',
+    },
+  })
+})
+
+test('catalog deps are replace', async () => {
+  const catalogProtocolPackageManifest: ProjectManifest = {
+    name: 'catalog-protocol-package',
+    version: '1.0.0',
+
+    dependencies: {
+      bar: 'catalog:',
+    },
+    optionalDependencies: {
+      baz: 'catalog:baz',
+    },
+    peerDependencies: {
+      foo: 'catalog:foo',
+    },
+  }
+
+  preparePackages([catalogProtocolPackageManifest])
+
+  const workspaceManifest = {
+    packages: ['**', '!store/**'],
+    catalog: {
+      bar: '^1.2.3',
+    },
+    catalogs: {
+      foo: {
+        foo: '^1.2.4',
+      },
+      baz: {
+        baz: '^1.2.5',
+      },
+    },
+  }
+  writeYamlFile('pnpm-workspace.yaml', workspaceManifest)
+
+  crossSpawn.sync(pnpmBin, ['install', '--store-dir=store'])
+
+  process.chdir('catalog-protocol-package')
+
+  const catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
+  expect(await createExportableManifest(process.cwd(), catalogProtocolPackageManifest, { catalogs })).toStrictEqual({
+    name: 'catalog-protocol-package',
+    version: '1.0.0',
+    dependencies: {
+      bar: '^1.2.3',
+    },
+    optionalDependencies: {
+      baz: '^1.2.5',
+    },
+    peerDependencies: {
+      foo: '^1.2.4',
     },
   })
 })

--- a/pkg-manifest/exportable-manifest/tsconfig.json
+++ b/pkg-manifest/exportable-manifest/tsconfig.json
@@ -13,6 +13,15 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
+      "path": "../../catalogs/resolver"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../packages/error"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,6 +642,12 @@ importers:
 
   config/config:
     dependencies:
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/config.env-replace':
         specifier: 3.0.0
         version: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5109,6 +5109,9 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
     devDependencies:
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
       '@pnpm/plugin-commands-publishing':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4442,6 +4442,9 @@ importers:
 
   pkg-manifest/exportable-manifest:
     dependencies:
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: link:../../catalogs/resolver
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -4458,6 +4461,12 @@ importers:
         specifier: npm:@pnpm/ramda@0.28.1
         version: '@pnpm/ramda@0.28.1'
     devDependencies:
+      '@pnpm/catalogs.config':
+        specifier: workspace:*
+        version: link:../../catalogs/config
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/exportable-manifest':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5021,6 +5021,9 @@ importers:
 
   releasing/plugin-commands-publishing:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/cli-utils':
         specifier: workspace:*
         version: link:../../cli/cli-utils

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/releasing/plugin-commands-publishing#readme",
   "devDependencies": {
+    "@pnpm/catalogs.config": "workspace:*",
     "@pnpm/workspace.filter-packages-from-dir": "workspace:*",
     "@pnpm/plugin-commands-publishing": "workspace:*",
     "@pnpm/prepare": "workspace:*",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -53,6 +53,7 @@
     "write-yaml-file": "^5.0.0"
   },
   "dependencies": {
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/client": "workspace:*",
     "@pnpm/common-cli-options-help": "workspace:*",

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { createGzip } from 'zlib'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import { PnpmError } from '@pnpm/error'
 import { types as allTypes, type UniversalOptions, type Config } from '@pnpm/config'
 import { readProjectManifest } from '@pnpm/cli-utils'
@@ -58,7 +59,7 @@ export function help (): string {
 }
 
 export async function handler (
-  opts: Pick<UniversalOptions, 'dir'> & Pick<Config, 'ignoreScripts' | 'rawConfig' | 'embedReadme' | 'packGzipLevel' | 'nodeLinker'> & Partial<Pick<Config, 'extraBinPaths' | 'extraEnv'>> & {
+  opts: Pick<UniversalOptions, 'dir'> & Pick<Config, 'catalogs' | 'ignoreScripts' | 'rawConfig' | 'embedReadme' | 'packGzipLevel' | 'nodeLinker'> & Partial<Pick<Config, 'extraBinPaths' | 'extraEnv'>> & {
     argv: {
       original: string[]
     }
@@ -103,6 +104,7 @@ export async function handler (
     modulesDir: path.join(opts.dir, 'node_modules'),
     manifest,
     embedReadme: opts.embedReadme,
+    catalogs: opts.catalogs ?? {},
   })
   const files = await packlist(dir, {
     packageJsonCache: {
@@ -202,8 +204,13 @@ async function createPublishManifest (opts: {
   embedReadme?: boolean
   modulesDir: string
   manifest: ProjectManifest
+  catalogs: Catalogs
 }): Promise<ProjectManifest> {
-  const { projectDir, embedReadme, modulesDir, manifest } = opts
+  const { projectDir, embedReadme, modulesDir, manifest, catalogs } = opts
   const readmeFile = embedReadme ? await readReadmeFile(projectDir) : undefined
-  return createExportableManifest(projectDir, manifest, { readmeFile, modulesDir })
+  return createExportableManifest(projectDir, manifest, {
+    catalogs,
+    readmeFile,
+    modulesDir,
+  })
 }

--- a/releasing/plugin-commands-publishing/src/recursivePublish.ts
+++ b/releasing/plugin-commands-publishing/src/recursivePublish.ts
@@ -22,6 +22,7 @@ export type PublishRecursiveOpts = Required<Pick<Config,
 Partial<Pick<Config,
 | 'tag'
 | 'ca'
+| 'catalogs'
 | 'cert'
 | 'fetchTimeout'
 | 'force'

--- a/releasing/plugin-commands-publishing/tsconfig.json
+++ b/releasing/plugin-commands-publishing/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../__utils__/test-ipc-server"
     },
     {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {

--- a/releasing/plugin-commands-publishing/tsconfig.json
+++ b/releasing/plugin-commands-publishing/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../__utils__/test-ipc-server"
     },
     {
+      "path": "../../catalogs/config"
+    },
+    {
       "path": "../../catalogs/types"
     },
     {


### PR DESCRIPTION
## Changes

Part of https://github.com/pnpm/pnpm/issues/7072

- The `@pnpm/exportable-manifest` now handles `catalog:` protocol dependencies.
- The `pnpm publish` command now replaces `catalog:` protocol dependencies to make `package.json` files portable outside of a pnpm workspace/monorepo.