### PR TITLE
feat(cli): create alias `--package-lock-only`

### DIFF
--- a/.changeset/pretty-pandas-taste.md
+++ b/.changeset/pretty-pandas-taste.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": minor
+"pnpm": minor
+---
+
+Add `--package-lock-only` as an alias for `--lockfile-only` [#8229](https://github.com/pnpm/pnpm/issues/8229).

--- a/pkg-manager/plugin-commands-installation/src/add.ts
+++ b/pkg-manager/plugin-commands-installation/src/add.ts
@@ -80,6 +80,10 @@ export function cliOptionsTypes (): Record<string, unknown> {
   }
 }
 
+export const shorthands: Record<string, string> = {
+  'package-lock-only': '--lockfile-only',
+}
+
 export const commandNames = ['add']
 
 export function help (): string {

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -79,6 +79,7 @@ export const cliOptionsTypes = (): Record<string, unknown> => ({
 export const shorthands: Record<string, string> = {
   D: '--dev',
   P: '--production',
+  'package-lock-only': '--lockfile-only',
 }
 
 export const commandNames = ['install', 'i']

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -127,6 +127,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
             name: '--lockfile-only',
           },
           {
+            description: 'Alias for --lockfile-only',
+            name: '--package-lock-only',
+          },
+          {
             description: "Don't generate a lockfile and fail if an update is needed. This setting is on by default in CI environments, so use --no-frozen-lockfile if you need to disable it for some reason",
             name: '--[no-]frozen-lockfile',
           },

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -114,6 +114,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
   })
 }
 
+export const shorthands: Record<string, string> = {
+  'package-lock-only': '--lockfile-only',
+}
+
 // Unlike npm, pnpm does not treat "r" as an alias of "remove".
 // This way we avoid the confusion about whether "pnpm r" means remove, run, or recursive.
 export const commandNames = ['remove', 'uninstall', 'rm', 'un', 'uni']

--- a/pkg-manager/plugin-commands-installation/src/update/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/index.ts
@@ -86,6 +86,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
 export const shorthands: Record<string, string> = {
   D: '--dev',
   P: '--production',
+  'package-lock-only': '--lockfile-only',
 }
 
 export const commandNames = ['update', 'up', 'upgrade']


### PR DESCRIPTION
Resolves https://github.com/pnpm/pnpm/issues/8229

### Potential drawback

pnpm doesn't use `package-lock.json` as its lockfile, so using the term "package-lock" could confuse the users.