### PR TITLE
refactor: remove filter-packages-from-dir dependency from core tests

### DIFF
--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -92,7 +92,6 @@
     "@pnpm/test-fixtures": "workspace:*",
     "@pnpm/test-ipc-server": "workspace:*",
     "@pnpm/workspace.find-packages": "workspace:*",
-    "@pnpm/workspace.filter-packages-from-dir": "workspace:*",
     "@types/fs-extra": "^9.0.13",
     "@types/is-windows": "^1.0.2",
     "@types/normalize-path": "^3.0.2",

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -6,11 +6,11 @@ import { arrayOfWorkspacePackagesToMap } from '@pnpm/workspace.find-packages'
 import path from 'path'
 import { testDefaults } from './utils'
 
-function preparePackagesAndReturnObjects (pkgs: Array<{ location: string, package: ProjectManifest }>) {
+function preparePackagesAndReturnObjects (manifests: Array<ProjectManifest & Required<Pick<ProjectManifest, 'name'>>>) {
   const project = prepareEmpty()
   const projects: Record<ProjectId, ProjectManifest> = {}
-  for (const { location, package: manifest } of pkgs) {
-    projects[location as ProjectId] = manifest
+  for (const manifest of manifests) {
+    projects[manifest.name as ProjectId] = manifest
   }
   const allProjects: ProjectOptions[] = Object.entries(projects)
     .map(([id, manifest]) => ({
@@ -42,17 +42,14 @@ function installProjects (projects: Record<ProjectId, ProjectManifest>): Mutated
 test('installing with "catalog:" should work', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          'is-positive': 'catalog:',
-        },
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
       },
     },
     // Empty second project to create a multi-package workspace.
     {
-      location: 'packages/project2',
-      package: {},
+      name: 'project2',
     },
   ])
 
@@ -65,7 +62,7 @@ test('installing with "catalog:" should work', async () => {
   })
 
   const lockfile = readLockfile()
-  expect(lockfile.importers['packages/project1' as ProjectId]).toEqual({
+  expect(lockfile.importers['project1' as ProjectId]).toEqual({
     dependencies: {
       'is-positive': {
         specifier: 'catalog:',
@@ -78,21 +75,15 @@ test('installing with "catalog:" should work', async () => {
 test('importer to importer dependency with "catalog:" should work', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        name: 'project1',
-        dependencies: {
-          project2: 'workspace:*',
-        },
+      name: 'project1',
+      dependencies: {
+        project2: 'workspace:*',
       },
     },
     {
-      location: 'packages/project2',
-      package: {
-        name: 'project2',
-        dependencies: {
-          'is-positive': 'catalog:',
-        },
+      name: 'project2',
+      dependencies: {
+        'is-positive': 'catalog:',
       },
     },
   ])
@@ -106,7 +97,7 @@ test('importer to importer dependency with "catalog:" should work', async () => 
   })
 
   const lockfile = readLockfile()
-  expect(lockfile.importers['packages/project2' as ProjectId]).toEqual({
+  expect(lockfile.importers['project2' as ProjectId]).toEqual({
     dependencies: {
       'is-positive': {
         specifier: 'catalog:',
@@ -119,31 +110,27 @@ test('importer to importer dependency with "catalog:" should work', async () => 
 test('importer with different peers uses correct peer', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          '@pnpm.e2e/has-foo100-peer': 'catalog:',
-          // Define a peer with an exact version to ensure the dep above uses
-          // this peer.
-          '@pnpm.e2e/foo': '100.0.0',
-        },
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/has-foo100-peer': 'catalog:',
+        // Define a peer with an exact version to ensure the dep above uses
+        // this peer.
+        '@pnpm.e2e/foo': '100.0.0',
       },
     },
     {
-      location: 'packages/project2',
-      package: {
-        dependencies: {
-          '@pnpm.e2e/has-foo100-peer': 'catalog:',
-          // Note that this peer is intentionally different than the one above
-          // for project 1. (100.1.0 instead of 100.0.0).
-          //
-          // We want to ensure project2 resolves to the same catalog version for
-          // @pnpm.e2e/has-foo100-peer, but uses a different peers suffix.
-          //
-          // Catalogs allow versions to be reused, but this test ensures we
-          // don't reuse versions too aggressively.
-          '@pnpm.e2e/foo': '100.1.0',
-        },
+      name: 'project2',
+      dependencies: {
+        '@pnpm.e2e/has-foo100-peer': 'catalog:',
+        // Note that this peer is intentionally different than the one above
+        // for project 1. (100.1.0 instead of 100.0.0).
+        //
+        // We want to ensure project2 resolves to the same catalog version for
+        // @pnpm.e2e/has-foo100-peer, but uses a different peers suffix.
+        //
+        // Catalogs allow versions to be reused, but this test ensures we
+        // don't reuse versions too aggressively.
+        '@pnpm.e2e/foo': '100.1.0',
       },
     },
   ])
@@ -159,11 +146,11 @@ test('importer with different peers uses correct peer', async () => {
   })
 
   const lockfile = readLockfile()
-  expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
+  expect(lockfile.importers['project1' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
     specifier: 'catalog:',
     version: `1.0.0${createPeersDirSuffix([{ name: '@pnpm.e2e/foo', version: '100.0.0' }])}`,
   })
-  expect(lockfile.importers['packages/project2' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
+  expect(lockfile.importers['project2' as ProjectId]?.dependencies?.['@pnpm.e2e/has-foo100-peer']).toEqual({
     specifier: 'catalog:',
     //              This version is intentionally different from the one above    ꜜ
     version: `1.0.0${createPeersDirSuffix([{ name: '@pnpm.e2e/foo', version: '100.1.0' }])}`,
@@ -173,19 +160,15 @@ test('importer with different peers uses correct peer', async () => {
 test('lockfile contains catalog snapshots', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          'is-positive': 'catalog:',
-        },
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
       },
     },
     {
-      location: 'packages/project2',
-      package: {
-        dependencies: {
-          'is-negative': 'catalog:',
-        },
+      name: 'project2',
+      dependencies: {
+        'is-negative': 'catalog:',
       },
     },
   ])
@@ -213,11 +196,9 @@ test('lockfile contains catalog snapshots', async () => {
 test('lockfile is updated if catalog config changes', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          'is-positive': 'catalog:',
-        },
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
       },
     },
   ])
@@ -232,7 +213,7 @@ test('lockfile is updated if catalog config changes', async () => {
     },
   })
 
-  expect(readLockfile().importers['packages/project1' as ProjectId]).toEqual({
+  expect(readLockfile().importers['project1' as ProjectId]).toEqual({
     dependencies: {
       'is-positive': {
         specifier: 'catalog:',
@@ -251,7 +232,7 @@ test('lockfile is updated if catalog config changes', async () => {
     },
   })
 
-  expect(readLockfile().importers['packages/project1' as ProjectId]).toEqual({
+  expect(readLockfile().importers['project1' as ProjectId]).toEqual({
     dependencies: {
       'is-positive': {
         specifier: 'catalog:',
@@ -264,19 +245,15 @@ test('lockfile is updated if catalog config changes', async () => {
 test('lockfile catalog snapshots retain existing entries on --filter', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          'is-negative': 'catalog:',
-        },
+      name: 'project1',
+      dependencies: {
+        'is-negative': 'catalog:',
       },
     },
     {
-      location: 'packages/project2',
-      package: {
-        dependencies: {
-          'is-positive': 'catalog:',
-        },
+      name: 'project2',
+      dependencies: {
+        'is-positive': 'catalog:',
       },
     },
   ])
@@ -336,12 +313,10 @@ test('lockfile catalog snapshots retain existing entries on --filter', async () 
 test('lockfile catalog snapshots should remove unused entries', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {
-      location: 'packages/project1',
-      package: {
-        dependencies: {
-          'is-negative': 'catalog:',
-          'is-positive': 'catalog:',
-        },
+      name: 'project1',
+      dependencies: {
+        'is-negative': 'catalog:',
+        'is-positive': 'catalog:',
       },
     },
   ])
@@ -360,7 +335,7 @@ test('lockfile catalog snapshots should remove unused entries', async () => {
 
   {
     const lockfile = readLockfile()
-    expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies).toEqual({
+    expect(lockfile.importers['project1' as ProjectId]?.dependencies).toEqual({
       'is-negative': { specifier: 'catalog:', version: '1.0.0' },
       'is-positive': { specifier: 'catalog:', version: '1.0.0' },
     })
@@ -371,7 +346,7 @@ test('lockfile catalog snapshots should remove unused entries', async () => {
   }
 
   // Update package.json to no longer depend on is-positive.
-  projects['packages/project1' as ProjectId].dependencies = {
+  projects['project1' as ProjectId].dependencies = {
     'is-negative': 'catalog:',
   }
   await mutateModules(installProjects(projects), {
@@ -382,7 +357,7 @@ test('lockfile catalog snapshots should remove unused entries', async () => {
 
   {
     const lockfile = readLockfile()
-    expect(lockfile.importers['packages/project1' as ProjectId]?.dependencies).toEqual({
+    expect(lockfile.importers['project1' as ProjectId]?.dependencies).toEqual({
       'is-negative': { specifier: 'catalog:', version: '1.0.0' },
     })
     // Only "is-negative" should be in the catalogs section of the lockfile

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -142,9 +142,6 @@
       "path": "../../worker"
     },
     {
-      "path": "../../workspace/filter-packages-from-dir"
-    },
-    {
       "path": "../../workspace/find-packages"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3351,9 +3351,6 @@ importers:
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
-      '@pnpm/workspace.filter-packages-from-dir':
-        specifier: workspace:*
-        version: link:../../workspace/filter-packages-from-dir
       '@pnpm/workspace.find-packages':
         specifier: workspace:*
         version: link:../../workspace/find-packages


### PR DESCRIPTION
## Changes

Addressing feedback from:

- https://github.com/pnpm/pnpm/pull/8221#discussion_r1654685354