### PR TITLE
chore: upgrade `@pnpm/registry-mock` from 3.32.1 to 3.33.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 0.0.0
       version: 0.0.0
     '@pnpm/registry-mock':
-      specifier: 3.32.1
-      version: 3.32.1
+      specifier: 3.33.0
+      version: 3.33.0
     '@pnpm/semver-diff':
       specifier: ^1.1.0
       version: 1.1.0
@@ -715,7 +715,7 @@ importers:
         version: 1.0.0
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/tsconfig':
         specifier: workspace:*
         version: link:__utils__/tsconfig
@@ -830,7 +830,7 @@ importers:
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -864,7 +864,7 @@ importers:
     dependencies:
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs
@@ -2030,7 +2030,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2163,7 +2163,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -3699,7 +3699,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -3977,7 +3977,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -4262,7 +4262,7 @@ importers:
         version: link:../read-projects-context
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -4625,7 +4625,7 @@ importers:
         version: 'link:'
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4818,7 +4818,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5411,7 +5411,7 @@ importers:
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -5680,7 +5680,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/workspace.filter-packages-from-dir':
         specifier: workspace:*
         version: link:../../workspace/filter-packages-from-dir
@@ -5786,7 +5786,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -6361,7 +6361,7 @@ importers:
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6428,7 +6428,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/workspace.filter-packages-from-dir':
         specifier: workspace:*
         version: link:../../workspace/filter-packages-from-dir
@@ -6519,7 +6519,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6857,7 +6857,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 3.32.1(encoding@0.1.13)(typanion@3.14.0)
+        version: 3.33.0(encoding@0.1.13)(typanion@3.14.0)
       '@types/archy':
         specifier: 'catalog:'
         version: 0.0.33
@@ -8438,8 +8438,8 @@ packages:
     resolution: {integrity: sha512-MDXuQpYFbabSXzAnqP7VIQqBx5Z1fzOhzB/3YmIXJ+tE7Wue//IR3itMSYlWeaFLo1G5PCJklM2zBdvggRw1nw==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/registry-mock@3.32.1':
-    resolution: {integrity: sha512-Di/f/drK2UfNL/6sLTBJJioiWClfq2g99OU5QMmASdJbB9qDcq5oNk+oXDAfakBnMkNZw/y9LvT627izZbpcKg==}
+  '@pnpm/registry-mock@3.33.0':
+    resolution: {integrity: sha512-Y7/QOZ3BPCH5i5OdtglaVTsmEXYZ91ebIxAST3+eBwu8iP0W8AEIw95hYl10jLzWRtUjuIPCph9mTdMWM4h9dg==}
     engines: {node: '>=10.13'}
     hasBin: true
 
@@ -15235,7 +15235,7 @@ snapshots:
       sort-keys: 4.2.0
       strip-bom: 4.0.0
 
-  '@pnpm/registry-mock@3.32.1(encoding@0.1.13)(typanion@3.14.0)':
+  '@pnpm/registry-mock@3.33.0(encoding@0.1.13)(typanion@3.14.0)':
     dependencies:
       anonymous-npm-registry-client: 0.2.0
       execa: 5.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   "@pnpm/npm-package-arg": ^1.0.0
   "@pnpm/os.env.path-extender": ^2.0.0
   "@pnpm/patch-package": 0.0.0
-  "@pnpm/registry-mock": 3.32.1
+  "@pnpm/registry-mock": 3.33.0
   "@pnpm/semver-diff": ^1.1.0
   "@pnpm/tabtab": ^0.5.4
   "@pnpm/util.lex-comparator": 3.0.0


### PR DESCRIPTION
## Changes

Upgrading `@pnpm/registry-mock` to 3.33.0 for the change below.

- https://github.com/pnpm/registry-mock/pull/16
