### PR TITLE
fix: show better error when encountering external catalog protocol usage

### DIFF
--- a/.changeset/chatty-buses-cheer.md
+++ b/.changeset/chatty-buses-cheer.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"@pnpm/default-reporter": patch
+---
+
+When encountering an external dependency using the `catalog:` protocol, a clearer error will be shown. Previously a confusing `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` error was thrown. The new error message will explain that the author of the dependency needs to run `pnpm publish` to replace the catalog protocol.

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -83,8 +83,8 @@ function getErrorInfo (logObj: Log, config?: Config, peerDependencyRules?: PeerD
       return reportPeerDependencyIssuesError(err, logObj as any, peerDependencyRules) // eslint-disable-line @typescript-eslint/no-explicit-any
     case 'ERR_PNPM_DEDUPE_CHECK_ISSUES':
       return reportDedupeCheckIssuesError(err, logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
-    case 'ERR_PNPM_CATALOG_PROTOCOL_IN_EXTERNAL_DEP':
-      return reportExternalCatalogProtocolError(err, logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+    case 'ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER':
+      return reportSpecNotSupportedByAnyResolverError(err, logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
     case 'ERR_PNPM_FETCH_401':
     case 'ERR_PNPM_FETCH_403':
       return reportAuthError(err, logObj as any, config) // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -443,6 +443,28 @@ function reportDedupeCheckIssuesError (err: Error, msg: { dedupeCheckIssues: Ded
 ${renderDedupeCheckIssues(msg.dedupeCheckIssues)}
 Run ${chalk.yellow('pnpm dedupe')} to apply the changes above.
 `,
+  }
+}
+
+function reportSpecNotSupportedByAnyResolverError (err: Error, logObj: Log): ErrorInfo {
+  // If the catalog protocol specifier was sent to a "real resolver", it'll
+  // eventually throw a "specifier not supported" error since the catalog
+  // protocol is meant to be replaced before it's passed to any of the real
+  // resolvers.
+  //
+  // If this kind of error is thrown, and the dependency pref is using the
+  // catalog protocol it's most likely because we're trying to install an out of
+  // repo dependency that was published incorrectly. For example, it may be been
+  // mistakenly published with 'npm publish' instead of 'pnpm publish'. Report a
+  // more clear error in this case.
+  if (logObj['package']?.['pref']?.startsWith('catalog:')) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return reportExternalCatalogProtocolError(err, logObj as any)
+  }
+
+  return {
+    title: err.message ?? '',
+    body: logObj['hint'],
   }
 }
 

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -476,13 +476,13 @@ function reportExternalCatalogProtocolError (err: Error, logObj: Log): ErrorInfo
 An external package outside of the pnpm workspace declared a dependency using
 the catalog protocol. This is likely a bug in that external package. Only
 packages within the pnpm workspace may use catalogs. Usages of the catalog
-protocol replaced with real specifiers on 'pnpm publish'.
+protocol are replaced with real specifiers on 'pnpm publish'.
 `
 
   if (problemDep != null) {
     body += `\
 
-This is likely a bug in the publishing automation this package. Consider filing
+This is likely a bug in the publishing automation of this package. Consider filing
 a bug with the authors of:
 
   ${highlight(`${problemDep.name}@${problemDep.version}`)}

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -299,6 +299,24 @@ test('lockfile catalog snapshots retain existing entries on --filter', async () 
   })
 })
 
+test('external dependency using catalog protocol errors', async () => {
+  const { options, projects } = preparePackagesAndReturnObjects([
+    {
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/pkg-with-accidentally-published-catalog-protocol': '1.0.0',
+      },
+    },
+  ])
+
+  await expect(() =>
+    mutateModules(installProjects(projects), {
+      ...options,
+      lockfileOnly: true,
+    })
+  ).rejects.toThrow('An external package is using the catalog protocol.')
+})
+
 // If a catalog specifier was used in one or more package.json files and all
 // usages were removed later, we should remove the catalog snapshot from
 // pnpm-lock.yaml. This should happen even if the dependency is still defined in

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -314,7 +314,7 @@ test('external dependency using catalog protocol errors', async () => {
       ...options,
       lockfileOnly: true,
     })
-  ).rejects.toThrow('An external package is using the catalog protocol.')
+  ).rejects.toThrow("@pnpm.e2e/hello-world-js-bin@catalog:foo isn't supported by any available resolver.")
 })
 
 // If a catalog specifier was used in one or more package.json files and all

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1185,6 +1185,17 @@ async function resolveDependency (
     }
   }
   try {
+    // For dependencies of importers, the catalog protocol should be substituted
+    // by this point. If a dependency pref using the catalog protocol is
+    // encountered this deep into resolution, it's likely because it's an out of
+    // repo dependency that was published incorrectly. For example, it may be
+    // been mistakenly published with 'npm publish' instead of 'pnpm publish'.
+    if (wantedDependency.pref.startsWith('catalog:')) {
+      throw new PnpmError(
+        'CATALOG_PROTOCOL_IN_EXTERNAL_DEP',
+        'An external package is using the catalog protocol.')
+    }
+
     if (!options.update && currentPkg.version && currentPkg.pkgId?.endsWith(`@${currentPkg.version}`)) {
       wantedDependency.pref = replaceVersionInPref(wantedDependency.pref, currentPkg.version)
     }


### PR DESCRIPTION
## Problem

I'm predicting a common problem with the `catalog:` protocol will be users running `npm publish` instead of `pnpm publish`. I'd like to make errors related to this mistake more clear.

## Changes

### Before

<img width="842" alt="Screenshot 2024-06-28 at 1 16 47 AM" src="https://github.com/pnpm/pnpm/assets/906558/f402902e-d689-4211-bb20-7d359f454cc1">


### After
<img width="842" alt="Screenshot 2024-06-28 at 1 41 04 AM" src="https://github.com/pnpm/pnpm/assets/906558/629a4033-6019-42ab-a619-e8644da2a213">

