### PR TITLE
fix: prevent catalogs using the `workspace:`, `link:`, and `file:` protocols

### DIFF
--- a/catalogs/resolver/src/resolveFromCatalog.ts
+++ b/catalogs/resolver/src/resolveFromCatalog.ts
@@ -103,6 +103,20 @@ export function resolveFromCatalog (catalogs: Catalogs, wantedDependency: Wanted
     }
   }
 
+  // A future version of pnpm will try to support this. These protocols aren't
+  // supported today since these are often relative file paths that users expect
+  // to be relative to the repo root rather than the location of the pnpm
+  // workspace package.
+  if (['link', 'file'].includes(protocolOfLookup)) {
+    return {
+      type: 'misconfiguration',
+      catalogName,
+      error: new PnpmError(
+        'CATALOG_ENTRY_INVALID_SPEC',
+        `The entry for '${wantedDependency.alias}' in catalog '${catalogName}' declares a dependency using the '${protocolOfLookup}' protocol. This is not yet supported, but may be in a future version of pnpm.`),
+    }
+  }
+
   return {
     type: 'found',
     resolution: {

--- a/catalogs/resolver/src/resolveFromCatalog.ts
+++ b/catalogs/resolver/src/resolveFromCatalog.ts
@@ -85,6 +85,24 @@ export function resolveFromCatalog (catalogs: Catalogs, wantedDependency: Wanted
     }
   }
 
+  // Ban catalog entries that use the workspace protocol for a few reasons:
+  //
+  //   1. It's kind of silly. It'd be better to encourage users to use the
+  //      workspace protocol directly.
+  //   2. Catalogs cache the resolved version of a dependency specifier in
+  //      pnpm-lock.yaml for more consistent resolution across importers. The
+  //      link: resolutions can't be shared between importers.
+  const protocolOfLookup = catalogLookup.split(':')[0]
+  if (protocolOfLookup === 'workspace') {
+    return {
+      type: 'misconfiguration',
+      catalogName,
+      error: new PnpmError(
+        'CATALOG_ENTRY_INVALID_WORKSPACE_SPEC',
+        `The workspace protocol cannot be used as a catalog value. The entry for '${wantedDependency.alias}' in catalog '${catalogName}' is invalid.`),
+    }
+  }
+
   return {
     type: 'found',
     resolution: {

--- a/catalogs/resolver/test/resolveFromCatalog.test.ts
+++ b/catalogs/resolver/test/resolveFromCatalog.test.ts
@@ -85,4 +85,26 @@ describe('misconfiguration', () => {
     expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
       .toThrow("The workspace protocol cannot be used as a catalog value. The entry for 'bar' in catalog 'foo' is invalid.")
   })
+
+  test('returns error for file protocol in catalog', () => {
+    const catalogs = {
+      foo: {
+        bar: 'file:./bar.tgz',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
+      .toThrow("The entry for 'bar' in catalog 'foo' declares a dependency using the 'file' protocol. This is not yet supported, but may be in a future version of pnpm.")
+  })
+
+  test('returns error for link protocol in catalog', () => {
+    const catalogs = {
+      foo: {
+        bar: 'link:./bar',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
+      .toThrow("The entry for 'bar' in catalog 'foo' declares a dependency using the 'link' protocol. This is not yet supported, but may be in a future version of pnpm.")
+  })
 })

--- a/catalogs/resolver/test/resolveFromCatalog.test.ts
+++ b/catalogs/resolver/test/resolveFromCatalog.test.ts
@@ -74,4 +74,15 @@ describe('misconfiguration', () => {
     expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
       .toThrow("Found invalid catalog entry using the catalog protocol recursively. The entry for 'bar' in catalog 'foo' is invalid.")
   })
+
+  test('returns error for workspace protocol in catalog', () => {
+    const catalogs = {
+      foo: {
+        bar: 'workspace:*',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
+      .toThrow("The workspace protocol cannot be used as a catalog value. The entry for 'bar' in catalog 'foo' is invalid.")
+  })
 })


### PR DESCRIPTION
## Changes

Using pnpm catalogs with the `workspace:`, `link:`, and `file:` protocols "_kind of works in the beta release today_". However, I think there's surprising behavior in each.

- For the `workspace:` protocol, it's kind of weird to see the `workspace:*` protocol defined in catalogs in the first place. I can't think of a good reason for this indirection. I think spending time trying to support this isn't a good use of developer time.
- The `link:` and `file:` protocols are often used to refer to relative paths. Since pnpm catalogs are defined in `pnpm-workspace.yaml`, I think most users will expect paths to be relative to that file. Unfortunately they're relative to the project's `package.json`, which doesn't feel right. Let's disable this until we have time to better support it in a future pnpm release.