### PR TITLE
fix: reuse existing cataloged resolutions for consistency

### DIFF
--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -532,7 +532,18 @@ async function resolveDependenciesOfImporterDependency (
   })
 
   if (catalogLookup != null) {
-    extendedWantedDep.wantedDependency.pref = catalogLookup.specifier
+    // The lockfile from a previous installation may have already resolved this
+    // cataloged dependency. Reuse the exact version in the lockfile catalog
+    // snapshot to ensure all projects using the same cataloged dependency get
+    // the same version.
+    const existingCatalogResolution = ctx.wantedLockfile.catalogs
+      ?.[catalogLookup.catalogName]
+      ?.[extendedWantedDep.wantedDependency.alias]
+    const replacementPref = existingCatalogResolution?.specifier === catalogLookup.specifier
+      ? existingCatalogResolution.version
+      : catalogLookup.specifier
+
+    extendedWantedDep.wantedDependency.pref = replacementPref
   }
 
   const result = await resolveDependenciesOfDependency(


### PR DESCRIPTION
## Context

In cases where multiple versions of a dependency are present in `pnpm-lock.yaml`, I believe users will expect dependencies using the `catalog:` protocol to all resolve to the same version.

In other words, a lockfile that looks like this would be surprising:

```yaml
# pnpm-lock.yaml
importers:

  project1:
    dependencies:
      'is-positive':
        specifier: catalog:
        version: 3.0.0

  project3:
    dependencies:
      'is-positive':
        specifier: catalog:
        version: 3.1.0
```

## Changes

If there's already a catalog resolution in the `pnpm-lock.yaml` file, use the version field.

```yaml
# pnpm-lock.yaml
catalogs:
  default:
    'is-positive':
      specifier: ^3.0.0
      version: 3.0.0 # 👈 Pick this version when resolving.
```