### PR TITLE
fix: preserve workspace peerDependencies versions if present

### DIFF
--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -160,18 +160,18 @@ async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec:
   }
 
   // Dependencies with bare "*", "^", "~",">=",">","<=",< versions
-  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)/
+  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)(.*?)$/
   const versionAliasSpecParts = workspaceSemverRegex.exec(depSpec)
 
   if (versionAliasSpecParts != null) {
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const manifest = await resolveManifest(depName, modulesDir)
 
-    const [,semverRangGroup] = versionAliasSpecParts
+    const [,semverRangGroup, maybeVersion] = versionAliasSpecParts
 
     const semverRangeToken = semverRangGroup !== '*' ? semverRangGroup : ''
 
-    return depSpec.replace(workspaceSemverRegex, `${semverRangeToken}${manifest.version}`)
+    return depSpec.replace(workspaceSemverRegex, `${semverRangeToken}${maybeVersion || manifest.version}`)
   }
 
   depSpec = depSpec.replace('workspace:', '')


### PR DESCRIPTION
This closes #8260 

Currently, something like

```json
  "peerDependencies": {
    "pockethost": "workspace:^1.6.0"
  }
```

will pack as 

```json
  "peerDependencies": {
    "pockethost": "^1.6.01.6.0"
  }
```

This fix will preserve any version specified and will only include the latest manifest version if no version is explicitly specified.

Example:

`pockethost` is at `1.7.0`

| package.json peerDependencies | packs as |
|--|--|
| `"pockethost": "workspace:^1.6.0"` | `"pockethost": "^1.6.0"` |
| `"pockethost": "workspace:^"` | `"pockethost": "^1.7.0"` |
