### PR TITLE
fix: reuse catalog resolutions of complex version references correctly

### DIFF
--- a/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
+++ b/pkg-manager/resolve-dependencies/src/getCatalogSnapshots.ts
@@ -1,4 +1,5 @@
 import { type CatalogSnapshots } from '@pnpm/lockfile-types'
+import { depPathToRef } from './depPathToRef'
 import { type ResolvedDirectDependency } from './resolveDependencyTree'
 
 export function getCatalogSnapshots (resolvedDirectDeps: readonly ResolvedDirectDependency[]): CatalogSnapshots {
@@ -7,9 +8,19 @@ export function getCatalogSnapshots (resolvedDirectDeps: readonly ResolvedDirect
 
   for (const dep of catalogedDeps) {
     const snapshotForSingleCatalog = (catalogSnapshots[dep.catalogLookup.catalogName] ??= {})
+
     snapshotForSingleCatalog[dep.alias] = {
       specifier: dep.catalogLookup.specifier,
-      version: dep.version,
+
+      // Note: The version recorded here is used for lookups of this cataloged
+      // dependency in future installs. This should be computed the same as
+      // other version refs in the lockfile (which are also computed through
+      // depPathToRef).
+      version: depPathToRef(dep.pkgId, {
+        alias: dep.alias,
+        realName: dep.name,
+        resolution: dep.resolution,
+      }),
     }
   }
 


### PR DESCRIPTION
## Problem

I noticed in the pnpm repo that the catalog snapshot version we're storing for npm aliases is wrong.

```yaml
# pnpm-lock.yaml

catalogs:
  default:
    execa:
      specifier: npm:safe-execa@0.1.2
      version: 0.1.2 # 👈 This is wrong
```

It should match the version used by importers. (i.e. `safe-execa@0.1.2`)

```yaml
# pnpm-lock.yaml

importers:

  __utils__/scripts:
    dependencies:
      execa:
        specifier: 'catalog:'
        version: safe-execa@0.1.2 # 👈 Catalogs should be storing this
```

This caused a bug where `pnpm update` accidentally looked for `execa@0.1.2` and 404'ed instead of looking for `safe-execa@0.1.2`.

<img width="842" alt="Screenshot 2024-07-04 at 8 40 17 PM" src="https://github.com/pnpm/pnpm/assets/906558/e5da860b-0801-44e5-9c15-c1149b3882a0">

## Changes

Using the `depPathToRef` function to compute the version stored for the `pnpm-lock.yaml` `catalogs` section, similar to how we compute the version ref for the `importers` section.

https://github.com/pnpm/pnpm/blob/0406d4ad3d2a10326cd46ccc242aadad878a5ead/pkg-manager/resolve-dependencies/src/index.ts#L395-L399

After this change, catalog snapshots store the right version reference.

```yaml
# pnpm-lock.yaml

catalogs:
  default:
    execa:
      specifier: npm:safe-execa@0.1.2
      version: safe-execa@0.1.2
```

On the resolution side, we also need to parse the stored version reference correctly.