### PR TITLE
fix: reuse catalog resolutions of npm aliases correctly

### DIFF
--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -390,6 +390,57 @@ test('catalog resolutions should be consistent', async () => {
   }))
 })
 
+// Similar to the 'catalog resolutions should be consistent' test above, but
+// ensures this works for catalog entries using npm aliases.
+test('catalog entry using npm alias can be reused', async () => {
+  const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+    {
+      name: 'project1',
+      dependencies: {
+        '@pnpm.test/is-positive-alias': 'catalog:',
+      },
+    },
+    {
+      name: 'project2',
+      dependencies: {},
+    },
+  ])
+
+  const mutateOpts: MutateModulesOptions = {
+    ...options,
+    lockfileOnly: true,
+    catalogs: {
+      default: {
+        '@pnpm.test/is-positive-alias': 'npm:is-positive@1.0.0',
+      },
+    },
+  }
+
+  await mutateModules(installProjects(projects), mutateOpts)
+
+  // Sanity check that we're recording an expected version specifier.
+  expect(readLockfile().catalogs.default?.['@pnpm.test/is-positive-alias']).toEqual({
+    specifier: 'npm:is-positive@1.0.0',
+    version: '1.0.0',
+  })
+
+  // If project2 now reuses a catalog entry with the catalog specifier, the
+  // catalog snapshot above should be used and work.
+  projects['project2' as ProjectId].dependencies = {
+    '@pnpm.test/is-positive-alias': 'catalog:',
+  }
+
+  await mutateModules(installProjects(projects), mutateOpts)
+
+  expect(readLockfile()).toEqual(expect.objectContaining({
+    catalogs: { default: { '@pnpm.test/is-positive-alias': { specifier: 'npm:is-positive@1.0.0', version: '1.0.0' } } },
+    importers: expect.objectContaining({
+      project1: expect.objectContaining({ dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } }),
+      project2: expect.objectContaining({ dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } }),
+    }),
+  }))
+})
+
 // If a catalog specifier was used in one or more package.json files and all
 // usages were removed later, we should remove the catalog snapshot from
 // pnpm-lock.yaml. This should happen even if the dependency is still defined in

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -540,7 +540,7 @@ async function resolveDependenciesOfImporterDependency (
       ?.[catalogLookup.catalogName]
       ?.[extendedWantedDep.wantedDependency.alias]
     const replacementPref = existingCatalogResolution?.specifier === catalogLookup.specifier
-      ? existingCatalogResolution.version
+      ? replaceVersionInPref(catalogLookup.specifier, existingCatalogResolution.version)
       : catalogLookup.specifier
 
     extendedWantedDep.wantedDependency.pref = replacementPref


### PR DESCRIPTION
## Problem

When running `pnpm update` in this repo, pnpm looks for `execa@0.1.2` and 404s instead of looking for `safe-execa@0.1.2`.

<img width="842" alt="Screenshot 2024-07-04 at 8 40 17 PM" src="https://github.com/pnpm/pnpm/assets/906558/e5da860b-0801-44e5-9c15-c1149b3882a0">

This is because of a bug in my prior PR from a few days ago. 🤦🏻‍♂️

- https://github.com/pnpm/pnpm/pull/8259.

The repo uses the catalog specifier for `execa`. The change above isn't handling npm aliases correctly.

https://github.com/pnpm/pnpm/blob/a3d5f609d01be80582e52b48839aaddf8470562d/pnpm-workspace.yaml#L136

## Changes

Using `replaceVersionInPref` to fix the bug above. This function handles `npm:` specifiers correctly.

We're currently using this function elsewhere for a very similar short-circuiting purpose.

https://github.com/pnpm/pnpm/blob/89363fa7dfa3e5c51c2cd17e715e8ff7fd7579f0/pkg-manager/resolve-dependencies/src/resolveDependencies.ts#L1200