### PR TITLE
fix: skip cataloged dependencies when running `pnpm update --latest`

### DIFF
--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -630,4 +630,51 @@ describe('update', () => {
       packages: { 'is-positive@3.0.0': expect.objectContaining({}) },
     }))
   })
+
+  test('update latest does modify catalog: protocol', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { 'is-positive': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check that the is-positive dependency is installed on the older
+    // requested version.
+    expect(readLockfile().catalogs.default).toEqual({
+      'is-positive': { specifier: '1.0.0', version: '1.0.0' },
+    })
+
+    const updatedManifest = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['is-positive'],
+      {
+        ...mutateOpts,
+        allowNew: false,
+        update: true,
+        updateToLatest: true,
+      })
+
+    // Expecting the manifest to remain unchanged.
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        'is-positive': 'catalog:',
+      },
+    })
+
+    expect(Object.keys(readLockfile().snapshots)).toEqual(['is-positive@1.0.0'])
+  })
 })

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -631,7 +631,7 @@ describe('update', () => {
     }))
   })
 
-  test('update latest does modify catalog: protocol', async () => {
+  test('update latest does not modify catalog: protocol', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',
       dependencies: {

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -554,6 +554,12 @@ async function resolveDependenciesOfImporterDependency (
       ...importer.options,
       parentPkgAliases: importer.parentPkgAliases,
       pickLowestVersion: pickLowestVersion && !importer.updatePackageManifest,
+      // Cataloged dependencies cannot be upgraded yet since they require
+      // updating the pnpm-workspace.yaml file. This will be handled in a future
+      // version of pnpm.
+      updateToLatest: catalogLookup != null
+        ? false
+        : importer.options.updateToLatest,
     },
     extendedWantedDep
   )


### PR DESCRIPTION
## Problem

Running `pnpm update --latest` currently causes a consistency bug. Since `pnpm update` doesn't know how to update `pnpm-workspace.yaml` yet,

- The old specifier (ex: `^1.0.0`) of a cataloged dependency would still be present in `pnpm-workspace.yaml`,
- But the latest version (ex: `3.1.0`) would be present in `pnpm-workspace.yaml` and installed on disk.

## Changes

Let's skip over `catalog:` protocol dependencies until `pnpm update` is refactored to handle `pnpm-workspace.yaml` edits in the future.