### PR TITLE
fix: install failure on pnpm deploy when using catalogs

### DIFF
--- a/.changeset/calm-files-hide.md
+++ b/.changeset/calm-files-hide.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/plugin-commands-deploy": patch
+pnpm: patch
+---
+
+The `pnpm deploy` command now supports the [`catalog:` protocol](https://pnpm.io/catalogs).

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -251,6 +251,7 @@ export type InstallCommandOptions = Pick<Config,
 | 'autoInstallPeers'
 | 'bail'
 | 'bin'
+| 'catalogs'
 | 'cliOptions'
 | 'dedupeDirectDeps'
 | 'dedupePeerDependents'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5611,6 +5611,12 @@ importers:
 
   releasing/plugin-commands-deploy:
     dependencies:
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: link:../../catalogs/resolver
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/cli-utils':
         specifier: workspace:*
         version: link:../../cli/cli-utils

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -42,6 +42,8 @@
     "@pnpm/workspace.filter-packages-from-dir": "workspace:*"
   },
   "dependencies": {
+    "@pnpm/catalogs.resolver": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/common-cli-options-help": "workspace:*",
     "@pnpm/directory-fetcher": "workspace:*",

--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -11,6 +11,7 @@ import rimraf from '@zkochan/rimraf'
 import renderHelp from 'render-help'
 import { deployHook } from './deployHook'
 import { logger } from '@pnpm/logger'
+import { deployCatalogHook } from './deployCatalogHook'
 
 export const shorthands = install.shorthands
 
@@ -101,6 +102,7 @@ export async function handler (
       readPackage: [
         ...(opts.hooks?.readPackage ?? []),
         deployHook,
+        deployCatalogHook.bind(null, opts.catalogs ?? {}),
       ],
     },
     frozenLockfile: false,

--- a/releasing/plugin-commands-deploy/src/deployCatalogHook.ts
+++ b/releasing/plugin-commands-deploy/src/deployCatalogHook.ts
@@ -1,0 +1,51 @@
+import { matchCatalogResolveResult, resolveFromCatalog } from '@pnpm/catalogs.resolver'
+import { type Catalogs } from '@pnpm/catalogs.types'
+import { type ProjectManifest, DEPENDENCIES_FIELDS } from '@pnpm/types'
+
+/**
+ * Teach the `pnpm deploy` command how to interpret the catalog: protocol.
+ *
+ * This is a hack to workaround a design problem between pnpm deploy and
+ * catalogs.
+ *
+ *   - The catalog protocol is intentionally only allowed to be used by
+ *     importers. External dependencies cannot use the catalog: protocol by
+ *     design.
+ *   - When using pnpm deploy, dependency workspace packages aren't considered
+ *     "importers".
+ *
+ * To work around the conflict of designs above, this readPackage hook exists to
+ * make catalogs usable by non-importers specifically on pnpm deploy.
+ *
+ * Unfortunately this introduces a correctness issue where the catalog: protocol
+ * is replaced for all packages (even external dependencies), not just packages
+ * within the pnpm workspace. This caveat is somewhat mitigated by the fact that
+ * a regular pnpm install would still fail before users could pnpm deploy a
+ * project.
+ */
+export function deployCatalogHook (catalogs: Catalogs, pkg: ProjectManifest): ProjectManifest {
+  for (const depField of DEPENDENCIES_FIELDS) {
+    const depsBlock = pkg[depField]
+    if (depsBlock == null) {
+      continue
+    }
+
+    for (const [alias, pref] of Object.entries(depsBlock)) {
+      const resolveResult = resolveFromCatalog(catalogs, { alias, pref })
+
+      matchCatalogResolveResult(resolveResult, {
+        unused: () => {},
+
+        misconfiguration: (result) => {
+          throw result.error
+        },
+
+        found: (result) => {
+          depsBlock[alias] = result.resolution.specifier
+        },
+      })
+    }
+  }
+
+  return pkg
+}

--- a/releasing/plugin-commands-deploy/src/deployCatalogHook.ts
+++ b/releasing/plugin-commands-deploy/src/deployCatalogHook.ts
@@ -5,7 +5,7 @@ import { type ProjectManifest, DEPENDENCIES_FIELDS } from '@pnpm/types'
 /**
  * Teach the `pnpm deploy` command how to interpret the catalog: protocol.
  *
- * This is a hack to workaround a design problem between pnpm deploy and
+ * This is a hack to work around a design problem between pnpm deploy and
  * catalogs.
  *
  *   - The catalog protocol is intentionally only allowed to be used by

--- a/releasing/plugin-commands-deploy/test/deployCatalogHook.ts
+++ b/releasing/plugin-commands-deploy/test/deployCatalogHook.ts
@@ -1,0 +1,37 @@
+import { deployCatalogHook } from '../src/deployCatalogHook'
+
+test('deployCatalogHook()', () => {
+  const catalogs = {
+    default: {
+      a: '^1.0.0',
+    },
+    foo: {
+      b: '^2.0.0',
+    },
+    bar: {
+      c: '^3.0.0',
+    },
+  }
+
+  expect(deployCatalogHook(catalogs, {
+    dependencies: {
+      a: 'catalog:',
+    },
+    devDependencies: {
+      b: 'catalog:foo',
+    },
+    optionalDependencies: {
+      c: 'catalog:bar',
+    },
+  })).toStrictEqual({
+    dependencies: {
+      a: '^1.0.0',
+    },
+    devDependencies: {
+      b: '^2.0.0',
+    },
+    optionalDependencies: {
+      c: '^3.0.0',
+    },
+  })
+})

--- a/releasing/plugin-commands-deploy/tsconfig.json
+++ b/releasing/plugin-commands-deploy/tsconfig.json
@@ -16,6 +16,12 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../catalogs/resolver"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {


### PR DESCRIPTION
## Problem

Using [catalogs](https://pnpm.io/catalogs) breaks `pnpm deploy`. 🤦🏻‍♂️

<img width="842" alt="Screenshot 2024-07-12 at 12 02 27 AM" src="https://github.com/user-attachments/assets/1c24880a-439e-4ae6-aad5-44153478b6e0">

There's a design problem between pnpm catalogs and `pnpm deploy` that makes this a bit hard to fix correctly.

- The `catalog:` protocol is intentionally only allowed to be used by "_importers_". External dependencies cannot use the `catalog:` protocol by design.
- When using `pnpm deploy`, dependency workspace packages are no longer considered "importers".

## Changes

Using a `readPackage` hook that only runs within `pnpm deploy`.

This is a bit hacky and has the consequence of allowing the `catalog:` protocol to be usable by external dependencies. See a recent comment on the tradeoffs between this approach and an alternative: https://github.com/pnpm/pnpm/issues/8297#issuecomment-2219484009