### PR TITLE
fix(dlx/cache): account for customized registries

### DIFF
--- a/.changeset/wild-mayflies-compete.md
+++ b/.changeset/wild-mayflies-compete.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-script-runners": major
+"@pnpm/plugin-commands-store": patch
+"pnpm": patch
+---
+
+Add registries information to the calculation of dlx cache hash.

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -64,7 +64,7 @@ export function help (): string {
 export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
-} & Pick<Config, 'extraBinPaths'| 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'useNodeVersion'> & add.AddCommandOptions
+} & Pick<Config, 'extraBinPaths' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'useNodeVersion'> & add.AddCommandOptions
 
 export async function handler (
   opts: DlxCommandOptions,

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -162,16 +162,22 @@ function findCache (pkgs: string[], opts: {
   dlxCacheMaxAge: number
   registries: Record<string, string>
 }): { cacheLink: string, prepareDir: string | null } {
-  const dlxCommandCacheDir = createDlxCommandCacheDir(opts.cacheDir, pkgs, opts.registries)
+  const dlxCommandCacheDir = createDlxCommandCacheDir(pkgs, opts)
   const cacheLink = path.join(dlxCommandCacheDir, 'pkg')
   const valid = isCacheValid(cacheLink, opts.dlxCacheMaxAge)
   const prepareDir = valid ? null : getPrepareDir(dlxCommandCacheDir)
   return { cacheLink, prepareDir }
 }
 
-function createDlxCommandCacheDir (cacheDir: string, pkgs: string[], registries: Record<string, string>): string {
-  const dlxCacheDir = path.resolve(cacheDir, 'dlx')
-  const cacheKey = createCacheKey(pkgs, registries)
+function createDlxCommandCacheDir (
+  pkgs: string[],
+  opts: {
+    registries: Record<string, string>
+    cacheDir: string
+  }
+): string {
+  const dlxCacheDir = path.resolve(opts.cacheDir, 'dlx')
+  const cacheKey = createCacheKey(pkgs, opts.registries)
   const cachePath = path.join(dlxCacheDir, cacheKey)
   fs.mkdirSync(cachePath, { recursive: true })
   return cachePath

--- a/exec/plugin-commands-script-runners/test/dlx.createCacheKey.test.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.createCacheKey.test.ts
@@ -1,0 +1,30 @@
+import { createBase32Hash } from '@pnpm/crypto.base32-hash'
+import { createCacheKey } from '../src/dlx'
+
+test('creates a hash', () => {
+  const received = createCacheKey(['shx', '@foo/bar'], {
+    default: 'https://registry.npmjs.com/',
+    '@foo': 'https://example.com/npm-registry/foo/',
+  })
+  const expected = createBase32Hash(JSON.stringify([['@foo/bar', 'shx'], [
+    ['@foo', 'https://example.com/npm-registry/foo/'],
+    ['default', 'https://registry.npmjs.com/'],
+  ]]))
+  expect(received).toBe(expected)
+})
+
+test('is agnostic to package order', () => {
+  const registries = { default: 'https://registry.npmjs.com/' }
+  expect(createCacheKey(['a', 'c', 'b'], registries)).toBe(createCacheKey(['a', 'b', 'c'], registries))
+  expect(createCacheKey(['b', 'a', 'c'], registries)).toBe(createCacheKey(['a', 'b', 'c'], registries))
+  expect(createCacheKey(['b', 'c', 'a'], registries)).toBe(createCacheKey(['a', 'b', 'c'], registries))
+  expect(createCacheKey(['c', 'a', 'b'], registries)).toBe(createCacheKey(['a', 'b', 'c'], registries))
+  expect(createCacheKey(['c', 'b', 'a'], registries)).toBe(createCacheKey(['a', 'b', 'c'], registries))
+})
+
+test('is agnostic to registry key order', () => {
+  const packages = ['a', 'b', 'c']
+  const foo = 'https://example.com/foo/'
+  const bar = 'https://example.com/bar/'
+  expect(createCacheKey(packages, { '@foo': foo, '@bar': bar })).toBe(createCacheKey(packages, { '@bar': bar, '@foo': foo }))
+})

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -1,6 +1,5 @@
 import fs from 'fs'
 import path from 'path'
-import { createBase32Hash } from '@pnpm/crypto.base32-hash'
 import { add } from '@pnpm/plugin-commands-installation'
 import { dlx } from '@pnpm/plugin-commands-script-runners'
 import { prepareEmpty } from '@pnpm/prepare'
@@ -20,6 +19,8 @@ function sanitizeDlxCacheComponent (cacheName: string): string {
   }
   return '***********-*****'
 }
+
+const createCacheKey = (...pkgs: string[]): string => dlx.createCacheKey(pkgs, DEFAULT_OPTS.registries)
 
 function verifyDlxCache (cacheName: string): void {
   expect(
@@ -198,7 +199,7 @@ test('dlx with cache', async () => {
   }, ['shx', 'touch', 'foo'])
 
   expect(fs.existsSync('foo')).toBe(true)
-  verifyDlxCache(createBase32Hash('shx'))
+  verifyDlxCache(createCacheKey('shx'))
   expect(spy).toHaveBeenCalled()
 
   spy.mockReset()
@@ -212,7 +213,7 @@ test('dlx with cache', async () => {
   }, ['shx', 'touch', 'bar'])
 
   expect(fs.existsSync('bar')).toBe(true)
-  verifyDlxCache(createBase32Hash('shx'))
+  verifyDlxCache(createCacheKey('shx'))
   expect(spy).not.toHaveBeenCalled()
 
   spy.mockRestore()
@@ -231,11 +232,11 @@ test('dlx does not reuse expired cache', async () => {
     cacheDir: path.resolve('cache'),
     dlxCacheMaxAge: Infinity,
   }, ['shx', 'echo', 'hello world'])
-  verifyDlxCache(createBase32Hash('shx'))
+  verifyDlxCache(createCacheKey('shx'))
 
   // change the date attributes of the cache to 30 minutes older than now
   const newDate = new Date(now.getTime() - 30 * 60_000)
-  fs.lutimesSync(path.resolve('cache', 'dlx', createBase32Hash('shx'), 'pkg'), newDate, newDate)
+  fs.lutimesSync(path.resolve('cache', 'dlx', createCacheKey('shx'), 'pkg'), newDate, newDate)
 
   const spy = jest.spyOn(add, 'handler')
 
@@ -254,7 +255,7 @@ test('dlx does not reuse expired cache', async () => {
   spy.mockRestore()
 
   expect(
-    fs.readdirSync(path.resolve('cache', 'dlx', createBase32Hash('shx')))
+    fs.readdirSync(path.resolve('cache', 'dlx', createCacheKey('shx')))
       .map(sanitizeDlxCacheComponent)
       .sort()
   ).toStrictEqual([
@@ -262,7 +263,7 @@ test('dlx does not reuse expired cache', async () => {
     '***********-*****',
     '***********-*****',
   ].sort())
-  verifyDlxCacheLink(createBase32Hash('shx'))
+  verifyDlxCacheLink(createCacheKey('shx'))
 })
 
 test('dlx still saves cache even if execution fails', async () => {
@@ -279,5 +280,5 @@ test('dlx still saves cache even if execution fails', async () => {
   }, ['shx', 'mkdir', path.resolve('not-a-dir')])
 
   expect(fs.readFileSync(path.resolve('not-a-dir'), 'utf-8')).toEqual(expect.anything())
-  verifyDlxCache(createBase32Hash('shx'))
+  verifyDlxCache(createCacheKey('shx'))
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6816,12 +6816,12 @@ importers:
       '@pnpm/assert-store':
         specifier: workspace:*
         version: link:../../__utils__/assert-store
-      '@pnpm/crypto.base32-hash':
-        specifier: workspace:*
-        version: link:../../packages/crypto.base32-hash
       '@pnpm/lockfile-file':
         specifier: workspace:*
         version: link:../../lockfile/lockfile-file
+      '@pnpm/plugin-commands-script-runners':
+        specifier: workspace:*
+        version: link:../../exec/plugin-commands-script-runners
       '@pnpm/plugin-commands-store':
         specifier: workspace:*
         version: 'link:'

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -31,8 +31,8 @@
   "homepage": "https://github.com/pnpm/pnpm/blob/main/store/plugin-commands-store#readme",
   "devDependencies": {
     "@pnpm/assert-store": "workspace:*",
-    "@pnpm/crypto.base32-hash": "workspace:*",
     "@pnpm/lockfile-file": "workspace:*",
+    "@pnpm/plugin-commands-script-runners": "workspace:*",
     "@pnpm/plugin-commands-store": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "catalog:",

--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { assertStore } from '@pnpm/assert-store'
-import { createBase32Hash } from '@pnpm/crypto.base32-hash'
+import { dlx } from '@pnpm/plugin-commands-script-runners'
 import { store } from '@pnpm/plugin-commands-store'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
@@ -12,6 +12,8 @@ import ssri from 'ssri'
 const STORE_VERSION = 'v3'
 const REGISTRY = `http://localhost:${REGISTRY_MOCK_PORT}/`
 const pnpmBin = path.join(__dirname, '../../../pnpm/bin/pnpm.cjs')
+
+const createCacheKey = (...pkgs: string[]): string => dlx.createCacheKey(pkgs, { default: REGISTRY })
 
 test('remove unreferenced packages', async () => {
   const project = prepare()
@@ -288,7 +290,7 @@ function createSampleDlxCacheLinkTarget (dirPath: string): void {
 }
 
 function createSampleDlxCacheItem (cacheDir: string, cmd: string, now: Date, age: number): void {
-  const hash = createBase32Hash(cmd)
+  const hash = createCacheKey(cmd)
   const newDate = new Date(now.getTime() - age * 60_000)
   const timeError = 432 // just an arbitrary amount, nothing is special about this number
   const pid = 71014 // just an arbitrary number to represent pid
@@ -342,7 +344,7 @@ test('prune removes cache directories that outlives dlx-cache-max-age', async ()
       .sort()
   ).toStrictEqual(
     ['foo', 'bar']
-      .map(createBase32Hash)
+      .map(cmd => createCacheKey(cmd))
       .sort()
   )
 })

--- a/store/plugin-commands-store/tsconfig.json
+++ b/store/plugin-commands-store/tsconfig.json
@@ -28,13 +28,13 @@
       "path": "../../config/pick-registry-for-package"
     },
     {
+      "path": "../../exec/plugin-commands-script-runners"
+    },
+    {
       "path": "../../lockfile/lockfile-file"
     },
     {
       "path": "../../lockfile/lockfile-utils"
-    },
-    {
-      "path": "../../packages/crypto.base32-hash"
     },
     {
       "path": "../../packages/dependency-path"


### PR DESCRIPTION
Different registries potentially return different packages for the same name, so reusing dlx cache for packages from a different registry would be incorrect.