### PR TITLE
fix(plugin-commands-script-runners): align `runRecursive` with how `run` assigns silent loglevel

### DIFF
--- a/.changeset/quiet-wasps-melt.md
+++ b/.changeset/quiet-wasps-melt.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+Silent reporting fixed with the `pnpm exec` command [#7608](https://github.com/pnpm/pnpm/issues/7608).

--- a/exec/plugin-commands-script-runners/src/runRecursive.ts
+++ b/exec/plugin-commands-script-runners/src/runRecursive.ts
@@ -29,7 +29,7 @@ export type RecursiveRunOpts = Pick<Config,
 | 'shellEmulator'
 | 'stream'
 > & Required<Pick<Config, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir' | 'dir'>> &
-Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'reverse' | 'sort' | 'workspaceConcurrency'>> &
+Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'reporter' | 'reverse' | 'sort' | 'workspaceConcurrency'>> &
 {
   ifPresent?: boolean
   resumeFrom?: string
@@ -117,6 +117,7 @@ export async function runRecursive (
             rootModulesDir: await realpathMissing(path.join(prefix, 'node_modules')),
             scriptsPrependNodePath: opts.scriptsPrependNodePath,
             scriptShell: opts.scriptShell,
+            silent: opts.reporter === 'silent',
             shellEmulator: opts.shellEmulator,
             stdio,
             unsafePerm: true, // when running scripts explicitly, assume that they're trusted.


### PR DESCRIPTION
Fixes #7608

-----

I originally reported the issue a few months ago. Now it's blocking our infrastructure plans so I put the time to fix it myself. This only adds a line that is likely forgotten in the [original implementation](https://github.com/pnpm/pnpm/commit/76aaead321cc10b0dea7ebba3e9a8e123bd82794#diff-c0a21f7925dd7f02d9af2aeb8297f31b6eb5a6bbe684bd7e2344a34f26bbd4e3 ).

The bug was that if you have recursive runs to `pnpm` or if a script in `package.json` calls `pnpm` again (_which probably is the same as recursive run_) then the calls don't respect the `--silent` argument.

I found the commit  by @zkochan from 4 years ago that made `silent` mode work: https://github.com/pnpm/pnpm/commit/76aaead321cc10b0dea7ebba3e9a8e123bd82794#diff-c0a21f7925dd7f02d9af2aeb8297f31b6eb5a6bbe684bd7e2344a34f26bbd4e3 

And what I can see there is that the `lifeCycleOptions` in `run.ts`  has this:
https://github.com/pnpm/pnpm/blob/a2e9bdcc028c729dc22fc9518650a34747fbeb8f/exec/plugin-commands-script-runners/src/run.ts#L248

And the `lifeCycleOptions` in `runRecursive.ts` **_didn't have this_**. Once I added it all worked out! 🎉 
