### PR TITLE
fix: `pnpm outdated` should work with `catalog:` protocol

### DIFF
--- a/.changeset/dull-rats-cheer.md
+++ b/.changeset/dull-rats-cheer.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-outdated": patch
+"@pnpm/outdated": patch
+pnpm: patch
+---
+
+The `pnpm outdated` command now supports the [`catalog:` protocol](https://pnpm.io/catalogs).

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/.gitignore
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/.gitignore
@@ -1,0 +1,2 @@
+!**/node_modules/**/*
+!/node_modules/

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/.npmrc
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/.npmrc
@@ -1,0 +1,1 @@
+shared-workspace-lockfile=false

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.modules.yaml
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.modules.yaml
@@ -1,0 +1,22 @@
+hoistPattern:
+  - '*'
+hoistedDependencies: {}
+included:
+  dependencies: true
+  devDependencies: true
+  optionalDependencies: true
+injectedDeps: {}
+layoutVersion: 5
+nodeLinker: isolated
+packageManager: pnpm@9.5.0
+pendingBuilds: []
+prunedAt: Fri, 12 Jul 2024 05:02:19 GMT
+publicHoistPattern:
+  - '*eslint*'
+  - '*prettier*'
+registries:
+  default: https://registry.npmjs.org/
+skipped: []
+storeDir: /Users/gluxon/Library/pnpm/store/v3
+virtualStoreDir: .pnpm
+virtualStoreDirMaxLength: 120

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/index.js
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (n) {
+	if (typeof n !== 'number') {
+		throw new TypeError('Expected a number');
+	}
+
+	return n < 0;
+};

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/license
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Kevin Martensson <kevinmartensson@gmail.com> (github.com/kevva)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/package.json
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "is-negative",
+  "version": "1.0.0",
+  "description": "Test if a number is negative",
+  "license": "MIT",
+  "repository": "kevva/is-negative",
+  "author": {
+    "name": "Kevin Martensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "github.com/kevva"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "negative",
+    "number",
+    "test"
+  ],
+  "devDependencies": {
+    "ava": "^0.0.4"
+  }
+}

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/readme.md
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/readme.md
@@ -1,0 +1,31 @@
+# is-negative [![Build Status](https://travis-ci.org/kevva/is-negative.svg?branch=master)](https://travis-ci.org/kevva/is-negative)
+
+> Test if a number is positive
+
+
+## Install
+
+```
+$ npm install --save is-negative
+```
+
+
+## Usage
+
+```js
+var isNegative = require('is-negative');
+
+isNegative(-1);
+//=> true
+
+isNegative(1);
+//=> false
+
+isNegative(0);
+//=> false
+```
+
+
+## License
+
+MIT © [Kevin Martensson](http://github.com/kevva)

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/index.js
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (n) {
+	if (typeof n !== 'number') {
+		throw new TypeError('Expected a number');
+	}
+
+	return n < 0;
+};

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/license
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Kevin Martensson <kevinmartensson@gmail.com> (github.com/kevva)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/package.json
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "is-negative",
+  "version": "1.0.1",
+  "description": "Test if a number is negative",
+  "license": "MIT",
+  "repository": "kevva/is-negative",
+  "author": {
+    "name": "Kevin Martensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "github.com/kevva"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "negative",
+    "number",
+    "test"
+  ],
+  "devDependencies": {
+    "ava": "^0.0.4"
+  }
+}

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/readme.md
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/is-negative@1.0.1/node_modules/is-negative/readme.md
@@ -1,0 +1,31 @@
+# is-negative [![Build Status](https://travis-ci.org/kevva/is-negative.svg?branch=master)](https://travis-ci.org/kevva/is-negative)
+
+> Test if a number is negative
+
+
+## Install
+
+```
+$ npm install --save is-negative
+```
+
+
+## Usage
+
+```js
+var isNegative = require('is-negative');
+
+isNegative(-1);
+//=> true
+
+isNegative(1);
+//=> false
+
+isNegative(0);
+//=> false
+```
+
+
+## License
+
+MIT © [Kevin Martensson](http://github.com/kevva)

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/.pnpm/lock.yaml
@@ -1,0 +1,29 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    is-negative:
+      specifier: ^1.0.0
+      version: 1.0.0
+
+importers:
+
+  .:
+    dependencies:
+      is-negative:
+        specifier: 'catalog:'
+        version: 1.0.0
+
+packages:
+
+  is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-negative@1.0.0: {}

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/is-negative
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/node_modules/is-negative
@@ -1,0 +1,1 @@
+.pnpm/is-negative@1.0.0/node_modules/is-negative

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/package.json
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "is-negative": "catalog:"
+  }
+}

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/pnpm-lock.yaml
@@ -1,0 +1,29 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    is-negative:
+      specifier: ^1.0.0
+      version: 1.0.0
+
+importers:
+
+  .:
+    dependencies:
+      is-negative:
+        specifier: 'catalog:'
+        version: 1.0.0
+
+packages:
+
+  is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-negative@1.0.0: {}

--- a/__fixtures__/has-outdated-deps-using-catalog-protocol/pnpm-workspace.yaml
+++ b/__fixtures__/has-outdated-deps-using-catalog-protocol/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - '.'
+
+catalog:
+  is-negative: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6213,6 +6213,12 @@ importers:
 
   reviewing/outdated:
     dependencies:
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: link:../../catalogs/resolver
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../catalogs/types
       '@pnpm/client':
         specifier: workspace:*
         version: link:../../pkg-manager/client

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -33,6 +33,8 @@
     "@pnpm/logger": "^5.0.0"
   },
   "dependencies": {
+    "@pnpm/catalogs.resolver": "workspace:*",
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/client": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",

--- a/reviewing/outdated/src/outdatedDepsOfProjects.ts
+++ b/reviewing/outdated/src/outdatedDepsOfProjects.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import {
   readCurrentLockfile,
   readWantedLockfile,
@@ -18,6 +19,7 @@ export async function outdatedDepsOfProjects (
   pkgs: Array<{ rootDir: ProjectRootDir, manifest: ProjectManifest }>,
   args: string[],
   opts: Omit<ManifestGetterOptions, 'fullMetadata' | 'lockfileDir'> & {
+    catalogs?: Catalogs
     compatible?: boolean
     ignoreDependencies?: string[]
     include: IncludedDependencies
@@ -43,6 +45,7 @@ export async function outdatedDepsOfProjects (
   return Promise.all(pkgs.map(async ({ rootDir, manifest }): Promise<OutdatedPackage[]> => {
     const match = (args.length > 0) && createMatcher(args) || undefined
     return outdated({
+      catalogs: opts.catalogs,
       compatible: opts.compatible,
       currentLockfile,
       getLatestManifest,

--- a/reviewing/outdated/tsconfig.json
+++ b/reviewing/outdated/tsconfig.json
@@ -10,6 +10,12 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/resolver"
+    },
+    {
+      "path": "../../catalogs/types"
+    },
+    {
       "path": "../../config/matcher"
     },
     {

--- a/reviewing/plugin-commands-outdated/src/outdated.ts
+++ b/reviewing/plugin-commands-outdated/src/outdated.ts
@@ -129,6 +129,7 @@ export type OutdatedCommandOptions = {
 | 'allProjects'
 | 'ca'
 | 'cacheDir'
+| 'catalogs'
 | 'cert'
 | 'dev'
 | 'dir'

--- a/reviewing/plugin-commands-outdated/test/index.ts
+++ b/reviewing/plugin-commands-outdated/test/index.ts
@@ -17,6 +17,7 @@ const hasNotOutdatedDepsFixture = f.find('has-not-outdated-deps')
 const hasMajorOutdatedDepsFixture = f.find('has-major-outdated-deps')
 const hasNoLockfileFixture = f.find('has-no-lockfile')
 const withPnpmUpdateIgnore = f.find('with-pnpm-update-ignore')
+const hasOutdatedDepsUsingCatalogProtocol = f.find('has-outdated-deps-using-catalog-protocol')
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
 
@@ -375,6 +376,27 @@ test('ignore packages in package.json > pnpm.updateConfig.ignoreDependencies in 
   const { output, exitCode } = await outdated.handler({
     ...OUTDATED_OPTIONS,
     dir: withPnpmUpdateIgnore,
+  })
+
+  expect(exitCode).toBe(1)
+  expect(stripAnsi(output)).toBe(`\
+┌─────────────┬─────────┬────────┐
+│ Package     │ Current │ Latest │
+├─────────────┼─────────┼────────┤
+│ is-negative │ 1.0.0   │ 2.1.0  │
+└─────────────┴─────────┴────────┘
+`)
+})
+
+test('pnpm outdated: catalog protocol', async () => {
+  const { output, exitCode } = await outdated.handler({
+    ...OUTDATED_OPTIONS,
+    catalogs: {
+      // Duplicating the catalog config in the pnpm-workspace.yaml inline to
+      // avoid an async read and catalog config normalization call.
+      default: { 'is-negative': '^1.0.0' },
+    },
+    dir: hasOutdatedDepsUsingCatalogProtocol,
   })
 
   expect(exitCode).toBe(1)


### PR DESCRIPTION
## Problem

Dependencies using the `catalog:` protocol were accidentally skipped over in `pnpm outdated`.

For example, `cd pkg-manager/core && pnpm outdated` in this repo shows no output:

<img width="842" alt="Screenshot 2024-07-13 at 9 52 07 PM" src="https://github.com/user-attachments/assets/e2d1690d-b41b-48ec-86c7-96278139cb76">

## Changes

The `pnpm outdated` and `pnpm outdated --recursive` commands should now work as expected when using catalogs.

<img width="842" alt="Screenshot 2024-07-13 at 9 52 28 PM" src="https://github.com/user-attachments/assets/ab3b1c6e-be67-4016-b65b-9dd0a1c55424">


<img width="1026" alt="Screenshot 2024-07-13 at 9 53 39 PM" src="https://github.com/user-attachments/assets/f541f039-e6d6-45fc-b897-93a97ea09a78">
