### PR TITLE
fix: better error message when catalog is not used

### DIFF
--- a/catalogs/resolver/src/resolveFromCatalog.ts
+++ b/catalogs/resolver/src/resolveFromCatalog.ts
@@ -61,6 +61,18 @@ export function resolveFromCatalog (catalogs: Catalogs, wantedDependency: Wanted
   const catalogName = parseCatalogProtocol(wantedDependency.pref)
 
   if (catalogName == null) {
+    for (const catalogName in catalogs) {
+      const catalog = catalogs[catalogName]!
+      if (catalog[wantedDependency.alias]) {
+        return {
+          type: 'misconfiguration',
+          catalogName,
+          error: new PnpmError(
+            'CATALOG_ENTRY_NOT_USED',
+            `The catalog entry '${wantedDependency.alias}' in catalog '${catalogName}' is not used. The entry should be referenced using the catalog protocol.`),
+        }
+      }
+    }
     return { type: 'unused' }
   }
 

--- a/catalogs/resolver/test/resolveFromCatalog.test.ts
+++ b/catalogs/resolver/test/resolveFromCatalog.test.ts
@@ -30,16 +30,6 @@ test('resolves named catalog', () => {
     .toEqual({ type: 'found', resolution: { catalogName: 'foo', specifier: '1.0.0' } })
 })
 
-test('returns unused for specifier not using catalog protocol', () => {
-  const catalogs = {
-    foo: {
-      bar: '1.0.0',
-    },
-  }
-
-  expect(resolveFromCatalog(catalogs, { alias: 'bar', pref: '^2.0.0' })).toEqual({ type: 'unused' })
-})
-
 describe('misconfiguration', () => {
   function resolveFromCatalogOrThrow (catalogs: Catalogs, wantedDependency: WantedDependency) {
     const result = resolveFromCatalog(catalogs, wantedDependency)
@@ -106,5 +96,16 @@ describe('misconfiguration', () => {
 
     expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: 'catalog:foo' }))
       .toThrow("The entry for 'bar' in catalog 'foo' declares a dependency using the 'link' protocol. This is not yet supported, but may be in a future version of pnpm.")
+  })
+
+  test('returns error for not used catalog protocol', () => {
+    const catalogs = {
+      foo: {
+        bar: '1.0.0',
+      },
+    }
+
+    expect(() => resolveFromCatalogOrThrow(catalogs, { alias: 'bar', pref: '1.0.0' }))
+      .toThrow("The catalog entry 'bar' in catalog 'foo' is not used. The entry should be referenced using the catalog protocol.")
   })
 })


### PR DESCRIPTION
If the user configures the catalog, then I think it should be decided to use it. If it is not used, throwing an error prompt will make it easier to prompt the user to modify it.