### PR TITLE
feat(deps): migrate js-yaml to yaml

### DIFF
--- a/lockfile/lockfile-file/package.json
+++ b/lockfile/lockfile-file/package.json
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@pnpm/lockfile-file": "workspace:*",
-    "@types/js-yaml": "catalog:",
     "@types/normalize-path": "catalog:",
     "@types/ramda": "catalog:",
     "@types/semver": "catalog:",
@@ -58,7 +57,7 @@
     "@pnpm/util.lex-comparator": "catalog:",
     "@zkochan/rimraf": "catalog:",
     "comver-to-semver": "catalog:",
-    "js-yaml": "catalog:",
+    "yaml": "catalog:",
     "normalize-path": "catalog:",
     "ramda": "catalog:",
     "semver": "catalog:",

--- a/lockfile/lockfile-file/src/gitMergeFile.ts
+++ b/lockfile/lockfile-file/src/gitMergeFile.ts
@@ -1,6 +1,6 @@
 import { type Lockfile, type LockfileFile } from '@pnpm/lockfile-types'
 import { mergeLockfileChanges } from '@pnpm/merge-lockfile-changes'
-import yaml from 'js-yaml'
+import yaml from 'yaml'
 import { convertToLockfileObject } from './lockfileFormatConverters'
 
 const MERGE_CONFLICT_PARENT = '|||||||'
@@ -11,8 +11,8 @@ const MERGE_CONFLICT_OURS = '<<<<<<<'
 export function autofixMergeConflicts (fileContent: string): Lockfile {
   const { ours, theirs } = parseMergeFile(fileContent)
   return mergeLockfileChanges(
-    convertToLockfileObject(yaml.load(ours) as LockfileFile),
-    convertToLockfileObject(yaml.load(theirs) as LockfileFile)
+    convertToLockfileObject(yaml.parse(ours) as LockfileFile),
+    convertToLockfileObject(yaml.parse(theirs) as LockfileFile)
   )
 }
 

--- a/lockfile/lockfile-file/src/read.ts
+++ b/lockfile/lockfile-file/src/read.ts
@@ -10,7 +10,7 @@ import { mergeLockfileChanges } from '@pnpm/merge-lockfile-changes'
 import { type Lockfile } from '@pnpm/lockfile-types'
 import { type ProjectId } from '@pnpm/types'
 import comverToSemver from 'comver-to-semver'
-import yaml from 'js-yaml'
+import yaml from 'yaml'
 import semver from 'semver'
 import stripBom from 'strip-bom'
 import { LockfileBreakingChangeError } from './errors'
@@ -88,7 +88,7 @@ async function _read (
   let lockfile: Lockfile
   let hadConflicts!: boolean
   try {
-    lockfile = convertToLockfileObject(yaml.load(lockfileRawContent) as any) // eslint-disable-line
+    lockfile = convertToLockfileObject(yaml.parse(lockfileRawContent) as any) // eslint-disable-line
     hadConflicts = false
   } catch (err: unknown) {
     if (!opts.autofixMergeConflicts || !isDiff(lockfileRawContent)) {

--- a/lockfile/lockfile-file/src/write.ts
+++ b/lockfile/lockfile-file/src/write.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { type LockfileFileV9, type Lockfile, type LockfileFile } from '@pnpm/lockfile-types'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import rimraf from '@zkochan/rimraf'
-import yaml from 'js-yaml'
+import yaml from 'yaml'
 import isEmpty from 'ramda/src/isEmpty'
 import writeFileAtomicCB from 'write-file-atomic'
 import { lockfileLogger as logger } from './logger'
@@ -20,11 +20,9 @@ async function writeFileAtomic (filename: string, data: string): Promise<void> {
 }
 
 const LOCKFILE_YAML_FORMAT = {
-  blankLines: true,
-  lineWidth: -1, // This is setting line width to never wrap
-  noCompatMode: true,
-  noRefs: true,
-  sortKeys: false,
+  lineWidth: 0, // This is setting line width to never wrap
+  schema: 'core',
+  aliasDuplicateObjects: false,
 }
 
 export async function writeWantedLockfile (
@@ -70,7 +68,7 @@ async function writeLockfile (
 
 function yamlStringify (lockfile: LockfileFile) {
   const sortedLockfile = sortLockfileKeys(lockfile as LockfileFileV9)
-  return yaml.dump(sortedLockfile, LOCKFILE_YAML_FORMAT)
+  return yaml.stringify(sortedLockfile, LOCKFILE_YAML_FORMAT)
 }
 
 export function isEmptyLockfile (lockfile: Lockfile): boolean {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
       "glob-parent@<5.1.2": ">=5.1.2",
       "hosted-git-info@1": "npm:@pnpm/hosted-git-info@1.0.0",
       "istanbul-reports": "npm:@zkochan/istanbul-reports",
-      "js-yaml@^4.0.0": "npm:@zkochan/js-yaml@0.0.7",
       "json5@<2.2.2": ">=2.2.2",
       "jsonwebtoken@<=8.5.1": ">=9.0.0",
       "nopt@5": "npm:@pnpm/nopt@^0.2.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,6 @@ catalog:
   "@types/ini": 1.3.31
   "@types/is-gzip": 2.0.0
   "@types/is-windows": ^1.0.2
-  "@types/js-yaml": ^4.0.9
   "@types/lodash.clonedeep": ^4.5.9
   "@types/lodash.throttle": 4.1.7
   "@types/micromatch": ^4.0.7
@@ -105,7 +104,6 @@ catalog:
   "@zkochan/rimraf": ^3.0.2
   "@zkochan/table": ^2.0.1
   "dint": ^5.1.0
-  "js-yaml": npm:@zkochan/js-yaml@0.0.7
   adm-zip: ^0.5.14
   ansi-diff: ^1.1.1
   archy: ^1.0.0
@@ -248,3 +246,4 @@ catalog:
   write-pkg: 4.0.0
   write-yaml-file: ^5.0.0
   yaml-tag: 1.1.0
+  yaml: ^2.4.5


### PR DESCRIPTION
[yaml](https://eemeli.org/yaml) is a better library, and handles comments much better than js-yaml, which is no longer maintained, since ~3 years now.

Precondition for #6273. Also related to https://github.com/zkochan/packages/pull/198.