### PR TITLE
fix: print warnings to stderr

### DIFF
--- a/.changeset/tall-shirts-scream.md
+++ b/.changeset/tall-shirts-scream.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli-utils": patch
+"pnpm": patch
+---
+
+Print warnings to stderr [#8342](https://github.com/pnpm/pnpm/pull/8342).

--- a/cli/cli-utils/src/getConfig.ts
+++ b/cli/cli-utils/src/getConfig.ts
@@ -28,9 +28,8 @@ export async function getConfig (
     delete config.reporter // This is a silly workaround because @pnpm/core expects a function as opts.reporter
   }
 
-  // The warning should not be printed when --json is specified
-  if (warnings.length > 0 && !cliOptions.json) {
-    console.log(warnings.map((warning) => formatWarn(warning)).join('\n'))
+  if (warnings.length > 0) {
+    console.warn(warnings.map((warning) => formatWarn(warning)).join('\n'))
   }
 
   return config

--- a/cli/cli-utils/test/getConfig.test.ts
+++ b/cli/cli-utils/test/getConfig.test.ts
@@ -4,11 +4,11 @@ import { getConfig } from '@pnpm/cli-utils'
 import { prepare } from '@pnpm/prepare'
 
 beforeEach(() => {
-  jest.spyOn(console, 'log')
+  jest.spyOn(console, 'warn')
 })
 
 afterEach(() => {
-  (console.log as jest.Mock).mockRestore()
+  (console.warn as jest.Mock).mockRestore()
 })
 
 test('console a warning when the .npmrc has an env variable that does not exist', async () => {
@@ -25,22 +25,5 @@ test('console a warning when the .npmrc has an env variable that does not exist'
   })
 
   // eslint-disable-next-line no-template-curly-in-string
-  expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
-})
-
-test('should not console a warning when --json is specified', async () => {
-  prepare()
-
-  fs.writeFileSync('.npmrc', 'foo=${ENV_VAR_123}', 'utf8') // eslint-disable-line
-
-  await getConfig({
-    json: true,
-  }, {
-    workspaceDir: '.',
-    excludeReporter: false,
-    rcOptionsTypes: {},
-  })
-
-  // eslint-disable-next-line no-template-curly-in-string
-  expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
+  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
 })


### PR DESCRIPTION
resolves https://github.com/pnpm/pnpm/issues/5682

Errors and warning should be printed to `stderr`, so that people can use the output in `stdout` in their scripts.

For example, with the changes in this PR `pnpm list --json | jq` will work as expected.