### PR TITLE
fix(exportable-manifest): replace semver in peerDependency with workspace protocol

### DIFF
--- a/.changeset/smooth-ravens-wave.md
+++ b/.changeset/smooth-ravens-wave.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/exportable-manifest": patch
+---
+
+fix(exportable-manifest): replace semver in peerDependency with workspace protocol

--- a/.changeset/smooth-ravens-wave.md
+++ b/.changeset/smooth-ravens-wave.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/exportable-manifest": patch
+pnpm: patch
 ---
 
-fix(exportable-manifest): replace semver in peerDependency with workspace protocol
+Replace semver in peerDependency with workspace protocol [#8355](https://github.com/pnpm/pnpm/issues/8355).

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -159,19 +159,25 @@ async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec:
     return depSpec
   }
 
-  // Dependencies with bare "*", "^", "~",">=",">","<=",< versions
-  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)/
+  // Dependencies with bare "*", "^", "~",">=",">","<=", "<", version
+  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)?(\d+\.\d+\.\d+)?/
   const versionAliasSpecParts = workspaceSemverRegex.exec(depSpec)
 
   if (versionAliasSpecParts != null) {
+    const [, semverRangGroup = '', version] = versionAliasSpecParts
+
+    if (version) {
+      return depSpec.replace('workspace:', '')
+    }
+
     modulesDir = modulesDir ?? path.join(dir, 'node_modules')
     const manifest = await resolveManifest(depName, modulesDir)
-
-    const [,semverRangGroup] = versionAliasSpecParts
-
     const semverRangeToken = semverRangGroup !== '*' ? semverRangGroup : ''
 
-    return depSpec.replace(workspaceSemverRegex, `${semverRangeToken}${manifest.version}`)
+    return depSpec.replace(
+      workspaceSemverRegex,
+      `${semverRangeToken}${manifest.version}`
+    )
   }
 
   depSpec = depSpec.replace('workspace:', '')

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -160,7 +160,7 @@ async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec:
   }
 
   // Dependencies with bare "*", "^", "~",">=",">","<=", "<", version
-  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)?(\d+\.\d+\.\d+)?/
+  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)?((\d+|[xX]|\*)(\.(\d+|[xX]|\*)){0,2})?/
   const versionAliasSpecParts = workspaceSemverRegex.exec(depSpec)
 
   if (versionAliasSpecParts != null) {

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -174,13 +174,8 @@ async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec:
     const manifest = await resolveManifest(depName, modulesDir)
     const semverRangeToken = semverRangGroup !== '*' ? semverRangGroup : ''
 
-    return depSpec.replace(
-      workspaceSemverRegex,
-      `${semverRangeToken}${manifest.version}`
-    )
+    return depSpec.replace(workspaceSemverRegex, `${semverRangeToken}${manifest.version}`)
   }
 
-  depSpec = depSpec.replace('workspace:', '')
-
-  return depSpec
+  return depSpec.replace('workspace:', '')
 }

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -96,12 +96,14 @@ test('workspace deps are replaced', async () => {
       baz: 'workspace:baz@^',
       foo: 'workspace:*',
       qux: 'workspace:^',
+      waldo: 'workspace:^',
     },
     peerDependencies: {
       foo: 'workspace:>= || ^3.9.0',
       baz: '^1.0.0 || workspace:>',
       bar: 'workspace:^3.0.0',
       qux: 'workspace:^',
+      waldo: 'workspace:^1.x',
     },
   }
 
@@ -123,6 +125,10 @@ test('workspace deps are replaced', async () => {
       name: 'qux',
       version: '1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
     },
+    {
+      name: 'waldo',
+      version: '1.9.0',
+    },
   ])
 
   writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
@@ -139,12 +145,14 @@ test('workspace deps are replaced', async () => {
       baz: '^1.2.3',
       foo: '4.5.6',
       qux: '^1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
+      waldo: '^1.9.0',
     },
     peerDependencies: {
       baz: '^1.0.0 || >1.2.3',
       foo: '>=4.5.6 || ^3.9.0',
       bar: '^3.0.0',
       qux: '^1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
+      waldo: '^1.x',
     },
   })
 })

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -95,11 +95,13 @@ test('workspace deps are replaced', async () => {
       bar: 'workspace:@foo/bar@*',
       baz: 'workspace:baz@^',
       foo: 'workspace:*',
+      qux: 'workspace:^',
     },
     peerDependencies: {
       foo: 'workspace:>= || ^3.9.0',
       baz: '^1.0.0 || workspace:>',
       bar: 'workspace:^3.0.0',
+      qux: 'workspace:^',
     },
   }
 
@@ -117,6 +119,10 @@ test('workspace deps are replaced', async () => {
       name: 'foo',
       version: '4.5.6',
     },
+    {
+      name: 'qux',
+      version: '1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
+    },
   ])
 
   writeYamlFile('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
@@ -132,11 +138,13 @@ test('workspace deps are replaced', async () => {
       bar: 'npm:@foo/bar@3.2.1',
       baz: '^1.2.3',
       foo: '4.5.6',
+      qux: '^1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
     },
     peerDependencies: {
       baz: '^1.0.0 || >1.2.3',
       foo: '>=4.5.6 || ^3.9.0',
       bar: '^3.0.0',
+      qux: '^1.0.0-alpha-a.b-c-something+build.1-aef.1-its-okay',
     },
   })
 })

--- a/pkg-manifest/exportable-manifest/test/index.test.ts
+++ b/pkg-manifest/exportable-manifest/test/index.test.ts
@@ -99,6 +99,7 @@ test('workspace deps are replaced', async () => {
     peerDependencies: {
       foo: 'workspace:>= || ^3.9.0',
       baz: '^1.0.0 || workspace:>',
+      bar: 'workspace:^3.0.0',
     },
   }
 
@@ -135,6 +136,7 @@ test('workspace deps are replaced', async () => {
     peerDependencies: {
       baz: '^1.0.0 || >1.2.3',
       foo: '>=4.5.6 || ^3.9.0',
+      bar: '^3.0.0',
     },
   })
 })


### PR DESCRIPTION
fixed: #8355

- If dependencies and `peerDependencies` had the same package version specified, the version in `peerDependencies` would be `depSpec.replace` to change to the incorrect version.
- Fixed so that if peerDependencies specifies a version, it is fixed to that version.

example (before)
```typescript
// pkg-manifest/exportable-manifest/src/index.ts (replaceWorkspaceProtocolPeerDependency)

// depSpec: "workspace:^1.0.0"
// manifest.version: "2.0.0"

 return depSpec.replace(
    workspaceSemverRegex, // "workspace:^"
    `${semverRangeToken}${manifest.version}` // "^2.0.0"
  )
// "workspace:^1.0.0" -> "^2.0.01.0.0"
```