### PR TITLE
chore: remove always undefined variable

### DIFF
--- a/fs/find-packages/src/index.ts
+++ b/fs/find-packages/src/index.ts
@@ -22,7 +22,7 @@ export interface Options {
 
 export async function findPackages (root: string, opts?: Options): Promise<Project[]> {
   opts = opts ?? {}
-  const globOpts = { ...opts, cwd: root, includeRoot: undefined }
+  const globOpts = { ...opts, cwd: root }
   globOpts.ignore = opts.ignore ?? DEFAULT_IGNORE
   const patterns = normalizePatterns(opts.patterns ?? ['.', '**'])
   const paths: string[] = await fastGlob(patterns, globOpts)


### PR DESCRIPTION
I happened to notice this small opportunity for cleanup. This variable is always `undefined`, so there's no reason to include it. Further, I don't see it in the list of available `fast-glob` options: https://www.npmjs.com/package/fast-glob