### PR TITLE
chore: add `packageManager` field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4.0.0
       with:
-        version: next-9
         standalone: true
     - name: Setup Node
       uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0
         with:
-          version: next-9
           standalone: true
       - name: pnpm install
         # We use --force because we want all artifacts of @reflink/reflink to be installed.

--- a/.npmrc
+++ b/.npmrc
@@ -12,3 +12,4 @@ save-prefix=
 patches-dir=__patches__
 resolution-mode=time-based
 enable-pre-post-scripts=false
+manage-package-manager-versions=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "monorepo-root",
   "private": true,
+  "packageManager": "pnpm@9.7.0",
   "scripts": {
     "bump": "changeset version && pnpm update-manifests",
     "changeset": "changeset",


### PR DESCRIPTION
It is convenient to automatically switch to the appropriate pnpm version when debugging source code locally.