### PR TITLE
fix: should not delete state.json info after apply patch

### DIFF
--- a/.changeset/yellow-dodos-press.md
+++ b/.changeset/yellow-dodos-press.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": major
+---
+
+The contents of the state.json file should not be deleted after applying the patch.

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -20,7 +20,7 @@ import tempy from 'tempy'
 import { writePackage } from './writePackage'
 import { type ParseWantedDependencyResult, parseWantedDependency } from '@pnpm/parse-wanted-dependency'
 import { type GetPatchedDependencyOptions, getVersionsFromLockfile } from './getPatchedDependency'
-import { readEditDirState, deleteEditDirState } from './stateFile'
+import { readEditDirState } from './stateFile'
 
 export const rcOptionsTypes = cliOptionsTypes
 
@@ -80,10 +80,6 @@ export async function handler (opts: PatchCommitCommandOptions, params: string[]
   }
   const srcDir = tempy.directory()
   await writePackage(parseWantedDependency(gitTarballUrl ? `${patchedPkgManifest.name}@${gitTarballUrl}` : nameAndVersion), srcDir, opts)
-  deleteEditDirState({
-    editDir: userDir,
-    modulesDir: opts.modulesDir ?? 'node_modules',
-  })
   const patchedPkgDir = await preparePkgFilesForDiff(userDir)
   const patchContent = await diffFolders(srcDir, patchedPkgDir)
   if (patchedPkgDir !== userDir) {


### PR DESCRIPTION
After executing `pnpm patch-commit`, the corresponding dependency information in `state.json` will be deleted. If I edit the content of the dependency package for the second time and execute `pnpm patch-commit` again, the following error message will appear. I think this is unreasonable.

![image](https://github.com/user-attachments/assets/32651f04-1ea6-41a1-8b6f-e39cec73be27)
