### PR TITLE
fix(setup): never switch to a different CLI version during setup

### DIFF
--- a/.changeset/happy-dodos-shake.md
+++ b/.changeset/happy-dodos-shake.md
@@ -1,0 +1,7 @@
+---
+"pnpm": patch
+---
+
+`pnpm setup` should never switch to another version of pnpm.
+
+This fixes installation with the standalone script from a directory that has a `package.json` with the `packageManager` field. pnpm was installing the version of pnpm specified in the `packageManager` field due to this issue.

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -105,7 +105,7 @@ export async function main (inputArgv: string[]): Promise<void> {
       checkUnknownSetting: false,
       ignoreNonAuthSettingsFromLocal: isDlxCommand,
     }) as typeof config
-    if (!isExecutedByCorepack() && config.wantedPackageManager != null) {
+    if (!isExecutedByCorepack() && cmd !== 'setup' && config.wantedPackageManager != null) {
       if (config.managePackageManagerVersions) {
         await switchCliVersion(config)
       } else {


### PR DESCRIPTION
This fixes installation with the standalone script from a directory that has a `package.json` with the `packageManager` field. pnpm was installing the version of pnpm specified in the `packageManager`
field due to  this issue.

close #8422