### PR TITLE
fix(package-is-installable): handle null values in wanted platform gracefully

### DIFF
--- a/.changeset/light-walls-flash.md
+++ b/.changeset/light-walls-flash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/package-is-installable": patch
+---
+
+Handle null values in wanted platform gracefully

--- a/.changeset/light-walls-flash.md
+++ b/.changeset/light-walls-flash.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/package-is-installable": patch
+"pnpm": patch
 ---
 
-Handle null values in wanted platform gracefully
+Ignore non-string value in the os, cpu, libc fields, which checking optional dependencies [#8431](https://github.com/pnpm/pnpm/pull/8431).

--- a/config/package-is-installable/src/checkPlatform.ts
+++ b/config/package-is-installable/src/checkPlatform.ts
@@ -62,10 +62,7 @@ function checkList (value: string | string[], list: string | string[]): boolean 
     list = [list]
   }
 
-  list = list.filter(Boolean)
-  if (list.length === 0) {
-    return true
-  }
+  list = list.filter((value) => typeof value === 'string')
 
   if (list.length === 1 && list[0] === 'any') {
     return true
@@ -74,7 +71,6 @@ function checkList (value: string | string[], list: string | string[]): boolean 
   for (const value of values) {
     for (let i = 0; i < list.length; ++i) {
       tmp = list[i]
-
       if (tmp[0] === '!') {
         tmp = tmp.slice(1)
         if (tmp === value) {

--- a/config/package-is-installable/src/checkPlatform.ts
+++ b/config/package-is-installable/src/checkPlatform.ts
@@ -61,6 +61,12 @@ function checkList (value: string | string[], list: string | string[]): boolean 
   if (typeof list === 'string') {
     list = [list]
   }
+
+  list = list.filter(Boolean)
+  if (list.length === 0) {
+    return true
+  }
+
   if (list.length === 1 && list[0] === 'any') {
     return true
   }
@@ -68,6 +74,7 @@ function checkList (value: string | string[], list: string | string[]): boolean 
   for (const value of values) {
     for (let i = 0; i < list.length; ++i) {
       tmp = list[i]
+
       if (tmp[0] === '!') {
         tmp = tmp.slice(1)
         if (tmp === value) {

--- a/config/package-is-installable/test/checkPlatform.ts
+++ b/config/package-is-installable/test/checkPlatform.ts
@@ -43,6 +43,33 @@ test('libc wrong', () => {
   expect(err?.code).toBe('ERR_PNPM_UNSUPPORTED_PLATFORM')
 })
 
+test('cpu null', () => {
+  const target = {
+    cpu: [null] as unknown as string[], // Casting since this is technically invalid by the pnpm spec.
+    os: 'any',
+    libc: 'any',
+  }
+  expect(checkPlatform(packageId, target)).toBeFalsy()
+})
+
+test('os null', () => {
+  const target = {
+    cpu: 'any',
+    os: [null] as unknown as string[], // Casting since this is technically invalid by the pnpm spec.
+    libc: 'any',
+  }
+  expect(checkPlatform(packageId, target)).toBeFalsy()
+})
+
+test('libc null', () => {
+  const target = {
+    cpu: 'any',
+    os: 'any',
+    libc: [null] as unknown as string[], // Casting since this is technically invalid by the pnpm spec.
+  }
+  expect(checkPlatform(packageId, target)).toBeFalsy()
+})
+
 test('nothing wrong', () => {
   const target = {
     cpu: 'any',


### PR DESCRIPTION
pnpm currently have an issue when going through certain `package.json` properties when installing the dependency graph.

We, me and my colleague, encountered the issue when our CI pipeline suddenly went haywire during some repo maintenance. We started to see this:
<img width="997" alt="image" src="https://github.com/user-attachments/assets/efffbfc9-afaa-4d80-8da6-caf1dd982f26">

The line where the exception throws is here:
https://github.com/pnpm/pnpm/blob/v9.7.1/config/package-is-installable/src/checkPlatform.ts#L70-L71

A bit of digging revealed that the [oxc-parser](https://github.com/oxc-project/oxc) npm package had a faulty specified `package.json` in one of their distributed platform targets [@oxc-parser/binding-win32-arm64-msvc](https://www.npmjs.com/package/@oxc-parser/binding-win32-arm64-msvc/v/0.24.2?activeTab=code)

It reads:
```json
{
  "name": "@oxc-parser/binding-win32-arm64-msvc",
  "version": "0.24.2",
  "main": "parser.win32-arm64-msvc.node",
  "license": "MIT",
  "author": "Boshen and oxc contributors",
  "bugs": "https://github.com/oxc-project/oxc/issues",
  "homepage": "https://oxc.rs",
  "repository": {
    "type": "git",
    "url": "https://github.com/oxc-project/oxc.git",
    "directory": "npm/oxc-parser"
  },
  "files": [
    "parser.win32-arm64-msvc.node"
  ],
  "cpu": [
    "arm64"
  ],
  "os": [
    "win32"
  ],
  "libc": [
    null
  ]
}
```

The `libc` property is set to `[null]`, it causes the exception to occur when running `pnpm install --frozen-lockfile` (maybe even `pnpm install` too) on, in this case, a Linux image.

In a previous version of `@oxc-parser/binding-win32-arm64-msvc` the `libc` value wasn't present at all, making it work. Pnpm doesn't only treats unset values for the `cpu`, `os` & `libc` properties and not nullish values.

I'm not too sure how much of an issue this is. We encountered it in one of our repos after said maintenance. It's possible that we facilitated it due to the changes made. We are a bit stuck with manually removing the `libc: [null]` from the lock file, like this:
<img width="190" alt="image" src="https://github.com/user-attachments/assets/8ccf4a36-99c1-4e62-9f2a-a5ce5752d5e4">

This specific issue might be hard to replicate on your own if you don't run pnpm within an Linux image. We caught this issue in our CI environment, which runs an Linux image. Trying it on our own platforms, that being MacOS and Windows, installation worked fine. But any package maintainer, especially those who use [napi-rs](https://github.com/napi-rs/napi-rs), could accidentally distribute faulty packages by setting any of the platform specific properties to null.

---

I hope that the PR could yield some insight of a way forward here! Thanks!

_Edited for a better description of the issue_