### PR TITLE
test: fix failures when retry downloading node

### DIFF
--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -271,7 +271,7 @@ test('recursive run when some packages define different node versions', async ()
       .toString()
       .trim()
       .split('\n')
-      .filter(x => /v[0-9]+\.[0-9]+\.[0-9]+/.test(x))
+      .filter(x => /print-node-version.*v[0-9]+\.[0-9]+\.[0-9]+/.test(x))
       .sort()
 
   expect(


### PR DESCRIPTION
This should fix the failures like this:

![subject test failure](https://github.com/user-attachments/assets/1484e183-bd25-49bd-9c48-158641f0089e)
