### PR TITLE
Fix white text on light bg for render-peer-issues

### DIFF
--- a/.changeset/eight-comics-peel.md
+++ b/.changeset/eight-comics-peel.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/render-peer-issues": patch
+---
+
+Fix white text on light background for project name [#8526](https://github.com/pnpm/pnpm/pull/8526).

--- a/packages/render-peer-issues/src/index.ts
+++ b/packages/render-peer-issues/src/index.ts
@@ -81,7 +81,7 @@ export function renderPeerIssues (
           `Peer dependencies that should be installed:\n  ${cliColumns(Object.entries(intersections).map(([name, version]) => formatNameAndRange(name, version)), cliColumnsOptions)}`
         )
       }
-      const title = chalk.white(projectKey)
+      const title = chalk.reset(projectKey)
       let summariesConcatenated = summaries.join('\n')
       if (summariesConcatenated) {
         summariesConcatenated += '\n'


### PR DESCRIPTION
Similar issue to https://github.com/pnpm/pnpm/pull/7454

White text on light background for project name.