### PR TITLE
fix: don't print a warning when printing packages globally

### DIFF
--- a/.changeset/shaggy-tools-jog.md
+++ b/.changeset/shaggy-tools-jog.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Don't print a warning when linking packages globally [#4761](https://github.com/pnpm/pnpm/issues/4761).

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1333,6 +1333,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       const projectToInstall = projects[index]
       if (opts.global && projectToInstall.mutation.includes('install')) {
         projectToInstall.wantedDependencies.forEach(pkg => {
+          // This warning is never printed currently during "pnpm link --global"
+          // due to the following issue: https://github.com/pnpm/pnpm/issues/4761
           if (pkg.alias && !linkedPackages?.includes(pkg.alias)) {
             logger.warn({ message: `${pkg.alias} has no binaries`, prefix: opts.lockfileDir })
           }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1333,8 +1333,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       const projectToInstall = projects[index]
       if (opts.global && projectToInstall.mutation.includes('install')) {
         projectToInstall.wantedDependencies.forEach(pkg => {
-          if (!linkedPackages?.includes(pkg.alias)) {
-            logger.warn({ message: `${pkg.alias ?? pkg.pref} has no binaries`, prefix: opts.lockfileDir })
+          if (pkg.alias && !linkedPackages?.includes(pkg.alias)) {
+            logger.warn({ message: `${pkg.alias} has no binaries`, prefix: opts.lockfileDir })
           }
         })
       }


### PR DESCRIPTION
close #4761