### PR TITLE
refactor: replace `forEach` with `for`-loops

### DIFF
--- a/__utils__/test-fixtures/src/index.ts
+++ b/__utils__/test-fixtures/src/index.ts
@@ -38,7 +38,7 @@ function copyFixture (searchFromDir: string, name: string, dest: string): void {
 function copyAndRename (src: string, dest: string): void {
   const entries = fs.readdirSync(src)
 
-  entries.forEach(entry => {
+  for (const entry of entries) {
     const srcPath = path.join(src, entry)
     const destPath = path.join(dest, entry.startsWith('_') ? entry.substring(1) : entry)
     const stats = fs.statSync(srcPath)
@@ -52,7 +52,7 @@ function copyAndRename (src: string, dest: string): void {
     } else if (stats.isFile()) {
       fs.copyFileSync(srcPath, destPath)
     }
-  })
+  }
 }
 
 function findFixture (dir: string, name: string): string {

--- a/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -84,12 +84,11 @@ function sanitizeFilenames (filenames: Record<string, string>): SanitizeFilename
 function tryImportIndexedDir (importFile: ImportFile, newDir: string, filenames: Record<string, string>): void {
   makeEmptyDir(newDir, { recursive: true })
   const allDirs = new Set<string>()
-  Object.keys(filenames)
-    .forEach((f) => {
-      const dir = path.dirname(f)
-      if (dir === '.') return
-      allDirs.add(dir)
-    })
+  for (const f in filenames) {
+    const dir = path.dirname(f)
+    if (dir === '.') return
+    allDirs.add(dir)
+  }
   Array.from(allDirs)
     .sort((d1, d2) => d1.length - d2.length) // from shortest to longest
     .forEach((dir) => fs.mkdirSync(path.join(newDir, dir), { recursive: true }))

--- a/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -86,7 +86,7 @@ function tryImportIndexedDir (importFile: ImportFile, newDir: string, filenames:
   const allDirs = new Set<string>()
   for (const f in filenames) {
     const dir = path.dirname(f)
-    if (dir === '.') return
+    if (dir === '.') continue
     allDirs.add(dir)
   }
   Array.from(allDirs)

--- a/hooks/read-package-hook/src/createPackageExtender.ts
+++ b/hooks/read-package-hook/src/createPackageExtender.ts
@@ -13,14 +13,14 @@ export function createPackageExtender (
   packageExtensions: Record<string, PackageExtension>
 ): ReadPackageHook {
   const extensionsByPkgName: ExtensionsByPkgName = new Map()
-  Object.entries(packageExtensions)
-    .forEach(([selector, packageExtension]) => {
-      const { alias, pref } = parseWantedDependency(selector)
-      if (!extensionsByPkgName.has(alias!)) {
-        extensionsByPkgName.set(alias!, [])
-      }
-      extensionsByPkgName.get(alias!)!.push({ packageExtension, range: pref })
-    })
+  for (const selector in packageExtensions) {
+    const packageExtension = packageExtensions[selector]
+    const { alias, pref } = parseWantedDependency(selector)
+    if (!extensionsByPkgName.has(alias!)) {
+      extensionsByPkgName.set(alias!, [])
+    }
+    extensionsByPkgName.get(alias!)!.push({ packageExtension, range: pref })
+  }
   return extendPkgHook.bind(null, extensionsByPkgName) as ReadPackageHook
 }
 

--- a/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
+++ b/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
@@ -220,9 +220,9 @@ function toImporterDepPaths (
   if (!nextImporterIds.length) {
     return depPaths
   }
-  nextImporterIds.forEach((importerId) => {
+  for (const importerId of nextImporterIds) {
     opts.importerIdSet.add(importerId)
-  })
+  }
   return [
     ...depPaths,
     ...toImporterDepPaths(lockfile, nextImporterIds, opts),

--- a/lockfile/pruner/src/index.ts
+++ b/lockfile/pruner/src/index.ts
@@ -67,9 +67,9 @@ export function pruneLockfile (
   const lockfileOptionalDependencies: ResolvedDependencies = {}
   const lockfileDevDependencies: ResolvedDependencies = {}
 
-  Object.entries(lockfileSpecs).forEach(([depName, spec]) => {
-    if (!allDeps.has(depName)) return
-    specifiers[depName] = spec
+  for (const depName in lockfileSpecs) {
+    if (!allDeps.has(depName)) continue
+    specifiers[depName] = lockfileSpecs[depName]
     if (importer.dependencies?.[depName]) {
       lockfileDependencies[depName] = importer.dependencies[depName]
     } else if (importer.optionalDependencies?.[depName]) {
@@ -77,7 +77,7 @@ export function pruneLockfile (
     } else if (importer.devDependencies?.[depName]) {
       lockfileDevDependencies[depName] = importer.devDependencies[depName]
     }
-  })
+  }
   if (importer.dependencies != null) {
     for (const [alias, dep] of Object.entries(importer.dependencies)) {
       if (

--- a/lockfile/walker/src/index.ts
+++ b/lockfile/walker/src/index.ts
@@ -64,7 +64,7 @@ export function lockfileWalker (
   const entryNodes = [] as DepPath[]
   const directDeps = [] as Array<{ alias: string, depPath: DepPath }>
 
-  importerIds.forEach((importerId) => {
+  for (const importerId of importerIds) {
     const projectSnapshot = lockfile.importers[importerId]
     Object.entries({
       ...(opts?.include?.devDependencies === false ? {} : projectSnapshot.devDependencies),
@@ -77,7 +77,7 @@ export function lockfileWalker (
         entryNodes.push(depPath)
         directDeps.push({ alias: pkgName, depPath })
       })
-  })
+  }
   return {
     directDeps,
     step: step({

--- a/network/auth-header/test/removePort.test.ts
+++ b/network/auth-header/test/removePort.test.ts
@@ -21,13 +21,13 @@ describe('removePort()', () => {
     const expectedOutput = (protocol: string) =>
       `${protocol}://custom.domain.com/artifactory/api/npm/npm-virtual/-/foo-1.0.0.tgz`
 
-    portsToTest.forEach((port: number) => {
-      protocols.forEach((protocol) => {
+    for (const port of portsToTest) {
+      for (const protocol of protocols) {
         expect(removePort(getUrl(port, protocol))).toEqual(
           expectedOutput(protocol)
         )
-      })
-    })
+      }
+    }
   })
 
   it('removes ports from valid urls with http, https, ws, wss protocols', () => {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1332,13 +1332,13 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       }
       const projectToInstall = projects[index]
       if (opts.global && projectToInstall.mutation.includes('install')) {
-        projectToInstall.wantedDependencies.forEach(pkg => {
+        for (const pkg of projectToInstall.wantedDependencies) {
           // This warning is never printed currently during "pnpm link --global"
           // due to the following issue: https://github.com/pnpm/pnpm/issues/4761
           if (pkg.alias && !linkedPackages?.includes(pkg.alias)) {
             logger.warn({ message: `${pkg.alias} has no binaries`, prefix: opts.lockfileDir })
           }
-        })
+        }
       }
     }))
 

--- a/pkg-manager/core/src/uninstall/removeDeps.ts
+++ b/pkg-manager/core/src/uninstall/removeDeps.ts
@@ -16,17 +16,16 @@ export async function removeDeps (
   if (opts.saveType) {
     if (packageManifest[opts.saveType] == null) return packageManifest
 
-    removedPackages.forEach((dependency) => {
+    for (const dependency of removedPackages) {
       delete packageManifest[opts.saveType as DependenciesField]![dependency]
-    })
+    }
   } else {
-    DEPENDENCIES_FIELDS
-      .filter((depField) => packageManifest[depField])
-      .forEach((depField) => {
-        removedPackages.forEach((dependency) => {
-          delete packageManifest[depField]![dependency]
-        })
-      })
+    for (const depField of DEPENDENCIES_FIELDS) {
+      if (!packageManifest[depField]) continue
+      for (const dependency of removedPackages) {
+        delete packageManifest[depField]![dependency]
+      }
+    }
   }
   if (packageManifest.peerDependencies != null) {
     for (const removedDependency of removedPackages) {

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -155,12 +155,12 @@ export async function getContext (
 
   await fs.mkdir(opts.storeDir, { recursive: true })
 
-  opts.allProjects.forEach((project) => {
+  for (const project of opts.allProjects) {
     packageManifestLogger.debug({
       initial: project.manifest,
       prefix: project.rootDir,
     })
-  })
+  }
   if (opts.readPackageHook != null) {
     await Promise.all(importersContext.projects.map(async (project) => {
       project.originalManifest = project.manifest

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -501,12 +501,12 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   if (!opts.ignoreScripts || Object.keys(opts.patchedDependencies ?? {}).length > 0) {
     const directNodes = new Set<string>()
     for (const id of union(importerIds, ['.'])) {
-      Object
-        .values(directDependenciesByImporterId[id] ?? {})
-        .filter((loc) => graph[loc])
-        .forEach((loc) => {
-          directNodes.add(loc)
-        })
+      const directDependencies = directDependenciesByImporterId[id]
+      for (const alias in directDependencies) {
+        const loc = directDependencies[alias]
+        if (!graph[loc]) continue
+        directNodes.add(loc)
+      }
     }
     const extraBinPaths = [...opts.extraBinPaths ?? []]
     if (opts.hoistPattern != null) {
@@ -681,14 +681,14 @@ async function symlinkDirectDependencies (
     symlink,
   }: SymlinkDirectDependenciesOpts
 ): Promise<number> {
-  projects.forEach(({ rootDir, manifest }) => {
+  for (const { rootDir, manifest } of projects) {
     // Even though headless installation will never update the package.json
     // this needs to be logged because otherwise install summary won't be printed
     packageManifestLogger.debug({
       prefix: rootDir,
       updated: manifest,
     })
-  })
+  }
   if (symlink === false) return 0
   const importerManifestsByImporterId = {} as { [id: string]: ProjectManifest }
   for (const { id, manifest } of projects) {

--- a/pkg-manager/modules-cleaner/src/prune.ts
+++ b/pkg-manager/modules-cleaner/src/prune.ts
@@ -76,7 +76,7 @@ export async function prune (
     const depsToRemove = new Set(
       (removePackages ?? []).filter((removePackage) => allCurrentPackages.has(removePackage))
     )
-    currentPkgs.forEach(([depName, depVersion]) => {
+    for (const [depName, depVersion] of currentPkgs) {
       if (
         !wantedPkgs[depName] ||
         wantedPkgs[depName] !== depVersion ||
@@ -84,7 +84,7 @@ export async function prune (
       ) {
         depsToRemove.add(depName)
       }
-    })
+    }
     if (pruneDirectDependencies) {
       const publiclyHoistedDeps = getPubliclyHoistedDependencies(opts.hoistedDependencies)
       if (allCurrentPackages.size > 0) {

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -221,14 +221,12 @@ function parseYarn2Lock (lockFileContents: string): YarnLock2Struct {
     parseRange
   )
 
-  Object.entries(parseYarnLock).forEach(
-    // eslint-disable-next-line
-    ([fullDescriptor, versionData]: [string, any]) => {
-      keyNormalizer(fullDescriptor).forEach((descriptor) => {
-        dependencies[descriptor] = versionData
-      })
+  for (const fullDescriptor in parseYarnLock) {
+    const versionData = parseYarnLock[fullDescriptor]
+    for (const descriptor of keyNormalizer(fullDescriptor)) {
+      dependencies[descriptor] = versionData
     }
-  )
+  }
   return {
     object: dependencies,
     type: YarnLockType.yarn2,

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -167,7 +167,7 @@ export async function resolveDependencies (
         project.modulesDir
       )
       : []
-    resolvedImporter.linkedDependencies.forEach((linkedDependency) => {
+    for (const linkedDependency of resolvedImporter.linkedDependencies) {
       // The location of the external link may vary on different machines, so it is better not to include it in the lockfile.
       // As a workaround, we symlink to the root of node_modules, which is a symlink to the actual location of the external link.
       const target = !opts.excludeLinksFromLockfile || isSubdir(opts.lockfileDir, linkedDependency.resolution.directory)
@@ -179,7 +179,7 @@ export async function resolveDependencies (
         version: linkedDependency.version,
         linkedDir,
       })
-    })
+    }
 
     return {
       binsDir: project.binsDir,
@@ -370,9 +370,9 @@ function addDirectDependenciesToLockfile (
     newProjectSnapshot.publishDirectory = newManifest.publishConfig.directory
   }
 
-  linkedPackages.forEach((linkedPkg) => {
+  for (const linkedPkg of linkedPackages) {
     newProjectSnapshot.specifiers[linkedPkg.alias] = getSpecFromPackageManifest(newManifest, linkedPkg.alias)
-  })
+  }
 
   const directDependenciesByAlias = directDependencies.reduce((acc, directDependency) => {
     acc[directDependency.alias] = directDependency

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1417,14 +1417,14 @@ async function resolveDependency (
   }
 
   if (pkg.peerDependencies != null) {
-    Object.keys(pkg.peerDependencies).forEach((name) => {
+    for (const name in pkg.peerDependencies) {
       ctx.allPeerDepNames.add(name)
-    })
+    }
   }
   if (pkg.peerDependenciesMeta != null) {
-    Object.keys(pkg.peerDependenciesMeta).forEach((name) => {
+    for (const name in pkg.peerDependenciesMeta) {
       ctx.allPeerDepNames.add(name)
-    })
+    }
   }
   // In case of leaf dependencies (dependencies that have no prod deps or peer deps),
   // we only ever need to analyze one leaf dep in a graph, so the nodeId can be short and stateless.

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -231,7 +231,7 @@ export async function resolveDependencyTree<T> (
   const { pkgAddressesByImporters, time } = await resolveRootDependencies(ctx, resolveArgs)
   const directDepsByImporterId = zipObj(importers.map(({ id }) => id), pkgAddressesByImporters)
 
-  ctx.pendingNodes.forEach((pendingNode) => {
+  for (const pendingNode of ctx.pendingNodes) {
     ctx.dependenciesTree.set(pendingNode.nodeId, {
       children: () => buildTree(ctx, pendingNode.resolvedPackage.id,
         pendingNode.parentIds,
@@ -240,7 +240,7 @@ export async function resolveDependencyTree<T> (
       installable: pendingNode.installable,
       resolvedPackage: pendingNode.resolvedPackage,
     })
-  })
+  }
 
   const resolvedImporters: ResolvedImporters = {}
 

--- a/pkg-manager/resolve-dependencies/src/resolvePeers.ts
+++ b/pkg-manager/resolve-dependencies/src/resolvePeers.ts
@@ -154,13 +154,13 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
   const depGraphWithResolvedChildren = resolveChildren(depGraph)
 
   function resolveChildren<T extends PartialResolvedPackage> (depGraph: GenericDependenciesGraph<T>): GenericDependenciesGraphWithResolvedChildren<T> {
-    Object.values(depGraph).forEach((node) => {
+    for (const node of Object.values(depGraph)) {
       node.children = {}
       for (const [alias, childNodeId] of Object.entries<NodeId>(node.childrenNodeIds)) {
         node.children[alias] = pathsByNodeId.get(childNodeId) ?? (childNodeId as unknown as DepPath)
       }
       delete node.childrenNodeIds
-    })
+    }
     return depGraph as unknown as GenericDependenciesGraphWithResolvedChildren<T>
   }
 
@@ -209,13 +209,13 @@ function deduplicateAll<T extends PartialResolvedPackage> (
   if (remainingDuplicates.length === duplicates.length) {
     return depPathsMap
   }
-  Object.values(depGraph).forEach((node) => {
+  for (const node of Object.values(depGraph)) {
     for (const [alias, childDepPath] of Object.entries<DepPath>(node.children)) {
       if (depPathsMap[childDepPath]) {
         node.children[alias] = depPathsMap[childDepPath]
       }
     }
-  })
+  }
   if (Object.keys(depPathsMap).length > 0) {
     return {
       ...depPathsMap,

--- a/pkg-manifest/exportable-manifest/src/overridePublishConfig.ts
+++ b/pkg-manifest/exportable-manifest/src/overridePublishConfig.ts
@@ -30,12 +30,12 @@ export function overridePublishConfig (publishManifest: ProjectManifest): void {
   const { publishConfig } = publishManifest
   if (!publishConfig) return
 
-  Object.entries(publishConfig)
-    .filter(([key]) => PUBLISH_CONFIG_WHITELIST.has(key))
-    .forEach(([key, value]) => {
-      publishManifest[key as keyof ProjectManifest] = value as any // eslint-disable-line @typescript-eslint/no-explicit-any
-      delete publishConfig[key]
-    })
+  for (const key in publishConfig) {
+    if (!PUBLISH_CONFIG_WHITELIST.has(key)) continue
+    const value = publishConfig[key]
+    publishManifest[key as keyof ProjectManifest] = value as any // eslint-disable-line @typescript-eslint/no-explicit-any
+    delete publishConfig[key]
+  }
 
   if (isEmpty(publishConfig)) {
     delete publishManifest.publishConfig

--- a/pkg-manifest/exportable-manifest/test/overridePublishConfig.test.ts
+++ b/pkg-manifest/exportable-manifest/test/overridePublishConfig.test.ts
@@ -25,7 +25,7 @@ test('publish config to be overridden', async () => {
   }
   overridePublishConfig(publishManifest)
 
-  Object.keys(publishConfig).forEach((publishConfigKey) => {
+  for (const publishConfigKey in publishConfig) {
     expect(publishManifest[publishConfigKey as keyof PackageManifest]).toEqual(publishConfig[publishConfigKey])
-  })
+  }
 })

--- a/pkg-manifest/manifest-utils/src/updateProjectManifestObject.ts
+++ b/pkg-manifest/manifest-utils/src/updateProjectManifestObject.ts
@@ -20,17 +20,17 @@ export async function updateProjectManifestObject (
   packageManifest: ProjectManifest,
   packageSpecs: PackageSpecObject[]
 ): Promise<ProjectManifest> {
-  packageSpecs.forEach((packageSpec) => {
+  for (const packageSpec of packageSpecs) {
     if (packageSpec.saveType) {
       const spec = packageSpec.pref ?? findSpec(packageSpec.alias, packageManifest)
       if (spec) {
         packageManifest[packageSpec.saveType] = packageManifest[packageSpec.saveType] ?? {}
         packageManifest[packageSpec.saveType]![packageSpec.alias] = spec
-        DEPENDENCIES_FIELDS.filter((depField) => depField !== packageSpec.saveType).forEach((deptype) => {
-          if (packageManifest[deptype] != null) {
-            delete packageManifest[deptype]![packageSpec.alias]
+        for (const deptype of DEPENDENCIES_FIELDS) {
+          if (deptype !== packageSpec.saveType) {
+            delete packageManifest[deptype]?.[packageSpec.alias]
           }
-        })
+        }
         if (packageSpec.peer === true) {
           packageManifest.peerDependencies = packageManifest.peerDependencies ?? {}
           packageManifest.peerDependencies[packageSpec.alias] = spec
@@ -49,7 +49,7 @@ export async function updateProjectManifestObject (
       }
       packageManifest.dependenciesMeta[packageSpec.alias] = { node: packageSpec.nodeExecPath }
     }
-  })
+  }
 
   packageManifestLogger.debug({
     prefix,

--- a/releasing/plugin-commands-deploy/test/deploy.test.ts
+++ b/releasing/plugin-commands-deploy/test/deploy.test.ts
@@ -42,10 +42,10 @@ test('deploy', async () => {
     },
   ])
 
-  ; ['project-1', 'project-2', 'project-3'].forEach(name => {
+  for (const name of ['project-1', 'project-2', 'project-3']) {
     fs.writeFileSync(`${name}/test.js`, '', 'utf8')
     fs.writeFileSync(`${name}/index.js`, '', 'utf8')
-  })
+  }
 
   const { allProjects, selectedProjectsGraph } = await filterPackagesFromDir(process.cwd(), [{ namePattern: 'project-1' }])
 
@@ -112,10 +112,10 @@ test('deploy in workspace with shared-workspace-lockfile=false', async () => {
     },
   ])
 
-  ; ['project-1', 'project-2', 'project-3'].forEach(name => {
+  for (const name of ['project-1', 'project-2', 'project-3']) {
     fs.writeFileSync(`${name}/test.js`, '', 'utf8')
     fs.writeFileSync(`${name}/index.js`, '', 'utf8')
-  })
+  }
 
   const { allProjects, selectedProjectsGraph } = await filterPackagesFromDir(process.cwd(), [{ namePattern: 'project-1' }])
 

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -86,16 +86,28 @@ export async function buildDependenciesHierarchy (
     virtualStoreDir: modules?.virtualStoreDir,
     virtualStoreDirMaxLength: modules?.virtualStoreDirMaxLength ?? maybeOpts.virtualStoreDirMaxLength,
   }
-  ; (
-    await Promise.all(projectPaths.map(async (projectPath) => {
-      return [
-        projectPath,
-        await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts),
-      ] as [string, DependenciesHierarchy]
-    }))
-  ).forEach(([projectPath, dependenciesHierarchy]) => {
+  // ; (
+  // //   await Promise.all(projectPaths.map(async (projectPath) => {
+  //     return [
+  //       projectPath,
+  //       await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts),
+  //     ] as [string, DependenciesHierarchy]
+  //   }))
+  // ).forEach(([projectPath, dependenciesHierarchy]) => {
+  //   result[projectPath] = dependenciesHierarchy
+  // })
+  const pairs = await Promise.all(projectPaths.map(async (projectPath) => {
+    return [
+      projectPath,
+      await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts),
+    ] as [string, DependenciesHierarchy]
+  }))
+  for (const [projectPath, dependenciesHierarchy] of pairs) {
     result[projectPath] = dependenciesHierarchy
-  })
+  }
+  // await Promise.all(projectPaths.map(async (projectPath) => {
+  //   result[projectPath] = await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts)
+  // }))
   return result
 }
 
@@ -150,7 +162,8 @@ async function dependenciesHierarchyForPackage (
   for (const dependenciesField of DEPENDENCIES_FIELDS.sort().filter(dependenciesField => opts.include[dependenciesField])) {
     const topDeps = currentLockfile.importers[importerId][dependenciesField] ?? {}
     result[dependenciesField] = []
-    Object.entries(topDeps).forEach(([alias, ref]) => {
+    for (const alias in topDeps) {
+      const ref = topDeps[alias]
       const packageInfo = getPkgInfo({
         alias,
         currentPackages: currentLockfile.packages ?? {},
@@ -173,9 +186,9 @@ async function dependenciesHierarchyForPackage (
         importers: currentLockfile.importers,
       })
       if (opts.onlyProjects && nodeId?.type !== 'importer') {
-        return
+        continue
       } else if (nodeId == null) {
-        if ((opts.search != null) && !matchedSearched) return
+        if ((opts.search != null) && !matchedSearched) continue
         newEntry = packageInfo
       } else {
         const dependencies = getChildrenTree(nodeId)
@@ -194,7 +207,7 @@ async function dependenciesHierarchyForPackage (
         }
         result[dependenciesField]!.push(newEntry)
       }
-    })
+    }
   }
 
   await Promise.all(

--- a/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
+++ b/reviewing/dependencies-hierarchy/src/buildDependenciesHierarchy.ts
@@ -86,16 +86,6 @@ export async function buildDependenciesHierarchy (
     virtualStoreDir: modules?.virtualStoreDir,
     virtualStoreDirMaxLength: modules?.virtualStoreDirMaxLength ?? maybeOpts.virtualStoreDirMaxLength,
   }
-  // ; (
-  // //   await Promise.all(projectPaths.map(async (projectPath) => {
-  //     return [
-  //       projectPath,
-  //       await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts),
-  //     ] as [string, DependenciesHierarchy]
-  //   }))
-  // ).forEach(([projectPath, dependenciesHierarchy]) => {
-  //   result[projectPath] = dependenciesHierarchy
-  // })
   const pairs = await Promise.all(projectPaths.map(async (projectPath) => {
     return [
       projectPath,
@@ -105,9 +95,6 @@ export async function buildDependenciesHierarchy (
   for (const [projectPath, dependenciesHierarchy] of pairs) {
     result[projectPath] = dependenciesHierarchy
   }
-  // await Promise.all(projectPaths.map(async (projectPath) => {
-  //   result[projectPath] = await dependenciesHierarchyForPackage(projectPath, currentLockfile, wantedLockfile, opts)
-  // }))
   return result
 }
 

--- a/reviewing/dependencies-hierarchy/src/getTree.ts
+++ b/reviewing/dependencies-hierarchy/src/getTree.ts
@@ -125,7 +125,8 @@ function getTreeHelper (
   let resultHeight: number | 'unknown' = 0
   let resultCircular: boolean = false
 
-  Object.entries(deps).forEach(([alias, ref]) => {
+  for (const alias in deps) {
+    const ref = deps[alias]
     const packageInfo = getPkgInfo({
       alias,
       currentPackages: opts.currentPackages,
@@ -151,7 +152,7 @@ function getTreeHelper (
     })
 
     if (opts.onlyProjects && nodeId?.type !== 'importer') {
-      return
+      continue
     } else if (nodeId == null) {
       circular = false
       if (opts.search == null || matchedSearched) {
@@ -214,7 +215,7 @@ function getTreeHelper (
         resultDependencies.push(newEntry)
       }
     }
-  })
+  }
 
   const result: DependencyInfo = {
     dependencies: resultDependencies,

--- a/reviewing/license-scanner/src/licenses.ts
+++ b/reviewing/license-scanner/src/licenses.ts
@@ -109,13 +109,13 @@ export async function findDependencyLicenses (opts: {
     const licenseNode = licenseNodeTree.dependencies[dependencyName]
     const dependenciesOfNode = getDependenciesFromLicenseNode(licenseNode)
 
-    dependenciesOfNode.forEach((dependencyNode) => {
+    for (const dependencyNode of dependenciesOfNode) {
       const mapKey = `${dependencyNode.name}@${dependencyNode.version}`
       const existingVersion = licensePackages.get(mapKey)?.version
       if (existingVersion === undefined) {
         licensePackages.set(mapKey, dependencyNode)
       }
-    })
+    }
   }
 
   // Get all non-duplicate dependencies of the project

--- a/reviewing/plugin-commands-outdated/src/recursive.ts
+++ b/reviewing/plugin-commands-outdated/src/recursive.ts
@@ -68,13 +68,13 @@ export async function outdatedRecursive (
   })
   for (let i = 0; i < outdatedPackagesByProject.length; i++) {
     const { rootDir, manifest } = pkgs[i]
-    outdatedPackagesByProject[i].forEach((outdatedPkg) => {
+    for (const outdatedPkg of outdatedPackagesByProject[i]) {
       const key = JSON.stringify([outdatedPkg.packageName, outdatedPkg.current, outdatedPkg.belongsTo])
       if (!outdatedMap[key]) {
         outdatedMap[key] = { ...outdatedPkg, dependentPkgs: [] }
       }
       outdatedMap[key].dependentPkgs.push({ location: rootDir, manifest })
-    })
+    }
   }
 
   let output!: string

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -52,16 +52,16 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
   const cafsChildrenDirs = fs.readdirSync(cafsDir, { withFileTypes: true }).filter(file => file.isDirectory())
   const indexFiles: string[] = []; const result: FindHashResult[] = []
 
-  cafsChildrenDirs.forEach(({ name: dirName }) => {
+  for (const { name: dirName } of cafsChildrenDirs) {
     const dirIndexFiles = fs
       .readdirSync(`${cafsDir}/${dirName}`)
       .filter((fileName) => fileName.includes('-index.json'))
       ?.map((fileName) => `${cafsDir}/${dirName}/${fileName}`)
 
     indexFiles.push(...dirIndexFiles)
-  })
+  }
 
-  indexFiles.forEach(filesIndexFile => {
+  for (const filesIndexFile of indexFiles) {
     const pkgFilesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
 
     for (const [, file] of Object.entries(pkgFilesIndex.files)) {
@@ -69,7 +69,7 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
         result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 
         // a package is only found once.
-        return
+        continue
       }
     }
 
@@ -80,12 +80,12 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 
             // a package is only found once.
-            return
+            continue
           }
         }
       }
     }
-  })
+  }
 
   if (!result.length) {
     throw new PnpmError(

--- a/workspace/filter-workspace-packages/src/index.ts
+++ b/workspace/filter-workspace-packages/src/index.ts
@@ -276,23 +276,23 @@ async function _filterGraph<Pkg extends Package> (
 
 function pkgGraphToGraph<Pkg extends Package> (pkgGraph: PackageGraph<Pkg>): Graph {
   const graph: Graph = {}
-  ;(Object.keys(pkgGraph) as ProjectRootDir[]).forEach((nodeId) => {
+  for (const nodeId of Object.keys(pkgGraph) as ProjectRootDir[]) {
     graph[nodeId] = pkgGraph[nodeId].dependencies
-  })
+  }
   return graph
 }
 
 function reverseGraph (graph: Graph): Graph {
   const reversedGraph: Graph = {}
-  ;(Object.keys(graph) as ProjectRootDir[]).forEach((dependentNodeId) => {
-    graph[dependentNodeId].forEach((dependencyNodeId) => {
+  for (const dependentNodeId of Object.keys(graph) as ProjectRootDir[]) {
+    for (const dependencyNodeId of graph[dependentNodeId]) {
       if (!reversedGraph[dependencyNodeId]) {
         reversedGraph[dependencyNodeId] = [dependentNodeId]
       } else {
         reversedGraph[dependencyNodeId].push(dependentNodeId)
       }
-    })
-  })
+    }
+  }
   return reversedGraph
 }
 


### PR DESCRIPTION
Changes:
* Most `Object.keys(object).forEach` are replaced by `for in`.
* Most `array.filter(condition).forEach` are replaced by `for of` + `if (!condition) continue`.
* `return` in `forEach` callbacks are replaced by `continue`.

There may be minor improvement to memory footprint as this change would reduce the creations of temporary arrays and temporary functions.