### PR TITLE
Fix `Maximum call stack size exceeded` error related to circular workspace dependencies

### DIFF
--- a/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
+++ b/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
@@ -215,11 +215,14 @@ function toImporterDepPaths (
     }))
     .map(Object.entries)
 
-  const { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
+  let { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
 
   if (!nextImporterIds.length) {
     return depPaths
   }
+  
+  nextImporterIds = nextImporterIds.filter(x => !opts.importerIdSet.has(x))
+
   nextImporterIds.forEach((importerId) => {
     opts.importerIdSet.add(importerId)
   })


### PR DESCRIPTION
Recently I encountered many `Maximum call stack size exceeded` errors for the `toImporterDepPaths` function when trying to add a package, in a repo that uses circular workspace deps.

This is only happening with a recent update, I had to use this patch to continue installing packages but did not manage to create a minimal repro.