### PR TITLE
fixes #8543: incorrect self update command provided

### DIFF
--- a/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -51,11 +51,11 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 }
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
-  if (opts.env.PNPM_HOME) {
-    return 'pnpm self-update'
-  }
   if (isExecutedByCorepack(opts.env)) {
     return `corepack install -g pnpm@${opts.latestVersion}`
+  }
+  if (opts.env.PNPM_HOME) {
+    return 'pnpm self-update'
   }
   const pkgName = opts.currentPkgIsExecutable ? '@pnpm/exe' : 'pnpm'
   return `pnpm add -g ${pkgName}`


### PR DESCRIPTION
`echo $PNPM_HOME`
gives output:
/Users/matthew/Library/pnpm

so the check `isExecutedByCorepack(opts.env)`
needs to come first to avoid the issue #8543 
