### PR TITLE
fix(store prune): will not fail if store dir does not exist

### DIFF
--- a/.changeset/silly-teachers-cry.md
+++ b/.changeset/silly-teachers-cry.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/package-store": patch
+---
+
+`pnpm store prune` should not fail if the store directory doesn't exist.

--- a/store/package-store/src/storeController/prune.ts
+++ b/store/package-store/src/storeController/prune.ts
@@ -24,9 +24,18 @@ export async function prune ({ cacheDir, storeDir }: PruneOptions, removeAlienFi
   globalInfo('Removed all cached metadata files')
   const pkgIndexFiles = [] as string[]
   const removedHashes = new Set<string>()
-  const dirs = (await fs.readdir(cafsDir, { withFileTypes: true }).catch(() => []))
-    .filter(entry => entry.isDirectory())
-    .map(dir => dir.name)
+  const dirs = await fs.readdir(cafsDir, { withFileTypes: true })
+    .then((entries) => {
+      return entries
+        .filter(entry => entry.isDirectory())
+        .map(dir => dir.name)
+    })
+    .catch((error) => {
+      if (error.code === 'ENOENT') {
+        return []
+      }
+      return Promise.reject(error)
+    })
   let fileCounter = 0
   await Promise.all(dirs.map(async (dir) => {
     const subdir = path.join(cafsDir, dir)

--- a/store/package-store/src/storeController/prune.ts
+++ b/store/package-store/src/storeController/prune.ts
@@ -24,7 +24,7 @@ export async function prune ({ cacheDir, storeDir }: PruneOptions, removeAlienFi
   globalInfo('Removed all cached metadata files')
   const pkgIndexFiles = [] as string[]
   const removedHashes = new Set<string>()
-  const dirs = (await fs.readdir(cafsDir, { withFileTypes: true }))
+  const dirs = (await fs.readdir(cafsDir, { withFileTypes: true }).catch(() => []))
     .filter(entry => entry.isDirectory())
     .map(dir => dir.name)
   let fileCounter = 0

--- a/store/package-store/src/storeController/prune.ts
+++ b/store/package-store/src/storeController/prune.ts
@@ -1,4 +1,5 @@
-import { promises as fs } from 'fs'
+import { type Dirent, promises as fs } from 'fs'
+import util from 'util'
 import path from 'path'
 import { type PackageFilesIndex } from '@pnpm/store.cafs'
 import { globalInfo, globalWarn } from '@pnpm/logger'
@@ -24,18 +25,7 @@ export async function prune ({ cacheDir, storeDir }: PruneOptions, removeAlienFi
   globalInfo('Removed all cached metadata files')
   const pkgIndexFiles = [] as string[]
   const removedHashes = new Set<string>()
-  const dirs = await fs.readdir(cafsDir, { withFileTypes: true })
-    .then((entries) => {
-      return entries
-        .filter(entry => entry.isDirectory())
-        .map(dir => dir.name)
-    })
-    .catch((error) => {
-      if (error.code === 'ENOENT') {
-        return []
-      }
-      return Promise.reject(error)
-    })
+  const dirs = await getSubdirsSafely(cafsDir)
   let fileCounter = 0
   await Promise.all(dirs.map(async (dir) => {
     const subdir = path.join(cafsDir, dir)
@@ -75,4 +65,19 @@ export async function prune ({ cacheDir, storeDir }: PruneOptions, removeAlienFi
     }
   }))
   globalInfo(`Removed ${pkgCounter} package${pkgCounter === 1 ? '' : 's'}`)
+}
+
+async function getSubdirsSafely (dir: string): Promise<string[]> {
+  let entries: Dirent[]
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true }) as Dirent[]
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return []
+    }
+    throw err
+  }
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(dir => dir.name)
 }

--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -281,6 +281,43 @@ test('prune removes alien files from the store if the --force flag is used', asy
   expect(fs.existsSync(alienDir)).toBeFalsy()
 })
 
+test('prune does not fail if the store directly does not exist', async () => {
+  const cacheDir = path.resolve('cache')
+  const storeDir = path.resolve('store')
+  const reporter = jest.fn()
+
+  await expect(
+    store.handler({
+      cacheDir,
+      dir: process.cwd(),
+      pnpmHomeDir: '',
+      rawConfig: {
+        registry: REGISTRY,
+      },
+      registries: { default: REGISTRY },
+      reporter,
+      storeDir,
+      userConfig: {},
+      dlxCacheMaxAge: Infinity,
+      virtualStoreDirMaxLength: 120,
+    }, ['prune'])
+  ).resolves.toBeUndefined()
+
+  expect(reporter).toHaveBeenCalledWith(
+    expect.objectContaining({
+      level: 'info',
+      message: 'Removed 0 files',
+    })
+  )
+
+  expect(reporter).toHaveBeenCalledWith(
+    expect.objectContaining({
+      level: 'info',
+      message: 'Removed 0 packages',
+    })
+  )
+})
+
 function createSampleDlxCacheLinkTarget (dirPath: string): void {
   fs.mkdirSync(path.join(dirPath, 'node_modules', '.pnpm'), { recursive: true })
   fs.mkdirSync(path.join(dirPath, 'node_modules', '.bin'), { recursive: true })


### PR DESCRIPTION
If you attempt to prune the store but the store doesn't yet exist:

```sh
mkdir store-prune-test
cd store-prune-test
corepack pnpm@9 init
corepack use pnpm@9
echo "store-dir=./store" > .npmrc
pnpm store prune
```

You'll receive the following error:

```sh
Removed all cached metadata files
 ENOENT  ENOENT: no such file or directory, scandir '/<HOME>/tmp/pnpm-no-modules/store/v3/files'

pnpm: ENOENT: no such file or directory, scandir '/<HOME>/tmp/pnpm-no-modules/store/v3/files'
    at async Object.readdir (node:internal/fs/promises:950:18)
    at async prune (/<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:135292:21)
    at async storePrune (/<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:231814:7)
    at async /<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:234402:21
    at async main (/<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:234361:34)
    at async runPnpm (/<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:234631:5)
    at async /<HOME>/.cache/node/corepack/v1/pnpm/9.11.0/dist/pnpm.cjs:234623:7
```

This PR fixes this so no error occurs if the store dir doesn't exist. It will instead be treated as if there was a store dir but it was empty.