### PR TITLE
fix: prevent `ENOENT` caused by parallel `store prune`

### DIFF
--- a/.changeset/grumpy-taxis-own.md
+++ b/.changeset/grumpy-taxis-own.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-store": patch
+"pnpm": patch
+---
+
+Prevent ENOENT errors caused by running `store prune` in parallel.

--- a/cspell.json
+++ b/cspell.json
@@ -57,6 +57,7 @@
     "enametoolong",
     "endregion",
     "eneedauth",
+    "enoent",
     "enten",
     "eperm",
     "etamponi",

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.test.ts
@@ -78,7 +78,7 @@ test('cleanExpiredCache removes items that outlive dlxCacheMaxAge', async () => 
   )
   expect(rmSpy).toHaveBeenCalledWith(
     expect.stringContaining(path.join(cacheDir, 'dlx', createCacheKey('baz'))),
-    { recursive: true }
+    { recursive: true, force: true }
   )
 
   readdirSyncSpy.mockRestore()
@@ -117,7 +117,7 @@ test('cleanExpiredCache removes all directories without checking stat if dlxCach
   expect(readdirSyncSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx'), expect.anything())
   expect(lstatSpy).not.toHaveBeenCalled()
   for (const key of ['foo', 'bar', 'baz']) {
-    expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createCacheKey(key)), { recursive: true })
+    expect(rmSpy).toHaveBeenCalledWith(path.join(cacheDir, 'dlx', createCacheKey(key)), { recursive: true, force: true })
   }
 
   readdirSyncSpy.mockRestore()

--- a/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
+++ b/store/plugin-commands-store/src/cleanExpiredDlxCache.ts
@@ -30,7 +30,7 @@ export async function cleanExpiredDlxCache ({
     }
     if (shouldClean) {
       // delete the symlink, the symlink's target, and orphans (if any)
-      await fs.rm(dlxCachePath, { recursive: true })
+      await fs.rm(dlxCachePath, { recursive: true, force: true })
     }
   }))
 
@@ -45,7 +45,7 @@ export async function cleanOrphans (dlxCacheDir: string): Promise<void> {
     const dlxCacheLink = path.join(dlxCachePath, 'pkg')
     const dlxCacheLinkStats = await getStats(dlxCacheLink)
     if (dlxCacheLinkStats === 'ENOENT') {
-      return fs.rm(dlxCachePath, { recursive: true })
+      return fs.rm(dlxCachePath, { recursive: true, force: true })
     }
     const dlxCacheLinkTarget = await getRealPath(dlxCacheLink)
     const children = await fs.readdir(dlxCachePath)
@@ -53,7 +53,7 @@ export async function cleanOrphans (dlxCacheDir: string): Promise<void> {
       if (name === 'pkg') return
       const fullPath = path.join(dlxCachePath, name)
       if (fullPath === dlxCacheLinkTarget) return
-      await fs.rm(fullPath, { recursive: true })
+      await fs.rm(fullPath, { recursive: true, force: true })
     }))
   }))
 }


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/8579