### PR TITLE
chore: output the registry address when running the `view versions` command

### DIFF
--- a/pnpm/src/runNpm.ts
+++ b/pnpm/src/runNpm.ts
@@ -14,5 +14,8 @@ export async function runNpm (args: string[]): Promise<SpawnSyncReturns<Buffer>>
       ], allTypes),
     },
   })
+  if (args[0] === 'view' && args[2] === 'versions') {
+    console.log('registry: ' + config.registry)
+  }
   return _runNpm(config.npmPath, args)
 }


### PR DESCRIPTION
When you specify the value of the registry, if you install a recently released package, the mirror source may not be synchronized yet so the installation will report an error.

Currently, if you execute `pnpm view pkg versions`, the printed version will not include the latest version, which may cause some trouble to the user. 

Therefore, printing the value of the registry at this time may help users quickly locate the problem.

similar issue #7442