### PR TITLE
Fix maximum call stack size exceeded error related to circular workspace dependencies

### DIFF
--- a/.changeset/many-cycles-search.md
+++ b/.changeset/many-cycles-search.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/lockfile.filtering": patch
+"pnpm": patch
 ---
 
-Fix Maximum call stack size exceeded error related to circular workspace dependencies
+Fix maximum call stack size exceeded error related to circular workspace dependencies [#8599](https://github.com/pnpm/pnpm/pull/8599).

--- a/.changeset/many-cycles-search.md
+++ b/.changeset/many-cycles-search.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lockfile.filtering": patch
+---
+
+Fix Maximum call stack size exceeded error related to circular workspace dependencies

--- a/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
+++ b/lockfile/filtering/src/filterLockfileByImportersAndEngine.ts
@@ -215,11 +215,12 @@ function toImporterDepPaths (
     }))
     .map(Object.entries)
 
-  const { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
+  let { depPaths, importerIds: nextImporterIds } = parseDepRefs(unnest(importerDeps), lockfile)
 
   if (!nextImporterIds.length) {
     return depPaths
   }
+  nextImporterIds = nextImporterIds.filter(importerId => !opts.importerIdSet.has(importerId))
   for (const importerId of nextImporterIds) {
     opts.importerIdSet.add(importerId)
   }

--- a/lockfile/plugin-commands-audit/src/audit.ts
+++ b/lockfile/plugin-commands-audit/src/audit.ts
@@ -266,7 +266,7 @@ function reportSummary (vulnerabilities: AuditVulnerabilityCounts, totalVulnerab
   return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${
     Object.entries(vulnerabilities)
       .filter(([auditLevel, vulnerabilitiesCount]) => vulnerabilitiesCount > 0)
-      .map(([auditLevel, vulnerabilitiesCount]) => AUDIT_COLOR[auditLevel as AuditLevelString](`${vulnerabilitiesCount} ${auditLevel}`))
+      .map(([auditLevel, vulnerabilitiesCount]) => AUDIT_COLOR[auditLevel as AuditLevelString](`${vulnerabilitiesCount as string} ${auditLevel}`))
       .join(' | ')
   }`
 }


### PR DESCRIPTION
Recently I encountered many Maximum call stack size exceeded errors for the toImporterDepPaths function when trying to add a package, in a repo that uses circular workspace deps.

This is only happening with a recent update, I had to use this patch to continue installing packages but did not manage to create a minimal repro.