### PR TITLE
fix: prevent `EBUSY` caused by parallel `dlx`

### DIFF
--- a/.changeset/green-bikes-sparkle.md
+++ b/.changeset/green-bikes-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+Prevent `EBUSY` errors caused by calling `symlinkDir` in parallel `dlx` processes.

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -95,7 +95,9 @@ export async function handler (
       await symlinkDir(cachedDir, cacheLink, { overwrite: true })
     } catch (error) {
       // EBUSY means that there is another dlx process running in parallel that has acquired the cache link first.
-      // The current process should yield.
+      // The link created by the other process is just as up-to-date as the link the current process was attempting
+      // to create. Therefore, instead of re-attempting to create the current link again, it is just as good to let
+      // the other link stays. The current process should yield.
       if (util.types.isNativeError(error) && 'code' in error && error.code === 'EBUSY') {
         await new Promise(resolve => setTimeout(resolve, 0))
       } else {

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -97,7 +97,7 @@ export async function handler (
       // EBUSY means that there is another dlx process running in parallel that has acquired the cache link first.
       // The link created by the other process is just as up-to-date as the link the current process was attempting
       // to create. Therefore, instead of re-attempting to create the current link again, it is just as good to let
-      // the other link stays. The current process should yield.
+      // the other link stay. The current process should yield.
       if (util.types.isNativeError(error) && 'code' in error && error.code === 'EBUSY') {
         await new Promise(resolve => setTimeout(resolve, 0))
       } else {

--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -98,9 +98,7 @@ export async function handler (
       // The link created by the other process is just as up-to-date as the link the current process was attempting
       // to create. Therefore, instead of re-attempting to create the current link again, it is just as good to let
       // the other link stay. The current process should yield.
-      if (util.types.isNativeError(error) && 'code' in error && error.code === 'EBUSY') {
-        await new Promise(resolve => setTimeout(resolve, 0))
-      } else {
+      if (!util.types.isNativeError(error) || !('code' in error) || error.code !== 'EBUSY') {
         throw error
       }
     }


### PR DESCRIPTION
The error log from the [last CI failure](https://github.com/pnpm/pnpm/actions/runs/11167032739/job/31049686221?pr=8597):

```log
2024-10-03T21:08:32.6409045Z  EBUSY  EBUSY: resource busy or locked, unlink 'D:\a\pnpm\pnpm_tmp\101_4308\9\project\cache\dlx\v26vuq7etgal3io6jt4obph2cy\pkg'
2024-10-03T21:08:32.6410308Z
2024-10-03T21:08:32.6411283Z pnpm: EBUSY: resource busy or locked, unlink 'D:\a\pnpm\pnpm_tmp\101_4308\9\project\cache\dlx\v26vuq7etgal3io6jt4obph2cy\pkg'
2024-10-03T21:08:32.6412559Z     at async Object.unlink (node:internal/fs/promises:1066:10)
2024-10-03T21:08:32.6413401Z     at async forceSymlink (D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:105133:7)
2024-10-03T21:08:32.6414373Z     at async Object.handler [as dlx] (D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:224929:9)
2024-10-03T21:08:32.6415256Z     at async D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:234531:21
2024-10-03T21:08:32.6416005Z     at async main (D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:234490:34)
2024-10-03T21:08:32.6416809Z     at async runPnpm (D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:234761:5)
2024-10-03T21:08:32.6417572Z     at async D:\a\pnpm\pnpm\pnpm\dist\pnpm.cjs:234753:7
2024-10-03T21:08:32.7994631Z  LOGGING RETRY ERRORS  parallel dlx calls of the same package
2024-10-03T21:08:32.8079887Z  RETRY 1
2024-10-03T21:08:32.8080173Z
2024-10-03T21:08:32.8080550Z     Exit code 4294963214
2024-10-03T21:08:32.8081092Z
2024-10-03T21:08:32.8081544Z       34 |
2024-10-03T21:08:32.8082289Z       35 |       if (code > 0) {
2024-10-03T21:08:32.8083550Z     > 36 |         reject(new Error(`Exit code ${code}`))
2024-10-03T21:08:32.8084657Z          |                ^
2024-10-03T21:08:32.8085357Z       37 |       } else {
2024-10-03T21:08:32.8086003Z       38 |         resolve()
2024-10-03T21:08:32.8086605Z       39 |       }
2024-10-03T21:08:32.8086932Z
2024-10-03T21:08:32.8087269Z       at ChildProcess.<anonymous> (test/utils/execPnpm.ts:36:16)
2024-10-03T21:08:32.8088967Z       at ChildProcess.cp.emit (../node_modules/.pnpm/cross-spawn@7.0.3/node_modules/cross-spawn/lib/enoent.js:34:29)
2024-10-03T21:08:32.8089895Z
2024-10-03T21:08:32.8090072Z FAIL test/dlx.ts (107.889 s)
2024-10-03T21:08:32.8090925Z   ● parallel dlx calls of the same package
2024-10-03T21:08:32.8091354Z
2024-10-03T21:08:32.8091515Z     Exit code 4294963214
2024-10-03T21:08:32.8091789Z
2024-10-03T21:08:32.8091993Z       34 |
2024-10-03T21:08:32.8092662Z       35 |       if (code > 0) {
2024-10-03T21:08:32.8093864Z     > 36 |         reject(new Error(`Exit code ${code}`))
2024-10-03T21:08:32.8094918Z          |                ^
2024-10-03T21:08:32.8095607Z       37 |       } else {
2024-10-03T21:08:32.8096226Z       38 |         resolve()
2024-10-03T21:08:32.8096788Z       39 |       }
2024-10-03T21:08:32.8097113Z
2024-10-03T21:08:32.8097420Z       at ChildProcess.<anonymous> (test/utils/execPnpm.ts:36:16)
2024-10-03T21:08:32.8098848Z       at ChildProcess.cp.emit (../node_modules/.pnpm/cross-spawn@7.0.3/node_modules/cross-spawn/lib/enoent.js:34:29)
```