### PR TITLE
fix(windows): splat arguments for pnpx

### DIFF
--- a/.changeset/forty-goats-exist.md
+++ b/.changeset/forty-goats-exist.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-setup": patch
+"pnpm": patch
+---
+
+The pnpx command should work correctly on Windows, when pnpm is installed via the standalone installation script [#8608](https://github.com/pnpm/pnpm/pull/8608).

--- a/packages/plugin-commands-setup/src/setup.ts
+++ b/packages/plugin-commands-setup/src/setup.ts
@@ -86,7 +86,7 @@ function createPnpxScripts (targetDir: string): void {
     ].join('\n')
     fs.writeFileSync(path.join(targetDir, 'pnpx.cmd'), batchScript)
 
-    const powershellScript = 'pnpm dlx $args'
+    const powershellScript = 'pnpm dlx @args'
     fs.writeFileSync(path.join(targetDir, 'pnpx.ps1'), powershellScript)
   }
 }


### PR DESCRIPTION
Here, using `$args` causes powershell to join the entire array of arguments into a single string, so we should expand the `args` array using the splat operator (`@`) to keep argument semantics.

Before:
```
PS > pnpx serve ./output
ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  serve ./output isn't supported by any available resolver.
```

After:
```
PS > pnpx serve ./output
[ output omitted ]
```