### PR TITLE
fix: .pnpm/<module name> with hash character breaks vite build

### DIFF
--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -165,7 +165,7 @@ export function parse (dependencyPath: string): DependencyPath {
 }
 
 export function depPathToFilename (depPath: string, maxLengthWithoutHash: number): string {
-  let filename = depPathToFilenameUnescaped(depPath).replace(/[\\/:*?"<>|]/g, '+')
+  let filename = depPathToFilenameUnescaped(depPath).replace(/[\\/:*?"<>|#]/g, '+')
   if (filename.includes('(')) {
     filename = filename
       .replace(/\)$/, '')

--- a/packages/dependency-path/test/index.ts
+++ b/packages/dependency-path/test/index.ts
@@ -91,6 +91,7 @@ test('depPathToFilename()', () => {
   expect(depPathToFilename('\\//:*?"<>|', 120)).toBe('++++++++++')
   expect(depPathToFilename('/foo@1.0.0(react@16.0.0)(react-dom@16.0.0)', 120)).toBe('foo@1.0.0_react@16.0.0_react-dom@16.0.0')
   expect(depPathToFilename('/foo@1.0.0(react@16.0.0(react-dom@1.0.0))(react-dom@16.0.0)', 120)).toBe('foo@1.0.0_react@16.0.0_react-dom@1.0.0__react-dom@16.0.0')
+  expect(depPathToFilename('github.com/something/foo/0000?v=1#sub/dir', 120)).toBe('github.com+something+foo+0000+v=1+sub+dir')
 
   const filename = depPathToFilename('file:test/foo-1.0.0.tgz_foo@2.0.0', 120)
   expect(filename).toBe('file+test+foo-1.0.0.tgz_foo@2.0.0')


### PR DESCRIPTION
A git repo dependency uses the '#' character to separate the url/project from a subdirectory, semver, or committish. If this character is present in directory name created under node_modules/.pnpm then vite build cannot find sub-dependencies.

Since naming is changed node_modules should be cleaned and re-installed.