### PR TITLE
fix: unprefixed package name in readme

### DIFF
--- a/packages/dependency-path/README.md
+++ b/packages/dependency-path/README.md
@@ -1,4 +1,4 @@
-# dependency-path
+# @pnpm/dependency-path
 
 > Utilities for working with symlinked node_modules
 
@@ -12,7 +12,7 @@ Like `path` but for packages in a symlinked `node_modules`. Symlinked `node_modu
 ## Installation
 
 ```sh
-pnpm add dependency-path
+pnpm add @pnpm/dependency-path
 ```
 
 ## Usage
@@ -20,7 +20,7 @@ pnpm add dependency-path
 <!--/* cspell:disable */-->
 <!--@example('./example.js')-->
 ```js
-const dependencyPath = require('dependency-path')
+const dependencyPath = require('@pnpm/dependency-path')
 
 const registry = 'https://registry.npmjs.org/'
 


### PR DESCRIPTION
It seems the `@pnpm/dependency-path` package _was_ previously published under just `dependency-path`, but is now published under `@pnpm/dependency-path`. Ideally the old one should be deprecated and pointed to this one.