### PR TITLE
feat!: remove prettier and eslint from the default value of public-hoist-pattern

### DIFF
--- a/.changeset/honest-fans-sip.md
+++ b/.changeset/honest-fans-sip.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": major
+"pnpm": major
+---
+
+Do not hoist to the root of `node_modules` packages that contain the word `eslint` or `prettier` in their name. Changed the default value of the `public-hoist-pattern` setting [#8378](https://github.com/pnpm/pnpm/issues/8378).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -157,10 +157,7 @@ export async function getConfig (opts: {
     'package-manager-strict': process.env.COREPACK_ENABLE_STRICT !== '0',
     'package-manager-strict-version': false,
     'prefer-workspace-packages': false,
-    'public-hoist-pattern': [
-      '*eslint*',
-      '*prettier*',
-    ],
+    'public-hoist-pattern': [],
     'recursive-install': true,
     registry: npmDefaults.registry,
     'resolution-mode': 'highest',


### PR DESCRIPTION
close #8378