### PR TITLE
fix: detecting files with executable permissions in side effects cache

### DIFF
--- a/.changeset/olive-pants-know.md
+++ b/.changeset/olive-pants-know.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/store.cafs": patch
+"pnpm": patch
+---
+
+When checking whether a file in the store has executable permissions, the new approach checks if at least one of the executable bits (owner, group, and others) is set to 1. Previously, a file was incorrectly considered executable only when all the executable bits were set to 1. This fix ensures that files with any executable permission, regardless of the user class, are now correctly identified as executable [#8546](https://github.com/pnpm/pnpm/issues/8546).

--- a/store/cafs/src/getFilePathInCafs.ts
+++ b/store/cafs/src/getFilePathInCafs.ts
@@ -1,7 +1,20 @@
 import path from 'path'
 import ssri, { type IntegrityLike } from 'ssri'
 
-export const modeIsExecutable = (mode: number): boolean => (mode & 0o111) === 0o111
+/**
+ * Checks if a file mode has any executable permissions set.
+ *
+ * This function performs a bitwise check to determine if at least one of the
+ * executable bits (owner, group, or others) is set in the file mode.
+ *
+ * The bit mask `0o111` corresponds to the executable bits for the owner (0o100),
+ * group (0o010), and others (0o001). If any of these bits are set, the file
+ * is considered executable.
+ *
+ * @param {number} mode - The file mode (permission bits) to check.
+ * @returns {boolean} - Returns true if any of the executable bits are set, false otherwise.
+ */
+export const modeIsExecutable = (mode: number): boolean => (mode & 0o111) !== 0
 
 export type FileType = 'exec' | 'nonexec' | 'index'
 


### PR DESCRIPTION
close #8546
close #7746