### PR TITLE
perf: use `hash` to replace `createHash`

### DIFF
--- a/.changeset/lemon-sheep-rhyme.md
+++ b/.changeset/lemon-sheep-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/crypto.polyfill": major
+---
+
+Initial release.

--- a/.changeset/quiet-carrots-march.md
+++ b/.changeset/quiet-carrots-march.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/npm-resolver": patch
+"@pnpm/core": patch
+"@pnpm/crypto.polyfill": patch
+"@pnpm/list": patch
+"@pnpm/worker": patch
+"pnpm": patch
+---
+
+Use `crypto.hash`, when available, for improved performance [#8629](https://github.com/pnpm/pnpm/pull/8629).

--- a/crypto/polyfill/README.md
+++ b/crypto/polyfill/README.md
@@ -1,0 +1,15 @@
+# @pnpm/crypto.polyfill
+
+> Polyfill for functions in the crypto library
+
+[![npm version](https://img.shields.io/npm/v/@pnpm/crypto.polyfill.svg)](https://www.npmjs.com/package/@pnpm/crypto.polyfill)
+
+## Installation
+
+```sh
+pnpm add @pnpm/crypto.polyfill
+```
+
+## License
+
+MIT

--- a/crypto/polyfill/package.json
+++ b/crypto/polyfill/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@pnpm/crypto.polyfill",
+  "version": "0.0.0",
+  "description": "Polyfill for functions in the crypto library",
+  "funding": "https://opencollective.com/pnpm",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "engines": {
+    "node": ">=18.12"
+  },
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
+    "_test": "jest",
+    "test": "pnpm run compile",
+    "prepublishOnly": "pnpm run compile",
+    "compile": "tsc --build && pnpm run lint --fix"
+  },
+  "repository": "https://github.com/pnpm/pnpm/blob/main/crypto/polyfill",
+  "keywords": [
+    "pnpm9",
+    "pnpm",
+    "crypto"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/crypto/polyfill#readme",
+  "devDependencies": {
+    "@pnpm/crypto.polyfill": "workspace:*"
+  }
+}

--- a/crypto/polyfill/package.json
+++ b/crypto/polyfill/package.json
@@ -17,7 +17,6 @@
   },
   "scripts": {
     "lint": "eslint \"src/**/*.ts\"",
-    "_test": "jest",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/crypto/polyfill/src/index.ts
+++ b/crypto/polyfill/src/index.ts
@@ -1,0 +1,10 @@
+import crypto from 'crypto'
+
+export const hash =
+  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  crypto.hash ??
+  ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))

--- a/crypto/polyfill/tsconfig.json
+++ b/crypto/polyfill/tsconfig.json
@@ -8,12 +8,5 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": [
-    {
-      "path": "../../__utils__/prepare"
-    },
-    {
-      "path": "../../crypto/polyfill"
-    }
-  ]
+  "references": []
 }

--- a/crypto/polyfill/tsconfig.lint.json
+++ b/crypto/polyfill/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/packages/crypto.base32-hash/package.json
+++ b/packages/crypto.base32-hash/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/packages/crypto.base32-hash#readme",
   "dependencies": {
+    "@pnpm/crypto.polyfill": "workspace:*",
     "rfc4648": "catalog:"
   },
   "devDependencies": {

--- a/packages/crypto.base32-hash/src/index.ts
+++ b/packages/crypto.base32-hash/src/index.ts
@@ -1,18 +1,9 @@
-import crypto from 'crypto'
+import * as crypto from '@pnpm/crypto.polyfill'
 import fs from 'fs'
 import { base32 } from 'rfc4648'
 
-const hash =
-  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
-  crypto.hash ??
-  ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
-
 export function createBase32Hash (str: string): string {
-  return base32.stringify(hash('md5', str, 'buffer')).replace(/(=+)$/, '').toLowerCase()
+  return base32.stringify(crypto.hash('md5', str, 'buffer')).replace(/(=+)$/, '').toLowerCase()
 }
 
 export async function createBase32HashFromFile (file: string): Promise<string> {

--- a/packages/crypto.base32-hash/src/index.ts
+++ b/packages/crypto.base32-hash/src/index.ts
@@ -12,7 +12,7 @@ const hash =
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function createBase32Hash (str: string): string {
-  return base32.stringify(hash('md5', str)).replace(/(=+)$/, '').toLowerCase()
+  return base32.stringify(hash('md5', str, 'buffer')).replace(/(=+)$/, '').toLowerCase()
 }
 
 export async function createBase32HashFromFile (file: string): Promise<string> {

--- a/packages/crypto.base32-hash/src/index.ts
+++ b/packages/crypto.base32-hash/src/index.ts
@@ -8,7 +8,7 @@ const hash =
   ((
     algorithm: string,
     data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
+    outputEncoding: crypto.BinaryToTextEncoding
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function createBase32Hash (str: string): string {

--- a/packages/crypto.base32-hash/src/index.ts
+++ b/packages/crypto.base32-hash/src/index.ts
@@ -2,8 +2,17 @@ import crypto from 'crypto'
 import fs from 'fs'
 import { base32 } from 'rfc4648'
 
+const hash =
+  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  crypto.hash ??
+  ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding,
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
+
 export function createBase32Hash (str: string): string {
-  return base32.stringify(crypto.createHash('md5').update(str).digest()).replace(/(=+)$/, '').toLowerCase()
+  return base32.stringify(hash('md5', str)).replace(/(=+)$/, '').toLowerCase()
 }
 
 export async function createBase32HashFromFile (file: string): Promise<string> {

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -24,6 +24,7 @@
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/crypto.base32-hash": "workspace:*",
+    "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",
     "@pnpm/deps.graph-sequencer": "workspace:*",
     "@pnpm/error": "workspace:*",

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -14,6 +14,7 @@ import {
   stageLogger,
   summaryLogger,
 } from '@pnpm/core-loggers'
+import * as crypto from '@pnpm/crypto.polyfill'
 import {
   calcPatchHashes,
   createOverridesMapFromParsed,
@@ -744,18 +745,9 @@ Note that in CI environments, this setting is enabled by default.`,
   }
 }
 
-const hash =
-  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
-  crypto.hash ??
-  ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
-
 export function createObjectChecksum (obj: Record<string, unknown>): string {
   const s = JSON.stringify(sortKeys(obj, { deep: true }))
-  return hash('md5', s, 'hex')
+  return crypto.hash('md5', s, 'hex')
 }
 
 function cacheExpired (prunedAt: string, maxAgeInMinutes: number): boolean {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -744,9 +744,18 @@ Note that in CI environments, this setting is enabled by default.`,
   }
 }
 
+const hash =
+  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  crypto.hash ??
+  ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding,
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
+
 export function createObjectChecksum (obj: Record<string, unknown>): string {
   const s = JSON.stringify(sortKeys(obj, { deep: true }))
-  return crypto.createHash('md5').update(s).digest('hex')
+  return hash('md5', s, 'hex')
 }
 
 function cacheExpired (prunedAt: string, maxAgeInMinutes: number): boolean {

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import path from 'path'
 import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/build-modules'
 import { createAllowBuildFunction } from '@pnpm/builder.policy'

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -750,7 +750,7 @@ const hash =
   ((
     algorithm: string,
     data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
+    outputEncoding: crypto.BinaryToTextEncoding
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function createObjectChecksum (obj: Record<string, unknown>): string {

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "../../crypto/object-hasher"
     },
     {
+      "path": "../../crypto/polyfill"
+    },
+    {
       "path": "../../deps/graph-sequencer"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1644,6 +1644,12 @@ importers:
         specifier: 'catalog:'
         version: 3.0.6
 
+  crypto/polyfill:
+    devDependencies:
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: 'link:'
+
   dedupe/check:
     dependencies:
       '@pnpm/dedupe.types':
@@ -3563,6 +3569,9 @@ importers:
 
   packages/crypto.base32-hash:
     dependencies:
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: link:../../crypto/polyfill
       rfc4648:
         specifier: 'catalog:'
         version: 1.5.3
@@ -4062,6 +4071,9 @@ importers:
       '@pnpm/crypto.base32-hash':
         specifier: workspace:*
         version: link:../../packages/crypto.base32-hash
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: link:../../crypto/polyfill
       '@pnpm/dependency-path':
         specifier: workspace:*
         version: link:../../packages/dependency-path
@@ -6247,6 +6259,9 @@ importers:
       '@pnpm/core-loggers':
         specifier: workspace:*
         version: link:../../packages/core-loggers
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: link:../../crypto/polyfill
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -6498,6 +6513,9 @@ importers:
 
   reviewing/list:
     dependencies:
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: link:../../crypto/polyfill
       '@pnpm/read-package-json':
         specifier: workspace:*
         version: link:../../pkg-manifest/read-package-json
@@ -7499,6 +7517,9 @@ importers:
       '@pnpm/create-cafs-store':
         specifier: workspace:*
         version: link:../store/create-cafs-store
+      '@pnpm/crypto.polyfill':
+        specifier: workspace:*
+        version: link:../crypto/polyfill
       '@pnpm/error':
         specifier: workspace:*
         version: link:../packages/error

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
+    "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/fetching-types": "workspace:*",
     "@pnpm/graceful-fs": "workspace:*",

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -268,9 +268,18 @@ function clearMeta (pkg: PackageMeta): PackageMeta {
   }
 }
 
+const hash =
+  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  crypto.hash ??
+  ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding,
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
+
 function encodePkgName (pkgName: string): string {
   if (pkgName !== pkgName.toLowerCase()) {
-    return `${pkgName}_${crypto.createHash('md5').update(pkgName).digest('hex')}`
+    return `${pkgName}_${hash('md5', pkgName, 'hex')}`
   }
   return pkgName
 }

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto'
 import { promises as fs } from 'fs'
 import path from 'path'
+import * as crypto from '@pnpm/crypto.polyfill'
 import { PnpmError } from '@pnpm/error'
 import { logger } from '@pnpm/logger'
 import gfs from '@pnpm/graceful-fs'
@@ -268,18 +268,9 @@ function clearMeta (pkg: PackageMeta): PackageMeta {
   }
 }
 
-const hash =
-  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
-  crypto.hash ??
-  ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
-
 function encodePkgName (pkgName: string): string {
   if (pkgName !== pkgName.toLowerCase()) {
-    return `${pkgName}_${hash('md5', pkgName, 'hex')}`
+    return `${pkgName}_${crypto.hash('md5', pkgName, 'hex')}`
   }
   return pkgName
 }

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -274,7 +274,7 @@ const hash =
   ((
     algorithm: string,
     data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
+    outputEncoding: crypto.BinaryToTextEncoding
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 function encodePkgName (pkgName: string): string {

--- a/resolving/npm-resolver/tsconfig.json
+++ b/resolving/npm-resolver/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../crypto/polyfill"
+    },
+    {
       "path": "../../fs/graceful-fs"
     },
     {

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/pnpm/pnpm/blob/main/reviewing/list#readme",
   "dependencies": {
+    "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/reviewing.dependencies-hierarchy": "workspace:*",

--- a/reviewing/list/src/pruneTree.ts
+++ b/reviewing/list/src/pruneTree.ts
@@ -1,15 +1,7 @@
+import * as crypto from '@pnpm/crypto.polyfill'
 import { type DependenciesHierarchy, type PackageNode } from '@pnpm/reviewing.dependencies-hierarchy'
 import { type PackageDependencyHierarchy } from './types'
 import crypto from 'crypto'
-
-const hash =
-  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
-  crypto.hash ??
-  ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | null, limit: number): PackageDependencyHierarchy[] {
   if (trees === null) {
@@ -66,7 +58,7 @@ export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | nu
 
       for (const node of path) {
         pathSoFar += `${node.name}@${node.version},`
-        const id = hash('sha256', pathSoFar, 'hex')
+        const id = crypto.hash('sha256', pathSoFar, 'hex')
         let existingNode = map.get(id)
 
         if (!existingNode) {

--- a/reviewing/list/src/pruneTree.ts
+++ b/reviewing/list/src/pruneTree.ts
@@ -1,7 +1,6 @@
 import * as crypto from '@pnpm/crypto.polyfill'
 import { type DependenciesHierarchy, type PackageNode } from '@pnpm/reviewing.dependencies-hierarchy'
 import { type PackageDependencyHierarchy } from './types'
-import crypto from 'crypto'
 
 export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | null, limit: number): PackageDependencyHierarchy[] {
   if (trees === null) {

--- a/reviewing/list/src/pruneTree.ts
+++ b/reviewing/list/src/pruneTree.ts
@@ -1,6 +1,15 @@
 import { type DependenciesHierarchy, type PackageNode } from '@pnpm/reviewing.dependencies-hierarchy'
 import { type PackageDependencyHierarchy } from './types'
-import { createHash } from 'crypto'
+import crypto from 'crypto'
+
+const hash =
+  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
+  crypto.hash ??
+  ((
+    algorithm: string,
+    data: crypto.BinaryLike,
+    outputEncoding: crypto.BinaryToTextEncoding,
+  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | null, limit: number): PackageDependencyHierarchy[] {
   if (trees === null) {
@@ -57,7 +66,7 @@ export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | nu
 
       for (const node of path) {
         pathSoFar += `${node.name}@${node.version},`
-        const id = createHash('sha256').update(pathSoFar).digest('hex')
+        const id = hash('sha256', pathSoFar, 'hex')
         let existingNode = map.get(id)
 
         if (!existingNode) {

--- a/reviewing/list/src/pruneTree.ts
+++ b/reviewing/list/src/pruneTree.ts
@@ -8,7 +8,7 @@ const hash =
   ((
     algorithm: string,
     data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
+    outputEncoding: crypto.BinaryToTextEncoding
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 export function pruneDependenciesTrees (trees: PackageDependencyHierarchy[] | null, limit: number): PackageDependencyHierarchy[] {

--- a/reviewing/list/tsconfig.json
+++ b/reviewing/list/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/test-fixtures"
     },
     {
+      "path": "../../crypto/polyfill"
+    },
+    {
       "path": "../../packages/types"
     },
     {

--- a/worker/package.json
+++ b/worker/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/cafs-types": "workspace:*",
     "@pnpm/create-cafs-store": "workspace:*",
+    "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.pkg-requires-build": "workspace:*",
     "@pnpm/fs.hard-link-dir": "workspace:*",

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -41,7 +41,7 @@ const hash =
   ((
     algorithm: string,
     data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding,
+    outputEncoding: crypto.BinaryToTextEncoding
   ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 const cafsCache = new Map<string, CafsFunctions>()

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs'
 import gfs from '@pnpm/graceful-fs'
-import * as crypto from 'crypto'
 import { type Cafs } from '@pnpm/cafs-types'
 import { createCafsStore } from '@pnpm/create-cafs-store'
 import * as crypto from '@pnpm/crypto.polyfill'

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -4,6 +4,7 @@ import gfs from '@pnpm/graceful-fs'
 import * as crypto from 'crypto'
 import { type Cafs } from '@pnpm/cafs-types'
 import { createCafsStore } from '@pnpm/create-cafs-store'
+import * as crypto from '@pnpm/crypto.polyfill'
 import { pkgRequiresBuild } from '@pnpm/exec.pkg-requires-build'
 import { hardLinkDir } from '@pnpm/fs.hard-link-dir'
 import {
@@ -34,15 +35,6 @@ import {
 const INTEGRITY_REGEX: RegExp = /^([^-]+)-([A-Za-z0-9+/=]+)$/
 
 parentPort!.on('message', handleMessage)
-
-const hash =
-  // @ts-expect-error -- crypto.hash is supported in Node 21.7.0+, 20.12.0+
-  crypto.hash ??
-  ((
-    algorithm: string,
-    data: crypto.BinaryLike,
-    outputEncoding: crypto.BinaryToTextEncoding
-  ) => crypto.createHash(algorithm).update(data).digest(outputEncoding))
 
 const cafsCache = new Map<string, CafsFunctions>()
 const cafsStoreCache = new Map<string, Cafs>()
@@ -138,7 +130,7 @@ function addTarballToStore ({ buffer, cafsDir, integrity, filesIndexFile }: Tarb
     // Compensate for the possibility of non-uniform Base64 padding
     const normalizedRemoteHash: string = Buffer.from(integrityHash, 'base64').toString('hex')
 
-    const calculatedHash: string = hash(algo, buffer, 'hex')
+    const calculatedHash: string = crypto.hash(algo, buffer, 'hex')
     if (calculatedHash !== normalizedRemoteHash) {
       return {
         status: 'error',

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../crypto/polyfill"
+    },
+    {
       "path": "../exec/pkg-requires-build"
     },
     {


### PR DESCRIPTION
`crypto.hash` seems to be faster than `crypto.createHash`.

https://nodejs.org/docs/latest-v20.x/api/crypto.html#cryptohashalgorithm-data-outputencoding