### PR TITLE
feat!: don't duplicate all file entries in the side effects section of the index file

### DIFF
--- a/.changeset/smart-flowers-cheat.md
+++ b/.changeset/smart-flowers-cheat.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/plugin-commands-store-inspecting": major
+"@pnpm/headless": major
+"@pnpm/core": major
+"@pnpm/cafs-types": major
+"@pnpm/store.cafs": major
+"@pnpm/worker": major
+"pnpm": major
+---
+
+Changed the structure of the index files in the store to store side effects cache information more efficiently. In the new version, side effects do not list all the files of the package but just the differences [#8636](https://github.com/pnpm/pnpm/pull/8636).

--- a/exec/plugin-commands-rebuild/test/index.ts
+++ b/exec/plugin-commands-rebuild/test/index.ts
@@ -79,8 +79,8 @@ test('rebuilds dependencies', async () => {
   const cacheIntegrity = loadJsonFile.sync<any>(cacheIntegrityPath) // eslint-disable-line @typescript-eslint/no-explicit-any
   expect(cacheIntegrity!.sideEffects).toBeTruthy()
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
-  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'generated-by-postinstall.js'])
-  delete cacheIntegrity!.sideEffects[sideEffectsKey]['generated-by-postinstall.js']
+  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'added', 'generated-by-postinstall.js'])
+  delete cacheIntegrity!.sideEffects[sideEffectsKey].added['generated-by-postinstall.js']
 })
 
 test('skipIfHasSideEffectsCache', async () => {
@@ -104,7 +104,7 @@ test('skipIfHasSideEffectsCache', async () => {
   let cacheIntegrity = loadJsonFile.sync<any>(cacheIntegrityPath) // eslint-disable-line @typescript-eslint/no-explicit-any
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
   cacheIntegrity.sideEffects = {
-    [sideEffectsKey]: { foo: 'bar' },
+    [sideEffectsKey]: { added: { foo: 'bar' } },
   }
   fs.writeFileSync(cacheIntegrityPath, JSON.stringify(cacheIntegrity, null, 2), 'utf8')
 
@@ -130,7 +130,7 @@ test('skipIfHasSideEffectsCache', async () => {
 
   cacheIntegrity = loadJsonFile.sync<any>(cacheIntegrityPath) // eslint-disable-line @typescript-eslint/no-explicit-any
   expect(cacheIntegrity!.sideEffects).toBeTruthy()
-  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'foo'])
+  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'added', 'foo'])
 })
 
 test('rebuild does not fail when a linked package is present', async () => {

--- a/pkg-manager/core/test/install/patch.ts
+++ b/pkg-manager/core/test/install/patch.ts
@@ -46,7 +46,7 @@ test('patch package', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey]['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -213,7 +213,7 @@ test('patch package when scripts are ignored', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey]['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -300,7 +300,7 @@ test('patch package when the package is not in onlyBuiltDependencies list', asyn
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey]['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()

--- a/pkg-manager/core/test/install/patch.ts
+++ b/pkg-manager/core/test/install/patch.ts
@@ -46,7 +46,7 @@ test('patch package', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added?.['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -213,7 +213,7 @@ test('patch package when scripts are ignored', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added?.['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -300,7 +300,7 @@ test('patch package when the package is not in onlyBuiltDependencies list', asyn
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added?.['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()

--- a/pkg-manager/core/test/install/patch.ts
+++ b/pkg-manager/core/test/install/patch.ts
@@ -46,7 +46,7 @@ test('patch package', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -213,7 +213,7 @@ test('patch package when scripts are ignored', async () => {
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -300,7 +300,7 @@ test('patch package when the package is not in onlyBuiltDependencies list', asyn
   const filesIndexFile = path.join(opts.storeDir, 'files/c7/1ccf199e0fdae37aad13946b937d67bcd35fa111b84d21b3a19439cfdc2812-is-positive@1.0.0.json')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   const sideEffectsKey = `${ENGINE_NAME}-${patchFileHash}`
-  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].modified['index.js']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[sideEffectsKey].added['index.js']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['index.js'].integrity
   expect(originalFileIntegrity).toBeTruthy()

--- a/pkg-manager/core/test/install/sideEffects.ts
+++ b/pkg-manager/core/test/install/sideEffects.ts
@@ -177,7 +177,7 @@ test('a postinstall script does not modify the original sources added to the sto
   const cafsDir = path.join(opts.storeDir, 'files')
   const filesIndexFile = getIndexFilePathInCafs(cafsDir, getIntegrity('@pnpm/postinstall-modifies-source', '1.0.0'), '@pnpm/postinstall-modifies-source@1.0.0')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
-  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`].modified['empty-file.txt']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`].added['empty-file.txt']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['empty-file.txt'].integrity
   expect(originalFileIntegrity).toBeTruthy()

--- a/pkg-manager/core/test/install/sideEffects.ts
+++ b/pkg-manager/core/test/install/sideEffects.ts
@@ -87,9 +87,9 @@ test('using side effects cache', async () => {
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   expect(filesIndex.sideEffects).toBeTruthy() // files index has side effects
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
-  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'generated-by-preinstall.js'])
-  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'generated-by-postinstall.js'])
-  delete filesIndex.sideEffects![sideEffectsKey]['generated-by-postinstall.js']
+  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-preinstall.js'])
+  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-postinstall.js'])
+  delete filesIndex.sideEffects![sideEffectsKey].added['generated-by-postinstall.js']
   writeJsonFile.sync(filesIndexFile, filesIndex)
 
   rimraf('node_modules')
@@ -177,7 +177,7 @@ test('a postinstall script does not modify the original sources added to the sto
   const cafsDir = path.join(opts.storeDir, 'files')
   const filesIndexFile = getIndexFilePathInCafs(cafsDir, getIntegrity('@pnpm/postinstall-modifies-source', '1.0.0'), '@pnpm/postinstall-modifies-source@1.0.0')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
-  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`]['empty-file.txt']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`].modified['empty-file.txt']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['empty-file.txt'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -202,8 +202,8 @@ test('a corrupted side-effects cache is ignored', async () => {
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
   expect(filesIndex.sideEffects).toBeTruthy() // files index has side effects
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
-  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'generated-by-preinstall.js'])
-  const sideEffectFileStat = filesIndex.sideEffects![sideEffectsKey]['generated-by-preinstall.js']
+  expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-preinstall.js'])
+  const sideEffectFileStat = filesIndex.sideEffects![sideEffectsKey].added['generated-by-preinstall.js']
   const sideEffectFile = getFilePathByModeInCafs(cafsDir, sideEffectFileStat.integrity, sideEffectFileStat.mode)
   expect(fs.existsSync(sideEffectFile)).toBeTruthy()
   rimraf(sideEffectFile) // we remove the side effect file to break the store

--- a/pkg-manager/core/test/install/sideEffects.ts
+++ b/pkg-manager/core/test/install/sideEffects.ts
@@ -89,7 +89,7 @@ test('using side effects cache', async () => {
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
   expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-preinstall.js'])
   expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-postinstall.js'])
-  delete filesIndex.sideEffects![sideEffectsKey].added['generated-by-postinstall.js']
+  delete filesIndex.sideEffects![sideEffectsKey].added?.['generated-by-postinstall.js']
   writeJsonFile.sync(filesIndexFile, filesIndex)
 
   rimraf('node_modules')
@@ -177,7 +177,7 @@ test('a postinstall script does not modify the original sources added to the sto
   const cafsDir = path.join(opts.storeDir, 'files')
   const filesIndexFile = getIndexFilePathInCafs(cafsDir, getIntegrity('@pnpm/postinstall-modifies-source', '1.0.0'), '@pnpm/postinstall-modifies-source@1.0.0')
   const filesIndex = loadJsonFile.sync<PackageFilesIndex>(filesIndexFile)
-  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`].added['empty-file.txt']?.integrity
+  const patchedFileIntegrity = filesIndex.sideEffects?.[`${ENGINE_NAME}-${hashObject({})}`].added?.['empty-file.txt']?.integrity
   expect(patchedFileIntegrity).toBeTruthy()
   const originalFileIntegrity = filesIndex.files['empty-file.txt'].integrity
   expect(originalFileIntegrity).toBeTruthy()
@@ -203,7 +203,7 @@ test('a corrupted side-effects cache is ignored', async () => {
   expect(filesIndex.sideEffects).toBeTruthy() // files index has side effects
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
   expect(filesIndex.sideEffects).toHaveProperty([sideEffectsKey, 'added', 'generated-by-preinstall.js'])
-  const sideEffectFileStat = filesIndex.sideEffects![sideEffectsKey].added['generated-by-preinstall.js']
+  const sideEffectFileStat = filesIndex.sideEffects![sideEffectsKey].added!['generated-by-preinstall.js']
   const sideEffectFile = getFilePathByModeInCafs(cafsDir, sideEffectFileStat.integrity, sideEffectFileStat.mode)
   expect(fs.existsSync(sideEffectFile)).toBeTruthy()
   rimraf(sideEffectFile) // we remove the side effect file to break the store

--- a/pkg-manager/headless/test/index.ts
+++ b/pkg-manager/headless/test/index.ts
@@ -682,10 +682,10 @@ test.each([['isolated'], ['hoisted']])('using side effects cache with nodeLinker
   const cacheIntegrity = loadJsonFile.sync<any>(cacheIntegrityPath) // eslint-disable-line @typescript-eslint/no-explicit-any
   expect(cacheIntegrity!.sideEffects).toBeTruthy()
   const sideEffectsKey = `${ENGINE_NAME}-${hashObject({ '@pnpm.e2e/hello-world-js-bin@1.0.0': {} })}`
-  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'generated-by-postinstall.js'])
-  delete cacheIntegrity!.sideEffects[sideEffectsKey]['generated-by-postinstall.js']
+  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'added', 'generated-by-postinstall.js'])
+  delete cacheIntegrity!.sideEffects[sideEffectsKey].added['generated-by-postinstall.js']
 
-  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'generated-by-preinstall.js'])
+  expect(cacheIntegrity).toHaveProperty(['sideEffects', sideEffectsKey, 'added', 'generated-by-preinstall.js'])
   writeJsonFile.sync(cacheIntegrityPath, cacheIntegrity)
 
   prefix = f.prepare('side-effects')

--- a/reviewing/license-scanner/src/getPkgInfo.ts
+++ b/reviewing/license-scanner/src/getPkgInfo.ts
@@ -8,6 +8,7 @@ import { type PackageManifest, type Registries } from '@pnpm/types'
 import {
   getFilePathByModeInCafs,
   getIndexFilePathInCafs,
+  type PackageFiles,
   type PackageFileInfo,
   type PackageFilesIndex,
 } from '@pnpm/store.cafs'
@@ -155,7 +156,7 @@ async function parseLicense (
     manifest: PackageManifest
     files:
     | { local: true, files: Record<string, string> }
-    | { local: false, files: Record<string, PackageFileInfo> }
+    | { local: false, files: PackageFiles }
   },
   opts: { cafsDir: string }
 ): Promise<LicenseInfo> {
@@ -213,7 +214,7 @@ async function readLicenseFileFromCafs (cafsDir: string, { integrity, mode }: Pa
 }
 
 export type ReadPackageIndexFileResult =
-  | { local: false, files: Record<string, PackageFileInfo> }
+  | { local: false, files: PackageFiles }
   | { local: true, files: Record<string, string> }
 
 export interface ReadPackageIndexFileOptions {

--- a/store/cafs-types/src/index.ts
+++ b/store/cafs-types/src/index.ts
@@ -13,8 +13,8 @@ export interface PackageFileInfo {
 export type SideEffects = Record<string, SideEffectsDiff>
 
 export interface SideEffectsDiff {
-  deleted: string[]
-  added: PackageFiles
+  deleted?: string[]
+  added?: PackageFiles
 }
 
 export type ResolvedFrom = 'store' | 'local-dir' | 'remote'

--- a/store/cafs-types/src/index.ts
+++ b/store/cafs-types/src/index.ts
@@ -1,6 +1,8 @@
 import type { IntegrityLike } from 'ssri'
 import type { DependencyManifest } from '@pnpm/types'
 
+export type PackageFileInfoMap = Record<string, PackageFileInfo>
+
 export interface PackageFileInfo {
   checkedAt?: number // Nullable for backward compatibility
   integrity: string
@@ -8,19 +10,27 @@ export interface PackageFileInfo {
   size: number
 }
 
+export type SideEffects = Record<string, SideEffectsDiff>
+
+export interface SideEffectsDiff {
+  deleted: string[]
+  modified: PackageFileInfoMap
+  added: PackageFileInfoMap
+}
+
 export type ResolvedFrom = 'store' | 'local-dir' | 'remote'
 
 export type PackageFilesResponse = {
   resolvedFrom: ResolvedFrom
   packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone' | 'clone-or-copy'
-  sideEffects?: Record<string, Record<string, PackageFileInfo>>
+  sideEffects?: SideEffects
   requiresBuild: boolean
 } & ({
   unprocessed?: false
   filesIndex: Record<string, string>
 } | {
   unprocessed: true
-  filesIndex: Record<string, PackageFileInfo>
+  filesIndex: PackageFileInfoMap
 })
 
 export interface ImportPackageOpts {

--- a/store/cafs-types/src/index.ts
+++ b/store/cafs-types/src/index.ts
@@ -1,7 +1,7 @@
 import type { IntegrityLike } from 'ssri'
 import type { DependencyManifest } from '@pnpm/types'
 
-export type PackageFileInfoMap = Record<string, PackageFileInfo>
+export type PackageFiles = Record<string, PackageFileInfo>
 
 export interface PackageFileInfo {
   checkedAt?: number // Nullable for backward compatibility
@@ -14,8 +14,8 @@ export type SideEffects = Record<string, SideEffectsDiff>
 
 export interface SideEffectsDiff {
   deleted: string[]
-  modified: PackageFileInfoMap
-  added: PackageFileInfoMap
+  modified: PackageFiles
+  added: PackageFiles
 }
 
 export type ResolvedFrom = 'store' | 'local-dir' | 'remote'
@@ -30,7 +30,7 @@ export type PackageFilesResponse = {
   filesIndex: Record<string, string>
 } | {
   unprocessed: true
-  filesIndex: PackageFileInfoMap
+  filesIndex: PackageFiles
 })
 
 export interface ImportPackageOpts {

--- a/store/cafs-types/src/index.ts
+++ b/store/cafs-types/src/index.ts
@@ -14,7 +14,6 @@ export type SideEffects = Record<string, SideEffectsDiff>
 
 export interface SideEffectsDiff {
   deleted: string[]
-  modified: PackageFiles
   added: PackageFiles
 }
 

--- a/store/cafs/src/addFilesFromDir.ts
+++ b/store/cafs/src/addFilesFromDir.ts
@@ -48,10 +48,11 @@ export function addFilesFromDir (
     if (opts.readManifest && relativePath === 'package.json') {
       manifest = parseJsonBufferSync(buffer) as DependencyManifest
     }
+    const mode = stat.mode & 0o777
     filesIndex[relativePath] = {
-      mode: stat.mode,
+      mode,
       size: stat.size,
-      ...addBuffer(buffer, stat.mode),
+      ...addBuffer(buffer, mode),
     }
   }
   return { manifest, filesIndex }
@@ -78,7 +79,9 @@ function findFiles (
   for (const file of files) {
     const relativeSubdir = `${relativeDir}${relativeDir ? '/' : ''}${file.name}`
     if (file.isDirectory()) {
-      findFiles(filesList, path.join(dir, file.name), relativeSubdir)
+      if (relativeDir !== '' || file.name !== 'node_modules') {
+        findFiles(filesList, path.join(dir, file.name), relativeSubdir)
+      }
       continue
     }
     const absolutePath = path.join(dir, file.name)

--- a/store/cafs/src/addFilesFromDir.ts
+++ b/store/cafs/src/addFilesFromDir.ts
@@ -48,6 +48,7 @@ export function addFilesFromDir (
     if (opts.readManifest && relativePath === 'package.json') {
       manifest = parseJsonBufferSync(buffer) as DependencyManifest
     }
+    // Remove the file type information (regular file, directory, etc.) and leave just the permission bits (rwx for owner, group, and others)
     const mode = stat.mode & 0o777
     filesIndex[relativePath] = {
       mode,

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import util from 'util'
-import { type PackageFileInfo, type SideEffects } from '@pnpm/cafs-types'
+import { type PackageFiles, type PackageFileInfo, type SideEffects } from '@pnpm/cafs-types'
 import gfs from '@pnpm/graceful-fs'
 import { type DependencyManifest } from '@pnpm/types'
 import rimraf from '@zkochan/rimraf'
@@ -29,7 +29,7 @@ export interface PackageFilesIndex {
   version?: string
   requiresBuild?: boolean
 
-  files: Record<string, PackageFileInfo>
+  files: PackageFiles
   sideEffects?: SideEffects
 }
 
@@ -64,7 +64,7 @@ export function checkPkgFilesIntegrity (
 function checkFilesIntegrity (
   verifiedFilesCache: Set<string>,
   cafsDir: string,
-  files: Record<string, PackageFileInfo>,
+  files: PackageFiles,
   readManifest?: boolean
 ): VerifyResult {
   let allVerified = true

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import util from 'util'
-import type { PackageFileInfo } from '@pnpm/cafs-types'
+import { type PackageFileInfo, type SideEffects } from '@pnpm/cafs-types'
 import gfs from '@pnpm/graceful-fs'
 import { type DependencyManifest } from '@pnpm/types'
 import rimraf from '@zkochan/rimraf'
@@ -19,8 +19,6 @@ export interface VerifyResult {
   passed: boolean
   manifest?: DependencyManifest
 }
-
-export type SideEffects = Record<string, Record<string, PackageFileInfo>>
 
 export interface PackageFilesIndex {
   // name and version are nullable for backward compatibility
@@ -51,8 +49,8 @@ export function checkPkgFilesIntegrity (
     // We verify all side effects cache. We could optimize it to verify only the side effects cache
     // that satisfies the current os/arch/platform.
     // However, it likely won't make a big difference.
-    for (const [sideEffectName, files] of Object.entries(pkgIndex.sideEffects)) {
-      const { passed } = _checkFilesIntegrity(files)
+    for (const [sideEffectName, diff] of Object.entries(pkgIndex.sideEffects)) {
+      const { passed } = _checkFilesIntegrity(diff.modified)
       if (!passed) {
         delete pkgIndex.sideEffects![sideEffectName]
       }

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -50,7 +50,7 @@ export function checkPkgFilesIntegrity (
     // that satisfies the current os/arch/platform.
     // However, it likely won't make a big difference.
     for (const [sideEffectName, diff] of Object.entries(pkgIndex.sideEffects)) {
-      const { passed } = _checkFilesIntegrity(diff.modified)
+      const { passed } = _checkFilesIntegrity({ ...diff.modified, ...diff.added })
       if (!passed) {
         delete pkgIndex.sideEffects![sideEffectName]
       }

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -50,9 +50,11 @@ export function checkPkgFilesIntegrity (
     // that satisfies the current os/arch/platform.
     // However, it likely won't make a big difference.
     for (const [sideEffectName, { added }] of Object.entries(pkgIndex.sideEffects)) {
-      const { passed } = _checkFilesIntegrity(added)
-      if (!passed) {
-        delete pkgIndex.sideEffects![sideEffectName]
+      if (added) {
+        const { passed } = _checkFilesIntegrity(added)
+        if (!passed) {
+          delete pkgIndex.sideEffects![sideEffectName]
+        }
       }
     }
   }

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -49,8 +49,8 @@ export function checkPkgFilesIntegrity (
     // We verify all side effects cache. We could optimize it to verify only the side effects cache
     // that satisfies the current os/arch/platform.
     // However, it likely won't make a big difference.
-    for (const [sideEffectName, diff] of Object.entries(pkgIndex.sideEffects)) {
-      const { passed } = _checkFilesIntegrity({ ...diff.modified, ...diff.added })
+    for (const [sideEffectName, { added, modified }] of Object.entries(pkgIndex.sideEffects)) {
+      const { passed } = _checkFilesIntegrity({ ...modified, ...added })
       if (!passed) {
         delete pkgIndex.sideEffects![sideEffectName]
       }

--- a/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -49,8 +49,8 @@ export function checkPkgFilesIntegrity (
     // We verify all side effects cache. We could optimize it to verify only the side effects cache
     // that satisfies the current os/arch/platform.
     // However, it likely won't make a big difference.
-    for (const [sideEffectName, { added, modified }] of Object.entries(pkgIndex.sideEffects)) {
-      const { passed } = _checkFilesIntegrity({ ...modified, ...added })
+    for (const [sideEffectName, { added }] of Object.entries(pkgIndex.sideEffects)) {
+      const { passed } = _checkFilesIntegrity(added)
       if (!passed) {
         delete pkgIndex.sideEffects![sideEffectName]
       }

--- a/store/cafs/src/index.ts
+++ b/store/cafs/src/index.ts
@@ -5,7 +5,6 @@ import { addFilesFromTarball } from './addFilesFromTarball'
 import {
   checkPkgFilesIntegrity,
   type PackageFilesIndex,
-  type SideEffects,
   type VerifyResult,
 } from './checkPkgFilesIntegrity'
 import { readManifestFromStore } from './readManifestFromStore'
@@ -28,7 +27,6 @@ export {
   getIndexFilePathInCafs,
   type PackageFileInfo,
   type PackageFilesIndex,
-  type SideEffects,
   optimisticRenameOverwrite,
   type FilesIndex,
   type VerifyResult,

--- a/store/cafs/src/index.ts
+++ b/store/cafs/src/index.ts
@@ -1,4 +1,4 @@
-import { type AddToStoreResult, type FileWriteResult, type PackageFileInfo, type FilesIndex } from '@pnpm/cafs-types'
+import { type AddToStoreResult, type FileWriteResult, type PackageFiles, type PackageFileInfo, type FilesIndex } from '@pnpm/cafs-types'
 import ssri from 'ssri'
 import { addFilesFromDir } from './addFilesFromDir'
 import { addFilesFromTarball } from './addFilesFromTarball'
@@ -26,6 +26,7 @@ export {
   getFilePathByModeInCafs,
   getIndexFilePathInCafs,
   type PackageFileInfo,
+  type PackageFiles,
   type PackageFilesIndex,
   optimisticRenameOverwrite,
   type FilesIndex,

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -103,17 +103,14 @@ function getFlatMap (
 }
 
 function applySideEffectsDiff (baseFiles: PackageFiles, diff: SideEffectsDiff): PackageFiles {
-  const result: PackageFiles = {}
+  const result: PackageFiles = {
+    ...diff.modified,
+    ...diff.added,
+  }
   for (const [fileName, file] of Object.entries(baseFiles)) {
-    if (diff.deleted.includes(fileName)) continue
-    if (diff.modified[fileName]) {
-      result[fileName] = diff.modified[fileName]
-    } else {
+    if (!diff.deleted.includes(fileName) && !result[fileName]) {
       result[fileName] = file
     }
-  }
-  for (const fileName of Object.keys(diff.added)) {
-    result[fileName] = diff.added[fileName]
   }
   return result
 }

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -102,13 +102,13 @@ function getFlatMap (
   return { filesMap, isBuilt }
 }
 
-function applySideEffectsDiff (baseFiles: PackageFiles, diff: SideEffectsDiff): PackageFiles {
+function applySideEffectsDiff (baseFiles: PackageFiles, { modified, added, deleted }: SideEffectsDiff): PackageFiles {
   const result: PackageFiles = {
-    ...diff.modified,
-    ...diff.added,
+    ...modified,
+    ...added,
   }
   for (const [fileName, file] of Object.entries(baseFiles)) {
-    if (!diff.deleted.includes(fileName) && !result[fileName]) {
+    if (!deleted.includes(fileName) && !result[fileName]) {
       result[fileName] = file
     }
   }

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -105,7 +105,7 @@ function getFlatMap (
 function applySideEffectsDiff (baseFiles: PackageFiles, { added, deleted }: SideEffectsDiff): PackageFiles {
   const filesWithSideEffects: PackageFiles = { ...added }
   for (const fileName in baseFiles) {
-    if (!deleted.includes(fileName) && !filesWithSideEffects[fileName]) {
+    if (!deleted?.includes(fileName) && !filesWithSideEffects[fileName]) {
       filesWithSideEffects[fileName] = baseFiles[fileName]
     }
   }

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -5,7 +5,7 @@ import {
   createCafs,
   getFilePathByModeInCafs,
 } from '@pnpm/store.cafs'
-import { type Cafs, type PackageFilesResponse, type PackageFileInfoMap, type SideEffectsDiff } from '@pnpm/cafs-types'
+import { type Cafs, type PackageFilesResponse, type PackageFiles, type SideEffectsDiff } from '@pnpm/cafs-types'
 import { createIndexedPkgImporter } from '@pnpm/fs.indexed-pkg-importer'
 import {
   type ImportIndexedPackage,
@@ -85,9 +85,9 @@ function getFlatMap (
   targetEngine?: string
 ): { filesMap: Record<string, string>, isBuilt: boolean } {
   let isBuilt!: boolean
-  let filesIndex!: PackageFileInfoMap
+  let filesIndex!: PackageFiles
   if (targetEngine && ((filesResponse.sideEffects?.[targetEngine]) != null)) {
-    filesIndex = applySideEffectsDiff(filesResponse.filesIndex as PackageFileInfoMap, filesResponse.sideEffects?.[targetEngine])
+    filesIndex = applySideEffectsDiff(filesResponse.filesIndex as PackageFiles, filesResponse.sideEffects?.[targetEngine])
     isBuilt = true
   } else if (!filesResponse.unprocessed) {
     return {
@@ -102,8 +102,8 @@ function getFlatMap (
   return { filesMap, isBuilt }
 }
 
-function applySideEffectsDiff (baseFiles: PackageFileInfoMap, diff: SideEffectsDiff): PackageFileInfoMap {
-  const result: PackageFileInfoMap = {}
+function applySideEffectsDiff (baseFiles: PackageFiles, diff: SideEffectsDiff): PackageFiles {
+  const result: PackageFiles = {}
   for (const [fileName, file] of Object.entries(baseFiles)) {
     if (diff.deleted.includes(fileName)) continue
     if (diff.modified[fileName]) {

--- a/store/create-cafs-store/src/index.ts
+++ b/store/create-cafs-store/src/index.ts
@@ -102,17 +102,14 @@ function getFlatMap (
   return { filesMap, isBuilt }
 }
 
-function applySideEffectsDiff (baseFiles: PackageFiles, { modified, added, deleted }: SideEffectsDiff): PackageFiles {
-  const result: PackageFiles = {
-    ...modified,
-    ...added,
-  }
-  for (const [fileName, file] of Object.entries(baseFiles)) {
-    if (!deleted.includes(fileName) && !result[fileName]) {
-      result[fileName] = file
+function applySideEffectsDiff (baseFiles: PackageFiles, { added, deleted }: SideEffectsDiff): PackageFiles {
+  const filesWithSideEffects: PackageFiles = { ...added }
+  for (const fileName in baseFiles) {
+    if (!deleted.includes(fileName) && !filesWithSideEffects[fileName]) {
+      filesWithSideEffects[fileName] = baseFiles[fileName]
     }
   }
-  return result
+  return filesWithSideEffects
 }
 
 export function createCafsStore (

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -75,7 +75,7 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
 
     if (pkgFilesIndex?.sideEffects) {
       for (const [, diff] of Object.entries(pkgFilesIndex.sideEffects)) {
-        for (const [, file] of Object.entries(diff.modified)) {
+        for (const file of Object.values({ ...diff.modified, ...diff.added })) {
           if (file?.integrity === hash) {
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -74,8 +74,8 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
     }
 
     if (pkgFilesIndex?.sideEffects) {
-      for (const { modified, added } of Object.values(pkgFilesIndex.sideEffects)) {
-        for (const file of Object.values({ ...modified, ...added })) {
+      for (const { added } of Object.values(pkgFilesIndex.sideEffects)) {
+        for (const file of Object.values(added)) {
           if (file?.integrity === hash) {
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -74,8 +74,8 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
     }
 
     if (pkgFilesIndex?.sideEffects) {
-      for (const [, files] of Object.entries(pkgFilesIndex.sideEffects)) {
-        for (const [, file] of Object.entries(files)) {
+      for (const [, diff] of Object.entries(pkgFilesIndex.sideEffects)) {
+        for (const [, file] of Object.entries(diff.modified)) {
           if (file?.integrity === hash) {
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -74,8 +74,8 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
     }
 
     if (pkgFilesIndex?.sideEffects) {
-      for (const [, diff] of Object.entries(pkgFilesIndex.sideEffects)) {
-        for (const file of Object.values({ ...diff.modified, ...diff.added })) {
+      for (const { modified, added } of Object.values(pkgFilesIndex.sideEffects)) {
+        for (const file of Object.values({ ...modified, ...added })) {
           if (file?.integrity === hash) {
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })
 

--- a/store/plugin-commands-store-inspecting/src/findHash.ts
+++ b/store/plugin-commands-store-inspecting/src/findHash.ts
@@ -75,6 +75,7 @@ export async function handler (opts: FindHashCommandOptions, params: string[]): 
 
     if (pkgFilesIndex?.sideEffects) {
       for (const { added } of Object.values(pkgFilesIndex.sideEffects)) {
+        if (!added) continue
         for (const file of Object.values(added)) {
           if (file?.integrity === hash) {
             result.push({ name: pkgFilesIndex.name ?? 'unknown', version: pkgFilesIndex?.version ?? 'unknown', filesIndexFile: filesIndexFile.replace(cafsDir, '') })

--- a/store/server/test/index.ts
+++ b/store/server/test/index.ts
@@ -164,7 +164,13 @@ test('server upload', async () => {
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
 
   const fakeEngine = 'client-engine'
-  const filesIndexFile = path.join(storeDir, 'test.example.com/fake-pkg/1.0.0.json')
+  const filesIndexFile = path.join(storeDir, 'fake-pkg@1.0.0.json')
+
+  fs.writeFileSync(filesIndexFile, JSON.stringify({
+    name: 'fake-pkg',
+    version: '1.0.0',
+    files: {},
+  }), 'utf8')
 
   await storeCtrl.upload(path.join(__dirname, 'side-effect-fake-dir'), {
     sideEffectsCacheKey: fakeEngine,

--- a/store/server/test/index.ts
+++ b/store/server/test/index.ts
@@ -172,7 +172,7 @@ test('server upload', async () => {
   })
 
   const cacheIntegrity = loadJsonFile.sync<any>(filesIndexFile) // eslint-disable-line @typescript-eslint/no-explicit-any
-  expect(Object.keys(cacheIntegrity?.['sideEffects'][fakeEngine]).sort()).toStrictEqual(['side-effect.js', 'side-effect.txt'])
+  expect(Object.keys(cacheIntegrity?.['sideEffects'][fakeEngine].added).sort()).toStrictEqual(['side-effect.js', 'side-effect.txt'])
 
   await server.close()
   await storeCtrl.close()

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -202,7 +202,7 @@ function addFilesFromDir ({ dir, cafsDir, filesIndexFile, sideEffectsCacheKey, f
 function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles): SideEffectsDiff {
   const deleted: string[] = []
   const added: PackageFiles = {}
-  for (const file of Array.from(new Set([...Object.keys(baseFiles), ...Object.keys(sideEffectsFiles)]))) {
+  for (const file of new Set([...Object.keys(baseFiles), ...Object.keys(sideEffectsFiles)])) {
     if (!sideEffectsFiles[file]) {
       deleted.push(file)
     } else if (
@@ -213,14 +213,14 @@ function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles)
       added[file] = sideEffectsFiles[file]
     }
   }
-  const result: SideEffectsDiff = {}
+  const diff: SideEffectsDiff = {}
   if (deleted.length > 0) {
-    result.deleted = deleted
+    diff.deleted = deleted
   }
   if (Object.keys(added).length > 0) {
-    result.added = added
+    diff.added = added
   }
-  return result
+  return diff
 }
 
 interface ProcessFilesIndexResult {

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -176,7 +176,15 @@ function addFilesFromDir ({ dir, cafsDir, filesIndexFile, sideEffectsCacheKey, f
     try {
       filesIndex = loadJsonFile<PackageFilesIndex>(filesIndexFile)
     } catch {
-      filesIndex = { name: manifest?.name, version: manifest?.version, files: {} }
+      // If there is no existing index file, then we cannot store the side effects.
+      return {
+        status: 'success',
+        value: {
+          filesIndex: filesMap,
+          manifest,
+          requiresBuild: pkgRequiresBuild(manifest, filesIntegrity),
+        },
+      }
     }
     filesIndex.sideEffects = filesIndex.sideEffects ?? {}
     filesIndex.sideEffects[sideEffectsCacheKey] = calculateDiff(filesIndex.files, filesIntegrity)

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -10,7 +10,6 @@ import {
   type CafsFunctions,
   checkPkgFilesIntegrity,
   createCafs,
-  type PackageFileInfo,
   type PackageFilesIndex,
   type FilesIndex,
   optimisticRenameOverwrite,
@@ -225,12 +224,12 @@ function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles)
 }
 
 interface ProcessFilesIndexResult {
-  filesIntegrity: Record<string, PackageFileInfo>
+  filesIntegrity: PackageFiles
   filesMap: Record<string, string>
 }
 
 function processFilesIndex (filesIndex: FilesIndex): ProcessFilesIndexResult {
-  const filesIntegrity: Record<string, PackageFileInfo> = {}
+  const filesIntegrity: PackageFiles = {}
   const filesMap: Record<string, string> = {}
   for (const [k, { checkedAt, filePath, integrity, mode, size }] of Object.entries(filesIndex)) {
     filesIntegrity[k] = {
@@ -294,7 +293,7 @@ function writeFilesIndexFile (
   filesIndexFile: string,
   { manifest, files, sideEffects }: {
     manifest: Partial<DependencyManifest>
-    files: Record<string, PackageFileInfo>
+    files: PackageFiles
     sideEffects?: SideEffects
   }
 ): boolean {

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -214,7 +214,14 @@ function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles)
       added[file] = sideEffectsFiles[file]
     }
   }
-  return { deleted, added }
+  const result: SideEffectsDiff = {}
+  if (deleted.length > 0) {
+    result.deleted = deleted
+  }
+  if (Object.keys(added).length > 0) {
+    result.added = added
+  }
+  return result
 }
 
 interface ProcessFilesIndexResult {

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -176,7 +176,7 @@ function addFilesFromDir ({ dir, cafsDir, filesIndexFile, sideEffectsCacheKey, f
     try {
       filesIndex = loadJsonFile<PackageFilesIndex>(filesIndexFile)
     } catch {
-      filesIndex = { name: manifest?.name, version: manifest?.version, files: filesIntegrity }
+      filesIndex = { name: manifest?.name, version: manifest?.version, files: {} }
     }
     filesIndex.sideEffects = filesIndex.sideEffects ?? {}
     filesIndex.sideEffects[sideEffectsCacheKey] = calculateDiff(filesIndex.files, filesIntegrity)

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -208,7 +208,8 @@ function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles)
       deleted.push(file)
     } else if (
       !baseFiles[file] ||
-      (baseFiles[file].integrity !== sideEffectsFiles[file].integrity || baseFiles[file].mode !== sideEffectsFiles[file].mode)
+      baseFiles[file].integrity !== sideEffectsFiles[file].integrity ||
+      baseFiles[file].mode !== sideEffectsFiles[file].mode
     ) {
       added[file] = sideEffectsFiles[file]
     }

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import gfs from '@pnpm/graceful-fs'
 import * as crypto from 'crypto'
-import { type Cafs, type PackageFileInfoMap, type SideEffects, type SideEffectsDiff } from '@pnpm/cafs-types'
+import { type Cafs, type PackageFiles, type SideEffects, type SideEffectsDiff } from '@pnpm/cafs-types'
 import { createCafsStore } from '@pnpm/create-cafs-store'
 import { pkgRequiresBuild } from '@pnpm/exec.pkg-requires-build'
 import { hardLinkDir } from '@pnpm/fs.hard-link-dir'
@@ -192,10 +192,10 @@ function addFilesFromDir ({ dir, cafsDir, filesIndexFile, sideEffectsCacheKey, f
   return { status: 'success', value: { filesIndex: filesMap, manifest, requiresBuild } }
 }
 
-function calculateDiff (baseFiles: PackageFileInfoMap, sideEffectsFiles: PackageFileInfoMap): SideEffectsDiff {
+function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles): SideEffectsDiff {
   const deleted: string[] = []
-  const modified: PackageFileInfoMap = {}
-  const added: PackageFileInfoMap = {}
+  const modified: PackageFiles = {}
+  const added: PackageFiles = {}
   for (const file of Array.from(new Set([...Object.keys(baseFiles), ...Object.keys(sideEffectsFiles)]))) {
     if (!sideEffectsFiles[file]) {
       deleted.push(file)

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -202,18 +202,18 @@ function addFilesFromDir ({ dir, cafsDir, filesIndexFile, sideEffectsCacheKey, f
 
 function calculateDiff (baseFiles: PackageFiles, sideEffectsFiles: PackageFiles): SideEffectsDiff {
   const deleted: string[] = []
-  const modified: PackageFiles = {}
   const added: PackageFiles = {}
   for (const file of Array.from(new Set([...Object.keys(baseFiles), ...Object.keys(sideEffectsFiles)]))) {
     if (!sideEffectsFiles[file]) {
       deleted.push(file)
-    } else if (!baseFiles[file]) {
+    } else if (
+      !baseFiles[file] ||
+      (baseFiles[file].integrity !== sideEffectsFiles[file].integrity || baseFiles[file].mode !== sideEffectsFiles[file].mode)
+    ) {
       added[file] = sideEffectsFiles[file]
-    } else if (baseFiles[file].integrity !== sideEffectsFiles[file].integrity || baseFiles[file].mode !== sideEffectsFiles[file].mode) {
-      modified[file] = sideEffectsFiles[file]
     }
   }
-  return { deleted, modified, added }
+  return { deleted, added }
 }
 
 interface ProcessFilesIndexResult {


### PR DESCRIPTION
The previous structure of the index file:

```
{
  "files": {
    "<filePath>": {<fileInfo>}
  },
  "sideEffects": {
    "<key>": {
      "<filePath>": {<fileInfo>}
    }
  }
}
```

Side effects listed all the files not just those created by postinstall scripts.

The new format will save a diff instead:

```
{
  "files": {
    "<filePath>": {<fileInfo>}
  },
  "sideEffects": {
    "<key>": {
      "deleted": [<list of deleted files>],
      "added": {
        "<filePath>": {<fileInfo>} // added or modified files
      }
    }
  }
}
```