### PR TITLE
fix: properly check modules purge confirmation answer

### DIFF
--- a/.changeset/friendly-meals-kick.md
+++ b/.changeset/friendly-meals-kick.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/get-context": patch
+"pnpm": patch
+---
+
+Don't purge `node_modules`, when typing "n" in the prompt that asks whether to remove `node_modules` before installation [#8655](https://github.com/pnpm/pnpm/pull/8655).

--- a/pkg-manager/get-context/src/index.ts
+++ b/pkg-manager/get-context/src/index.ts
@@ -346,7 +346,7 @@ async function purgeModulesDirsOfImporters (
   importers: ImporterToPurge[]
 ): Promise<void> {
   if (opts.confirmModulesPurge ?? true) {
-    const confirmed = await enquirer.prompt({
+    const confirmed = await enquirer.prompt<{ question: boolean }>({
       type: 'confirm',
       name: 'question',
       message: importers.length === 1
@@ -354,7 +354,7 @@ async function purgeModulesDirsOfImporters (
         : 'The modules directories will be removed and reinstalled from scratch. Proceed?',
       initial: true,
     })
-    if (!confirmed) {
+    if (!confirmed.question) {
       throw new PnpmError('ABORTED_REMOVE_MODULES_DIR', 'Aborted removal of modules directory')
     }
   }


### PR DESCRIPTION
Return value is `{ question: boolean }` (where `question` is the string given for argument `name`), not `boolean`.

Previously `node_modules` would be purged no matter what answer is given.

Discovered while investigating #8654