### PR TITLE
fix(pnpm): change `printError` to write to `stderr` instead of `stdout`

### DIFF
--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -344,9 +344,9 @@ export async function main (inputArgv: string[]): Promise<void> {
 
 function printError (message: string, hint?: string): void {
   const ERROR = chalk.bgRed.black('\u2009ERROR\u2009')
-  console.log(`${message.startsWith(ERROR) ? '' : ERROR + ' '}${chalk.red(message)}`)
+  console.error(`${message.startsWith(ERROR) ? '' : ERROR + ' '}${chalk.red(message)}`)
   if (hint) {
-    console.log(hint)
+    console.error(hint)
   }
 }
 

--- a/pnpm/test/cli.ts
+++ b/pnpm/test/cli.ts
@@ -79,10 +79,10 @@ test('pnpm fails when no command is specified', async () => {
 test('command fails when an unsupported flag is used', async () => {
   prepare()
 
-  const { status, stdout } = execPnpmSync(['update', '--save-dev'])
+  const { status, stderr } = execPnpmSync(['update', '--save-dev'])
 
   expect(status).toBe(1)
-  expect(stdout.toString()).toMatch(/Unknown option: 'save-dev'/)
+  expect(stderr.toString()).toMatch(/Unknown option: 'save-dev'/)
 })
 
 test('command does not fail when a deprecated option is used', async () => {

--- a/pnpm/test/install/hooks.ts
+++ b/pnpm/test/install/hooks.ts
@@ -304,7 +304,7 @@ test('fails when .pnpmfile.cjs requires a non-existed module', async () => {
 
   const proc = execPnpmSync(['install', '@pnpm.e2e/pkg-with-1-dep'])
 
-  expect(proc.stdout.toString()).toContain('Error during pnpmfile execution')
+  expect(proc.stderr.toString()).toContain('Error during pnpmfile execution')
   expect(proc.status).toBe(1)
 })
 

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -272,10 +272,10 @@ test('install should not fail if the used pnpm version does not satisfy the pnpm
 
   expect(execPnpmSync(['install']).status).toBe(0)
 
-  const { status, stdout } = execPnpmSync(['install', '--config.package-manager-strict-version=true'])
+  const { status, stderr } = execPnpmSync(['install', '--config.package-manager-strict-version=true'])
 
   expect(status).toBe(1)
-  expect(stdout.toString()).toContain('This project is configured to use v0.0.0 of pnpm. Your current pnpm is')
+  expect(stderr.toString()).toContain('This project is configured to use v0.0.0 of pnpm. Your current pnpm is')
 })
 
 test('install should fail if the project requires a different package manager', async () => {
@@ -286,10 +286,10 @@ test('install should fail if the project requires a different package manager', 
     packageManager: 'yarn@4.0.0',
   })
 
-  const { status, stdout } = execPnpmSync(['install'])
+  const { status, stderr } = execPnpmSync(['install'])
 
   expect(status).toBe(1)
-  expect(stdout.toString()).toContain('This project is configured to use yarn')
+  expect(stderr.toString()).toContain('This project is configured to use yarn')
 
   expect(execPnpmSync(['install', '--config.package-manager-strict=false']).status).toBe(0)
 })

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -71,8 +71,8 @@ test('incorrect workspace manifest', async () => {
 
   writeYamlFile('pnpm-workspace.yml', { packages: ['**', '!store/**'] })
 
-  const { status, stdout } = execPnpmSync(['install'])
-  expect(stdout.toString()).toMatch(/The workspace manifest file should be named "pnpm-workspace.yaml"/)
+  const { status, stderr } = execPnpmSync(['install'])
+  expect(stderr.toString()).toMatch(/The workspace manifest file should be named "pnpm-workspace.yaml"/)
   expect(status).toBe(1)
 })
 


### PR DESCRIPTION
Command-line utilities typically write error messages, including usage/help messages for invalid options, to the standard error (`stderr`).  This ensures that the standard output (`stdout`) remains clean and is especially important if the output is expected to be read by other tools.

For example, if I run `grep --invalid-opt`, all the following gets written to `stderr`, and nothing to `stdout`:

```
grep: unrecognized option '--invalid-opt'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
```

This pattern is followed by most common utilities like `cd`, `ls`, `find`, and `tar` to name a few off the top of my head.

Recently, I ran into some cryptic errors when I launched my terminal:

```
bash:  ERROR : command not found...
bash: For: command not found...
```

It turns out this was because I `source`'d the output of `pnpm completion bash` in my `.bashrc` file, as per suggestion in the docs. "And what's there in the output", you might ask. Surprise, surprise, an error message:

```
 ERROR  This project is configured to use npm
For help, run: pnpm help
```

Apparently, when `pnpm completion bash` was run, an error occurred, and instead of being displayed to the terminal, the error message was written to a file and subsequently interpreted as shell commands by Bash. 🤦

This issue could be avoided by following the convention of writing error messages to `stderr`, which this pull request addresses. Specially, it fixes the `printError` function in `pnpm/src/main.ts`.

While there may be other instances of this issue throughout the codebase, this PR should resolve the problem I encountered and will serve as a good starting point. 🙂