### PR TITLE
chore: add "directory" to package.json "repository"

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -274,12 +274,13 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
   scripts.compile = 'tsc --build && pnpm run lint --fix'
   delete scripts.tsc
   let homepage: string
-  let repository: string | { type: 'git', url: string }
+  let repository: string | { type: 'git', url: string, directory: 'pnpm' }
   if (manifest.name === CLI_PKG_NAME) {
     homepage = 'https://pnpm.io'
     repository = {
       type: 'git',
       url: 'git+https://github.com/pnpm/pnpm.git',
+      directory: 'pnpm',
     }
     scripts.compile += ' && rimraf dist bin/nodes && pnpm run bundle \
 && shx cp -r node-gyp-bin dist/node-gyp-bin \

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -158,7 +158,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pnpm/pnpm.git"
+    "url": "git+https://github.com/pnpm/pnpm.git",
+    "directory": "pnpm"
   },
   "scripts": {
     "bundle": "ts-node bundle.ts",


### PR DESCRIPTION
This further specification of npm's ["repository"](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) key allows tools like @renovate-bot to locate the precise package and report on the CHANGELOG.md w/in its auto-generated dependency upgrade reports.

Currently:

<img width="356" alt="image" src="https://github.com/user-attachments/assets/192de6f9-11de-472b-91c6-05442c6de9d5">

Afterwards, that disclosure will include the diff of the changes between the versions being upgraded between

Ex from vitest:

<img width="843" alt="image" src="https://github.com/user-attachments/assets/dedcf61d-ef80-4191-80d5-1077e9dbd35c">
