### PR TITLE
fix: fork bomb when pnpm self-manages its version

### DIFF
--- a/.changeset/great-onions-matter.md
+++ b/.changeset/great-onions-matter.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fix a bug causing pnpm to infinitely spawn itself when `manage-package-manager-versions=true` is set and the `.tools` directory is corrupt.

--- a/.changeset/swift-panthers-matter.md
+++ b/.changeset/swift-panthers-matter.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+When `manage-package-manager-versions` is set to `true`, errors spawning a self-managed version of `pnpm` will now be shown (instead of being silent).

--- a/pnpm/src/switchCliVersion.ts
+++ b/pnpm/src/switchCliVersion.ts
@@ -44,7 +44,19 @@ export async function switchCliVersion (config: Config): Promise<void> {
     // We throw this error to prevent an infinite recursive call of the same pnpm version.
     throw new PnpmError('VERSION_SWITCH_FAIL', `Failed to switch pnpm to v${pm.version}. Looks like pnpm CLI is missing at "${wantedPnpmBinDir}" or is incorrect`)
   }
-  const { status } = spawn.sync('pnpm', process.argv.slice(2), {
+
+  // Specify the exact pnpm file path that's expected to execute to spawn.sync()
+  //
+  // It's not safe spawn 'pnpm' (without specifying an absolute path) and expect
+  // it to resolve to the same file path computed above due to the $PATH
+  // environment variable. While that does happen in most cases, there's a
+  // scenario where the wanted pnpm bin dir exists, but no pnpm binary is
+  // present within that directory. If that's the case, a different pnpm bin can
+  // get executed, causing infinite spawn and fork bombing the user. See details
+  // at https://github.com/pnpm/pnpm/pull/8679.
+  const pnpmBinPath = path.join(wantedPnpmBinDir, 'pnpm')
+
+  const { status } = spawn.sync(pnpmBinPath, process.argv.slice(2), {
     stdio: 'inherit',
     env: {
       ...process.env,

--- a/pnpm/src/switchCliVersion.ts
+++ b/pnpm/src/switchCliVersion.ts
@@ -42,7 +42,7 @@ export async function switchCliVersion (config: Config): Promise<void> {
   const pnpmEnv = prependDirsToPath([wantedPnpmBinDir])
   if (!pnpmEnv.updated) {
     // We throw this error to prevent an infinite recursive call of the same pnpm version.
-    throw new PnpmError('VERSION_SWITCH_FAIL', `Failed to switch pnpm to v${pm.version}. Looks like pnpm CLI is missing at "${wantedPnpmBinDir}" or is incorrect`)
+    throw new VersionSwitchFail(pm.version, wantedPnpmBinDir)
   }
 
   // Specify the exact pnpm file path that's expected to execute to spawn.sync()
@@ -64,4 +64,10 @@ export async function switchCliVersion (config: Config): Promise<void> {
     },
   })
   process.exit(status ?? 0)
+}
+
+class VersionSwitchFail extends PnpmError {
+  constructor (version: string, wantedPnpmBinDir: string) {
+    super('VERSION_SWITCH_FAIL', `Failed to switch pnpm to v${version}. Looks like pnpm CLI is missing at "${wantedPnpmBinDir}" or is incorrect`)
+  }
 }

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -1,8 +1,10 @@
 import path from 'path'
 import fs from 'fs'
 import { prepare } from '@pnpm/prepare'
+import { getToolDirPath } from '@pnpm/tools.path'
 import { sync as writeJsonFile } from 'write-json-file'
 import { execPnpmSync } from './utils'
+import isWindows from 'is-windows'
 
 test('switch to the pnpm version specified in the packageManager field of package.json, when manager-package-manager=versions is true', async () => {
   prepare()
@@ -57,4 +59,28 @@ test('do not switch to pnpm version when a range is specified', async () => {
   const { stdout } = execPnpmSync(['help'], { env })
 
   expect(stdout.toString()).toContain('Cannot switch to pnpm@^9.3.0')
+})
+
+test('throws error if pnpm tools dir is corrupt', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  const version = '9.3.0'
+  fs.writeFileSync('.npmrc', 'manage-package-manager-versions=true')
+  writeJsonFile('package.json', {
+    packageManager: `pnpm@${version}`,
+  })
+
+  // Run pnpm once to ensure the tools dir is created.
+  execPnpmSync(['help'], { env })
+
+  // Intentionally corrupt the tool dir.
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
+  fs.rmSync(path.join(toolDir, 'bin/pnpm'))
+  if (isWindows()) {
+    fs.rmSync(path.join(toolDir, 'bin/pnpm.cmd'))
+  }
+
+  const { stdout } = execPnpmSync(['help'], { env })
+  expect(stdout.toString()).toContain('Failed to switch pnpm to v9.3.0. Looks like pnpm CLI is missing')
 })

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -81,6 +81,6 @@ test('throws error if pnpm tools dir is corrupt', () => {
     fs.rmSync(path.join(toolDir, 'bin/pnpm.cmd'))
   }
 
-  const { stdout } = execPnpmSync(['help'], { env })
-  expect(stdout.toString()).toContain('Failed to switch pnpm to v9.3.0. Looks like pnpm CLI is missing')
+  const { stderr } = execPnpmSync(['help'], { env })
+  expect(stderr.toString()).toContain('Failed to switch pnpm to v9.3.0. Looks like pnpm CLI is missing')
 })


### PR DESCRIPTION
## Problem

I recently updated my pnpm git clone and ran:

```sh
❯ pnpm install
```

This hung for 10+ minutes and ended up [fork bombing](https://en.wikipedia.org/wiki/Fork_bomb) my laptop. My laptop became unusable and crashed. Note the 13GB+ of swap used and hundreds of `pnpm` processes.

<img width="1072" alt="Screenshot 2024-10-20 at 2 52 04 PM" src="https://github.com/user-attachments/assets/72c59355-2ef4-458f-8a80-c33dfe51ff36">

## Debugging

This took me a bit to root cause, but what was happening was the `.tools/9.12.0` directory had a partial download.

Here's the **bad state**:

```
❯ tree -L2 ~/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.0
/Users/gluxon/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.0
├── node_modules
└── package.json
```

Here's what a **good state** is supposed to look like:

```
❯ tree -L2 ~/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.0
/Users/gluxon/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.0
├── bin
│   └── pnpm
├── node_modules
│   └── @pnpm
├── package.json
└── pnpm-lock.yaml
```

If the `$PNPM_HOME/.tools/@pnpm+macos-arm64/9.12.0/bin/pnpm` file doesn't exist, the original `pnpm` binary at `~/Library/pnpm/pnpm` gets spawned instead.

## Steps to Reproduce

1. Configure `packageManager` in a `package.json` file.
2. Configure `manage-package-manager-versions=true` in an `.npmrc` file.
3. **Run `pnpm --version`, but immediately Ctrl-C.** You'll now have a partially downloaded directory at `$PNPM_HOME/.tools/<dist>/<version>`.
5. Run `pnpm --version` again and observe the fork bomb.

## Changes

To prevent a fork bomb, let's specify the absolute file path of `pnpm` that we expect to execute and not rely on `$PATH` resolution.

<img width="842" alt="Screenshot 2024-10-20 at 3 50 35 PM" src="https://github.com/user-attachments/assets/ddb3e0b3-8dbf-4c5a-a7c8-e91ac4278b09">

## Future

In a future PR, we should also make `.tools/<dist>/<version>` creation more atomic. Ideally this directory shouldn't exist if if the contents aren't complete.