### PR TITLE
refactor: remove `!` usages from `prependDirsToPath`

### DIFF
--- a/env/path/src/index.ts
+++ b/env/path/src/index.ts
@@ -9,10 +9,11 @@ export interface PrependDirsToPathResult {
 
 export function prependDirsToPath (prependDirs: string[], env = process.env): PrependDirsToPathResult {
   const prepend = prependDirs.join(path.delimiter)
-  if (env[PATH] != null && (env[PATH] === prepend || env[PATH]!.startsWith(`${prepend}${path.delimiter}`))) {
+  const envPath = env[PATH]
+  if (envPath != null && (envPath === prepend || envPath.startsWith(`${prepend}${path.delimiter}`))) {
     return {
       name: PATH,
-      value: env[PATH]!,
+      value: envPath,
       updated: false,
     }
   }
@@ -20,7 +21,7 @@ export function prependDirsToPath (prependDirs: string[], env = process.env): Pr
     name: PATH,
     value: [
       prepend,
-      ...(env[PATH] != null ? [env[PATH]] : []),
+      ...(envPath != null ? [envPath] : []),
     ].join(path.delimiter),
     updated: true,
   }


### PR DESCRIPTION
## Changes

While investigating a separate bug (https://github.com/pnpm/pnpm/pull/8679), I noticed we could remove usages of `!` in `prependDirsToPath`.

No changeset in this PR since it should be a no-op.