### PR TITLE
fix: disregard `wantedPackageManager` for certain commands

### DIFF
--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -106,7 +106,23 @@ export async function main (inputArgv: string[]): Promise<void> {
       checkUnknownSetting: false,
       ignoreNonAuthSettingsFromLocal: isDlxCommand,
     }) as typeof config
-    if (!isExecutedByCorepack() && cmd !== 'setup' && config.wantedPackageManager != null) {
+    // In some cases, we would want to proceed without regard for the
+    // "packageManager" field in the manifest file.
+    const ignoreWantedPackageManager = isExecutedByCorepack() ||
+    // Some commands should run irrespective of the current project.
+    !cmd || [
+      'cat-file',
+      'cat-index',
+      'completion',
+      'completion-server',
+      'env',
+      'find-hash',
+      'init',
+      'self-update',
+      'setup',
+      'store',
+    ].includes(cmd)
+    if (!ignoreWantedPackageManager && config.wantedPackageManager != null) {
       if (config.managePackageManagerVersions) {
         await switchCliVersion(config)
       } else {


### PR DESCRIPTION
Currently, there is a class of CLI commands that at a conceptual level, ought to run "globally" irrespective of the current project. For instance, when running `pnpm self-update`, we really shouldn't care about the `"packageManager"` field (or any other field, in fact) in the project manifest, as the action we're performing isn't concerned with any specific project.

This PR makes sure that for these commands, the `switchCliVersion` and `checkPackageManager` functions will not be called, so that they can be executed smoothly.

close #7959