### PR TITLE
chore: fix esbuild external warning

### DIFF
--- a/pnpm/bundle.ts
+++ b/pnpm/bundle.ts
@@ -12,7 +12,10 @@ import { build } from 'esbuild'
       bundle: true,
       platform: 'node',
       outfile: 'dist/pnpm.cjs',
-      external: ['node-gyp'],
+      external: [
+        'node-gyp',
+        './get-uid-gid.js', // traces back to: https://github.com/npm/uid-number/blob/6e9bdb302ae4799d05abf12e922ccdb4bd9ea023/uid-number.js#L31
+      ],
       define: {
         'process.env.npm_package_name': JSON.stringify(
           process.env.npm_package_name


### PR DESCRIPTION
Fix esbuild external  warning while running `pnpm run compile`, no changeset needed
```
▲ [WARNING] "./get-uid-gid.js" should be marked as external for use with "require.resolve" [require-resolve-not-external]
```