### PR TITLE
feat: display packed files list in `pnpm pack`

### DIFF
--- a/.changeset/large-buses-destroy.md
+++ b/.changeset/large-buses-destroy.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+Display packed files list in `pnpm pack`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6111,6 +6111,9 @@ importers:
       '@zkochan/rimraf':
         specifier: 'catalog:'
         version: 3.0.2
+      chalk:
+        specifier: 'catalog:'
+        version: 4.1.2
       enquirer:
         specifier: 'catalog:'
         version: 2.4.1

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -73,6 +73,7 @@
     "@pnpm/sort-packages": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@zkochan/rimraf": "catalog:",
+    "chalk": "catalog:",
     "enquirer": "catalog:",
     "execa": "catalog:",
     "fast-glob": "catalog:",

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -112,8 +112,6 @@ export async function handler (
       [path.join(dir, 'package.json')]: publishManifest as Record<string, unknown>,
     },
   })
-  // display order by name
-  const packFiles = files.sort().join('\n')
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line
   if (opts.workspaceDir != null && dir !== opts.workspaceDir && !files.some((file) => /LICEN[CS]E(\..+)?/i.test(file))) {
@@ -147,7 +145,7 @@ export async function handler (
   } else {
     packPath = path.relative(opts.dir, path.join(dir, tarballName))
   }
-  return `${chalk.blueBright('Tarball Contents')}\n${packFiles}\n\n${chalk.blueBright('Tarball Details')}\n${packPath}`
+  return `${chalk.blueBright('Tarball Contents')}\n${files.sort((a, b) => a.localeCompare(b, 'en')).join('\n')}\n\n${chalk.blueBright('Tarball Details')}\n${packPath}`
 }
 
 function preventBundledDependenciesWithoutHoistedNodeLinker (nodeLinker: Config['nodeLinker'], manifest: ProjectManifest): void {

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -139,13 +139,17 @@ export async function handler (
   if (!opts.ignoreScripts) {
     await _runScriptsIfPresent(['postpack'], entryManifest)
   }
-  let packPath
+  let packedTarballPath
   if (opts.dir !== destDir) {
-    packPath = path.join(destDir, tarballName)
+    packedTarballPath = path.join(destDir, tarballName)
   } else {
-    packPath = path.relative(opts.dir, path.join(dir, tarballName))
+    packedTarballPath = path.relative(opts.dir, path.join(dir, tarballName))
   }
-  return `${chalk.blueBright('Tarball Contents')}\n${files.sort((a, b) => a.localeCompare(b, 'en')).join('\n')}\n\n${chalk.blueBright('Tarball Details')}\n${packPath}`
+  return `${chalk.blueBright('Tarball Contents')}
+${files.sort((a, b) => a.localeCompare(b, 'en')).join('\n')}
+
+${chalk.blueBright('Tarball Details')}
+${packedTarballPath}`
 }
 
 function preventBundledDependenciesWithoutHoistedNodeLinker (nodeLinker: Config['nodeLinker'], manifest: ProjectManifest): void {

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -15,7 +15,6 @@ import realpathMissing from 'realpath-missing'
 import renderHelp from 'render-help'
 import tar from 'tar-stream'
 import { runScriptsIfPresent } from './publish'
-import { globalInfo } from '@pnpm/logger'
 import chalk from 'chalk'
 
 const LICENSE_GLOB = 'LICEN{S,C}E{,.*}' // cspell:disable-line
@@ -114,7 +113,7 @@ export async function handler (
     },
   })
   // display order by name
-  globalInfo(`${chalk.blueBright('Tarball Contents')}\n${files.sort().join('\n')}`)
+  const packFiles = files.sort().join('\n')
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line
   if (opts.workspaceDir != null && dir !== opts.workspaceDir && !files.some((file) => /LICEN[CS]E(\..+)?/i.test(file))) {
@@ -148,7 +147,7 @@ export async function handler (
   } else {
     packPath = path.relative(opts.dir, path.join(dir, tarballName))
   }
-  return `\n${chalk.blueBright('Tarball Details')}\n${packPath}`
+  return `${chalk.blueBright('Tarball Contents')}\n${packFiles}\n\n${chalk.blueBright('Tarball Details')}\n${packPath}`
 }
 
 function preventBundledDependenciesWithoutHoistedNodeLinker (nodeLinker: Config['nodeLinker'], manifest: ProjectManifest): void {

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -3,20 +3,8 @@ import path from 'path'
 import { pack } from '@pnpm/plugin-commands-publishing'
 import { prepare, tempDir } from '@pnpm/prepare'
 import tar from 'tar'
+import chalk from 'chalk'
 import { DEFAULT_OPTS } from './utils'
-import { globalInfo } from '@pnpm/logger'
-
-jest.mock('@pnpm/logger', () => {
-  const originalModule = jest.requireActual('@pnpm/logger')
-  return {
-    ...originalModule,
-    globalInfo: jest.fn(),
-  }
-})
-
-beforeEach(() => {
-  ;(globalInfo as jest.Mock).mockClear()
-})
 
 test('pack: package with package.json', async () => {
   prepare({
@@ -437,12 +425,12 @@ test('pack: should display packed contents order by name', async () => {
   fs.writeFileSync('./a.js', 'a', 'utf8')
   fs.writeFileSync('./b.js', 'b', 'utf8')
 
-  await pack.handler({
+  const output = await pack.handler({
     ...DEFAULT_OPTS,
     argv: { original: [] },
     dir: process.cwd(),
     extraBinPaths: [],
   })
 
-  expect(globalInfo).toHaveBeenCalledWith(expect.stringContaining('a.js\nb.js\npackage.json\nsrc/index.ts'))
+  expect(output).toBe(`${chalk.blueBright('Tarball Contents')}\na.js\nb.js\npackage.json\nsrc/index.ts\n\n${chalk.blueBright('Tarball Details')}\ntest-publish-package.json-0.0.0.tgz`)
 })


### PR DESCRIPTION
close #8676 

It's useful to display packed files since `pnpm pack` only shows tarball filename now

## Before
![image](https://github.com/user-attachments/assets/320bfb86-b88e-4f4d-96f2-1f159d85e56d)

## After
![image](https://github.com/user-attachments/assets/5a16c12f-c980-4c8d-a4ed-4f8be1a71f6a)
