### PR TITLE
fix: print ERR_PNPM_NO_GLOBAL_BIN_DIR error  when global bin directory is not found

### DIFF
--- a/.changeset/shaggy-poems-appear.md
+++ b/.changeset/shaggy-poems-appear.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+Print ERR_PNPM_NO_GLOBAL_BIN_DIR error in `pnpm link --global` when global bin directory is not found

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -144,6 +144,12 @@ export async function handler (
     workspacePackages,
   })
 
+  if (opts.cliOptions?.global && !opts.bin) {
+    throw new PnpmError('NO_GLOBAL_BIN_DIR', 'Unable to find the global bin directory', {
+      hint: 'Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable. The global bin directory should be in the PATH.',
+    })
+  }
+
   const linkCwdDir = opts.cliOptions?.dir && opts.cliOptions?.global ? path.resolve(opts.cliOptions.dir) : cwd
 
   // pnpm link

--- a/pkg-manager/plugin-commands-installation/test/link.ts
+++ b/pkg-manager/plugin-commands-installation/test/link.ts
@@ -10,6 +10,7 @@ import { sync as loadJsonFile } from 'load-json-file'
 import PATH from 'path-name'
 import writePkg from 'write-pkg'
 import { DEFAULT_OPTS } from './utils'
+import { type PnpmError } from '@pnpm/error'
 
 const f = fixtures(__dirname)
 
@@ -356,4 +357,25 @@ test('logger should not warn about peer dependencies when it is an empty object'
   }))
 
   warnMock.mockRestore()
+})
+
+test('link: fail when global bin directory is not found', async () => {
+  prepare()
+
+  const globalDir = path.resolve('global')
+
+  let err!: PnpmError
+  try {
+    await link.handler({
+      ...DEFAULT_OPTS,
+      bin: undefined as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      dir: globalDir,
+      cliOptions: {
+        global: true,
+      },
+    })
+  } catch (_err: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    err = _err
+  }
+  expect(err.code).toBe('ERR_PNPM_NO_GLOBAL_BIN_DIR')
 })


### PR DESCRIPTION
 `pnpm link --global`  should print ERR_PNPM_NO_GLOBAL_BIN_DIR error when global bin directory is not found. Fow now, it prints nothing.