### PR TITLE
♿️ Add alt text to README pnpm logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-![](https://i.imgur.com/qlW1eEG.png)
+# <a href="#"> ![pnpm](https://i.imgur.com/qlW1eEG.png) </a>
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-# <picture> ![pnpm](https://i.imgur.com/qlW1eEG.png) </picture>
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+    <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+    <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+  </picture>
+</h1>
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ To quote the [Rush](https://rushjs.io/) team:
     <tr>
       <td align="center" valign="middle">
         <a href="https://route4me.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <picture>
-            <img src="https://pnpm.io/img/users/route4me.svg" width="220" />
-          </picture>
+          <img src="https://pnpm.io/img/users/route4me.svg" width="220" />
         </a>
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<picture>
-  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
-  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
-  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
-</picture>
+<img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-# <a href="#"> ![pnpm](https://i.imgur.com/qlW1eEG.png) </a>
+# <picture> ![pnpm](https://i.imgur.com/qlW1eEG.png) </picture>
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+</picture>
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<h1>
-  <picture>
-    <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
-    <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
-    <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
-  </picture>
-</h1>
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+</picture>
 
 Fast, disk space efficient package manager:
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ To quote the [Rush](https://rushjs.io/) team:
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
+        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://figma.com/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80"></a>
+        <a href="https://figma.com/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80" alt="Figma"></a>
       </td>
     </tr>
   </tbody>
@@ -60,7 +60,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/discord.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/discord_light.svg" />
-            <img src="https://pnpm.io/img/users/discord.svg" width="220" />
+            <img src="https://pnpm.io/img/users/discord.svg" width="220" alt="Discord" />
           </picture>
         </a>
       </td>
@@ -69,7 +69,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/prisma.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/prisma_light.svg" />
-            <img src="https://pnpm.io/img/users/prisma.svg" width="180" />
+            <img src="https://pnpm.io/img/users/prisma.svg" width="180" alt="Prisma" />
           </picture>
         </a>
       </td>
@@ -80,7 +80,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/uscreen.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/uscreen_light.svg" />
-            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" />
+            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" alt="u|screen" />
           </picture>
         </a>
       </td>
@@ -89,7 +89,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
-            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" />
+            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" alt="JetBrains" />
           </picture>
         </a>
       </td>
@@ -100,7 +100,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nx.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nx_light.svg" />
-            <img src="https://pnpm.io/img/users/nx.svg" width="120" />
+            <img src="https://pnpm.io/img/users/nx.svg" width="120" alt="Nx" />
           </picture>
         </a>
       </td>
@@ -109,7 +109,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/coderabbit.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/coderabbit_light.svg" />
-            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" />
+            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" alt="CodeRabbit" />
           </picture>
         </a>
       </td>
@@ -117,7 +117,7 @@ To quote the [Rush](https://rushjs.io/) team:
     <tr>
       <td align="center" valign="middle">
         <a href="https://route4me.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <img src="https://pnpm.io/img/users/route4me.svg" width="220" />
+          <img src="https://pnpm.io/img/users/route4me.svg" width="220" alt="Route4Me" />
         </a>
       </td>
     </tr>
@@ -131,7 +131,7 @@ To quote the [Rush](https://rushjs.io/) team:
     <tr>
       <td align="center" valign="middle">
         <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80">
+          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80" alt="Leniolabs_">
         </a>
       </td>
       <td align="center" valign="middle">
@@ -139,7 +139,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vercel.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vercel_light.svg" />
-            <img src="https://pnpm.io/img/users/vercel.svg" width="180" />
+            <img src="https://pnpm.io/img/users/vercel.svg" width="180" alt="Vercel" />
           </picture>
         </a>
       </td>
@@ -150,7 +150,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/depot.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/depot_light.svg" />
-            <img src="https://pnpm.io/img/users/depot.svg" width="200" />
+            <img src="https://pnpm.io/img/users/depot.svg" width="200" alt="Depot" />
           </picture>
         </a>
       </td>
@@ -159,7 +159,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/moonrepo.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/moonrepo_light.svg" />
-            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" />
+            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" alt="moonrepo" />
           </picture>
         </a>
       </td>
@@ -170,7 +170,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/devowlio.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/devowlio.svg" />
-            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" />
+            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" alt="devowl.io" />
           </picture>
         </a>
       </td>
@@ -179,7 +179,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/cerbos.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/cerbos_light.svg" />
-            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" />
+            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" alt="Cerbos" />
           </picture>
         </a>
       </td>
@@ -190,13 +190,13 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vlt.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vlt_light.svg" />
-            <img src="https://pnpm.io/img/users/vlt.svg" width="140" />
+            <img src="https://pnpm.io/img/users/vlt.svg" width="140" alt="vlt" />
           </picture>
         </a>
       </td>
       <td align="center" valign="middle">
         <a href="https://vite.dev/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <img src="https://pnpm.io/img/users/vitejs.svg" width="65">
+          <img src="https://pnpm.io/img/users/vitejs.svg" width="65" alt="Vite">
         </a>
       </td>
     </tr>
@@ -243,13 +243,13 @@ Benchmarks on an app with lots of dependencies:
 
 Thank you to all our backers! [Become a backer](https://opencollective.com/pnpm#backer)
 
-<a href="https://opencollective.com/pnpm#backers" target="_blank"><img src="https://opencollective.com/pnpm/backers.svg?width=890"></a>
+<a href="https://opencollective.com/pnpm#backers" target="_blank"><img src="https://opencollective.com/pnpm/backers.svg?width=890" alt="Open Collective"></a>
 
 ## Contributors
 
 This project exists thanks to all the people who contribute. [Contribute](../../blob/main/CONTRIBUTING.md).
 
-<a href="../../graphs/contributors"><img src="https://opencollective.com/pnpm/contributors.svg?width=890&button=false" /></a>
+<a href="../../graphs/contributors"><img src="https://opencollective.com/pnpm/contributors.svg?width=890&button=false" alt="Contributors"></a>
 
 ## License
 

--- a/__utils__/get-release-text/src/main.ts
+++ b/__utils__/get-release-text/src/main.ts
@@ -166,7 +166,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
   </tbody>
 </table>
 
-## Our Silver Sponsors
+## Silver Sponsors
 
 <table>
   <tbody>

--- a/__utils__/get-release-text/src/main.ts
+++ b/__utils__/get-release-text/src/main.ts
@@ -83,10 +83,10 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
+        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://figma.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80"></a>
+        <a href="https://figma.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80" alt="Figma"></a>
       </td>
     </tr>
   </tbody>
@@ -102,7 +102,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/discord.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/discord_light.svg" />
-            <img src="https://pnpm.io/img/users/discord.svg" width="220" />
+            <img src="https://pnpm.io/img/users/discord.svg" width="220" alt="Discord" />
           </picture>
         </a>
       </td>
@@ -111,7 +111,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/prisma.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/prisma_light.svg" />
-            <img src="https://pnpm.io/img/users/prisma.svg" width="180" />
+            <img src="https://pnpm.io/img/users/prisma.svg" width="180" alt="Prisma" />
           </picture>
         </a>
       </td>
@@ -122,7 +122,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/uscreen.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/uscreen_light.svg" />
-            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" />
+            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" alt="u|screen" />
           </picture>
         </a>
       </td>
@@ -131,7 +131,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
-            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" />
+            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" alt="JetBrains" />
           </picture>
         </a>
       </td>
@@ -142,7 +142,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nx.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nx_light.svg" />
-            <img src="https://pnpm.io/img/users/nx.svg" width="120" />
+            <img src="https://pnpm.io/img/users/nx.svg" width="120" alt="Nx" />
           </picture>
         </a>
       </td>
@@ -151,7 +151,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/coderabbit.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/coderabbit_light.svg" />
-            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" />
+            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" alt="CodeRabbit" />
           </picture>
         </a>
       </td>
@@ -159,9 +159,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
     <tr>
       <td align="center" valign="middle">
         <a href="https://route4me.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
-          <picture>
-            <img src="https://pnpm.io/img/users/route4me.svg" width="220" />
-          </picture>
+          <img src="https://pnpm.io/img/users/route4me.svg" width="220" alt="Route4Me" />
         </a>
       </td>
     </tr>
@@ -175,7 +173,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
     <tr>
       <td align="center" valign="middle">
         <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
-          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80">
+          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80" alt="Leniolabs_">
         </a>
       </td>
       <td align="center" valign="middle">
@@ -183,7 +181,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vercel.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vercel_light.svg" />
-            <img src="https://pnpm.io/img/users/vercel.svg" width="180" />
+            <img src="https://pnpm.io/img/users/vercel.svg" width="180" alt="Vercel" />
           </picture>
         </a>
       </td>
@@ -194,7 +192,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/depot.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/depot_light.svg" />
-            <img src="https://pnpm.io/img/users/depot.svg" width="200" />
+            <img src="https://pnpm.io/img/users/depot.svg" width="200" alt="Depot" />
           </picture>
         </a>
       </td>
@@ -203,7 +201,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/moonrepo.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/moonrepo_light.svg" />
-            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" />
+            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" alt="moonrepo" />
           </picture>
         </a>
       </td>
@@ -214,7 +212,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/devowlio.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/devowlio.svg" />
-            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" />
+            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" alt="devowl.io" />
           </picture>
         </a>
       </td>
@@ -223,7 +221,7 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/cerbos.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/cerbos_light.svg" />
-            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" />
+            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" alt="Cerbos" />
           </picture>
         </a>
       </td>
@@ -234,13 +232,13 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vlt.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vlt_light.svg" />
-            <img src="https://pnpm.io/img/users/vlt.svg" width="140" />
+            <img src="https://pnpm.io/img/users/vlt.svg" width="140" alt="vlt" />
           </picture>
         </a>
       </td>
       <td align="center" valign="middle">
         <a href="https://vite.dev/?utm_source=pnpm&utm_medium=release_notes" target="_blank">
-          <img src="https://pnpm.io/img/users/vitejs.svg" width="65">
+          <img src="https://pnpm.io/img/users/vitejs.svg" width="65" alt="Vite">
         </a>
       </td>
     </tr>

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -4,11 +4,7 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<picture>
-  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
-  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
-  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
-</picture>
+<img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
 
 Fast, disk space efficient package manager:
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -4,7 +4,13 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-![](https://i.imgur.com/qlW1eEG.png)
+<h1>
+  <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+    <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+    <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+  </picture>
+</h1>
 
 Fast, disk space efficient package manager:
 
@@ -35,10 +41,10 @@ To quote the [Rush](https://rushjs.io/) team:
   <tbody>
     <tr>
       <td align="center" valign="middle">
-        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80"></a>
+        <a href="https://bit.dev/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/bit.svg" width="80" alt="Bit"></a>
       </td>
       <td align="center" valign="middle">
-        <a href="https://figma.com/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80"></a>
+        <a href="https://figma.com/?utm_source=pnpm&utm_medium=readme" target="_blank"><img src="https://pnpm.io/img/users/figma.svg" width="80" alt="Figma"></a>
       </td>
     </tr>
   </tbody>
@@ -54,7 +60,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/discord.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/discord_light.svg" />
-            <img src="https://pnpm.io/img/users/discord.svg" width="220" />
+            <img src="https://pnpm.io/img/users/discord.svg" width="220" alt="Discord" />
           </picture>
         </a>
       </td>
@@ -63,7 +69,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/prisma.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/prisma_light.svg" />
-            <img src="https://pnpm.io/img/users/prisma.svg" width="180" />
+            <img src="https://pnpm.io/img/users/prisma.svg" width="180" alt="Prisma" />
           </picture>
         </a>
       </td>
@@ -74,7 +80,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/uscreen.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/uscreen_light.svg" />
-            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" />
+            <img src="https://pnpm.io/img/users/uscreen.svg" width="180" alt="u|screen" />
           </picture>
         </a>
       </td>
@@ -83,7 +89,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/jetbrains.svg" />
-            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" />
+            <img src="https://pnpm.io/img/users/jetbrains.svg" width="180" alt="JetBrains" />
           </picture>
         </a>
       </td>
@@ -94,7 +100,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/nx.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/nx_light.svg" />
-            <img src="https://pnpm.io/img/users/nx.svg" width="120" />
+            <img src="https://pnpm.io/img/users/nx.svg" width="120" alt="Nx" />
           </picture>
         </a>
       </td>
@@ -103,7 +109,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/coderabbit.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/coderabbit_light.svg" />
-            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" />
+            <img src="https://pnpm.io/img/users/coderabbit.svg" width="220" alt="CodeRabbit" />
           </picture>
         </a>
       </td>
@@ -111,9 +117,7 @@ To quote the [Rush](https://rushjs.io/) team:
     <tr>
       <td align="center" valign="middle">
         <a href="https://route4me.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <picture>
-            <img src="https://pnpm.io/img/users/route4me.svg" width="220" />
-          </picture>
+          <img src="https://pnpm.io/img/users/route4me.svg" width="220" alt="Route4Me" />
         </a>
       </td>
     </tr>
@@ -127,7 +131,7 @@ To quote the [Rush](https://rushjs.io/) team:
     <tr>
       <td align="center" valign="middle">
         <a href="https://leniolabs.com/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80">
+          <img src="https://pnpm.io/img/users/leniolabs.jpg" width="80" alt="Leniolabs_">
         </a>
       </td>
       <td align="center" valign="middle">
@@ -135,7 +139,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vercel.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vercel_light.svg" />
-            <img src="https://pnpm.io/img/users/vercel.svg" width="180" />
+            <img src="https://pnpm.io/img/users/vercel.svg" width="180" alt="Vercel" />
           </picture>
         </a>
       </td>
@@ -146,7 +150,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/depot.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/depot_light.svg" />
-            <img src="https://pnpm.io/img/users/depot.svg" width="200" />
+            <img src="https://pnpm.io/img/users/depot.svg" width="200" alt="Depot" />
           </picture>
         </a>
       </td>
@@ -155,7 +159,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/moonrepo.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/moonrepo_light.svg" />
-            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" />
+            <img src="https://pnpm.io/img/users/moonrepo.svg" width="200" alt="moonrepo" />
           </picture>
         </a>
       </td>
@@ -166,7 +170,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/devowlio.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/devowlio.svg" />
-            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" />
+            <img src="https://pnpm.io/img/users/devowlio.svg" width="200" alt="devowl.io" />
           </picture>
         </a>
       </td>
@@ -175,7 +179,7 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/cerbos.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/cerbos_light.svg" />
-            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" />
+            <img src="https://pnpm.io/img/users/cerbos.svg" width="180" alt="Cerbos" />
           </picture>
         </a>
       </td>
@@ -186,13 +190,13 @@ To quote the [Rush](https://rushjs.io/) team:
           <picture>
             <source media="(prefers-color-scheme: light)" srcset="https://pnpm.io/img/users/vlt.svg" />
             <source media="(prefers-color-scheme: dark)" srcset="https://pnpm.io/img/users/vlt_light.svg" />
-            <img src="https://pnpm.io/img/users/vlt.svg" width="140" />
+            <img src="https://pnpm.io/img/users/vlt.svg" width="140" alt="vlt" />
           </picture>
         </a>
       </td>
       <td align="center" valign="middle">
         <a href="https://vite.dev/?utm_source=pnpm&utm_medium=readme" target="_blank">
-          <img src="https://pnpm.io/img/users/vitejs.svg" width="65">
+          <img src="https://pnpm.io/img/users/vitejs.svg" width="65" alt="Vite">
         </a>
       </td>
     </tr>
@@ -251,13 +255,13 @@ Benchmarks on an app with lots of dependencies:
 
 Thank you to all our backers! [Become a backer](https://opencollective.com/pnpm#backer)
 
-<a href="https://opencollective.com/pnpm#backers" target="_blank"><img src="https://opencollective.com/pnpm/backers.svg?width=890"></a>
+<a href="https://opencollective.com/pnpm#backers" target="_blank"><img src="https://opencollective.com/pnpm/backers.svg?width=890" alt="Open Collective"></a>
 
 ## Contributors
 
 This project exists thanks to all the people who contribute. [Contribute](../../blob/main/CONTRIBUTING.md).
 
-<a href="../../graphs/contributors"><img src="https://opencollective.com/pnpm/contributors.svg?width=890&button=false" /></a>
+<a href="../../graphs/contributors"><img src="https://opencollective.com/pnpm/contributors.svg?width=890&button=false" alt="Contributors"></a>
 
 ## License
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -4,7 +4,11 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+</picture>
 
 Fast, disk space efficient package manager:
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -4,13 +4,11 @@
 [Italiano](https://pnpm.io/it/) |
 [Português Brasileiro](https://pnpm.io/pt/)
 
-<h1>
-  <picture>
-    <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
-    <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
-    <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
-  </picture>
-</h1>
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="https://i.imgur.com/qlW1eEG.png">
+  <source media="(prefers-color-scheme: dark)"  srcset="https://i.imgur.com/qlW1eEG.png">
+  <img src="https://i.imgur.com/qlW1eEG.png" alt="pnpm">
+</picture>
 
 Fast, disk space efficient package manager:
 


### PR DESCRIPTION
Selecting the logo image enables us to copy the alt text.

---

**What**:

Improving accessibility and usability.

**Why**:

The links to logo images on GitHub are unnecessary.
Additionally, improve semantics.

**How**:

1. Add h1 heading
2. Remove link to image on GitHub (_ref:_ https://stackoverflow.com/a/48744957/9287284)
3. Set alt text