### PR TITLE
fix(dlx): `ENOENT` when `symlink=false` (#8732)

### DIFF
--- a/exec/plugin-commands-script-runners/src/dlx.ts
+++ b/exec/plugin-commands-script-runners/src/dlx.ts
@@ -64,7 +64,7 @@ export function help (): string {
 export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
-} & Pick<Config, 'extraBinPaths' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'useNodeVersion'> & add.AddCommandOptions
+} & Pick<Config, 'extraBinPaths' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'useNodeVersion' | 'symlink'> & add.AddCommandOptions
 
 export async function handler (
   opts: DlxCommandOptions,
@@ -81,7 +81,7 @@ export async function handler (
     await add.handler({
       // Ideally the config reader should ignore these settings when the dlx command is executed.
       // This is a temporary solution until "@pnpm/config" is refactored.
-      ...omit(['workspaceDir', 'rootProjectManifest'], opts),
+      ...omit(['workspaceDir', 'rootProjectManifest', 'symlink'], opts),
       bin: path.join(cachedDir, 'node_modules/.bin'),
       dir: cachedDir,
       lockfileDir: cachedDir,

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -160,6 +160,20 @@ test('dlx should work in shell mode', async () => {
   expect(fs.existsSync('foo')).toBeTruthy()
 })
 
+test('dlx should work when symlink=false', async () => {
+  prepareEmpty()
+
+  await dlx.handler({
+    ...DEFAULT_OPTS,
+    dir: path.resolve('project'),
+    storeDir: path.resolve('store'),
+    cacheDir: path.resolve('cache'),
+    symlink: false,
+  }, ['@pnpm.e2e/touch-file-good-bin-name'])
+
+  expect(fs.existsSync('touch.txt')).toBeTruthy()
+})
+
 test('dlx should return a non-zero exit code when the underlying script fails', async () => {
   prepareEmpty()
 

--- a/exec/plugin-commands-script-runners/test/utils/index.ts
+++ b/exec/plugin-commands-script-runners/test/utils/index.ts
@@ -87,6 +87,7 @@ export const DLX_DEFAULT_OPTS = {
   rootProjectManifestDir: '',
   sort: true,
   storeDir: path.join(tmp, 'store'),
+  symlink: true,
   userConfig: {},
   workspaceConcurrency: 1,
   supportedArchitectures: {


### PR DESCRIPTION
Prior to this commit, if `symlink` was set to `false` (such as in an RC file), `dlx` would throw `ENOENT` because it expected the `node_modules/the-package` symlink to exist:

  ```console
  $ pnpm config get symlink
  false

  $ rm -rf ~/.cache/pnpm/

  $ pnpm dlx the-package
  Packages: +1
  +
  Progress: resolved 1, reused 1, downloaded 0, added 1, done
   ENOENT  ENOENT: no such file or directory, open '/home/${USER}/.cache/pnpm/dlx/.../
                                                    node_modules/the-package/package.json'
  ```

This commit filters the `symlink` option before installing the package, allowing the symlink to be created, preventing the error.

Fixes #8732.