### PR TITLE
feat: suppress resolutions and overrides workspace warnings when not needed

### DIFF
--- a/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/package.json
+++ b/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "root",
+  "version": "1.0.0",
+  "pnpm": {
+    "overrides": {
+      "cowsay": "1.0.0"
+    }
+  }
+}

--- a/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/packages/bar/package.json
+++ b/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/packages/bar/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "bar",
+  "version": "1.0.0",
+  "resolutions": {
+    "cowsay": "1.0.0"
+  }
+}

--- a/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/packages/foo/package.json
+++ b/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/packages/foo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "foo",
+  "version": "1.0.0",
+  "pnpm": {
+    "overrides": {},
+    "resolutions": {}
+  },
+  "resolutions": {}
+}

--- a/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/pnpm-workspace.yaml
+++ b/workspace/find-packages/test/__fixtures__/suppress-warning-for-non-root-project/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/workspace/find-packages/test/__fixtures__/warning-for-non-root-project/packages/bar/package.json
+++ b/workspace/find-packages/test/__fixtures__/warning-for-non-root-project/packages/bar/package.json
@@ -2,8 +2,12 @@
   "name": "bar",
   "version": "1.0.0",
   "pnpm": {
-    "overrides": {},
+    "overrides": {
+      "pokesay": "1.0.0"
+    },
     "executionEnv": {}
   },
-  "resolutions": {}
+  "resolutions": {
+    "cowsay": "1.0.0"
+  }
 }

--- a/workspace/find-packages/test/__fixtures__/warning-for-non-root-project/packages/foo/package.json
+++ b/workspace/find-packages/test/__fixtures__/warning-for-non-root-project/packages/foo/package.json
@@ -2,7 +2,9 @@
   "name": "foo",
   "version": "1.0.0",
   "pnpm": {
-    "overrides": {},
+    "overrides": {
+      "pokesay": "1.0.0"
+    },
     "executionEnv": {}
   }
 }

--- a/workspace/find-packages/test/index.ts
+++ b/workspace/find-packages/test/index.ts
@@ -53,3 +53,22 @@ test('findWorkspacePackages() output warnings for non-root workspace project', a
     [{ prefix: barPath, message: `The field "resolutions" was found in ${barPath}/package.json. This will not take effect. You should configure "resolutions" at the root of the workspace instead.` }],
   ])
 })
+
+test('findWorkspacePackages() suppress "resolutions" warnings when entries are found in root workspace project', async () => {
+  const fixturePath = path.join(__dirname, '__fixtures__/suppress-warning-for-non-root-project')
+
+  const workspaceManifest = await readWorkspaceManifest(fixturePath)
+  if (workspaceManifest?.packages == null) {
+    throw new Error(`Unexpected test setup failure. No pnpm-workspace.yaml packages were defined at ${fixturePath}`)
+  }
+
+  const pkgs = await findWorkspacePackages(fixturePath, {
+    patterns: workspaceManifest.packages,
+    sharedWorkspaceLockfile: true,
+  })
+  expect(pkgs.length).toBe(3)
+  expect(
+    (logger.warn as jest.Mock).mock.calls
+      .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+  ).toStrictEqual([])
+})


### PR DESCRIPTION
Addresses https://github.com/pnpm/pnpm/issues/8740 to only warn about "resolutions" or "overrides" if they don't fully exist in the root workspace already.