### PR TITLE
fix: `ERR_PNPM_TARBALL_EXTRACT` when the URL's hash contains a slash

### DIFF
--- a/.changeset/serious-yaks-dance.md
+++ b/.changeset/serious-yaks-dance.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tarball-resolver": patch
+"pnpm": patch
+---
+
+Fix `ERR_PNPM_TARBALL_EXTRACT` error while installing a dependency from GitHub having a slash in branch name [#7697](https://github.com/pnpm/pnpm/issues/7697).

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -568,7 +568,7 @@ test('install success even though the url\'s hash contains slash', async () => {
   const settings = ['--fetch-retries=0']
   const result = execPnpmSync([
     'add',
-    'https://github.com/actions/toolkit.git#core/1.10',
+    'https://github.com/pnpm-e2e/simple-pkg.git#branch/with-slash',
     ...settings,
   ])
   expect(result.status).toBe(0)

--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -561,3 +561,15 @@ test('do not hang on circular peer dependencies', () => {
   expect(result.status).toBe(0)
   expect(fs.existsSync(path.join(tempDir, WANTED_LOCKFILE))).toBeTruthy()
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/7697
+test('install success even though the url\'s hash contains slash', async () => {
+  prepare()
+  const settings = ['--fetch-retries=0']
+  const result = execPnpmSync([
+    'add',
+    'https://github.com/actions/toolkit.git#core/1.10',
+    ...settings,
+  ])
+  expect(result.status).toBe(0)
+})

--- a/resolving/tarball-resolver/src/index.ts
+++ b/resolving/tarball-resolver/src/index.ts
@@ -3,7 +3,7 @@ import { type PkgResolutionId, type ResolveResult } from '@pnpm/resolver-base'
 export async function resolveFromTarball (
   wantedDependency: { pref: string }
 ): Promise<ResolveResult | null> {
-  if (!(wantedDependency.pref.startsWith('http:') || wantedDependency.pref.startsWith('https:'))) {
+  if (!wantedDependency.pref.startsWith('http:') && !wantedDependency.pref.startsWith('https:')) {
     return null
   }
 

--- a/resolving/tarball-resolver/src/index.ts
+++ b/resolving/tarball-resolver/src/index.ts
@@ -3,7 +3,7 @@ import { type PkgResolutionId, type ResolveResult } from '@pnpm/resolver-base'
 export async function resolveFromTarball (
   wantedDependency: { pref: string }
 ): Promise<ResolveResult | null> {
-  if (!wantedDependency.pref.startsWith('http:') && !wantedDependency.pref.startsWith('https:')) {
+  if (!(wantedDependency.pref.startsWith('http:') || wantedDependency.pref.startsWith('https:'))) {
     return null
   }
 
@@ -26,6 +26,11 @@ const GIT_HOSTERS = new Set([
 ])
 
 function isRepository (pref: string): boolean {
+  const url = new URL(pref)
+  if (url.hash && url.hash.includes('/')) {
+    url.hash = encodeURIComponent(url.hash.substring(1))
+    pref = url.href
+  }
   if (pref.endsWith('/')) {
     pref = pref.slice(0, -1)
   }

--- a/resolving/tarball-resolver/test/index.ts
+++ b/resolving/tarball-resolver/test/index.ts
@@ -60,3 +60,13 @@ test('ignore direct URLs to repositories', async () => {
   expect(await resolveFromTarball({ pref: 'https://gitlab.com/foo/bar' })).toBe(null)
   expect(await resolveFromTarball({ pref: 'https://bitbucket.org/foo/bar' })).toBe(null)
 })
+
+test('ignore slash in hash', async () => {
+  // expect resolve from git.
+  let hash = 'path:/packages/simple-react-app'
+  expect(await resolveFromTarball({ pref: `RexSkz/test-git-subdir-fetch#${hash}` })).toBe(null)
+  expect(await resolveFromTarball({ pref: `RexSkz/test-git-subdir-fetch#${encodeURIComponent(hash)}` })).toBe(null)
+  hash = 'heads/canary'
+  expect(await resolveFromTarball({ pref: `zkochan/is-negative#${hash}` })).toBe(null)
+  expect(await resolveFromTarball({ pref: `zkochan/is-negative#${encodeURIComponent(hash)}` })).toBe(null)
+})


### PR DESCRIPTION
Before determine the URL type, encode the hash if it contains a slash. 

Fix: #7697 