### PR TITLE
fix: simplify common root calculation for workspace project filtering

### DIFF
--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -412,6 +412,9 @@ function calculateCommonRoot (
   // common root between the first and the last project. Exclude the workspace dir project from
   // the calculation since we know it belongs to the workspace
   const sortedProjectDirs = projectDirs.filter(dir => dir !== workspaceDir).sort()
+  if (sortedProjectDirs.length === 0) {
+    return workspaceDir
+  }
   const firstProjectDir = sortedProjectDirs[0]
   const lastProjectDir = sortedProjectDirs[sortedProjectDirs.length - 1]
   let lastSeparatorIndex = -1


### PR DESCRIPTION
This change is intended to simplify the calculation of the common root used during workspace project filtering.

## Context for change
While working on the Rush monorepo manager, an issue came up (https://github.com/microsoft/rushstack/issues/4974) about being unable to move the common/temp directory (the root of our PNPM installs) to another path. This is primarily not possible because when using workspace mode the pnpm-lock.yaml file contains relative paths from the common/temp directory to the project directories (which exist at `../../<path-to-project-from-root>`). If we were to allow moving the common/temp directory as we do with other package managers, we would break this relative path and the lockfile would no longer be valid.

I started experimenting with performing our installs by creating a symlink/junction into the root of the Rush project and pathing the install through this symlink (ex. `common/temp/rush-root` would link to the root of the package, and we would then list the projects in pnpm-workspace.yaml as `rush-root/<path-to-project-from-root>`). This would allow us to maintain a consistent lockfile path for the importers while also allowing us to move the common/temp directory.

The issue with taking the symlink approach is that the common root would be mapped to common/temp folder due to the workspace root project being included. This change updates the logic to:
- always assume that the workspace root project should be excluded from this calculation, unless it's the only project in the workspace
- ensure that the workspace root project importer is always included as long as it was provided in the list of workspace projects to filter
- simplify the common root calculation to avoid expensive relative path logic