### PR TITLE
fix(init): --dir option should be respected

### DIFF
--- a/.changeset/ten-socks-cross.md
+++ b/.changeset/ten-socks-cross.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-init": patch
+---
+
+`pnpm init` should respect --dir option

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { docsUrl } from '@pnpm/cli-utils'
-import { type UniversalOptions } from '@pnpm/config'
+import { type CliOptions, type UniversalOptions } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
 import { writeProjectManifest } from '@pnpm/write-project-manifest'
 import renderHelp from 'render-help'
@@ -25,7 +25,7 @@ export function help (): string {
 }
 
 export async function handler (
-  opts: Pick<UniversalOptions, 'rawConfig'>,
+  opts: Pick<UniversalOptions, 'rawConfig'> & { cliOptions: CliOptions },
   params?: string[]
 ): Promise<string> {
   if (params?.length) {
@@ -34,8 +34,9 @@ export async function handler (
     })
   }
   // Using cwd instead of the dir option because the dir option
-  // is set to the first parent directory that has a package.json file.
-  const manifestPath = path.join(process.cwd(), 'package.json')
+  // is set to the first parent directory that has a package.json file
+  // But --dir option from cliOptions should be respected.
+  const manifestPath = path.join(opts.cliOptions.dir ?? process.cwd(), 'package.json')
   if (fs.existsSync(manifestPath)) {
     throw new PnpmError('PACKAGE_JSON_EXISTS', 'package.json already exists')
   }

--- a/packages/plugin-commands-init/test/init.test.ts
+++ b/packages/plugin-commands-init/test/init.test.ts
@@ -1,11 +1,12 @@
 import path from 'path'
+import fs from 'fs'
 import { init } from '@pnpm/plugin-commands-init'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { sync as loadJsonFile } from 'load-json-file'
 
 test('init a new package.json', async () => {
   prepareEmpty()
-  await init.handler({ rawConfig: {} })
+  await init.handler({ rawConfig: {}, cliOptions: {} })
   const manifest = loadJsonFile(path.resolve('package.json'))
   expect(manifest).toBeTruthy()
 })
@@ -14,7 +15,7 @@ test('throws an error if a package.json exists in the current directory', async 
   prepare({})
 
   await expect(
-    init.handler({ rawConfig: {} })
+    init.handler({ rawConfig: {}, cliOptions: {} })
   ).rejects.toThrow('package.json already exists')
 })
 
@@ -27,7 +28,7 @@ test('init a new package.json with npmrc', async () => {
     'init-version': '2.0.0',
   }
   prepareEmpty()
-  await init.handler({ rawConfig })
+  await init.handler({ rawConfig, cliOptions: {} })
   const manifest: Record<string, string> = loadJsonFile(path.resolve('package.json'))
   const expectAuthor = `${rawConfig['init-author-name']} <${rawConfig['init-author-email']}> (${rawConfig['init-author-url']})`
   expect(manifest.version).toBe(rawConfig['init-version'])
@@ -39,6 +40,30 @@ test('throw an error if params are passed to the init command', async () => {
   prepare({})
 
   await expect(
-    init.handler({ rawConfig: {} }, ['react-app'])
+    init.handler({ rawConfig: {}, cliOptions: {} }, ['react-app'])
   ).rejects.toThrow('init command does not accept any arguments')
+})
+
+test('init a new package.json if a package.json exists in the parent directory', async () => {
+  prepare({})
+  fs.mkdirSync('empty-dir1')
+  process.chdir('./empty-dir1')
+
+  await init.handler({ rawConfig: {}, cliOptions: {} })
+  const manifest = loadJsonFile(path.resolve('package.json'))
+  expect(manifest).toBeTruthy()
+})
+
+test('init a new package.json if a package.json exists in the current directory but specifies --dir option', async () => {
+  prepare({})
+  fs.mkdirSync('empty-dir2')
+
+  await init.handler({
+    rawConfig: {},
+    cliOptions: {
+      dir: './empty-dir2',
+    },
+  })
+  const manifest = loadJsonFile(path.resolve('empty-dir2/package.json'))
+  expect(manifest).toBeTruthy()
 })


### PR DESCRIPTION
It's inconvenient to init project in monorepo via pnpm since `pnpm init` doesn't respect either `--dir` option nor `recursive` option. Both of them will return error if you run init in a monorepo root directory: 
```
# pnpm -F=your-submodule init
ERROR  Unknown option: 'recursive'
```
```
# pnpm -C ./your-submodule init
ERR_PNPM_PACKAGE_JSON_EXISTS  package.json already exists
```

This pr allows `pnpm init` to recognize `--dir` option