### PR TITLE
perf: use enableCompileCache in node.js 22

### DIFF
--- a/pnpm/bin/pnpm.cjs
+++ b/pnpm/bin/pnpm.cjs
@@ -14,7 +14,9 @@ ${COMPATIBILITY_PAGE}`)
 
 // We need to load v8-compile-cache.js separately in order to have effect
 try {
-  require('v8-compile-cache');
+  // Use node.js 22 new API for better performance.
+  if(!require('module')?.enableCompileCache?.())
+    require('v8-compile-cache');
 } catch {
   // We don't have/need to care about v8-compile-cache failed
 }


### PR DESCRIPTION
The enableCompileCache function is a new api in [Nodejs 22 LTS](https://nodejs.org/docs/latest/api/module.html#module-compile-cache) which can speed up the startup time of CLI.

On my laptop, `pnpm -v` costs 650ms and it was 930ms before.

As a reference for a mature project, [TypeScript 5.7 support V8 compile caching in Node.js](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7-rc/#support-for-v8-compile-caching-in-node.js)