### PR TITLE
feature: allow only trusted dependencies to run scripts

### DIFF
--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -153,6 +153,7 @@ export interface ProjectManifest extends BaseManifest {
   }
   private?: boolean
   resolutions?: Record<string, string>
+  trustedDependencies?: string[]
 }
 
 export interface PackageManifest extends DependencyManifest {

--- a/pkg-manager/headless/test/fixtures/has-trusted-deps/.gitignore
+++ b/pkg-manager/headless/test/fixtures/has-trusted-deps/.gitignore
@@ -1,0 +1,1 @@
+test.sock

--- a/pkg-manager/headless/test/fixtures/has-trusted-deps/package.json
+++ b/pkg-manager/headless/test/fixtures/has-trusted-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "install": "node -e \"console.log('install')\" | test-ipc-server-client ./test.sock",
+    "postinstall": "node -e \"console.log('postinstall')\" | test-ipc-server-client ./test.sock"
+  },
+  "dependencies": {
+    "@pnpm.e2e/pre-and-postinstall-scripts-example": "*"
+  },
+  "trustedDependencies": [
+    "."
+  ]
+}

--- a/pkg-manager/headless/test/fixtures/has-trusted-deps/pnpm-lock.yaml
+++ b/pkg-manager/headless/test/fixtures/has-trusted-deps/pnpm-lock.yaml
@@ -1,0 +1,30 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@pnpm.e2e/pre-and-postinstall-scripts-example':
+        specifier: '*'
+        version: 2.0.0
+
+packages:
+
+  '@pnpm.e2e/hello-world-js-bin@1.0.0':
+    resolution: {integrity: sha512-EDvJzSLCEMnUnrrIGdV+IUWP/8w+nUjOuay2u0KW20Mnfnm3lyrdquQ+gKPNAOUfAsKL1y21np1nQN0PyP+57A==}
+    hasBin: true
+
+  '@pnpm.e2e/pre-and-postinstall-scripts-example@2.0.0':
+    resolution: {integrity: sha512-o1ULljloNzGcHI+k0NuY7aZigV5F551GpY9prYIrhMjIVNyMsERQMxLYZeKQJUnhZO5VKJNtGZlrUYkmJ1qDbw==}
+
+snapshots:
+
+  '@pnpm.e2e/hello-world-js-bin@1.0.0': {}
+
+  '@pnpm.e2e/pre-and-postinstall-scripts-example@2.0.0':
+    dependencies:
+      '@pnpm.e2e/hello-world-js-bin': 1.0.0

--- a/pkg-manager/headless/test/index.ts
+++ b/pkg-manager/headless/test/index.ts
@@ -366,6 +366,20 @@ test('ignores pre/postinstall scripts', async () => {
   expect(modulesYaml!.pendingBuilds).toStrictEqual(['.', '@pnpm.e2e/pre-and-postinstall-scripts-example@2.0.0'])
 })
 
+test('trusts pre/postinstall scripts', async () => {
+  const prefix = f.prepare('has-trusted-deps')
+  await using server = await createTestIpcServer(path.join(prefix, 'test.sock'))
+
+  await headlessInstall(await testDefaults({ lockfileDir: prefix, ignoreScripts: true }))
+
+  expect(server.getLines()).toStrictEqual(['install', 'postinstall'])
+
+  const nmPath = path.join(prefix, 'node_modules')
+  const modulesYaml = await readModulesManifest(nmPath)
+  expect(modulesYaml).toBeTruthy()
+  expect(modulesYaml!.pendingBuilds).toStrictEqual(['@pnpm.e2e/pre-and-postinstall-scripts-example@2.0.0'])
+})
+
 test('orphan packages are removed', async () => {
   const projectDir = f.prepare('simple-with-more-deps')
 

--- a/pkg-manager/headless/test/index.ts
+++ b/pkg-manager/headless/test/index.ts
@@ -332,7 +332,7 @@ test('skipping optional dependency if it cannot be fetched', async () => {
 })
 
 test('run pre/postinstall scripts', async () => {
-  let prefix = f.prepare('deps-have-lifecycle-scripts')
+  const prefix = f.prepare('deps-have-lifecycle-scripts')
   await using server = await createTestIpcServer(path.join(prefix, 'test.sock'))
 
   await headlessInstall(await testDefaults({ lockfileDir: prefix }))
@@ -346,8 +346,15 @@ test('run pre/postinstall scripts', async () => {
 
   expect(server.getLines()).toStrictEqual(['install', 'postinstall'])
 
-  prefix = f.prepare('deps-have-lifecycle-scripts')
-  server.clear()
+  const nmPath = path.join(prefix, 'node_modules')
+  const modulesYaml = await readModulesManifest(nmPath)
+  expect(modulesYaml).toBeTruthy()
+  expect(modulesYaml!.pendingBuilds).toStrictEqual([])
+})
+
+test('ignores pre/postinstall scripts', async () => {
+  const prefix = f.prepare('deps-have-lifecycle-scripts')
+  await using server = await createTestIpcServer(path.join(prefix, 'test.sock'))
 
   await headlessInstall(await testDefaults({ lockfileDir: prefix, ignoreScripts: true }))
 


### PR DESCRIPTION
This is not a *complete* PR since there could be some discussion about how this behavior should be implemented, but I wanted to get it started with some actual code, not just an issue.

Currently the options `ignoreScripts` ignores all lifecycle scripts. Sometimes you just have some dependency (or local) lifecycle scripts you'd still like to allow.

This follows Buns pattern for `trustedDependencies` array in `package.json`.

Per this PRs behavior:
- Default: All lifecycle scripts run
- ignoreScripts: Lifecycle scripts of packages not in `trustedDependencies` are ignored, and those in `trustedDependencies` are run

I think some may want more nuance, or even a new default behavior could be introduced.

What are your thoughts?

I think the ideal would be:
- Default w/o trusted: All lifecycle scripts run
- Default w/ trusted: Only `trustedDependencies` run their lifecycle scripts
- ignoreScripts: ignores all lifecycle scripts

Would changing to this above behavior be considered a breaking change?