### PR TITLE
fix: don't crash when use-node-version is set and there is no node.js

### DIFF
--- a/.changeset/seven-sheep-reflect.md
+++ b/.changeset/seven-sheep-reflect.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/package-is-installable": patch
+"@pnpm/env.system-node-version": patch
+"pnpm": patch
+---
+
+Don't crash if the `use-node-version` setting is used and the system has no Node.js installed [#8769](https://github.com/pnpm/pnpm/issues/8769).

--- a/config/package-is-installable/src/index.ts
+++ b/config/package-is-installable/src/index.ts
@@ -86,7 +86,7 @@ export function checkPackage (
     (manifest.engines == null)
       ? null
       : checkEngine(pkgId, manifest.engines, {
-        node: options.nodeVersion ?? getSystemNodeVersion(),
+        node: options.nodeVersion ?? getSystemNodeVersion() ?? process.version,
         pnpm: options.pnpmVersion,
       })
   )

--- a/env/system-node-version/src/index.ts
+++ b/env/system-node-version/src/index.ts
@@ -2,9 +2,14 @@ import { detectIfCurrentPkgIsExecutable } from '@pnpm/cli-meta'
 import mem from 'mem'
 import * as execa from 'execa'
 
-export function getSystemNodeVersionNonCached (): string {
+export function getSystemNodeVersionNonCached (): string | undefined {
   if (detectIfCurrentPkgIsExecutable()) {
-    return execa.sync('node', ['--version']).stdout.toString()
+    try {
+      return execa.sync('node', ['--version']).stdout.toString()
+    } catch {
+      // Node.js is not installed on the system
+      return undefined
+    }
   }
   return process.version
 }

--- a/env/system-node-version/test/getSystemNodeVersion.test.ts
+++ b/env/system-node-version/test/getSystemNodeVersion.test.ts
@@ -19,3 +19,15 @@ test('getSystemNodeVersion() from a non-executable pnpm CLI', () => {
   delete process['pkg']
   expect(getSystemNodeVersionNonCached()).toBe(process.version)
 })
+
+test('getSystemNodeVersion() returns undefined if execa.sync throws an error', () => {
+  // Mock execa.sync to throw an error
+  (execa.sync as jest.Mock).mockImplementationOnce(() => {
+    throw new Error('not found: node')
+  })
+
+  // @ts-expect-error
+  process['pkg'] = {}
+  expect(getSystemNodeVersionNonCached()).toBeUndefined()
+  expect(execa.sync).toHaveBeenCalledWith('node', ['--version'])
+})


### PR DESCRIPTION
close #8769