### PR TITLE
fix: recalculate relative transitive local peer references on deploy

### DIFF
--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1227,6 +1227,15 @@ async function resolveDependency (
     if (!options.update && currentPkg.version && currentPkg.pkgId?.endsWith(`@${currentPkg.version}`)) {
       wantedDependency.pref = replaceVersionInPref(wantedDependency.pref, currentPkg.version)
     }
+
+    // The dependency is described in a parent lockfile - we should treat the reference as relative from there
+    if (wantedDependency.pref.startsWith('workspace:') && options.parentPkg?.pkgId?.startsWith('file:')) {
+      const parentRelRoot = options.parentPkg.pkgId.split(':')[1]
+      const depRelParent = wantedDependency.pref.split(':')[1]
+      const depRelRoot = path.normalize(path.join(parentRelRoot, depRelParent))
+      wantedDependency.pref = `workspace:${depRelRoot}`
+    }
+
     pkgResponse = await ctx.storeController.requestPackage(wantedDependency, {
       alwaysTryWorkspacePackages: ctx.linkWorkspacePackagesDepth >= options.currentDepth,
       currentPkg: currentPkg


### PR DESCRIPTION
The change is to recalculate local workspace references based on the position of their lockfile from the project root.
This is important in case of transitive local peer dependencies lying in a different levels in directory structure.
ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND happened during deploy command execution for such a projects.

Fixes #8159, might also help with #5042, #4514