### PR TITLE
fix: catalogs exception when running `pnpm outdated` with `--compatible` flag

### DIFF
--- a/.changeset/weak-peaches-sip.md
+++ b/.changeset/weak-peaches-sip.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/outdated": patch
+pnpm: patch
+---
+
+Fix an exception when running `pnpm update --interactive` if catalogs are used.

--- a/__fixtures__/has-outdated-deps-using-npm-alias/.gitignore
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/.gitignore
@@ -1,0 +1,2 @@
+!**/node_modules/**/*
+!/node_modules/

--- a/__fixtures__/has-outdated-deps-using-npm-alias/.npmrc
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/.npmrc
@@ -1,0 +1,1 @@
+shared-workspace-lockfile=false

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.modules.yaml
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.modules.yaml
@@ -1,0 +1,22 @@
+hoistPattern:
+  - '*'
+hoistedDependencies: {}
+included:
+  dependencies: true
+  devDependencies: true
+  optionalDependencies: true
+injectedDeps: {}
+layoutVersion: 5
+nodeLinker: isolated
+packageManager: pnpm@9.9.0
+pendingBuilds: []
+prunedAt: Sun, 01 Dec 2024 19:56:24 GMT
+publicHoistPattern:
+  - '*eslint*'
+  - '*prettier*'
+registries:
+  default: https://registry.npmjs.org/
+skipped: []
+storeDir: /Users/gluxon/Library/pnpm/store/v3
+virtualStoreDir: .pnpm
+virtualStoreDirMaxLength: 120

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/index.js
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (n) {
+	if (typeof n !== 'number') {
+		throw new TypeError('Expected a number');
+	}
+
+	return n < 0;
+};

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/license
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Kevin Martensson <kevinmartensson@gmail.com> (github.com/kevva)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/package.json
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "is-negative",
+  "version": "1.0.0",
+  "description": "Test if a number is negative",
+  "license": "MIT",
+  "repository": "kevva/is-negative",
+  "author": {
+    "name": "Kevin Martensson",
+    "email": "kevinmartensson@gmail.com",
+    "url": "github.com/kevva"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "node test.js"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [
+    "negative",
+    "number",
+    "test"
+  ],
+  "devDependencies": {
+    "ava": "^0.0.4"
+  }
+}

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/readme.md
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/is-negative@1.0.0/node_modules/is-negative/readme.md
@@ -1,0 +1,31 @@
+# is-negative [![Build Status](https://travis-ci.org/kevva/is-negative.svg?branch=master)](https://travis-ci.org/kevva/is-negative)
+
+> Test if a number is positive
+
+
+## Install
+
+```
+$ npm install --save is-negative
+```
+
+
+## Usage
+
+```js
+var isNegative = require('is-negative');
+
+isNegative(-1);
+//=> true
+
+isNegative(1);
+//=> false
+
+isNegative(0);
+//=> false
+```
+
+
+## License
+
+MIT © [Kevin Martensson](http://github.com/kevva)

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/lock.yaml
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/.pnpm/lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-negative-alias:
+        specifier: npm:is-negative@^1.0.0
+        version: is-negative@1.0.0
+
+packages:
+
+  is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-negative@1.0.0: {}

--- a/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/is-negative-alias
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/node_modules/is-negative-alias
@@ -1,0 +1,1 @@
+.pnpm/is-negative@1.0.0/node_modules/is-negative

--- a/__fixtures__/has-outdated-deps-using-npm-alias/package.json
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "is-negative-alias": "npm:is-negative@^1.0.0"
+  }
+}

--- a/__fixtures__/has-outdated-deps-using-npm-alias/pnpm-lock.yaml
+++ b/__fixtures__/has-outdated-deps-using-npm-alias/pnpm-lock.yaml
@@ -1,0 +1,23 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-negative-alias:
+        specifier: npm:is-negative@^1.0.0
+        version: is-negative@1.0.0
+
+packages:
+
+  is-negative@1.0.0:
+    resolution: {integrity: sha512-1aKMsFUc7vYQGzt//8zhkjRWPoYkajY/I5MJEvrc0pDoHXrW7n5ri8DYxhy3rR+Dk0QFl7GjHHsZU1sppQrWtw==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-negative@1.0.0: {}

--- a/reviewing/outdated/src/outdated.ts
+++ b/reviewing/outdated/src/outdated.ts
@@ -155,7 +155,7 @@ export async function outdated (
 
           const latestManifest = await opts.getLatestManifest(
             name,
-            opts.compatible ? (allDeps[name] ?? 'latest') : 'latest'
+            opts.compatible ? (pref ?? 'latest') : 'latest'
           )
 
           if (latestManifest == null) return

--- a/reviewing/plugin-commands-outdated/test/index.ts
+++ b/reviewing/plugin-commands-outdated/test/index.ts
@@ -18,6 +18,7 @@ const hasMajorOutdatedDepsFixture = f.find('has-major-outdated-deps')
 const hasNoLockfileFixture = f.find('has-no-lockfile')
 const withPnpmUpdateIgnore = f.find('with-pnpm-update-ignore')
 const hasOutdatedDepsUsingCatalogProtocol = f.find('has-outdated-deps-using-catalog-protocol')
+const hasOutdatedDepsUsingNpmAlias = f.find('has-outdated-deps-using-npm-alias')
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
 
@@ -405,6 +406,25 @@ test('pnpm outdated: catalog protocol', async () => {
 │ Package     │ Current │ Latest │
 ├─────────────┼─────────┼────────┤
 │ is-negative │ 1.0.0   │ 2.1.0  │
+└─────────────┴─────────┴────────┘
+`)
+})
+
+test('pnpm outdated: --compatible works with npm aliases', async () => {
+  const { output, exitCode } = await outdated.handler({
+    ...OUTDATED_OPTIONS,
+    compatible: true,
+    dir: hasOutdatedDepsUsingNpmAlias,
+  })
+
+  // Although is-negative@2.1.0 is the latest version at the time of writing,
+  // the "compatible: true" option above should make pnpm to only find 1.0.1.
+  expect(exitCode).toBe(1)
+  expect(stripAnsi(output)).toBe(`\
+┌─────────────┬─────────┬────────┐
+│ Package     │ Current │ Latest │
+├─────────────┼─────────┼────────┤
+│ is-negative │ 1.0.0   │ 1.0.1  │
 └─────────────┴─────────┴────────┘
 `)
 })


### PR DESCRIPTION
## Changes

Fixes https://github.com/pnpm/pnpm/issues/8566.

<img width="842" alt="Screenshot 2024-12-01 at 3 06 02 PM" src="https://github.com/user-attachments/assets/eb1629e1-2e64-43f3-af78-6042094ff69a">

## Explanation

This bug only manifests when `opts.compatible` is `true`. In this case we were using `allDeps[name]` instead of the catalog-resolved `pref` constant computed earlier in the same function.

https://github.com/pnpm/pnpm/blob/d2e83b0f3ecbb22aafac3269fb9768ed44ce1102/reviewing/outdated/src/outdated.ts#L158

## New Test

I think `allDeps[name]` was incorrect to use originally. Even before catalogs support was added to the `outdated` command, it should have been `allDeps[alias]`.

The `allDeps[name]` lookup would become `undefined` when using npm aliases. I've added a new test around this.

## Caveats

Although this makes `pnpm update --interactive` no longer crash, updating dependencies using catalogs still isn't possible until https://github.com/pnpm/pnpm/issues/8641 is resolved. I'm still tracking this.

Catalog entries are currently filtered out of `pnpm update --interactive` and `pnpm outdated`.