### PR TITLE
fix(remove): ensure that link-workspace-packages=false is respected in single project runs in a workspace

### DIFF
--- a/.changeset/hip-rats-love.md
+++ b/.changeset/hip-rats-love.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+`pnpm remove` should not link dependencies from the workspace, when `link-workspace-packages` is set to `false` [#7674](https://github.com/pnpm/pnpm/issues/7674).

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -174,6 +174,7 @@ export async function handler (
   const store = await createOrConnectStoreController(opts)
   const removeOpts = Object.assign(opts, {
     ...getOptionsFromRootManifest(opts.rootProjectManifestDir, opts.rootProjectManifest ?? {}),
+    linkWorkspacePackagesDepth: opts.linkWorkspacePackages === 'deep' ? Infinity : opts.linkWorkspacePackages ? 0 : -1,
     storeController: store.ctrl,
     storeDir: store.dir,
     include,

--- a/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
+++ b/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
@@ -1,0 +1,167 @@
+import path from 'path'
+import { filterPackagesFromDir } from '@pnpm/workspace.filter-packages-from-dir'
+import { type LockfileFile } from '@pnpm/lockfile.types'
+import { install, remove } from '@pnpm/plugin-commands-installation'
+import { preparePackages } from '@pnpm/prepare'
+import { sync as readYamlFile } from 'read-yaml-file'
+import { DEFAULT_OPTS } from '../utils'
+
+test('pnpm remove --filter only changes the specified dependency, when run with link-workspace-packages=false', async () => {
+  const projects = preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1.0.0',
+        'is-negative': '1.0.0',
+      },
+    },
+  ])
+
+  const sharedOpts = {
+    dir: process.cwd(),
+    // NOTE: recursive here does not mean --recursive, but it also means the
+    // mechanism that allows --filter to work
+    recursive: true,
+    workspaceDir: process.cwd(),
+    lockfileDir: process.cwd(),
+    sharedWorkspaceLockfile: true,
+    linkWorkspacePackages: false,
+  }
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    ...await filterPackagesFromDir(process.cwd(), []),
+    ...sharedOpts,
+  })
+
+  await remove.handler({
+    ...DEFAULT_OPTS,
+    // Only remove is-negative from project-2
+    ...await filterPackagesFromDir(process.cwd(), [{ namePattern: 'project-2' }]),
+    ...sharedOpts,
+  }, ['is-negative'])
+
+  // project-1 should be unchanged
+  {
+    const pkg = await import(path.resolve('project-1/package.json'))
+    expect(pkg?.dependencies).toStrictEqual({
+      'is-negative': '1.0.0',
+    })
+  }
+
+  // project-2 has the is-negative dependency removed
+  {
+    const pkg = await import(path.resolve('project-2/package.json'))
+    expect(pkg?.dependencies).toStrictEqual({
+      'project-1': '1.0.0',
+    })
+  }
+
+  // Anything left is still resolveable
+  projects['project-1'].has('is-negative')
+  projects['project-2'].has('project-1')
+  projects['project-2'].hasNot('is-negative')
+
+  // The lockfile agrees with the above
+  const lockfile = readYamlFile<LockfileFile>('./pnpm-lock.yaml')
+
+  expect(lockfile.importers?.['project-1'].dependencies?.['is-negative']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+
+  expect(lockfile.importers?.['project-2'].dependencies?.['project-1']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+})
+
+test('pnpm remove from within package directory only affects the target depencency, when run with link-workspace-packages=false', async () => {
+  const projects = preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '1.0.0',
+
+      dependencies: {
+        'project-1': '1.0.0',
+        'is-negative': '1.0.0',
+      },
+    },
+  ])
+
+  const sharedOpts = {
+    dir: process.cwd(),
+    recursive: true,
+    workspaceDir: process.cwd(),
+    lockfileDir: process.cwd(),
+    sharedWorkspaceLockfile: true,
+    linkWorkspacePackages: false,
+  }
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    ...await filterPackagesFromDir(process.cwd(), []),
+    ...sharedOpts,
+  })
+
+  await remove.handler({
+    ...DEFAULT_OPTS,
+    ...sharedOpts,
+    // In this scenario, remove is invoked from within a workspace directory,
+    // non-recursively
+    dir: projects['project-2'].dir(),
+    recursive: false,
+  }, ['is-negative'])
+
+  // project-1 should be unchanged
+  {
+    const pkg = await import(path.resolve('project-1/package.json'))
+    expect(pkg?.dependencies).toStrictEqual({
+      'is-negative': '1.0.0',
+    })
+  }
+
+  // project-2 has the is-negative dependency removed
+  {
+    const pkg = await import(path.resolve('project-2/package.json'))
+    expect(pkg?.dependencies).toStrictEqual({
+      'project-1': '1.0.0',
+    })
+  }
+
+  // Anything left is still resolveable
+  projects['project-1'].has('is-negative')
+  projects['project-2'].has('project-1')
+  projects['project-2'].hasNot('is-negative')
+
+  // The lockfile agrees with the above
+  const lockfile = readYamlFile<LockfileFile>('./pnpm-lock.yaml')
+
+  expect(lockfile.importers?.['project-1'].dependencies?.['is-negative']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+
+  expect(lockfile.importers?.['project-2'].dependencies?.['project-1']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+})

--- a/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
+++ b/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
@@ -6,7 +6,7 @@ import { preparePackages } from '@pnpm/prepare'
 import { sync as readYamlFile } from 'read-yaml-file'
 import { DEFAULT_OPTS } from '../utils'
 
-test('pnpm remove --filter only changes the specified dependency, when run with link-workspace-packages=false', async () => {
+test('remove --filter only changes the specified dependency, when run with link-workspace-packages=false', async () => {
   const projects = preparePackages([
     {
       name: 'project-1',
@@ -29,8 +29,6 @@ test('pnpm remove --filter only changes the specified dependency, when run with 
 
   const sharedOpts = {
     dir: process.cwd(),
-    // NOTE: recursive here does not mean --recursive, but it also means the
-    // mechanism that allows --filter to work
     recursive: true,
     workspaceDir: process.cwd(),
     lockfileDir: process.cwd(),
@@ -86,7 +84,7 @@ test('pnpm remove --filter only changes the specified dependency, when run with 
   })
 })
 
-test('pnpm remove from within package directory only affects the target dependency, when run with link-workspace-packages=false', async () => {
+test.failing('remove from within a workspace package dir only affects the specified dependency, when run with link-workspace-packages=false', async () => {
   const projects = preparePackages([
     {
       name: 'project-1',
@@ -109,7 +107,6 @@ test('pnpm remove from within package directory only affects the target dependen
 
   const sharedOpts = {
     dir: process.cwd(),
-    recursive: true,
     workspaceDir: process.cwd(),
     lockfileDir: process.cwd(),
     sharedWorkspaceLockfile: true,
@@ -120,6 +117,7 @@ test('pnpm remove from within package directory only affects the target dependen
     ...DEFAULT_OPTS,
     ...await filterPackagesFromDir(process.cwd(), []),
     ...sharedOpts,
+    recursive: true,
   })
 
   await remove.handler({

--- a/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
+++ b/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
@@ -67,7 +67,7 @@ test('pnpm remove --filter only changes the specified dependency, when run with 
     })
   }
 
-  // Anything left is still resolveable
+  // Anything left can still be resolved
   projects['project-1'].has('is-negative')
   projects['project-2'].has('project-1')
   projects['project-2'].hasNot('is-negative')
@@ -86,7 +86,7 @@ test('pnpm remove --filter only changes the specified dependency, when run with 
   })
 })
 
-test('pnpm remove from within package directory only affects the target depencency, when run with link-workspace-packages=false', async () => {
+test('pnpm remove from within package directory only affects the target dependency, when run with link-workspace-packages=false', async () => {
   const projects = preparePackages([
     {
       name: 'project-1',
@@ -147,7 +147,7 @@ test('pnpm remove from within package directory only affects the target depencen
     })
   }
 
-  // Anything left is still resolveable
+  // Anything left can still be resolved
   projects['project-1'].has('is-negative')
   projects['project-2'].has('project-1')
   projects['project-2'].hasNot('is-negative')

--- a/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
+++ b/pkg-manager/plugin-commands-installation/test/remove/workspace.ts
@@ -84,7 +84,7 @@ test('remove --filter only changes the specified dependency, when run with link-
   })
 })
 
-test.failing('remove from within a workspace package dir only affects the specified dependency, when run with link-workspace-packages=false', async () => {
+test('remove from within a workspace package dir only affects the specified dependency, when run with link-workspace-packages=false', async () => {
   const projects = preparePackages([
     {
       name: 'project-1',


### PR DESCRIPTION
Closes #7674, by ensuring that `linkWorkspacePackagesDepth` is passed to the single project version of the `remove` command.

This started out by writing a test, but then I spotted the relevant part for the single run codepath, and the title has been updated as appropriate.

---

Original description:

This PR adds tests for https://github.com/pnpm/pnpm/issues/7674, and more specifically the reproduction mentioned in https://github.com/pnpm/pnpm/issues/7674#issuecomment-2546429388 and at https://github.com/vluoto/pnpm-remove-link-workspace-packages-false.

This is my first direct contribution to pnpm, and I might have missed a lot of things, regarding the test structure or the expectations. I used `pkg-manager/plugin-commands-installation/test/miscRecursive.ts` as my guide for these tests, and read through the relevant types and commands. Please let me know if any of this can be made more idiomatic, or whether I am going down the wrong avenue of investigation.

Since one of the tests in this PR reproduces an issue, the tests currently fail, and I am wondering what action to take next. **I would be happy to contribute a fix, but I am wary of wasting both the maintainers' and mine time, or duplicating effort**. So, please let me know if you are happy with me working on this, and I will dedicate appropriate time for it. Alternatively, I could contribute this PR with a `test.failing` or equivalent. I did not find a mention of such contribution processes in CONTRIBUTING.md, so I am following my gut feeling here 😅 

Edit: I slept on it, and it's not nice if the CI fails only this test, so I used `test.failing` to clarify the intent.

Thanks for all the work you have done on pnpm over the years!