### PR TITLE
feat: add support for specifying a custom output path in the pack command

### DIFF
--- a/.changeset/large-steaks-rhyme.md
+++ b/.changeset/large-steaks-rhyme.md
@@ -2,4 +2,4 @@
 "@pnpm/plugin-commands-publishing": patch
 ---
 
-add custom filename support to the pack command
+Add support for specifying a custom output path in the pack command

--- a/.changeset/large-steaks-rhyme.md
+++ b/.changeset/large-steaks-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+add custom filename support to the pack command

--- a/.changeset/large-steaks-rhyme.md
+++ b/.changeset/large-steaks-rhyme.md
@@ -1,5 +1,6 @@
 ---
-"@pnpm/plugin-commands-publishing": patch
+"@pnpm/plugin-commands-publishing": minor
+"pnpm": minor
 ---
 
-Add support for specifying a custom output path in the pack command
+Add support for specifying a custom output path in the pack command using a new `--out` flag [#8900](https://github.com/pnpm/pnpm/pull/8900).

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -60,7 +60,7 @@ export function help (): string {
             name: '--json',
           },
           {
-            description: 'Custom filename for the tarball. By default, it is the name of the package and its version concatenated with a dash, e.g `foo-1.2.3.tgz`.',
+            description: 'Custom filename for the tarball. By default, it is the name of the package and its version concatenated with a dash, e.g `my-package-1.2.3.tgz`. Use `%s` and `%v` in the filename to interpolate the package name and version, respectively, e.g. `%s-%v.tgz`.',
             name: '--filename <filename>',
           },
         ],
@@ -129,13 +129,14 @@ export async function api (opts: PackOptions): Promise<PackResult> {
     throw new PnpmError('PACKAGE_VERSION_NOT_FOUND', `Package version is not defined in the ${manifestFileName}.`)
   }
   let tarballName: string
+  const normalizedName = manifest.name.replace('@', '').replace('/', '-')
   if (opts.filename) {
-    tarballName = opts.filename
+    tarballName = opts.filename.replace('%s', normalizedName).replace('%v', manifest.version)
     if (path.basename(tarballName) !== tarballName) {
       throw new PnpmError('INVALID_FILENAME', 'Filename should not contain path specifiers. For specifying the directory where the tarball should be saved, use the --pack-destination option.')
     }
   } else {
-    tarballName = `${manifest.name.replace('@', '').replace('/', '-')}-${manifest.version}.tgz`
+    tarballName = `${normalizedName}-${manifest.version}.tgz`
   }
   const publishManifest = await createPublishManifest({
     projectDir: dir,

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -60,7 +60,7 @@ export function help (): string {
             name: '--json',
           },
           {
-            description: 'Customizes the output path for the tarball. Defaults to `<package-name>-<version>.tgz`. Use `%s` and `%v` to include the package name and version, e.g., `some/folder/%s.tgz`.',
+            description: 'Customizes the output path for the tarball. Use `%s` and `%v` to include the package name and version, e.g., `%s.tgz` or `some-dir/%s-%v.tgz`. By default, the tarball is saved in the current working directory with the name `<package-name>-<version>.tgz`.',
             name: '--out <path>',
           },
         ],

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -95,6 +95,48 @@ test('pack when there is bundledDependencies but without node-linker=hoisted', a
   })
 })
 
+test('pack: package with custom tarball name', async () => {
+  prepare({
+    name: 'test-publish-package.json',
+    version: '0.0.0',
+  })
+
+  await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    filename: 'custom-name.tgz',
+  })
+
+  expect(fs.existsSync('custom-name.tgz')).toBeTruthy()
+  expect(fs.existsSync('package.json')).toBeTruthy()
+})
+
+test('pack: path specifiers in the tarball name', async () => {
+  prepare({
+    name: 'test-publish-package.json',
+    version: '0.0.0',
+  })
+
+  const cases = [
+    './custom-name.tgz',
+    '../custom-name.tgz',
+    '/home/user/custom-name.tgz',
+  ]
+
+  for (const filename of cases) {
+    // eslint-disable-next-line no-await-in-loop
+    await expect(pack.handler({
+      ...DEFAULT_OPTS,
+      argv: { original: [] },
+      dir: process.cwd(),
+      extraBinPaths: [],
+      filename,
+    })).rejects.toThrow('Filename should not contain path specifiers. For specifying the directory where the tarball should be saved, use the --pack-destination option.')
+  }
+})
+
 test('pack a package without package name', async () => {
   prepare({
     name: undefined,

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -95,23 +95,15 @@ test('pack when there is bundledDependencies but without node-linker=hoisted', a
   })
 })
 
-test('pack: package with custom tarball name', async () => {
-  prepare({
-    name: 'test-publish-package.json',
-    version: '0.0.0',
+describe('pack: package with custom tarball name', () => {
+  beforeAll(() => {
+    prepare({
+      name: 'test-publish-package',
+      version: '0.0.0',
+    })
   })
 
-  const generateHandlerConfig = (filename: string) => ({
-    ...DEFAULT_OPTS,
-    argv: { original: [] },
-    dir: process.cwd(),
-    extraBinPaths: [],
-    filename,
-  })
-
-  expect(fs.existsSync('package.json')).toBeTruthy()
-
-  const cases = [
+  test.each([
     {
       actual: 'custom-name.tgz',
       expected: 'custom-name.tgz',
@@ -128,29 +120,32 @@ test('pack: package with custom tarball name', async () => {
       actual: '%s-%v.tgz',
       expected: 'test-publish-package-0.0.0.tgz',
     },
-  ]
+  ])('should pack $actual as $expected', async ({ actual, expected }) => {
+    await pack.handler({
+      ...DEFAULT_OPTS,
+      argv: { original: [] },
+      dir: process.cwd(),
+      extraBinPaths: [],
+      filename: actual,
+    })
 
-  for (const { actual, expected } of cases) {
-    // eslint-disable-next-line no-await-in-loop
-    await pack.handler(generateHandlerConfig(actual))
     expect(fs.existsSync(expected)).toBeTruthy()
-  }
+  })
 })
 
-test('pack: path specifiers in the tarball name', async () => {
-  prepare({
-    name: 'test-publish-package.json',
-    version: '0.0.0',
+describe('pack: path specifiers in the tarball name', () => {
+  beforeAll(() => {
+    prepare({
+      name: 'test-publish-package',
+      version: '0.0.0',
+    })
   })
 
-  const cases = [
+  test.each([
     './custom-name.tgz',
     '../custom-name.tgz',
     '/home/user/custom-name.tgz',
-  ]
-
-  for (const filename of cases) {
-    // eslint-disable-next-line no-await-in-loop
+  ])('should throw on %s', async (filename) => {
     await expect(pack.handler({
       ...DEFAULT_OPTS,
       argv: { original: [] },
@@ -158,7 +153,7 @@ test('pack: path specifiers in the tarball name', async () => {
       extraBinPaths: [],
       filename,
     })).rejects.toThrow('Filename should not contain path specifiers. For specifying the directory where the tarball should be saved, use the --pack-destination option.')
-  }
+  })
 })
 
 test('pack a package without package name', async () => {

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -105,40 +105,40 @@ describe('pack: package with custom tarball path', () => {
 
   test.each([
     {
-      actual: 'custom-name.tgz',
+      out: 'custom-name.tgz',
       expected: 'custom-name.tgz',
     },
     {
-      actual: '%s.tgz',
+      out: '%s.tgz',
       expected: 'test-publish-package.tgz',
     },
     {
-      actual: 'custom-name-%v.tgz',
+      out: 'custom-name-%v.tgz',
       expected: 'custom-name-0.0.0.tgz',
     },
     {
-      actual: '%s-%v.tgz',
+      out: '%s-%v.tgz',
       expected: 'test-publish-package-0.0.0.tgz',
     },
     {
-      actual: './foo/%s-%v.tgz',
+      out: './foo/%s-%v.tgz',
       expected: './foo/test-publish-package-0.0.0.tgz',
     },
     {
-      actual: './%s/out/%v.tgz',
+      out: './%s/out/%v.tgz',
       expected: './test-publish-package/out/0.0.0.tgz',
     },
     {
-      actual: './%s/%s-%v.tgz',
+      out: './%s/%s-%v.tgz',
       expected: './test-publish-package/test-publish-package-0.0.0.tgz',
     },
-  ])('should pack $actual as $expected', async ({ actual, expected }) => {
+  ])('should pack $actual as $expected', async ({ out, expected }) => {
     await pack.handler({
       ...DEFAULT_OPTS,
       argv: { original: [] },
       dir: process.cwd(),
       extraBinPaths: [],
-      out: actual,
+      out,
     })
 
     expect(fs.existsSync(expected)).toBeTruthy()

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -101,16 +101,40 @@ test('pack: package with custom tarball name', async () => {
     version: '0.0.0',
   })
 
-  await pack.handler({
+  const generateHandlerConfig = (filename: string) => ({
     ...DEFAULT_OPTS,
     argv: { original: [] },
     dir: process.cwd(),
     extraBinPaths: [],
-    filename: 'custom-name.tgz',
+    filename,
   })
 
-  expect(fs.existsSync('custom-name.tgz')).toBeTruthy()
   expect(fs.existsSync('package.json')).toBeTruthy()
+
+  const cases = [
+    {
+      actual: 'custom-name.tgz',
+      expected: 'custom-name.tgz',
+    },
+    {
+      actual: '%s.tgz',
+      expected: 'test-publish-package.tgz',
+    },
+    {
+      actual: 'custom-name-%v.tgz',
+      expected: 'custom-name-0.0.0.tgz',
+    },
+    {
+      actual: '%s-%v.tgz',
+      expected: 'test-publish-package-0.0.0.tgz',
+    },
+  ]
+
+  for (const { actual, expected } of cases) {
+    // eslint-disable-next-line no-await-in-loop
+    await pack.handler(generateHandlerConfig(actual))
+    expect(fs.existsSync(expected)).toBeTruthy()
+  }
 })
 
 test('pack: path specifiers in the tarball name', async () => {


### PR DESCRIPTION
This PR allows specifying the desired output path when running the `pnpm pack` command, e.g., `pnpm pack --out my-package.tgz` or `pnpm pack --out ./some-dir/%s.tgz`. Yarn also has a similar feature: https://yarnpkg.com/cli/pack#details

Closes https://github.com/pnpm/pnpm/issues/7834