### PR TITLE
fix: ensure that recursive `pnpm update --latest <pkg>` updates only the specified package

### DIFF
--- a/.changeset/friendly-tips-rest.md
+++ b/.changeset/friendly-tips-rest.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/resolve-dependencies": patch
+---
+
+Fix a case in `resolveDependencies`, whereby an importer that should not have been updated altogether, was being updated when `updateToLatest` was specified in the options.

--- a/.changeset/serious-swans-wonder.md
+++ b/.changeset/serious-swans-wonder.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/package-requester": major
+"@pnpm/store-controller-types": major
+---
+
+`RequestPackageOptions` now takes a union type for the `update` option, instead of a separate `updateToLatest` option.
+
+This avoids pitfalls around specifying only `update` or, specifying `update: false`, but still providing `updateToLatest: true`.

--- a/.changeset/shy-hounds-wave.md
+++ b/.changeset/shy-hounds-wave.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Ensure that recursive `pnpm update --latest <pkg>` updates only the specified package, with `dedupe-peer-dependents=true`.

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -187,7 +187,7 @@ async function resolveAndFetch (
       projectDir: options.projectDir,
       registry: options.registry,
       workspacePackages: options.workspacePackages,
-      updateToLatest: options.updateToLatest,
+      updateToLatest: options.update === 'latest',
       injectWorkspacePackages: options.injectWorkspacePackages,
     }), { priority: options.downloadPriority })
 

--- a/pkg-manager/package-requester/test/index.ts
+++ b/pkg-manager/package-requester/test/index.ts
@@ -15,7 +15,7 @@ import loadJsonFile from 'load-json-file'
 import nock from 'nock'
 import normalize from 'normalize-path'
 import tempy from 'tempy'
-import { type PkgResolutionId, type PkgRequestFetchResult } from '@pnpm/store-controller-types'
+import { type PkgResolutionId, type PkgRequestFetchResult, type RequestPackageOptions } from '@pnpm/store-controller-types'
 
 const registry = `http://localhost:${REGISTRY_MOCK_PORT}`
 const f = fixtures(__dirname)
@@ -182,7 +182,7 @@ test('refetch local tarball if its integrity has changed', async () => {
     registry,
     skipFetch: true,
     update: false,
-  }
+  } satisfies RequestPackageOptions
 
   {
     const requestPackage = createPackageRequester({
@@ -288,7 +288,7 @@ test('refetch local tarball if its integrity has changed. The requester does not
     projectDir,
     registry,
     update: false,
-  }
+  } satisfies RequestPackageOptions
 
   {
     const requestPackage = createPackageRequester({

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -824,7 +824,7 @@ async function resolveDependenciesOfDependency (
     prefix: options.prefix,
     proceed: extendedWantedDep.proceed || updateShouldContinue || ctx.updatedSet.size > 0,
     publishedBy: options.publishedBy,
-    update: update ? options.updateToLatest ? 'latest' : 'in-range' : false,
+    update: update ? options.updateToLatest ? 'latest' : 'compatible' : false,
     updateDepth,
     updateMatching: options.updateMatching,
     supportedArchitectures: options.supportedArchitectures,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -828,7 +828,7 @@ async function resolveDependenciesOfDependency (
     updateDepth,
     updateMatching: options.updateMatching,
     supportedArchitectures: options.supportedArchitectures,
-    updateToLatest: options.updateToLatest,
+    updateToLatest: update && options.updateToLatest,
     parentIds: options.parentIds,
   }
   const resolveDependencyResult = await resolveDependency(extendedWantedDep.wantedDependency, ctx, resolveDependencyOpts)

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1174,7 +1174,7 @@ interface ResolveDependencyOptions {
   proceed: boolean
   publishedBy?: Date
   pickLowestVersion?: boolean
-  update: false | 'in-range' | 'latest'
+  update: false | 'compatible' | 'latest'
   updateDepth: number
   updateMatching?: UpdateMatchingFunction
   supportedArchitectures?: SupportedArchitectures
@@ -1250,8 +1250,7 @@ async function resolveDependency (
         : options.parentPkg.rootDir,
       registry: wantedDependency.alias && pickRegistryForPackage(ctx.registries, wantedDependency.alias, wantedDependency.pref) || ctx.registries.default,
       skipFetch: ctx.dryRun,
-      update: options.update === 'in-range',
-      updateToLatest: options.update === 'latest',
+      update: options.update,
       workspacePackages: ctx.workspacePackages,
       supportedArchitectures: options.supportedArchitectures,
       onFetchError: (err: any) => { // eslint-disable-line

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -828,7 +828,7 @@ async function resolveDependenciesOfDependency (
     updateDepth,
     updateMatching: options.updateMatching,
     supportedArchitectures: options.supportedArchitectures,
-    updateToLatest: update && options.updateToLatest,
+    updateToLatest: options.updateToLatest,
     parentIds: options.parentIds,
   }
   const resolveDependencyResult = await resolveDependency(extendedWantedDep.wantedDependency, ctx, resolveDependencyOpts)
@@ -1260,7 +1260,7 @@ async function resolveDependency (
         err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
         return err
       },
-      updateToLatest: options.updateToLatest,
+      updateToLatest: options.update && options.updateToLatest,
       injectWorkspacePackages: ctx.injectWorkspacePackages,
     })
   } catch (err: any) { // eslint-disable-line

--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -1190,6 +1190,7 @@ async function resolveDependency (
   options: ResolveDependencyOptions
 ): Promise<ResolveDependencyResult> {
   const currentPkg = options.currentPkg ?? {}
+  const updateToLatest = options.update && options.updateToLatest
 
   const currentLockfileContainsTheDep = currentPkg.depPath
     ? Boolean(ctx.currentLockfile.packages?.[currentPkg.depPath])
@@ -1260,7 +1261,7 @@ async function resolveDependency (
         err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
         return err
       },
-      updateToLatest: options.update && options.updateToLatest,
+      updateToLatest,
       injectWorkspacePackages: ctx.injectWorkspacePackages,
     })
   } catch (err: any) { // eslint-disable-line

--- a/pnpm/test/monorepo/dedupePeers.test.ts
+++ b/pnpm/test/monorepo/dedupePeers.test.ts
@@ -92,7 +92,7 @@ auto-install-peers=false`, 'utf8')
 })
 
 // Covers https://github.com/pnpm/pnpm/issues/8877
-test.only('partial update --latest in a workspace should not affect other packages when dedupe-peer-dependents is true', async () => {
+test('partial update --latest in a workspace should not affect other packages when dedupe-peer-dependents is true', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' })
 
@@ -129,7 +129,8 @@ auto-install-peers=false`, 'utf8')
   await addDistTag({ package: '@pnpm.e2e/foo', version: '2.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
 
-  await execPnpm(['update', '--filter', 'project-2', '--latest'])
+  // update foo only for project-2
+  await execPnpm(['update', '--filter', 'project-2', '--latest', '@pnpm.e2e/foo'])
 
   // project 1's manifest is unaffected, while project 2 has only foo updated
   expect(loadJsonFile<any>('project-1/package.json').dependencies['@pnpm.e2e/foo']).toBe('1.0.0') // eslint-disable-line

--- a/store/store-controller-types/src/index.ts
+++ b/store/store-controller-types/src/index.ts
@@ -126,12 +126,11 @@ export interface RequestPackageOptions {
   registry: string
   sideEffectsCache?: boolean
   skipFetch?: boolean
-  update?: boolean
+  update?: false | 'compatible' | 'latest'
   workspacePackages?: WorkspacePackages
   forceResolve?: boolean
   supportedArchitectures?: SupportedArchitectures
   onFetchError?: OnFetchError
-  updateToLatest?: boolean
   injectWorkspacePackages?: boolean
 }
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/pnpm/pnpm/pull/8905.

After merging the PR to fix `pnpm update --filter` changing unrelated projects, I started going through the issue tracker around recursive `update`, to see whether other scenarios would be fixed by those changes. 

There are a handful of issues (https://github.com/pnpm/pnpm/issues/8661, https://github.com/pnpm/pnpm/issues/8329, https://github.com/pnpm/pnpm/issues/8772) that fit the bill, though not all of them with minimal reproductions (especially with regard to listing the `.npmrc` settings). Folks in those issues dicuss the `--interactive` flag, but I was able to reproduce the issue with a non-interactive recursive update and `dedupe-peer-dependents=true`.

The root cause seems similar to #8905: `opts.dedupePeerDependencies` includes the whole project graph in an installation, and the `updateToLatest` option ends up applying to all packages for the selected project, not just the wanted package. I think I am missing something about the exact mechanism here.

My previous PR narrowed down these updates to the specified project, but all dependencies within that project are still affected. This PR expands the 'dedupePeers' test case to catch this scenario, and changes the `updateToLatest` option in `resolveDependency` to be gated on `update`. I'm not 100% confident about this fix, to be honest. I wonder if this issue should be fixed somewhere higher-up than `resolveDependency`?

Please let me know if this approach makes sense! Thank you for your work on pnpm as always :relieved:
