### PR TITLE
fix(pack): missing end of line anchor in package.json regex filter

### DIFF
--- a/.changeset/eleven-cameras-invite.md
+++ b/.changeset/eleven-cameras-invite.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"pnpm": patch
+---
+
+Fixed the Regex used to find the package manifest during packing [#8938](https://github.com/pnpm/pnpm/pull/8938).

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -241,7 +241,7 @@ async function packPkg (opts: {
   await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
     const isExecutable = bins.some((bin) => path.relative(bin, source) === '')
     const mode = isExecutable ? 0o755 : 0o644
-    if (/^package\/package\.(json|json5|yaml)/.test(name)) {
+    if (/^package\/package\.(json|json5|yaml)$/.test(name)) {
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(manifest, null, 2))
       return
     }


### PR DESCRIPTION
Regression #3608.

Missing end of line anchors in regex (`$`) will cause every files under package root that has prefixed `package.(json|json5|yaml)` being matched and replaced with `package.json`:
```
/^package\/package\.(json|json5|yaml)/.test("package/package.json.meta")
true

/^package\/package\.(json|json5|yaml)/.test("package/package.yamlol")
true

/^package\/package\.(json|json5|yaml)/.test("package/package.json567")
true
```