### PR TITLE
fix: don't print patched dependencies in list of non-built deps

### DIFF
--- a/.changeset/shaggy-news-tickle.md
+++ b/.changeset/shaggy-news-tickle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/build-modules": patch
+"pnpm": patch
+---
+
+Do not print patched dependencies as ignored dependencies that require a build [#8952](https://github.com/pnpm/pnpm/issues/8952).


### PR DESCRIPTION
close #8952