### PR TITLE
ci: update winget releaser action

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -34,7 +34,7 @@ jobs:
     environment: release
     needs: tag-in-registry
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: pnpm.pnpm
           version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Update to `vedantmgoyal9/winget-releaser@main`, which should hopefully fix the CI errors. Manually created a PR to winget-pkgs for now (and added the `arm64` binary): https://github.com/microsoft/winget-pkgs/pull/213396