### PR TITLE
fix: deploy should maintain `type` on new manifest

### DIFF
--- a/.changeset/happy-bottles-greet.md
+++ b/.changeset/happy-bottles-greet.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-deploy": patch
+"@pnpm/types": patch
+---
+
+Fix `pnpm deploy` creating a package.json without the `"type"` key [#8962](https://github.com/pnpm/pnpm/issues/8962).

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -72,6 +72,7 @@ export interface TypesVersions {
 export interface BaseManifest {
   name?: string
   version?: string
+  type?: string
   bin?: PackageBin
   description?: string
   directories?: {

--- a/releasing/plugin-commands-deploy/src/createDeployFiles.ts
+++ b/releasing/plugin-commands-deploy/src/createDeployFiles.ts
@@ -28,6 +28,7 @@ const INHERITED_MANIFEST_KEYS = [
   'version',
   'private',
   'author',
+  'type',
   'bin',
   'scripts',
   'packageManager',


### PR DESCRIPTION
Fixes https://github.com/pnpm/pnpm/issues/8962