### PR TITLE
feat(git-resolver): respect proxy settings when resolving git

### DIFF
--- a/.changeset/ninety-countries-dance.md
+++ b/.changeset/ninety-countries-dance.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/git-resolver": patch
+"pnpm": patch
+---
+
+Proxy settings should be respected, when resolving Git-hosted dependencies [#6530](https://github.com/pnpm/pnpm/issues/6530).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6467,6 +6467,9 @@ importers:
       '@pnpm/git-resolver':
         specifier: workspace:*
         version: 'link:'
+      '@pnpm/network.agent':
+        specifier: 'catalog:'
+        version: 2.0.0
       '@types/hosted-git-info':
         specifier: 'catalog:'
         version: 3.0.5

--- a/resolving/git-resolver/__mocks__/@pnpm/fetch.js
+++ b/resolving/git-resolver/__mocks__/@pnpm/fetch.js
@@ -1,6 +1,6 @@
 module.exports = jest.createMockFromModule('@pnpm/fetch')
 
 // default implementation
-module.exports.fetch.mockImplementation(async (_url, _opts) => {
+module.exports.fetchWithAgent.mockImplementation(async (_url, _opts) => {
   return { ok: true }
 })

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@pnpm/git-resolver": "workspace:*",
+    "@pnpm/network.agent": "catalog:",
     "@types/hosted-git-info": "catalog:",
     "@types/is-windows": "catalog:",
     "@types/semver": "catalog:",

--- a/resolving/git-resolver/src/index.ts
+++ b/resolving/git-resolver/src/index.ts
@@ -3,6 +3,7 @@ import git from 'graceful-git'
 import semver from 'semver'
 import { parsePref, type HostedPackageSpec } from './parsePref'
 import { createGitHostedPkgId } from './createGitHostedPkgId'
+import { type AgentOptions } from '@pnpm/network.agent'
 
 export { createGitHostedPkgId }
 
@@ -13,10 +14,10 @@ export type GitResolver = (wantedDependency: {
 }) => Promise<ResolveResult | null>
 
 export function createGitResolver (
-  opts: unknown
+  opts: AgentOptions
 ): GitResolver {
   return async function resolveGit (wantedDependency): Promise<ResolveResult | null> {
-    const parsedSpec = await parsePref(wantedDependency.pref)
+    const parsedSpec = await parsePref(wantedDependency.pref, opts)
 
     if (parsedSpec == null) return null
 

--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -3,14 +3,14 @@ import path from 'path'
 import { createGitResolver } from '@pnpm/git-resolver'
 import git from 'graceful-git'
 import isWindows from 'is-windows'
-import { fetch } from '@pnpm/fetch'
+import { fetchWithAgent } from '@pnpm/fetch'
 
 const resolveFromGit = createGitResolver({})
 
 function mockFetchAsPrivate (): void {
-  type Fetch = typeof fetch
-  type MockedFetch = jest.MockedFunction<Fetch>
-  (fetch as MockedFetch).mockImplementation(async (_url, _opts) => {
+  type FetchWithAgent = typeof fetchWithAgent
+  type MockedFetchWithAgent = jest.MockedFunction<FetchWithAgent>
+  (fetchWithAgent as MockedFetchWithAgent).mockImplementation(async (_url, _opts) => {
     return { ok: false } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
 }

--- a/resolving/git-resolver/test/parsePref.test.ts
+++ b/resolving/git-resolver/test/parsePref.test.ts
@@ -13,7 +13,7 @@ test.each([
   ['git+ssh://username:password@example.com:22/repo/@foo.git#path:/a/@b', 'ssh://username:password@example.com:22/repo/@foo.git'],
   ['git+ssh://username:password@example.com:22/repo/@foo.git#path:/a/@b&dev', 'ssh://username:password@example.com:22/repo/@foo.git'],
 ])('the right colon is escaped in %s', async (input, output) => {
-  const parsed = await parsePref(input)
+  const parsed = await parsePref(input, {})
   expect(parsed?.fetchSpec).toBe(output)
 })
 
@@ -41,13 +41,13 @@ test.each([
   ['git+ssh://username:password@example.com:22/repo/@foo.git', undefined],
   ['git+ssh://username:password@example.com:22/repo/@foo.git#dev', undefined],
 ])('the path of %s should be %s', async (input, output) => {
-  const parsed = await parsePref(input)
+  const parsed = await parsePref(input, {})
   expect(parsed?.path).toBe(output)
 })
 
 test.each([
   ['git+https://github.com/pnpm/pnpm.git', 'https://github.com/pnpm/pnpm.git'],
 ])('the fetchSpec of %s should be %s', async (input, output) => {
-  const parsed = await parsePref(input)
+  const parsed = await parsePref(input, {})
   expect(parsed?.fetchSpec).toBe(output)
 })


### PR DESCRIPTION
Change to respect proxy settings when resolving git dependancies.
To do this, I have exchanged to `fetchWithAgent` instead of `fetch` and pass down pnpm options.

close: #6530