### PR TITLE
chore: replace `lodash.clonedeep` with the built-in `structuredClone`

### DIFF
--- a/.changeset/loud-weeks-camp.md
+++ b/.changeset/loud-weeks-camp.md
@@ -2,4 +2,4 @@
 "@pnpm/read-project-manifest": patch
 ---
 
-Replace `lodash.clonedeep` with the built-in `structuredClone`.
+Replaced `lodash.clonedeep` with the built-in `structuredClone`.

--- a/.changeset/loud-weeks-camp.md
+++ b/.changeset/loud-weeks-camp.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/read-project-manifest": patch
+---
+
+Replace `lodash.clonedeep` with the built-in `structuredClone`.

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -38,7 +38,6 @@
     "fast-deep-equal": "catalog:",
     "is-windows": "catalog:",
     "json5": "catalog:",
-    "lodash.clonedeep": "catalog:",
     "parse-json": "catalog:",
     "read-yaml-file": "catalog:",
     "sort-keys": "catalog:",
@@ -47,7 +46,6 @@
   "devDependencies": {
     "@pnpm/read-project-manifest": "workspace:*",
     "@types/is-windows": "catalog:",
-    "@types/lodash.clonedeep": "catalog:",
     "@types/parse-json": "catalog:",
     "tempy": "catalog:"
   },

--- a/pkg-manifest/read-project-manifest/src/index.ts
+++ b/pkg-manifest/read-project-manifest/src/index.ts
@@ -8,7 +8,6 @@ import readYamlFile from 'read-yaml-file'
 import detectIndent from '@gwhitney/detect-indent'
 import equal from 'fast-deep-equal'
 import isWindows from 'is-windows'
-import cloneDeep from 'lodash.clonedeep'
 import {
   readJson5File,
   readJsonFile,
@@ -235,7 +234,7 @@ function normalize (manifest: ProjectManifest): ProjectManifest {
     if (Object.prototype.hasOwnProperty.call(manifest, key)) {
       const value = manifest[key as keyof ProjectManifest]
       if (typeof value !== 'object' || !dependencyKeys.has(key)) {
-        result[key] = cloneDeep(value)
+        result[key] = structuredClone(value)
       } else {
         const keys = Object.keys(value)
         if (keys.length !== 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ catalogs:
     '@types/js-yaml':
       specifier: ^4.0.9
       version: 4.0.9
-    '@types/lodash.clonedeep':
-      specifier: ^4.5.9
-      version: 4.5.9
     '@types/lodash.throttle':
       specifier: 4.1.7
       version: 4.1.7
@@ -387,9 +384,6 @@ catalogs:
     load-json-file:
       specifier: ^6.2.0
       version: 6.2.0
-    lodash.clonedeep:
-      specifier: ^4.5.0
-      version: 4.5.0
     lodash.throttle:
       specifier: 4.1.1
       version: 4.1.1
@@ -5728,9 +5722,6 @@ importers:
       json5:
         specifier: 'catalog:'
         version: 2.2.3
-      lodash.clonedeep:
-        specifier: 'catalog:'
-        version: 4.5.0
       parse-json:
         specifier: 'catalog:'
         version: 5.2.0
@@ -5750,9 +5741,6 @@ importers:
       '@types/is-windows':
         specifier: 'catalog:'
         version: 1.0.2
-      '@types/lodash.clonedeep':
-        specifier: 'catalog:'
-        version: 4.5.9
       '@types/parse-json':
         specifier: 'catalog:'
         version: 4.0.2
@@ -9434,9 +9422,6 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
-
-  '@types/lodash.clonedeep@4.5.9':
-    resolution: {integrity: sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==}
 
   '@types/lodash.throttle@4.1.7':
     resolution: {integrity: sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==}
@@ -16384,10 +16369,6 @@ snapshots:
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 22.13.0
-
-  '@types/lodash.clonedeep@4.5.9':
-    dependencies:
-      '@types/lodash': 4.17.15
 
   '@types/lodash.throttle@4.1.7':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,6 @@ catalog:
   "@types/is-gzip": 2.0.0
   "@types/is-windows": ^1.0.2
   "@types/js-yaml": ^4.0.9
-  "@types/lodash.clonedeep": ^4.5.9
   "@types/lodash.throttle": 4.1.7
   "@types/micromatch": ^4.0.7
   "@types/node": ^18.19.34
@@ -167,7 +166,6 @@ catalog:
   jest-diff: ^29.7.0
   json5: ^2.2.3
   load-json-file: ^6.2.0
-  lodash.clonedeep: ^4.5.0
   lodash.throttle: 4.1.1
   loud-rejection: ^2.2.0
   lru-cache: ^10.2.2


### PR DESCRIPTION
Replaced `lodash.clonedeep` with the built-in `structuredClone` supported [from Node 17.0.0](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone#browser_compatibility).

I initially created a discussion regarding some dependency cleanup (https://github.com/orgs/pnpm/discussions/9012), but I figured it wouldn't hurt to make a PR for such a tiny change.