### PR TITLE
fix: don't read from side-effects cache packages that aren't allowed to be built

### DIFF
--- a/.changeset/proud-crabs-own.md
+++ b/.changeset/proud-crabs-own.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/headless": patch
+"@pnpm/build-modules": patch
+"@pnpm/core": patch
+"pnpm": patch
+---
+
+Don't read a package from side-effects cache if it isn't allowed to be built [#9042](https://github.com/pnpm/pnpm/issues/9042).

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -395,6 +395,7 @@ async function linkNewPackages (
         optional: opts.optional,
       }),
     linkAllPkgs(opts.storeController, newPkgs, {
+      allowBuild: opts.allowBuild,
       depGraph,
       depsStateCache: opts.depsStateCache,
       disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,


### PR DESCRIPTION
close #9042