### PR TITLE
fix: lockfile not frozen when prefer-frozen-lockfile is set to true in .npmrc

### DIFF
--- a/__utils__/tsconfig/tsconfig.json
+++ b/__utils__/tsconfig/tsconfig.json
@@ -12,7 +12,8 @@
     "removeComments": false,
     "sourceMap": true,
     "strict": true,
-    "target": "es2021"
+    "target": "es2021",
+    "skipLibCheck": true
   },
   "atom": {
     "rewriteTsconfig": true

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -329,6 +329,15 @@ export type InstallCommandOptions = Pick<Config,
   confirmModulesPurge?: boolean
 } & Partial<Pick<Config, 'modulesCacheMaxAge' | 'pnpmHomeDir' | 'preferWorkspacePackages' | 'useLockfile'>>
 
+export function shouldFreezeLockfileIfExists (opts: InstallCommandOptions, onCI: boolean): boolean {
+  if (opts.frozenLockfileIfExists != null) {
+    return opts.frozenLockfileIfExists
+  }
+  return onCI && !opts.lockfileOnly &&
+    opts.rawLocalConfig['frozen-lockfile'] !== false &&
+    opts.rawLocalConfig['prefer-frozen-lockfile'] !== false
+}
+
 export async function handler (opts: InstallCommandOptions): Promise<void> {
   const include = {
     dependencies: opts.production !== false,
@@ -340,11 +349,7 @@ export async function handler (opts: InstallCommandOptions): Promise<void> {
   const fetchFullMetadata: true | undefined = opts.rootProjectManifest?.pnpm?.supportedArchitectures?.libc && true
   const installDepsOptions: InstallDepsOptions = {
     ...opts,
-    frozenLockfileIfExists: opts.frozenLockfileIfExists ?? (
-      isCI && !opts.lockfileOnly &&
-      typeof opts.rawLocalConfig['frozen-lockfile'] === 'undefined' &&
-      typeof opts.rawLocalConfig['prefer-frozen-lockfile'] === 'undefined'
-    ),
+    frozenLockfileIfExists: shouldFreezeLockfileIfExists(opts, isCI),
     include,
     includeDirect: include,
     prepareExecutionEnv: prepareExecutionEnv.bind(null, opts),

--- a/pkg-manager/plugin-commands-installation/test/install.ts
+++ b/pkg-manager/plugin-commands-installation/test/install.ts
@@ -90,3 +90,91 @@ describeOnLinuxOnly('filters optional dependencies based on libc', () => {
     expect(pkgDirs).not.toContain(notFound)
   })
 })
+
+describe('shouldFreezeLockfileIfExists', () => {
+  describe('when opts.frozenLockfileIfExists is set', () => {
+    it('is true', () => {
+      expect(install.shouldFreezeLockfileIfExists({
+        ...DEFAULT_OPTS,
+        dir: 'does-not-matter',
+        frozenLockfileIfExists: true,
+      }, false)).toEqual(true)
+    })
+
+    it('is false', () => {
+      expect(install.shouldFreezeLockfileIfExists({
+        ...DEFAULT_OPTS,
+        dir: 'does-not-matter',
+        frozenLockfileIfExists: false,
+        rawLocalConfig: {
+          'frozen-lockfile': true,
+          'prefer-frozen-lockfile': true,
+        },
+      }, true)).toEqual(false)
+    })
+  })
+
+  describe('when opts.frozenLockfileIfExists is not set', () => {
+    it('is false if not on CI', () => {
+      expect(install.shouldFreezeLockfileIfExists({
+        ...DEFAULT_OPTS,
+        dir: 'does-not-matter',
+        rawLocalConfig: {
+          'frozen-lockfile': true,
+          'prefer-frozen-lockfile': true,
+        },
+      }, false)).toEqual(false)
+    })
+
+    describe('when on CI', () => {
+      it('is true if frozen-lockfile and prefer-frozen-lockfile is true or unset', () => {
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {
+            'frozen-lockfile': true,
+            'prefer-frozen-lockfile': true,
+          },
+        }, true)).toEqual(true)
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {
+            'prefer-frozen-lockfile': true,
+          },
+        }, true)).toEqual(true)
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {
+            'frozen-lockfile': true,
+          },
+        }, true)).toEqual(true)
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {},
+        }, true)).toEqual(true)
+      })
+
+      it('is false if either frozen-lockfile or prefer-frozen-lockfile is false', () => {
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {
+            'frozen-lockfile': true,
+            'prefer-frozen-lockfile': false,
+          },
+        }, true)).toEqual(false)
+        expect(install.shouldFreezeLockfileIfExists({
+          ...DEFAULT_OPTS,
+          dir: 'does-not-matter',
+          rawLocalConfig: {
+            'frozen-lockfile': false,
+            'prefer-frozen-lockfile': true,
+          },
+        }, true)).toEqual(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
When pnpm lock file is outdated
`pnpm i --frozen-lockfile` -> `ERR_PNPM_OUTDATED_LOCKFILE`
`CI=1 pnpm i --frozen-lockfile`  -> `ERR_PNPM_OUTDATED_LOCKFILE`

However, after
`echo prefer-frozen-lockfile=true > .npmrc`
`pnpm i --frozen-lockfile` ->  `ERR_PNPM_OUTDATED_LOCKFILE`
`CI=1 pnpm i --frozen-lockfile`  -> no error

This issue can be reproduced in https://github.com/fa93hws/pnpm-freeze-lockfile-reproduce
After checking out
- `pnpm install --frozen-lockfile` failed
- `CI=1 pnpm install` success
- `CI=1 pnpm install` failed after `git reset --hard` and comment out `prefer-frozen-lockfile=true`

After taking a look at the code, it's caused by checking whether the corresponding config is `undefined` or not. So even the value is set to `true` explicitly in `.npmrc`, it's treated as false when deciding whether to freeze lockfile...