### PR TITLE
fix(publish): --config.unknown CLI options needs special handling when passing them to npm 

### DIFF
--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -205,6 +205,8 @@ Do you want to continue?`,
       args.splice(index, 2)
     }
   }
+  // Convert Pnpm's "unknown config" form into regular form so that npm can understand it
+  args = args.map(a => a.replace(/^--config\./, '--'))
 
   if (dirInParams?.endsWith('.tgz')) {
     const { status } = runNpm(opts.npmPath, ['publish', dirInParams, ...args])


### PR DESCRIPTION
This should fix https://github.com/pnpm/pnpm/issues/9084

If this direction looks good, I can add tests

So far I quickly verified by modifying `dist/pnpm.cjs` directly inside `node_modules` for the corresponding place