### PR TITLE
fix: correct corepack self-update instructions

### DIFF
--- a/.changeset/gold-cameras-talk.md
+++ b/.changeset/gold-cameras-talk.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": patch
+---
+
+Correct instruction for updating pnpm with corepack

--- a/.changeset/gold-cameras-talk.md
+++ b/.changeset/gold-cameras-talk.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/default-reporter": patch
+"pnpm": patch
 ---
 
-Correct instruction for updating pnpm with corepack
+Fix instruction for updating pnpm with corepack [#9101](https://github.com/pnpm/pnpm/pull/9101).

--- a/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
+++ b/cli/default-reporter/src/reporterForClient/reportUpdateCheck.ts
@@ -50,7 +50,7 @@ function renderUpdateMessage (opts: UpdateMessageOptions): string {
 
 function renderUpdateCommand (opts: UpdateMessageOptions): string {
   if (isExecutedByCorepack(opts.env)) {
-    return `corepack install -g pnpm@${opts.latestVersion}`
+    return `corepack use pnpm@${opts.latestVersion}`
   }
   if (opts.env.PNPM_HOME) {
     return 'pnpm self-update'

--- a/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
+++ b/cli/default-reporter/test/__snapshots__/reportingUpdateCheck.ts.snap
@@ -6,7 +6,7 @@ exports[`print update notification for Corepack if the latest version is greater
    │                                                                  │
    │                Update available! 10.0.0 → 11.0.0.                │
    │   Changelog: https://github.com/pnpm/pnpm/releases/tag/v11.0.0   │
-   │         Run "corepack install -g pnpm@11.0.0" to update.         │
+   │            Run "corepack use pnpm@11.0.0" to update.             │
    │                                                                  │
    ╰──────────────────────────────────────────────────────────────────╯
 "


### PR DESCRIPTION
The previous instructions did not actually update the pnpm version used by corepack in the local project.

See https://github.com/nodejs/corepack/issues/587