### PR TITLE
fix: don't remove ignored builds list on repeat install

### DIFF
--- a/.changeset/clean-houses-sparkle.md
+++ b/.changeset/clean-houses-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/headless": patch
+"@pnpm/build-modules": patch
+---
+
+`pnpm approve-builds` should work after two consecutive `pnpm install`.

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -550,7 +550,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
       unsafePerm: opts.unsafePerm,
       userAgent: opts.userAgent,
     })).ignoredBuilds
-    if (ignoredBuilds == null && opts.modulesFile?.ignoredBuilds?.length) {
+    if (!ignoredBuilds?.length && opts.modulesFile?.ignoredBuilds?.length) {
       ignoredBuilds = opts.modulesFile.ignoredBuilds
       ignoredScriptsLogger.debug({ packageNames: ignoredBuilds })
     }


### PR DESCRIPTION
fix #9106