### PR TITLE
fix: stale catalog protocol reference on filtered install

### DIFF
--- a/.changeset/smooth-geckos-jog.md
+++ b/.changeset/smooth-geckos-jog.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/core": patch
+"pnpm": patch
 ---
 
-Fix a bug causing catalog protocol dependencies to not re-resolve on a filtered install.
+Fix a bug causing catalog protocol dependencies to not re-resolve on a filtered install [#8638](https://github.com/pnpm/pnpm/issues/8638).

--- a/.changeset/smooth-geckos-jog.md
+++ b/.changeset/smooth-geckos-jog.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/core": patch
+---
+
+Fix a bug causing catalog protocol dependencies to not re-resolve on a filtered install.

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1387,10 +1387,15 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
             nodeExecPath: opts.nodeExecPath,
             injectWorkspacePackages: opts.injectWorkspacePackages,
           }
+          const _isWantedDepPrefSame = isWantedDepPrefSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
           for (const project of allProjectsLocatedInsideWorkspace) {
             if (!newProjects.some(({ rootDir }) => rootDir === project.rootDir)) {
+              // This code block mirrors the installCase() function in
+              // mutateModules(). Consider a refactor that combines this logic
+              // to deduplicate code.
               const wantedDependencies = getWantedDependencies(project.manifest, getWantedDepsOpts)
                 .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
+              forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, _isWantedDepPrefSame)
               newProjects.push({
                 mutation: 'install',
                 ...project,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/build-modules'
 import { createAllowBuildFunction } from '@pnpm/builder.policy'
 import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+import { type Catalogs } from '@pnpm/catalogs.types'
 import {
   LAYOUT_VERSION,
   LOCKFILE_VERSION,
@@ -36,6 +37,7 @@ import {
   writeWantedLockfile,
   cleanGitBranchLockfiles,
   type PatchFile,
+  type CatalogSnapshots,
 } from '@pnpm/lockfile.fs'
 import { writePnpFile } from '@pnpm/lockfile-to-pnp'
 import { extendProjectsWithTargetDirs } from '@pnpm/lockfile.utils'
@@ -379,6 +381,7 @@ export async function mutateModules (
         throw new LockfileConfigMismatchError(outdatedLockfileSettingName!)
       }
     }
+    const _isWantedDepPrefSame = isWantedDepPrefSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let needsFullResolution = outdatedLockfileSettings ||
       opts.fixLockfile ||
@@ -591,28 +594,6 @@ Note that in CI environments, this setting is enabled by default.`,
     }
     /* eslint-enable no-await-in-loop */
 
-    function isWantedDepPrefSame (alias: string, prevPref: string | undefined, nextPref: string): boolean {
-      if (prevPref !== nextPref) {
-        return false
-      }
-
-      // When pnpm catalogs are used, the specifiers can be the same (e.g.
-      // "catalog:default"), but the wanted versions for the dependency can be
-      // different after resolution if the catalog config was just edited.
-      const catalogName = parseCatalogProtocol(prevPref)
-
-      // If there's no catalog name, the catalog protocol was not used and we
-      // can assume the pref is the same since prevPref and nextPref match.
-      if (catalogName === null) {
-        return true
-      }
-
-      const prevCatalogEntrySpec = ctx.wantedLockfile.catalogs?.[catalogName]?.[alias]?.specifier
-      const nextCatalogEntrySpec = opts.catalogs[catalogName]?.[alias]
-
-      return prevCatalogEntrySpec === nextCatalogEntrySpec
-    }
-
     async function installCase (project: any) { // eslint-disable-line
       const wantedDependencies = getWantedDependencies(project.manifest, {
         autoInstallPeers: opts.autoInstallPeers,
@@ -623,7 +604,7 @@ Note that in CI environments, this setting is enabled by default.`,
         .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
 
       if (ctx.wantedLockfile?.importers) {
-        forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, isWantedDepPrefSame)
+        forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, _isWantedDepPrefSame)
       }
       if (opts.ignoreScripts && project.manifest?.scripts &&
         (project.manifest.scripts.preinstall ||
@@ -753,6 +734,42 @@ function forgetResolutionsOfAllPrevWantedDeps (wantedLockfile: LockfileObject): 
       ({ dependencies, optionalDependencies, ...rest }) => rest,
       wantedLockfile.packages)
   }
+}
+
+/**
+ * Check if a wanted pref is the same.
+ *
+ * It would be different if the user modified a dependency in package.json or a
+ * catalog entry in pnpm-workspace.yaml. This is normally a simple check to see
+ * if the specifier strings match, but catalogs make this more involved since we
+ * also have to check if the catalog config in pnpm-workspace.yaml is the same.
+ */
+function isWantedDepPrefSame (
+  prevCatalogs: CatalogSnapshots | undefined,
+  catalogsConfig: Catalogs | undefined,
+  alias: string,
+  prevPref: string | undefined,
+  nextPref: string
+): boolean {
+  if (prevPref !== nextPref) {
+    return false
+  }
+
+  // When pnpm catalogs are used, the specifiers can be the same (e.g.
+  // "catalog:default"), but the wanted versions for the dependency can be
+  // different after resolution if the catalog config was just edited.
+  const catalogName = parseCatalogProtocol(prevPref)
+
+  // If there's no catalog name, the catalog protocol was not used and we
+  // can assume the pref is the same since prevPref and nextPref match.
+  if (catalogName === null) {
+    return true
+  }
+
+  const prevCatalogEntrySpec = prevCatalogs?.[catalogName]?.[alias]?.specifier
+  const nextCatalogEntrySpec = catalogsConfig?.[catalogName]?.[alias]
+
+  return prevCatalogEntrySpec === nextCatalogEntrySpec
 }
 
 export async function addDependenciesToPackage (

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -344,11 +344,24 @@ test('lockfile catalog snapshots do not contain stale references on --filter', a
     },
   })
 
-  expect(readLockfile().catalogs).toStrictEqual({
-    default: {
-      'is-positive': { specifier: '=3.1.0', version: '3.1.0' },
+  expect(readLockfile()).toEqual(expect.objectContaining({
+    catalogs: {
+      default: {
+        'is-positive': { specifier: '=3.1.0', version: '3.1.0' },
+      },
     },
-  })
+    importers: expect.objectContaining({
+      project1: {},
+      project2: expect.objectContaining({
+        dependencies: {
+          // project 2 should be updated even though it wasn't part of the
+          // filtered install. This is due to a filtered install updating
+          // the lockfile first: https://github.com/pnpm/pnpm/pull/8183
+          'is-positive': { specifier: 'catalog:', version: '3.1.0' },
+        },
+      }),
+    }),
+  }))
 })
 
 test('external dependency using catalog protocol errors', async () => {


### PR DESCRIPTION
## Context

Fixes a bug originally reported by @sergioflores-j.

- https://github.com/pnpm/pnpm/issues/8638.

## Explanation

When users change the catalog configuration in `pnpm-workspace.yaml`, the catalog resolution process relies on `forgetResolutionsOfPrevWantedDeps()` being called to know which catalog protocol usages have changed. This function is correctly called in the regular non-filtered code path, but was missed in installation code path for `--filter` installs.

This was a mistake I made when implementing catalogs originally.

## Changes

Let's call `forgetResolutionsOfPrevWantedDeps()` on filtered installs too.

## Followups

There's likely some refactor to the filtered install code path we could do to make sure these types of bugs are harder to make for others in the future.

## Testing

I was able to reproduce the issue locally end-to-end. The newly added test correctly fails when this fix hasn't been applied yet.

<img width="842" alt="Screenshot 2025-02-17 at 4 08 58 PM" src="https://github.com/user-attachments/assets/f83d3ae5-510b-4d2e-9cd5-6bef4e41b493" />

