### PR TITLE
refactor: make frozen install logic clearer

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -442,12 +442,19 @@ export async function mutateModules (
      */
     async function tryFrozenInstall (): Promise<InnerInstallResult | null> {
       const isFrozenInstallPossible =
+        // A frozen install is never possible when any of these are true:
         !ctx.lockfileHadConflicts &&
         !opts.fixLockfile &&
         !opts.dedupe &&
+
         installsOnly &&
         (
+          // If the user explicitly requested a frozen lockfile install, attempt
+          // to perform one. An error will be thrown if updates are required.
           frozenLockfile ||
+
+          // Otherwise, check if a frozen-like install is possible for
+          // performance. This will be the case if all projects are up-to-date.
           opts.ignorePackageManifest ||
           !needsFullResolution &&
           opts.preferFrozenLockfile &&

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -320,7 +320,14 @@ export async function mutateModules (
     ignoredBuilds: result.ignoredBuilds,
   }
 
-  async function _install (): Promise<{ updatedProjects: UpdatedProject[], stats?: InstallationResultStats, depsRequiringBuild?: DepPath[], ignoredBuilds: string[] | undefined }> {
+  interface InnerInstallResult {
+    readonly updatedProjects: UpdatedProject[]
+    readonly stats?: InstallationResultStats
+    readonly depsRequiringBuild?: DepPath[]
+    readonly ignoredBuilds: string[] | undefined
+  }
+
+  async function _install (): Promise<InnerInstallResult> {
     const scriptsOpts: RunLifecycleHooksConcurrentlyOptions = {
       extraBinPaths: opts.extraBinPaths,
       extraNodePaths: ctx.extraNodePaths,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -441,7 +441,7 @@ export async function mutateModules (
      * not change recorded dependency resolutions.
      */
     async function tryFrozenInstall (): Promise<InnerInstallResult | undefined> {
-      if (
+      const isFrozenInstallPossible =
         !ctx.lockfileHadConflicts &&
         !opts.fixLockfile &&
         !opts.dedupe &&
@@ -464,128 +464,131 @@ export async function mutateModules (
             lockfileDir: opts.lockfileDir,
           })
         )
-      ) {
-        if (needsFullResolution) {
-          throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
-            'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
-            {
-              hint: `Try either:
-  1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
-  2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
-  3. Using "pnpm install --no-frozen-lockfile".
-  Note that in CI environments, this setting is enabled by default.`,
-            }
-          )
-        }
-        if (!opts.ignorePackageManifest) {
-          const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, {
-            autoInstallPeers: opts.autoInstallPeers,
-            excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-          })
-          for (const { id, manifest, rootDir } of Object.values(ctx.projects)) {
-            const { satisfies, detailedReason } = _satisfiesPackageManifest(ctx.wantedLockfile.importers[id], manifest)
-            if (!satisfies) {
-              if (!ctx.existsWantedLockfile) {
-                throw new PnpmError('NO_LOCKFILE',
-                  `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`, {
-                    hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
-                  })
-              }
 
-              throw new PnpmError('OUTDATED_LOCKFILE',
-                `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with ` +
-                path.join('<ROOT>', path.relative(opts.lockfileDir, path.join(rootDir, 'package.json'))), {
-                  hint: `Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
+      if (!isFrozenInstallPossible) {
+        return undefined
+      }
 
-      Failure reason:
-      ${detailedReason ?? ''}`,
+      if (needsFullResolution) {
+        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+          'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
+          {
+            hint: `Try either:
+1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
+2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
+3. Using "pnpm install --no-frozen-lockfile".
+Note that in CI environments, this setting is enabled by default.`,
+          }
+        )
+      }
+      if (!opts.ignorePackageManifest) {
+        const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, {
+          autoInstallPeers: opts.autoInstallPeers,
+          excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+        })
+        for (const { id, manifest, rootDir } of Object.values(ctx.projects)) {
+          const { satisfies, detailedReason } = _satisfiesPackageManifest(ctx.wantedLockfile.importers[id], manifest)
+          if (!satisfies) {
+            if (!ctx.existsWantedLockfile) {
+              throw new PnpmError('NO_LOCKFILE',
+                `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`, {
+                  hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
                 })
             }
-          }
-        }
-        if (opts.lockfileOnly) {
-          // The lockfile will only be changed if the workspace will have new projects with no dependencies.
-          await writeWantedLockfile(ctx.lockfileDir, ctx.wantedLockfile)
-          return {
-            updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
-            ignoredBuilds: undefined,
-          }
-        }
-        if (!ctx.existsNonEmptyWantedLockfile) {
-          if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
-            throw new Error(`Headless installation requires a ${WANTED_LOCKFILE} file`)
-          }
-        } else {
-          if (maybeOpts.ignorePackageManifest) {
-            logger.info({ message: 'Importing packages to virtual store', prefix: opts.lockfileDir })
-          } else {
-            logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
-          }
-          try {
-            const { stats, ignoredBuilds } = await headlessInstall({
-              ...ctx,
-              ...opts,
-              currentEngine: {
-                nodeVersion: opts.nodeVersion,
-                pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
-              },
-              currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
-              patchedDependencies: patchedDependenciesWithResolvedPath,
-              selectedProjectDirs: projects.map((project) => project.rootDir),
-              allProjects: ctx.projects,
-              prunedAt: ctx.modulesFile?.prunedAt,
-              pruneVirtualStore,
-              wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
-              useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
-            })
-            if (
-              opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
-              !upToDateLockfileMajorVersion && !opts.frozenLockfile
-            ) {
-              await writeLockfiles({
-                currentLockfile: ctx.currentLockfile,
-                currentLockfileDir: ctx.virtualStoreDir,
-                wantedLockfile: ctx.wantedLockfile,
-                wantedLockfileDir: ctx.lockfileDir,
-                useGitBranchLockfile: opts.useGitBranchLockfile,
-                mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+
+            throw new PnpmError('OUTDATED_LOCKFILE',
+              `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with ` +
+              path.join('<ROOT>', path.relative(opts.lockfileDir, path.join(rootDir, 'package.json'))), {
+                hint: `Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
+
+    Failure reason:
+    ${detailedReason ?? ''}`,
               })
-            }
-            return {
-              updatedProjects: projects.map((mutatedProject) => {
-                const project = ctx.projects[mutatedProject.rootDir]
-                return {
-                  ...project,
-                  manifest: project.originalManifest ?? project.manifest,
-                }
-              }),
-              stats,
-              ignoredBuilds,
-            }
-          } catch (error: any) { // eslint-disable-line
-            if (
-              frozenLockfile ||
-              (
-                error.code !== 'ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY' &&
-                !BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)
-              ) ||
-              (!ctx.existsNonEmptyWantedLockfile && !ctx.existsCurrentLockfile)
-            ) throw error
-            if (BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)) {
-              needsFullResolution = true
-              // Ideally, we would not update but currently there is no other way to redownload the integrity of the package
-              for (const project of projects) {
-                (project as InstallMutationOptions).update = true
-              }
-            }
-            // A broken lockfile may be caused by a badly resolved Git conflict
-            logger.warn({
-              error,
-              message: error.message,
-              prefix: ctx.lockfileDir,
-            })
-            logger.error(new PnpmError(error.code, 'The lockfile is broken! Resolution step will be performed to fix it.'))
           }
+        }
+      }
+      if (opts.lockfileOnly) {
+        // The lockfile will only be changed if the workspace will have new projects with no dependencies.
+        await writeWantedLockfile(ctx.lockfileDir, ctx.wantedLockfile)
+        return {
+          updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
+          ignoredBuilds: undefined,
+        }
+      }
+      if (!ctx.existsNonEmptyWantedLockfile) {
+        if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
+          throw new Error(`Headless installation requires a ${WANTED_LOCKFILE} file`)
+        }
+      } else {
+        if (maybeOpts.ignorePackageManifest) {
+          logger.info({ message: 'Importing packages to virtual store', prefix: opts.lockfileDir })
+        } else {
+          logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
+        }
+        try {
+          const { stats, ignoredBuilds } = await headlessInstall({
+            ...ctx,
+            ...opts,
+            currentEngine: {
+              nodeVersion: opts.nodeVersion,
+              pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
+            },
+            currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
+            patchedDependencies: patchedDependenciesWithResolvedPath,
+            selectedProjectDirs: projects.map((project) => project.rootDir),
+            allProjects: ctx.projects,
+            prunedAt: ctx.modulesFile?.prunedAt,
+            pruneVirtualStore,
+            wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
+            useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
+          })
+          if (
+            opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
+            !upToDateLockfileMajorVersion && !opts.frozenLockfile
+          ) {
+            await writeLockfiles({
+              currentLockfile: ctx.currentLockfile,
+              currentLockfileDir: ctx.virtualStoreDir,
+              wantedLockfile: ctx.wantedLockfile,
+              wantedLockfileDir: ctx.lockfileDir,
+              useGitBranchLockfile: opts.useGitBranchLockfile,
+              mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+            })
+          }
+          return {
+            updatedProjects: projects.map((mutatedProject) => {
+              const project = ctx.projects[mutatedProject.rootDir]
+              return {
+                ...project,
+                manifest: project.originalManifest ?? project.manifest,
+              }
+            }),
+            stats,
+            ignoredBuilds,
+          }
+        } catch (error: any) { // eslint-disable-line
+          if (
+            frozenLockfile ||
+            (
+              error.code !== 'ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY' &&
+              !BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)
+            ) ||
+            (!ctx.existsNonEmptyWantedLockfile && !ctx.existsCurrentLockfile)
+          ) throw error
+          if (BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)) {
+            needsFullResolution = true
+            // Ideally, we would not update but currently there is no other way to redownload the integrity of the package
+            for (const project of projects) {
+              (project as InstallMutationOptions).update = true
+            }
+          }
+          // A broken lockfile may be caused by a badly resolved Git conflict
+          logger.warn({
+            error,
+            message: error.message,
+            prefix: ctx.lockfileDir,
+          })
+          logger.error(new PnpmError(error.code, 'The lockfile is broken! Resolution step will be performed to fix it.'))
         }
       }
     }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -432,7 +432,7 @@ export async function mutateModules (
      * if --frozen-lockfile wasn't explicitly specified. This allows users to
      * benefit from the increased performance of a frozen install automatically.
      *
-     * If a frozen install is not possible, this function will return undefined.
+     * If a frozen install is not possible, this function will return null.
      * This indicates a standard mutable install needs to be performed.
      *
      * Note this function may update the pnpm-lock.yaml file if the lockfile was
@@ -440,7 +440,7 @@ export async function mutateModules (
      * etc. These changes update the format of the pnpm-lock.yaml file, but do
      * not change recorded dependency resolutions.
      */
-    async function tryFrozenInstall (): Promise<InnerInstallResult | undefined> {
+    async function tryFrozenInstall (): Promise<InnerInstallResult | null> {
       const isFrozenInstallPossible =
         !ctx.lockfileHadConflicts &&
         !opts.fixLockfile &&
@@ -466,7 +466,7 @@ export async function mutateModules (
         )
 
       if (!isFrozenInstallPossible) {
-        return undefined
+        return null
       }
 
       if (needsFullResolution) {
@@ -519,7 +519,7 @@ Note that in CI environments, this setting is enabled by default.`,
         if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
           throw new Error(`Headless installation requires a ${WANTED_LOCKFILE} file`)
         }
-        return undefined
+        return null
       }
 
       if (maybeOpts.ignorePackageManifest) {
@@ -591,11 +591,12 @@ Note that in CI environments, this setting is enabled by default.`,
           prefix: ctx.lockfileDir,
         })
         logger.error(new PnpmError(error.code, 'The lockfile is broken! Resolution step will be performed to fix it.'))
+        return null
       }
     }
 
     const frozenInstallResult = await tryFrozenInstall()
-    if (frozenInstallResult !== undefined) {
+    if (frozenInstallResult !== null) {
       return frozenInstallResult
     }
 

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -415,196 +415,18 @@ export async function mutateModules (
       }
     }
 
-    /**
-     * Attempt to perform a "frozen install".
-     *
-     * A "frozen install" will be performed if:
-     *
-     *   1. The --frozen-lockfile flag was explicitly specified or evaluates to
-     *      true based on conditions like running on CI.
-     *   2. No workspace modifications have been made that would invalidate the
-     *      pnpm-lock.yaml file. In other words, the pnpm-lock.yaml file is
-     *      known to be "up-to-date".
-     *
-     * A frozen install is significantly faster since the pnpm-lock.yaml file
-     * can treated as immutable, skipping expensive lookups to acquire new
-     * dependencies. For this reason, a frozen install should be performed even
-     * if --frozen-lockfile wasn't explicitly specified. This allows users to
-     * benefit from the increased performance of a frozen install automatically.
-     *
-     * If a frozen install is not possible, this function will return null.
-     * This indicates a standard mutable install needs to be performed.
-     *
-     * Note this function may update the pnpm-lock.yaml file if the lockfile was
-     * on a different major version, needs to be merged due to git conflicts,
-     * etc. These changes update the format of the pnpm-lock.yaml file, but do
-     * not change recorded dependency resolutions.
-     */
-    async function tryFrozenInstall (): Promise<InnerInstallResult | null> {
-      const isFrozenInstallPossible =
-        // A frozen install is never possible when any of these are true:
-        !ctx.lockfileHadConflicts &&
-        !opts.fixLockfile &&
-        !opts.dedupe &&
-
-        installsOnly &&
-        (
-          // If the user explicitly requested a frozen lockfile install, attempt
-          // to perform one. An error will be thrown if updates are required.
-          frozenLockfile ||
-
-          // Otherwise, check if a frozen-like install is possible for
-          // performance. This will be the case if all projects are up-to-date.
-          opts.ignorePackageManifest ||
-          !needsFullResolution &&
-          opts.preferFrozenLockfile &&
-          (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
-          ctx.existsNonEmptyWantedLockfile &&
-          ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
-          await allProjectsAreUpToDate(Object.values(ctx.projects), {
-            catalogs: opts.catalogs,
-            autoInstallPeers: opts.autoInstallPeers,
-            excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-            linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
-            wantedLockfile: ctx.wantedLockfile,
-            workspacePackages: ctx.workspacePackages,
-            lockfileDir: opts.lockfileDir,
-          })
-        )
-
-      if (!isFrozenInstallPossible) {
-        return null
-      }
-
-      if (needsFullResolution) {
-        throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
-          'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
-          {
-            hint: `Try either:
-1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
-2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
-3. Using "pnpm install --no-frozen-lockfile".
-Note that in CI environments, this setting is enabled by default.`,
-          }
-        )
-      }
-      if (!opts.ignorePackageManifest) {
-        const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, {
-          autoInstallPeers: opts.autoInstallPeers,
-          excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-        })
-        for (const { id, manifest, rootDir } of Object.values(ctx.projects)) {
-          const { satisfies, detailedReason } = _satisfiesPackageManifest(ctx.wantedLockfile.importers[id], manifest)
-          if (!satisfies) {
-            if (!ctx.existsWantedLockfile) {
-              throw new PnpmError('NO_LOCKFILE',
-                `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`, {
-                  hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
-                })
-            }
-
-            throw new PnpmError('OUTDATED_LOCKFILE',
-              `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with ` +
-              path.join('<ROOT>', path.relative(opts.lockfileDir, path.join(rootDir, 'package.json'))), {
-                hint: `Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
-
-    Failure reason:
-    ${detailedReason ?? ''}`,
-              })
-          }
-        }
-      }
-      if (opts.lockfileOnly) {
-        // The lockfile will only be changed if the workspace will have new projects with no dependencies.
-        await writeWantedLockfile(ctx.lockfileDir, ctx.wantedLockfile)
-        return {
-          updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
-          ignoredBuilds: undefined,
-        }
-      }
-      if (!ctx.existsNonEmptyWantedLockfile) {
-        if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
-          throw new Error(`Headless installation requires a ${WANTED_LOCKFILE} file`)
-        }
-        return null
-      }
-
-      if (maybeOpts.ignorePackageManifest) {
-        logger.info({ message: 'Importing packages to virtual store', prefix: opts.lockfileDir })
-      } else {
-        logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
-      }
-      try {
-        const { stats, ignoredBuilds } = await headlessInstall({
-          ...ctx,
-          ...opts,
-          currentEngine: {
-            nodeVersion: opts.nodeVersion,
-            pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
-          },
-          currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
-          patchedDependencies: patchedDependenciesWithResolvedPath,
-          selectedProjectDirs: projects.map((project) => project.rootDir),
-          allProjects: ctx.projects,
-          prunedAt: ctx.modulesFile?.prunedAt,
-          pruneVirtualStore,
-          wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
-          useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
-        })
-        if (
-          opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
-          !upToDateLockfileMajorVersion && !opts.frozenLockfile
-        ) {
-          await writeLockfiles({
-            currentLockfile: ctx.currentLockfile,
-            currentLockfileDir: ctx.virtualStoreDir,
-            wantedLockfile: ctx.wantedLockfile,
-            wantedLockfileDir: ctx.lockfileDir,
-            useGitBranchLockfile: opts.useGitBranchLockfile,
-            mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
-          })
-        }
-        return {
-          updatedProjects: projects.map((mutatedProject) => {
-            const project = ctx.projects[mutatedProject.rootDir]
-            return {
-              ...project,
-              manifest: project.originalManifest ?? project.manifest,
-            }
-          }),
-          stats,
-          ignoredBuilds,
-        }
-      } catch (error: any) { // eslint-disable-line
-        if (
-          frozenLockfile ||
-          (
-            error.code !== 'ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY' &&
-            !BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)
-          ) ||
-          (!ctx.existsNonEmptyWantedLockfile && !ctx.existsCurrentLockfile)
-        ) throw error
-        if (BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)) {
-          needsFullResolution = true
-          // Ideally, we would not update but currently there is no other way to redownload the integrity of the package
-          for (const project of projects) {
-            (project as InstallMutationOptions).update = true
-          }
-        }
-        // A broken lockfile may be caused by a badly resolved Git conflict
-        logger.warn({
-          error,
-          message: error.message,
-          prefix: ctx.lockfileDir,
-        })
-        logger.error(new PnpmError(error.code, 'The lockfile is broken! Resolution step will be performed to fix it.'))
-        return null
-      }
-    }
-
-    const frozenInstallResult = await tryFrozenInstall()
+    const frozenInstallResult = await tryFrozenInstall({
+      frozenLockfile,
+      needsFullResolution,
+      patchedDependenciesWithResolvedPath,
+      upToDateLockfileMajorVersion,
+    })
     if (frozenInstallResult !== null) {
-      return frozenInstallResult
+      if ('needsFullResolution' in frozenInstallResult) {
+        needsFullResolution = frozenInstallResult.needsFullResolution
+      } else {
+        return frozenInstallResult
+      }
     }
 
     const projectsToInstall = [] as ImporterToUpdate[]
@@ -729,6 +551,203 @@ Note that in CI environments, this setting is enabled by default.`,
       stats: result.stats,
       depsRequiringBuild: result.depsRequiringBuild,
       ignoredBuilds: result.ignoredBuilds,
+    }
+  }
+
+  /**
+   * Attempt to perform a "frozen install".
+   *
+   * A "frozen install" will be performed if:
+   *
+   *   1. The --frozen-lockfile flag was explicitly specified or evaluates to
+   *      true based on conditions like running on CI.
+   *   2. No workspace modifications have been made that would invalidate the
+   *      pnpm-lock.yaml file. In other words, the pnpm-lock.yaml file is
+   *      known to be "up-to-date".
+   *
+   * A frozen install is significantly faster since the pnpm-lock.yaml file
+   * can treated as immutable, skipping expensive lookups to acquire new
+   * dependencies. For this reason, a frozen install should be performed even
+   * if --frozen-lockfile wasn't explicitly specified. This allows users to
+   * benefit from the increased performance of a frozen install automatically.
+   *
+   * If a frozen install is not possible, this function will return null.
+   * This indicates a standard mutable install needs to be performed.
+   *
+   * Note this function may update the pnpm-lock.yaml file if the lockfile was
+   * on a different major version, needs to be merged due to git conflicts,
+   * etc. These changes update the format of the pnpm-lock.yaml file, but do
+   * not change recorded dependency resolutions.
+   */
+  async function tryFrozenInstall ({
+    frozenLockfile,
+    needsFullResolution,
+    patchedDependenciesWithResolvedPath,
+    upToDateLockfileMajorVersion,
+  }: {
+    frozenLockfile: boolean
+    needsFullResolution: boolean
+    patchedDependenciesWithResolvedPath?: Record<string, PatchFile>
+    upToDateLockfileMajorVersion: boolean
+  }): Promise<InnerInstallResult | { needsFullResolution: boolean } | null> {
+    const isFrozenInstallPossible =
+      // A frozen install is never possible when any of these are true:
+      !ctx.lockfileHadConflicts &&
+      !opts.fixLockfile &&
+      !opts.dedupe &&
+
+      installsOnly &&
+      (
+        // If the user explicitly requested a frozen lockfile install, attempt
+        // to perform one. An error will be thrown if updates are required.
+        frozenLockfile ||
+
+        // Otherwise, check if a frozen-like install is possible for
+        // performance. This will be the case if all projects are up-to-date.
+        opts.ignorePackageManifest ||
+        !needsFullResolution &&
+        opts.preferFrozenLockfile &&
+        (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
+        ctx.existsNonEmptyWantedLockfile &&
+        ctx.wantedLockfile.lockfileVersion === LOCKFILE_VERSION &&
+        await allProjectsAreUpToDate(Object.values(ctx.projects), {
+          catalogs: opts.catalogs,
+          autoInstallPeers: opts.autoInstallPeers,
+          excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+          linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
+          wantedLockfile: ctx.wantedLockfile,
+          workspacePackages: ctx.workspacePackages,
+          lockfileDir: opts.lockfileDir,
+        })
+      )
+
+    if (!isFrozenInstallPossible) {
+      return null
+    }
+
+    if (needsFullResolution) {
+      throw new PnpmError('FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE',
+        'Cannot perform a frozen installation because the version of the lockfile is incompatible with this version of pnpm',
+        {
+          hint: `Try either:
+1. Aligning the version of pnpm that generated the lockfile with the version that installs from it, or
+2. Migrating the lockfile so that it is compatible with the newer version of pnpm, or
+3. Using "pnpm install --no-frozen-lockfile".
+Note that in CI environments, this setting is enabled by default.`,
+        }
+      )
+    }
+    if (!opts.ignorePackageManifest) {
+      const _satisfiesPackageManifest = satisfiesPackageManifest.bind(null, {
+        autoInstallPeers: opts.autoInstallPeers,
+        excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+      })
+      for (const { id, manifest, rootDir } of Object.values(ctx.projects)) {
+        const { satisfies, detailedReason } = _satisfiesPackageManifest(ctx.wantedLockfile.importers[id], manifest)
+        if (!satisfies) {
+          if (!ctx.existsWantedLockfile) {
+            throw new PnpmError('NO_LOCKFILE',
+              `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is absent`, {
+                hint: 'Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"',
+              })
+          }
+
+          throw new PnpmError('OUTDATED_LOCKFILE',
+            `Cannot install with "frozen-lockfile" because ${WANTED_LOCKFILE} is not up to date with ` +
+            path.join('<ROOT>', path.relative(opts.lockfileDir, path.join(rootDir, 'package.json'))), {
+              hint: `Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
+
+  Failure reason:
+  ${detailedReason ?? ''}`,
+            })
+        }
+      }
+    }
+    if (opts.lockfileOnly) {
+      // The lockfile will only be changed if the workspace will have new projects with no dependencies.
+      await writeWantedLockfile(ctx.lockfileDir, ctx.wantedLockfile)
+      return {
+        updatedProjects: projects.map((mutatedProject) => ctx.projects[mutatedProject.rootDir]),
+        ignoredBuilds: undefined,
+      }
+    }
+    if (!ctx.existsNonEmptyWantedLockfile) {
+      if (Object.values(ctx.projects).some((project) => pkgHasDependencies(project.manifest))) {
+        throw new Error(`Headless installation requires a ${WANTED_LOCKFILE} file`)
+      }
+      return null
+    }
+
+    if (maybeOpts.ignorePackageManifest) {
+      logger.info({ message: 'Importing packages to virtual store', prefix: opts.lockfileDir })
+    } else {
+      logger.info({ message: 'Lockfile is up to date, resolution step is skipped', prefix: opts.lockfileDir })
+    }
+    try {
+      const { stats, ignoredBuilds } = await headlessInstall({
+        ...ctx,
+        ...opts,
+        currentEngine: {
+          nodeVersion: opts.nodeVersion,
+          pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
+        },
+        currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
+        patchedDependencies: patchedDependenciesWithResolvedPath,
+        selectedProjectDirs: projects.map((project) => project.rootDir),
+        allProjects: ctx.projects,
+        prunedAt: ctx.modulesFile?.prunedAt,
+        pruneVirtualStore,
+        wantedLockfile: maybeOpts.ignorePackageManifest ? undefined : ctx.wantedLockfile,
+        useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
+      })
+      if (
+        opts.useLockfile && opts.saveLockfile && opts.mergeGitBranchLockfiles ||
+        !upToDateLockfileMajorVersion && !opts.frozenLockfile
+      ) {
+        await writeLockfiles({
+          currentLockfile: ctx.currentLockfile,
+          currentLockfileDir: ctx.virtualStoreDir,
+          wantedLockfile: ctx.wantedLockfile,
+          wantedLockfileDir: ctx.lockfileDir,
+          useGitBranchLockfile: opts.useGitBranchLockfile,
+          mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+        })
+      }
+      return {
+        updatedProjects: projects.map((mutatedProject) => {
+          const project = ctx.projects[mutatedProject.rootDir]
+          return {
+            ...project,
+            manifest: project.originalManifest ?? project.manifest,
+          }
+        }),
+        stats,
+        ignoredBuilds,
+      }
+    } catch (error: any) { // eslint-disable-line
+      if (
+        frozenLockfile ||
+        (
+          error.code !== 'ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY' &&
+          !BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)
+        ) ||
+        (!ctx.existsNonEmptyWantedLockfile && !ctx.existsCurrentLockfile)
+      ) throw error
+      if (BROKEN_LOCKFILE_INTEGRITY_ERRORS.has(error.code)) {
+        needsFullResolution = true
+        // Ideally, we would not update but currently there is no other way to redownload the integrity of the package
+        for (const project of projects) {
+          (project as InstallMutationOptions).update = true
+        }
+      }
+      // A broken lockfile may be caused by a badly resolved Git conflict
+      logger.warn({
+        error,
+        message: error.message,
+        prefix: ctx.lockfileDir,
+      })
+      logger.error(new PnpmError(error.code, 'The lockfile is broken! Resolution step will be performed to fix it.'))
+      return { needsFullResolution }
     }
   }
 }


### PR DESCRIPTION
## Motivation

There's a large block of code in `mutateModules()`'s inner `_install()` function that's responsible for performing an installation when the `pnpm-lock.yaml` file is "_up to date_". This PR attempts a few refactors to make that code block easier to understand.

The block of code in question starts with a large if-statement here:

https://github.com/pnpm/pnpm/blob/2d16f7a4a945b3c24936cb5eacf55283aa40d3ab/pkg-manager/core/src/install/index.ts#L410-L434

## Changes

This PR mostly moves the frozen install code into its own function and adds more comments to it. I'm hoping this makes it easier for others to see the intention of this code in the future.

If I've done this refactor correctly, there should be no differences in pnpm's runtime behavior. Everything should run behave exactly the same.

## Reviewing

- Each refactor was isolated into its own commit. Reviewing this PR commit by commit should be a lot easier.
- It should also be easier to see what's actually changing by hiding whitespace since code was indented to the left and back to the right in a few places.

<img width="252" alt="Screenshot 2025-02-22 at 11 37 17 PM" src="https://github.com/user-attachments/assets/e6a6e549-eb36-4362-8bd6-24b32e0c798a" />
