### PR TITLE
fix: catalog snapshots removed on filtered install with `--fix-lockfile`

### DIFF
--- a/.changeset/rare-avocados-listen.md
+++ b/.changeset/rare-avocados-listen.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+pnpm: patch
+---
+
+Fix a bug causing catalog snapshots to be removed from the `pnpm-lock.yaml` file when using `--fix-lockfile` and `--filter`. [#8639](https://github.com/pnpm/pnpm/issues/8639)


### PR DESCRIPTION
## Context

Fixes:

- https://github.com/pnpm/pnpm/issues/8639

## Changes

This PR looks a bit strange because it's only removing code, but I think it's the right fix. I could use help code reviewing to make sure though. Here's my thought process:

Within the `installInContext` function, there seems to be a second attempt at performing a frozen install. This happens after the `tryFrozenInstall` function bails out.

https://github.com/pnpm/pnpm/blob/43681529cfa70da4f8256512522894683d3453b9/pkg-manager/core/src/install/index.ts#L1436-L1451

I believe we can remove the secondary frozen install here without affecting performance. For a filtered install:

- If the lockfile is up to date, the standard `tryFrozenInstall` function will still be used.
- If the lockfile needs updates, we use the existing code path to compute the lockfile before performing the filtered install and mutating modules.

## Alternatives

It feels as if the bug is happening because the secondary frozen install attempt doesn't contain as many conditions/checks as `tryFrozenInstall`. It currently just checks if all mutations are installs and projects are up to date.

https://github.com/pnpm/pnpm/blob/43681529cfa70da4f8256512522894683d3453b9/pkg-manager/core/src/install/index.ts#L1437-L1438

We could copy the additional conditions from `tryFrozenInstall` to fix this bug, but I think that causes us to just duplicate `tryFrozenInstall` when taking this copy approach to the limit. I think it makes more sense to remove the secondary install frozen install.

https://github.com/pnpm/pnpm/blob/43681529cfa70da4f8256512522894683d3453b9/pkg-manager/core/src/install/index.ts#L594-L597

## Reviewing

This PR should be easier to review after hiding whitespace-only changes.