### PR TITLE
fix: avoid printing undefined for package version when reporting error

### DIFF
--- a/.changeset/lemon-schools-jog.md
+++ b/.changeset/lemon-schools-jog.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/default-reporter": patch
+---
+
+Fix undefined being printed in install errors when a package does not have a version field.

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -103,10 +103,24 @@ function getErrorInfo (logObj: Log, config?: Config, peerDependencyRules?: PeerD
   return { title: logObj.message! }
 }
 
-function formatPkgsStack (pkgsStack: Array<{ id: string, name: string, version: string }>) {
+interface PkgStackItem {
+  readonly id: string
+  readonly name: string
+  // The version may be missing if this was a private workspace package without
+  // the version field set.
+  readonly version?: string
+}
+
+function formatPkgNameVer ({ name, version }: PkgStackItem) {
+  return version == null
+    ? name
+    : `${name}@${version}`
+}
+
+function formatPkgsStack (pkgsStack: readonly PkgStackItem[]) {
   return `This error happened while installing the dependencies of \
-${pkgsStack[0].name}@${pkgsStack[0].version}\
-${pkgsStack.slice(1).map(({ name, version }) => `${EOL} at ${name}@${version}`).join('')}`
+${formatPkgNameVer(pkgsStack[0])}\
+${pkgsStack.slice(1).map((pkgInfo) => `${EOL} at ${formatPkgNameVer(pkgInfo)}`).join('')}`
 }
 
 interface PackageMeta {
@@ -489,7 +503,7 @@ protocol are replaced with real specifiers on 'pnpm publish'.
 This is likely a bug in the publishing automation of this package. Consider filing
 a bug with the authors of:
 
-  ${highlight(`${problemDep.name}@${problemDep.version}`)}
+  ${highlight(formatPkgNameVer(problemDep))}
 `
   }
 


### PR DESCRIPTION
## Changes

Fixing a minor bug I noticed while working on a different issue. We can probably omit the `@undefined` part of the package ID when there's no `version`.

### Before

<img width="842" alt="Screenshot 2025-02-23 at 5 29 50 PM" src="https://github.com/user-attachments/assets/285d2d69-fbda-4100-9f97-03a7ce21fc1f" />

### After

<img width="842" alt="Screenshot 2025-02-23 at 5 30 04 PM" src="https://github.com/user-attachments/assets/e7ec6569-aca0-48d5-837f-d25ecf31f572" />
