### PR TITLE
fix: catalog snapshots removed on filtered install with --fix-lockfile (v9)

### DIFF
--- a/.changeset/rare-avocados-listen.md
+++ b/.changeset/rare-avocados-listen.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/core": patch
+pnpm: patch
+---
+
+Fix a bug causing catalog snapshots to be removed from the `pnpm-lock.yaml` file when using `--fix-lockfile` and `--filter`. [#8639](https://github.com/pnpm/pnpm/issues/8639)

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1414,71 +1414,53 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
       const allProjectsLocatedInsideWorkspace = Object.values(ctx.projects)
         .filter((project) => isPathInsideWorkspace(project.rootDirRealPath ?? project.rootDir))
       if (allProjectsLocatedInsideWorkspace.length > projects.length) {
-        if (
-          allMutationsAreInstalls(projects) &&
-          await allProjectsAreUpToDate(allProjectsLocatedInsideWorkspace, {
-            catalogs: opts.catalogs,
-            autoInstallPeers: opts.autoInstallPeers,
-            excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-            linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
-            wantedLockfile: ctx.wantedLockfile,
-            workspacePackages: ctx.workspacePackages,
-            lockfileDir: opts.lockfileDir,
-          })
-        ) {
-          return installInContext(projects, ctx, {
-            ...opts,
-            frozenLockfile: true,
-          })
-        } else {
-          const newProjects = [...projects]
-          const getWantedDepsOpts = {
-            autoInstallPeers: opts.autoInstallPeers,
-            includeDirect: opts.includeDirect,
-            updateWorkspaceDependencies: false,
-            nodeExecPath: opts.nodeExecPath,
+        const newProjects = [...projects]
+        const getWantedDepsOpts = {
+          autoInstallPeers: opts.autoInstallPeers,
+          includeDirect: opts.includeDirect,
+          updateWorkspaceDependencies: false,
+          nodeExecPath: opts.nodeExecPath,
+        }
+        const _isWantedDepPrefSame = isWantedDepPrefSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
+        for (const project of allProjectsLocatedInsideWorkspace) {
+          if (!newProjects.some(({ rootDir }) => rootDir === project.rootDir)) {
+            // This code block mirrors the installCase() function in
+            // mutateModules(). Consider a refactor that combines this logic to
+            // deduplicate code.
+            const wantedDependencies = getWantedDependencies(project.manifest, getWantedDepsOpts)
+              .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
+            forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, _isWantedDepPrefSame)
+            newProjects.push({
+              mutation: 'install',
+              ...project,
+              wantedDependencies,
+              pruneDirectDependencies: false,
+              updatePackageManifest: false,
+            })
           }
-          const _isWantedDepPrefSame = isWantedDepPrefSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
-          for (const project of allProjectsLocatedInsideWorkspace) {
-            if (!newProjects.some(({ rootDir }) => rootDir === project.rootDir)) {
-              // This code block mirrors the installCase() function in
-              // mutateModules(). Consider a refactor that combines this logic
-              // to deduplicate code.
-              const wantedDependencies = getWantedDependencies(project.manifest, getWantedDepsOpts)
-                .map((wantedDependency) => ({ ...wantedDependency, updateSpec: true, preserveNonSemverVersionSpec: true }))
-              forgetResolutionsOfPrevWantedDeps(ctx.wantedLockfile.importers[project.id], wantedDependencies, _isWantedDepPrefSame)
-              newProjects.push({
-                mutation: 'install',
-                ...project,
-                wantedDependencies,
-                pruneDirectDependencies: false,
-                updatePackageManifest: false,
-              })
-            }
-          }
-          const result = await installInContext(newProjects, ctx, {
-            ...opts,
-            lockfileOnly: true,
-          })
-          const { stats } = await headlessInstall({
-            ...ctx,
-            ...opts,
-            currentEngine: {
-              nodeVersion: opts.nodeVersion,
-              pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
-            },
-            currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
-            selectedProjectDirs: projects.map((project) => project.rootDir),
-            allProjects: ctx.projects,
-            prunedAt: ctx.modulesFile?.prunedAt,
-            wantedLockfile: result.newLockfile,
-            useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
-            hoistWorkspacePackages: opts.hoistWorkspacePackages,
-          })
-          return {
-            ...result,
-            stats,
-          }
+        }
+        const result = await installInContext(newProjects, ctx, {
+          ...opts,
+          lockfileOnly: true,
+        })
+        const { stats } = await headlessInstall({
+          ...ctx,
+          ...opts,
+          currentEngine: {
+            nodeVersion: opts.nodeVersion,
+            pnpmVersion: opts.packageManager.name === 'pnpm' ? opts.packageManager.version : '',
+          },
+          currentHoistedLocations: ctx.modulesFile?.hoistedLocations,
+          selectedProjectDirs: projects.map((project) => project.rootDir),
+          allProjects: ctx.projects,
+          prunedAt: ctx.modulesFile?.prunedAt,
+          wantedLockfile: result.newLockfile,
+          useLockfile: opts.useLockfile && ctx.wantedLockfileIsModified,
+          hoistWorkspacePackages: opts.hoistWorkspacePackages,
+        })
+        return {
+          ...result,
+          stats,
         }
       }
     }


### PR DESCRIPTION
## Changes

This is a backport of https://github.com/pnpm/pnpm/pull/9126 for the v9 branch.

## Merge Conflict

There were a merge conflict cherry-picking https://github.com/pnpm/pnpm/commit/41dada429bff5be4391516fd82dbd442f6ca38f5 due to some changes to `injectWorkspacePackages` and `ignoredBuilds` in this function.

To fix, I manually performed the same code edits again rather than try to resolve the conflict.

I also ran a quick `git diff` of the `installInContext` function on `v9` and `main` to make sure I resolved the merge conflicts correctly.

<img width="1627" alt="Screenshot 2025-02-23 at 9 55 42 PM" src="https://github.com/user-attachments/assets/5ff8aa51-7693-4d51-a4d5-a94d949d778f" />

