### PR TITLE
fix: catalog snapshots removed on filtered install with `dedupe-peer-dependents=false`

### DIFF
--- a/.changeset/strange-tigers-dress.md
+++ b/.changeset/strange-tigers-dress.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/plugin-commands-deploy": patch
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/core": patch
+pnpm: patch
+---
+
+Fix a bug causing entries in the `catalogs` section of the `pnpm-lock.yaml` file to be removed when `dedupe-peer-dependents=false` on a filtered install. [#9112](https://github.com/pnpm/pnpm/issues/9112)

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -219,8 +219,19 @@ when running add/update with the --workspace option')
         })
       }
 
+      const didUserConfigureCatalogs = Object.values(opts.catalogs ?? {})
+        .some(catalog => Object.keys(catalog ?? {}).length > 0)
+
+      // pnpm catalogs and dedupe-peer-dependents are features that require the
+      // allProjectsGraph to contain all projects to correctly update the wanted
+      // lockfile. Otherwise the wanted lockfile would be partially updated for
+      // only the selected projects specified for the filtered install.
+      //
+      // This should still be performance since only dependencies for the
+      // selectedProjectsGraph are installed. The allProjectsGraph is only used
+      // to compute the wanted lockfile.
       let allProjectsGraph!: ProjectsGraph
-      if (opts.dedupePeerDependents) {
+      if (didUserConfigureCatalogs || opts.dedupePeerDependents) {
         allProjectsGraph = opts.allProjectsGraph ?? createPkgGraph(allProjects, {
           linkWorkspacePackages: Boolean(opts.linkWorkspacePackages),
         }).graph

--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -135,6 +135,13 @@ export async function handler (opts: DeployOptions, params: string[]): Promise<v
     // doesn't work with filters right now.
     // Related issue: https://github.com/pnpm/pnpm/issues/6858
     dedupePeerDependents: false,
+    // If enabled, dedupe-injected-deps will symlink workspace packages in the
+    // deployed dir to their original (non-deployed) directory in an attempt to
+    // dedupe workspace packages that don't need to be injected. The deployed
+    // dir shouldn't have symlinks to the original workspace. Disable
+    // dedupe-injected-deps to always inject workspace packages since copying is
+    // desirable.
+    dedupeInjectedDeps: false,
     depth: Infinity,
     hooks: {
       ...opts.hooks,


### PR DESCRIPTION
## Context

Fixes:

- https://github.com/pnpm/pnpm/issues/9112

## Explanation

For accurate `pnpm-lock.yaml` updates on a filtered install, catalogs relies on `ctx.projects` here to be all projects in the workspace. This supports a code path to compute the full `pnpm-lock.yaml` file before performing mutating modules on a filtered install.

https://github.com/pnpm/pnpm/blob/41dada429bff5be4391516fd82dbd442f6ca38f5/pkg-manager/core/src/install/index.ts#L1433

It turns out this is only the case if `dedupe-peer-dependents` is enabled. I missed this since `dedupe-peer-dependents` defaults to `true`.

https://github.com/pnpm/pnpm/blob/76973d8c81cde9de5174f219e6ff2486a9dc53b2/pkg-manager/plugin-commands-installation/src/installDeps.ts#L222-L227

For completeness, here's where `allProjectsGraph` becomes `ctx.allProjects`

https://github.com/pnpm/pnpm/blob/76973d8c81cde9de5174f219e6ff2486a9dc53b2/pkg-manager/plugin-commands-installation/src/recursive.ts#L138

## Changes

Updating the condition above to check for `dedupe-peer-dependents` or if a user has configured a catalog.