### PR TITLE
feat: support frozen installs in projects using local tarball dependencies

### DIFF
--- a/.changeset/common-pugs-flash.md
+++ b/.changeset/common-pugs-flash.md
@@ -2,4 +2,4 @@
 "@pnpm/crypto.hash": minor
 ---
 
-Added a new `createLocalTarballFileIntegrity` function. This function was moved from `@pnpm/local-resolver` and is used to compute the integrity hash of a local tarball `file:` dependency in the `pnpm-lock.yaml` file.
+Added a new `getTarballIntegrity` function. This function was moved from `@pnpm/local-resolver` and is used to compute the integrity hash of a local tarball `file:` dependency in the `pnpm-lock.yaml` file.

--- a/.changeset/common-pugs-flash.md
+++ b/.changeset/common-pugs-flash.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/crypto.hash": minor
+---
+
+Added a new `createLocalTarballFileIntegrity` function. This function was moved from `@pnpm/local-resolver` and is used to compute the integrity hash of a local tarball `file:` dependency in the `pnpm-lock.yaml` file.

--- a/.changeset/empty-windows-ring.md
+++ b/.changeset/empty-windows-ring.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.verification": minor
+pnpm: minor
+---
+
+Projects using a `file:` dependency on a local tarball file (i.e. `.tgz`, `.tar.gz`, `.tar`) will see a performance improvement during installation. Previously, using a `file:` dependency on a tarball caused the lockfile resolution step to always run. The lockfile will now be considered up-to-date if the tarball is unchanged.

--- a/crypto/hash/package.json
+++ b/crypto/hash/package.json
@@ -34,14 +34,14 @@
   "dependencies": {
     "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/graceful-fs": "workspace:*",
-    "ssri": "catalog:",
-    "tar-stream": "catalog:"
+    "ssri": "catalog:"
   },
   "devDependencies": {
     "@pnpm/crypto.hash": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@types/ssri": "catalog:",
-    "@types/tar-stream": "catalog:"
+    "@types/tar-stream": "catalog:",
+    "tar-stream": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/crypto/hash/package.json
+++ b/crypto/hash/package.json
@@ -34,12 +34,14 @@
   "dependencies": {
     "@pnpm/crypto.polyfill": "workspace:*",
     "@pnpm/graceful-fs": "workspace:*",
-    "ssri": "catalog:"
+    "ssri": "catalog:",
+    "tar-stream": "catalog:"
   },
   "devDependencies": {
     "@pnpm/crypto.hash": "workspace:*",
     "@pnpm/prepare": "workspace:*",
-    "@types/ssri": "catalog:"
+    "@types/ssri": "catalog:",
+    "@types/tar-stream": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/crypto/hash/package.json
+++ b/crypto/hash/package.json
@@ -32,11 +32,14 @@
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
-    "@pnpm/crypto.polyfill": "workspace:*"
+    "@pnpm/crypto.polyfill": "workspace:*",
+    "@pnpm/graceful-fs": "workspace:*",
+    "ssri": "catalog:"
   },
   "devDependencies": {
     "@pnpm/crypto.hash": "workspace:*",
-    "@pnpm/prepare": "workspace:*"
+    "@pnpm/prepare": "workspace:*",
+    "@types/ssri": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/crypto/hash/src/index.ts
+++ b/crypto/hash/src/index.ts
@@ -28,6 +28,6 @@ async function readNormalizedFile (file: string): Promise<string> {
   return content.split('\r\n').join('\n')
 }
 
-export async function createLocalTarballFileIntegrity (filename: string): Promise<string> {
+export async function getTarballIntegrity (filename: string): Promise<string> {
   return (await ssri.fromStream(gfs.createReadStream(filename))).toString()
 }

--- a/crypto/hash/src/index.ts
+++ b/crypto/hash/src/index.ts
@@ -1,5 +1,7 @@
 import * as crypto from '@pnpm/crypto.polyfill'
 import fs from 'fs'
+import gfs from '@pnpm/graceful-fs'
+import ssri from 'ssri'
 
 export function createShortHash (input: string): string {
   return createHexHash(input).substring(0, 32)
@@ -24,4 +26,8 @@ export async function createHexHashFromFile (file: string): Promise<string> {
 async function readNormalizedFile (file: string): Promise<string> {
   const content = await fs.promises.readFile(file, 'utf8')
   return content.split('\r\n').join('\n')
+}
+
+export async function createLocalTarballFileIntegrity (filename: string): Promise<string> {
+  return (await ssri.fromStream(gfs.createReadStream(filename))).toString()
 }

--- a/crypto/hash/test/index.ts
+++ b/crypto/hash/test/index.ts
@@ -1,7 +1,9 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import fs from 'fs'
-import { createShortHash, createHashFromFile } from '@pnpm/crypto.hash'
+import { createShortHash, createHashFromFile, createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
 import { tempDir } from '@pnpm/prepare'
+import { pipeline } from 'node:stream/promises'
+import tar from 'tar-stream'
 
 test('createShortHash()', () => {
   expect(createShortHash('AAA')).toEqual('cb1ad2119d8fafb69566510ee712661f')
@@ -12,4 +14,21 @@ test('createHashFromFile normalizes line endings before calculating the hash', a
   fs.writeFileSync('win-eol.txt', 'a\r\nb\r\nc')
   fs.writeFileSync('posix-eol.txt', 'a\nb\r\nc')
   expect(await createHashFromFile('win-eol.txt')).toEqual(await createHashFromFile('posix-eol.txt'))
+})
+
+test('createLocalTarballFileIntegrity creates integrity hash for tarball', async () => {
+  expect.hasAssertions()
+  tempDir()
+
+  const pack = tar.pack()
+  pack.entry({ name: 'package.json', mtime: new Date('1970-01-01T00:00:00.000Z') }, JSON.stringify({
+    name: 'local-tarball',
+    version: '1.0.0',
+  }))
+  pack.finalize()
+
+  await pipeline(pack, fs.createWriteStream('./local-tarball.tar'))
+
+  await expect(createLocalTarballFileIntegrity('./local-tarball.tar'))
+    .resolves.toEqual('sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==')
 })

--- a/crypto/hash/test/index.ts
+++ b/crypto/hash/test/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import fs from 'fs'
-import { createShortHash, createHashFromFile, createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
+import { createShortHash, createHashFromFile, getTarballIntegrity } from '@pnpm/crypto.hash'
 import { tempDir } from '@pnpm/prepare'
 import { pipeline } from 'node:stream/promises'
 import tar from 'tar-stream'
@@ -16,7 +16,7 @@ test('createHashFromFile normalizes line endings before calculating the hash', a
   expect(await createHashFromFile('win-eol.txt')).toEqual(await createHashFromFile('posix-eol.txt'))
 })
 
-test('createLocalTarballFileIntegrity creates integrity hash for tarball', async () => {
+test('getTarballIntegrity creates integrity hash for tarball', async () => {
   expect.hasAssertions()
   tempDir()
 
@@ -29,6 +29,6 @@ test('createLocalTarballFileIntegrity creates integrity hash for tarball', async
 
   await pipeline(pack, fs.createWriteStream('./local-tarball.tar'))
 
-  await expect(createLocalTarballFileIntegrity('./local-tarball.tar'))
+  await expect(getTarballIntegrity('./local-tarball.tar'))
     .resolves.toEqual('sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==')
 })

--- a/crypto/hash/tsconfig.json
+++ b/crypto/hash/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../fs/graceful-fs"
+    },
+    {
       "path": "../polyfill"
     }
   ]

--- a/lockfile/verification/package.json
+++ b/lockfile/verification/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/crypto.hash": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",
     "@pnpm/get-context": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",

--- a/lockfile/verification/package.json
+++ b/lockfile/verification/package.json
@@ -53,7 +53,9 @@
     "@pnpm/logger": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@types/ramda": "catalog:",
-    "@types/semver": "catalog:"
+    "@types/semver": "catalog:",
+    "@types/tar-stream": "catalog:",
+    "tar-stream": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/lockfile/verification/src/allProjectsAreUpToDate.ts
+++ b/lockfile/verification/src/allProjectsAreUpToDate.ts
@@ -2,18 +2,16 @@ import { type Catalogs } from '@pnpm/catalogs.types'
 import { type ProjectOptions } from '@pnpm/get-context'
 import {
   type LockfileObject,
-  type ProjectSnapshot,
 } from '@pnpm/lockfile.types'
-import { refIsLocalTarball } from '@pnpm/lockfile.utils'
 import { type WorkspacePackages } from '@pnpm/resolver-base'
 import { DEPENDENCIES_FIELDS, type ProjectId } from '@pnpm/types'
 import pEvery from 'p-every'
-import any from 'ramda/src/any'
 import isEmpty from 'ramda/src/isEmpty'
 import { allCatalogsAreUpToDate } from './allCatalogsAreUpToDate'
 import { getWorkspacePackagesByDirectory } from './getWorkspacePackagesByDirectory'
 import { linkedPackagesAreUpToDate } from './linkedPackagesAreUpToDate'
 import { satisfiesPackageManifest } from './satisfiesPackageManifest'
+import { localTarballDepsAreUpToDate } from './localTarballDepsAreUpToDate'
 
 export async function allProjectsAreUpToDate (
   projects: Array<Pick<ProjectOptions, 'manifest' | 'rootDir'> & { id: ProjectId }>,
@@ -46,24 +44,26 @@ export async function allProjectsAreUpToDate (
     lockfilePackages: opts.wantedLockfile.packages,
     lockfileDir: opts.lockfileDir,
   })
-  return pEvery(projects, (project) => {
+  const _localTarballDepsAreUpToDate = localTarballDepsAreUpToDate.bind(null, {
+    fileIntegrityCache: new Map(),
+    lockfilePackages: opts.wantedLockfile.packages,
+    lockfileDir: opts.lockfileDir,
+  })
+  return pEvery(projects, async (project) => {
     const importer = opts.wantedLockfile.importers[project.id]
     if (importer == null) {
       return DEPENDENCIES_FIELDS.every((depType) => project.manifest[depType] == null || isEmpty(project.manifest[depType]))
     }
-    return importer != null &&
-      !hasLocalTarballDepsInRoot(importer) &&
-      _satisfiesPackageManifest(importer, project.manifest).satisfies &&
-      _linkedPackagesAreUpToDate({
-        dir: project.rootDir,
-        manifest: project.manifest,
-        snapshot: importer,
-      })
-  })
-}
 
-function hasLocalTarballDepsInRoot (importer: ProjectSnapshot): boolean {
-  return any(refIsLocalTarball, Object.values(importer.dependencies ?? {})) ||
-    any(refIsLocalTarball, Object.values(importer.devDependencies ?? {})) ||
-    any(refIsLocalTarball, Object.values(importer.optionalDependencies ?? {}))
+    const projectInfo = {
+      dir: project.rootDir,
+      manifest: project.manifest,
+      snapshot: importer,
+    }
+
+    return importer != null &&
+      _satisfiesPackageManifest(importer, project.manifest).satisfies &&
+      (await _localTarballDepsAreUpToDate(projectInfo)) &&
+      (_linkedPackagesAreUpToDate(projectInfo))
+  })
 }

--- a/lockfile/verification/src/index.ts
+++ b/lockfile/verification/src/index.ts
@@ -1,4 +1,5 @@
 export { allProjectsAreUpToDate } from './allProjectsAreUpToDate'
 export { getWorkspacePackagesByDirectory } from './getWorkspacePackagesByDirectory'
+export { localTarballDepsAreUpToDate } from './localTarballDepsAreUpToDate'
 export { linkedPackagesAreUpToDate } from './linkedPackagesAreUpToDate'
 export { satisfiesPackageManifest } from './satisfiesPackageManifest'

--- a/lockfile/verification/src/localTarballDepsAreUpToDate.ts
+++ b/lockfile/verification/src/localTarballDepsAreUpToDate.ts
@@ -1,0 +1,90 @@
+import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
+import { refToRelative } from '@pnpm/dependency-path'
+import {
+  type ProjectSnapshot,
+  type PackageSnapshots,
+  type TarballResolution,
+} from '@pnpm/lockfile.types'
+import { refIsLocalTarball } from '@pnpm/lockfile.utils'
+import { DEPENDENCIES_FIELDS } from '@pnpm/types'
+import path from 'node:path'
+import pEvery from 'p-every'
+
+export interface LocalTarballDepsUpToDateContext {
+  /**
+   * Local cache of local absolute file paths to their integrity. Expected to be
+   * initialized to an empty map by the caller.
+   */
+  readonly fileIntegrityCache: Map<string, Promise<string>>
+  readonly lockfilePackages?: PackageSnapshots
+  readonly lockfileDir: string
+}
+
+/**
+ * Returns false if a local tarball file has been changed on disk since the last
+ * installation recorded by the project snapshot.
+ *
+ * This function only inspects the project's lockfile snapshot. It does not
+ * inspect the current project manifest. The caller of this function is expected
+ * to handle changes to the project manifest that would cause the corresponding
+ * project snapshot to become out of date.
+ */
+export async function localTarballDepsAreUpToDate (
+  {
+    fileIntegrityCache,
+    lockfilePackages,
+    lockfileDir,
+  }: LocalTarballDepsUpToDateContext,
+  project: {
+    snapshot: ProjectSnapshot
+  }
+): Promise<boolean> {
+  return pEvery(DEPENDENCIES_FIELDS, (depField) => {
+    const lockfileDeps = project.snapshot[depField]
+
+    // If the lockfile is missing a snapshot for this project's dependencies, we
+    // can return true. The "satisfiesPackageManifest" logic in
+    // "allProjectsAreUpToDate" will catch mismatches between a project's
+    // manifest and snapshot dependencies size.
+    if (lockfileDeps == null) {
+      return true
+    }
+
+    return pEvery(
+      Object.entries(lockfileDeps),
+      async ([depName, ref]) => {
+        if (!refIsLocalTarball(ref)) {
+          return true
+        }
+
+        const depPath = refToRelative(ref, depName)
+        const packageSnapshot = depPath != null ? lockfilePackages?.[depPath] : null
+
+        // If there's no snapshot for this local tarball yet, the project is out
+        // of date and needs to be resolved. This should only happen with a
+        // broken lockfile.
+        if (packageSnapshot == null) {
+          return false
+        }
+
+        const filePath = path.join(lockfileDir, ref.slice('file:'.length))
+
+        const fileIntegrityPromise = fileIntegrityCache.get(filePath) ?? createLocalTarballFileIntegrity(filePath)
+        if (!fileIntegrityCache.has(filePath)) {
+          fileIntegrityCache.set(filePath, fileIntegrityPromise)
+        }
+
+        let fileIntegrity: string
+        try {
+          fileIntegrity = await fileIntegrityPromise
+        } catch (err) {
+          // If there was an error reading the tarball, assume the lockfile is
+          // out of date. The full resolution process will emit a clearer error
+          // later during install.
+          return false
+        }
+
+        return (packageSnapshot.resolution as TarballResolution).integrity === fileIntegrity
+      })
+  })
+}

--- a/lockfile/verification/src/localTarballDepsAreUpToDate.ts
+++ b/lockfile/verification/src/localTarballDepsAreUpToDate.ts
@@ -1,4 +1,4 @@
-import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
+import { getTarballIntegrity } from '@pnpm/crypto.hash'
 import { refToRelative } from '@pnpm/dependency-path'
 import {
   type ProjectSnapshot,
@@ -69,7 +69,7 @@ export async function localTarballDepsAreUpToDate (
 
         const filePath = path.join(lockfileDir, ref.slice('file:'.length))
 
-        const fileIntegrityPromise = fileIntegrityCache.get(filePath) ?? createLocalTarballFileIntegrity(filePath)
+        const fileIntegrityPromise = fileIntegrityCache.get(filePath) ?? getTarballIntegrity(filePath)
         if (!fileIntegrityCache.has(filePath)) {
           fileIntegrityCache.set(filePath, fileIntegrityPromise)
         }

--- a/lockfile/verification/test/allProjectsAreUpToDate.test.ts
+++ b/lockfile/verification/test/allProjectsAreUpToDate.test.ts
@@ -8,7 +8,7 @@ import { writeFile, mkdir } from 'fs/promises'
 import { type LockfileObject } from '@pnpm/lockfile.types'
 import tar from 'tar-stream'
 import { pipeline } from 'stream/promises'
-import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
+import { getTarballIntegrity } from '@pnpm/crypto.hash'
 
 const fooManifest = {
   name: 'foo',
@@ -561,7 +561,7 @@ describe('local tgz file dependency', () => {
 
     // Make the test is set up correctly and the local-tarball.tar created above
     // has the expected integrity hash.
-    await expect(createLocalTarballFileIntegrity('./local-tarball.tar')).resolves.toEqual('sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==')
+    await expect(getTarballIntegrity('./local-tarball.tar')).resolves.toEqual('sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==')
 
     const lockfileDir = process.cwd()
     expect(await allProjectsAreUpToDate(projects, { ...options, lockfileDir })).toBeTruthy()

--- a/lockfile/verification/test/allProjectsAreUpToDate.test.ts
+++ b/lockfile/verification/test/allProjectsAreUpToDate.test.ts
@@ -1,10 +1,14 @@
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import { prepareEmpty } from '@pnpm/prepare'
 import { type WorkspacePackages } from '@pnpm/resolver-base'
-import { type DependencyManifest, type ProjectId, type ProjectRootDir } from '@pnpm/types'
+import { type DepPath, type DependencyManifest, type ProjectId, type ProjectRootDir } from '@pnpm/types'
 import { allProjectsAreUpToDate } from '@pnpm/lockfile.verification'
+import { createWriteStream } from 'fs'
 import { writeFile, mkdir } from 'fs/promises'
 import { type LockfileObject } from '@pnpm/lockfile.types'
+import tar from 'tar-stream'
+import { pipeline } from 'stream/promises'
+import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
 
 const fooManifest = {
   name: 'foo',
@@ -486,6 +490,104 @@ describe('local file dependency', () => {
       ...options,
       lockfileDir: process.cwd(),
     })).toBeFalsy()
+  })
+})
+
+describe('local tgz file dependency', () => {
+  beforeEach(async () => {
+    prepareEmpty()
+  })
+
+  const projects = [
+    {
+      id: 'bar' as ProjectId,
+      manifest: {
+        dependencies: {
+          'local-tarball': 'file:local-tarball.tar',
+        },
+      },
+      rootDir: 'bar' as ProjectRootDir,
+    },
+    {
+      id: 'foo' as ProjectId,
+      manifest: fooManifest,
+      rootDir: 'foo' as ProjectRootDir,
+    },
+  ]
+
+  const wantedLockfile: LockfileObject = {
+    lockfileVersion: LOCKFILE_VERSION,
+    importers: {
+      ['bar' as ProjectId]: {
+        dependencies: { 'local-tarball': 'file:local-tarball.tar' },
+        specifiers: { 'local-tarball': 'file:local-tarball.tar' },
+      },
+      ['foo' as ProjectId]: {
+        specifiers: {},
+      },
+    },
+    packages: {
+      ['local-tarball@file:local-tarball.tar' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==',
+          tarball: 'file:local-tarball.tar',
+        },
+        version: '1.0.0',
+      },
+    },
+  }
+
+  const options = {
+    autoInstallPeers: false,
+    catalogs: {},
+    excludeLinksFromLockfile: false,
+    linkWorkspacePackages: true,
+    wantedLockfile,
+    workspacePackages,
+    lockfileDir: process.cwd(),
+  }
+
+  test('allProjectsAreUpToDate(): returns true if local file not changed', async () => {
+    expect.hasAssertions()
+
+    const pack = tar.pack()
+    pack.entry({ name: 'package.json', mtime: new Date('1970-01-01T00:00:00.000Z') }, JSON.stringify({
+      name: 'local-tarball',
+      version: '1.0.0',
+    }))
+    pack.finalize()
+
+    await pipeline(pack, createWriteStream('./local-tarball.tar'))
+
+    // Make the test is set up correctly and the local-tarball.tar created above
+    // has the expected integrity hash.
+    await expect(createLocalTarballFileIntegrity('./local-tarball.tar')).resolves.toEqual('sha512-nQP7gWOhNQ/5HoM/rJmzOgzZt6Wg6k56CyvO/0sMmiS3UkLSmzY5mW8mMrnbspgqpmOW8q/FHyb0YIr4n2A8VQ==')
+
+    const lockfileDir = process.cwd()
+    expect(await allProjectsAreUpToDate(projects, { ...options, lockfileDir })).toBeTruthy()
+  })
+
+  test('allProjectsAreUpToDate(): returns false if local file has changed', async () => {
+    expect.hasAssertions()
+
+    const pack = tar.pack()
+    pack.entry({ name: 'package.json', mtime: new Date('2000-01-01T00:00:00') }, JSON.stringify({
+      name: 'local-tarball',
+      version: '1.0.0',
+    }))
+    pack.entry({ name: 'newly-added-file.txt' }, 'This file changes the tarball.')
+    pack.finalize()
+    await pipeline(pack, createWriteStream('./local-tarball.tar'))
+
+    const lockfileDir = process.cwd()
+    expect(await allProjectsAreUpToDate(projects, { ...options, lockfileDir })).toBeFalsy()
+  })
+
+  test('allProjectsAreUpToDate(): returns false if local dep does not exist', async () => {
+    expect.hasAssertions()
+
+    const lockfileDir = process.cwd()
+    expect(await allProjectsAreUpToDate(projects, { ...options, lockfileDir })).toBeFalsy()
   })
 })
 

--- a/lockfile/verification/tsconfig.json
+++ b/lockfile/verification/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../catalogs/types"
     },
     {
+      "path": "../../crypto/hash"
+    },
+    {
       "path": "../../packages/constants"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1683,9 +1683,6 @@ importers:
       ssri:
         specifier: 'catalog:'
         version: 10.0.5
-      tar-stream:
-        specifier: 'catalog:'
-        version: 2.2.0
     devDependencies:
       '@pnpm/crypto.hash':
         specifier: workspace:*
@@ -1699,6 +1696,9 @@ importers:
       '@types/tar-stream':
         specifier: 'catalog:'
         version: 2.2.3
+      tar-stream:
+        specifier: 'catalog:'
+        version: 2.2.0
 
   crypto/object-hasher:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3640,6 +3640,12 @@ importers:
       '@types/semver':
         specifier: 'catalog:'
         version: 7.5.3
+      '@types/tar-stream':
+        specifier: 'catalog:'
+        version: 2.2.3
+      tar-stream:
+        specifier: 'catalog:'
+        version: 2.2.0
 
   lockfile/walker:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3588,6 +3588,9 @@ importers:
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types
+      '@pnpm/crypto.hash':
+        specifier: workspace:*
+        version: link:../../crypto/hash
       '@pnpm/dependency-path':
         specifier: workspace:*
         version: link:../../packages/dependency-path

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1683,6 +1683,9 @@ importers:
       ssri:
         specifier: 'catalog:'
         version: 10.0.5
+      tar-stream:
+        specifier: 'catalog:'
+        version: 2.2.0
     devDependencies:
       '@pnpm/crypto.hash':
         specifier: workspace:*
@@ -1693,6 +1696,9 @@ importers:
       '@types/ssri':
         specifier: 'catalog:'
         version: 7.1.5
+      '@types/tar-stream':
+        specifier: 'catalog:'
+        version: 2.2.3
 
   crypto/object-hasher:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1677,6 +1677,12 @@ importers:
       '@pnpm/crypto.polyfill':
         specifier: workspace:*
         version: link:../polyfill
+      '@pnpm/graceful-fs':
+        specifier: workspace:*
+        version: link:../../fs/graceful-fs
+      ssri:
+        specifier: 'catalog:'
+        version: 10.0.5
     devDependencies:
       '@pnpm/crypto.hash':
         specifier: workspace:*
@@ -1684,6 +1690,9 @@ importers:
       '@pnpm/prepare':
         specifier: workspace:*
         version: link:../../__utils__/prepare
+      '@types/ssri':
+        specifier: 'catalog:'
+        version: 7.1.5
 
   crypto/object-hasher:
     dependencies:
@@ -6530,12 +6539,12 @@ importers:
 
   resolving/local-resolver:
     dependencies:
+      '@pnpm/crypto.hash':
+        specifier: workspace:*
+        version: link:../../crypto/hash
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
-      '@pnpm/graceful-fs':
-        specifier: workspace:*
-        version: link:../../fs/graceful-fs
       '@pnpm/read-project-manifest':
         specifier: workspace:*
         version: link:../../pkg-manifest/read-project-manifest
@@ -6548,9 +6557,6 @@ importers:
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
-      ssri:
-        specifier: 'catalog:'
-        version: 10.0.5
     devDependencies:
       '@pnpm/local-resolver':
         specifier: workspace:*
@@ -6561,9 +6567,6 @@ importers:
       '@types/normalize-path':
         specifier: 'catalog:'
         version: 3.0.2
-      '@types/ssri':
-        specifier: 'catalog:'
-        version: 7.1.5
 
   resolving/npm-resolver:
     dependencies:

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -33,13 +33,12 @@
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
+    "@pnpm/crypto.hash": "workspace:*",
     "@pnpm/error": "workspace:*",
-    "@pnpm/graceful-fs": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "normalize-path": "catalog:",
-    "ssri": "catalog:"
+    "normalize-path": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": ">=5.1.0 <1001.0.0"
@@ -47,8 +46,7 @@
   "devDependencies": {
     "@pnpm/local-resolver": "workspace:*",
     "@pnpm/logger": "workspace:*",
-    "@types/normalize-path": "catalog:",
-    "@types/ssri": "catalog:"
+    "@types/normalize-path": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/resolving/local-resolver/src/index.ts
+++ b/resolving/local-resolver/src/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs'
 import path from 'path'
+import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
-import gfs from '@pnpm/graceful-fs'
 import { readProjectManifestOnly } from '@pnpm/read-project-manifest'
 import {
   type DirectoryResolution,
@@ -9,7 +9,6 @@ import {
   type TarballResolution,
 } from '@pnpm/resolver-base'
 import { type DependencyManifest } from '@pnpm/types'
-import ssri from 'ssri'
 import { logger } from '@pnpm/logger'
 import { parsePref, type WantedLocalDependency } from './parsePref'
 
@@ -38,7 +37,7 @@ export async function resolveFromLocal (
       id: spec.id,
       normalizedPref: spec.normalizedPref,
       resolution: {
-        integrity: await getFileIntegrity(spec.fetchSpec),
+        integrity: await createLocalTarballFileIntegrity(spec.fetchSpec),
         tarball: spec.id,
       },
       resolvedVia: 'local-filesystem',
@@ -92,8 +91,4 @@ export async function resolveFromLocal (
     },
     resolvedVia: 'local-filesystem',
   }
-}
-
-async function getFileIntegrity (filename: string): Promise<string> {
-  return (await ssri.fromStream(gfs.createReadStream(filename))).toString()
 }

--- a/resolving/local-resolver/src/index.ts
+++ b/resolving/local-resolver/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs'
 import path from 'path'
-import { createLocalTarballFileIntegrity } from '@pnpm/crypto.hash'
+import { getTarballIntegrity } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
 import { readProjectManifestOnly } from '@pnpm/read-project-manifest'
 import {
@@ -37,7 +37,7 @@ export async function resolveFromLocal (
       id: spec.id,
       normalizedPref: spec.normalizedPref,
       resolution: {
-        integrity: await createLocalTarballFileIntegrity(spec.fetchSpec),
+        integrity: await getTarballIntegrity(spec.fetchSpec),
         tarball: spec.id,
       },
       resolvedVia: 'local-filesystem',

--- a/resolving/local-resolver/tsconfig.json
+++ b/resolving/local-resolver/tsconfig.json
@@ -10,7 +10,7 @@
   ],
   "references": [
     {
-      "path": "../../fs/graceful-fs"
+      "path": "../../crypto/hash"
     },
     {
       "path": "../../packages/error"


### PR DESCRIPTION
## Context

Today, adding a local tarball dependency to a project makes `pnpm install` significantly slower on every subsequent run.

This is because part of the logic determining whether the `pnpm-lock.yaml` file is up to date returns false if any project in the workspace uses a `file:` dependency on a tarball. The `allProjectsAreUpToDate` function doesn't check if contents of the tarball to see if the tarball has changed since the last installation.

### Changes

Updating `allProjectsAreUpToDate` to check if the referenced tarball has changed on disk.

If the tarball is unchanged, this results in a significant performance improvement during installation. In a large project I work on, this reduced installation time from 70s to 10s when the lockfile doesn't need to be updated.