### PR TITLE
refactor: improve regexp

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -46,7 +46,7 @@ export default async (workspaceDir: string) => { // eslint-disable-line
       manifest.keywords = [
         'pnpm',
         pnpmMajorKeyword,
-        ...Array.from(new Set((manifest.keywords ?? []).filter((keyword) => keyword !== 'pnpm' && !/^pnpm[0-9]+$/.test(keyword)))).sort(),
+        ...Array.from(new Set((manifest.keywords ?? []).filter((keyword) => keyword !== 'pnpm' && !/^pnpm\d+$/.test(keyword)))).sort(),
       ]
       const smallestAllowedLibVersion = Number(pnpmMajorNumber) * 100
       const libMajorVersion = Number(manifest.version!.split('.')[0])

--- a/env/plugin-commands-env/src/parseNodeSpecifier.ts
+++ b/env/plugin-commands-env/src/parseNodeSpecifier.ts
@@ -5,7 +5,7 @@ export interface NodeSpecifier {
   useNodeVersion: string
 }
 
-const isStableVersion = (version: string) => /^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)
+const isStableVersion = (version: string) => /^\d+\.\d+\.\d+$/.test(version)
 const STABLE_RELEASE_ERROR_HINT = 'The correct syntax for stable release is strictly X.Y.Z or release/X.Y.Z'
 
 export function parseNodeSpecifier (specifier: string): NodeSpecifier {
@@ -25,7 +25,7 @@ export function parseNodeSpecifier (specifier: string): NodeSpecifier {
     return { releaseChannel, useNodeVersion }
   }
 
-  const prereleaseMatch = specifier.match(/^[0-9]+\.[0-9]+\.[0-9]+-(nightly|rc|test|v8-canary)(\..+)$/)
+  const prereleaseMatch = specifier.match(/^\d+\.\d+\.\d+-(nightly|rc|test|v8-canary)(\..+)$/)
   if (prereleaseMatch != null) {
     return { releaseChannel: prereleaseMatch[1], useNodeVersion: specifier }
   }
@@ -37,7 +37,7 @@ export function parseNodeSpecifier (specifier: string): NodeSpecifier {
   let hint: string | undefined
   if (['nightly', 'rc', 'test', 'v8-canary'].includes(specifier)) {
     hint = `The correct syntax for ${specifier} release is strictly X.Y.Z-${specifier}.W`
-  } else if (/^[0-9]+\.[0-9]+$/.test(specifier) || /^[0-9]+$/.test(specifier) || ['release', 'stable', 'latest'].includes(specifier)) {
+  } else if (/^\d+\.\d+$/.test(specifier) || /^\d+$/.test(specifier) || ['release', 'stable', 'latest'].includes(specifier)) {
     hint = STABLE_RELEASE_ERROR_HINT
   }
   throw new PnpmError('INVALID_NODE_VERSION', `"${specifier}" is not a valid Node.js version`, { hint })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslintConfig from "@pnpm/eslint-config";
+import * as regexpPlugin from "eslint-plugin-regexp";
 
 export default [{
     ignores: ["**/fixtures", "**/__fixtures__"],
-}, ...eslintConfig];
+}, ...eslintConfig, regexpPlugin.configs['flat/recommended']];

--- a/exec/pkg-requires-build/src/index.ts
+++ b/exec/pkg-requires-build/src/index.ts
@@ -13,5 +13,5 @@ export function pkgRequiresBuild (manifest: Partial<DependencyManifest> | undefi
 
 function filesIncludeInstallScripts (filesIndex: Record<string, unknown>): boolean {
   return filesIndex['binding.gyp'] != null ||
-    Object.keys(filesIndex).some((filename) => !(filename.match(/^[.]hooks[\\/]/) == null)) // TODO: optimize this
+    Object.keys(filesIndex).some((filename) => !(filename.match(/^\.hooks[\\/]/) == null)) // TODO: optimize this
 }

--- a/fetching/tarball-fetcher/src/localTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/localTarballFetcher.ts
@@ -4,7 +4,7 @@ import type { Cafs } from '@pnpm/cafs-types'
 import gfs from '@pnpm/graceful-fs'
 import { addFilesFromTarball } from '@pnpm/worker'
 
-const isAbsolutePath = /^[/]|^[A-Za-z]:/
+const isAbsolutePath = /^\/|^[A-Z]:/i
 
 interface Resolution {
   integrity?: string

--- a/lockfile/fs/src/gitBranchLockfile.ts
+++ b/lockfile/fs/src/gitBranchLockfile.ts
@@ -3,7 +3,8 @@ import path from 'path'
 
 export async function getGitBranchLockfileNames (lockfileDir: string): Promise<string[]> {
   const files = await fs.readdir(lockfileDir)
-  const gitBranchLockfileNames: string[] = files.filter(file => file.match(/^pnpm-lock\..*\.yaml$/))
+  // eslint-disable-next-line regexp/no-useless-non-capturing-group
+  const gitBranchLockfileNames: string[] = files.filter(file => file.match(/^pnpm-lock.(?:.*).yaml$/))
   return gitBranchLockfileNames
 }
 

--- a/lockfile/fs/src/gitBranchLockfile.ts
+++ b/lockfile/fs/src/gitBranchLockfile.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 export async function getGitBranchLockfileNames (lockfileDir: string): Promise<string[]> {
   const files = await fs.readdir(lockfileDir)
-  const gitBranchLockfileNames: string[] = files.filter(file => file.match(/^pnpm-lock.(?:.*).yaml$/))
+  const gitBranchLockfileNames: string[] = files.filter(file => file.match(/^pnpm-lock\..*\.yaml$/))
   return gitBranchLockfileNames
 }
 

--- a/lockfile/fs/src/gitMergeFile.ts
+++ b/lockfile/fs/src/gitMergeFile.ts
@@ -22,7 +22,7 @@ interface MergeFileInfo {
 }
 
 function parseMergeFile (fileContent: string): MergeFileInfo {
-  const lines = fileContent.split(/[\n\r]+/g)
+  const lines = fileContent.split(/[\n\r]+/)
   let state: 'top' | 'ours' | 'theirs' | 'parent' = 'top'
   const ours = []
   const theirs = []

--- a/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/lockfile/fs/src/lockfileFormatConverters.ts
@@ -138,7 +138,7 @@ function refToRelative (
   if (reference.startsWith('file:')) {
     return reference
   }
-  if (!reference.includes('/') || !reference.replace(/(\([^)]+\))+$/, '').includes('/')) {
+  if (!reference.includes('/') || !reference.replace(/(?:\([^)]+\))+$/, '').includes('/')) {
     return `/${pkgName}@${reference}`
   }
   return reference

--- a/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/lockfile/fs/src/lockfileFormatConverters.ts
@@ -138,7 +138,7 @@ function refToRelative (
   if (reference.startsWith('file:')) {
     return reference
   }
-  if (!reference.includes('/') || !reference.replace(/\([^)]+\)+$/, '').includes('/')) {
+  if (!reference.includes('/') || !reference.replace(/(\([^)]+\))+$/, '').includes('/')) {
     return `/${pkgName}@${reference}`
   }
   return reference

--- a/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/lockfile/fs/src/lockfileFormatConverters.ts
@@ -138,7 +138,7 @@ function refToRelative (
   if (reference.startsWith('file:')) {
     return reference
   }
-  if (!reference.includes('/') || !reference.replace(/(\([^)]+\))+$/, '').includes('/')) {
+  if (!reference.includes('/') || !reference.replace(/\([^)]+\)+$/, '').includes('/')) {
     return `/${pkgName}@${reference}`
   }
   return reference

--- a/lockfile/fs/src/lockfileName.ts
+++ b/lockfile/fs/src/lockfileName.ts
@@ -21,5 +21,5 @@ export async function getWantedLockfileName (opts: GetWantedLockfileNameOptions 
  * 2. Filesystem may be case-insensitive, so we need to convert branch name to lowercase
  */
 function stringifyBranchName (branchName: string = ''): string {
-  return branchName.replace(/[^a-zA-Z0-9-_.]/g, '!').toLowerCase()
+  return branchName.replace(/[^\w.]/g, '!').toLowerCase()
 }

--- a/lockfile/fs/src/lockfileName.ts
+++ b/lockfile/fs/src/lockfileName.ts
@@ -21,5 +21,5 @@ export async function getWantedLockfileName (opts: GetWantedLockfileNameOptions 
  * 2. Filesystem may be case-insensitive, so we need to convert branch name to lowercase
  */
 function stringifyBranchName (branchName: string = ''): string {
-  return branchName.replace(/[^\w.]/g, '!').toLowerCase()
+  return branchName.replace(/[^\w-.]/g, '!').toLowerCase()
 }

--- a/lockfile/fs/src/lockfileName.ts
+++ b/lockfile/fs/src/lockfileName.ts
@@ -21,5 +21,5 @@ export async function getWantedLockfileName (opts: GetWantedLockfileNameOptions 
  * 2. Filesystem may be case-insensitive, so we need to convert branch name to lowercase
  */
 function stringifyBranchName (branchName: string = ''): string {
-  return branchName.replace(/[^\w-.]/g, '!').toLowerCase()
+  return branchName.replace(/[^\w.-]/g, '!').toLowerCase()
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cross-env": "^7.0.3",
     "cspell": "8.17.5",
     "eslint": "^8.57.1",
+    "eslint-plugin-regexp": "2.7.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "keyv": "4.5.4",

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -169,7 +169,7 @@ export function depPathToFilename (depPath: string, maxLengthWithoutHash: number
   if (filename.includes('(')) {
     filename = filename
       .replace(/\)$/, '')
-      .replace(/(\)\()|\(|\)/g, '_')
+      .replace(/\)\(|\(|\)/g, '_')
   }
   if (filename.length > maxLengthWithoutHash || filename !== filename.toLowerCase() && !filename.startsWith('file+')) {
     return `${filename.substring(0, maxLengthWithoutHash - 33)}_${createShortHash(filename)}`

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -169,7 +169,7 @@ export function depPathToFilename (depPath: string, maxLengthWithoutHash: number
   if (filename.includes('(')) {
     filename = filename
       .replace(/\)$/, '')
-      .replace(/\)\(|\(|\)/g, '_')
+      .replace(/(\)\()|\(|\)/g, '_')
   }
   if (filename.length > maxLengthWithoutHash || filename !== filename.toLowerCase() && !filename.startsWith('file+')) {
     return `${filename.substring(0, maxLengthWithoutHash - 33)}_${createShortHash(filename)}`

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -165,7 +165,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
     .replace(new RegExp(escapeStringRegexp(`${folderAN}/`), 'g'), '')
     .replace(new RegExp(escapeStringRegexp(`${folderBN}/`), 'g'), '')
     .replace(/\n\\ No newline at end of file\n$/, '\n')
-    .replace(/^diff --git a\/.*\.DS_Store b\/.*\.DS_Store[\s\S]*?(?=^diff --git)/gm, '')
+    .replace(/^diff --git a\/.*\.DS_Store b\/.*\.DS_Store[\s\S]+?(?=^diff --git)/gm, '')
     .replace(/^diff --git a\/.*\.DS_Store b\/.*\.DS_Store[\s\S]*$/gm, '')
 }
 

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -110,7 +110,7 @@ describe('patch and commit', () => {
     const patchDir = getPatchDirFromPatchOutput(output)
 
     expect(patchDir).toContain(path.join('node_modules', '.pnpm_patches', 'is-positive@'))
-    expect(path.basename(patchDir)).toMatch(/^is-positive@[0-9]+\.[0-9]+\.[0-9]+$/)
+    expect(path.basename(patchDir)).toMatch(/^is-positive@\d+\.\d+\.\d+$/)
     expect(fs.existsSync(patchDir)).toBe(true)
 
     // sanity check to ensure that the license file contains the expected string
@@ -565,7 +565,7 @@ describe('patch and commit', () => {
     const output = await patch.handler(defaultPatchOption, ['is-positive@1'])
     const patchDir = getPatchDirFromPatchOutput(output)
     expect(patchDir).toContain(path.join('node_modules', '.pnpm_patches', 'is-positive@1'))
-    expect(path.basename(patchDir)).toMatch(/^is-positive@1\.[0-9]+\.[0-9]+$/)
+    expect(path.basename(patchDir)).toMatch(/^is-positive@1\.\d+\.\d+$/)
     expect(fs.existsSync(patchDir)).toBe(true)
     expect(JSON.parse(fs.readFileSync(path.join(patchDir, 'package.json'), 'utf8')).version).toBe('1.0.0')
   })
@@ -775,7 +775,7 @@ describe('prompt to choose version', () => {
     const patchDir = getPatchDirFromPatchOutput(output)
 
     expect(patchDir).toContain(path.join('node_modules', '.pnpm_patches', 'chalk@'))
-    expect(path.basename(patchDir)).toMatch(/^chalk@[0-9]+\.[0-9]+\.[0-9]+$/)
+    expect(path.basename(patchDir)).toMatch(/^chalk@\d+\.\d+\.\d+$/)
     expect(fs.existsSync(patchDir)).toBe(true)
     expect(JSON.parse(fs.readFileSync(path.join(patchDir, 'package.json'), 'utf8')).version).toBe('5.3.0')
     expect(fs.existsSync(path.join(patchDir, 'source/index.js'))).toBe(true)
@@ -842,7 +842,7 @@ describe('prompt to choose version', () => {
     const patchDir = getPatchDirFromPatchOutput(output)
 
     expect(patchDir).toContain(path.join('node_modules', '.pnpm_patches', 'chalk@'))
-    expect(path.basename(patchDir)).toMatch(/^chalk@[0-9]+\.[0-9]+\.[0-9]+$/)
+    expect(path.basename(patchDir)).toMatch(/^chalk@\d+\.\d+\.\d+$/)
     expect(fs.existsSync(patchDir)).toBe(true)
     expect(JSON.parse(fs.readFileSync(path.join(patchDir, 'package.json'), 'utf8')).version).toBe('5.3.0')
     expect(fs.existsSync(path.join(patchDir, 'source/index.js'))).toBe(true)
@@ -1293,7 +1293,7 @@ describe('patch with custom modules-dir and virtual-store-dir', () => {
     const output = await patch.handler(defaultPatchOption, ['is-positive@1'])
     const patchDir = getPatchDirFromPatchOutput(output)
     expect(patchDir).toContain(path.join('fake_modules', '.pnpm_patches', 'is-positive@1'))
-    expect(path.basename(patchDir)).toMatch(/^is-positive@1\.[0-9]+\.[0-9]+$/)
+    expect(path.basename(patchDir)).toMatch(/^is-positive@1\.\d+\.\d+$/)
     expect(fs.existsSync(patchDir)).toBe(true)
     expect(JSON.parse(fs.readFileSync(path.join(patchDir, 'package.json'), 'utf8')).version).toBe('1.0.0')
 

--- a/pkg-manager/core/src/install/link.ts
+++ b/pkg-manager/core/src/install/link.ts
@@ -307,7 +307,7 @@ export async function linkPackages (projects: ImporterToUpdate[], depGraph: Depe
   }
 }
 
-const isAbsolutePath = /^[/]|^[A-Za-z]:/
+const isAbsolutePath = /^\/|^[A-Z]:/i
 
 // This function is copied from @pnpm/local-resolver
 function resolvePath (where: string, spec: string): string {

--- a/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/yarnUtil.ts
@@ -4,7 +4,7 @@
 import { type structUtils } from '@yarnpkg/core'
 
 const BUILTIN_PLACEHOLDER = 'builtin'
-const MULTIPLE_KEYS_REGEXP = / *, */g
+const MULTIPLE_KEYS_REGEXP = / *, */
 
 export type ParseDescriptor = typeof structUtils.parseDescriptor
 export type ParseRange = typeof structUtils.parseRange

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -24,7 +24,7 @@ import normalize from 'normalize-path'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
+const isFilespec = isWindows ? /^(?:[./\\]|~\/|[a-z]:)/i : /^(?:[./]|~\/|[a-z]:)/i
 
 type LinkOpts = Pick<Config,
 | 'bin'

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -24,7 +24,7 @@ import normalize from 'normalize-path'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
+const isFilespec = isWindows ? /^(?:[./\\]|~\/|[A-Z]:)/i : /^(?:[./]|~\/|[A-Z]:)/i
 
 type LinkOpts = Pick<Config,
 | 'bin'

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -24,7 +24,7 @@ import normalize from 'normalize-path'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[./\\]|~\/|[A-Z]:)/i : /^(?:[./]|~\/|[A-Z]:)/i
+const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
 
 type LinkOpts = Pick<Config,
 | 'bin'

--- a/pkg-manager/plugin-commands-installation/test/add.ts
+++ b/pkg-manager/plugin-commands-installation/test/add.ts
@@ -319,7 +319,7 @@ test('pnpm add - should add prefix when set in .npmrc when a range is not specif
 
     expect(
       manifest.dependencies['is-positive']
-    ).toMatch(/~([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/)
+    ).toMatch(/~(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Z-]+(?:\.[0-9A-Z-]+)*))?(?:\+[0-9A-Z-]+)?$/i)
   }
 })
 

--- a/pkg-manager/plugin-commands-installation/test/add.ts
+++ b/pkg-manager/plugin-commands-installation/test/add.ts
@@ -319,7 +319,7 @@ test('pnpm add - should add prefix when set in .npmrc when a range is not specif
 
     expect(
       manifest.dependencies['is-positive']
-    ).toMatch(/~(\d+)\.(\d+)\.(\d+)(?:-([\w-]+(?:\.[\w-]+)*))?(?:\+[\w-]+)?$/)
+    ).toMatch(/~([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/)
   }
 })
 

--- a/pkg-manager/plugin-commands-installation/test/add.ts
+++ b/pkg-manager/plugin-commands-installation/test/add.ts
@@ -319,7 +319,7 @@ test('pnpm add - should add prefix when set in .npmrc when a range is not specif
 
     expect(
       manifest.dependencies['is-positive']
-    ).toMatch(/~([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/)
+    ).toMatch(/~(\d+)\.(\d+)\.(\d+)(?:-([\w-]+(?:\.[\w-]+)*))?(?:\+[\w-]+)?$/)
   }
 })
 

--- a/pkg-manifest/exportable-manifest/src/index.ts
+++ b/pkg-manifest/exportable-manifest/src/index.ts
@@ -159,7 +159,7 @@ async function replaceWorkspaceProtocolPeerDependency (depName: string, depSpec:
   }
 
   // Dependencies with bare "*", "^", "~",">=",">","<=", "<", version
-  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)?((\d+|[xX]|\*)(\.(\d+|[xX]|\*)){0,2})?/
+  const workspaceSemverRegex = /workspace:([\^~*]|>=|>|<=|<)?((\d+|[xX*])(\.(\d+|[xX*])){0,2})?/
   const versionAliasSpecParts = workspaceSemverRegex.exec(depSpec)
 
   if (versionAliasSpecParts != null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -748,6 +748,9 @@ importers:
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
+      eslint-plugin-regexp:
+        specifier: 2.7.0
+        version: 2.7.0(eslint@8.57.1)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -10548,6 +10551,10 @@ packages:
     resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
     engines: {node: '>= 6'}
 
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
+
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
@@ -11146,6 +11153,12 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-plugin-regexp@2.7.0:
+    resolution: {integrity: sha512-U8oZI77SBtH8U3ulZ05iu0qEzIizyEDXd+BWHvyVxTOjGwcDcvy/kEpgFG4DYca2ByRLiVPFZ2GeH7j1pdvZTA==}
+    engines: {node: ^18 || >=20}
+    peerDependencies:
+      eslint: '>=8.44.0'
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -12341,6 +12354,10 @@ packages:
   jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
+  jsdoc-type-pratt-parser@4.1.0:
+    resolution: {integrity: sha512-Hicd6JK5Njt2QB6XYFS7ok9e37O8AYk3jTcppG4YVQnYjOemymvTcmc7OWsmq/Qqj5TdRFO5/x/tIPmBeRtGHg==}
+    engines: {node: '>=12.0.0'}
+
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -12491,9 +12508,11 @@ packages:
 
   lodash.clone@4.3.2:
     resolution: {integrity: sha512-Yc/0UmZvWkFsbx7NB4feSX5bSX03SR0ft8CTkI8RCb3w/TzT71HXew2iNDm0aml93P49tIR/NJHOIoE+XEKz9A==}
+    deprecated: This package is deprecated. Use structuredClone instead.
 
   lodash.clone@4.5.0:
     resolution: {integrity: sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==}
+    deprecated: This package is deprecated. Use structuredClone instead.
 
   lodash.deburr@4.1.0:
     resolution: {integrity: sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==}
@@ -13567,12 +13586,20 @@ packages:
     resolution: {integrity: sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==}
     engines: {node: '>=12'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -13786,6 +13813,10 @@ packages:
 
   sanitize-filename@1.6.3:
     resolution: {integrity: sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   semver-range-intersect@0.3.1:
     resolution: {integrity: sha512-dZAVI9Gdl3uBvs1CBK1KHeCyiZDn4X14DW4C+QFQj+0k+l9L+pY1swt4KVt1hGU2dP77but4vx+N5XeYQsDteQ==}
@@ -17778,6 +17809,8 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
+  comment-parser@1.4.1: {}
+
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
@@ -18489,6 +18522,17 @@ snapshots:
   eslint-plugin-promise@6.6.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+
+  eslint-plugin-regexp@2.7.0(eslint@8.57.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.1
+      comment-parser: 1.4.1
+      eslint: 8.57.1
+      jsdoc-type-pratt-parser: 4.1.0
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+      scslre: 0.3.0
 
   eslint-scope@7.2.2:
     dependencies:
@@ -20021,6 +20065,8 @@ snapshots:
 
   jsbn@1.1.0: {}
 
+  jsdoc-type-pratt-parser@4.1.0: {}
+
   jsesc@2.5.2: {}
 
   jsesc@3.1.0: {}
@@ -21267,6 +21313,10 @@ snapshots:
       indent-string: 5.0.0
       strip-indent: 4.0.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -21279,6 +21329,11 @@ snapshots:
       which-builtin-type: 1.2.1
 
   regenerator-runtime@0.14.1: {}
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -21488,6 +21543,12 @@ snapshots:
   sanitize-filename@1.6.3:
     dependencies:
       truncate-utf8-bytes: 1.0.2
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   semver-range-intersect@0.3.1:
     dependencies:

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -273,7 +273,7 @@ test('recursive run when some packages define different node versions', async ()
       .toString()
       .trim()
       .split('\n')
-      .filter(x => /print-node-version.*v[0-9]+\.[0-9]+\.[0-9]+/.test(x))
+      .filter(x => /print-node-version.*v\d+\.\d+\.\d+/.test(x))
       .sort()
 
   expect(

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -161,7 +161,7 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   })
   const filesMap = Object.fromEntries(files.map((file) => [`package/${file}`, path.join(dir, file)]))
   // cspell:disable-next-line
-  if (opts.workspaceDir != null && dir !== opts.workspaceDir && !files.some((file) => /LICEN[CS]E(\..+)?/i.test(file))) {
+  if (opts.workspaceDir != null && dir !== opts.workspaceDir && !files.some((file) => /LICEN[CS]E(?:\..+)?/i.test(file))) {
     const licenses = await findLicenses({ cwd: opts.workspaceDir })
     for (const license of licenses) {
       filesMap[`package/${license}`] = path.join(opts.workspaceDir, license)
@@ -245,7 +245,7 @@ async function packPkg (opts: {
   await Promise.all(Object.entries(filesMap).map(async ([name, source]) => {
     const isExecutable = bins.some((bin) => path.relative(bin, source) === '')
     const mode = isExecutable ? 0o755 : 0o644
-    if (/^package\/package\.(json|json5|yaml)$/.test(name)) {
+    if (/^package\/package\.(?:json|json5|yaml)$/.test(name)) {
       pack.entry({ mode, mtime, name: 'package/package.json' }, JSON.stringify(manifest, null, 2))
       return
     }

--- a/resolving/git-resolver/src/index.ts
+++ b/resolving/git-resolver/src/index.ts
@@ -118,11 +118,11 @@ function resolveRefFromRefs (refs: { [ref: string]: string }, repo: string, ref:
     const vTags =
       Object.keys(refs)
         // using the same semantics of version tags as https://github.com/zkat/pacote
-        .filter((key: string) => /^refs\/tags\/v?(\d+\.\d+\.\d+(?:[-+].+)?)(\^{})?$/.test(key))
+        .filter((key: string) => /^refs\/tags\/v?\d+\.\d+\.\d+(?:[-+].+)?(?:\^\{\})?$/.test(key))
         .map((key: string) => {
           return key
             .replace(/^refs\/tags\//, '')
-            .replace(/\^{}$/, '') // accept annotated tags
+            .replace(/\^\{\}$/, '') // accept annotated tags
         })
         .filter((key: string) => semver.valid(key, true))
     const refVTag = resolveVTags(vTags, range)

--- a/resolving/local-resolver/src/parsePref.ts
+++ b/resolving/local-resolver/src/parsePref.ts
@@ -6,9 +6,9 @@ import { type PkgResolutionId } from '@pnpm/resolver-base'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
-const isFilename = /[.](?:tgz|tar.gz|tar)$/i
-const isAbsolutePath = /^[/]|^[A-Za-z]:/
+const isFilespec = isWindows ? /^(?:[./\\]|~\/|[A-Z]:)/i : /^(?:[./]|~\/|[A-Z]:)/i
+const isFilename = /\.(?:tgz|tar.gz|tar)$/i
+const isAbsolutePath = /^\/|^[A-Z]:/i
 
 export interface LocalPackageSpec {
   dependencyPath: string
@@ -61,8 +61,8 @@ function fromLocal (
   type: 'file' | 'directory'
 ): LocalPackageSpec {
   const spec = pref.replace(/\\/g, '/')
-    .replace(/^(file|link|workspace):[/]*([A-Za-z]:)/, '$2') // drive name paths on windows
-    .replace(/^(file|link|workspace):(?:[/]*([~./]))?/, '$2')
+    .replace(/^(file|link|workspace):\/*([A-Z]:)/i, '$2') // drive name paths on windows
+    .replace(/^(file|link|workspace):(?:\/*([~./]))?/, '$2')
 
   let protocol!: string
   if (pref.startsWith('file:')) {
@@ -74,7 +74,7 @@ function fromLocal (
   }
   let fetchSpec!: string
   let normalizedPref!: string
-  if (/^~[/]/.test(spec)) {
+  if (/^~\//.test(spec)) {
     // this is needed for windows and for file:~/foo/bar
     fetchSpec = resolvePath(os.homedir(), spec.slice(2))
     normalizedPref = `${protocol}${spec}`
@@ -113,6 +113,6 @@ function resolvePath (where: string, spec: string): string {
 
 function isAbsolute (dir: string): boolean {
   if (dir[0] === '/') return true
-  if (/^[A-Za-z]:/.test(dir)) return true
+  if (/^[A-Z]:/i.test(dir)) return true
   return false
 }

--- a/resolving/local-resolver/src/parsePref.ts
+++ b/resolving/local-resolver/src/parsePref.ts
@@ -6,7 +6,7 @@ import { type PkgResolutionId } from '@pnpm/resolver-base'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
+const isFilespec = isWindows ? /^(?:[./\\]|~\/|[a-z]:)/i : /^(?:[./]|~\/|[a-z]:)/i
 const isFilename = /\.(?:tgz|tar.gz|tar)$/i
 const isAbsolutePath = /^\/|^[A-Z]:/i
 
@@ -61,8 +61,8 @@ function fromLocal (
   type: 'file' | 'directory'
 ): LocalPackageSpec {
   const spec = pref.replace(/\\/g, '/')
-    .replace(/^(file|link|workspace):\/*([A-Z]:)/i, '$2') // drive name paths on windows
-    .replace(/^(file|link|workspace):(?:\/*([~./]))?/, '$2')
+    .replace(/^(?:file|link|workspace):\/*([A-Z]:)/i, '$1') // drive name paths on windows
+    .replace(/^(?:file|link|workspace):(?:\/*([~./]))?/, '$1')
 
   let protocol!: string
   if (pref.startsWith('file:')) {

--- a/resolving/local-resolver/src/parsePref.ts
+++ b/resolving/local-resolver/src/parsePref.ts
@@ -6,7 +6,7 @@ import { type PkgResolutionId } from '@pnpm/resolver-base'
 
 // @ts-expect-error
 const isWindows = process.platform === 'win32' || global['FAKE_WINDOWS']
-const isFilespec = isWindows ? /^(?:[./\\]|~\/|[A-Z]:)/i : /^(?:[./]|~\/|[A-Z]:)/i
+const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
 const isFilename = /\.(?:tgz|tar.gz|tar)$/i
 const isAbsolutePath = /^\/|^[A-Z]:/i
 

--- a/resolving/npm-resolver/src/fetch.ts
+++ b/resolving/npm-resolver/src/fetch.ts
@@ -17,7 +17,8 @@ interface RegistryResponse {
 }
 
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-const semverRegex = /(.*)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+// eslint-disable-next-line regexp/no-super-linear-backtracking
+const semverRegex = /(.*)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*))*))?(?:\+([0-9a-z-]+(?:\.[0-9a-z-]+)*))?$/i
 
 export class RegistryResponseError extends FetchError {
   public readonly pkgName: string

--- a/resolving/npm-resolver/src/fetch.ts
+++ b/resolving/npm-resolver/src/fetch.ts
@@ -17,8 +17,8 @@ interface RegistryResponse {
 }
 
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-// eslint-disable-next-line regexp/no-super-linear-backtracking
-const semverRegex = /(.*)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-z-][0-9a-z-]*))*))?(?:\+([0-9a-z-]+(?:\.[0-9a-z-]+)*))?$/i
+// eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/use-ignore-case
+const semverRegex = /(.*)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 export class RegistryResponseError extends FetchError {
   public readonly pkgName: string

--- a/reviewing/license-scanner/src/getPkgInfo.ts
+++ b/reviewing/license-scanner/src/getPkgInfo.ts
@@ -185,7 +185,8 @@ async function parseLicense (
       const licenseContent = licenseContents?.toString('utf-8')
       let name = 'Unknown'
       if (licenseContent) {
-        const match = licenseContent.match(new RegExp(`\\b(${LICENSE_NAMES.join('|')})\\b`, 'igm'))
+        // eslint-disable-next-line regexp/no-unused-capturing-group
+        const match = licenseContent.match(new RegExp(`\\b(${LICENSE_NAMES.join('|')})\\b`, 'gi'))
         if (match) {
           name = [...new Set(match)].join(' OR ')
         }

--- a/reviewing/list/src/renderTree.ts
+++ b/reviewing/list/src/renderTree.ts
@@ -97,6 +97,7 @@ async function renderTreeForPackage (
       return null
     }))).filter(Boolean).join('\n')
 
+  // eslint-disable-next-line regexp/no-unused-capturing-group
   return `${chalk.bold.underline(label)}\n\n${output}`.replace(/(\n)+$/, '')
 }
 

--- a/reviewing/list/src/renderTree.ts
+++ b/reviewing/list/src/renderTree.ts
@@ -97,7 +97,7 @@ async function renderTreeForPackage (
       return null
     }))).filter(Boolean).join('\n')
 
-  return `${chalk.bold.underline(label)}\n\n${output}`.replace(/(\n)+$/, '')
+  return `${chalk.bold.underline(label)}\n\n${output}`.replace(/\n+$/, '')
 }
 
 type GetPkgColor = (node: PackageNode) => (s: string) => string

--- a/reviewing/list/src/renderTree.ts
+++ b/reviewing/list/src/renderTree.ts
@@ -97,7 +97,7 @@ async function renderTreeForPackage (
       return null
     }))).filter(Boolean).join('\n')
 
-  return `${chalk.bold.underline(label)}\n\n${output}`.replace(/\n+$/, '')
+  return `${chalk.bold.underline(label)}\n\n${output}`.replace(/(\n)+$/, '')
 }
 
 type GetPkgColor = (node: PackageNode) => (s: string) => string

--- a/store/plugin-commands-store-inspecting/src/catFile.ts
+++ b/store/plugin-commands-store-inspecting/src/catFile.ts
@@ -8,7 +8,7 @@ import { getStorePath } from '@pnpm/store-path'
 
 import renderHelp from 'render-help'
 
-const INTEGRITY_REGEX: RegExp = /^([^-]+)-([A-Za-z0-9+/=]+)$/
+const INTEGRITY_REGEX: RegExp = /^[^-]+-[A-Z0-9+/=]+$/i
 
 export const skipPackageManagerCheck = true
 

--- a/store/plugin-commands-store-inspecting/src/catFile.ts
+++ b/store/plugin-commands-store-inspecting/src/catFile.ts
@@ -8,7 +8,8 @@ import { getStorePath } from '@pnpm/store-path'
 
 import renderHelp from 'render-help'
 
-const INTEGRITY_REGEX: RegExp = /^[^-]+-[A-Z0-9+/=]+$/i
+// eslint-disable-next-line regexp/no-unused-capturing-group, regexp/use-ignore-case
+const INTEGRITY_REGEX: RegExp = /^([^-]+)-([A-Za-z0-9+/=]+)$/
 
 export const skipPackageManagerCheck = true
 

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -30,7 +30,7 @@ import {
   type InitStoreMessage,
 } from './types'
 
-const INTEGRITY_REGEX: RegExp = /^([^-]+)-([A-Za-z0-9+/=]+)$/
+const INTEGRITY_REGEX: RegExp = /^([^-]+)-([a-z0-9+/=]+)$/i
 
 parentPort!.on('message', handleMessage)
 

--- a/workspace/spec-parser/src/index.ts
+++ b/workspace/spec-parser/src/index.ts
@@ -1,4 +1,4 @@
-const WORKSPACE_PREF_REGEX = /^workspace:((?<alias>[^._/][^@]*)@)?(?<version>.*)$/
+const WORKSPACE_PREF_REGEX = /^workspace:(?:(?<alias>[^._/][^@]*)@)?(?<version>.*)$/
 
 export class WorkspaceSpec {
   alias?: string


### PR DESCRIPTION
1. Reduce unnecessary capture groups.
2. Replace a single character set.
3. Use `i` flag.
4. Use 	`\d` or `\w` to replace range characters.
5. add eslint plugin https://github.com/ota-meshi/eslint-plugin-regexp