### PR TITLE
fix: update choice list not show deprecated pkg

### DIFF
--- a/.changeset/orange-lights-wish.md
+++ b/.changeset/orange-lights-wish.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+`pnpm update -i` should list only packages that have newer versions [#9206](https://github.com/pnpm/pnpm/issues/9206).

--- a/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
@@ -4,6 +4,7 @@ import semverDiff from '@pnpm/semver-diff'
 import { getBorderCharacters, table } from '@zkochan/table'
 import { pipe, groupBy, pluck, uniqBy, pickBy, and } from 'ramda'
 import isEmpty from 'ramda/src/isEmpty'
+import chalk from 'chalk'
 
 export interface ChoiceRow {
   name: string
@@ -84,9 +85,12 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
 
 function buildPkgChoice (outdatedPkg: OutdatedPackage, workspacesEnabled: boolean): { raw: string[], name: string, disabled?: boolean } {
   const sdiff = semverDiff(outdatedPkg.wanted, outdatedPkg.latestManifest!.version)
-  const nextVersion = sdiff.change === null
+  let nextVersion = sdiff.change === null
     ? outdatedPkg.latestManifest!.version
     : colorizeSemverDiff(sdiff as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (outdatedPkg.latestManifest?.deprecated) {
+    nextVersion += chalk.red('(deprecated)')
+  }
   const label = outdatedPkg.packageName
 
   const lineParts = {
@@ -136,7 +140,7 @@ function alignColumns (rows: string[][]): string[] {
           {
             0: { width: 50, truncate: 100 },
             1: { width: 15, alignment: 'right' },
-            3: { width: 15 },
+            3: { width: 30 },
             4: { paddingLeft: 2 },
             5: { paddingLeft: 2 },
           },

--- a/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
@@ -48,7 +48,7 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
   const finalChoices: ChoiceGroup = []
   for (const [depGroup, choiceRows] of Object.entries(groupPkgsByType)) {
     if (choiceRows.length === 0) continue
-    const rawChoices = choiceRows.filter(choice => !choice.latestManifest?.deprecated).map(choice => buildPkgChoice(choice, workspacesEnabled))
+    const rawChoices = choiceRows.filter(choice => choice.latestManifest?.version !== choice.current).map(choice => buildPkgChoice(choice, workspacesEnabled))
     if (rawChoices.length === 0) continue
     // add in a header row for each group
     rawChoices.unshift({

--- a/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
@@ -57,7 +57,8 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
       name: '',
       disabled: true,
     })
-    const renderedTable = alignColumns(pluck('raw', rawChoices)).filter(Boolean)
+    const hasDeprecated = rawChoices.some((outdatedPkg) => outdatedPkg.raw[3].includes('(deprecated)'))
+    const renderedTable = alignColumns(pluck('raw', rawChoices), hasDeprecated).filter(Boolean)
 
     const choices = rawChoices.map((outdatedPkg, i) => {
       if (i === 0) {
@@ -126,7 +127,7 @@ function getPkgUrl (pkg: OutdatedPackage): string {
   return ''
 }
 
-function alignColumns (rows: string[][]): string[] {
+function alignColumns (rows: string[][], hasDeprecated: boolean): string[] {
   return table(
     rows,
     {
@@ -140,7 +141,7 @@ function alignColumns (rows: string[][]): string[] {
           {
             0: { width: 50, truncate: 100 },
             1: { width: 15, alignment: 'right' },
-            3: { width: 30 },
+            3: { width: hasDeprecated ? 30 : 15 },
             4: { paddingLeft: 2 },
             5: { paddingLeft: 2 },
           },

--- a/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
+++ b/pkg-manager/plugin-commands-installation/src/update/getUpdateChoices.ts
@@ -48,7 +48,14 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
   const finalChoices: ChoiceGroup = []
   for (const [depGroup, choiceRows] of Object.entries(groupPkgsByType)) {
     if (choiceRows.length === 0) continue
-    const rawChoices = choiceRows.filter(choice => choice.latestManifest?.version !== choice.current).map(choice => buildPkgChoice(choice, workspacesEnabled))
+    const rawChoices: RawChoice[] = []
+    for (const choice of choiceRows) {
+      // The list of outdated dependencies also contains deprecated packages.
+      // But we only want to show those dependencies that have newer versions.
+      if (choice.latestManifest?.version !== choice.current) {
+        rawChoices.push(buildPkgChoice(choice, workspacesEnabled))
+      }
+    }
     if (rawChoices.length === 0) continue
     // add in a header row for each group
     rawChoices.unshift({
@@ -82,7 +89,13 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
   return finalChoices
 }
 
-function buildPkgChoice (outdatedPkg: OutdatedPackage, workspacesEnabled: boolean): { raw: string[], name: string, disabled?: boolean } {
+interface RawChoice {
+  raw: string[]
+  name: string
+  disabled?: boolean
+}
+
+function buildPkgChoice (outdatedPkg: OutdatedPackage, workspacesEnabled: boolean): RawChoice {
   const sdiff = semverDiff(outdatedPkg.wanted, outdatedPkg.latestManifest!.version)
   const nextVersion = sdiff.change === null
     ? outdatedPkg.latestManifest!.version


### PR DESCRIPTION
A deprecation mark is added based on the original logic to prompt the user.

close #9206