### PR TITLE
test: turn off test retries since they can hide buggy tests

### DIFF
--- a/__utils__/jest-config/setupFilesAfterEnv.js
+++ b/__utils__/jest-config/setupFilesAfterEnv.js
@@ -1,14 +1,5 @@
 const { finishWorkers } = require('@pnpm/worker')
 
-jest.retryTimes(1, {
-  // Some tests don't clean up their resources completely and cause the retried
-  // run fail. Set logErrorsBeforeRetry to make it more clear that the retried
-  // run was a retry and not the first attempt. Otherwise Jest hides the first
-  // attempt. This makes it easier to distinguish between a test that's truly
-  // broken and one that's not retry-able.
-  logErrorsBeforeRetry: true
-})
-
 afterAll(async () => {
   await finishWorkers()
 })

--- a/cli/default-reporter/test/filterLogHook.ts
+++ b/cli/default-reporter/test/filterLogHook.ts
@@ -1,8 +1,9 @@
 import { type Log } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { logger, createStreamParser } from '@pnpm/logger'
+import { firstValueFrom } from 'rxjs'
 
-test('logger with filterLog hook', (done) => {
+test('logger with filterLog hook', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -49,16 +50,6 @@ test('logger with filterLog hook', (done) => {
 
   expect.assertions(1)
 
-  const subscription = output$.subscribe({
-    complete: () => done(),
-    error: done,
-    next: (msg) => {
-      expect(msg).toEqual(expect.stringContaining('bbb'))
-    },
-  })
-
-  setTimeout(() => {
-    done()
-    subscription.unsubscribe()
-  }, 10)
+  const msg = await firstValueFrom(output$)
+  expect(msg).toEqual(expect.stringContaining('bbb'))
 })

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -291,6 +291,9 @@ test('prints summary without the filtered out entries', async () => {
   expect(output).toBe(EOL + `\
 ${h1('dependencies:')}
 ${ADD} foo ${versionColor('1.0.0')} ${versionColor('(2.0.0 is available)')}
+
+${h1('devDependencies:')}
+${ADD} qar ${versionColor('2.0.0')}
 `)
 })
 
@@ -617,7 +620,11 @@ test('prints summary when some packages fail', async () => {
   logger.error(err, err)
 
   const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
-  expect(output).toBe(EOL + `Summary: ${chalk.red('6 fails')}, 7 passes
+  expect(output).toBe(`\
+${formatError('ERR_PNPM_RECURSIVE_FAIL', '')}
+
+
+Summary: ${chalk.red('6 fails')}, 7 passes
 
 /a:
 ${formatError('ERROR', 'a failed')}
@@ -1055,7 +1062,7 @@ test('logLevel=default', async () => {
   const output = await firstValueFrom(output$.pipe(skip(2), take(1)))
   expect(output).toBe(`Info message
 ${formatWarn('Some issue')}
-${formatError('ERROR', 'some error')}`)
+${formatError('ERR_PNPM_SOME_CODE', 'some error')}`)
 })
 
 test('logLevel=warn', async () => {

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -20,6 +20,7 @@ import {
 import { map, skip, take } from 'rxjs/operators'
 import chalk from 'chalk'
 import normalizeNewline from 'normalize-newline'
+import { firstValueFrom } from 'rxjs'
 import repeat from 'ramda/src/repeat'
 import { formatWarn } from '../src/reporterForClient/utils/formatWarn'
 
@@ -35,7 +36,7 @@ const h1 = chalk.cyanBright
 
 const EOL = '\n'
 
-test('prints summary (of current package only)', (done) => {
+test('prints summary (of current package only)', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -198,11 +199,8 @@ test('prints summary (of current package only)', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(2), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`packages/foo                             |   ${chalk.green('+5')}   ${chalk.red('-1')} ${ADD + SUB}${EOL}` +
+  const output = await firstValueFrom(output$.pipe(skip(2), take(1), map(normalizeNewline)))
+  expect(output).toBe(`packages/foo                             |   ${chalk.green('+5')}   ${chalk.red('-1')} ${ADD + SUB}${EOL}` +
         `${formatWarn(`${DEPRECATED} bar@2.0.0: This package was deprecated because bla bla bla`)}${EOL}${EOL}` +
         `\
 ${h1('dependencies:')}
@@ -226,11 +224,9 @@ ${ADD} qar ${versionColor('2.0.0')}
 ${h1('node_modules:')}
 ${ADD} is-linked2 ${chalk.grey(`<- ${path.relative(prefix, '/src/is-linked2')}`)}
 `)
-    },
-  })
 })
 
-test('prints summary without the filtered out entries', (done) => {
+test('prints summary without the filtered out entries', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -291,19 +287,14 @@ test('prints summary without the filtered out entries', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `\
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
 ${h1('dependencies:')}
 ${ADD} foo ${versionColor('1.0.0')} ${versionColor('(2.0.0 is available)')}
 `)
-    },
-  })
 })
 
-test('does not print deprecation message when log level is set to error', (done) => {
+test('does not print deprecation message when log level is set to error', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -354,16 +345,11 @@ test('does not print deprecation message when log level is set to error', (done)
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatError('ERR_PNPM_SOME_CODE', 'some error'))
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(formatError('ERR_PNPM_SOME_CODE', 'some error'))
 })
 
-test('prints summary for global installation', (done) => {
+test('prints summary for global installation', async () => {
   const prefix = '/home/jane/.nvs/node/10.0.0/x64/pnpm-global/1'
   const output$ = toOutput$({
     context: {
@@ -413,20 +399,15 @@ test('prints summary for global installation', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `\
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
 ${h1(`${prefix}:`)}
 ${ADD} bar ${versionColor('2.0.0')}
 ${ADD} foo ${versionColor('1.0.0')} ${versionColor('(2.0.0 is available)')}
 `)
-    },
-  })
 })
 
-test('prints added peer dependency', (done) => {
+test('prints added peer dependency', async () => {
   const prefix = '/home/jane/.nvs/node/10.0.0/x64/pnpm-global/1'
   const output$ = toOutput$({
     context: {
@@ -457,22 +438,17 @@ test('prints added peer dependency', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `\
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
 ${h1('peerDependencies:')}
 ${ADD} is-negative ${versionColor('^1.0.0')}
 
 ${h1('devDependencies:')}
 ${ADD} is-negative ${versionColor('^1.0.0')}
 `)
-    },
-  })
 })
 
-test('prints summary correctly when the same package is specified both in optional and prod dependencies', (done) => {
+test('prints summary correctly when the same package is specified both in optional and prod dependencies', async () => {
   const prefix = '/home/jane/.nvs/node/10.0.0/x64/pnpm-global/1'
   const output$ = toOutput$({
     context: {
@@ -524,19 +500,14 @@ test('prints summary correctly when the same package is specified both in option
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `\
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
 ${h1('dependencies:')}
 ${ADD} bar ${versionColor('2.0.0')}
 `)
-    },
-  })
 })
 
-test('in the installation summary report which dependency types are skipped', (done) => {
+test('in the installation summary report which dependency types are skipped', async () => {
   const prefix = '/home/jane/.nvs/node/10.0.0/x64/pnpm-global/1'
   const output$ = toOutput$({
     context: {
@@ -594,11 +565,8 @@ test('in the installation summary report which dependency types are skipped', (d
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `\
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
 ${h1('dependencies:')}
 ${ADD} bar ${versionColor('2.0.0')}
 
@@ -606,11 +574,9 @@ ${h1('optionalDependencies:')} skipped
 
 ${h1('devDependencies:')} skipped
 `)
-    },
-  })
 })
 
-test('prints summary when some packages fail', (done) => {
+test('prints summary when some packages fail', async () => {
   const output$ = toOutput$({
     context: { argv: ['run'], config: { recursive: true } as Config },
     streamParser: createStreamParser(),
@@ -650,11 +616,8 @@ test('prints summary when some packages fail', (done) => {
 
   logger.error(err, err)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `Summary: ${chalk.red('6 fails')}, 7 passes
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `Summary: ${chalk.red('6 fails')}, 7 passes
 
 /a:
 ${formatError('ERROR', 'a failed')}
@@ -673,11 +636,9 @@ ${formatError('ERROR', 'e failed')}
 
 /f:
 ${formatError('ERROR', 'f failed')}`)
-    },
-  })
 })
 
-test('prints info', (done) => {
+test('prints info', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -687,16 +648,11 @@ test('prints info', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe('info message')
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe('info message')
 })
 
-test('prints added/removed stats during installation', (done) => {
+test('prints added/removed stats during installation', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -708,18 +664,12 @@ test('prints added/removed stats during installation', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+5')} ${chalk.red('-1')}
-${ADD + ADD + ADD + ADD + ADD + SUB}`
-      )
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+5')} ${chalk.red('-1')}
+${ADD + ADD + ADD + ADD + ADD + SUB}`)
 })
 
-test('prints added/removed stats during installation when 0 removed', (done) => {
+test('prints added/removed stats during installation when 0 removed', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -731,18 +681,12 @@ test('prints added/removed stats during installation when 0 removed', (done) => 
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+2')}
-${ADD + ADD}`
-      )
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+2')}
+${ADD + ADD}`)
 })
 
-test('prints only the added stats if nothing was removed', (done) => {
+test('prints only the added stats if nothing was removed', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -754,17 +698,12 @@ test('prints only the added stats if nothing was removed', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+1')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+1')}
 ${ADD}`)
-    },
-  })
 })
 
-test('prints only the removed stats if nothing was added', (done) => {
+test('prints only the removed stats if nothing was added', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -776,17 +715,12 @@ test('prints only the removed stats if nothing was added', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.red('-1')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.red('-1')}
 ${SUB}`)
-    },
-  })
 })
 
-test('prints only the added stats if nothing was removed and a lot added', (done) => {
+test('prints only the added stats if nothing was removed and a lot added', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 20 },
@@ -799,17 +733,12 @@ test('prints only the added stats if nothing was removed and a lot added', (done
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+100')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+100')}
 ${repeat(ADD, 20).join('')}`)
-    },
-  })
 })
 
-test('prints only the removed stats if nothing was added and a lot removed', (done) => {
+test('prints only the removed stats if nothing was added and a lot removed', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 20 },
@@ -822,17 +751,12 @@ test('prints only the removed stats if nothing was added and a lot removed', (do
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.red('-100')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.red('-100')}
 ${repeat(SUB, 20).join('')}`)
-    },
-  })
 })
 
-test('prints at least one remove sign when removed !== 0', (done) => {
+test('prints at least one remove sign when removed !== 0', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 20 },
@@ -845,18 +769,12 @@ test('prints at least one remove sign when removed !== 0', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+100')} ${chalk.red('-1')}
-${repeat(ADD, 19).join('') + SUB}`
-      )
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+100')} ${chalk.red('-1')}
+${repeat(ADD, 19).join('') + SUB}`)
 })
 
-test('prints at least one add sign when added !== 0', (done) => {
+test('prints at least one add sign when added !== 0', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 20 },
@@ -869,17 +787,12 @@ test('prints at least one add sign when added !== 0', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.green('+1')} ${chalk.red('-100')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.green('+1')} ${chalk.red('-100')}
 ${ADD + repeat(SUB, 19).join('')}`)
-    },
-  })
 })
 
-test('prints just removed during uninstallation', (done) => {
+test('prints just removed during uninstallation', async () => {
   const output$ = toOutput$({
     context: { argv: ['remove'] },
     streamParser: createStreamParser(),
@@ -890,17 +803,12 @@ test('prints just removed during uninstallation', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Packages: ${chalk.red('-4')}
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`Packages: ${chalk.red('-4')}
 ${SUB + SUB + SUB + SUB}`)
-    },
-  })
 })
 
-test('prints added/removed stats and warnings during recursive installation', (done) => {
+test('prints added/removed stats and warnings during recursive installation', async () => {
   const rootPrefix = '/home/jane/repo'
   const output$ = toOutput$({
     context: {
@@ -945,12 +853,9 @@ test('prints added/removed stats and warnings during recursive installation', (d
 
   expect.assertions(1)
 
-  output$.pipe(skip(8), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      // cspell:disable
-      expect(output).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(8), take(1), map(normalizeNewline)))
+  // cspell:disable
+  expect(output).toBe(`\
 pkg-5                                    | ${formatWarn('Some issue')}
 .                                        | ${formatWarn('Some other issue')}
 .                                        |   ${chalk.red('-1')} ${SUB}
@@ -960,12 +865,10 @@ dir/pkg-2                                |   ${chalk.green('+2')} ${ADD}
 .../pkg-3                                |   ${chalk.green('+1')} ${ADD}
 ...ooooooooooooooooooooooooooooong-pkg-4 |   ${chalk.red('-1')} ${SUB}
 .                                        | ${formatWarn(`${DEPRECATED} foo@1.0.0`)}`)
-      // cspell:enable
-    },
-  })
+  // cspell:enable
 })
 
-test('recursive installation: prints only the added stats if nothing was removed and a lot added', (done) => {
+test('recursive installation: prints only the added stats if nothing was removed and a lot added', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['recursive'],
@@ -980,16 +883,11 @@ test('recursive installation: prints only the added stats if nothing was removed
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    | ${chalk.green('+190')} ${repeat(ADD, 12).join('')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    | ${chalk.green('+190')} ${repeat(ADD, 12).join('')}`)
 })
 
-test('recursive installation: prints only the removed stats if nothing was added and a lot removed', (done) => {
+test('recursive installation: prints only the removed stats if nothing was added and a lot removed', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['recursive'],
@@ -1004,16 +902,11 @@ test('recursive installation: prints only the removed stats if nothing was added
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    | ${chalk.red('-190')} ${repeat(SUB, 12).join('')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    | ${chalk.red('-190')} ${repeat(SUB, 12).join('')}`)
 })
 
-test('recursive installation: prints at least one remove sign when removed !== 0', (done) => {
+test('recursive installation: prints at least one remove sign when removed !== 0', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['recursive'],
@@ -1028,16 +921,11 @@ test('recursive installation: prints at least one remove sign when removed !== 0
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    | ${chalk.green('+100')}   ${chalk.red('-1')} ${repeat(ADD, 8).join('') + SUB}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    | ${chalk.green('+100')}   ${chalk.red('-1')} ${repeat(ADD, 8).join('') + SUB}`)
 })
 
-test('recursive installation: prints at least one add sign when added !== 0', (done) => {
+test('recursive installation: prints at least one add sign when added !== 0', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['recursive'],
@@ -1052,16 +940,11 @@ test('recursive installation: prints at least one add sign when added !== 0', (d
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    |   ${chalk.green('+1')} ${chalk.red('-100')} ${ADD + repeat(SUB, 8).join('')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    |   ${chalk.green('+1')} ${chalk.red('-100')} ${ADD + repeat(SUB, 8).join('')}`)
 })
 
-test('recursive uninstall: prints removed packages number', (done) => {
+test('recursive uninstall: prints removed packages number', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['remove'],
@@ -1075,16 +958,11 @@ test('recursive uninstall: prints removed packages number', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    |   ${chalk.red('-1')} ${SUB}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    |   ${chalk.red('-1')} ${SUB}`)
 })
 
-test('install: print hook message', (done) => {
+test('install: print hook message', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -1102,16 +980,11 @@ test('install: print hook message', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`${chalk.magentaBright('readPackage')}: foo`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`${chalk.magentaBright('readPackage')}: foo`)
 })
 
-test('recursive: print hook message', (done) => {
+test('recursive: print hook message', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['recursive'],
@@ -1129,16 +1002,11 @@ test('recursive: print hook message', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`pkg-1                                    | ${chalk.magentaBright('readPackage')}: foo`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`pkg-1                                    | ${chalk.magentaBright('readPackage')}: foo`)
 })
 
-test('prints skipped optional dependency info message', (done) => {
+test('prints skipped optional dependency info message', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1163,16 +1031,11 @@ test('prints skipped optional dependency info message', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`info: ${pkgId} is an optional dependency and failed compatibility check. Excluding it from installation.`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`info: ${pkgId} is an optional dependency and failed compatibility check. Excluding it from installation.`)
 })
 
-test('logLevel=default', (done) => {
+test('logLevel=default', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1189,18 +1052,13 @@ test('logLevel=default', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(2), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Info message
+  const output = await firstValueFrom(output$.pipe(skip(2), take(1)))
+  expect(output).toBe(`Info message
 ${formatWarn('Some issue')}
 ${formatError('ERROR', 'some error')}`)
-    },
-  })
 })
 
-test('logLevel=warn', (done) => {
+test('logLevel=warn', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1220,17 +1078,12 @@ test('logLevel=warn', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(1), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`${formatWarn('Some issue')}
+  const output = await firstValueFrom(output$.pipe(skip(1), take(1)))
+  expect(output).toBe(`${formatWarn('Some issue')}
 ${formatError('ERR_PNPM_SOME_CODE', 'some error')}`)
-    },
-  })
 })
 
-test('logLevel=error', (done) => {
+test('logLevel=error', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1250,16 +1103,11 @@ test('logLevel=error', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatError('ERR_PNPM_SOME_CODE', 'some error'))
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(formatError('ERR_PNPM_SOME_CODE', 'some error'))
 })
 
-test('warnings are collapsed', (done) => {
+test('warnings are collapsed', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1282,21 +1130,16 @@ test('warnings are collapsed', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(6), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`${formatWarn('Some issue 1')}
+  const output = await firstValueFrom(output$.pipe(skip(6), take(1)))
+  expect(output).toBe(`${formatWarn('Some issue 1')}
 ${formatWarn('Some issue 2')}
 ${formatWarn('Some issue 3')}
 ${formatWarn('Some issue 4')}
 ${formatWarn('Some issue 5')}
 ${formatWarn('2 other warnings')}`)
-    },
-  })
 })
 
-test('warnings are not collapsed when append-only is true', (done) => {
+test('warnings are not collapsed when append-only is true', async () => {
   const prefix = process.cwd()
   const output$ = toOutput$({
     context: {
@@ -1320,11 +1163,6 @@ test('warnings are not collapsed when append-only is true', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(6), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatWarn('Some issue 7'))
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(skip(6), take(1)))
+  expect(output).toBe(formatWarn('Some issue 7'))
 })

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -618,32 +618,6 @@ test('prints summary when some packages fail', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(EOL + `Summary: ${chalk.red('6 fails')}, 7 passes
-
-/a:
-${formatError('ERROR', 'a failed')}
-
-/b:
-${formatError('ERROR', 'b failed')}
-
-/c:
-${formatError('ERROR', 'c failed')}
-
-/d:
-${formatError('ERROR', 'd failed')}
-
-/e:
-${formatError('ERROR', 'e failed')}
-
-/f:
-${formatError('ERROR', 'f failed')}`)
-    },
-  })
-
   const err = Object.assign(new PnpmError('RECURSIVE_FAIL', '...'), {
     failures: [
       {
@@ -675,6 +649,32 @@ ${formatError('ERROR', 'f failed')}`)
   })
 
   logger.error(err, err)
+
+  output$.pipe(take(1), map(normalizeNewline)).subscribe({
+    complete: () => done(),
+    error: done,
+    next: output => {
+      expect(output).toBe(EOL + `Summary: ${chalk.red('6 fails')}, 7 passes
+
+/a:
+${formatError('ERROR', 'a failed')}
+
+/b:
+${formatError('ERROR', 'b failed')}
+
+/c:
+${formatError('ERROR', 'c failed')}
+
+/d:
+${formatError('ERROR', 'd failed')}
+
+/e:
+${formatError('ERROR', 'e failed')}
+
+/f:
+${formatError('ERROR', 'f failed')}`)
+    },
+  })
 })
 
 test('prints info', (done) => {

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -1038,7 +1038,7 @@ test('prints skipped optional dependency info message', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`info: ${pkgId} is an optional dependency and failed compatibility check. Excluding it from installation.`)
 })
 
@@ -1110,7 +1110,7 @@ test('logLevel=error', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(formatError('ERR_PNPM_SOME_CODE', 'some error'))
 })
 

--- a/cli/default-reporter/test/reportingContext.ts
+++ b/cli/default-reporter/test/reportingContext.ts
@@ -5,7 +5,6 @@ import {
   createStreamParser,
 } from '@pnpm/logger'
 import { firstValueFrom } from 'rxjs'
-import { take } from 'rxjs/operators'
 
 const NO_OUTPUT = Symbol('test should not log anything')
 
@@ -28,7 +27,7 @@ test('print context and import method info', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`\
 Packages are hard linked from the content-addressable store to the virtual store.
   Content-addressable store is at: ~/.pnpm-store/v3

--- a/cli/default-reporter/test/reportingContext.ts
+++ b/cli/default-reporter/test/reportingContext.ts
@@ -1,11 +1,15 @@
+import { setTimeout } from 'node:timers/promises'
 import { contextLogger, packageImportMethodLogger } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import {
   createStreamParser,
 } from '@pnpm/logger'
+import { firstValueFrom } from 'rxjs'
 import { take } from 'rxjs/operators'
 
-test('print context and import method info', (done) => {
+const NO_OUTPUT = Symbol('test should not log anything')
+
+test('print context and import method info', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -24,19 +28,14 @@ test('print context and import method info', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`\
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`\
 Packages are hard linked from the content-addressable store to the virtual store.
   Content-addressable store is at: ~/.pnpm-store/v3
   Virtual store is at:             node_modules/.pnpm`)
-    },
-  })
 })
 
-test('do not print info if not fresh install', (done) => {
+test('do not print info if not fresh install', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -53,21 +52,15 @@ test('do not print info if not fresh install', (done) => {
     method: 'hardlink',
   })
 
-  const subscription = output$.subscribe({
-    complete: () => done(),
-    error: done,
-    next: (msg) => {
-      expect(msg).toBeFalsy()
-    },
-  })
+  const output = await Promise.race([
+    firstValueFrom(output$),
+    setTimeout(10).then(() => NO_OUTPUT),
+  ])
 
-  setTimeout(() => {
-    done()
-    subscription.unsubscribe()
-  }, 10)
+  expect(output).toEqual(NO_OUTPUT)
 })
 
-test('do not print info if dlx is the executed command', (done) => {
+test('do not print info if dlx is the executed command', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['dlx'],
@@ -84,16 +77,10 @@ test('do not print info if dlx is the executed command', (done) => {
     method: 'hardlink',
   })
 
-  const subscription = output$.subscribe({
-    complete: () => done(),
-    error: done,
-    next: (msg) => {
-      expect(msg).toBeFalsy()
-    },
-  })
+  const output = await Promise.race([
+    firstValueFrom(output$),
+    setTimeout(10).then(() => NO_OUTPUT),
+  ])
 
-  setTimeout(() => {
-    done()
-    subscription.unsubscribe()
-  }, 10)
+  expect(output).toEqual(NO_OUTPUT)
 })

--- a/cli/default-reporter/test/reportingDeprecations.ts
+++ b/cli/default-reporter/test/reportingDeprecations.ts
@@ -5,12 +5,13 @@ import {
 } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
+import { firstValueFrom } from 'rxjs'
 import { map, take } from 'rxjs/operators'
 import chalk from 'chalk'
 import normalizeNewline from 'normalize-newline'
 import { formatWarn } from '../src/reporterForClient/utils/formatWarn'
 
-test('prints summary of deprecated subdependencies', (done) => {
+test('prints summary of deprecated subdependencies', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({
     context: {
@@ -43,11 +44,6 @@ test('prints summary of deprecated subdependencies', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`${formatWarn(`${chalk.red('2 deprecated subdependencies found:')} bar@2.0.0, qar@3.0.0`)}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`${formatWarn(`${chalk.red('2 deprecated subdependencies found:')} bar@2.0.0, qar@3.0.0`)}`)
 })

--- a/cli/default-reporter/test/reportingErrors.ts
+++ b/cli/default-reporter/test/reportingErrors.ts
@@ -36,6 +36,7 @@ test('prints generic error', async () => {
 
   const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
   expect(output).toBe(`${formatError('ERROR', 'some error')}
+${ERROR_PAD}
 ${ERROR_PAD}${(new StackTracey(err.stack).asTable() as string).split('\n').join(`\n${ERROR_PAD}`)}`)
 })
 
@@ -356,6 +357,7 @@ test('prints error with packages stacktrace - depth 1 and hint', async () => {
   expect(output).toBe(`${formatError('ERR_PNPM_SOME_ERROR', 'some error')}
 ${ERROR_PAD}
 ${ERROR_PAD}This error happened while installing the dependencies of foo@1.0.0
+${ERROR_PAD}
 ${ERROR_PAD}hint`)
 })
 

--- a/cli/default-reporter/test/reportingErrors.ts
+++ b/cli/default-reporter/test/reportingErrors.ts
@@ -75,6 +75,11 @@ test('prints no matching version error when many dist-tags exist', (done) => {
 
   expect.assertions(1)
 
+  const err = Object.assign(new PnpmError('NO_MATCHING_VERSION', 'No matching version found for pnpm@1000.0.0'), {
+    packageMeta: loadJsonFile.sync(path.join(__dirname, 'pnpm-meta.json')),
+  })
+  logger.error(err, err)
+
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
     error: done,
@@ -91,11 +96,6 @@ ${ERROR_PAD}
 ${ERROR_PAD}If you need the full list of all 281 published versions run "$ pnpm view pnpm versions".`)
     },
   })
-
-  const err = Object.assign(new PnpmError('NO_MATCHING_VERSION', 'No matching version found for pnpm@1000.0.0'), {
-    packageMeta: loadJsonFile.sync(path.join(__dirname, 'pnpm-meta.json')),
-  })
-  logger.error(err, err)
 })
 
 test('prints no matching version error when only the latest dist-tag exists', (done) => {
@@ -105,6 +105,11 @@ test('prints no matching version error when only the latest dist-tag exists', (d
   })
 
   expect.assertions(1)
+
+  const err = Object.assign(new PnpmError('NO_MATCHING_VERSION', 'No matching version found for is-positive@1000.0.0'), {
+    packageMeta: loadJsonFile.sync(path.join(__dirname, 'is-positive-meta.json')),
+  })
+  logger.error(err, err)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
@@ -117,11 +122,6 @@ ${ERROR_PAD}
 ${ERROR_PAD}If you need the full list of all 4 published versions run "$ pnpm view is-positive versions".`)
     },
   })
-
-  const err = Object.assign(new PnpmError('NO_MATCHING_VERSION', 'No matching version found for is-positive@1000.0.0'), {
-    packageMeta: loadJsonFile.sync(path.join(__dirname, 'is-positive-meta.json')),
-  })
-  logger.error(err, err)
 })
 
 test('prints suggestions when an internet-connection related error happens', (done) => {
@@ -131,6 +131,23 @@ test('prints suggestions when an internet-connection related error happens', (do
   })
 
   expect.assertions(1)
+
+  const err = Object.assign(
+    new PnpmError('BAD_TARBALL_SIZE', 'Actual size (99) of tarball (https://foo) did not match the one specified in \'Content-Length\' header (100)'),
+    {
+      prefix: '/project-dir',
+      pkgsStack: [
+        {
+          id: 'registry.npmjs.org/foo/1.0.0',
+          name: 'foo',
+          version: '1.0.0',
+        },
+      ],
+      expectedSize: 100,
+      receivedSize: 99,
+    }
+  )
+  logger.error(err, err)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
@@ -157,23 +174,6 @@ ${ERROR_PAD}NOTE: You may also override configs via flags.
 ${ERROR_PAD}For instance, \`pnpm install --fetch-retries 5 --network-concurrency 1\``)
     },
   })
-
-  const err = Object.assign(
-    new PnpmError('BAD_TARBALL_SIZE', 'Actual size (99) of tarball (https://foo) did not match the one specified in \'Content-Length\' header (100)'),
-    {
-      prefix: '/project-dir',
-      pkgsStack: [
-        {
-          id: 'registry.npmjs.org/foo/1.0.0',
-          name: 'foo',
-          version: '1.0.0',
-        },
-      ],
-      expectedSize: 100,
-      receivedSize: 99,
-    }
-  )
-  logger.error(err, err)
 })
 
 test('prints test error', (done) => {
@@ -184,6 +184,12 @@ test('prints test error', (done) => {
 
   expect.assertions(1)
 
+  const err = Object.assign(new Error('Tests failed'), {
+    code: 'ELIFECYCLE',
+    stage: 'test',
+  })
+  logger.error(err, err)
+
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
     error: done,
@@ -191,12 +197,6 @@ test('prints test error', (done) => {
       expect(output).toBe(`${formatError('ELIFECYCLE', 'Test failed. See above for more details.')}`)
     },
   })
-
-  const err = Object.assign(new Error('Tests failed'), {
-    code: 'ELIFECYCLE',
-    stage: 'test',
-  })
-  logger.error(err, err)
 })
 
 test('prints command error with exit code', (done) => {
@@ -207,6 +207,12 @@ test('prints command error with exit code', (done) => {
 
   expect.assertions(1)
 
+  const err: Exception = new Error('Command failed')
+  err['errno'] = 100
+  err['stage'] = 'lint'
+  err['code'] = 'ELIFECYCLE'
+  logger.error(err, err)
+
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
     error: done,
@@ -214,12 +220,6 @@ test('prints command error with exit code', (done) => {
       expect(output).toBe(`${formatError('ELIFECYCLE', 'Command failed with exit code 100.')}`)
     },
   })
-
-  const err: Exception = new Error('Command failed')
-  err['errno'] = 100
-  err['stage'] = 'lint'
-  err['code'] = 'ELIFECYCLE'
-  logger.error(err, err)
 })
 
 test('prints command error without exit code', (done) => {
@@ -230,6 +230,11 @@ test('prints command error without exit code', (done) => {
 
   expect.assertions(1)
 
+  const err: Exception = new Error('Command failed')
+  err['stage'] = 'lint'
+  err['code'] = 'ELIFECYCLE'
+  logger.error(err, err)
+
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
     error: done,
@@ -237,11 +242,6 @@ test('prints command error without exit code', (done) => {
       expect(output).toBe(`${formatError('ELIFECYCLE', 'Command failed.')}`)
     },
   })
-
-  const err: Exception = new Error('Command failed')
-  err['stage'] = 'lint'
-  err['code'] = 'ELIFECYCLE'
-  logger.error(err, err)
 })
 
 test('prints unsupported pnpm version error', (done) => {
@@ -251,6 +251,13 @@ test('prints unsupported pnpm version error', (done) => {
   })
 
   expect.assertions(1)
+
+  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
+    packageId: '/home/zoltan/project',
+    wanted: { pnpm: '2' },
+    current: { pnpm: '3.0.0', node: '10.0.0' },
+  })
+  logger.error(err, err)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
@@ -270,13 +277,6 @@ ${ERROR_PAD}To install the latest version of pnpm, run "pnpm i -g pnpm".
 ${ERROR_PAD}To check your pnpm version, run "pnpm -v".`)
     },
   })
-
-  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
-    packageId: '/home/zoltan/project',
-    wanted: { pnpm: '2' },
-    current: { pnpm: '3.0.0', node: '10.0.0' },
-  })
-  logger.error(err, err)
 })
 
 test('prints unsupported Node version error', (done) => {
@@ -286,6 +286,13 @@ test('prints unsupported Node version error', (done) => {
   })
 
   expect.assertions(1)
+
+  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
+    packageId: '/home/zoltan/project',
+    wanted: { node: '>=12' },
+    current: { pnpm: '3.0.0', node: '10.0.0' },
+  })
+  logger.error(err, err)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
@@ -302,13 +309,6 @@ ${ERROR_PAD}This is happening because the package's manifest has an engines.node
 ${ERROR_PAD}To fix this issue, install the required Node version.`)
     },
   })
-
-  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
-    packageId: '/home/zoltan/project',
-    wanted: { node: '>=12' },
-    current: { pnpm: '3.0.0', node: '10.0.0' },
-  })
-  logger.error(err, err)
 })
 
 test('prints unsupported pnpm and Node versions error', (done) => {
@@ -318,6 +318,13 @@ test('prints unsupported pnpm and Node versions error', (done) => {
   })
 
   expect.assertions(1)
+
+  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
+    packageId: '/home/zoltan/project',
+    wanted: { pnpm: '2', node: '>=12' },
+    current: { pnpm: '3.0.0', node: '10.0.0' },
+  })
+  logger.error(err, err)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
     complete: () => done(),
@@ -344,13 +351,6 @@ ${ERROR_PAD}This is happening because the package's manifest has an engines.node
 ${ERROR_PAD}To fix this issue, install the required Node version.`)
     },
   })
-
-  const err = Object.assign(new PnpmError('UNSUPPORTED_ENGINE', 'Unsupported pnpm version'), {
-    packageId: '/home/zoltan/project',
-    wanted: { pnpm: '2', node: '>=12' },
-    current: { pnpm: '3.0.0', node: '10.0.0' },
-  })
-  logger.error(err, err)
 })
 
 test('prints error even if the error object not passed in through the message object', (done) => {
@@ -404,16 +404,6 @@ test('prints error with packages stacktrace - depth 1 and hint', (done) => {
     streamParser: createStreamParser(),
   })
 
-  const err = new PnpmError('SOME_ERROR', 'some error', { hint: 'hint' })
-  err.pkgsStack = [
-    {
-      id: 'registry.npmjs.org/foo/1.0.0',
-      name: 'foo',
-      version: '1.0.0',
-    },
-  ]
-  logger.error(err, err)
-
   expect.assertions(1)
 
   output$.pipe(take(1), map(normalizeNewline)).subscribe({
@@ -426,6 +416,16 @@ ${ERROR_PAD}This error happened while installing the dependencies of foo@1.0.0
 ${ERROR_PAD}hint`)
     },
   })
+
+  const err = new PnpmError('SOME_ERROR', 'some error', { hint: 'hint' })
+  err.pkgsStack = [
+    {
+      id: 'registry.npmjs.org/foo/1.0.0',
+      name: 'foo',
+      version: '1.0.0',
+    },
+  ]
+  logger.error(err, err)
 })
 
 test('prints error with packages stacktrace - depth 2', (done) => {

--- a/cli/default-reporter/test/reportingExecutionTime.ts
+++ b/cli/default-reporter/test/reportingExecutionTime.ts
@@ -1,10 +1,14 @@
+import { setTimeout } from 'node:timers/promises'
 import { executionTimeLogger } from '@pnpm/core-loggers'
 import { packageManager } from '@pnpm/cli-meta'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
 import { take } from 'rxjs/operators'
+import { firstValueFrom } from 'rxjs'
 
-test('does not print execution time for help command', (done) => {
+const NO_OUTPUT = Symbol('test should not log anything')
+
+test('does not print execution time for help command', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['help'],
@@ -17,21 +21,15 @@ test('does not print execution time for help command', (done) => {
     endedAt: 1665279413671,
   })
 
-  const subscription = output$.subscribe({
-    complete: () => done(),
-    error: done,
-    next: () => {
-      done('should not log anything')
-    },
-  })
+  const output = await Promise.race([
+    firstValueFrom(output$),
+    setTimeout(10).then(() => NO_OUTPUT),
+  ])
 
-  setTimeout(() => {
-    done()
-    subscription.unsubscribe()
-  }, 10)
+  expect(output).toEqual(NO_OUTPUT)
 })
 
-test('prints execution time for install command', (done) => {
+test('prints execution time for install command', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -46,11 +44,6 @@ test('prints execution time for install command', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Done in 10.8s using ${packageManager.name} v${packageManager.version}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Done in 10.8s using ${packageManager.name} v${packageManager.version}`)
 })

--- a/cli/default-reporter/test/reportingExecutionTime.ts
+++ b/cli/default-reporter/test/reportingExecutionTime.ts
@@ -3,7 +3,6 @@ import { executionTimeLogger } from '@pnpm/core-loggers'
 import { packageManager } from '@pnpm/cli-meta'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
-import { take } from 'rxjs/operators'
 import { firstValueFrom } from 'rxjs'
 
 const NO_OUTPUT = Symbol('test should not log anything')
@@ -44,6 +43,6 @@ test('prints execution time for install command', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Done in 10.8s using ${packageManager.name} v${packageManager.version}`)
 })

--- a/cli/default-reporter/test/reportingLifecycleScripts.ts
+++ b/cli/default-reporter/test/reportingLifecycleScripts.ts
@@ -116,7 +116,7 @@ test('groups lifecycle output', async () => {
   const output = await firstValueFrom(output$.pipe(skip(9), take(1), map(normalizeNewline)))
   expect(replaceTimeWith1Sec(output)).toBe(`\
 packages/foo ${PREINSTALL}$ node foo
-${OUTPUT_INDENTATION} foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
+${OUTPUT_INDENTATION} foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 2…
 ${STATUS_INDENTATION} ${STATUS_RUNNING}
 packages/foo ${POSTINSTALL}$ node foo
 ${OUTPUT_INDENTATION} foo I
@@ -867,8 +867,8 @@ test('collapses lifecycle output from preparation of a git-hosted dependency', a
 
   const output = await firstValueFrom(output$.pipe(skip(2), take(1), map(normalizeNewline)))
   expect(replaceTimeWith1Sec(output)).toBe(`\
-${chalk.gray('tmp')}_tmp_01234: Running preinstall script...
-${chalk.gray('tmp')}_tmp_01234: Running postinstall script, done in 1s`)
+${chalk.gray('tmp/')}_tmp_01243 [registry.npmjs.org/foo/1.0.0]: Running preinstall script...
+${chalk.gray('tmp/')}_tmp_01243 [registry.npmjs.org/foo/1.0.0]: Running postinstall script, done in 1s`)
 })
 
 test('output of failed optional dependency is not shown', async () => {

--- a/cli/default-reporter/test/reportingLifecycleScripts.ts
+++ b/cli/default-reporter/test/reportingLifecycleScripts.ts
@@ -26,7 +26,7 @@ function replaceTimeWith1Sec (text: string) {
     .replace(/failed in [a-z0-9μ]+/g, 'failed in 1s')
 }
 
-test('groups lifecycle output', (done) => {
+test('groups lifecycle output', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -113,11 +113,8 @@ test('groups lifecycle output', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(9), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(9), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 packages/foo ${PREINSTALL}$ node foo
 ${OUTPUT_INDENTATION} foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27
 ${STATUS_INDENTATION} ${STATUS_RUNNING}
@@ -131,8 +128,6 @@ ${OUTPUT_INDENTATION} bar I
 ${STATUS_INDENTATION} ${STATUS_RUNNING}
 packages/qar ${INSTALL}$ node qar
 ${STATUS_INDENTATION} ${STATUS_DONE}`)
-    },
-  })
 })
 
 test('groups lifecycle output when append-only is used', async () => {
@@ -363,7 +358,7 @@ test('groups lifecycle output when append-only and aggregate-output are used', a
   ])
 })
 
-test('groups lifecycle output when streamLifecycleOutput is used', (done) => {
+test('groups lifecycle output when streamLifecycleOutput is used', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: {
@@ -460,11 +455,8 @@ test('groups lifecycle output when streamLifecycleOutput is used', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(11), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(output).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(11), take(1), map(normalizeNewline)))
+  expect(output).toBe(`\
 ${chalk.cyan('packages/foo')} ${PREINSTALL}$ node foo
 ${chalk.cyan('packages/foo')} ${PREINSTALL}: foo 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
 ${chalk.cyan('packages/foo')} ${PREINSTALL}: Failed
@@ -477,8 +469,6 @@ ${chalk.cyan('packages/foo')} ${POSTINSTALL}: foo III
 ${chalk.blue('packages/qar')} ${INSTALL}$ node qar
 ${chalk.blue('packages/qar')} ${INSTALL}: Done
 ${chalk.cyan('packages/foo')} ${POSTINSTALL}: Done`)
-    },
-  })
 })
 
 test('groups lifecycle output when append-only and aggregate-output are used with mixed stages', async () => {
@@ -663,7 +653,7 @@ test('groups lifecycle output when append-only and reporter-hide-prefix are used
   ])
 })
 
-test('collapse lifecycle output when it has too many lines', (done) => {
+test('collapse lifecycle output when it has too many lines', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -696,11 +686,8 @@ test('collapse lifecycle output when it has too many lines', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(101), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(101), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 packages/foo ${POSTINSTALL}$ node foo
 [90 lines collapsed]
 ${OUTPUT_INDENTATION} foo 90
@@ -714,11 +701,9 @@ ${OUTPUT_INDENTATION} foo 97
 ${OUTPUT_INDENTATION} foo 98
 ${OUTPUT_INDENTATION} foo 99
 ${STATUS_INDENTATION} ${STATUS_DONE}`)
-    },
-  })
 })
 
-test('collapses lifecycle output of packages from node_modules', (done) => {
+test('collapses lifecycle output of packages from node_modules', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -810,20 +795,15 @@ test('collapses lifecycle output of packages from node_modules', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(5), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(5), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 ${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running preinstall script...
 ${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running postinstall script, done in 1s
 ${chalk.gray('node_modules/.registry.npmjs.org/bar/1.0.0/node_modules/')}bar: Running postinstall script...
 ${chalk.gray('node_modules/.registry.npmjs.org/qar/1.0.0/node_modules/')}qar: Running install script, done in 1s`)
-    },
-  })
 })
 
-test('collapses lifecycle output from preparation of a git-hosted dependency', (done) => {
+test('collapses lifecycle output from preparation of a git-hosted dependency', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -885,18 +865,13 @@ test('collapses lifecycle output from preparation of a git-hosted dependency', (
 
   expect.assertions(1)
 
-  output$.pipe(skip(2), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: unknown) => {
-      expect(replaceTimeWith1Sec(output as string)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(2), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 ${chalk.gray('tmp')}_tmp_01234: Running preinstall script...
 ${chalk.gray('tmp')}_tmp_01234: Running postinstall script, done in 1s`)
-    },
-  })
 })
 
-test('output of failed optional dependency is not shown', (done) => {
+test('output of failed optional dependency is not shown', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -929,16 +904,11 @@ test('output of failed optional dependency is not shown', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(1), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running install script, failed in 1s (skipped as optional)`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(skip(1), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running install script, failed in 1s (skipped as optional)`)
 })
 
-test('output of failed non-optional dependency is printed', (done) => {
+test('output of failed non-optional dependency is printed', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -971,20 +941,15 @@ test('output of failed non-optional dependency is printed', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(1), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(1), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 ${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running install script, failed in 1s
 .../foo/1.0.0/node_modules/foo ${INSTALL}$ node foo
 ${OUTPUT_INDENTATION} foo 0 1 2 3 4 5 6 7 8 9
 ${STATUS_INDENTATION} ${failedAt(wd)}`)
-    },
-  })
 })
 
-test('do not fail if the debug log has no output', (done) => {
+test('do not fail if the debug log has no output', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     reportingOptions: { outputMaxWidth: 79 },
@@ -1017,21 +982,16 @@ test('do not fail if the debug log has no output', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(1), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: (output: string) => {
-      expect(replaceTimeWith1Sec(output)).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(1), take(1), map(normalizeNewline)))
+  expect(replaceTimeWith1Sec(output)).toBe(`\
 ${chalk.gray('node_modules/.registry.npmjs.org/foo/1.0.0/node_modules/')}foo: Running install script, failed in 1s
 .../foo/1.0.0/node_modules/foo ${INSTALL}$ node foo
 ${OUTPUT_INDENTATION} 
 ${STATUS_INDENTATION} ${failedAt(wd)}`)
-    },
-  })
 })
 
 // Many libs use stderr for logging, so showing all stderr adds not much value
-test['skip']('prints lifecycle progress', (done) => {
+test['skip']('prints lifecycle progress', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -1077,17 +1037,12 @@ test['skip']('prints lifecycle progress', (done) => {
   const childOutputColor = chalk.grey
   const childOutputError = chalk.red
 
-  output$.pipe(skip(3), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`\
+  const output = await firstValueFrom(output$.pipe(skip(3), take(1), map(normalizeNewline)))
+  expect(output).toBe(`\
 Running ${POSTINSTALL} for ${hlPkgId('registry.npmjs.org/foo/1.0.0')}: ${childOutputColor('foo I')}
 Running ${POSTINSTALL} for ${hlPkgId('registry.npmjs.org/foo/1.0.0')}! ${childOutputError('foo II')}
 Running ${POSTINSTALL} for ${hlPkgId('registry.npmjs.org/foo/1.0.0')}: ${childOutputColor('foo III')}
 Running ${POSTINSTALL} for ${hlPkgId('registry.npmjs.org/bar/1.0.0')}: ${childOutputColor('bar I')}`)
-    },
-  })
 })
 
 function failedAt (wd: string) {

--- a/cli/default-reporter/test/reportingPeerDependencyIssues.ts
+++ b/cli/default-reporter/test/reportingPeerDependencyIssues.ts
@@ -4,9 +4,10 @@ import {
   createStreamParser,
   logger,
 } from '@pnpm/logger'
+import { firstValueFrom } from 'rxjs'
 import { take } from 'rxjs/operators'
 
-test('print peer dependency issues warning', (done) => {
+test('print peer dependency issues warning', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -42,16 +43,11 @@ test('print peer dependency issues warning', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toContain('.')
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toContain('.')
 })
 
-test('print peer dependency issues error', (done) => {
+test('print peer dependency issues error', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -89,11 +85,6 @@ test('print peer dependency issues error', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toContain('.')
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toContain('.')
 })

--- a/cli/default-reporter/test/reportingPeerDependencyIssues.ts
+++ b/cli/default-reporter/test/reportingPeerDependencyIssues.ts
@@ -5,7 +5,6 @@ import {
   logger,
 } from '@pnpm/logger'
 import { firstValueFrom } from 'rxjs'
-import { take } from 'rxjs/operators'
 
 test('print peer dependency issues warning', async () => {
   const output$ = toOutput$({
@@ -43,7 +42,7 @@ test('print peer dependency issues warning', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toContain('.')
 })
 
@@ -85,6 +84,6 @@ test('print peer dependency issues error', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toContain('.')
 })

--- a/cli/default-reporter/test/reportingProgress.ts
+++ b/cli/default-reporter/test/reportingProgress.ts
@@ -10,7 +10,8 @@ import {
   createStreamParser,
   logger,
 } from '@pnpm/logger'
-import { map, skip, take } from 'rxjs/operators'
+import { firstValueFrom } from 'rxjs'
+import { map, skip, take, toArray } from 'rxjs/operators'
 import chalk from 'chalk'
 import normalizeNewline from 'normalize-newline'
 import { formatWarn } from '../src/reporterForClient/utils/formatWarn'
@@ -20,7 +21,7 @@ const hlPkgId = chalk['whiteBright']
 
 const EOL = '\n'
 
-test('prints progress beginning', (done) => {
+test('prints progress beginning', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -41,16 +42,11 @@ test('prints progress beginning', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
-test('prints progress without added packages stats', (done) => {
+test('prints progress without added packages stats', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -74,16 +70,11 @@ test('prints progress without added packages stats', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}`)
 })
 
-test('prints all progress stats', (done) => {
+test('prints all progress stats', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -120,16 +111,11 @@ test('prints all progress stats', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(skip(3), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('1')}, downloaded ${hlValue('1')}, added ${hlValue('1')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(skip(3), take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('1')}, downloaded ${hlValue('1')}, added ${hlValue('1')}`)
 })
 
-test('prints progress beginning of node_modules from not cwd', (done) => {
+test('prints progress beginning of node_modules from not cwd', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -150,16 +136,11 @@ test('prints progress beginning of node_modules from not cwd', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`foo                                      | Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`foo                                      | Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
-test('prints progress beginning of node_modules from not cwd, when progress prefix is hidden', (done) => {
+test('prints progress beginning of node_modules from not cwd, when progress prefix is hidden', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -183,16 +164,11 @@ test('prints progress beginning of node_modules from not cwd, when progress pref
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
-test('prints progress beginning when appendOnly is true', (done) => {
+test('prints progress beginning when appendOnly is true', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -216,16 +192,11 @@ test('prints progress beginning when appendOnly is true', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
-test('prints progress beginning during recursive install', (done) => {
+test('prints progress beginning during recursive install', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -249,16 +220,11 @@ test('prints progress beginning during recursive install', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
-test('prints progress on first download', (done) => {
+test('prints progress on first download', async () => {
   expect.assertions(1)
 
   const output$ = toOutput$({
@@ -268,14 +234,6 @@ test('prints progress on first download', (done) => {
     },
     reportingOptions: { throttleProgress: 0 },
     streamParser: createStreamParser(),
-  })
-
-  output$.pipe(skip(1), take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}`)
-    },
   })
 
   const packageId = 'registry.npmjs.org/foo/1.0.0'
@@ -295,9 +253,12 @@ test('prints progress on first download', (done) => {
     requester: '/src/project',
     status: 'fetched',
   })
+
+  const output = await firstValueFrom(output$.pipe(skip(1), take(1)))
+  expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}`)
 })
 
-test('moves fixed line to the end', (done) => {
+test('moves fixed line to the end', async () => {
   expect.assertions(1)
   const prefix = '/src/project'
   const output$ = toOutput$({
@@ -337,17 +298,12 @@ test('moves fixed line to the end', (done) => {
     stage: 'importing_done',
   })
 
-  output$.pipe(skip(3), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatWarn('foo') + EOL +
-        `Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}, done`)
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(skip(3), take(1), map(normalizeNewline)))
+  expect(output).toBe(formatWarn('foo') + EOL +
+    `Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}, done`)
 })
 
-test('prints "Already up to date"', (done) => {
+test('prints "Already up to date"', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },
     streamParser: createStreamParser(),
@@ -360,16 +316,11 @@ test('prints "Already up to date"', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe('Already up to date')
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe('Already up to date')
 })
 
-test('prints progress of big files download', (done) => {
+test('prints progress of big files download', async () => {
   expect.assertions(6)
 
   const output$ = toOutput$({
@@ -453,47 +404,40 @@ test('prints progress of big files download', (done) => {
     status: 'in_progress',
   })
 
-  output$.pipe(
-    take(9),
-    map(normalizeNewline),
-    map((output, index) => {
-      switch (index) {
-      case 0:
-        expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-        return
-      case 1:
-        expect(output).toBe(`\
+  const output = await firstValueFrom(output$.pipe(take(9), map(normalizeNewline), toArray()))
+
+  output.forEach((output, index) => {
+    switch (index) {
+    case 0:
+      expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
+      return
+    case 1:
+      expect(output).toBe(`\
 Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
 Downloading ${hlPkgId(pkgId1)}: ${hlValue('0.00 B')}/${hlValue('10.49 MB')}`)
-        return
-      case 2:
-        expect(output).toBe(`\
+      return
+    case 2:
+      expect(output).toBe(`\
 Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
 Downloading ${hlPkgId(pkgId1)}: ${hlValue('5.77 MB')}/${hlValue('10.49 MB')}`)
-        return
-      case 4:
-        expect(output).toBe(`\
+      return
+    case 4:
+      expect(output).toBe(`\
 Progress: resolved ${hlValue('2')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
 Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}`)
-        return
-      case 7:
-        expect(output).toBe(`\
+      return
+    case 7:
+      expect(output).toBe(`\
 Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
 Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}
 Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
-        return
-      case 8:
-        expect(output).toBe(`\
+      return
+    case 8:
+      expect(output).toBe(`\
 Downloading ${hlPkgId(pkgId1)}: ${hlValue('10.49 MB')}/${hlValue('10.49 MB')}, done
 Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
 Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
-        return // eslint-disable-line
-      }
-    })
-  )
-    .subscribe({
-      complete: () => done(),
-      error: done,
-      next: () => undefined,
-    })
+      return // eslint-disable-line
+    }
+  })
 })

--- a/cli/default-reporter/test/reportingProgress.ts
+++ b/cli/default-reporter/test/reportingProgress.ts
@@ -42,7 +42,7 @@ test('prints progress beginning', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
@@ -70,7 +70,7 @@ test('prints progress without added packages stats', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}`)
 })
 
@@ -136,7 +136,7 @@ test('prints progress beginning of node_modules from not cwd', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`foo                                      | Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
@@ -164,7 +164,7 @@ test('prints progress beginning of node_modules from not cwd, when progress pref
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
@@ -192,7 +192,7 @@ test('prints progress beginning when appendOnly is true', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 
@@ -220,7 +220,7 @@ test('prints progress beginning during recursive install', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
 })
 

--- a/cli/default-reporter/test/reportingProgress.ts
+++ b/cli/default-reporter/test/reportingProgress.ts
@@ -309,15 +309,6 @@ test('moves fixed line to the end', (done) => {
     streamParser: createStreamParser(),
   })
 
-  output$.pipe(skip(3), take(1), map(normalizeNewline)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatWarn('foo') + EOL +
-        `Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}, done`)
-    },
-  })
-
   const packageId = 'registry.npmjs.org/foo/1.0.0'
 
   stageLogger.debug({
@@ -344,6 +335,15 @@ test('moves fixed line to the end', (done) => {
   stageLogger.debug({
     prefix,
     stage: 'importing_done',
+  })
+
+  output$.pipe(skip(3), take(1), map(normalizeNewline)).subscribe({
+    complete: () => done(),
+    error: done,
+    next: output => {
+      expect(output).toBe(formatWarn('foo') + EOL +
+        `Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('1')}, added ${hlValue('0')}, done`)
+    },
   })
 })
 
@@ -384,50 +384,6 @@ test('prints progress of big files download', (done) => {
   const pkgId1 = 'registry.npmjs.org/foo/1.0.0'
   const pkgId2 = 'registry.npmjs.org/bar/2.0.0'
   const pkgId3 = 'registry.npmjs.org/qar/3.0.0'
-
-  output$.pipe(
-    take(9),
-    map(normalizeNewline),
-    map((output, index) => {
-      switch (index) {
-      case 0:
-        expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
-        return
-      case 1:
-        expect(output).toBe(`\
-Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('0.00 B')}/${hlValue('10.49 MB')}`)
-        return
-      case 2:
-        expect(output).toBe(`\
-Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('5.77 MB')}/${hlValue('10.49 MB')}`)
-        return
-      case 4:
-        expect(output).toBe(`\
-Progress: resolved ${hlValue('2')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}`)
-        return
-      case 7:
-        expect(output).toBe(`\
-Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}
-Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
-        return
-      case 8:
-        expect(output).toBe(`\
-Downloading ${hlPkgId(pkgId1)}: ${hlValue('10.49 MB')}/${hlValue('10.49 MB')}, done
-Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
-Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
-        return // eslint-disable-line
-      }
-    })
-  )
-    .subscribe({
-      complete: () => done(),
-      error: done,
-      next: () => undefined,
-    })
 
   stageLogger.debug({
     prefix: '/src/project',
@@ -496,4 +452,48 @@ Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
     packageId: pkgId1,
     status: 'in_progress',
   })
+
+  output$.pipe(
+    take(9),
+    map(normalizeNewline),
+    map((output, index) => {
+      switch (index) {
+      case 0:
+        expect(output).toBe(`Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}`)
+        return
+      case 1:
+        expect(output).toBe(`\
+Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('0.00 B')}/${hlValue('10.49 MB')}`)
+        return
+      case 2:
+        expect(output).toBe(`\
+Progress: resolved ${hlValue('1')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('5.77 MB')}/${hlValue('10.49 MB')}`)
+        return
+      case 4:
+        expect(output).toBe(`\
+Progress: resolved ${hlValue('2')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}`)
+        return
+      case 7:
+        expect(output).toBe(`\
+Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('7.34 MB')}/${hlValue('10.49 MB')}
+Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
+        return
+      case 8:
+        expect(output).toBe(`\
+Downloading ${hlPkgId(pkgId1)}: ${hlValue('10.49 MB')}/${hlValue('10.49 MB')}, done
+Progress: resolved ${hlValue('3')}, reused ${hlValue('0')}, downloaded ${hlValue('0')}, added ${hlValue('0')}
+Downloading ${hlPkgId(pkgId3)}: ${hlValue('19.92 MB')}/${hlValue('20.97 MB')}`)
+        return // eslint-disable-line
+      }
+    })
+  )
+    .subscribe({
+      complete: () => done(),
+      error: done,
+      next: () => undefined,
+    })
 })

--- a/cli/default-reporter/test/reportingRequestRetry.ts
+++ b/cli/default-reporter/test/reportingRequestRetry.ts
@@ -4,9 +4,10 @@ import {
   createStreamParser,
 } from '@pnpm/logger'
 import { take } from 'rxjs/operators'
+import { firstValueFrom } from 'rxjs'
 import { formatWarn } from '../src/reporterForClient/utils/formatWarn'
 
-test('print warning about request retry', (done) => {
+test('print warning about request retry', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -25,11 +26,6 @@ test('print warning about request retry', (done) => {
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(output).toBe(formatWarn('GET https://foo.bar/qar error (undefined). Will retry in 12.5 seconds. 4 retries left.'))
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(output).toBe(formatWarn('GET https://foo.bar/qar error (undefined). Will retry in 12.5 seconds. 4 retries left.'))
 })

--- a/cli/default-reporter/test/reportingRequestRetry.ts
+++ b/cli/default-reporter/test/reportingRequestRetry.ts
@@ -3,7 +3,6 @@ import { toOutput$ } from '@pnpm/default-reporter'
 import {
   createStreamParser,
 } from '@pnpm/logger'
-import { take } from 'rxjs/operators'
 import { firstValueFrom } from 'rxjs'
 import { formatWarn } from '../src/reporterForClient/utils/formatWarn'
 
@@ -26,6 +25,6 @@ test('print warning about request retry', async () => {
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe(formatWarn('GET https://foo.bar/qar error (undefined). Will retry in 12.5 seconds. 4 retries left.'))
 })

--- a/cli/default-reporter/test/reportingScope.ts
+++ b/cli/default-reporter/test/reportingScope.ts
@@ -4,7 +4,6 @@ import { scopeLogger } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
 import { firstValueFrom } from 'rxjs'
-import { take } from 'rxjs/operators'
 
 const NO_OUTPUT = Symbol('test should not log anything')
 
@@ -46,7 +45,7 @@ test('prints scope of recursive install in a workspace when not all packages are
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe('Scope: 2 of 10 workspace projects')
 })
 
@@ -67,7 +66,7 @@ test('prints scope of recursive install in a workspace when all packages are sel
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe('Scope: all 10 workspace projects')
 })
 
@@ -87,7 +86,7 @@ test('prints scope of recursive install not in a workspace when not all packages
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe('Scope: 2 of 10 projects')
 })
 
@@ -107,6 +106,6 @@ test('prints scope of recursive install not in a workspace when all packages are
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(output).toBe('Scope: all 10 projects')
 })

--- a/cli/default-reporter/test/reportingUpdateCheck.ts
+++ b/cli/default-reporter/test/reportingUpdateCheck.ts
@@ -4,7 +4,6 @@ import { updateCheckLogger } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
 import { firstValueFrom } from 'rxjs'
-import { take } from 'rxjs/operators'
 import { stripVTControlCharacters as stripAnsi } from 'util'
 
 const NO_OUTPUT = Symbol('test should not log anything')
@@ -48,7 +47,7 @@ test('print update notification if the latest version is greater than the curren
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(stripAnsi(output)).toMatchSnapshot()
 })
 
@@ -71,7 +70,7 @@ test('print update notification for Corepack if the latest version is greater th
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(stripAnsi(output)).toMatchSnapshot()
 })
 
@@ -97,6 +96,6 @@ test('print update notification that suggests to use the standalone scripts for 
 
   expect.assertions(1)
 
-  const output = await firstValueFrom(output$.pipe(take(1)))
+  const output = await firstValueFrom(output$)
   expect(stripAnsi(output)).toMatchSnapshot()
 })

--- a/cli/default-reporter/test/reportingUpdateCheck.ts
+++ b/cli/default-reporter/test/reportingUpdateCheck.ts
@@ -1,11 +1,15 @@
+import { setTimeout } from 'node:timers/promises'
 import { type Config } from '@pnpm/config'
 import { updateCheckLogger } from '@pnpm/core-loggers'
 import { toOutput$ } from '@pnpm/default-reporter'
 import { createStreamParser } from '@pnpm/logger'
+import { firstValueFrom } from 'rxjs'
 import { take } from 'rxjs/operators'
 import { stripVTControlCharacters as stripAnsi } from 'util'
 
-test('does not print update if latest is less than current', (done) => {
+const NO_OUTPUT = Symbol('test should not log anything')
+
+test('does not print update if latest is less than current', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -19,21 +23,15 @@ test('does not print update if latest is less than current', (done) => {
     latestVersion: '9.0.0',
   })
 
-  const subscription = output$.subscribe({
-    complete: () => done(),
-    error: done,
-    next: () => {
-      done('should not log anything')
-    },
-  })
+  const output = await Promise.race([
+    firstValueFrom(output$),
+    setTimeout(10).then(() => NO_OUTPUT),
+  ])
 
-  setTimeout(() => {
-    done()
-    subscription.unsubscribe()
-  }, 10)
+  expect(output).toEqual(NO_OUTPUT)
 })
 
-test('print update notification if the latest version is greater than the current', (done) => {
+test('print update notification if the latest version is greater than the current', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -50,16 +48,11 @@ test('print update notification if the latest version is greater than the curren
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(stripAnsi(output)).toMatchSnapshot()
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(stripAnsi(output)).toMatchSnapshot()
 })
 
-test('print update notification for Corepack if the latest version is greater than the current', (done) => {
+test('print update notification for Corepack if the latest version is greater than the current', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -78,16 +71,11 @@ test('print update notification for Corepack if the latest version is greater th
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(stripAnsi(output)).toMatchSnapshot()
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(stripAnsi(output)).toMatchSnapshot()
 })
 
-test('print update notification that suggests to use the standalone scripts for the upgrade', (done) => {
+test('print update notification that suggests to use the standalone scripts for the upgrade', async () => {
   const output$ = toOutput$({
     context: {
       argv: ['install'],
@@ -109,11 +97,6 @@ test('print update notification that suggests to use the standalone scripts for 
 
   expect.assertions(1)
 
-  output$.pipe(take(1)).subscribe({
-    complete: () => done(),
-    error: done,
-    next: output => {
-      expect(stripAnsi(output)).toMatchSnapshot()
-    },
-  })
+  const output = await firstValueFrom(output$.pipe(take(1)))
+  expect(stripAnsi(output)).toMatchSnapshot()
 })


### PR DESCRIPTION
## Proposal

I strongly believe we should turn off `jest.retryTimes` globally. Retrying every test can hide buggy tests that should be fixed instead.

We can always add `jest.retryTimes(1)` to individual `.ts` test files that are failing in the future, but I do believe it shouldn't be the global default for all tests.

## Flakes

I've fixed a lot of flaking tests in the last year! I think we're now in a good state to turn off retries. 😊

- https://github.com/pnpm/pnpm/pull/9253
- https://github.com/pnpm/pnpm/pull/7472
- https://github.com/pnpm/pnpm/pull/7445
- https://github.com/pnpm/pnpm/pull/7346