### PR TITLE
refactor: prune lockfile importers when running `pnpm deploy` to prepare for `allProjectsGraph` refactor

### DIFF
--- a/.changeset/old-emus-double.md
+++ b/.changeset/old-emus-double.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": minor
+---
+
+The `install` function now accepts a `pruneLockfileImporters` option. This is used internally by pnpm to create a more accurate filtered lockfile.

--- a/.changeset/social-cooks-study.md
+++ b/.changeset/social-cooks-study.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-deploy": patch
+---
+
+An internal refactor was made to the `deploy` command to better handle a change in `plugin-commands-installation` when `node-linker=hoisted`. There are no behavior changes expected with this refactor.

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -323,6 +323,7 @@ export type InstallCommandOptions = Pick<Config,
   frozenLockfileIfExists?: boolean
   useBetaCli?: boolean
   pruneDirectDependencies?: boolean
+  pruneLockfileImporters?: boolean
   pruneStore?: boolean
   recursive?: boolean
   resolutionOnly?: boolean

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -135,6 +135,7 @@ export type InstallDepsOptions = Pick<Config,
   includeOnlyPackageFiles?: boolean
   prepareExecutionEnv: PrepareExecutionEnv
   fetchFullMetadata?: boolean
+  pruneLockfileImporters?: boolean
 } & Partial<Pick<Config, 'pnpmHomeDir' | 'strictDepBuilds'>>
 
 export async function installDeps (

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -92,6 +92,7 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
   selectedProjectsGraph: ProjectsGraph
   preferredVersions?: PreferredVersions
   pruneDirectDependencies?: boolean
+  pruneLockfileImporters?: boolean
   storeControllerAndDir?: {
     ctrl: StoreController
     dir: string
@@ -139,8 +140,9 @@ export async function recursive (
     linkWorkspacePackagesDepth: opts.linkWorkspacePackages === 'deep' ? Infinity : opts.linkWorkspacePackages ? 0 : -1,
     ownLifecycleHooksStdio: 'pipe',
     peer: opts.savePeer,
-    pruneLockfileImporters: ((opts.ignoredPackages == null) || opts.ignoredPackages.size === 0) &&
-      pkgs.length === allProjects.length,
+    pruneLockfileImporters: opts.pruneLockfileImporters ??
+      (((opts.ignoredPackages == null) || opts.ignoredPackages.size === 0) &&
+        pkgs.length === allProjects.length),
     storeController: store.ctrl,
     storeDir: store.dir,
     targetDependenciesField,


### PR DESCRIPTION
## Context

Upon updating `allProjectsGraph` to always contain all projects (https://github.com/pnpm/pnpm/pull/9259), only 1 test began failing:

<img width="842" alt="Screenshot 2025-03-10 at 12 04 59 AM" src="https://github.com/user-attachments/assets/093578dd-d2b1-4161-babb-eaeedc93c80f" />

## Explanation

This test caught a real problem. When `project-1` depends on `project-2`, the workspace dependency was no longer getting injected into the `deploy` directory.

This is because when `pnpm deploy` is ran with `node-linker=hoisted`, we add all workspace packages as an argument to the `hoist` function.

https://github.com/pnpm/pnpm/blob/a76da0c53c822943af7c5ba92ff3c53b63668751/pkg-manager/real-hoist/src/index.ts#L51-L66

This hoists all workspace packages into the original root `node_modules` **instead of the injected deploy directory**. As a result, pnpm installs them in their normal location and never in the deploy directory.

#### Why did the `allProjectsGraph` refactor cause this?

Before this change, the `allProjectsGraph` only contained the root project and the selected project for deploy. This meant  `lockfile.importers` only contained those 2 projects. When `allProjectsGraph` was updated to be all projects, the `lockfile.importers` object contained all projects.

Here's this loop before the `allProjectsGraph` refactor:

<img width="1401" alt="Screenshot 2025-03-10 at 12 16 58 AM" src="https://github.com/user-attachments/assets/a5ec6ea2-1a26-47cb-87bb-ed9e5f2f7072" />

Here's this same code path after my `allProjectsGraph` change. Note how `project-2` and `project-3` are now included.

<img width="1401" alt="Screenshot 2025-03-10 at 12 16 19 AM" src="https://github.com/user-attachments/assets/0e1a04f1-3eb5-426d-a840-22cf76547a4b" />

## Changes

I've brainstormed a few fixes, but I think the best one is to pass down `pruneLockfileImporters` from the `deploy` function. This results in `lockfile.importers` only containing the deployed project.

Workspace packages that the deployed project depends on are still recursively included through the `file:` protocol, but they're no longer seen as importers from the perspective of a deployed install. I think this makes sense, especially since the lockfile entry for the these importers are always empty objects in this scenario.

## Alternatives

We could also pass an `importersToHoist` array to `@pnpm/real-hoist` and iterate over that instead of `lockfile.importers`, but this felt hackier. It also doesn't fix the wanted lockfile for deploy. There would still be empty unused importers in `deploy/node_modules/.pnpm/lock.yaml`.

I also explored updating the `modulesDir` used to install hoisted workspace packages here:
https://github.com/pnpm/pnpm/blob/a76da0c53c822943af7c5ba92ff3c53b63668751/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts#L108

To respect `opts.modulesDir` like we do for external packages slightly above:

https://github.com/pnpm/pnpm/blob/a76da0c53c822943af7c5ba92ff3c53b63668751/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts#L87

However, this would be a very large refactor and potentially change the behavior of `node-linker=hoisted`.