### PR TITLE
test(dlx): use @pnpm.e2e/for-testing-pnpm-dlx from @pnpm/registry-mock

### DIFF
--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -115,21 +115,28 @@ test('dlx should not fail when the installed package has many commands and one e
   expect(fs.existsSync('touch.txt')).toBeTruthy()
 })
 
-test('dlx --package <pkg1> [--package <pkg2>]', async () => {
-  prepareEmpty()
+// Creating a describe block to scope the jest.retryTimes setting.
+describe('dlx on flaky test', () => {
+  // This test is more prone to network flakes since it reaches out to
+  // github.com for a dependency.
+  jest.retryTimes(1, { logErrorsBeforeRetry: true })
 
-  await dlx.handler({
-    ...DEFAULT_OPTS,
-    dir: path.resolve('project'),
-    storeDir: path.resolve('store'),
-    cacheDir: path.resolve('cache'),
-    package: [
-      'zkochan/for-testing-pnpm-dlx',
-      'is-positive',
-    ],
-  }, ['foo'])
+  test('dlx --package <pkg1> [--package <pkg2>]', async () => {
+    prepareEmpty()
 
-  expect(fs.existsSync('foo')).toBeTruthy()
+    await dlx.handler({
+      ...DEFAULT_OPTS,
+      dir: path.resolve('project'),
+      storeDir: path.resolve('store'),
+      cacheDir: path.resolve('cache'),
+      package: [
+        'zkochan/for-testing-pnpm-dlx',
+        'is-positive',
+      ],
+    }, ['foo'])
+
+    expect(fs.existsSync('foo')).toBeTruthy()
+  })
 })
 
 test('dlx should fail when the package has no bins', async () => {

--- a/exec/plugin-commands-script-runners/test/dlx.e2e.ts
+++ b/exec/plugin-commands-script-runners/test/dlx.e2e.ts
@@ -115,28 +115,21 @@ test('dlx should not fail when the installed package has many commands and one e
   expect(fs.existsSync('touch.txt')).toBeTruthy()
 })
 
-// Creating a describe block to scope the jest.retryTimes setting.
-describe('dlx on flaky test', () => {
-  // This test is more prone to network flakes since it reaches out to
-  // github.com for a dependency.
-  jest.retryTimes(1, { logErrorsBeforeRetry: true })
+test('dlx --package <pkg1> [--package <pkg2>]', async () => {
+  prepareEmpty()
 
-  test('dlx --package <pkg1> [--package <pkg2>]', async () => {
-    prepareEmpty()
+  await dlx.handler({
+    ...DEFAULT_OPTS,
+    dir: path.resolve('project'),
+    storeDir: path.resolve('store'),
+    cacheDir: path.resolve('cache'),
+    package: [
+      '@pnpm.e2e/for-testing-pnpm-dlx',
+      'is-positive',
+    ],
+  }, ['foo'])
 
-    await dlx.handler({
-      ...DEFAULT_OPTS,
-      dir: path.resolve('project'),
-      storeDir: path.resolve('store'),
-      cacheDir: path.resolve('cache'),
-      package: [
-        'zkochan/for-testing-pnpm-dlx',
-        'is-positive',
-      ],
-    }, ['foo'])
-
-    expect(fs.existsSync('foo')).toBeTruthy()
-  })
+  expect(fs.existsSync('foo')).toBeTruthy()
 })
 
 test('dlx should fail when the package has no bins', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 0.0.1
       version: 0.0.1
     '@pnpm/registry-mock':
-      specifier: 4.0.0
-      version: 4.0.0
+      specifier: 4.1.0
+      version: 4.1.0
     '@pnpm/semver-diff':
       specifier: ^1.1.0
       version: 1.1.0
@@ -859,7 +859,7 @@ importers:
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -893,7 +893,7 @@ importers:
     dependencies:
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs
@@ -968,7 +968,7 @@ importers:
     dependencies:
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/worker':
         specifier: workspace:*
         version: link:../../worker
@@ -1151,7 +1151,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.29.12
@@ -2153,7 +2153,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -2433,7 +2433,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2584,7 +2584,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -4268,7 +4268,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4561,7 +4561,7 @@ importers:
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -4837,7 +4837,7 @@ importers:
         version: link:../read-projects-context
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -5197,7 +5197,7 @@ importers:
         version: 'link:'
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5414,7 +5414,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6018,7 +6018,7 @@ importers:
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -6334,7 +6334,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6458,7 +6458,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -7051,7 +7051,7 @@ importers:
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -7115,7 +7115,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/workspace.filter-packages-from-dir':
         specifier: workspace:*
         version: link:../../workspace/filter-packages-from-dir
@@ -7200,7 +7200,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -7557,7 +7557,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.0.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.1.0(encoding@0.1.13)(typanion@3.14.0)
       '@types/archy':
         specifier: 'catalog:'
         version: 0.0.33
@@ -9388,8 +9388,8 @@ packages:
     resolution: {integrity: sha512-MnGXzzgCX1tkNskdJb/4WJr7OldPg8nhLe5RXN8W+nqt2a2vKLbbeDZmMkBUOvACLEKPRe58dMzs8h8g8gntuQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/registry-mock@4.0.0':
-    resolution: {integrity: sha512-jZTwFRF7hlTmlI6jiFEI8Mu6ZLPp86+I5QizHsctxbWdwgST6MO37p1l5BUAA7z5rTaNsjDeGDTlrm1xc7tZWg==}
+  '@pnpm/registry-mock@4.1.0':
+    resolution: {integrity: sha512-NyZapUwtybAsCy8YjoJ8JydgcI5s+l9Uw33I39Teor9cl5wJqSnW2vj/indMYIzgjQpCXSsds5meSgf2nkG5OQ==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -16382,7 +16382,7 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-bom: 4.0.0
 
-  '@pnpm/registry-mock@4.0.0(encoding@0.1.13)(typanion@3.14.0)':
+  '@pnpm/registry-mock@4.1.0(encoding@0.1.13)(typanion@3.14.0)':
     dependencies:
       anonymous-npm-registry-client: 0.3.2
       execa: 5.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,7 +73,7 @@ catalog:
   "@pnpm/npm-package-arg": ^1.0.0
   "@pnpm/os.env.path-extender": ^2.0.2
   "@pnpm/patch-package": 0.0.1
-  "@pnpm/registry-mock": 4.0.0
+  "@pnpm/registry-mock": 4.1.0
   "@pnpm/semver-diff": ^1.1.0
   "@pnpm/tabtab": ^0.5.4
   "@pnpm/util.lex-comparator": 3.0.1


### PR DESCRIPTION
We recently disabled Jest retries globally (https://github.com/pnpm/pnpm/pull/9255), but we should probably re-add retries for this one test that I'm noticing fail occasionally.

Example from: https://productionresultssa0.blob.core.windows.net/actions-results/c72271d4-7ce6-424d-8764-de766e462bbf/workflow-job-run-92795e1e-d0be-55e6-a5b9-6c5f23a789c1/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-10T03%3A45%3A07Z&sig=VQHdY%2FvSofp0FUwPJmnnZCP6Py6YRmPrSrP%2BifBStrg%3D&ske=2025-03-10T11%3A39%3A45Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-09T23%3A39%3A45Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-10T03%3A35%3A02Z&sv=2025-01-05

```
2025-03-10T03:14:29.8513611Z FAIL test/dlx.e2e.ts (355.572 s)
2025-03-10T03:14:29.8516494Z   ● dlx --package <pkg1> [--package <pkg2>]
2025-03-10T03:14:29.8517050Z 
2025-03-10T03:14:29.8517337Z     thrown: "Exceeded timeout of 240000 ms for a test.
2025-03-10T03:14:29.8518797Z     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
2025-03-10T03:14:29.8520151Z 
2025-03-10T03:14:29.8520546Z     [0m [90m 116 |[39m })
2025-03-10T03:14:29.8521119Z      [90m 117 |[39m
2025-03-10T03:14:29.8522309Z     [31m[1m>[22m[39m[90m 118 |[39m test([32m'dlx --package <pkg1> [--package <pkg2>]'[39m[33m,[39m [36masync[39m () [33m=>[39m {
2025-03-10T03:14:29.8523434Z      [90m     |[39m [31m[1m^[22m[39m
2025-03-10T03:14:29.8524016Z      [90m 119 |[39m   prepareEmpty()
2025-03-10T03:14:29.8524519Z      [90m 120 |[39m
2025-03-10T03:14:29.8525085Z      [90m 121 |[39m   [36mawait[39m dlx[33m.[39mhandler({[0m
2025-03-10T03:14:29.8525478Z 
2025-03-10T03:14:29.8525708Z       at Object.<anonymous> (test/dlx.e2e.ts:118:1)
```