### PR TITLE
fix: `terminalLink` does not support

### DIFF
--- a/.changeset/bumpy-forks-love.md
+++ b/.changeset/bumpy-forks-love.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+When `terminalLink` is not supported, it should fallback to the default text.

--- a/patching/plugin-commands-patching/src/patch.ts
+++ b/patching/plugin-commands-patching/src/patch.ts
@@ -127,7 +127,7 @@ export async function handler (opts: PatchCommandOptions, params: string[]): Pro
 
   return `Patch: You can now edit the package at:
 
-  ${terminalLink(chalk.blue(editDir), 'file://' + editDir)}
+  ${terminalLink(chalk.blue(editDir), 'file://' + editDir, { fallback: false })}
 
 To commit your changes, run:
 


### PR DESCRIPTION
The following are the results before and after the modification in an environment that does not support terminalLink :
|before|after|
|---|----|
|![image](https://github.com/user-attachments/assets/10dc1cc9-d055-4ce0-a38f-e79dbb2a62f0)|![image](https://github.com/user-attachments/assets/1612620e-361e-4f1f-b7c4-c44f17887a05)|