### PR TITLE
Prevent 'pnpm audit' from crashing with an OOM error by disabling the finding of dependency paths unless opted into

### DIFF
--- a/.changeset/stale-impalas-marry.md
+++ b/.changeset/stale-impalas-marry.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-audit": major
+"@pnpm/audit": major
+"pnpm": patch
+---
+
+Remove dependency paths from audit output to prevent out-of-memory errors [#9280](https://github.com/pnpm/pnpm/issues/9280).

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -34,7 +34,6 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/fetch": "workspace:*",
     "@pnpm/fetching-types": "workspace:*",
-    "@pnpm/list": "workspace:*",
     "@pnpm/lockfile.detect-dep-types": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/lockfile.utils": "workspace:*",

--- a/lockfile/audit/src/index.ts
+++ b/lockfile/audit/src/index.ts
@@ -23,6 +23,7 @@ export async function audit (
     registry: string
     retry?: RetryTimeoutOptions
     timeout?: number
+    showPaths?: boolean
     virtualStoreDirMaxLength: number
   }
 ): Promise<AuditReport> {
@@ -52,12 +53,16 @@ export async function audit (
   }
   const auditReport = await (res.json() as Promise<AuditReport>)
   try {
-    return await extendWithDependencyPaths(auditReport, {
-      lockfile,
-      lockfileDir: opts.lockfileDir,
-      include: opts.include,
-      virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
-    })
+    if (opts.showPaths) {
+      return await extendWithDependencyPaths(auditReport, {
+        lockfile,
+        lockfileDir: opts.lockfileDir,
+        include: opts.include,
+        virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+      })
+    }
+
+    return auditReport
   } catch (err: unknown) {
     assert(util.types.isNativeError(err))
     globalWarn(`Failed to extend audit report with dependency paths: ${err.message}`)

--- a/lockfile/audit/src/index.ts
+++ b/lockfile/audit/src/index.ts
@@ -45,7 +45,7 @@ export async function audit (
   if (res.status !== 200) {
     throw new PnpmError('AUDIT_BAD_RESPONSE', `The audit endpoint (at ${auditUrl}) responded with ${res.status}: ${await res.text()}`)
   }
-  return await (res.json() as Promise<AuditReport>)
+  return (res.json() as Promise<AuditReport>)
 }
 
 interface AuthHeaders {

--- a/lockfile/audit/src/index.ts
+++ b/lockfile/audit/src/index.ts
@@ -1,15 +1,10 @@
-import assert from 'assert'
-import path from 'path'
-import util from 'util'
 import { PnpmError } from '@pnpm/error'
 import { type AgentOptions, fetchWithAgent, type RetryTimeoutOptions } from '@pnpm/fetch'
 import { type GetAuthHeader } from '@pnpm/fetching-types'
 import { type LockfileObject } from '@pnpm/lockfile.types'
-import { globalWarn } from '@pnpm/logger'
 import { type DependenciesField } from '@pnpm/types'
 import { lockfileToAuditTree } from './lockfileToAuditTree'
 import { type AuditReport } from './types'
-import { searchForPackages, flattenSearchedPackages } from '@pnpm/list'
 
 export * from './types'
 
@@ -23,7 +18,6 @@ export async function audit (
     registry: string
     retry?: RetryTimeoutOptions
     timeout?: number
-    showPaths?: boolean
     virtualStoreDirMaxLength: number
   }
 ): Promise<AuditReport> {
@@ -51,23 +45,7 @@ export async function audit (
   if (res.status !== 200) {
     throw new PnpmError('AUDIT_BAD_RESPONSE', `The audit endpoint (at ${auditUrl}) responded with ${res.status}: ${await res.text()}`)
   }
-  const auditReport = await (res.json() as Promise<AuditReport>)
-  try {
-    if (opts.showPaths) {
-      return await extendWithDependencyPaths(auditReport, {
-        lockfile,
-        lockfileDir: opts.lockfileDir,
-        include: opts.include,
-        virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
-      })
-    }
-
-    return auditReport
-  } catch (err: unknown) {
-    assert(util.types.isNativeError(err))
-    globalWarn(`Failed to extend audit report with dependency paths: ${err.message}`)
-    return auditReport
-  }
+  return await (res.json() as Promise<AuditReport>)
 }
 
 interface AuthHeaders {
@@ -80,46 +58,6 @@ function getAuthHeaders (authHeaderValue: string | undefined): AuthHeaders {
     headers['authorization'] = authHeaderValue
   }
   return headers
-}
-
-async function extendWithDependencyPaths (auditReport: AuditReport, opts: {
-  lockfile: LockfileObject
-  lockfileDir: string
-  include?: { [dependenciesField in DependenciesField]: boolean }
-  virtualStoreDirMaxLength: number
-}): Promise<AuditReport> {
-  const { advisories } = auditReport
-  if (!Object.keys(advisories).length) return auditReport
-  const projectDirs = Object.keys(opts.lockfile.importers)
-    .map((importerId) => path.join(opts.lockfileDir, importerId))
-  const searchOpts = {
-    lockfileDir: opts.lockfileDir,
-    depth: Infinity,
-    include: opts.include,
-    virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
-  }
-  const _searchPackagePaths = searchPackagePaths.bind(null, searchOpts, projectDirs)
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  await Promise.all(Object.values(advisories).map(async ({ findings, module_name }) => {
-    await Promise.all(findings.map(async (finding) => {
-      finding.paths = await _searchPackagePaths(`${module_name}@${finding.version}`)
-    }))
-  }))
-  return auditReport
-}
-
-async function searchPackagePaths (
-  searchOpts: {
-    lockfileDir: string
-    depth: number
-    include?: { [dependenciesField in DependenciesField]: boolean }
-    virtualStoreDirMaxLength: number
-  },
-  projectDirs: string[],
-  pkg: string
-): Promise<string[]> {
-  const pkgs = await searchForPackages([pkg], projectDirs, searchOpts)
-  return flattenSearchedPackages(pkgs, { lockfileDir: searchOpts.lockfileDir }).map(({ depPath }) => depPath)
 }
 
 export class AuditEndpointNotExistsError extends PnpmError {

--- a/lockfile/audit/tsconfig.json
+++ b/lockfile/audit/tsconfig.json
@@ -34,9 +34,6 @@
       "path": "../../pkg-manifest/read-project-manifest"
     },
     {
-      "path": "../../reviewing/list"
-    },
-    {
       "path": "../detect-dep-types"
     },
     {

--- a/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
+++ b/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
@@ -10,9 +10,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-72mh-269x-7mh5      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -25,7 +24,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-48ww-j4fc-435p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -38,8 +37,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5          │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>cryptiles           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rq8g-5pc5-wrhr      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -52,9 +50,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.1.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4c7m-wxvm-r7gc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -67,9 +64,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.2                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cph5-m8f7-6c5x      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -83,8 +78,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-5955-9wpr-37jh      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -99,8 +93,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-qq89-hq3f-393p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -115,8 +108,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9r2w-394v-53qc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -129,9 +121,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0                                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9j49-mfvp-vmhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -144,11 +135,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=3.3.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > socket.io-parser@3.1.3        │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-parser@3.1.3                                 │
+│ Paths               │ .>karma>socket.io>socket.io-parser                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xfhh-g9f5-x4m4      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -161,9 +148,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-h4j5-c7cj-74xg      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -176,19 +162,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.12.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-direct-transport@3.3.2 >                    │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-pool@2.8.2 > smtp-connection@2.12.0 >  │
-│                     │ httpntlm@1.6.1 > underscore@1.7.0                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-transport@2.7.2 >                      │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
+│ Paths               │ .>karma>log4js>nodemailer>nodemailer-direct-           │
+│                     │ transport>smtp-connection>httpntlm>underscore          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cf4h-3jhx-xvhq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -201,8 +176,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9m6j-fcg5-2442      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -215,9 +189,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4w2v-q235-vp99      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -230,8 +202,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.2.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > bl@1.1.2                              │
+│ Paths               │ .>karma>log4js>loggly>request>bl                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pp7h-53gx-mx7r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -244,7 +215,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > http-proxy@1.18.0                    │
+│ Paths               │ .>karma>http-proxy                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6x33-pw7p-hmpq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -257,25 +228,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.0.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 >   │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-data-descriptor@1.0.0 >       │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > kind-of@6.0.2                    │
-│                     │                                                        │
-│                     │ ... Found 97 paths, run \`pnpm why kind-of\` for more    │
-│                     │ information                                            │
+│ Paths               │ .>karma>chokidar>anymatch>micromatch>kind-of           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6c8f-qphg-qjgp      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -288,9 +241,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-42xw-2xvc-qx8m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -303,13 +254,9 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.7                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-74fj-2j2h-c42q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -322,7 +269,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > glob-parent@3.1.0   │
+│ Paths               │ .>karma>chokidar>glob-parent                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-ww39-953v-wcq6      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -335,15 +282,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-35jh-r3h4-6jhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -356,15 +295,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.19                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-p6mc-m468-83gw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -377,7 +308,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 > engine.io@3.1.5    │
+│ Paths               │ .>karma>socket.io>engine.io                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-j4f2-536g-r55m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -390,8 +321,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.6                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rqff-837h-mm52      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -404,9 +334,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > har-validator@2.0.6 >                 │
-│                     │ is-my-json-valid@2.20.0 > jsonpointer@4.0.1            │
+│ Paths               │ .>karma>log4js>loggly>request>har-validator>is-my-     │
+│                     │ json-valid>jsonpointer                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-282f-qqgm-c34q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -419,8 +348,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hh27-ffr2-f2jc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -433,9 +361,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.0.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pch5-whg9-qr2r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -449,7 +376,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4                      │
+│ Paths               │ .>karma>socket.io                                      │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-fxwf-4rqh-v8g3      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -462,7 +389,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > sync-exec@0.6.2                                    │
+│ Paths               │ .>sync-exec                                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-38h8-x697-gh8q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -475,18 +402,9 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > mkdirp@0.5.1 > minimist@0.0.8    │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>mkdirp>minimist │
 │                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15 > mkdirp@0.5.1 >      │
-│                     │ minimist@0.0.8                                         │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > streamroller@0.7.0 > │
-│                     │ mkdirp@0.5.1 > minimist@0.0.8                          │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why minimist\` for more    │
-│                     │ information                                            │
+│                     │ .>karma>optimist>minimist                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-vh95-rmgr-6w4m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -499,8 +417,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.6.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > tunnel-agent@0.4.3                    │
+│ Paths               │ .>karma>log4js>loggly>request>tunnel-agent             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xc7v-wxcw-j472      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -513,19 +430,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > boom@2.10.1 >            │
-│                     │ hoek@2.16.3                                            │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5 >        │
-│                     │ boom@2.10.1 > hoek@2.16.3                              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > hoek@2.16.3              │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why hoek\` for more        │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>hoek                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-jp4x-w63m-7wgm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -538,22 +443,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > http-signature@1.1.1 > jsprim@1.4.1 > │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why json-schema\` for more │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>http-          │
+│                     │ signature>jsprim>json-schema                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-896r-f27r-55mw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -566,7 +457,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hwqf-gcqm-7353      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -579,7 +470,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0                        │
+│ Paths               │ .>karma>log4js                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-82v2-mx6x-wq7q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -592,15 +483,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-29mw-wpgm-hmr9      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -613,7 +496,7 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.3.14                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5                                        │
+│ Paths               │ .>karma                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-7x7c-qm48-pq9c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -626,16 +509,8 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.12.3                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 >   │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>har-           │
+│                     │ validator>ajv                                          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-v88g-cgmw-v5xw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -649,13 +524,9 @@ exports[`plugin-commands-audit audit --audit-level 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.8                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -673,7 +544,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.2                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cph5-m8f7-6c5x      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -686,7 +557,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4w2v-q235-vp99      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -699,7 +570,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-42xw-2xvc-qx8m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -712,7 +583,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.7                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > axios@0.15.3 > follow-redirects@1.0.0              │
+│ Paths               │ .>axios>follow-redirects                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-74fj-2j2h-c42q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -725,7 +596,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > sync-exec@0.6.2                                    │
+│ Paths               │ .>sync-exec                                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-38h8-x697-gh8q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -739,7 +610,7 @@ exports[`plugin-commands-audit audit --dev 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.8                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > axios@0.15.3 > follow-redirects@1.0.0              │
+│ Paths               │ .>axios>follow-redirects                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -757,9 +628,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-72mh-269x-7mh5      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -772,7 +642,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-48ww-j4fc-435p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -785,8 +655,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5          │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>cryptiles           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rq8g-5pc5-wrhr      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -799,9 +668,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.1.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4c7m-wxvm-r7gc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -814,9 +682,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.2                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cph5-m8f7-6c5x      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -830,8 +696,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-5955-9wpr-37jh      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -846,8 +711,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-qq89-hq3f-393p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -862,8 +726,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9r2w-394v-53qc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -876,9 +739,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0                                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9j49-mfvp-vmhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -891,11 +753,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=3.3.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > socket.io-parser@3.1.3        │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-parser@3.1.3                                 │
+│ Paths               │ .>karma>socket.io>socket.io-parser                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xfhh-g9f5-x4m4      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -908,9 +766,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-h4j5-c7cj-74xg      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -923,19 +780,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.12.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-direct-transport@3.3.2 >                    │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-pool@2.8.2 > smtp-connection@2.12.0 >  │
-│                     │ httpntlm@1.6.1 > underscore@1.7.0                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-transport@2.7.2 >                      │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
+│ Paths               │ .>karma>log4js>nodemailer>nodemailer-direct-           │
+│                     │ transport>smtp-connection>httpntlm>underscore          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cf4h-3jhx-xvhq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -948,8 +794,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9m6j-fcg5-2442      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -962,9 +807,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.21.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4w2v-q235-vp99      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -977,8 +820,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.2.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > bl@1.1.2                              │
+│ Paths               │ .>karma>log4js>loggly>request>bl                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pp7h-53gx-mx7r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -991,7 +833,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > http-proxy@1.18.0                    │
+│ Paths               │ .>karma>http-proxy                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6x33-pw7p-hmpq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1004,25 +846,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.0.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 >   │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-data-descriptor@1.0.0 >       │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > kind-of@6.0.2                    │
-│                     │                                                        │
-│                     │ ... Found 97 paths, run \`pnpm why kind-of\` for more    │
-│                     │ information                                            │
+│ Paths               │ .>karma>chokidar>anymatch>micromatch>kind-of           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6c8f-qphg-qjgp      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1035,9 +859,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3         │
-│                     │                                                        │
-│                     │ . > axios@0.15.3                                       │
+│ Paths               │ .>axios                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-42xw-2xvc-qx8m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1050,13 +872,9 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.7                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-74fj-2j2h-c42q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1069,7 +887,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > glob-parent@3.1.0   │
+│ Paths               │ .>karma>chokidar>glob-parent                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-ww39-953v-wcq6      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1082,15 +900,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-35jh-r3h4-6jhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1103,15 +913,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.19                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-p6mc-m468-83gw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1124,7 +926,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 > engine.io@3.1.5    │
+│ Paths               │ .>karma>socket.io>engine.io                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-j4f2-536g-r55m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1137,8 +939,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.6                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rqff-837h-mm52      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1151,9 +952,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > har-validator@2.0.6 >                 │
-│                     │ is-my-json-valid@2.20.0 > jsonpointer@4.0.1            │
+│ Paths               │ .>karma>log4js>loggly>request>har-validator>is-my-     │
+│                     │ json-valid>jsonpointer                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-282f-qqgm-c34q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1166,8 +966,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hh27-ffr2-f2jc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1180,9 +979,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.0.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pch5-whg9-qr2r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1196,7 +994,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4                      │
+│ Paths               │ .>karma>socket.io                                      │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-fxwf-4rqh-v8g3      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1209,7 +1007,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > sync-exec@0.6.2                                    │
+│ Paths               │ .>sync-exec                                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-38h8-x697-gh8q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1222,18 +1020,9 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > mkdirp@0.5.1 > minimist@0.0.8    │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>mkdirp>minimist │
 │                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15 > mkdirp@0.5.1 >      │
-│                     │ minimist@0.0.8                                         │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > streamroller@0.7.0 > │
-│                     │ mkdirp@0.5.1 > minimist@0.0.8                          │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why minimist\` for more    │
-│                     │ information                                            │
+│                     │ .>karma>optimist>minimist                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-vh95-rmgr-6w4m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1246,8 +1035,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.6.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > tunnel-agent@0.4.3                    │
+│ Paths               │ .>karma>log4js>loggly>request>tunnel-agent             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xc7v-wxcw-j472      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1260,19 +1048,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > boom@2.10.1 >            │
-│                     │ hoek@2.16.3                                            │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5 >        │
-│                     │ boom@2.10.1 > hoek@2.16.3                              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > hoek@2.16.3              │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why hoek\` for more        │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>hoek                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-jp4x-w63m-7wgm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1285,22 +1061,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > http-signature@1.1.1 > jsprim@1.4.1 > │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why json-schema\` for more │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>http-          │
+│                     │ signature>jsprim>json-schema                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-896r-f27r-55mw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1313,7 +1075,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hwqf-gcqm-7353      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1326,7 +1088,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0                        │
+│ Paths               │ .>karma>log4js                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-82v2-mx6x-wq7q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1339,15 +1101,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-29mw-wpgm-hmr9      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1360,7 +1114,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.3.14                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5                                        │
+│ Paths               │ .>karma                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-7x7c-qm48-pq9c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1373,16 +1127,8 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.12.3                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 >   │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>har-           │
+│                     │ validator>ajv                                          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-v88g-cgmw-v5xw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1396,13 +1142,9 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.8                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1415,7 +1157,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=3.1.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > redis@2.8.0          │
+│ Paths               │ .>karma>log4js>redis                                   │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-35q2-47q7-3pc3      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1428,8 +1170,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ timespan@2.3.0                                         │
+│ Paths               │ .>karma>log4js>loggly>timespan                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-f523-2f5j-gfcg      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1442,7 +1183,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.3.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > expand-braces@0.1.2 > braces@0.1.5   │
+│ Paths               │ .>karma>expand-braces>braces                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-g95f-p29q-9xw4      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1455,7 +1196,7 @@ exports[`plugin-commands-audit audit 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.3.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > expand-braces@0.1.2 > braces@0.1.5   │
+│ Paths               │ .>karma>expand-braces>braces                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cwfw-4gq5-mrqx      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1473,9 +1214,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-72mh-269x-7mh5      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1488,7 +1228,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-48ww-j4fc-435p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1501,8 +1241,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5          │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>cryptiles           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rq8g-5pc5-wrhr      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1515,9 +1254,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.1.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4c7m-wxvm-r7gc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1531,8 +1269,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-5955-9wpr-37jh      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1547,8 +1284,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-qq89-hq3f-393p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1563,8 +1299,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9r2w-394v-53qc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1577,9 +1312,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0                                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9j49-mfvp-vmhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1592,11 +1326,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=3.3.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > socket.io-parser@3.1.3        │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-parser@3.1.3                                 │
+│ Paths               │ .>karma>socket.io>socket.io-parser                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xfhh-g9f5-x4m4      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1609,9 +1339,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-h4j5-c7cj-74xg      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1624,19 +1353,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.12.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-direct-transport@3.3.2 >                    │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-pool@2.8.2 > smtp-connection@2.12.0 >  │
-│                     │ httpntlm@1.6.1 > underscore@1.7.0                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-transport@2.7.2 >                      │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
+│ Paths               │ .>karma>log4js>nodemailer>nodemailer-direct-           │
+│                     │ transport>smtp-connection>httpntlm>underscore          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cf4h-3jhx-xvhq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1649,8 +1367,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9m6j-fcg5-2442      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1663,8 +1380,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.2.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > bl@1.1.2                              │
+│ Paths               │ .>karma>log4js>loggly>request>bl                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pp7h-53gx-mx7r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1677,7 +1393,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > http-proxy@1.18.0                    │
+│ Paths               │ .>karma>http-proxy                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6x33-pw7p-hmpq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1690,25 +1406,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.0.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 >   │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-data-descriptor@1.0.0 >       │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > kind-of@6.0.2                    │
-│                     │                                                        │
-│                     │ ... Found 97 paths, run \`pnpm why kind-of\` for more    │
-│                     │ information                                            │
+│ Paths               │ .>karma>chokidar>anymatch>micromatch>kind-of           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6c8f-qphg-qjgp      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1721,13 +1419,9 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.7                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-74fj-2j2h-c42q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1740,7 +1434,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > glob-parent@3.1.0   │
+│ Paths               │ .>karma>chokidar>glob-parent                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-ww39-953v-wcq6      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1753,15 +1447,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-35jh-r3h4-6jhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1774,15 +1460,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.19                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-p6mc-m468-83gw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1795,7 +1473,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 > engine.io@3.1.5    │
+│ Paths               │ .>karma>socket.io>engine.io                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-j4f2-536g-r55m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1808,8 +1486,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.6                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rqff-837h-mm52      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1822,9 +1499,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > har-validator@2.0.6 >                 │
-│                     │ is-my-json-valid@2.20.0 > jsonpointer@4.0.1            │
+│ Paths               │ .>karma>log4js>loggly>request>har-validator>is-my-     │
+│                     │ json-valid>jsonpointer                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-282f-qqgm-c34q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1837,8 +1513,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hh27-ffr2-f2jc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1851,9 +1526,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.0.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pch5-whg9-qr2r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1867,7 +1541,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4                      │
+│ Paths               │ .>karma>socket.io                                      │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-fxwf-4rqh-v8g3      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1880,7 +1554,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > sync-exec@0.6.2                                    │
+│ Paths               │ .>sync-exec                                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-38h8-x697-gh8q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1893,8 +1567,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.6.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > tunnel-agent@0.4.3                    │
+│ Paths               │ .>karma>log4js>loggly>request>tunnel-agent             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xc7v-wxcw-j472      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1907,19 +1580,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > boom@2.10.1 >            │
-│                     │ hoek@2.16.3                                            │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5 >        │
-│                     │ boom@2.10.1 > hoek@2.16.3                              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > hoek@2.16.3              │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why hoek\` for more        │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>hoek                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-jp4x-w63m-7wgm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1932,22 +1593,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > http-signature@1.1.1 > jsprim@1.4.1 > │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why json-schema\` for more │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>http-          │
+│                     │ signature>jsprim>json-schema                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-896r-f27r-55mw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1960,7 +1607,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hwqf-gcqm-7353      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1973,7 +1620,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0                        │
+│ Paths               │ .>karma>log4js                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-82v2-mx6x-wq7q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -1986,15 +1633,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-29mw-wpgm-hmr9      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -2007,7 +1646,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.3.14                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5                                        │
+│ Paths               │ .>karma                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-7x7c-qm48-pq9c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -2020,16 +1659,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.12.3                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 >   │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>har-           │
+│                     │ validator>ajv                                          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-v88g-cgmw-v5xw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -2043,13 +1674,9 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.8                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -2585,7 +2212,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.0.1",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > har-validator@2.0.6 > is-my-json-valid@2.20.0 > jsonpointer@4.0.1"
+            ".>karma>log4js>loggly>request>har-validator>is-my-json-valid>jsonpointer"
           ]
         }
       ],
@@ -2618,7 +2245,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.4.15",
           "paths": [
-            ". > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 > node-pre-gyp@0.12.0 > tar@4.4.15"
+            ".>karma>chokidar>fsevents>node-pre-gyp>tar"
           ]
         }
       ],
@@ -2651,7 +2278,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.4.15",
           "paths": [
-            ". > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 > node-pre-gyp@0.12.0 > tar@4.4.15"
+            ".>karma>chokidar>fsevents>node-pre-gyp>tar"
           ]
         }
       ],
@@ -2684,7 +2311,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.4.15",
           "paths": [
-            ". > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 > node-pre-gyp@0.12.0 > tar@4.4.15"
+            ".>karma>chokidar>fsevents>node-pre-gyp>tar"
           ]
         }
       ],
@@ -2717,7 +2344,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "3.0.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 > pac-resolver@3.0.0"
+            ".>karma>log4js>mailgun-js>proxy-agent>pac-proxy-agent>pac-resolver"
           ]
         }
       ],
@@ -2750,7 +2377,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.4.7",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 > url-parse@1.4.7"
+            ".>karma>log4js>amqplib>url-parse"
           ]
         }
       ],
@@ -2783,8 +2410,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "3.1.3",
           "paths": [
-            ". > karma@2.0.5 > socket.io@2.0.4 > socket.io-client@2.0.4 > socket.io-parser@3.1.3",
-            ". > karma@2.0.5 > socket.io@2.0.4 > socket.io-parser@3.1.3"
+            ".>karma>socket.io>socket.io-parser"
           ]
         }
       ],
@@ -2817,7 +2443,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.5.5",
           "paths": [
-            ". > karma@2.0.5 > socket.io@2.0.4 > socket.io-client@2.0.4 > engine.io-client@3.1.6 > xmlhttprequest-ssl@1.5.5"
+            ".>karma>socket.io>socket.io-client>engine.io-client>xmlhttprequest-ssl"
           ]
         }
       ],
@@ -2850,7 +2476,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.5.5",
           "paths": [
-            ". > karma@2.0.5 > socket.io@2.0.4 > socket.io-client@2.0.4 > engine.io-client@3.1.6 > xmlhttprequest-ssl@1.5.5"
+            ".>karma>socket.io>socket.io-client>engine.io-client>xmlhttprequest-ssl"
           ]
         }
       ],
@@ -2883,7 +2509,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.8.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > redis@2.8.0"
+            ".>karma>log4js>redis"
           ]
         }
       ],
@@ -2916,7 +2542,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.7.2",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2"
+            ".>karma>log4js>nodemailer"
           ]
         }
       ],
@@ -2949,9 +2575,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.7.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 > nodemailer-direct-transport@3.3.2 > smtp-connection@2.12.0 > httpntlm@1.6.1 > underscore@1.7.0",
-            ". > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 > nodemailer-smtp-pool@2.8.2 > smtp-connection@2.12.0 > httpntlm@1.6.1 > underscore@1.7.0",
-            ". > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 > nodemailer-smtp-transport@2.7.2 > smtp-connection@2.12.0 > httpntlm@1.6.1 > underscore@1.7.0"
+            ".>karma>log4js>nodemailer>nodemailer-direct-transport>smtp-connection>httpntlm>underscore"
           ]
         }
       ],
@@ -2984,7 +2608,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.0.6",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 > pac-resolver@3.0.0 > netmask@1.0.6"
+            ".>karma>log4js>mailgun-js>proxy-agent>pac-proxy-agent>pac-resolver>netmask"
           ]
         }
       ],
@@ -3017,7 +2641,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.4.7",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 > url-parse@1.4.7"
+            ".>karma>log4js>amqplib>url-parse"
           ]
         }
       ],
@@ -3050,7 +2674,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.0.4",
           "paths": [
-            ". > karma@2.0.5 > socket.io@2.0.4"
+            ".>karma>socket.io"
           ]
         }
       ],
@@ -3083,7 +2707,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.1.2",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > bl@1.1.2"
+            ".>karma>log4js>loggly>request>bl"
           ]
         }
       ],
@@ -3116,7 +2740,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.18.0",
           "paths": [
-            ". > karma@2.0.5 > http-proxy@1.18.0"
+            ".>karma>http-proxy"
           ]
         }
       ],
@@ -3147,7 +2771,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.3.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > timespan@2.3.0"
+            ".>karma>log4js>loggly>timespan"
           ]
         }
       ],
@@ -3180,7 +2804,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "0.6.2",
           "paths": [
-            ". > sync-exec@0.6.2"
+            ".>sync-exec"
           ]
         }
       ],
@@ -3213,103 +2837,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "6.0.2",
           "paths": [
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > snapdragon-node@2.1.1 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > braces@2.3.2 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > expand-brackets@2.1.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > extglob@2.0.4 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > nanomatch@1.2.13 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > define-property@1.0.0 > is-descriptor@1.0.2 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > is-data-descriptor@1.0.0 > kind-of@6.0.2",
-            ". > karma@2.0.5 > chokidar@2.1.8 > readdirp@2.2.1 > micromatch@3.1.10 > to-regex@3.0.2 > define-property@2.0.2 > is-descriptor@1.0.2 > kind-of@6.0.2"
+            ".>karma>chokidar>anymatch>micromatch>kind-of"
           ]
         }
       ],
@@ -3342,7 +2870,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "0.1.5",
           "paths": [
-            ". > karma@2.0.5 > expand-braces@0.1.2 > braces@0.1.5"
+            ".>karma>expand-braces>braces"
           ]
         }
       ],
@@ -3373,7 +2901,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "0.4.3",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > tunnel-agent@0.4.3"
+            ".>karma>log4js>loggly>request>tunnel-agent"
           ]
         }
       ],
@@ -3404,7 +2932,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.0.5",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5"
+            ".>karma>log4js>loggly>request>hawk>cryptiles"
           ]
         }
       ],
@@ -3437,10 +2965,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.16.3",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > hawk@3.1.3 > boom@2.10.1 > hoek@2.16.3",
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5 > boom@2.10.1 > hoek@2.16.3",
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > hawk@3.1.3 > hoek@2.16.3",
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > hawk@3.1.3 > sntp@1.0.9 > hoek@2.16.3"
+            ".>karma>log4js>loggly>request>hawk>hoek"
           ]
         }
       ],
@@ -3473,10 +2998,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "0.2.3",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > hipchat-notifier@1.1.0 > request@2.88.0 > http-signature@1.2.0 > jsprim@1.4.1 > json-schema@0.2.3",
-            ". > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 > request@2.75.0 > http-signature@1.1.1 > jsprim@1.4.1 > json-schema@0.2.3",
-            ". > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 > requestretry@1.13.0 > request@2.88.0 > http-signature@1.2.0 > jsprim@1.4.1 > json-schema@0.2.3",
-            ". > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 > http-signature@1.2.0 > jsprim@1.4.1 > json-schema@0.2.3"
+            ".>karma>log4js>hipchat-notifier>request>http-signature>jsprim>json-schema"
           ]
         }
       ],
@@ -3509,7 +3031,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.7.2",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2"
+            ".>karma>log4js>nodemailer"
           ]
         }
       ],
@@ -3542,7 +3064,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.0.6",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 > pac-resolver@3.0.0 > netmask@1.0.6"
+            ".>karma>log4js>mailgun-js>proxy-agent>pac-proxy-agent>pac-resolver>netmask"
           ]
         }
       ],
@@ -3575,7 +3097,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "0.1.5",
           "paths": [
-            ". > karma@2.0.5 > expand-braces@0.1.2 > braces@0.1.5"
+            ".>karma>expand-braces>braces"
           ]
         }
       ],
@@ -3608,14 +3130,13 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.0.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 > follow-redirects@1.0.0",
-            ". > axios@0.15.3 > follow-redirects@1.0.0"
+            ".>axios>follow-redirects"
           ]
         },
         {
           "version": "1.9.0",
           "paths": [
-            ". > karma@2.0.5 > http-proxy@1.18.0 > follow-redirects@1.9.0"
+            ".>karma>http-proxy>follow-redirects"
           ]
         }
       ],
@@ -3648,7 +3169,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.11.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0"
+            ".>karma>log4js"
           ]
         }
       ],
@@ -3681,7 +3202,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "3.1.0",
           "paths": [
-            ". > karma@2.0.5 > chokidar@2.1.8 > glob-parent@3.1.0"
+            ".>karma>chokidar>glob-parent"
           ]
         }
       ],
@@ -3714,11 +3235,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.17.15",
           "paths": [
-            ". > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15",
-            ". > karma@2.0.5 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > hipchat-notifier@1.1.0 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > async@2.6.3 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 > requestretry@1.13.0 > lodash@4.17.15"
+            ".>karma>lodash"
           ]
         }
       ],
@@ -3751,11 +3268,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.17.15",
           "paths": [
-            ". > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15",
-            ". > karma@2.0.5 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > hipchat-notifier@1.1.0 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > async@2.6.3 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 > requestretry@1.13.0 > lodash@4.17.15"
+            ".>karma>lodash"
           ]
         }
       ],
@@ -3788,11 +3301,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "4.17.15",
           "paths": [
-            ". > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15",
-            ". > karma@2.0.5 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > hipchat-notifier@1.1.0 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 > async@2.6.3 > lodash@4.17.15",
-            ". > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 > requestretry@1.13.0 > lodash@4.17.15"
+            ".>karma>lodash"
           ]
         }
       ],
@@ -3825,7 +3334,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "3.1.5",
           "paths": [
-            ". > karma@2.0.5 > socket.io@2.0.4 > engine.io@3.1.5"
+            ".>karma>socket.io>engine.io"
           ]
         }
       ],
@@ -3858,7 +3367,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "2.0.5",
           "paths": [
-            ". > karma@2.0.5"
+            ".>karma"
           ]
         }
       ],
@@ -3891,9 +3400,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "6.10.2",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > hipchat-notifier@1.1.0 > request@2.88.0 > har-validator@5.1.3 > ajv@6.10.2",
-            ". > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 > requestretry@1.13.0 > request@2.88.0 > har-validator@5.1.3 > ajv@6.10.2",
-            ". > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 > har-validator@5.1.3 > ajv@6.10.2"
+            ".>karma>log4js>hipchat-notifier>request>har-validator>ajv"
           ]
         }
       ],
@@ -3926,14 +3433,13 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.0.0",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 > follow-redirects@1.0.0",
-            ". > axios@0.15.3 > follow-redirects@1.0.0"
+            ".>axios>follow-redirects"
           ]
         },
         {
           "version": "1.9.0",
           "paths": [
-            ". > karma@2.0.5 > http-proxy@1.18.0 > follow-redirects@1.9.0"
+            ".>karma>http-proxy>follow-redirects"
           ]
         }
       ],
@@ -3966,7 +3472,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSO
         {
           "version": "1.4.7",
           "paths": [
-            ". > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 > url-parse@1.4.7"
+            ".>karma>log4js>amqplib>url-parse"
           ]
         }
       ],
@@ -4022,9 +3528,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-72mh-269x-7mh5      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4037,7 +3542,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-48ww-j4fc-435p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4050,8 +3555,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5          │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>cryptiles           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rq8g-5pc5-wrhr      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4064,9 +3568,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.1.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-4c7m-wxvm-r7gc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4080,8 +3583,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-5955-9wpr-37jh      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4096,8 +3598,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.18                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-qq89-hq3f-393p      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4112,8 +3613,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.4.16                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > fsevents@1.2.9 >    │
-│                     │ node-pre-gyp@0.12.0 > tar@4.4.15                       │
+│ Paths               │ .>karma>chokidar>fsevents>node-pre-gyp>tar             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9r2w-394v-53qc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4126,9 +3626,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0                                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9j49-mfvp-vmhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4141,11 +3640,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=3.3.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > socket.io-parser@3.1.3        │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-parser@3.1.3                                 │
+│ Paths               │ .>karma>socket.io>socket.io-parser                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xfhh-g9f5-x4m4      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4158,9 +3653,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.6.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 >                    │
-│                     │ socket.io-client@2.0.4 > engine.io-client@3.1.6 >      │
-│                     │ xmlhttprequest-ssl@1.5.5                               │
+│ Paths               │ .>karma>socket.io>socket.io-client>engine.io-          │
+│                     │ client>xmlhttprequest-ssl                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-h4j5-c7cj-74xg      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4173,19 +3667,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.12.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-direct-transport@3.3.2 >                    │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-pool@2.8.2 > smtp-connection@2.12.0 >  │
-│                     │ httpntlm@1.6.1 > underscore@1.7.0                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2 >   │
-│                     │ nodemailer-smtp-transport@2.7.2 >                      │
-│                     │ smtp-connection@2.12.0 > httpntlm@1.6.1 >              │
-│                     │ underscore@1.7.0                                       │
+│ Paths               │ .>karma>log4js>nodemailer>nodemailer-direct-           │
+│                     │ transport>smtp-connection>httpntlm>underscore          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-cf4h-3jhx-xvhq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4198,8 +3681,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-9m6j-fcg5-2442      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4212,8 +3694,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.2.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > bl@1.1.2                              │
+│ Paths               │ .>karma>log4js>loggly>request>bl                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pp7h-53gx-mx7r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4226,7 +3707,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.18.1                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > http-proxy@1.18.0                    │
+│ Paths               │ .>karma>http-proxy                                     │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6x33-pw7p-hmpq      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4239,25 +3720,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.0.3                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-accessor-descriptor@1.0.0 >   │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > is-data-descriptor@1.0.0 >       │
-│                     │ kind-of@6.0.2                                          │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > chokidar@2.1.8 > anymatch@2.0.0 >    │
-│                     │ micromatch@3.1.10 > braces@2.3.2 > snapdragon@0.8.2 >  │
-│                     │ base@0.11.2 > define-property@1.0.0 >                  │
-│                     │ is-descriptor@1.0.2 > kind-of@6.0.2                    │
-│                     │                                                        │
-│                     │ ... Found 97 paths, run \`pnpm why kind-of\` for more    │
-│                     │ information                                            │
+│ Paths               │ .>karma>chokidar>anymatch>micromatch>kind-of           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-6c8f-qphg-qjgp      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4270,13 +3733,9 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.7                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-74fj-2j2h-c42q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4289,7 +3748,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.1.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > chokidar@2.1.8 > glob-parent@3.1.0   │
+│ Paths               │ .>karma>chokidar>glob-parent                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-ww39-953v-wcq6      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4302,15 +3761,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-35jh-r3h4-6jhm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4323,15 +3774,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.19                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-p6mc-m468-83gw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4344,7 +3787,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4 > engine.io@3.1.5    │
+│ Paths               │ .>karma>socket.io>engine.io                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-j4f2-536g-r55m      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4357,8 +3800,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.6                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-rqff-837h-mm52      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4371,9 +3813,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=5.0.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > har-validator@2.0.6 >                 │
-│                     │ is-my-json-valid@2.20.0 > jsonpointer@4.0.1            │
+│ Paths               │ .>karma>log4js>loggly>request>har-validator>is-my-     │
+│                     │ json-valid>jsonpointer                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-282f-qqgm-c34q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4386,8 +3827,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.5.2                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > amqplib@0.5.5 >      │
-│                     │ url-parse@1.4.7                                        │
+│ Paths               │ .>karma>log4js>amqplib>url-parse                       │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hh27-ffr2-f2jc      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4400,9 +3840,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.0.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > mailgun-js@0.18.1 >  │
-│                     │ proxy-agent@3.0.3 > pac-proxy-agent@3.0.1 >            │
-│                     │ pac-resolver@3.0.0 > netmask@1.0.6                     │
+│ Paths               │ .>karma>log4js>mailgun-js>proxy-agent>pac-proxy-       │
+│                     │ agent>pac-resolver>netmask                             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pch5-whg9-qr2r      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4416,7 +3855,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=2.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > socket.io@2.0.4                      │
+│ Paths               │ .>karma>socket.io                                      │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-fxwf-4rqh-v8g3      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4429,7 +3868,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ <0.0.0                                                 │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > sync-exec@0.6.2                                    │
+│ Paths               │ .>sync-exec                                            │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-38h8-x697-gh8q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4442,8 +3881,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.6.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > tunnel-agent@0.4.3                    │
+│ Paths               │ .>karma>log4js>loggly>request>tunnel-agent             │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-xc7v-wxcw-j472      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4456,19 +3894,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.2.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > boom@2.10.1 >            │
-│                     │ hoek@2.16.3                                            │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > cryptiles@2.0.5 >        │
-│                     │ boom@2.10.1 > hoek@2.16.3                              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > hawk@3.1.3 > hoek@2.16.3              │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why hoek\` for more        │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>loggly>request>hawk>hoek                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-jp4x-w63m-7wgm      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4481,22 +3907,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=0.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > loggly@1.1.1 >       │
-│                     │ request@2.75.0 > http-signature@1.1.1 > jsprim@1.4.1 > │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ http-signature@1.2.0 > jsprim@1.4.1 >                  │
-│                     │ json-schema@0.2.3                                      │
-│                     │                                                        │
-│                     │ ... Found 4 paths, run \`pnpm why json-schema\` for more │
-│                     │ information                                            │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>http-          │
+│                     │ signature>jsprim>json-schema                           │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-896r-f27r-55mw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4509,7 +3921,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.6.1                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > nodemailer@2.7.2     │
+│ Paths               │ .>karma>log4js>nodemailer                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-hwqf-gcqm-7353      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4522,7 +3934,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.4.0                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0                        │
+│ Paths               │ .>karma>log4js                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-82v2-mx6x-wq7q      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4535,15 +3947,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=4.17.21                                              │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > combine-lists@1.0.1 > lodash@4.17.15 │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > lodash@4.17.15                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > lodash@4.17.15                │
-│                     │                                                        │
-│                     │ ... Found 5 paths, run \`pnpm why lodash\` for more      │
-│                     │ information                                            │
+│ Paths               │ .>karma>lodash                                         │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-29mw-wpgm-hmr9      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4556,7 +3960,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.3.14                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5                                        │
+│ Paths               │ .>karma                                                │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-7x7c-qm48-pq9c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4569,16 +3973,8 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=6.12.3                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 >                      │
-│                     │ hipchat-notifier@1.1.0 > request@2.88.0 >              │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > log4js@2.11.0 > slack-node@0.2.0 >   │
-│                     │ requestretry@1.13.0 > request@2.88.0 >                 │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > useragent@2.2.1 > request@2.88.0 >   │
-│                     │ har-validator@5.1.3 > ajv@6.10.2                       │
+│ Paths               │ .>karma>log4js>hipchat-notifier>request>har-           │
+│                     │ validator>ajv                                          │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-v88g-cgmw-v5xw      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
@@ -4592,13 +3988,9 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ Patched versions    │ >=1.14.8                                               │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
-│ Paths               │ . > karma@2.0.5 > log4js@2.11.0 > axios@0.15.3 >       │
-│                     │ follow-redirects@1.0.0                                 │
+│ Paths               │ .>axios>follow-redirects                               │
 │                     │                                                        │
-│                     │ . > axios@0.15.3 > follow-redirects@1.0.0              │
-│                     │                                                        │
-│                     │ . > karma@2.0.5 > http-proxy@1.18.0 >                  │
-│                     │ follow-redirects@1.9.0                                 │
+│                     │ .>karma>http-proxy>follow-redirects                    │
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3135,9 +3135,6 @@ importers:
       '@pnpm/fetching-types':
         specifier: workspace:*
         version: link:../../network/fetching-types
-      '@pnpm/list':
-        specifier: workspace:*
-        version: link:../../reviewing/list
       '@pnpm/lockfile.detect-dep-types':
         specifier: workspace:*
         version: link:../detect-dep-types


### PR DESCRIPTION


Resolves: https://github.com/pnpm/pnpm/issues/9280