### PR TITLE
fix: setting `workspace-concurrency` to negative number

### DIFF
--- a/.changeset/moody-beans-like.md
+++ b/.changeset/moody-beans-like.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+Compatibility option `workspace-concurrency` is less than or equal to 0.

--- a/.changeset/moody-beans-like.md
+++ b/.changeset/moody-beans-like.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/config": patch
+pnpm: patch
 ---
 
-Compatibility option `workspace-concurrency` is less than or equal to 0.
+Setting `workspace-concurrency` to less than or equal to 0 should work [#9297](https://github.com/pnpm/pnpm/issues/9297).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -469,8 +469,6 @@ export async function getConfig (opts: {
     }
   }
 
-  pnpmConfig.workspaceConcurrency = getWorkspaceConcurrency(pnpmConfig.workspaceConcurrency)
-
   if (!opts.ignoreLocalSettings) {
     pnpmConfig.rootProjectManifestDir = pnpmConfig.lockfileDir ?? pnpmConfig.workspaceDir ?? pnpmConfig.dir
     pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir) ?? undefined
@@ -496,6 +494,8 @@ export async function getConfig (opts: {
       }
     }
   }
+
+  pnpmConfig.workspaceConcurrency = getWorkspaceConcurrency(pnpmConfig.workspaceConcurrency)
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig
 


### PR DESCRIPTION
close #9297