### PR TITLE
fix: remove package should not affect the `ignoredBuilds` config of other pkg

### DIFF
--- a/.changeset/floppy-items-train.md
+++ b/.changeset/floppy-items-train.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/core": major
+---
+
+When removing a dependency, if the dependency package does not have an executable script, the existing ignoredBuilds will not be deleted.

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -965,10 +965,14 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     }
   }
 
+  const removePackages = new Set<string>()
   await Promise.all(
     projects
       .map(async (project) => {
         if (project.mutation !== 'uninstallSome') return
+        if (project.removePackages) {
+          project.removePackages.forEach((depName) => removePackages.add(depName))
+        }
         const _removeDeps = async (manifest: ProjectManifest) => removeDeps(manifest, project.dependencyNames, { prefix: project.rootDir, saveType: project.targetDependenciesField })
         project.manifest = await _removeDeps(project.manifest)
         if (project.originalManifest != null) {
@@ -1232,6 +1236,8 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           ignoredScriptsLogger.debug({ packageNames: ignoredBuilds })
         }
       }
+    } else if (ctx.modulesFile?.ignoredBuilds?.length) {
+      ignoredBuilds = ctx.modulesFile.ignoredBuilds.filter((pkgId) => !removePackages.has(pkgId))
     }
 
     const binWarn = (prefix: string, message: string) => {


### PR DESCRIPTION
If install `esbuild` and then install `dayjs`, should not remove the `esbuild` information in ignoredBuilds when remove `dayjs`.