### PR TITLE
fix(reviewing/license-scanner): update license-scanner to support hoisted node modules

### DIFF
--- a/.changeset/cruel-peas-kick.md
+++ b/.changeset/cruel-peas-kick.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-licenses": patch
+---
+
+Update licenses cli to only return unique paths of dependencies

--- a/.changeset/large-crews-poke.md
+++ b/.changeset/large-crews-poke.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/license-scanner": patch
+---
+
+Update license-scanner to handle hoisted node modules

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6881,6 +6881,9 @@ importers:
 
   reviewing/license-scanner:
     dependencies:
+      '@pnpm/config':
+        specifier: workspace:*
+        version: link:../../config/config
       '@pnpm/dependency-path':
         specifier: workspace:*
         version: link:../../packages/dependency-path
@@ -6920,6 +6923,9 @@ importers:
       load-json-file:
         specifier: 'catalog:'
         version: 6.2.0
+      mem:
+        specifier: 'catalog:'
+        version: 8.1.1
       p-limit:
         specifier: 'catalog:'
         version: 3.1.0

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -31,6 +31,7 @@
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
+    "@pnpm/config": "workspace:*",
     "@pnpm/dependency-path": "workspace:*",
     "@pnpm/directory-fetcher": "workspace:*",
     "@pnpm/error": "workspace:*",
@@ -44,6 +45,7 @@
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/types": "workspace:*",
     "load-json-file": "catalog:",
+    "mem": "catalog:",
     "p-limit": "catalog:",
     "path-absolute": "catalog:",
     "ramda": "catalog:",

--- a/reviewing/license-scanner/tsconfig.json
+++ b/reviewing/license-scanner/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../config/config"
+    },
+    {
       "path": "../../config/package-is-installable"
     },
     {

--- a/reviewing/plugin-commands-licenses/src/outputRenderer.ts
+++ b/reviewing/plugin-commands-licenses/src/outputRenderer.ts
@@ -70,7 +70,7 @@ function renderLicensesJson (licensePackages: readonly LicensePackage[]): string
       if (inputList == null) continue
       inputList.sort((a, b) => semver.compare(a.version, b.version))
       const versions = inputList.map((item) => item.version)
-      const paths = inputList.map((item) => item.path ?? null)
+      const paths = Array.from(new Set(inputList.map((item) => item.path ?? null)))
       const lastInputItem = inputList.at(-1)! // last item is chosen for its latest information
       const outputItem: LicensePackageJson = {
         name: lastInputItem.name,

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/.npmrc
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pnpm-with-multiple-versions-hoisted",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "pnpm-with-file-protocol-sub-dep-1": "file:./sub-dep-1",
+    "pnpm-with-file-protocol-sub-dep-2": "file:./sub-dep-2"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      pnpm-with-file-protocol-sub-dep-1:
+        specifier: file:./sub-dep-1
+        version: file:sub-dep-1
+      pnpm-with-file-protocol-sub-dep-2:
+        specifier: file:./sub-dep-2
+        version: file:sub-dep-2
+
+packages:
+
+  pnpm-with-file-protocol-sub-dep-1@file:sub-dep-1:
+    resolution: {directory: sub-dep, type: directory}
+    version: 1.0.0
+  
+  pnpm-with-file-protocol-sub-dep-2@file:sub-dep-2:
+    resolution: {directory: sub-dep, type: directory}
+    version: 1.0.0
+
+snapshots:
+
+  pnpm-with-file-protocol-sub-dep-1@file:sub-dep-1:
+    dev: false
+
+  pnpm-with-file-protocol-sub-dep-2@file:sub-dep-2:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-1/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-with-multiple-versions-hoisted-sub-dep-1",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "is-positive": "3.0.0"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-1/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-1/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  is-positive@3.0.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-positive@3.0.0:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-2/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-with-multiple-versions-hoisted-sub-dep-2",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "is-positive": "3.1.0"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-2/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions-hoisted/sub-dep-2/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+
+packages:
+
+  is-positive@3.0.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-positive@3.1.0:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pnpm-with-multiple-versions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "pnpm-with-file-protocol-sub-dep-1": "file:./sub-dep-1",
+    "pnpm-with-file-protocol-sub-dep-2": "file:./sub-dep-2"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      pnpm-with-file-protocol-sub-dep-1:
+        specifier: file:./sub-dep-1
+        version: file:sub-dep-1
+      pnpm-with-file-protocol-sub-dep-2:
+        specifier: file:./sub-dep-2
+        version: file:sub-dep-2
+
+packages:
+
+  pnpm-with-file-protocol-sub-dep-1@file:sub-dep-1:
+    resolution: {directory: sub-dep, type: directory}
+    version: 1.0.0
+  
+  pnpm-with-file-protocol-sub-dep-2@file:sub-dep-2:
+    resolution: {directory: sub-dep, type: directory}
+    version: 1.0.0
+
+snapshots:
+
+  pnpm-with-file-protocol-sub-dep-1@file:sub-dep-1:
+    dev: false
+
+  pnpm-with-file-protocol-sub-dep-2@file:sub-dep-2:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-1/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-with-multiple-versions-sub-dep-1",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "is-positive": "3.0.0"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-1/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-1/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.0.0
+        version: 3.0.0
+
+packages:
+
+  is-positive@3.0.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-positive@3.0.0:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-2/package.json
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-with-multiple-versions-sub-dep-2",
+  "version": "1.0.0",
+  "license": "ISC",
+  "dependencies": {
+    "is-positive": "3.1.0"
+  }
+}

--- a/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-2/pnpm-lock.yaml
+++ b/reviewing/plugin-commands-licenses/test/fixtures/with-multiple-versions/sub-dep-2/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-positive:
+        specifier: 3.1.0
+        version: 3.1.0
+
+packages:
+
+  is-positive@3.0.0:
+    resolution: {integrity: sha512-8ND1j3y9/HP94TOvGzr69/FgbkX2ruOldhLEsTWwcJVfo4oRjwemJmJxt7RJkKYH8tz7vYBP9JcKQY8CLuJ90Q==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-positive@3.1.0:
+    dev: false

--- a/reviewing/plugin-commands-licenses/test/index.ts
+++ b/reviewing/plugin-commands-licenses/test/index.ts
@@ -343,3 +343,117 @@ test('pnpm licenses should work git repository name containing capital letters',
 
   expect(exitCode).toBe(0)
 })
+
+test('pnpm licenses: returns multiple paths when node-linker is isolated', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-multiple-versions', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  // Attempt to run the licenses command now
+  const { output, exitCode } = await licenses.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    long: false,
+    json: true,
+    // we need to prefix it with STORE_VERSION otherwise licenses tool can't find anything
+    // in the content-addressable directory
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+  }, ['list'])
+
+  expect(exitCode).toBe(0)
+  expect(output).not.toHaveLength(0)
+  expect(output).not.toBe('No licenses in packages found')
+  const parsedOutput = JSON.parse(output)
+  expect(parsedOutput).toEqual({
+    MIT: [
+      {
+        name: 'is-positive',
+        versions: ['3.0.0', '3.1.0'],
+        paths: [expect.stringContaining('is-positive@3.0.0'), expect.stringContaining('is-positive@3.1.0')],
+        license: 'MIT',
+        author: expect.any(String),
+        homepage: expect.any(String),
+        description: expect.any(String),
+      },
+    ],
+    ISC: [
+      {
+        name: 'pnpm-with-multiple-versions-sub-dep-1',
+        paths: [expect.stringContaining('pnpm-with-multiple-versions-sub-dep-1@file+sub-dep-1')],
+        license: 'ISC',
+        versions: [null],
+      },
+      {
+        name: 'pnpm-with-multiple-versions-sub-dep-2',
+        paths: [expect.stringContaining('pnpm-with-multiple-versions-sub-dep-2@file+sub-dep-2')],
+        license: 'ISC',
+        versions: [null],
+      },
+    ],
+  })
+})
+
+test('pnpm licenses: returns single path when node-linker is hoisted', async () => {
+  const workspaceDir = tempDir()
+  f.copy('with-multiple-versions-hoisted', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  // Attempt to run the licenses command now
+  const { output, exitCode } = await licenses.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    long: false,
+    json: true,
+    // we need to prefix it with STORE_VERSION otherwise licenses tool can't find anything
+    // in the content-addressable directory
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+  }, ['list'])
+
+  expect(exitCode).toBe(0)
+  expect(output).not.toHaveLength(0)
+  expect(output).not.toBe('No licenses in packages found')
+  const parsedOutput = JSON.parse(output)
+  expect(parsedOutput).toEqual({
+    MIT: [
+      {
+        name: 'is-positive',
+        versions: ['3.0.0', '3.1.0'],
+        paths: [expect.stringContaining('node_modules/is-positive')],
+        license: 'MIT',
+        author: expect.any(String),
+        homepage: expect.any(String),
+        description: expect.any(String),
+      },
+    ],
+    ISC: [
+      {
+        name: 'pnpm-with-multiple-versions-hoisted-sub-dep-1',
+        paths: [expect.stringContaining('node_modules/pnpm-with-multiple-versions-hoisted-sub-dep-1')],
+        license: 'ISC',
+        versions: [null],
+      },
+      {
+        name: 'pnpm-with-multiple-versions-hoisted-sub-dep-2',
+        paths: [expect.stringContaining('node_modules/pnpm-with-multiple-versions-hoisted-sub-dep-2')],
+        license: 'ISC',
+        versions: [null],
+      },
+    ],
+  })
+})


### PR DESCRIPTION
Applications built using electron and electron forge require node modules to be hoisted to the root of the project.

Libraries that depend on the output of `pnpm licenses` have issues resolving packages as the paths returned assume the node-linker is set to isolated (or undefined).

This change refactors the existing behaviour that generates the path of a given package. The abstracted method retrieves the config from the project root to determine if a different path should be returned when node-linker=hoisted.

This change may not cover all options for node-linker, however it does imporve on the existing behaviour. It shouldn't break anything more than what it already would be.

Closes: GitHub Issue #8589