### PR TITLE
chore(eslint): enable cache

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -323,9 +323,9 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
   }
   if (scripts.lint) {
     if (fs.existsSync(path.join(dir, 'test'))) {
-      scripts.lint = 'eslint "src/**/*.ts" "test/**/*.ts"'
+      scripts.lint = 'eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache "src/**/*.ts" "test/**/*.ts"'
     } else {
-      scripts.lint = 'eslint "src/**/*.ts"'
+      scripts.lint = 'eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache "src/**/*.ts"'
     }
   }
   const files: string[] = []

--- a/__utils__/assert-project/package.json
+++ b/__utils__/assert-project/package.json
@@ -32,7 +32,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/assert-project",
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts test/**/*.ts",
     "lint-test": "tslint -c tslint.json --project test",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
     "prepublishOnly": "pnpm run compile",

--- a/__utils__/assert-store/package.json
+++ b/__utils__/assert-store/package.json
@@ -22,7 +22,7 @@
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/assert-store",
   "scripts": {
     "compile": "tsc --build",
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts test/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm install -C test/fixture/project --force --no-shared-workspace-lockfile",
     "test": "pnpm pretest && pnpm run compile && jest"

--- a/__utils__/get-release-text/package.json
+++ b/__utils__/get-release-text/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "write-release-text": "node --loader ts-node/esm src/main.ts",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts"
   },
   "dependencies": {
     "mdast-util-to-string": "^2.0.0",

--- a/__utils__/prepare-temp-dir/package.json
+++ b/__utils__/prepare-temp-dir/package.json
@@ -9,7 +9,7 @@
     "@types/node": "catalog:"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build"

--- a/__utils__/prepare/package.json
+++ b/__utils__/prepare/package.json
@@ -16,7 +16,7 @@
     "@types/node": "catalog:"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build"

--- a/__utils__/test-fixtures/package.json
+++ b/__utils__/test-fixtures/package.json
@@ -26,7 +26,7 @@
   },
   "repository": "https://github.com/pnpm/pnpm/blob/master/privatePackages/test-fixtures",
   "scripts": {
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile"

--- a/__utils__/test-ipc-server/package.json
+++ b/__utils__/test-ipc-server/package.json
@@ -14,7 +14,7 @@
     "execa": "catalog:"
   },
   "scripts": {
-    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache src/**/*.ts test/**/*.ts",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
     "test": "pnpm run compile && jest"
   }

--- a/cache/api/package.json
+++ b/cache/api/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cache/commands/package.json
+++ b/cache/commands/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7770 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",

--- a/catalogs/protocol-parser/package.json
+++ b/catalogs/protocol-parser/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",

--- a/catalogs/resolver/package.json
+++ b/catalogs/resolver/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",

--- a/catalogs/types/package.json
+++ b/catalogs/types/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile"

--- a/cli/cli-meta/package.json
+++ b/cli/cli-meta/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/cli/cli-utils/package.json
+++ b/cli/cli-utils/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "test": "pnpm run compile && pnpm run _test",

--- a/cli/command/package.json
+++ b/cli/command/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/common-cli-options-help/package.json
+++ b/cli/common-cli-options-help/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "just-test-preview": "ts-node test --type-check",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/cli/parse-cli-args/package.json
+++ b/cli/parse-cli-args/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/completion/plugin-commands-completion/package.json
+++ b/completion/plugin-commands-completion/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/config-writer/package.json
+++ b/config/config-writer/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "start": "tsc --watch",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test-with-preview": "ts-node test",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/config/matcher/package.json
+++ b/config/matcher/package.json
@@ -26,7 +26,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/config/normalize-registries/package.json
+++ b/config/normalize-registries/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -26,7 +26,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/parse-overrides/package.json
+++ b/config/parse-overrides/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/pick-registry-for-package/package.json
+++ b/config/pick-registry-for-package/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/config/plugin-commands-config/package.json
+++ b/config/plugin-commands-config/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/crypto/hash/package.json
+++ b/crypto/hash/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/crypto/object-hasher/package.json
+++ b/crypto/object-hasher/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/crypto/polyfill/package.json
+++ b/crypto/polyfill/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/dedupe/check/package.json
+++ b/dedupe/check/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/dedupe/issues-renderer/package.json
+++ b/dedupe/issues-renderer/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/dedupe/types/package.json
+++ b/dedupe/types/package.json
@@ -26,7 +26,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "devDependencies": {
     "@pnpm/dedupe.types": "workspace:*"

--- a/deps/graph-builder/package.json
+++ b/deps/graph-builder/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/deps/graph-sequencer/package.json
+++ b/deps/graph-sequencer/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/deps/status/package.json
+++ b/deps/status/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/path/package.json
+++ b/env/path/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/env/system-node-version/package.json
+++ b/env/system-node-version/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/build-commands/package.json
+++ b/exec/build-commands/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7771 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/pkg-requires-build/package.json
+++ b/exec/pkg-requires-build/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7772 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7773 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/exec/pnpm-cli-runner/package.json
+++ b/exec/pnpm-cli-runner/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/exec/run-npm/package.json
+++ b/exec/run-npm/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fetching/directory-fetcher/package.json
+++ b/fetching/directory-fetcher/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/fetcher-base/package.json
+++ b/fetching/fetcher-base/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fetching/git-fetcher/package.json
+++ b/fetching/git-fetcher/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fetching/pick-fetcher/package.json
+++ b/fetching/pick-fetcher/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fetching/tarball-fetcher/package.json
+++ b/fetching/tarball-fetcher/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/find-packages/package.json
+++ b/fs/find-packages/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/graceful-fs/package.json
+++ b/fs/graceful-fs/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/fs/is-empty-dir-or-nothing/package.json
+++ b/fs/is-empty-dir-or-nothing/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/fs/packlist/package.json
+++ b/fs/packlist/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "test": "pnpm run compile"

--- a/fs/read-modules-dir/package.json
+++ b/fs/read-modules-dir/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/fs/symlink-dependency/package.json
+++ b/fs/symlink-dependency/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/hooks/pnpmfile/package.json
+++ b/hooks/pnpmfile/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/hooks/types/package.json
+++ b/hooks/types/package.json
@@ -26,7 +26,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "dependencies": {
     "@pnpm/lockfile.types": "workspace:*",

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/detect-dep-types/package.json
+++ b/lockfile/detect-dep-types/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/lockfile/filtering/package.json
+++ b/lockfile/filtering/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/fs/package.json
+++ b/lockfile/fs/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/lockfile-to-pnp/package.json
+++ b/lockfile/lockfile-to-pnp/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",

--- a/lockfile/merger/package.json
+++ b/lockfile/merger/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/plugin-commands-audit/package.json
+++ b/lockfile/plugin-commands-audit/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/preferred-versions/package.json
+++ b/lockfile/preferred-versions/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/lockfile/pruner/package.json
+++ b/lockfile/pruner/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/settings-checker/package.json
+++ b/lockfile/settings-checker/package.json
@@ -26,7 +26,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/lockfile/types/package.json
+++ b/lockfile/types/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix",
     "prepublishOnly": "pnpm run compile"
   },

--- a/lockfile/utils/package.json
+++ b/lockfile/utils/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/verification/package.json
+++ b/lockfile/verification/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/lockfile/walker/package.json
+++ b/lockfile/walker/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/modules-mounter/daemon/package.json
+++ b/modules-mounter/daemon/package.json
@@ -27,7 +27,7 @@
   ],
   "bin": "bin/mount-modules.js",
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "pretest": "node ../../pnpm/dist/pnpm.cjs install --dir=test/__fixtures__/simple",

--- a/network/auth-header/package.json
+++ b/network/auth-header/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/network/fetching-types/package.json
+++ b/network/fetching-types/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile"
   },

--- a/object/key-sorting/package.json
+++ b/object/key-sorting/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "pnpm run compile-only && pnpm --dir=__fixtures__ run prepareFixtures",
     "lint": "pnpm run spellcheck && pnpm lint:meta && pnpm run lint:ts",
     "spellcheck": "cspell \"**/*.ts\" \"**/README.md\" \".changeset/*.md\" --no-progress",
-    "lint:ts": "eslint \"**/src/**/*.ts\" \"**/test/**/*.ts\"",
+    "lint:ts": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"**/src/**/*.ts\" \"**/test/**/*.ts\"",
     "test-main": "pnpm pretest && pnpm lint --quiet && pnpm run test-pkgs-main",
     "remove-temp-dir": "shx rm -rf ../pnpm_tmp",
     "test-pkgs-main": "pnpm remove-temp-dir && pnpm run --no-sort --workspace-concurrency=1 -r _test",

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "devDependencies": {

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -26,7 +26,7 @@
   ],
   "bin": "./bin/make-dedicated-lockfile.js",
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/plugin-commands-doctor/package.json
+++ b/packages/plugin-commands-doctor/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "devDependencies": {
     "@pnpm/types": "workspace:*"

--- a/packages/which-version-is-pinned/package.json
+++ b/packages/which-version-is-pinned/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/patching/apply-patch/package.json
+++ b/patching/apply-patch/package.json
@@ -28,7 +28,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\""
   },
   "dependencies": {
     "@pnpm/error": "workspace:*",

--- a/patching/config/package.json
+++ b/patching/config/package.json
@@ -28,7 +28,7 @@
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\""
   },
   "dependencies": {
     "@pnpm/dependency-path": "workspace:*",

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7774 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/patching/types/package.json
+++ b/patching/types/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "devDependencies": {
     "@pnpm/patching.types": "workspace:*"

--- a/pkg-manager/client/package.json
+++ b/pkg-manager/client/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -47,7 +47,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test-with-preview": "preview && pnpm run test:e2e",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7769 jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/pkg-manager/direct-dep-linker/package.json
+++ b/pkg-manager/direct-dep-linker/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7775 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/hoist/package.json
+++ b/pkg-manager/hoist/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/modules-cleaner/package.json
+++ b/pkg-manager/modules-cleaner/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/modules-yaml/package.json
+++ b/pkg-manager/modules-yaml/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7776 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7777 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manager/read-projects-context/package.json
+++ b/pkg-manager/read-projects-context/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/real-hoist/package.json
+++ b/pkg-manager/real-hoist/package.json
@@ -26,7 +26,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/remove-bins/package.json
+++ b/pkg-manager/remove-bins/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
     "_test": "jest"

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/pkg-manifest/manifest-utils/package.json
+++ b/pkg-manifest/manifest-utils/package.json
@@ -26,7 +26,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/pkg-manifest/read-package-json/package.json
+++ b/pkg-manifest/read-package-json/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pkg-manifest/write-project-manifest/package.json
+++ b/pkg-manifest/write-project-manifest/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "bundle": "ts-node bundle.ts",
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "pretest:e2e": "rimraf node_modules/.bin/pnpm",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7778 jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7779 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7780 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/default-resolver/package.json
+++ b/resolving/default-resolver/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/resolving/resolver-base/package.json
+++ b/resolving/resolver-base/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "start": "tsc --watch",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/resolving/tarball-resolver/package.json
+++ b/resolving/tarball-resolver/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/reviewing/dependencies-hierarchy/package.json
+++ b/reviewing/dependencies-hierarchy/package.json
@@ -26,7 +26,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "_test": "jest",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepareFixtures": "cd test && node ../../pnpm recursive install --no-link-workspace-packages --no-shared-workspace-lockfile -f && cd ..",
     "prepublishOnly": "pnpm run compile",
     "pretest": "pnpm run --filter dependencies-hierarchy pretest",

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7781 jest",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7782 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7783 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/semver/peer-range/package.json
+++ b/semver/peer-range/package.json
@@ -25,7 +25,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/cafs-types/package.json
+++ b/store/cafs-types/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "devDependencies": {
     "@pnpm/cafs-types": "workspace:*",

--- a/store/cafs/package.json
+++ b/store/cafs/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/store/create-cafs-store/package.json
+++ b/store/create-cafs-store/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/package-store/package.json
+++ b/store/package-store/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "tsc --watch",
     "fix": "tslint -c tslint.json src/**/*.ts test/**/*.ts --fix",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "pretest": "rimraf .tmp",
     "_test": "pnpm pretest && jest",
     "test": "pnpm run compile && pnpm run _test",

--- a/store/plugin-commands-server/package.json
+++ b/store/plugin-commands-server/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/store/plugin-commands-store-inspecting/package.json
+++ b/store/plugin-commands-store-inspecting/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "cross-env PNPM_REGISTRY_MOCK_PORT=7784 jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/server/package.json
+++ b/store/server/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest --detectOpenHandles",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/store/store-connection-manager/package.json
+++ b/store/store-connection-manager/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "pretest": "rimraf node_modules/.bin/pnpm",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",

--- a/store/store-controller-types/package.json
+++ b/store/store-controller-types/package.json
@@ -27,7 +27,7 @@
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",
-    "lint": "eslint \"src/**/*.ts\""
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\""
   },
   "dependencies": {
     "@pnpm/fetcher-base": "workspace:*",

--- a/store/store-path/package.json
+++ b/store/store-path/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "prepublishOnly": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/text/comments-parser/package.json
+++ b/text/comments-parser/package.json
@@ -26,7 +26,7 @@
     "start": "tsc --watch",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/tools/path/package.json
+++ b/tools/path/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/tools/plugin-commands-self-updater/package.json
+++ b/tools/plugin-commands-self-updater/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile && pnpm run _test",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/worker/package.json
+++ b/worker/package.json
@@ -24,7 +24,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "test": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/workspace/filter-packages-from-dir/package.json
+++ b/workspace/filter-packages-from-dir/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-packages/package.json
+++ b/workspace/find-packages/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/find-workspace-dir/package.json
+++ b/workspace/find-workspace-dir/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/injected-deps-syncer/package.json
+++ b/workspace/injected-deps-syncer/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/workspace/manifest-writer/package.json
+++ b/workspace/manifest-writer/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix",

--- a/workspace/pkgs-graph/package.json
+++ b/workspace/pkgs-graph/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/read-manifest/package.json
+++ b/workspace/read-manifest/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/resolve-workspace-range/package.json
+++ b/workspace/resolve-workspace-range/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "tsc --watch",
     "test": "pnpm run compile",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },

--- a/workspace/sort-packages/package.json
+++ b/workspace/sort-packages/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\"",
     "test": "pnpm run compile",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"

--- a/workspace/spec-parser/package.json
+++ b/workspace/spec-parser/package.json
@@ -23,7 +23,7 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "_test": "jest",
     "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",

--- a/workspace/state/package.json
+++ b/workspace/state/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "test": "pnpm run compile && pnpm run _test",
     "_test": "jest",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint --cache --cache-location=node_modules/.cache/eslint/.eslint-cache \"src/**/*.ts\" \"test/**/*.ts\"",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsc --build && pnpm run lint --fix"
   },


### PR DESCRIPTION
### Summary

I've enabled caching in ESLint in order to reduce the execution time of `pnpm lint:ts`.

- The default [--cache-location](https://eslint.org/docs/latest/use/command-line-interface#--cache-location) is `.eslintcache`, but to avoid adding files to the root directory, I've changed it to `node_modules/.cache/eslint/.eslintcache` using [find-cache-dir](https://github.com/sindresorhus/find-cache-dir) as a reference.
- The default [--cache-strategy](https://eslint.org/docs/latest/use/command-line-interface#--cache-strategy) is `metadata`, which detects differences based on file timestamps. If caching the cache file in GitHub Actions, it's necessary to change to `content` to detect differences based on file hash values, but since it's currently only being executed locally, I've left it as `metadata`.

~~If necessary, update `.meta-updater/src/index.ts` to apply to all package.json files.~~
→ Updated every package.json file potentially processed by ESLint.

### Screenshots

<table>
<tr>
<th>Before</td>
<th>After(cached)</td>
</tr>
<tr>
<td>
12.0s

```sh
$ time pnpm lint:ts
> pnpm lint:ts  18.90s user 2.17s system 174% cpu 12.070 total
```
</td>
<td>
0.8s

```sh
$ time pnpm lint:ts
> pnpm lint:ts  0.87s user 0.22s system 135% cpu 0.806 total
```
</td>
</tr>
</table>

### Appendix

- https://eslint.org/docs/latest/use/command-line-interface#--cache