### PR TITLE
fix: `patch-remove` command failed to remove path file

### DIFF
--- a/.changeset/pretty-pandas-hear.md
+++ b/.changeset/pretty-pandas-hear.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": minor
+---
+
+The pnpm `patch-remove` command failed to remove the corresponding patch file.

--- a/patching/plugin-commands-patching/src/patchRemove.ts
+++ b/patching/plugin-commands-patching/src/patchRemove.ts
@@ -5,7 +5,6 @@ import { writeSettings } from '@pnpm/config.config-writer'
 import { install } from '@pnpm/plugin-commands-installation'
 import { type Config, types as allTypes } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
-import { type ProjectRootDir } from '@pnpm/types'
 import renderHelp from 'render-help'
 import { prompt } from 'enquirer'
 import pick from 'ramda/src/pick'
@@ -32,7 +31,6 @@ export type PatchRemoveCommandOptions = install.InstallCommandOptions & Pick<Con
 
 export async function handler (opts: PatchRemoveCommandOptions, params: string[]): Promise<void> {
   let patchesToRemove = params
-  const lockfileDir = (opts.lockfileDir ?? opts.dir ?? process.cwd()) as ProjectRootDir
   const patchedDependencies = opts.patchedDependencies ?? {}
 
   if (!params.length) {
@@ -59,7 +57,7 @@ export async function handler (opts: PatchRemoveCommandOptions, params: string[]
   const patchesDirs = new Set<string>()
   await Promise.all(patchesToRemove.map(async (patch) => {
     if (Object.prototype.hasOwnProperty.call(patchedDependencies, patch)) {
-      const patchFile = path.join(lockfileDir, patchedDependencies[patch])
+      const patchFile = patchedDependencies[patch]
       patchesDirs.add(path.dirname(patchFile))
       await fs.rm(patchFile, { force: true })
       delete patchedDependencies![patch]


### PR DESCRIPTION
When get configuration information, the stored `patchFile` file path has been spliced, and does not need to be spliced ​​again when removing it.
https://github.com/pnpm/pnpm/blob/01f2bcfa9b38b02db970641466c689a2602a7051/config/config/src/getOptionsFromRootManifest.ts#L81