### PR TITLE
fix(config): modify the default path of the global bin directory

### DIFF
--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -284,7 +284,7 @@ export async function getConfig (opts: {
 
   if (cliOptions['global']) {
     pnpmConfig.dir = pnpmConfig.globalPkgDir
-    pnpmConfig.bin = npmConfig.get('global-bin-dir') ?? env.PNPM_HOME
+    pnpmConfig.bin = npmConfig.get('global-bin-dir') ?? getDataDir(process)
     if (pnpmConfig.bin) {
       fs.mkdirSync(pnpmConfig.bin, { recursive: true })
       await checkGlobalBinDir(pnpmConfig.bin, { env, shouldAllowWrite: opts.globalDirShouldAllowWrite })


### PR DESCRIPTION
- change the default path of the global bin directory from env Change PNPM_HOME to getDataDir (process)
- this change can solve the path problem that may be caused by the PNPM_HOME variable in certain environments

in the document not effective
globalBinDir
default:
if the $XDG_DATA_HOME env variable is set, then $XDG_DATA_HOME/pnpm