### PR TITLE
refactor: workspace setting sorted by key

### DIFF
--- a/.changeset/free-chairs-cough.md
+++ b/.changeset/free-chairs-cough.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.manifest-writer": patch
+"pnpm": patch
+---
+
+Sort keys in `pnpm-workspace.yaml` [#9453](https://github.com/pnpm/pnpm/pull/9453).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8270,6 +8270,9 @@ importers:
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../packages/constants
+      '@pnpm/object.key-sorting':
+        specifier: workspace:*
+        version: link:../../object/key-sorting
       '@pnpm/workspace.read-manifest':
         specifier: workspace:*
         version: link:../read-manifest

--- a/workspace/manifest-writer/package.json
+++ b/workspace/manifest-writer/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@pnpm/constants": "workspace:*",
+    "@pnpm/object.key-sorting": "workspace:*",
     "@pnpm/workspace.read-manifest": "workspace:*",
     "ramda": "catalog:",
     "write-yaml-file": "catalog:"

--- a/workspace/manifest-writer/src/index.ts
+++ b/workspace/manifest-writer/src/index.ts
@@ -4,7 +4,7 @@ import { readWorkspaceManifest, type WorkspaceManifest } from '@pnpm/workspace.r
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import writeYamlFile from 'write-yaml-file'
 import equals from 'ramda/src/equals'
-import { sortDirectKeys } from '@pnpm/object.key-sorting'
+import { sortKeysByPriority } from '@pnpm/object.key-sorting'
 
 export async function updateWorkspaceManifest (dir: string, updatedFields: Partial<WorkspaceManifest>): Promise<void> {
   let manifest = await readWorkspaceManifest(dir) ?? {} as WorkspaceManifest
@@ -27,7 +27,10 @@ export async function updateWorkspaceManifest (dir: string, updatedFields: Parti
     await fs.promises.rm(path.join(dir, WORKSPACE_MANIFEST_FILENAME))
     return
   }
-  manifest = sortDirectKeys(manifest)
+  manifest = sortKeysByPriority({
+    priority: { packages: 0 },
+    deep: false,
+  }, manifest)
   await writeYamlFile(path.join(dir, WORKSPACE_MANIFEST_FILENAME), manifest, {
     lineWidth: -1, // This is setting line width to never wrap
     blankLines: true,

--- a/workspace/manifest-writer/src/index.ts
+++ b/workspace/manifest-writer/src/index.ts
@@ -4,9 +4,10 @@ import { readWorkspaceManifest, type WorkspaceManifest } from '@pnpm/workspace.r
 import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
 import writeYamlFile from 'write-yaml-file'
 import equals from 'ramda/src/equals'
+import { sortDirectKeys } from '@pnpm/object.key-sorting'
 
 export async function updateWorkspaceManifest (dir: string, updatedFields: Partial<WorkspaceManifest>): Promise<void> {
-  const manifest = await readWorkspaceManifest(dir) ?? {} as WorkspaceManifest
+  let manifest = await readWorkspaceManifest(dir) ?? {} as WorkspaceManifest
   let shouldBeUpdated = false
   for (const [key, value] of Object.entries(updatedFields)) {
     if (!equals(manifest[key as keyof WorkspaceManifest], value)) {
@@ -26,6 +27,7 @@ export async function updateWorkspaceManifest (dir: string, updatedFields: Parti
     await fs.promises.rm(path.join(dir, WORKSPACE_MANIFEST_FILENAME))
     return
   }
+  manifest = sortDirectKeys(manifest)
   await writeYamlFile(path.join(dir, WORKSPACE_MANIFEST_FILENAME), manifest, {
     lineWidth: -1, // This is setting line width to never wrap
     blankLines: true,

--- a/workspace/manifest-writer/tsconfig.json
+++ b/workspace/manifest-writer/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare-temp-dir"
     },
     {
+      "path": "../../object/key-sorting"
+    },
+    {
       "path": "../../packages/constants"
     },
     {


### PR DESCRIPTION
When writing the configuration into the `pnpm-workspace.yaml` file, the relevant information is not sorted by key. 

Now, many projects have configured relevant eslint rules to sort the field information. I think it is better to sort when writing the settings.