### PR TITLE
feat(plugin-commands-init): add support for --init-type flag in pnpm init

### DIFF
--- a/.changeset/afraid-banks-poke.md
+++ b/.changeset/afraid-banks-poke.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-init": minor
+"@pnpm/config": minor
+"pnpm": minor
+---
+
+A new setting added for `pnpm init` to create a `package.json` with `type=module`, when `init-type` is `module`. Works as a flag for the init command too [#9463](https://github.com/pnpm/pnpm/pull/9463).

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -218,6 +218,7 @@ export interface Config extends OptionsFromRootManifest {
   strictDepBuilds: boolean
   syncInjectedDepsAfterScripts?: string[]
   initPackageManager: boolean
+  initType: 'commonjs' | 'module'
   dangerouslyAllowAllBuilds: boolean
 }
 

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -155,6 +155,7 @@ export async function getConfig (opts: {
     'ignore-workspace-root-check': false,
     'optimistic-repeat-install': false,
     'init-package-manager': true,
+    'init-type': 'commonjs',
     'inject-workspace-packages': false,
     'link-workspace-packages': false,
     'lockfile-include-tarball-url': false,

--- a/config/config/src/types.ts
+++ b/config/config/src/types.ts
@@ -46,6 +46,7 @@ export const types = Object.assign({
   'optimistic-repeat-install': Boolean,
   'include-workspace-root': Boolean,
   'init-package-manager': Boolean,
+  'init-type': ['commonjs', 'module'],
   'inject-workspace-packages': Boolean,
   'legacy-dir-filtering': Boolean,
   'link-workspace-packages': [Boolean, 'deep'],

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -40,12 +40,14 @@
     "@pnpm/types": "workspace:*",
     "@pnpm/write-project-manifest": "workspace:*",
     "camelcase-keys": "catalog:",
+    "ramda": "catalog:",
     "render-help": "catalog:"
   },
   "devDependencies": {
     "@pnpm/plugin-commands-init": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@types/ramda": "catalog:",
     "load-json-file": "catalog:"
   },
   "engines": {

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -13,7 +13,10 @@ import { parseRawConfig } from './utils'
 export const rcOptionsTypes = cliOptionsTypes
 
 export function cliOptionsTypes (): Record<string, unknown> {
-  return {}
+  return {
+    module: Boolean,
+    m: Boolean,
+  }
 }
 
 export const commandNames = ['init']
@@ -55,6 +58,12 @@ export async function handler (
     author: '',
     license: 'ISC',
   }
+
+  // Add "type": "module" if --module or -m is passed
+  if (opts.cliOptions.module || opts.cliOptions.m) {
+    manifest.type = 'module'
+  }
+
   const config = await parseRawConfig(opts.rawConfig)
   const packageJson = { ...manifest, ...config }
   if (opts.initPackageManager) {

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -14,8 +14,7 @@ export const rcOptionsTypes = cliOptionsTypes
 
 export function cliOptionsTypes (): Record<string, unknown> {
   return {
-    module: Boolean,
-    m: Boolean,
+    'init-type': String,
   }
 }
 
@@ -59,9 +58,12 @@ export async function handler (
     license: 'ISC',
   }
 
-  // Add "type": "module" if --module or -m is passed
-  if (opts.cliOptions.module || opts.cliOptions.m) {
-    manifest.type = 'module'
+  // Add "type" based on --init-type value
+  const initType = opts.cliOptions['init-type']
+  if (initType === 'module' || initType === 'commonjs') {
+    manifest.type = initType
+  } else if (initType) {
+    throw new PnpmError('INVALID_INIT_TYPE', `Invalid value for --init-type: ${initType}. Allowed values are "module" or "commonjs".`)
   }
 
   const config = await parseRawConfig(opts.rawConfig)

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -2,20 +2,19 @@ import fs from 'fs'
 import path from 'path'
 import { docsUrl } from '@pnpm/cli-utils'
 import { packageManager } from '@pnpm/cli-meta'
-import { type Config, type UniversalOptions } from '@pnpm/config'
+import { types as allTypes, type Config, type UniversalOptions } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
 import { sortKeysByPriority } from '@pnpm/object.key-sorting'
 import { type ProjectManifest } from '@pnpm/types'
 import { writeProjectManifest } from '@pnpm/write-project-manifest'
+import pick from 'ramda/src/pick'
 import renderHelp from 'render-help'
 import { parseRawConfig } from './utils'
 
 export const rcOptionsTypes = cliOptionsTypes
 
 export function cliOptionsTypes (): Record<string, unknown> {
-  return {
-    'init-type': String,
-  }
+  return pick(['init-type', 'init-package-manager'], allTypes)
 }
 
 export const commandNames = ['init']
@@ -30,7 +29,7 @@ export function help (): string {
 }
 
 export async function handler (
-  opts: Pick<UniversalOptions, 'rawConfig'> & Pick<Config, 'cliOptions'> & Partial<Pick<Config, 'initPackageManager'>>,
+  opts: Pick<UniversalOptions, 'rawConfig'> & Pick<Config, 'cliOptions'> & Partial<Pick<Config, 'initPackageManager' | 'initType'>>,
   params?: string[]
 ): Promise<string> {
   if (params?.length) {
@@ -58,12 +57,8 @@ export async function handler (
     license: 'ISC',
   }
 
-  // Add "type" based on --init-type value
-  const initType = opts.cliOptions['init-type'] || opts.rawConfig['init-type'];
-  if (initType === 'module' || initType === 'commonjs') {
-    manifest.type = initType
-  } else if (initType) {
-    throw new PnpmError('INVALID_INIT_TYPE', `Invalid value for --init-type: ${initType}. Allowed values are "module" or "commonjs".`)
+  if (opts.initType === 'module') {
+    manifest.type = opts.initType
   }
 
   const config = await parseRawConfig(opts.rawConfig)

--- a/packages/plugin-commands-init/src/init.ts
+++ b/packages/plugin-commands-init/src/init.ts
@@ -59,7 +59,7 @@ export async function handler (
   }
 
   // Add "type" based on --init-type value
-  const initType = opts.cliOptions['init-type']
+  const initType = opts.cliOptions['init-type'] || opts.rawConfig['init-type'];
   if (initType === 'module' || initType === 'commonjs') {
     manifest.type = initType
   } else if (initType) {

--- a/packages/plugin-commands-init/test/init.test.ts
+++ b/packages/plugin-commands-init/test/init.test.ts
@@ -84,3 +84,10 @@ test('init a new package.json with init-package-manager=false', async () => {
   expect(manifest).toBeTruthy()
   expect(manifest).not.toHaveProperty('packageManager')
 })
+
+test('init a new package.json with init-type=module', async () => {
+  prepareEmpty()
+  await init.handler({ rawConfig: { 'init-type': 'module' }, cliOptions: {}, initType: 'module' })
+  const manifest = loadJsonFile<ProjectManifest>(path.resolve('package.json'))
+  expect(manifest.type).toEqual('module')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4159,6 +4159,9 @@ importers:
       camelcase-keys:
         specifier: 'catalog:'
         version: 6.2.2
+      ramda:
+        specifier: 'catalog:'
+        version: '@pnpm/ramda@0.28.1'
       render-help:
         specifier: 'catalog:'
         version: 1.0.3
@@ -4172,6 +4175,9 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@types/ramda':
+        specifier: 'catalog:'
+        version: 0.29.12
       load-json-file:
         specifier: 'catalog:'
         version: 6.2.0


### PR DESCRIPTION
add functionality to include "type": "module" in package.json when using --module or -m flag with pnpm init. Updated cliOptionsTypes and handler to handle the new flag and ensure proper sorting of fields in package.json

Closes #9416