### PR TITLE
fix: pnpm version management, when `dangerouslyAllowAllBuilds` is set to `true`

### DIFF
--- a/.changeset/curly-paths-wash.md
+++ b/.changeset/curly-paths-wash.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tools.plugin-commands-self-updater": patch
+"pnpm": patch
+---
+
+pnpm version management should work, when `dangerouslyAllowAllBuilds` is set to `true` [#9472](https://github.com/pnpm/pnpm/issues/9472).

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -44,6 +44,7 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
       `${currentPkgName}@${pnpmVersion}`,
       '--loglevel=error',
       '--allow-build=@pnpm/exe',
+      '--no-dangerously-allow-all-builds',
       // We want to avoid symlinks because of the rename step,
       // which breaks the junctions on Windows.
       '--config.node-linker=hoisted',


### PR DESCRIPTION
close #9472