### PR TITLE
feat(pack): add package filtering for pack command (#4351)

### DIFF
--- a/.changeset/cruel-onions-fix.md
+++ b/.changeset/cruel-onions-fix.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+Parallelly run recursive pack and publish

--- a/.changeset/eight-trams-vanish.md
+++ b/.changeset/eight-trams-vanish.md
@@ -3,4 +3,4 @@
 "@pnpm/config": patch
 ---
 
-Get `pack-destination` configuration from npmrc
+Get `pack-destination` configuration from settings.

--- a/.changeset/eight-trams-vanish.md
+++ b/.changeset/eight-trams-vanish.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+"@pnpm/config": patch
+---
+
+Get `pack-destination` configuration from npmrc

--- a/.changeset/thirty-islands-juggle.md
+++ b/.changeset/thirty-islands-juggle.md
@@ -1,5 +1,8 @@
 ---
-"@pnpm/plugin-commands-publishing": patch
+"@pnpm/plugin-commands-publishing": minor
+"pnpm": minor
 ---
 
-feat(pack): add package filtering for pack command [#4351](https://github.com/pnpm/pnpm/issues/4351)
+Added support for recursively running pack in every project of a workspace [#4351](https://github.com/pnpm/pnpm/issues/4351).
+
+Now you can run `pnpm -r pack` to pack all packages in the workspace.

--- a/.changeset/thirty-islands-juggle.md
+++ b/.changeset/thirty-islands-juggle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+feat(pack): add package filtering for pack command [#4351](https://github.com/pnpm/pnpm/issues/4351)

--- a/config/config/src/types.ts
+++ b/config/config/src/types.ts
@@ -67,6 +67,7 @@ export const types = Object.assign({
   'npm-path': String,
   offline: Boolean,
   'only-built-dependencies': [String],
+  'pack-destination': String,
   'pack-gzip-level': Number,
   'package-import-method': ['auto', 'hardlink', 'clone', 'copy'],
   'patches-dir': String,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6561,6 +6561,9 @@ importers:
       p-filter:
         specifier: 'catalog:'
         version: 2.1.0
+      p-limit:
+        specifier: 'catalog:'
+        version: 3.1.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -14820,6 +14823,7 @@ packages:
   verdaccio@5.20.1:
     resolution: {integrity: sha512-zKQXYubQOfl2w09gO9BR7U9ZZkFPPby8tvV+na86/2vGZnY79kNSVnSbK8CM1bpJHTCQ80AGsmIGovg2FgXhdQ==}
     engines: {node: '>=12.18'}
+    deprecated: this version is deprecated, please migrate to 6.x versions
     hasBin: true
 
   verror@1.10.0:

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -56,6 +56,7 @@
     "enquirer": "catalog:",
     "execa": "catalog:",
     "p-filter": "catalog:",
+    "p-limit": "catalog:",
     "ramda": "catalog:",
     "realpath-missing": "catalog:",
     "render-help": "catalog:",

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -161,21 +161,16 @@ export async function handler (opts: PackOptions): Promise<string> {
   }
 
   if (opts.json) {
-    return packedPackages.length > 1 ? JSON.stringify(packedPackages, null, 2) : JSON.stringify(packedPackages[0], null, 2)
+    return JSON.stringify(packedPackages.length > 1 ? packedPackages : packedPackages[0], null, 2)
   }
 
-  const printPackResult = function (packResultJson: PackResultJson): string {
-    const { name, version, filename, files } = packResultJson
-    return `${opts.unicode ? '📦 ' : 'package:'} ${name}@${version}
+  return packedPackages.map(
+    ({ name, version, filename, files }) => `${opts.unicode ? '📦 ' : 'package:'} ${name}@${version}
 ${chalk.blueBright('Tarball Contents')}
-${files.map(file => file.path).join('\n')}
+${files.map(({ path }) => path).join('\n')}
 ${chalk.blueBright('Tarball Details')}
 ${filename}`
-  }
-
-  return packedPackages.length > 1
-    ? packedPackages.map(printPackResult).join('\n\n')
-    : printPackResult(packedPackages[0])
+  ).join('\n\n')
 }
 
 export async function api (opts: PackOptions): Promise<PackResult> {

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -35,10 +35,10 @@ export function rcOptionsTypes (): Record<string, unknown> {
 
 export function cliOptionsTypes (): Record<string, unknown> {
   return {
-    'pack-destination': String,
     out: String,
     recursive: Boolean,
     ...pick([
+      'pack-destination',
       'pack-gzip-level',
       'json',
     ], allTypes),

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -142,9 +142,8 @@ export async function handler (opts: PackOptions): Promise<string> {
           const packResult = await api({
             ...opts,
             dir: pkg.rootDir,
-            // set the packDestination to the current dir if out and packDestination are not set
-            out: opts.out ? path.join(opts.dir, opts.out) : undefined,
-            packDestination: !opts.out ? path.join(opts.dir, opts.packDestination ?? '.') : undefined,
+            out: opts.out ? path.resolve(opts.dir, opts.out) : undefined,
+            packDestination: !opts.out ? path.resolve(opts.dir, opts.packDestination ?? '.') : undefined,
           })
           packedPackages.push(toPackResultJson(packResult))
         })

--- a/releasing/plugin-commands-publishing/src/pack.ts
+++ b/releasing/plugin-commands-publishing/src/pack.ts
@@ -8,7 +8,7 @@ import { readProjectManifest } from '@pnpm/cli-utils'
 import { createExportableManifest } from '@pnpm/exportable-manifest'
 import { packlist } from '@pnpm/fs.packlist'
 import { getBinsFromPackageManifest } from '@pnpm/package-bins'
-import { type ProjectManifest, type DependencyManifest } from '@pnpm/types'
+import { type ProjectManifest, type ProjectRootDir, type ProjectsGraph, type DependencyManifest } from '@pnpm/types'
 import { glob } from 'tinyglobby'
 import pick from 'ramda/src/pick'
 import realpathMissing from 'realpath-missing'
@@ -17,6 +17,10 @@ import tar from 'tar-stream'
 import { runScriptsIfPresent } from './publish'
 import chalk from 'chalk'
 import validateNpmPackageName from 'validate-npm-package-name'
+import pFilter from 'p-filter'
+import { FILTERING } from '@pnpm/common-cli-options-help'
+import { sortPackages } from '@pnpm/sort-packages'
+import { logger } from '@pnpm/logger'
 
 const LICENSE_GLOB = 'LICEN{S,C}E{,.*}' // cspell:disable-line
 
@@ -33,6 +37,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return {
     'pack-destination': String,
     out: String,
+    recursive: Boolean,
     ...pick([
       'pack-gzip-level',
       'json',
@@ -63,38 +68,95 @@ export function help (): string {
             description: 'Customizes the output path for the tarball. Use `%s` and `%v` to include the package name and version, e.g., `%s.tgz` or `some-dir/%s-%v.tgz`. By default, the tarball is saved in the current working directory with the name `<package-name>-<version>.tgz`.',
             name: '--out <path>',
           },
+          {
+            description: 'Pack all packages from the workspace',
+            name: '--recursive',
+            shortAlias: '-r',
+          },
         ],
       },
+      FILTERING,
     ],
   })
 }
 
-export type PackOptions = Pick<UniversalOptions, 'dir'> & Pick<Config, 'catalogs' | 'ignoreScripts' | 'rawConfig' | 'embedReadme' | 'packGzipLevel' | 'nodeLinker'> & Partial<Pick<Config, 'extraBinPaths' | 'extraEnv'>> & {
+export type PackOptions = Pick<UniversalOptions, 'dir'> & Pick<Config, 'catalogs' | 'ignoreScripts' | 'rawConfig' | 'embedReadme' | 'packGzipLevel' | 'nodeLinker'> & Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'selectedProjectsGraph'>> & {
   argv: {
     original: string[]
   }
   engineStrict?: boolean
   packDestination?: string
   out?: string
+  recursive?: boolean
   workspaceDir?: string
   json?: boolean
+  unicode?: boolean
+}
+
+export interface PackResultJson {
+  name: string
+  version: string
+  filename: string
+  files: Array<{ path: string }>
 }
 
 export async function handler (opts: PackOptions): Promise<string> {
-  const { publishedManifest, tarballPath, contents } = await api(opts)
-  if (opts.json) {
-    return JSON.stringify({
-      name: publishedManifest.name,
-      version: publishedManifest.version,
-      filename: tarballPath,
-      files: contents.map((path) => ({ path })),
-    }, null, 2)
-  }
-  return `${chalk.blueBright('Tarball Contents')}
-${contents.join('\n')}
+  const packedPackages: PackResultJson[] = []
 
+  if (opts.recursive) {
+    const selectedProjectsGraph = opts.selectedProjectsGraph as ProjectsGraph
+    const pkgs = Object.values(selectedProjectsGraph).map((wsPkg) => wsPkg.package)
+    const pkgsToPack = await pFilter(pkgs, async (pkg) => {
+      return Boolean(pkg.manifest.name && pkg.manifest.version)
+    })
+
+    const packedPkgDirs = new Set<ProjectRootDir>(pkgsToPack.map(({ rootDir }) => rootDir))
+
+    if (packedPkgDirs.size === 0) {
+      logger.info({
+        message: 'There are no packages that should be packed',
+        prefix: opts.dir,
+      })
+    }
+
+    const chunks = sortPackages(selectedProjectsGraph)
+
+    for (const chunk of chunks) {
+      for (const pkgDir of chunk) {
+        if (!packedPkgDirs.has(pkgDir)) continue
+        const pkg = selectedProjectsGraph[pkgDir].package
+        // eslint-disable-next-line no-await-in-loop
+        const packResult = await api({
+          ...opts,
+          dir: pkg.rootDir,
+          // set the packDestination to the current dir if out and packDestination are not set
+          out: opts.out ? path.join(opts.dir, opts.out) : undefined,
+          packDestination: !opts.out ? path.join(opts.dir, opts.packDestination ?? '.') : undefined,
+        })
+        packedPackages.push(toPackResultJson(packResult))
+      }
+    }
+  } else {
+    const packResult = await api(opts)
+    packedPackages.push(toPackResultJson(packResult))
+  }
+
+  if (opts.json) {
+    return packedPackages.length > 1 ? JSON.stringify(packedPackages, null, 2) : JSON.stringify(packedPackages[0], null, 2)
+  }
+
+  const printPackResult = function (packResultJson: PackResultJson): string {
+    const { name, version, filename, files } = packResultJson
+    return `${opts.unicode ? '📦 ' : 'package:'} ${name}@${version}
+${chalk.blueBright('Tarball Contents')}
+${files.map(file => file.path).join('\n')}
 ${chalk.blueBright('Tarball Details')}
-${tarballPath}`
+${filename}`
+  }
+
+  return packedPackages.length > 1
+    ? packedPackages.map(printPackResult).join('\n\n')
+    : printPackResult(packedPackages[0])
 }
 
 export async function api (opts: PackOptions): Promise<PackResult> {
@@ -274,4 +336,14 @@ async function createPublishManifest (opts: {
     readmeFile,
     modulesDir,
   })
+}
+
+function toPackResultJson (packResult: PackResult): PackResultJson {
+  const { publishedManifest, contents, tarballPath } = packResult
+  return {
+    name: publishedManifest.name as string,
+    version: publishedManifest.version as string,
+    filename: tarballPath,
+    files: contents.map((file) => ({ path: file })),
+  }
 }

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -1,9 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 import { pack } from '@pnpm/plugin-commands-publishing'
-import { prepare, tempDir } from '@pnpm/prepare'
+import { type PackResultJson } from '../src/pack'
+import { prepare, preparePackages, tempDir } from '@pnpm/prepare'
 import tar from 'tar'
 import chalk from 'chalk'
+import { sync as writeYamlFile } from 'write-yaml-file'
+import { filterPackagesFromDir } from '@pnpm/workspace.filter-packages-from-dir'
 import { DEFAULT_OPTS } from './utils'
 
 test('pack: package with package.json', async () => {
@@ -512,12 +515,12 @@ test('pack: should display packed contents order by name', async () => {
     extraBinPaths: [],
   })
 
-  expect(output).toBe(`${chalk.blueBright('Tarball Contents')}
+  expect(output).toBe(`package: test-publish-package.json@0.0.0
+${chalk.blueBright('Tarball Contents')}
 a.js
 b.js
 package.json
 src/index.ts
-
 ${chalk.blueBright('Tarball Details')}
 test-publish-package.json-0.0.0.tgz`)
 })
@@ -560,4 +563,165 @@ test('pack: display in json format', async () => {
       },
     ],
   }, null, 2))
+})
+
+test('pack: recursive pack and display in json format', async () => {
+  const dir = tempDir()
+
+  const pkg1 = {
+    name: '@pnpmtest/test-recursive-pack-project-1',
+    version: '1.0.0',
+
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }
+  const pkg2 = {
+    name: '@pnpmtest/test-recursive-pack-project-2',
+    version: '1.0.0',
+
+    dependencies: {
+      'is-negative': '1.0.0',
+    },
+  }
+
+  prepare({
+    name: '@pnpmtest/test-recursive-pack-project',
+    version: '0.0.0',
+  }, {
+    tempDir: dir,
+  })
+
+  const pkgs = [
+    pkg1,
+    pkg2,
+    // This will be packed because the pack command does not check whether it is in the registry
+    {
+      name: 'is-positive',
+      version: '1.0.0',
+
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+    // This will be packed because the pack command does not check whether it is a private package
+    {
+      name: 'i-am-private',
+      version: '1.0.0',
+
+      private: true,
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+  ]
+
+  preparePackages(pkgs, {
+    tempDir: path.join(dir, 'project'),
+  })
+
+  writeYamlFile(path.join(dir, 'pnpm-workspace.yaml'), { packages: pkgs.filter(pkg => pkg).map(pkg => pkg.name) })
+
+  const { selectedProjectsGraph } = await filterPackagesFromDir(dir, [])
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir,
+    extraBinPaths: [],
+    json: true,
+    recursive: true,
+    selectedProjectsGraph,
+  })
+
+  const json: PackResultJson[] = JSON.parse(output)
+
+  expect(Array.isArray(json)).toBeTruthy()
+  expect(json).toHaveLength(5)
+
+  for (const pkg of json) {
+    expect(pkg).toHaveProperty('name')
+    expect(pkg).toHaveProperty('version')
+    expect(pkg).toHaveProperty('filename')
+    expect(pkg).toHaveProperty('files')
+    expect(Array.isArray(pkg.files)).toBeTruthy()
+    for (const file of pkg.files) {
+      expect(file).toHaveProperty('path')
+    }
+    expect(fs.existsSync(pkg.filename)).toBeTruthy()
+  }
+})
+
+test('pack: recursive pack with filter', async () => {
+  const dir = tempDir()
+
+  const pkg1 = {
+    name: '@pnpmtest/test-recursive-pack-project-1',
+    version: '1.0.0',
+
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }
+  const pkg2 = {
+    name: '@pnpmtest/test-recursive-pack-project-2',
+    version: '1.0.0',
+
+    dependencies: {
+      'is-negative': '1.0.0',
+    },
+  }
+
+  prepare({
+    name: '@pnpmtest/test-recursive-pack-project',
+    version: '0.0.0',
+  }, {
+    tempDir: dir,
+  })
+
+  const pkgs = [
+    pkg1,
+    pkg2,
+    {
+      name: 'is-positive',
+      version: '1.0.0',
+
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+    {
+      name: 'i-am-private',
+      version: '1.0.0',
+
+      private: true,
+      scripts: {
+        prepublishOnly: 'exit 1',
+      },
+    },
+  ]
+
+  preparePackages(pkgs, {
+    tempDir: path.join(dir, 'project'),
+  })
+
+  writeYamlFile(path.join(dir, 'pnpm-workspace.yaml'), { packages: pkgs.filter(pkg => pkg).map(pkg => pkg.name) })
+
+  const { selectedProjectsGraph } = await filterPackagesFromDir(dir, [{ namePattern: '@pnpmtest/*' }])
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir,
+    extraBinPaths: [],
+    selectedProjectsGraph,
+    recursive: true,
+    unicode: false,
+  })
+
+  expect(output).toContain('package: @pnpmtest/test-recursive-pack-project@0.0.0')
+  expect(output).toContain('package: @pnpmtest/test-recursive-pack-project-1@1.0.0')
+  expect(output).toContain('package: @pnpmtest/test-recursive-pack-project-2@1.0.0')
+  expect(output).not.toContain('package: is-positive')
+  expect(output).not.toContain('package: i-am-private')
 })

--- a/releasing/plugin-commands-publishing/test/pack.ts
+++ b/releasing/plugin-commands-publishing/test/pack.ts
@@ -1,12 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 import { pack } from '@pnpm/plugin-commands-publishing'
-import { type PackResultJson } from '../src/pack'
 import { prepare, preparePackages, tempDir } from '@pnpm/prepare'
 import tar from 'tar'
 import chalk from 'chalk'
 import { sync as writeYamlFile } from 'write-yaml-file'
 import { filterPackagesFromDir } from '@pnpm/workspace.filter-packages-from-dir'
+import { type PackResultJson } from '../src/pack'
 import { DEFAULT_OPTS } from './utils'
 
 test('pack: package with package.json', async () => {


### PR DESCRIPTION

Add `--filter` and `--recursive` for `pack` command

Releated #4351 #4792 #3290

I have been waiting for this feature for a long time. The current version of pnpm does not support package filtering for the `pack` command, I mean `--filter` and `--recursive`. We need this feature to help reviewing the contents of the packages before they are published to the registry.

This PR changes:

1 Console report

  For single-package mode, the `--json` report will remain as is to maintain compatibility. For multi-package mode, the `--json` report will return an array (this may be a breaking change). You can use this array to check the packages info.
  
  The readable report style is changed to be consistent with the `npm pack --json` command, a title is added to each module for quick inspection.

2 Output path

`--output` takes precedence over `--pack-destination` because `--output` is more precise.

  If neither is specified, the current package's directory is used, and is passed to other packages so that all tarballs are generated in the same path.

3 Difference from `publish --recursive`

  Since `pack` command only performs packaging and does not actually publish tarballs to the registry, it does not check the registry and does not care whether the package manifest has the `private` field.
