### PR TITLE
fix: setting `overrides` invalid

### DIFF
--- a/config/config/src/getOptionsFromRootManifest.ts
+++ b/config/config/src/getOptionsFromRootManifest.ts
@@ -64,12 +64,8 @@ export function getOptionsFromRootManifest (manifestDir: string, manifest: Proje
 export function getOptionsFromPnpmSettings (manifestDir: string, pnpmSettings: PnpmSettings, manifest?: ProjectManifest): OptionsFromRootManifest {
   const renamedKeys = ['allowNonAppliedPatches'] as const satisfies Array<keyof PnpmSettings>
   const settings: OptionsFromRootManifest = omit(renamedKeys, replaceEnvInSettings(pnpmSettings))
-  if (settings.overrides) {
-    if (Object.keys(settings.overrides).length === 0) {
-      delete settings.overrides
-    } else if (manifest) {
-      settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
-    }
+  if (settings.overrides && manifest) {
+    settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
   }
   if (pnpmSettings.onlyBuiltDependenciesFile) {
     settings.onlyBuiltDependenciesFile = path.join(manifestDir, pnpmSettings.onlyBuiltDependenciesFile)

--- a/config/config/test/getOptionsFromRootManifest.test.ts
+++ b/config/config/test/getOptionsFromRootManifest.test.ts
@@ -106,6 +106,7 @@ test('getOptionsFromRootManifest() should derive allowUnusedPatches from allowNo
     },
   })).toStrictEqual({
     allowUnusedPatches: false,
+    overrides: {},
   })
 
   expect(getOptionsFromRootManifest(process.cwd(), {
@@ -114,6 +115,7 @@ test('getOptionsFromRootManifest() should derive allowUnusedPatches from allowNo
     },
   })).toStrictEqual({
     allowUnusedPatches: true,
+    overrides: {},
   })
 })
 
@@ -125,6 +127,7 @@ test('allowUnusedPatches should override allowNonAppliedPatches', () => {
     },
   })).toStrictEqual({
     allowUnusedPatches: false,
+    overrides: {},
   })
 
   expect(getOptionsFromRootManifest(process.cwd(), {
@@ -134,6 +137,7 @@ test('allowUnusedPatches should override allowNonAppliedPatches', () => {
     },
   })).toStrictEqual({
     allowUnusedPatches: false,
+    overrides: {},
   })
 
   expect(getOptionsFromRootManifest(process.cwd(), {
@@ -143,6 +147,7 @@ test('allowUnusedPatches should override allowNonAppliedPatches', () => {
     },
   })).toStrictEqual({
     allowUnusedPatches: false,
+    overrides: {},
   })
 
   expect(getOptionsFromRootManifest(process.cwd(), {
@@ -152,6 +157,7 @@ test('allowUnusedPatches should override allowNonAppliedPatches', () => {
     },
   })).toStrictEqual({
     allowUnusedPatches: false,
+    overrides: {},
   })
 })
 


### PR DESCRIPTION
close #9283

I am unsure what scenario #9176 solves, so I temporarily rolled back #9176, which solves #9283.