### PR TITLE
feat(init): initType default value is set to `module`

### DIFF
--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -155,7 +155,7 @@ export async function getConfig (opts: {
     'ignore-workspace-root-check': false,
     'optimistic-repeat-install': false,
     'init-package-manager': true,
-    'init-type': 'commonjs',
+    'init-type': 'module',
     'inject-workspace-packages': false,
     'link-workspace-packages': false,
     'lockfile-include-tarball-url': false,


### PR DESCRIPTION
Although the default value of npm's init-type parameter is also `commonjs`, many people still suggest changing it to `module`.

In my opinion, I also think it is OK to set the default value of `initType` to `module`.

Many developers have begun to abandon the `commonjs` syntax gradually. I have seen many projects already carrying out related code migration. Although the overall proportion is not particularly high so far, it is a trend.

I think we can also try to guide developers to use esm syntax by default.

