### PR TITLE
feat(config): add support for PNPM_CONFIG_USERCONFIG

### DIFF
--- a/config/config/src/dirs.ts
+++ b/config/config/src/dirs.ts
@@ -70,6 +70,9 @@ export function getConfigDir (
     platform: string
   }
 ): string {
+  if(opts.env.PNPM_CONFIG_USERCONFIG){
+    return path.join(opts.env.PNPM_CONFIG_USERCONFIG)
+  }
   if (opts.env.XDG_CONFIG_HOME) {
     return path.join(opts.env.XDG_CONFIG_HOME, 'pnpm')
   }


### PR DESCRIPTION
allow users to specify a custom configuration file path using the PNPM_CONFIG_USERCONFIG environment variable. This change ensures that if PNPM_CONFIG_USERCONFIG is declared, the configuration will be loaded from the specified path.

BREAKING CHANGE: the behavior of getConfigDir now proritizes PNPM_CONFIG_USERCONFIG over other environment variables like XDG_CONFIG_HOME.

Closes #9487 