### PR TITLE
test: use `toMatchObject` and `objectContaining` where appropriate

### DIFF
--- a/cache/commands/test/cacheView.cmd.test.ts
+++ b/cache/commands/test/cacheView.cmd.test.ts
@@ -45,7 +45,7 @@ describe('cache view', () => {
     }, ['view', 'is-negative'])
 
     expect(JSON.parse(result!)).toMatchObject({
-      [`localhost:${REGISTRY_MOCK_PORT}`]: expect.objectContaining({
+      [`localhost:${REGISTRY_MOCK_PORT}`]: {
         cachedVersions: ['2.1.0'],
         nonCachedVersions: [
           '1.0.0',
@@ -54,8 +54,8 @@ describe('cache view', () => {
           '2.0.1',
           '2.0.2',
         ],
-      }),
-      'registry.npmjs.org': expect.objectContaining({
+      },
+      'registry.npmjs.org': {
         cachedVersions: ['2.1.0'],
         nonCachedVersions: [
           '1.0.0',
@@ -64,7 +64,7 @@ describe('cache view', () => {
           '2.0.1',
           '2.0.2',
         ],
-      }),
+      },
     })
   })
   test('lists metadata for requested package from specified registry', async () => {
@@ -78,7 +78,7 @@ describe('cache view', () => {
     }, ['view', 'is-negative'])
 
     expect(JSON.parse(result!)).toMatchObject({
-      'registry.npmjs.org': expect.objectContaining({
+      'registry.npmjs.org': {
         cachedVersions: ['2.1.0'],
         nonCachedVersions: [
           '1.0.0',
@@ -87,7 +87,7 @@ describe('cache view', () => {
           '2.0.1',
           '2.0.2',
         ],
-      }),
+      },
     })
   })
 

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -344,7 +344,7 @@ test('lockfile catalog snapshots do not contain stale references on --filter', a
     },
   })
 
-  expect(readLockfile()).toMatchObject({
+  expect(readLockfile()).toStrictEqual(expect.objectContaining({
     catalogs: {
       default: {
         'is-positive': { specifier: '=3.1.0', version: '3.1.0' },
@@ -361,7 +361,7 @@ test('lockfile catalog snapshots do not contain stale references on --filter', a
         },
       }),
     }),
-  })
+  }))
 
   // is-positive was not updated because only dependencies of project1 were.
   const pathToIsPositivePkgJson = path.join(options.allProjects[1].rootDir!, 'node_modules/is-positive/package.json')
@@ -431,7 +431,7 @@ test('dedupe-peer-dependents=false with --filter does not erase catalog snapshot
 
   // The catalogs snapshot section was erased in the bug report from
   // https://github.com/pnpm/pnpm/issues/9112 when dedupe-peer-dependents=false.
-  expect(readLockfile()).toMatchObject({
+  expect(readLockfile()).toStrictEqual(expect.objectContaining({
     catalogs: {
       default: {
         'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
@@ -445,7 +445,7 @@ test('dedupe-peer-dependents=false with --filter does not erase catalog snapshot
         },
       }),
     }),
-  })
+  }))
 })
 
 // Regression test for https://github.com/pnpm/pnpm/issues/8639
@@ -572,13 +572,13 @@ test('catalog resolutions should be consistent', async () => {
 
   // At this point, both 3.0.0 and 3.1.0 should be in the lockfile, but the
   // catalog entry still resolves to 3.0.0.
-  expect(readLockfile()).toMatchObject({
+  expect(readLockfile()).toStrictEqual(expect.objectContaining({
     catalogs: { default: { 'is-positive': { specifier: '^3.0.0', version: '3.0.0' } } },
     packages: expect.objectContaining({
-      'is-positive@3.0.0': expect.objectContaining({}),
-      'is-positive@3.1.0': expect.objectContaining({}),
+      'is-positive@3.0.0': expect.any(Object),
+      'is-positive@3.1.0': expect.any(Object),
     }),
-  })
+  }))
 
   // Adding a new catalog dependency. It should resolve to 3.0.0 instead of 3.1.0, despite resolution-mode=highest.
   projects['project3' as ProjectId].dependencies = {
@@ -589,11 +589,11 @@ test('catalog resolutions should be consistent', async () => {
   // Expect all projects using the catalog specifier (e.g. project1 and project3) to resolve to the same version.
   expect(readLockfile()).toMatchObject({
     catalogs: { default: { 'is-positive': { specifier: '^3.0.0', version: '3.0.0' } } },
-    importers: expect.objectContaining({
-      project1: expect.objectContaining({ dependencies: { 'is-positive': { specifier: 'catalog:', version: '3.0.0' } } }),
-      project2: expect.objectContaining({ dependencies: { 'is-positive': { specifier: '3.1.0', version: '3.1.0' } } }),
-      project3: expect.objectContaining({ dependencies: { 'is-positive': { specifier: 'catalog:', version: '3.0.0' } } }),
-    }),
+    importers: {
+      project1: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '3.0.0' } } },
+      project2: { dependencies: { 'is-positive': { specifier: '3.1.0', version: '3.1.0' } } },
+      project3: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '3.0.0' } } },
+    },
   })
 })
 
@@ -641,10 +641,10 @@ test('catalog entry using npm alias can be reused', async () => {
 
   expect(readLockfile()).toMatchObject({
     catalogs: { default: { '@pnpm.test/is-positive-alias': { specifier: 'npm:is-positive@1.0.0', version: '1.0.0' } } },
-    importers: expect.objectContaining({
-      project1: expect.objectContaining({ dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } }),
-      project2: expect.objectContaining({ dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } }),
-    }),
+    importers: {
+      project1: { dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } },
+      project2: { dependencies: { '@pnpm.test/is-positive-alias': { specifier: 'catalog:', version: 'is-positive@1.0.0' } } },
+    },
   })
 })
 
@@ -902,7 +902,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
-      packages: { 'is-positive@1.0.0': expect.objectContaining({}) },
+      packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })
 
@@ -932,7 +932,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
-      packages: { 'is-positive@1.0.0': expect.objectContaining({}) },
+      packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })
 
@@ -962,7 +962,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
-      packages: { 'is-positive@1.0.0': expect.objectContaining({}) },
+      packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })
 
@@ -990,8 +990,8 @@ describe('add', () => {
         'is-positive': '2.0.0',
       },
     })
-    expect(readLockfile()).toMatchObject({
-      packages: { 'is-positive@2.0.0': expect.objectContaining({}) },
+    expect(readLockfile().packages).toStrictEqual({
+      'is-positive@2.0.0': expect.any(Object),
     })
   })
 })
@@ -1094,7 +1094,7 @@ describe('update', () => {
     // The lockfile should only contain 1.0.0 and not 1.3.0 (or a later version).
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' } } },
-      packages: { '@pnpm.e2e/foo@1.0.0': expect.objectContaining({}) },
+      packages: { '@pnpm.e2e/foo@1.0.0': expect.any(Object) },
     })
   })
 

--- a/pkg-manager/package-requester/test/index.ts
+++ b/pkg-manager/package-requester/test/index.ts
@@ -1022,9 +1022,7 @@ test('the version in the bundled manifest should be normalized', async () => {
     preferredVersions: {},
     projectDir: tempy.directory(),
   })
-  expect((await pkgResponse.fetching!()).bundledManifest).toMatchObject({
-    version: '1.2.1',
-  })
+  expect((await pkgResponse.fetching!()).bundledManifest?.version).toBe('1.2.1')
 })
 
 test('should skip store integrity check and resolve manifest if fetchRawManifest is true', async () => {

--- a/workspace/state/test/createWorkspaceState.test.ts
+++ b/workspace/state/test/createWorkspaceState.test.ts
@@ -20,11 +20,11 @@ test('createWorkspaceState() on empty list', () => {
         injectWorkspacePackages: false,
       },
     })
-  ).toMatchObject({
+  ).toStrictEqual(expect.objectContaining({
     projects: {},
     pnpmfileExists: true,
     lastValidatedTimestamp: expect.any(Number),
-  })
+  }))
 })
 
 test('createWorkspaceState() on non-empty list', () => {
@@ -57,7 +57,7 @@ test('createWorkspaceState() on non-empty list', () => {
       pnpmfileExists: false,
       filteredInstall: false,
     })
-  ).toMatchObject({
+  ).toStrictEqual(expect.objectContaining({
     settings: expect.objectContaining({
       catalogs: {
         default: {
@@ -73,5 +73,5 @@ test('createWorkspaceState() on non-empty list', () => {
       [path.resolve('packages/d')]: {},
     },
     pnpmfileExists: false,
-  })
+  }))
 })

--- a/workspace/state/test/updatePackagesList.test.ts
+++ b/workspace/state/test/updatePackagesList.test.ts
@@ -35,10 +35,10 @@ test('updateWorkspaceState()', async () => {
     },
   })
   expect((logger.debug as jest.Mock).mock.calls).toStrictEqual([[{ msg: 'updating workspace state' }]])
-  expect(loadWorkspaceState(workspaceDir)).toMatchObject({
+  expect(loadWorkspaceState(workspaceDir)).toStrictEqual(expect.objectContaining({
     lastValidatedTimestamp: expect.any(Number),
     projects: {},
-  })
+  }))
 
   logger.debug = jest.fn(originalLoggerDebug)
   await updateWorkspaceState({
@@ -66,7 +66,7 @@ test('updateWorkspaceState()', async () => {
     filteredInstall: false,
   })
   expect((logger.debug as jest.Mock).mock.calls).toStrictEqual([[{ msg: 'updating workspace state' }]])
-  expect(loadWorkspaceState(workspaceDir)).toMatchObject({
+  expect(loadWorkspaceState(workspaceDir)).toStrictEqual(expect.objectContaining({
     settings: expect.objectContaining({
       catalogs: {
         default: {
@@ -81,5 +81,5 @@ test('updateWorkspaceState()', async () => {
       [path.resolve('packages/c')]: {},
       [path.resolve('packages/d')]: {},
     },
-  })
+  }))
 })


### PR DESCRIPTION
Related PR: https://github.com/pnpm/pnpm/pull/9431

`toMatchObject` and `objectContaining` have a subtle difference in depth: `objectContaining` would fail if one of the nested object has more properties.

This PR:
* Replaces nested `objectContaining` with a single `toMatchObject` at the top.
* Brings back `objectContaining` where it makes sense (such as when it needs to guarantee empty objects, for example).
* Replaces `expect.objectContaining({})` with `expect.any(Object)`.