### PR TITLE
test: fix catalog tests adding dependencies to wrong package

### DIFF
--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -902,6 +902,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
+      importers: { project1: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '1.0.0' } } } },
       packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })
@@ -932,6 +933,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
+      importers: { project1: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '1.0.0' } } } },
       packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })
@@ -962,6 +964,7 @@ describe('add', () => {
     })
     expect(readLockfile()).toMatchObject({
       catalogs: { default: { 'is-positive': { specifier: '1.0.0', version: '1.0.0' } } },
+      importers: { project1: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '1.0.0' } } } },
       packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
   })

--- a/pkg-manager/core/test/catalogs.ts
+++ b/pkg-manager/core/test/catalogs.ts
@@ -10,6 +10,7 @@ import { testDefaults } from './utils'
 
 function preparePackagesAndReturnObjects (manifests: Array<ProjectManifest & Required<Pick<ProjectManifest, 'name'>>>) {
   const project = prepareEmpty()
+  const lockfileDir = process.cwd()
   const projects: Record<ProjectId, ProjectManifest> = {}
   for (const manifest of manifests) {
     projects[manifest.name as ProjectId] = manifest
@@ -23,9 +24,12 @@ function preparePackagesAndReturnObjects (manifests: Array<ProjectManifest & Req
   return {
     ...project,
     projects,
-    options: testDefaults({
-      allProjects,
-    }),
+    options: {
+      ...testDefaults({
+        allProjects,
+      }),
+      lockfileDir,
+    },
   }
 }
 
@@ -887,6 +891,7 @@ describe('add', () => {
       ['is-positive@catalog:'],
       {
         ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
         lockfileOnly: true,
         allowNew: true,
         catalogs: {
@@ -918,6 +923,7 @@ describe('add', () => {
       ['is-positive'],
       {
         ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
         lockfileOnly: true,
         allowNew: true,
         catalogs: {
@@ -949,6 +955,7 @@ describe('add', () => {
       ['is-positive@1.0.0'],
       {
         ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
         lockfileOnly: true,
         allowNew: true,
         catalogs: {
@@ -980,6 +987,7 @@ describe('add', () => {
       ['is-positive@2.0.0'],
       {
         ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
         lockfileOnly: true,
         allowNew: true,
         catalogs: {
@@ -1033,6 +1041,7 @@ describe('update', () => {
       ['@pnpm.e2e/foo'],
       {
         ...options,
+        dir: path.join(options.lockfileDir, 'project1'),
         lockfileOnly: true,
         allowNew: false,
         update: true,
@@ -1084,6 +1093,7 @@ describe('update', () => {
       ['@pnpm.e2e/foo'],
       {
         ...mutateOpts,
+        dir: path.join(options.lockfileDir, 'project1'),
         update: true,
       })
 
@@ -1132,6 +1142,7 @@ describe('update', () => {
       ['@pnpm.e2e/foo'],
       {
         ...mutateOpts,
+        dir: path.join(process.cwd(), 'project1'),
         allowNew: false,
         update: true,
         updateToLatest: true,


### PR DESCRIPTION
## Context

While working on https://github.com/pnpm/pnpm/issues/8641, I noticed our usage of `addDependenciesToPackage` in catalog tests are incorrect. Instead of updating dependencies of a specific importer (e.g. `project1` in most tests), it's getting added to the root project.

This caused a surprise when I wrote a `pnpm update` test and observed the old version of the package stick around in the lockfile.

## Changes

Updating the catalog tests to pass a `dir` option to `addDependenciesToPackage` so the correct importer is updated.

## Questions

We should consider making the `dir` option to `addDependenciesToPackage` required. To specify the root project, users would pass `"."`.