### PR TITLE
fix: fixed extra-bin-paths not set if using `ignore-script=true` in a monorepo

### DIFF
--- a/.changeset/mighty-guests-lay.md
+++ b/.changeset/mighty-guests-lay.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": major
+---
+
+fixed extra-bin-paths not set if using `ignore-script=true` in a monorepo

--- a/.changeset/mighty-guests-lay.md
+++ b/.changeset/mighty-guests-lay.md
@@ -1,5 +1,0 @@
----
-"@pnpm/config": major
----
-
-fixed extra-bin-paths not set if using `ignore-script=true` in a monorepo

--- a/.changeset/shy-seas-lick.md
+++ b/.changeset/shy-seas-lick.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/config": patch
+"pnpm": patch
 ---
 
-fixed extra-bin-paths not set if using `ignore-script=true` in a monorepo
+`pnpm run` should be able to run commands from the workspace root, if `ignoreScripts` is set tot `true` [#4858](https://github.com/pnpm/pnpm/issues/4858).

--- a/.changeset/shy-seas-lick.md
+++ b/.changeset/shy-seas-lick.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+fixed extra-bin-paths not set if using `ignore-script=true` in a monorepo

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -387,7 +387,7 @@ export async function getConfig (opts: {
     pnpmConfig.filterProd = (pnpmConfig.filterProd as string).split(' ')
   }
 
-  if (!pnpmConfig.ignoreScripts && pnpmConfig.workspaceDir) {
+  if (pnpmConfig.workspaceDir) {
     pnpmConfig.extraBinPaths = [path.join(pnpmConfig.workspaceDir, 'node_modules', '.bin')]
   } else {
     pnpmConfig.extraBinPaths = []

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -340,6 +340,21 @@ test('extraBinPaths', async () => {
         name: 'pnpm',
         version: '1.0.0',
       },
+      workspaceDir: process.cwd(),
+    })
+    // extraBinPaths has the node_modules/.bin folder from the root of the workspace if scripts are ignored
+    expect(config.extraBinPaths).toStrictEqual([path.resolve('node_modules/.bin')])
+  }
+
+  {
+    const { config } = await getConfig({
+      cliOptions: {
+        'ignore-scripts': true,
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
     })
     // extraBinPaths is empty inside a workspace if scripts are ignored
     expect(config.extraBinPaths).toEqual([])


### PR DESCRIPTION
closes https://github.com/pnpm/pnpm/issues/4858