### PR TITLE
feat: add new `catalogMode` setting

### DIFF
--- a/.changeset/wide-ghosts-own.md
+++ b/.changeset/wide-ghosts-own.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/core": minor
+"@pnpm/config": minor
+"@pnpm/plugin-commands-installation": minor
+"@pnpm/plugin-commands-patching": minor
+---
+
+A new `catalogMode` setting is available for controlling if and how dependencies are added to the default catalog. It can be configured to several modes:
+
+- `strict`: Only allows dependency versions from the catalog. Adding a dependency outside the catalog's version range will cause an error.
+- `prefer`: Prefers catalog versions, but will fall back to direct dependencies if no compatible version is found.
+- `manual` (default): Does not automatically add dependencies to the catalog.

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -149,6 +149,7 @@ export interface Config extends OptionsFromRootManifest {
   workspaceDir?: string
   workspacePackagePatterns?: string[]
   catalogs?: Catalogs
+  catalogMode?: 'strict' | 'prefer' | 'manual'
   reporter?: string
   aggregateOutput: boolean
   linkWorkspacePackages: boolean | 'deep'

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -121,6 +121,7 @@ export async function getConfig (opts: {
   const defaultOptions: Partial<KebabCaseConfig> | typeof npmTypes.types = {
     'auto-install-peers': true,
     bail: true,
+    'catalog-mode': 'manual',
     color: 'auto',
     'dangerously-allow-all-builds': false,
     'deploy-all-files': false,

--- a/config/config/src/types.ts
+++ b/config/config/src/types.ts
@@ -4,6 +4,7 @@ export const types = Object.assign({
   'auto-install-peers': Boolean,
   bail: Boolean,
   'cache-dir': String,
+  'catalog-mode': ['strict', 'prefer', 'manual'],
   'child-concurrency': Number,
   'merge-git-branch-lockfiles': Boolean,
   'merge-git-branch-lockfiles-branch-pattern': Array,

--- a/patching/plugin-commands-patching/test/patch.test.ts
+++ b/patching/plugin-commands-patching/test/patch.test.ts
@@ -1302,6 +1302,7 @@ describe('patch with custom modules-dir and virtual-store-dir', () => {
       saveLockfile: true,
       modulesDir: 'fake_modules',
       virtualStoreDir: 'fake_modules/.fake_store',
+      confirmModulesPurge: false,
     })
     const output = await patch.handler(defaultPatchOption, ['is-positive@1'])
     const patchDir = getPatchDirFromPatchOutput(output)
@@ -1326,6 +1327,7 @@ describe('patch with custom modules-dir and virtual-store-dir', () => {
       virtualStoreDir: 'fake_modules/.fake_store',
       lockfileDir: customModulesDirFixture,
       workspaceDir: customModulesDirFixture,
+      confirmModulesPurge: false,
     }, [patchDir])
     expect(fs.readFileSync(path.join(customModulesDirFixture, 'packages/bar/fake_modules/is-positive/index.js'), 'utf8')).toContain('// test patching')
   })

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -59,6 +59,7 @@
     "@pnpm/builder.policy": "catalog:",
     "@pnpm/calc-dep-state": "workspace:*",
     "@pnpm/catalogs.protocol-parser": "workspace:*",
+    "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",

--- a/pkg-manager/core/src/install/checkCompatibility/CatalogVersionMismatchError.ts
+++ b/pkg-manager/core/src/install/checkCompatibility/CatalogVersionMismatchError.ts
@@ -1,0 +1,16 @@
+import { PnpmError } from '@pnpm/error'
+
+export class CatalogVersionMismatchError extends PnpmError {
+  public catalogDep: string
+  public wantedDep: string
+  constructor (
+    opts: {
+      catalogDep: string
+      wantedDep: string
+    }
+  ) {
+    super('CATALOG_VERSION_MISMATCH', 'Wanted dependency outside the version range defined in catalog')
+    this.catalogDep = opts.catalogDep
+    this.wantedDep = opts.wantedDep
+  }
+}

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -27,7 +27,7 @@ export interface StrictInstallOptions {
   autoInstallPeers: boolean
   autoInstallPeersFromHighestMatch: boolean
   catalogs: Catalogs
-  catalogMode?: 'strict' | 'prefer' | 'manual'
+  catalogMode: 'strict' | 'prefer' | 'manual'
   frozenLockfile: boolean
   frozenLockfileIfExists: boolean
   enablePnp: boolean

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -27,6 +27,7 @@ export interface StrictInstallOptions {
   autoInstallPeers: boolean
   autoInstallPeersFromHighestMatch: boolean
   catalogs: Catalogs
+  catalogMode?: 'strict' | 'prefer' | 'manual'
   frozenLockfile: boolean
   frozenLockfileIfExists: boolean
   enablePnp: boolean
@@ -177,6 +178,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     ignorePatchFailures: undefined,
     autoInstallPeers: true,
     autoInstallPeersFromHighestMatch: false,
+    catalogs: {},
     childConcurrency: 5,
     confirmModulesPurge: !opts.force,
     depth: 0,
@@ -237,6 +239,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
       process.platform === 'cygwin' ||
       !process.setgid ||
       process.getuid?.() !== 0,
+    catalogMode: 'manual',
     useLockfile: true,
     saveLockfile: true,
     useGitBranchLockfile: false,

--- a/pkg-manager/core/tsconfig.json
+++ b/pkg-manager/core/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../catalogs/protocol-parser"
     },
     {
+      "path": "../../catalogs/resolver"
+    },
+    {
       "path": "../../catalogs/types"
     },
     {

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -53,6 +53,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'bail'
 | 'bin'
 | 'catalogs'
+| 'catalogMode'
 | 'cliOptions'
 | 'dedupePeerDependents'
 | 'depth'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4499,6 +4499,9 @@ importers:
       '@pnpm/catalogs.protocol-parser':
         specifier: workspace:*
         version: link:../../catalogs/protocol-parser
+      '@pnpm/catalogs.resolver':
+        specifier: workspace:*
+        version: link:../../catalogs/resolver
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types


### PR DESCRIPTION
Add new `catalogMode` setting for automatically adding new dependencies to the default catalog.

Closes pnpm#8876, Closes pnpm#8308

Related PR: https://github.com/pnpm/pnpm/pull/9484