### PR TITLE
feat(add): `allow-build` option support multiple package string

### DIFF
--- a/.changeset/six-mirrors-vanish.md
+++ b/.changeset/six-mirrors-vanish.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+The `allow-build` parameter of the `add` command allows receiving multiple packages as a string concatenated by commas.

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -189,6 +189,11 @@ export async function parseCliArgs (
   }
 
   const knownOptions = new Set(Object.keys(types))
+  for (const [optionName, optionValue] of Object.entries(options)) {
+    if (Array.isArray(optionValue) && optionValue.every((v) => typeof v === 'string')) {
+      options[optionName] = optionValue.map((v) => v.split(',')).flat()
+    }
+  }
   return {
     argv,
     cmd,

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -189,8 +189,9 @@ export async function parseCliArgs (
   }
 
   const knownOptions = new Set(Object.keys(types))
+  const allowConvertOptions = ['allow-build']
   for (const [optionName, optionValue] of Object.entries(options)) {
-    if (Array.isArray(optionValue) && optionValue.every((v) => typeof v === 'string')) {
+    if (allowConvertOptions.includes(optionName) && Array.isArray(optionValue) && optionValue.every((v) => typeof v === 'string')) {
       options[optionName] = optionValue.map((v) => v.split(',')).flat()
     }
   }

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -336,3 +336,11 @@ test('should not swallows empty string in params', async () => {
   expect(cmd).toBe('run')
   expect(params).toStrictEqual(['echo', '', 'foo', '', 'bar'])
 })
+
+test('the allow build option can be comma separated', async () => {
+  const { options } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { 'allow-build': [String, Array] },
+  }, ['--allow-build', 'foo,bar', '--allow-build', 'qar', 'install'])
+  expect(options['allow-build']).toStrictEqual(['foo', 'bar', 'qar'])
+})

--- a/pkg-manager/plugin-commands-installation/src/add.ts
+++ b/pkg-manager/plugin-commands-installation/src/add.ts
@@ -253,6 +253,7 @@ export async function handler (
     if (opts.argv.original.includes('--allow-build')) {
       throw new PnpmError('ALLOW_BUILD_MISSING_PACKAGE', 'The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
     }
+    opts.allowBuild = opts.allowBuild.map((pkg) => pkg.split(',')).flat()
     if (opts.rootProjectManifest?.pnpm?.ignoredBuiltDependencies?.length) {
       const overlapDependencies = opts.rootProjectManifest.pnpm.ignoredBuiltDependencies.filter((dep) => opts.allowBuild?.includes(dep))
       if (overlapDependencies.length) {

--- a/pkg-manager/plugin-commands-installation/src/add.ts
+++ b/pkg-manager/plugin-commands-installation/src/add.ts
@@ -253,7 +253,6 @@ export async function handler (
     if (opts.argv.original.includes('--allow-build')) {
       throw new PnpmError('ALLOW_BUILD_MISSING_PACKAGE', 'The --allow-build flag is missing a package name. Please specify the package name(s) that are allowed to run installation scripts.')
     }
-    opts.allowBuild = opts.allowBuild.map((pkg) => pkg.split(',')).flat()
     if (opts.rootProjectManifest?.pnpm?.ignoredBuiltDependencies?.length) {
       const overlapDependencies = opts.rootProjectManifest.pnpm.ignoredBuiltDependencies.filter((dep) => opts.allowBuild?.includes(dep))
       if (overlapDependencies.length) {

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -206,6 +206,20 @@ test('--allow-build flag should specify the package', async () => {
   expect(modulesManifest?.onlyBuiltDependencies).toStrictEqual(undefined)
 })
 
+test('--allow-build flag specify multiple package names', async () => {
+  const project = prepare({})
+  execPnpmSync(['add', '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0', '@pnpm.e2e/install-script-example', '--allow-build=@pnpm.e2e/install-script-example,@pnpm.e2e/pre-and-postinstall-scripts-example'])
+
+  expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-preinstall.js')).toBeTruthy()
+  expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')).toBeTruthy()
+  expect(fs.existsSync('node_modules/@pnpm.e2e/install-script-example/generated-by-install.js')).toBeTruthy()
+
+  const manifest = loadJsonFile.sync<ProjectManifest>('package.json')
+  expect(manifest.pnpm?.onlyBuiltDependencies).toStrictEqual(undefined)
+  const modulesManifest = await readWorkspaceManifest(project.dir())
+  expect(modulesManifest?.onlyBuiltDependencies).toStrictEqual(['@pnpm.e2e/install-script-example', '@pnpm.e2e/pre-and-postinstall-scripts-example'])
+})
+
 test('selectively allow scripts in some dependencies by --allow-build flag overlap ignoredBuiltDependencies', async () => {
   prepare({
     pnpm: {


### PR DESCRIPTION
Currently, when using the `allow-build` option, if there are multiple packages, I have to write `pnpm add a b --allow-build=a --allow-build=b`, this seems a bit complicated, and I think it would be more convenient to just `pnpm add a b --allow-build=a,b`.