### PR TITLE
refactor: rename `newCatalogs` to `updatedCatalogs`

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -142,7 +142,7 @@ type Opts = Omit<InstallOptions, 'allProjects'> & {
 } & InstallMutationOptions
 
 export interface InstallResult {
-  newCatalogs: CatalogSnapshots | undefined
+  updatedCatalogs: CatalogSnapshots | undefined
   updatedManifest: ProjectManifest
   ignoredBuilds: string[] | undefined
 }
@@ -152,7 +152,7 @@ export async function install (
   opts: Opts
 ): Promise<InstallResult> {
   const rootDir = (opts.dir ?? process.cwd()) as ProjectRootDir
-  const { newCatalogs, updatedProjects: projects, ignoredBuilds } = await mutateModules(
+  const { updatedCatalogs, updatedProjects: projects, ignoredBuilds } = await mutateModules(
     [
       {
         mutation: 'install',
@@ -174,7 +174,7 @@ export async function install (
       }],
     }
   )
-  return { newCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds }
+  return { updatedCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds }
 }
 
 interface ProjectToBeInstalled {
@@ -195,7 +195,7 @@ export type MutateModulesOptions = InstallOptions & {
 }
 
 export interface MutateModulesInSingleProjectResult {
-  newCatalogs: CatalogSnapshots | undefined
+  updatedCatalogs: CatalogSnapshots | undefined
   updatedProject: UpdatedProject
   ignoredBuilds: string[] | undefined
 }
@@ -228,14 +228,14 @@ export async function mutateModulesInSingleProject (
     }
   )
   return {
-    newCatalogs: result.newCatalogs,
+    updatedCatalogs: result.updatedCatalogs,
     updatedProject: result.updatedProjects[0],
     ignoredBuilds: result.ignoredBuilds,
   }
 }
 
 export interface MutateModulesResult {
-  newCatalogs?: CatalogSnapshots
+  updatedCatalogs?: CatalogSnapshots
   updatedProjects: UpdatedProject[]
   stats: InstallationResultStats
   depsRequiringBuild?: DepPath[]
@@ -332,7 +332,7 @@ export async function mutateModules (
   }
 
   return {
-    newCatalogs: result.newCatalogs,
+    updatedCatalogs: result.updatedCatalogs,
     updatedProjects: result.updatedProjects,
     stats: result.stats ?? { added: 0, removed: 0, linkedToRoot: 0 },
     depsRequiringBuild: result.depsRequiringBuild,
@@ -340,7 +340,7 @@ export async function mutateModules (
   }
 
   interface InnerInstallResult {
-    readonly newCatalogs?: CatalogSnapshots
+    readonly updatedCatalogs?: CatalogSnapshots
     readonly updatedProjects: UpdatedProject[]
     readonly stats?: InstallationResultStats
     readonly depsRequiringBuild?: DepPath[]
@@ -595,7 +595,7 @@ export async function mutateModules (
     })
 
     return {
-      newCatalogs: result.newCatalogs,
+      updatedCatalogs: result.updatedCatalogs,
       updatedProjects: result.projects,
       stats: result.stats,
       depsRequiringBuild: result.depsRequiringBuild,
@@ -904,7 +904,7 @@ export async function addDependenciesToPackage (
   } & InstallMutationOptions
 ): Promise<InstallResult> {
   const rootDir = (opts.dir ?? process.cwd()) as ProjectRootDir
-  const { newCatalogs, updatedProjects: projects, ignoredBuilds } = await mutateModules(
+  const { updatedCatalogs, updatedProjects: projects, ignoredBuilds } = await mutateModules(
     [
       {
         allowNew: opts.allowNew,
@@ -932,7 +932,7 @@ export async function addDependenciesToPackage (
         },
       ],
     })
-  return { newCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds }
+  return { updatedCatalogs, updatedManifest: projects[0].manifest, ignoredBuilds }
 }
 
 export type ImporterToUpdate = {
@@ -957,7 +957,7 @@ export interface UpdatedProject {
 }
 
 interface InstallFunctionResult {
-  newCatalogs?: CatalogSnapshots
+  updatedCatalogs?: CatalogSnapshots
   newLockfile: LockfileObject
   projects: UpdatedProject[]
   stats?: InstallationResultStats
@@ -1072,7 +1072,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     dependenciesGraph,
     dependenciesByProjectId,
     linkedDependenciesByProjectId,
-    newCatalogs,
+    updatedCatalogs,
     newLockfile,
     outdatedDependencies,
     peerDependencyIssuesByProjects,
@@ -1467,7 +1467,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
   }
 
   return {
-    newCatalogs,
+    updatedCatalogs,
     newLockfile,
     projects: projects.map(({ id, manifest, rootDir }) => ({
       manifest,

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -142,6 +142,12 @@ type Opts = Omit<InstallOptions, 'allProjects'> & {
 } & InstallMutationOptions
 
 export interface InstallResult {
+  /**
+   * A partial of new or updated catalog config entries. A change will be
+   * produced if a dependency using the catalog protocol was newly added or
+   * updated during this install. To obtain the full catalog, callers should
+   * merge this object with the current catalog configs in pnpm-workspace.yaml.
+   */
   updatedCatalogs: CatalogSnapshots | undefined
   updatedManifest: ProjectManifest
   ignoredBuilds: string[] | undefined

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -314,11 +314,11 @@ when running add/update with the --workspace option')
       rootDir: opts.dir as ProjectRootDir,
       targetDependenciesField: getSaveType(opts),
     }
-    const { newCatalogs, updatedProject, ignoredBuilds } = await mutateModulesInSingleProject(mutatedProject, installOpts)
+    const { updatedCatalogs, updatedProject, ignoredBuilds } = await mutateModulesInSingleProject(mutatedProject, installOpts)
     if (opts.save !== false) {
       await Promise.all([
         writeProjectManifest(updatedProject.manifest),
-        newCatalogs && addCatalogs(opts.workspaceDir ?? opts.dir, newCatalogs),
+        updatedCatalogs && addCatalogs(opts.workspaceDir ?? opts.dir, updatedCatalogs),
       ])
     }
     if (!opts.lockfileOnly) {
@@ -337,11 +337,11 @@ when running add/update with the --workspace option')
     return
   }
 
-  const { newCatalogs, updatedManifest, ignoredBuilds } = await install(manifest, installOpts)
+  const { updatedCatalogs, updatedManifest, ignoredBuilds } = await install(manifest, installOpts)
   if (opts.update === true && opts.save !== false) {
     await Promise.all([
       writeProjectManifest(updatedManifest),
-      newCatalogs && addCatalogs(opts.workspaceDir ?? opts.dir, newCatalogs),
+      updatedCatalogs && addCatalogs(opts.workspaceDir ?? opts.dir, updatedCatalogs),
     ])
   }
   if (opts.strictDepBuilds && ignoredBuilds?.length) {

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -94,7 +94,7 @@ export interface ImporterToResolve extends Importer<{
 export interface ResolveDependenciesResult {
   dependenciesByProjectId: DependenciesByProjectId
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<ResolvedPackage>
-  newCatalogs?: CatalogSnapshots | undefined
+  updatedCatalogs?: CatalogSnapshots | undefined
   outdatedDependencies: {
     [pkgId: string]: string
   }
@@ -137,7 +137,7 @@ export async function resolveDependencies (
     appliedPatches,
     time,
     allPeerDepNames,
-    newCatalogs,
+    updatedCatalogs,
   } = await resolveDependencyTree(projectsToResolve, opts)
 
   opts.storeController.clearResolutionCache()
@@ -308,13 +308,13 @@ export async function resolveDependencies (
 
   // Q: Why would `newLockfile.catalogs` be constructed twice?
   // A: `getCatalogSnapshots` handles new dependencies that were resolved as `catalog:*` (e.g. new entries in `package.json` whose values were `catalog:*`),
-  //    and `newCatalogs` handles dependencies that were added as CLI parameters from `pnpm add --save-catalog`.
+  //    and `updatedCatalogs` handles dependencies that were added as CLI parameters from `pnpm add --save-catalog`.
   newLockfile.catalogs = getCatalogSnapshots(Object.values(resolvedImporters).flatMap(({ directDependencies }) => directDependencies))
-  for (const catalogName in newCatalogs) {
-    for (const dependencyName in newCatalogs[catalogName]) {
+  for (const catalogName in updatedCatalogs) {
+    for (const dependencyName in updatedCatalogs[catalogName]) {
       newLockfile.catalogs ??= {}
       newLockfile.catalogs[catalogName] ??= {}
-      newLockfile.catalogs[catalogName][dependencyName] = newCatalogs[catalogName][dependencyName]
+      newLockfile.catalogs[catalogName][dependencyName] = updatedCatalogs[catalogName][dependencyName]
     }
   }
 
@@ -332,7 +332,7 @@ export async function resolveDependencies (
     dependenciesGraph,
     outdatedDependencies,
     linkedDependenciesByProjectId,
-    newCatalogs,
+    updatedCatalogs,
     newLockfile,
     peerDependencyIssuesByProjects,
     waitTillAllFetchingsFinish,

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -137,7 +137,7 @@ export interface ResolveDependenciesOptions {
 export interface ResolveDependencyTreeResult {
   allPeerDepNames: Set<string>
   dependenciesTree: DependenciesTree<ResolvedPackage>
-  newCatalogs?: CatalogSnapshots
+  updatedCatalogs?: CatalogSnapshots
   outdatedDependencies: {
     [pkgId: string]: string
   }
@@ -236,7 +236,7 @@ export async function resolveDependencyTree<T> (
   const { pkgAddressesByImporters, time } = await resolveRootDependencies(ctx, resolveArgs)
   const directDepsByImporterId = zipObj(importers.map(({ id }) => id), pkgAddressesByImporters)
 
-  let newCatalogs: CatalogSnapshots | undefined
+  let updatedCatalogs: CatalogSnapshots | undefined
   for (const directDependencies of pkgAddressesByImporters) {
     for (const directDep of directDependencies as PkgAddress[]) {
       const { alias, normalizedBareSpecifier, version, saveCatalogName } = directDep
@@ -248,9 +248,9 @@ export async function resolveDependencyTree<T> (
           )
         }
       } else if (saveCatalogName != null && normalizedBareSpecifier != null && version != null) {
-        newCatalogs ??= {}
-        newCatalogs[saveCatalogName] ??= {}
-        newCatalogs[saveCatalogName][alias] = {
+        updatedCatalogs ??= {}
+        updatedCatalogs[saveCatalogName] ??= {}
+        updatedCatalogs[saveCatalogName][alias] = {
           specifier: normalizedBareSpecifier,
           version,
         }
@@ -301,7 +301,7 @@ export async function resolveDependencyTree<T> (
 
   return {
     dependenciesTree: ctx.dependenciesTree,
-    newCatalogs,
+    updatedCatalogs,
     outdatedDependencies: ctx.outdatedDependencies,
     resolvedImporters,
     resolvedPkgsById: ctx.resolvedPkgsById,


### PR DESCRIPTION
Copying a small change from my `pnpm update` branch. It would be useful to rename the `newCatalogs` field returned during an install to `updatedCatalogs` for a few reasons:

1. This object will also contain changed catalogs as a part of a `pnpm update` soon.
2. I think the "_updated_" naming better matches the `updatedManifest` naming, which serves a very similar purpose.

https://github.com/pnpm/pnpm/blob/e6a194acdd927d5279bec196a6aa9c9d119f4333/pkg-manager/core/src/install/index.ts#L145-L146