### PR TITLE
refactor: delete travis links

### DIFF
--- a/pkg-manager/link-bins/README.md
+++ b/pkg-manager/link-bins/README.md
@@ -2,8 +2,8 @@
 
 > Link bins to node_modules/.bin
 
-<!--@shields('npm', 'travis')-->
-[![npm version](https://img.shields.io/npm/v/@pnpm/link-bins.svg)](https://www.npmjs.com/package/@pnpm/link-bins) [![Build Status](https://img.shields.io/travis/pnpm/link-bins/master.svg)](https://travis-ci.org/pnpm/link-bins)
+<!--@shields('npm')-->
+[![npm version](https://img.shields.io/npm/v/@pnpm/link-bins.svg)](https://www.npmjs.com/package/@pnpm/link-bins)
 <!--/@-->
 
 ## Installation

--- a/pkg-manager/package-bins/README.md
+++ b/pkg-manager/package-bins/README.md
@@ -2,8 +2,8 @@
 
 > Returns bins of a package
 
-<!--@shields('npm', 'travis')-->
-[![npm version](https://img.shields.io/npm/v/@pnpm/package-bins.svg)](https://www.npmjs.com/package/@pnpm/package-bins) [![Build Status](https://img.shields.io/travis/pnpm/package-bins/master.svg)](https://travis-ci.org/pnpm/package-bins)
+<!--@shields('npm')-->
+[![npm version](https://img.shields.io/npm/v/@pnpm/package-bins.svg)](https://www.npmjs.com/package/@pnpm/package-bins)
 <!--/@-->
 
 ## Installation

--- a/store/store-path/README.md
+++ b/store/store-path/README.md
@@ -2,8 +2,8 @@
 
 > Resolves the pnpm store path
 
-<!--@shields('npm', 'travis')-->
-[![npm version](https://img.shields.io/npm/v/@pnpm/store-path.svg)](https://www.npmjs.com/package/@pnpm/store-path) [![Build Status](https://img.shields.io/travis/pnpm/store-path/master.svg)](https://travis-ci.org/pnpm/store-path)
+<!--@shields('npm')-->
+[![npm version](https://img.shields.io/npm/v/@pnpm/store-path.svg)](https://www.npmjs.com/package/@pnpm/store-path)
 <!--/@-->
 
 ## Installation


### PR DESCRIPTION
I mentioned in https://github.com/pnpm/pnpm/pull/9573#issue-3091523102 that there were more Travis references in the codebase. I've deleted the pnpm specific ones in this pull request and left the others. If they shouldn't be deleted, let me know.