### PR TITLE
fix: sort package versions semantically in patch command

### DIFF
--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -106,8 +106,13 @@ export async function getVersionsFromLockfile (dep: ParseWantedDependencyResult,
     })
     .filter(({ name }) => name === pkgName)
 
+  const filteredVersions = versions.filter(({ version }) => dep.alias && dep.bareSpecifier ? semver.satisfies(version, dep.bareSpecifier) : true)
+
+  versions.sort((a, b) => semver.compare(b.version, a.version))
+  filteredVersions.sort((a, b) => semver.compare(b.version, a.version))
+
   return {
     versions,
-    preferredVersions: versions.filter(({ version }) => dep.alias && dep.bareSpecifier ? semver.satisfies(version, dep.bareSpecifier) : true),
+    preferredVersions: filteredVersions,
   }
 }


### PR DESCRIPTION
## Problem

When using the `pnpm patch` command, the list of versions is displayed in lexicographical order (as strings) rather than in semantic version order, which leads to unintuitive display. For example, version "9.10.0" appears after "9.2.0" because in string comparison "1" comes after "2".

<img width="872" alt="image" src="https://github.com/user-attachments/assets/88bf2f31-118a-42ca-9517-2b39fe74a4f2" />

## Solution

Added explicit version sorting using `semver.compare()` in the `getVersionsFromLockfile` function. Now versions are sorted semantically from oldest to newest (9.2.0 will come before 9.10.0).

## How to verify

Run `pnpm patch <package-name>` in a monorepo where multiple versions of the same package with different version numbers are installed, such as "9.0.22", "9.0.39", "9.10.0", "9.2.0". The versions should now be displayed in the correct semantic order: first 9.2.0, then 9.10.0, etc.
