### PR TITLE
ci: prevent duplicate builds for pull requests in original repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ permissions:
 
 jobs:
   build:
+    # Skip pull_request events from PRs in the same repo. This prevents
+    # duplicate build jobs from running when creating a PR in the original repo.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.node[0] }}
       cancel-in-progress: true


### PR DESCRIPTION
## Problem

Today, when pushing to a branch in the pnpm repo and opening a pull request, CI runs for both the `pull_request` and the `push` event.

<img width="822" src="https://github.com/user-attachments/assets/be63e220-d839-4089-ac28-4c2d271a3d27" />

## Changes

I suspect the duplicate builds aren't intentional and only running once saves on resources.

## Downsides

When the pull request event is skipped, it gets a weird title. It looks like there's [some discussion of this on GitHub](https://github.com/orgs/community/discussions/13261).

Contributors to pnpm opening a PR from a forked repository won't see this since GitHub Actions will run on their PR.

<img width="822" src="https://github.com/user-attachments/assets/658dafb6-3dea-4333-b2c3-a28e9e18961c" />

