### PR TITLE
fix: wait for server to listen

### DIFF
--- a/.changeset/bright-clubs-throw.md
+++ b/.changeset/bright-clubs-throw.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-server": patch
+"@pnpm/server": patch
+---
+
+Wait for server to listen [#9620](https://github.com/pnpm/pnpm/pull/9620).

--- a/store/plugin-commands-server/src/start.ts
+++ b/store/plugin-commands-server/src/start.ts
@@ -102,6 +102,7 @@ export async function start (
     ignoreStopRequests: opts.ignoreStopRequests,
     ignoreUploadRequests: opts.ignoreUploadRequests,
   })
+  await server.waitForListen
   // Make sure to populate server.json after the server has started, so clients know that the server is
   // listening if a server.json with valid JSON content exists.
   const serverJson = {

--- a/store/server/example/server.js
+++ b/store/server/example/server.js
@@ -32,6 +32,7 @@ async function main() {
     port,
     hostname,
   })
+  await server.waitForListen
 
   process.on('exit', () => server.close())
 }

--- a/store/server/src/createServer.ts
+++ b/store/server/src/createServer.ts
@@ -28,6 +28,7 @@ interface RequestBody {
 
 export interface StoreServerHandle {
   close: () => Promise<void>
+  waitForListen: Promise<void>
   waitForClose: Promise<void>
 }
 
@@ -169,17 +170,24 @@ export function createServer (
   })
 
   let listener: Server
-  if (opts.path) {
-    listener = server.listen(opts.path)
-  } else {
-    listener = server.listen(opts.port, opts.hostname)
-  }
+
+  const waitForListen = new Promise<void>((resolve) => {
+    if (opts.path) {
+      listener = server.listen(opts.path, () => {
+        resolve()
+      })
+    } else {
+      listener = server.listen(opts.port, opts.hostname, () => {
+        resolve()
+      })
+    }
+  })
 
   const waitForClose = new Promise<void>((resolve) => listener.once('close', () => {
     resolve()
   }))
 
-  return { close, waitForClose }
+  return { close, waitForListen, waitForClose }
 
   async function close (): Promise<void> {
     listener.close()

--- a/store/server/test/index.ts
+++ b/store/server/test/index.ts
@@ -48,6 +48,7 @@ test('server', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
   const projectDir = process.cwd()
   const response = await storeCtrl.requestPackage(
@@ -85,6 +86,7 @@ test('fetchPackage', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
   const pkgId = 'registry.npmjs.org/is-positive/1.0.0'
   // This should be fixed
@@ -123,6 +125,7 @@ test('server errors should arrive to the client', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
   let caught = false
   try {
@@ -163,6 +166,7 @@ test('server upload', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
 
   const fakeEngine = 'client-engine'
@@ -198,6 +202,7 @@ test('disable server upload', async () => {
     ignoreUploadRequests: true,
     port,
   })
+  await server.waitForListen
   const storeCtrl = await connectStoreController({ remotePrefix, concurrency: 100 })
 
   const fakeEngine = 'client-engine'
@@ -226,11 +231,12 @@ test('stop server with remote call', async () => {
   const hostname = 'localhost'
   const remotePrefix = `http://${hostname}:${port}`
   const storeCtrlForServer = await createStoreController()
-  createServer(storeCtrlForServer, {
+  const server = createServer(storeCtrlForServer, {
     hostname,
     ignoreStopRequests: false,
     port,
   })
+  await server.waitForListen
 
   expect(await isPortReachable(port)).toBeTruthy()
 
@@ -251,6 +257,7 @@ test('disallow stop server with remote call', async () => {
     ignoreStopRequests: true,
     port,
   })
+  await server.waitForListen
 
   expect(await isPortReachable(port)).toBeTruthy()
 
@@ -271,6 +278,7 @@ test('disallow store prune', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
 
   expect(await isPortReachable(port)).toBeTruthy()
 
@@ -290,6 +298,7 @@ test('server should only allow POST', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
 
   expect(await isPortReachable(port)).toBeTruthy()
 
@@ -318,6 +327,7 @@ test('server route not found', async () => {
     hostname,
     port,
   })
+  await server.waitForListen
 
   expect(await isPortReachable(port)).toBeTruthy()
 


### PR DESCRIPTION
Noticed while investigating tests in #8810 

Tests were flaking locally
`net.Server#listen` is not ready before it calls the callback, and connections failed randomly

Refs: https://nodejs.org/api/net.html#serverlistenoptions-callback

Alternatively this whole method could be made async

These random flakes/hangs could have been the reason why you had to add 38d7ca869de19b8473b6cc6767ee8b56560c8cb2 (which can now be removed, tests seem stable/fast here)