### PR TITLE
fix: support --help and -h flags for 'pnpm create' command

### DIFF
--- a/.changeset/icy-steaks-call.md
+++ b/.changeset/icy-steaks-call.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-script-runners": patch
+pnpm: patch
 ---
 
-Fix the '--help' and '-h' flags not working as expected for the 'pnpm create' command.
+Fix the `--help` and `-h` flags not working as expected for the `pnpm create` command.

--- a/.changeset/icy-steaks-call.md
+++ b/.changeset/icy-steaks-call.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+Fix the '--help' and '-h' flags not working as expected for the 'pnpm create' command.

--- a/exec/plugin-commands-script-runners/src/create.ts
+++ b/exec/plugin-commands-script-runners/src/create.ts
@@ -8,13 +8,19 @@ import * as dlx from './dlx'
 export const commandNames = ['create']
 
 export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): Promise<{ exitCode: number }> {
+  // If the first argument is --help or -h, we show the help message and exit with code 0.
+  if (params[0] === '--help' || params[0] === '-h') {
+    console.log(help())
+    return { exitCode: 0 }
+  }
+
   const [packageName, ...packageArgs] = params
   if (packageName === undefined) {
     throw new PnpmError(
       'MISSING_ARGS',
       'Missing the template package name.\n' +
-      'The correct usage is `pnpm create <name>` ' +
-      'with <name> substituted for a package name.'
+        'The correct usage is `pnpm create <name>` ' +
+        'with <name> substituted for a package name.'
     )
   }
 

--- a/exec/plugin-commands-script-runners/src/create.ts
+++ b/exec/plugin-commands-script-runners/src/create.ts
@@ -18,8 +18,8 @@ export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): 
     throw new PnpmError(
       'MISSING_ARGS',
       'Missing the template package name.\n' +
-        'The correct usage is `pnpm create <name>` ' +
-        'with <name> substituted for a package name.'
+      'The correct usage is `pnpm create <name>` ' +
+      'with <name> substituted for a package name.'
     )
   }
 

--- a/exec/plugin-commands-script-runners/src/create.ts
+++ b/exec/plugin-commands-script-runners/src/create.ts
@@ -8,7 +8,7 @@ import * as dlx from './dlx'
 export const commandNames = ['create']
 
 export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): Promise<{ exitCode: number } | string> {
-  // If the first argument is --help or -h, we show the help message and exit with code 0.
+  // If the first argument is --help or -h, we show the help message.
   if (params[0] === '--help' || params[0] === '-h') {
     return help()
   }

--- a/exec/plugin-commands-script-runners/src/create.ts
+++ b/exec/plugin-commands-script-runners/src/create.ts
@@ -7,11 +7,10 @@ import * as dlx from './dlx'
 
 export const commandNames = ['create']
 
-export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): Promise<{ exitCode: number }> {
+export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): Promise<{ exitCode: number } | string> {
   // If the first argument is --help or -h, we show the help message and exit with code 0.
   if (params[0] === '--help' || params[0] === '-h') {
-    console.log(help())
-    return { exitCode: 0 }
+    return help()
   }
 
   const [packageName, ...packageArgs] = params


### PR DESCRIPTION
Fixes #8545

- Adds option parsing to the 'create' command to detect --help and -h flags before package resolution.
- Displays the same help message as 'pnpm help create' and exits when either flag is present.
- Maintains backwards compatibility: all other arguments are treated as package names or parameters.