### PR TITLE
test: cleanup pnpm_ env variables in jest-config

### DIFF
--- a/__utils__/jest-config/config.js
+++ b/__utils__/jest-config/config.js
@@ -27,4 +27,12 @@ if (process.env.PNPM_SCRIPT_SRC_DIR) {
   config.cacheDirectory = path.join(__dirname, ".jest-cache", packageName)
 }
 
+// We are running test script from pnpm command, this seems to confuse tests
+// Clean up env from pnpm variables so that nested pnpm runs won't get affected on config read
+for (const key of Object.keys(process.env)) {
+  if (/^p?npm_(config|package|lifecycle|node|command|execpath)(_|$)/ui.test(key)) {
+    delete process.env[key]
+  }
+}
+
 module.exports = config


### PR DESCRIPTION
I am not sure how did this work on CI?

Tests seemed to fail locally for `pnpm run _test` but passed for `../../node_modules/.bin/jest`

Tests are run through pnpm itself, which pollutes env vars, and those `pnpm_*` env variables confused config reads in tests, e.g. added pnpmfile config property which wasn't present when `jest` was executed manually

This affected e.g. running `_test` in `exec/build-commands`

Before (`_test` only, `../../node_modules/.bin/jest` was fine):
```console
 FAIL  test/approveBuilds.test.ts (6.806 s)
  ✕ approve selected build (2028 ms)
  ✓ approve no builds (262 ms)
  ✓ works when root project manifest doesn't exist in a workspace (271 ms)
  ✓ should update onlyBuiltDependencies when package.json exists with ignoredBuiltDependencies defined (290 ms)
  ✓ should approve builds when package.json exists with onlyBuiltDependencies defined (299 ms)
  ✓ should approve builds with package.json that has no onlyBuiltDependencies and ignoredBuiltDependencies fields defined (251 ms)
```

After:
```console
 PASS  test/approveBuilds.test.ts (5.306 s)
  ✓ approve selected build (1209 ms)
  ✓ approve no builds (249 ms)
  ✓ works when root project manifest doesn't exist in a workspace (654 ms)
  ✓ should update onlyBuiltDependencies when package.json exists with ignoredBuiltDependencies defined (614 ms)
  ✓ should approve builds when package.json exists with onlyBuiltDependencies defined (285 ms)
  ✓ should approve builds with package.json that has no onlyBuiltDependencies and ignoredBuiltDependencies fields defined (621 ms)
```