### PR TITLE
test: fix case-insensitive install test

### DIFF
--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -163,9 +163,9 @@ test("don't fail on case insensitive filesystems when package has 2 files with s
   const files = fs.readdirSync('node_modules/@pnpm.e2e/with-same-file-in-different-cases')
   const storeDir = project.getStorePath()
   if (await dirIsCaseSensitive(storeDir)) {
-    expect([...files]).toStrictEqual(['Foo.js', 'foo.js', 'package.json'])
+    expect([...files].sort()).toStrictEqual(['Foo.js', 'foo.js', 'package.json'])
   } else {
-    expect([...files]).toStrictEqual(['Foo.js', 'package.json'])
+    expect([...files].map((f) => f.toLowerCase()).sort()).toStrictEqual(['foo.js', 'package.json'])
   }
 })
 


### PR DESCRIPTION
This test was failing locally on my mac, the files have been `foo.js` and `package.json`, not `Foo.js` and `package.json`

Is this behavior intended? Or is this a bug?

Also see https://github.com/nodejs/node/issues/3232 about readdir order stability

Without this PR:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/11ec9d01-a3d2-443a-92f1-679b940cfd04" />
