### PR TITLE
test: skip broken test which asks for ssh key

### DIFF
--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -420,7 +420,9 @@ test('resolveFromGit() normalizes full url (alternative form 2)', async () => {
 
 // This test relies on implementation detail.
 // current implementation does not try git ls-remote --refs on bareSpecifier with full commit hash, this fake repo url will pass.
-test('resolveFromGit() private repo with commit hash', async () => {
+//
+// Skipped because it prompts for ssh key / github username (and hangs if not reacted to), but passes if none given
+test.skip('resolveFromGit() private repo with commit hash', async () => {
   mockFetchAsPrivate()
   const resolveResult = await resolveFromGit({ bareSpecifier: 'fake/private-repo#2fa0531ab04e300a24ef4fd7fb3a280eccb7ccc5' })
   expect(resolveResult).toStrictEqual({


### PR DESCRIPTION
The assumption in this test looks either invalid or broken (impl detail changed? how was this supposed to behave?)

When running this test on `main`, it asks me for a password to my ssh key, github username, and github password

It passes if I just provide none of that and press enter three times

It hangs if I don't react

Given that, I treat this test as being broken
It could likely be fixed though? But having a broken test non-skipped looks more problematic