### PR TITLE
test: strip VT control chars in getLines()

### DIFF
--- a/__utils__/test-ipc-server/src/TestIpcServer.ts
+++ b/__utils__/test-ipc-server/src/TestIpcServer.ts
@@ -1,5 +1,5 @@
 import net from 'node:net'
-import { promisify } from 'node:util'
+import { promisify, stripVTControlCharacters } from 'node:util'
 import { computeHandlePath } from './computeHandlePath'
 
 // Polyfilling Symbol.asyncDispose for Jest.
@@ -66,11 +66,12 @@ export class TestIpcServer implements AsyncDisposable {
 
   /**
    * Return the buffer as an array of strings split by the new line character.
+   * VT control sequences are removed
    */
   public getLines (): string[] {
     return this.buffer === ''
       ? []
-      : this.buffer.trim().split('\n')
+      : stripVTControlCharacters(this.buffer).trim().split('\n')
   }
 
   /**


### PR DESCRIPTION
tests using `getLines()` assume no colors

and do things like parseInt on output, or just compare with hardcoded values

some tests get broken if color is forced with FORCE_COLOR, this addresses most of that

If something ever needs colors there, they could be restored e.g. via a flag in arguments to opt out of stripping
Also, `.getBuffer()` intentionally was not changed and returns raw output