### PR TITLE
test: unbreak test config in 3 __utils__

### DIFF
--- a/__utils__/assert-project/package.json
+++ b/__utils__/assert-project/package.json
@@ -50,5 +50,8 @@
     "isexe": "2.0.0",
     "read-yaml-file": "catalog:",
     "write-pkg": "catalog:"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
   }
 }

--- a/__utils__/assert-store/package.json
+++ b/__utils__/assert-store/package.json
@@ -34,5 +34,8 @@
   "devDependencies": {
     "@pnpm/assert-store": "workspace:*",
     "@pnpm/constants": "workspace:*"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
   }
 }

--- a/__utils__/test-ipc-server/package.json
+++ b/__utils__/test-ipc-server/package.json
@@ -17,5 +17,8 @@
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
     "test": "pnpm run compile && jest"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
   }
 }


### PR DESCRIPTION
`__utils__` dir has multiple issues

1. These tests are not run from CI (top-level script runs `_test`, these are called `test`)
2. `__utils__/assert-store/test/index.ts` and `__utils__/assert-project/test/index.ts` were not found by default jest pattern, and there was no jest config in these dirs, so even `pnpm test` in those dirs found no tests
3. `assert-store`, `assert-project`, `test-ipc-server` tests failed because ts-jest was not configured and tests are typescript
4. Even with above issues fixed, `assert-store` tests are broken
    (as the util itself, see #9645)

This PR addresses (2) and (3) by fixing jest config in these dirs

(1) could be fixed with e.g. a setup similar to this (like other packages do):
```json
    "_test": "pnpm pretest && jest",
    "test": "pnpm run compile && pnpm run _test",
```

But it needs first addressing (4), which should be done separately