### PR TITLE
test: storeHas/storeHasNot assertions are broken [Do not merge]

### DIFF
--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -36,6 +36,9 @@ test('remove unreferenced packages', async () => {
   ], { env: { npm_config_registry: REGISTRY } })
 
   project.storeHas('is-negative', '2.1.0')
+  project.storeHasNot('is-negative', '2.1.0')
+  project.storeHas('totally-not-is-negative', '999.2.1.0')
+  project.storeHasNot('totally-not-is-negative', '999.2.1.0')
 
   const reporter = jest.fn()
   await store.handler({


### PR DESCRIPTION
This a demo of an issue, not an actual fix PR

These assertions always pass

1. See https://github.com/pnpm/pnpm/pull/9644, those `__utils__` are not tested on CI
2. Those tests would actually fail if tested, `store.storeHas` / `store.storeHasNot` apparently assumes an older format of the store and the logic is not longer valid
3. `project.storeHas` and `project.storeHasNot` are not complementary -- both simultaneously pass on the same args


`project.storeHas` doesn't match `store.storeHas` -- project checks only .resolve, store checks actual file existence

`project.storeHasNot` checks inexistence as it calls `store.hasNot`

See:

https://github.com/pnpm/pnpm/blob/dc8a1f0f006f8d0358a7158d66a34021b5bdfe28/__utils__/assert-store/src/index.ts#L37-L44

https://github.com/pnpm/pnpm/blob/dc8a1f0f006f8d0358a7158d66a34021b5bdfe28/__utils__/assert-project/src/index.ts#L122-L136
