### PR TITLE
fix: patch support unpublished pkg

### DIFF
--- a/.changeset/blue-hairs-drum.md
+++ b/.changeset/blue-hairs-drum.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+When patching dependencies installed via `pkg.pr.new`, treat them as git tarball URLs.

--- a/.changeset/blue-hairs-drum.md
+++ b/.changeset/blue-hairs-drum.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/plugin-commands-patching": patch
+pnpm: patch
 ---
 
-When patching dependencies installed via `pkg.pr.new`, treat them as git tarball URLs.
+When patching dependencies installed via `pkg.pr.new`, treat them as git tarball URLs [#9694](https://github.com/pnpm/pnpm/pull/9694).

--- a/fetching/pick-fetcher/src/index.ts
+++ b/fetching/pick-fetcher/src/index.ts
@@ -23,10 +23,19 @@ export function pickFetcher (fetcherByHostingType: Partial<Fetchers>, resolution
   return fetch
 }
 
+// https://github.com/stackblitz-labs/pkg.pr.new
+// With pkg.pr.new, each of your commits and pull requests will trigger an instant preview release without publishing anything to NPM.
+// This enables users to access features and bug-fixes without the need to wait for release cycles using npm or pull request merges.
+// When a package is installed via pkg.pr.new and has never been published to npm,
+// the version or name obtained is incorrect, and an error will occur when patching. We can treat it as a tarball url.
+export function isPkgPrNewUrl (url: string): boolean {
+  return url.startsWith('https://pkg.pr.new/')
+}
+
 export function isGitHostedPkgUrl (url: string): boolean {
-  return ((
+  return (
     url.startsWith('https://codeload.github.com/') ||
     url.startsWith('https://bitbucket.org/') ||
     url.startsWith('https://gitlab.com/')
-  ) && url.includes('tar.gz')) || url.startsWith('https://pkg.pr.new/')
+  ) && url.includes('tar.gz')
 }

--- a/fetching/pick-fetcher/src/index.ts
+++ b/fetching/pick-fetcher/src/index.ts
@@ -23,15 +23,6 @@ export function pickFetcher (fetcherByHostingType: Partial<Fetchers>, resolution
   return fetch
 }
 
-// https://github.com/stackblitz-labs/pkg.pr.new
-// With pkg.pr.new, each of your commits and pull requests will trigger an instant preview release without publishing anything to NPM.
-// This enables users to access features and bug-fixes without the need to wait for release cycles using npm or pull request merges.
-// When a package is installed via pkg.pr.new and has never been published to npm,
-// the version or name obtained is incorrect, and an error will occur when patching. We can treat it as a tarball url.
-export function isPkgPrNewUrl (url: string): boolean {
-  return url.startsWith('https://pkg.pr.new/')
-}
-
 export function isGitHostedPkgUrl (url: string): boolean {
   return (
     url.startsWith('https://codeload.github.com/') ||

--- a/fetching/pick-fetcher/src/index.ts
+++ b/fetching/pick-fetcher/src/index.ts
@@ -24,9 +24,9 @@ export function pickFetcher (fetcherByHostingType: Partial<Fetchers>, resolution
 }
 
 export function isGitHostedPkgUrl (url: string): boolean {
-  return (
+  return ((
     url.startsWith('https://codeload.github.com/') ||
     url.startsWith('https://bitbucket.org/') ||
     url.startsWith('https://gitlab.com/')
-  ) && url.includes('tar.gz')
+  ) && url.includes('tar.gz')) || url.startsWith('https://pkg.pr.new/')
 }

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -60,7 +60,7 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
     const preferred = preferredVersions[0]
     return {
       ...dep,
-      applyToAll: !dep.bareSpecifier,
+      applyToAll: !dep.bareSpecifier && !preferred.gitTarballUrl,
       bareSpecifier: preferred.gitTarballUrl ?? preferred.version,
     }
   }

--- a/patching/plugin-commands-patching/src/getPatchedDependency.ts
+++ b/patching/plugin-commands-patching/src/getPatchedDependency.ts
@@ -4,7 +4,7 @@ import { prompt } from 'enquirer'
 import { readCurrentLockfile, type TarballResolution } from '@pnpm/lockfile.fs'
 import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
 import { PnpmError } from '@pnpm/error'
-import { isGitHostedPkgUrl, isPkgPrNewUrl } from '@pnpm/pick-fetcher'
+import { isGitHostedPkgUrl } from '@pnpm/pick-fetcher'
 import realpathMissing from 'realpath-missing'
 import semver from 'semver'
 import { type Config } from '@pnpm/config'
@@ -71,6 +71,15 @@ export async function getPatchedDependency (rawDependency: string, opts: GetPatc
       bareSpecifier: preferred.version,
     }
   }
+}
+
+// https://github.com/stackblitz-labs/pkg.pr.new
+// With pkg.pr.new, each of your commits and pull requests will trigger an instant preview release without publishing anything to NPM.
+// This enables users to access features and bug-fixes without the need to wait for release cycles using npm or pull request merges.
+// When a package is installed via pkg.pr.new and has never been published to npm,
+// the version or name obtained is incorrect, and an error will occur when patching. We can treat it as a tarball url.
+export function isPkgPrNewUrl (url: string): boolean {
+  return url.startsWith('https://pkg.pr.new/')
 }
 
 export interface LockfileVersion {

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -74,7 +74,7 @@ export async function handler (opts: PatchCommitCommandOptions, params: string[]
   if (!applyToAll) {
     gitTarballUrl = await getGitTarballUrlFromLockfile({
       alias: patchedPkgManifest.name,
-      bareSpecifier: patchedPkgManifest.version,
+      bareSpecifier: patchedPkgManifest.version || undefined,
     }, {
       lockfileDir,
       modulesDir: opts.modulesDir,


### PR DESCRIPTION
Dependencies installed via `pkg.pr.new` may not be published to npm, but we should also support patch-related operations.

For example, install the following dependencies and then add patches.
`pnpm i https://pkg.pr.new/@vue/runtime-vapor@13520`