### PR TITLE
fix: regexp match script name should not contain current script name

### DIFF
--- a/.changeset/many-pigs-cover.md
+++ b/.changeset/many-pigs-cover.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lifecycle": patch
+---
+
+When running the `pnpm run` command and using a regular expression to match multiple script names, an error should be thrown if the script name matches the current script name.

--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -120,7 +120,7 @@ Please unset the scriptShell option, or configure it to a .exe instead.
     if (regStr) {
       const commandRegExp = new RegExp(regStr)
       if (commandRegExp.test(stage)) {
-        throw new PnpmError('UNSUPPORTED_SCRIPT_COMMAND_FORMAT', `The script command "${stage}" is contained by regular expression ${commandRegExp}, This will cause the matching script to trigger in an infinite loop.`)
+        throw new PnpmError('INCORRECT_SCRIPT_COMMAND', `The script command "${stage}" is contained by regular expression ${commandRegExp}, This will cause the matching script to trigger in an infinite loop.`)
       }
     }
   }


### PR DESCRIPTION
When I have a script list like below:

![image](https://github.com/user-attachments/assets/55f99281-1d12-4c70-b0a3-911bdc3a6828)

If I run `pnpm dev`, the following will happen:

![image](https://github.com/user-attachments/assets/348ef626-9cbf-41e9-81a5-25ea1633de24)
