### PR TITLE
feat: set `approve-builds` command prompt init value to true

### DIFF
--- a/exec/build-commands/src/approveBuilds.ts
+++ b/exec/build-commands/src/approveBuilds.ts
@@ -119,7 +119,7 @@ export async function handler (opts: ApproveBuildsCommandOpts & RebuildCommandOp
       name: 'build',
       message: `The next packages will now be built: ${buildPackages.join(', ')}.
 Do you approve?`,
-      initial: false,
+      initial: true,
     })
     if (!confirmed.build) {
       return


### PR DESCRIPTION
Generally, the probability of applying relevant choices when executing the `pnpm approve-builds` command is relatively high, so the default value of prompt is set to true, which is convenient for quickly pressing the enter key to execute without entering `y`.