### PR TITLE
feat: loading pnpmfiles automatically from plugins

### DIFF
--- a/.changeset/floppy-grapes-kick.md
+++ b/.changeset/floppy-grapes-kick.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpmfile": major
+---
+
+Always expects an array of pnpmfiles.

--- a/.changeset/thin-ghosts-feel.md
+++ b/.changeset/thin-ghosts-feel.md
@@ -3,4 +3,6 @@
 "pnpm": minor
 ---
 
-pnpm will now automatically load the `pnpmfile.cjs` file from any [config dependency](https://pnpm.io/config-dependencies) that is named `@pnpm/plugin-*` or `pnpm-plugin-*` [#9729](https://github.com/pnpm/pnpm/pull/9729).
+pnpm will now automatically load the `pnpmfile.cjs` file from any [config dependency](https://pnpm.io/config-dependencies) named `@pnpm/plugin-*` or `pnpm-plugin-*` [#9729](https://github.com/pnpm/pnpm/pull/9729).
+
+The order in which config dependencies are initialized should not matter — they are initialized in alphabetical order. If a specific order is needed, the paths to the `pnpmfile.cjs` files in the config dependencies can be explicitly listed using the `pnpmfile` setting in `pnpm-workspace.yaml`.

--- a/.changeset/thin-ghosts-feel.md
+++ b/.changeset/thin-ghosts-feel.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli-utils": minor
+"pnpm": minor
+---
+
+pnpm will now automatically load the `pnpmfile.cjs` file from any [config dependency](https://pnpm.io/config-dependencies) that is named `@pnpm/plugin-*` or `pnpm-plugin-*` [#9729](https://github.com/pnpm/pnpm/pull/9729).

--- a/cli/cli-utils/package.json
+++ b/cli/cli-utils/package.json
@@ -41,6 +41,7 @@
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/store-connection-manager": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/util.lex-comparator": "catalog:",
     "chalk": "catalog:",
     "load-json-file": "catalog:"
   },

--- a/cli/cli-utils/src/getConfig.ts
+++ b/cli/cli-utils/src/getConfig.ts
@@ -36,7 +36,7 @@ export async function getConfig (
     })
   }
   if (!config.ignorePnpmfile) {
-    const pnpmfiles = Array.isArray(config.pnpmfile) ? config.pnpmfile : [config.pnpmfile]
+    const pnpmfiles = config.pnpmfile == null ? [] : Array.isArray(config.pnpmfile) ? config.pnpmfile : [config.pnpmfile]
     if (config.configDependencies) {
       const configModulesDir = path.join(config.lockfileDir ?? config.rootProjectManifestDir, 'node_modules/.pnpm-config')
       for (const configDepName of Object.keys(config.configDependencies)) {

--- a/cli/cli-utils/src/getConfig.ts
+++ b/cli/cli-utils/src/getConfig.ts
@@ -40,11 +40,7 @@ export async function getConfig (
     const pnpmfiles = config.pnpmfile == null ? [] : Array.isArray(config.pnpmfile) ? config.pnpmfile : [config.pnpmfile]
     if (config.configDependencies) {
       const configModulesDir = path.join(config.lockfileDir ?? config.rootProjectManifestDir, 'node_modules/.pnpm-config')
-      for (const configDepName of Object.keys(config.configDependencies).sort(lexCompare)) {
-        if (configDepName.startsWith('@pnpm/plugin-') || configDepName.startsWith('pnpm-plugin-')) {
-          pnpmfiles.push(path.join(configModulesDir, configDepName, 'pnpmfile.cjs'))
-        }
-      }
+      pnpmfiles.push(...calcPnpmfilePathsOfPluginDeps(configModulesDir, config.configDependencies))
     }
     const { hooks, resolvedPnpmfilePaths } = requireHooks(config.lockfileDir ?? config.dir, {
       globalPnpmfile: config.globalPnpmfile,
@@ -69,4 +65,12 @@ export async function getConfig (
   }
 
   return config
+}
+
+function * calcPnpmfilePathsOfPluginDeps (configModulesDir: string, configDependencies: Record<string, string>): Generator<string> {
+  for (const configDepName of Object.keys(configDependencies).sort(lexCompare)) {
+    if (configDepName.startsWith('@pnpm/plugin-') || configDepName.startsWith('pnpm-plugin-')) {
+      yield path.join(configModulesDir, configDepName, 'pnpmfile.cjs')
+    }
+  }
 }

--- a/cli/cli-utils/src/getConfig.ts
+++ b/cli/cli-utils/src/getConfig.ts
@@ -5,6 +5,7 @@ import { formatWarn } from '@pnpm/default-reporter'
 import { createOrConnectStoreController } from '@pnpm/store-connection-manager'
 import { installConfigDeps } from '@pnpm/config.deps-installer'
 import { requireHooks } from '@pnpm/pnpmfile'
+import { lexCompare } from '@pnpm/util.lex-comparator'
 
 export async function getConfig (
   cliOptions: CliOptions,
@@ -39,7 +40,7 @@ export async function getConfig (
     const pnpmfiles = config.pnpmfile == null ? [] : Array.isArray(config.pnpmfile) ? config.pnpmfile : [config.pnpmfile]
     if (config.configDependencies) {
       const configModulesDir = path.join(config.lockfileDir ?? config.rootProjectManifestDir, 'node_modules/.pnpm-config')
-      for (const configDepName of Object.keys(config.configDependencies)) {
+      for (const configDepName of Object.keys(config.configDependencies).sort(lexCompare)) {
         if (configDepName.startsWith('@pnpm/plugin-') || configDepName.startsWith('pnpm-plugin-')) {
           pnpmfiles.push(path.join(configModulesDir, configDepName, 'pnpmfile.cjs'))
         }

--- a/hooks/pnpmfile/src/requireHooks.ts
+++ b/hooks/pnpmfile/src/requireHooks.ts
@@ -47,7 +47,7 @@ export function requireHooks (
   prefix: string,
   opts: {
     globalPnpmfile?: string
-    pnpmfile?: string[] | string
+    pnpmfiles?: string[]
   }
 ): RequireHooksResult {
   const pnpmfiles: PnpmfileEntry[] = []
@@ -62,17 +62,10 @@ export function requireHooks (
     includeInChecksum: true,
     optional: true,
   })
-  if (opts.pnpmfile) {
-    if (Array.isArray(opts.pnpmfile)) {
-      for (const pnpmfile of opts.pnpmfile) {
-        pnpmfiles.push({
-          path: pnpmfile,
-          includeInChecksum: true,
-        })
-      }
-    } else {
+  if (opts.pnpmfiles) {
+    for (const pnpmfile of opts.pnpmfiles) {
       pnpmfiles.push({
-        path: opts.pnpmfile,
+        path: pnpmfile,
         includeInChecksum: true,
       })
     }

--- a/hooks/pnpmfile/test/index.ts
+++ b/hooks/pnpmfile/test/index.ts
@@ -30,7 +30,7 @@ test('readPackage hook run fails when returned dependencies is not an object ', 
 test('filterLog hook combines with the global hook', () => {
   const globalPnpmfile = path.join(__dirname, '__fixtures__/globalFilterLog.js')
   const pnpmfile = path.join(__dirname, '__fixtures__/filterLog.js')
-  const { hooks } = requireHooks(__dirname, { globalPnpmfile, pnpmfile: [pnpmfile] })
+  const { hooks } = requireHooks(__dirname, { globalPnpmfile, pnpmfiles: [pnpmfile] })
 
   expect(hooks.filterLog).toBeDefined()
   expect(hooks.filterLog!.length).toBe(2)
@@ -54,22 +54,22 @@ test('calculatePnpmfileChecksum is undefined when pnpmfile does not exist', asyn
 
 test('calculatePnpmfileChecksum resolves to hash string for existing pnpmfile', async () => {
   const pnpmfile = path.join(__dirname, '__fixtures__/readPackageNoObject.js')
-  const { hooks } = requireHooks(__dirname, { pnpmfile: [pnpmfile] })
+  const { hooks } = requireHooks(__dirname, { pnpmfiles: [pnpmfile] })
   expect(typeof await hooks.calculatePnpmfileChecksum?.()).toBe('string')
 })
 
 test('calculatePnpmfileChecksum is undefined if pnpmfile even when it exports undefined', async () => {
   const pnpmfile = path.join(__dirname, '__fixtures__/undefined.js')
-  const { hooks } = requireHooks(__dirname, { pnpmfile: [pnpmfile] })
+  const { hooks } = requireHooks(__dirname, { pnpmfiles: [pnpmfile] })
   expect(hooks.calculatePnpmfileChecksum).toBeUndefined()
 })
 
 test('updateConfig throws an error if it returns undefined', async () => {
   const pnpmfile = path.join(__dirname, '__fixtures__/updateConfigReturnsUndefined.js')
-  const { hooks } = requireHooks(__dirname, { pnpmfile: [pnpmfile] })
+  const { hooks } = requireHooks(__dirname, { pnpmfiles: [pnpmfile] })
   expect(() => hooks.updateConfig![0]!({})).toThrow('The updateConfig hook returned undefined')
 })
 
 test('requireHooks throw an error if one of the specified pnpmfiles does not exist', async () => {
-  expect(() => requireHooks(__dirname, { pnpmfile: ['does-not-exist.cjs'] })).toThrow('is not found')
+  expect(() => requireHooks(__dirname, { pnpmfiles: ['does-not-exist.cjs'] })).toThrow('is not found')
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 0.0.1
       version: 0.0.1
     '@pnpm/registry-mock':
-      specifier: 4.5.0
-      version: 4.5.0
+      specifier: 4.6.0
+      version: 4.6.0
     '@pnpm/semver-diff':
       specifier: ^1.1.0
       version: 1.1.0
@@ -865,7 +865,7 @@ importers:
         version: link:../../pkg-manager/modules-yaml
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -899,7 +899,7 @@ importers:
     dependencies:
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs
@@ -974,7 +974,7 @@ importers:
     dependencies:
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/worker':
         specifier: workspace:*
         version: link:../../worker
@@ -1160,7 +1160,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.29.12
@@ -1648,7 +1648,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/testing.temp-store':
         specifier: workspace:*
         version: link:../../testing/temp-store
@@ -2284,7 +2284,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -2570,7 +2570,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -2718,7 +2718,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -4404,7 +4404,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -4691,7 +4691,7 @@ importers:
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -4964,7 +4964,7 @@ importers:
         version: link:../read-projects-context
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-path':
         specifier: workspace:*
         version: link:../../store/store-path
@@ -5315,7 +5315,7 @@ importers:
         version: 'link:'
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -5541,7 +5541,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6145,7 +6145,7 @@ importers:
         version: link:../pkg-manifest/read-project-manifest
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/run-npm':
         specifier: workspace:*
         version: link:../exec/run-npm
@@ -6458,7 +6458,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -6585,7 +6585,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-ipc-server':
         specifier: workspace:*
         version: link:../../__utils__/test-ipc-server
@@ -7194,7 +7194,7 @@ importers:
         version: link:../../pkg-manifest/read-package-json
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -7258,7 +7258,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/workspace.filter-packages-from-dir':
         specifier: workspace:*
         version: link:../../workspace/filter-packages-from-dir
@@ -7343,7 +7343,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -7697,7 +7697,7 @@ importers:
         version: link:../../__utils__/prepare
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@types/archy':
         specifier: 'catalog:'
         version: 0.0.33
@@ -7951,7 +7951,7 @@ importers:
         version: link:../../store/package-store
       '@pnpm/registry-mock':
         specifier: 'catalog:'
-        version: 4.5.0(encoding@0.1.13)(typanion@3.14.0)
+        version: 4.6.0(encoding@0.1.13)(typanion@3.14.0)
       '@pnpm/store-controller-types':
         specifier: workspace:*
         version: link:../../store/store-controller-types
@@ -9797,8 +9797,8 @@ packages:
     resolution: {integrity: sha512-UY5ZFl8jTgWpPMp3qwVt1z455gDLGh4aAna7ufqsJP9qhI6lr9scFpnEamjpA51Y3MJMBtnML8KATmH6RY+NHQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/registry-mock@4.5.0':
-    resolution: {integrity: sha512-xLruwgulp1Q950TJeQmbDyXzH5wIEVM5Wdm2rFHplRLlBbM+9JGaJZpcU0LiqivizD60Ow6cSIZbQ9qxOi9tnQ==}
+  '@pnpm/registry-mock@4.6.0':
+    resolution: {integrity: sha512-VX2paPLc1wmv3mDNZiWVF+xqs47M7iLdemKkkvD50eG1kxjXyTjQMy6sfQjPCn/iFrxea1hpyi6FJ5AtROE7sw==}
     engines: {node: '>=18.12'}
     hasBin: true
 
@@ -17587,7 +17587,7 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-bom: 4.0.0
 
-  '@pnpm/registry-mock@4.5.0(encoding@0.1.13)(typanion@3.14.0)':
+  '@pnpm/registry-mock@4.6.0(encoding@0.1.13)(typanion@3.14.0)':
     dependencies:
       anonymous-npm-registry-client: 0.3.2
       execa: 5.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,7 +801,7 @@ importers:
         version: link:../packages/logger
       '@pnpm/meta-updater':
         specifier: 'catalog:'
-        version: 2.0.6(@types/node@22.15.29)(typanion@3.14.0)
+        version: 2.0.6(@types/node@18.19.34)(typanion@3.14.0)
       '@pnpm/object.key-sorting':
         specifier: workspace:*
         version: link:../object/key-sorting
@@ -1263,6 +1263,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@pnpm/util.lex-comparator':
+        specifier: 'catalog:'
+        version: 3.0.2
       chalk:
         specifier: 'catalog:'
         version: 4.1.2
@@ -16624,28 +16627,6 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/cli-utils@1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.8
-      '@pnpm/config': 1003.1.1(@pnpm/logger@1001.0.0)
-      '@pnpm/config.deps-installer': 1000.0.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))
-      '@pnpm/default-reporter': 1002.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/manifest-utils': 1001.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/package-is-installable': 1000.0.10(@pnpm/logger@1001.0.0)
-      '@pnpm/pnpmfile': 1001.2.2(@pnpm/logger@1001.0.0)
-      '@pnpm/read-project-manifest': 1000.0.11
-      '@pnpm/store-connection-manager': 1002.0.3(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
-      '@pnpm/types': 1000.6.0
-      chalk: 4.1.2
-      load-json-file: 6.2.0
-    transitivePeerDependencies:
-      - '@pnpm/worker'
-      - domexception
-      - supports-color
-      - typanion
-
   '@pnpm/client@1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))(typanion@3.14.0)':
     dependencies:
       '@pnpm/default-resolver': 1002.0.2(@pnpm/logger@1001.0.0)
@@ -16656,25 +16637,6 @@ snapshots:
       '@pnpm/network.auth-header': 1000.0.3
       '@pnpm/resolver-base': 1003.0.1
       '@pnpm/tarball-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))(typanion@3.14.0)
-      '@pnpm/types': 1000.6.0
-      ramda: '@pnpm/ramda@0.28.1'
-    transitivePeerDependencies:
-      - '@pnpm/logger'
-      - '@pnpm/worker'
-      - domexception
-      - supports-color
-      - typanion
-
-  '@pnpm/client@1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/default-resolver': 1002.0.2(@pnpm/logger@1001.0.0)
-      '@pnpm/directory-fetcher': 1000.1.7(@pnpm/logger@1001.0.0)
-      '@pnpm/fetch': 1000.2.2(@pnpm/logger@1001.0.0)
-      '@pnpm/fetching-types': 1000.1.0
-      '@pnpm/git-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
-      '@pnpm/network.auth-header': 1000.0.3
-      '@pnpm/resolver-base': 1003.0.1
-      '@pnpm/tarball-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
       '@pnpm/types': 1000.6.0
       ramda: '@pnpm/ramda@0.28.1'
     transitivePeerDependencies:
@@ -16705,28 +16667,6 @@ snapshots:
       '@pnpm/network.auth-header': 1000.0.3
       '@pnpm/npm-resolver': 1004.0.1(@pnpm/logger@1001.0.0)
       '@pnpm/package-store': 1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))
-      '@pnpm/parse-wanted-dependency': 1001.0.0
-      '@pnpm/pick-registry-for-package': 1000.0.8
-      '@pnpm/read-modules-dir': 1000.0.0
-      '@pnpm/read-package-json': 1000.0.9
-      '@pnpm/types': 1000.6.0
-      '@zkochan/rimraf': 3.0.2
-      get-npm-tarball-url: 2.1.0
-    transitivePeerDependencies:
-      - '@pnpm/worker'
-      - domexception
-      - supports-color
-
-  '@pnpm/config.deps-installer@1000.0.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))':
-    dependencies:
-      '@pnpm/config.config-writer': 1000.0.5
-      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/fetch': 1000.2.2(@pnpm/logger@1001.0.0)
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/network.auth-header': 1000.0.3
-      '@pnpm/npm-resolver': 1004.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/package-store': 1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))
       '@pnpm/parse-wanted-dependency': 1001.0.0
       '@pnpm/pick-registry-for-package': 1000.0.8
       '@pnpm/read-modules-dir': 1000.0.0
@@ -17048,19 +16988,6 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/git-fetcher@1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/fetcher-base': 1000.0.11
-      '@pnpm/fs.packlist': 2.0.0
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)
-      '@zkochan/rimraf': 3.0.2
-      execa: safe-execa@0.1.2
-    transitivePeerDependencies:
-      - supports-color
-      - typanion
-
   '@pnpm/git-resolver@1001.0.2(@pnpm/logger@1001.0.0)':
     dependencies:
       '@pnpm/fetch': 1000.2.2(@pnpm/logger@1001.0.0)
@@ -17196,24 +17123,6 @@ snapshots:
       '@pnpm/types': 1000.6.0
       '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34)
       '@pnpm/workspace.find-packages': 1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))(typanion@3.14.0)
-      '@pnpm/workspace.read-manifest': 1000.1.5
-      load-json-file: 7.0.1
-      meow: 11.0.0
-      print-diff: 2.0.0
-      write-json-file: 5.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - domexception
-      - supports-color
-      - typanion
-
-  '@pnpm/meta-updater@2.0.6(@types/node@22.15.29)(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/find-workspace-dir': 1000.1.0
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)
-      '@pnpm/workspace.find-packages': 1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
       '@pnpm/workspace.read-manifest': 1000.1.5
       load-json-file: 7.0.1
       meow: 11.0.0
@@ -17405,30 +17314,6 @@ snapshots:
       semver: 7.7.2
       ssri: 10.0.5
 
-  '@pnpm/package-requester@1004.0.2(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))':
-    dependencies:
-      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/dependency-path': 1000.0.9
-      '@pnpm/error': 1000.0.2
-      '@pnpm/fetcher-base': 1000.0.11
-      '@pnpm/graceful-fs': 1000.0.0
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/package-is-installable': 1000.0.10(@pnpm/logger@1001.0.0)
-      '@pnpm/pick-fetcher': 1000.0.0
-      '@pnpm/read-package-json': 1000.0.9
-      '@pnpm/resolver-base': 1003.0.1
-      '@pnpm/store-controller-types': 1003.0.2
-      '@pnpm/store.cafs': 1000.0.13
-      '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)
-      p-defer: 3.0.0
-      p-limit: 3.1.0
-      p-queue: 6.6.2
-      promise-share: 1.0.0
-      ramda: '@pnpm/ramda@0.28.1'
-      semver: 7.7.2
-      ssri: 10.0.5
-
   '@pnpm/package-store@1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))':
     dependencies:
       '@pnpm/create-cafs-store': 1000.0.14(@pnpm/logger@1001.0.0)
@@ -17440,22 +17325,6 @@ snapshots:
       '@pnpm/store.cafs': 1000.0.13
       '@pnpm/types': 1000.6.0
       '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34)
-      '@zkochan/rimraf': 3.0.2
-      load-json-file: 6.2.0
-      ramda: '@pnpm/ramda@0.28.1'
-      ssri: 10.0.5
-
-  '@pnpm/package-store@1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))':
-    dependencies:
-      '@pnpm/create-cafs-store': 1000.0.14(@pnpm/logger@1001.0.0)
-      '@pnpm/fetcher-base': 1000.0.11
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/package-requester': 1004.0.2(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))
-      '@pnpm/resolver-base': 1003.0.1
-      '@pnpm/store-controller-types': 1003.0.2
-      '@pnpm/store.cafs': 1000.0.13
-      '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)
       '@zkochan/rimraf': 3.0.2
       load-json-file: 6.2.0
       ramda: '@pnpm/ramda@0.28.1'
@@ -17677,25 +17546,6 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/store-connection-manager@1002.0.3(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.8
-      '@pnpm/client': 1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
-      '@pnpm/config': 1003.1.1(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/package-store': 1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))
-      '@pnpm/server': 1001.0.4(@pnpm/logger@1001.0.0)
-      '@pnpm/store-path': 1000.0.2
-      '@zkochan/diable': 1.0.2
-      delay: 5.0.0
-      dir-is-case-sensitive: 2.0.0
-    transitivePeerDependencies:
-      - '@pnpm/worker'
-      - domexception
-      - supports-color
-      - typanion
-
   '@pnpm/store-controller-types@1001.0.3':
     dependencies:
       '@pnpm/fetcher-base': 1000.0.5
@@ -17769,28 +17619,6 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/tarball-fetcher@1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/fetcher-base': 1000.0.11
-      '@pnpm/fetching-types': 1000.1.0
-      '@pnpm/fs.packlist': 2.0.0
-      '@pnpm/graceful-fs': 1000.0.0
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)
-      '@zkochan/retry': 0.2.0
-      lodash.throttle: 4.1.1
-      p-map-values: 1.0.0
-      path-temp: 2.1.0
-      ramda: '@pnpm/ramda@0.28.1'
-      rename-overwrite: 6.0.3
-    transitivePeerDependencies:
-      - domexception
-      - supports-color
-      - typanion
-
   '@pnpm/tarball-resolver@1002.0.2':
     dependencies:
       '@pnpm/fetching-types': 1000.1.0
@@ -17838,26 +17666,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@pnpm/worker@1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.29)':
-    dependencies:
-      '@pnpm/cafs-types': 1000.0.0
-      '@pnpm/create-cafs-store': 1000.0.14(@pnpm/logger@1001.0.0)
-      '@pnpm/crypto.polyfill': 1000.1.0
-      '@pnpm/error': 1000.0.2
-      '@pnpm/exec.pkg-requires-build': 1000.0.8
-      '@pnpm/fs.hard-link-dir': 1000.0.1(@pnpm/logger@1001.0.0)
-      '@pnpm/graceful-fs': 1000.0.0
-      '@pnpm/logger': link:packages/logger
-      '@pnpm/store.cafs': 1000.0.13
-      '@pnpm/symlink-dependency': 1000.0.9(@pnpm/logger@1001.0.0)
-      '@rushstack/worker-pool': 0.4.9(@types/node@22.15.29)
-      is-windows: 1.0.2
-      load-json-file: 6.2.0
-      p-limit: 3.1.0
-      shell-quote: 1.8.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@pnpm/workspace.find-packages@1000.0.15(@pnpm/logger@1000.0.0)':
     dependencies:
       '@pnpm/cli-utils': 1000.0.15(@pnpm/logger@1000.0.0)
@@ -17870,20 +17678,6 @@ snapshots:
   '@pnpm/workspace.find-packages@1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))(typanion@3.14.0)':
     dependencies:
       '@pnpm/cli-utils': 1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@18.19.34))(typanion@3.14.0)
-      '@pnpm/constants': 1001.1.0
-      '@pnpm/fs.find-packages': 1000.0.11
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/types': 1000.6.0
-      '@pnpm/util.lex-comparator': 3.0.2
-    transitivePeerDependencies:
-      - '@pnpm/worker'
-      - domexception
-      - supports-color
-      - typanion
-
-  '@pnpm/workspace.find-packages@1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)':
-    dependencies:
-      '@pnpm/cli-utils': 1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.29))(typanion@3.14.0)
       '@pnpm/constants': 1001.1.0
       '@pnpm/fs.find-packages': 1000.0.11
       '@pnpm/logger': 1001.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   '@pnpm/npm-package-arg': ^1.0.0
   '@pnpm/os.env.path-extender': ^2.0.3
   '@pnpm/patch-package': 0.0.1
-  '@pnpm/registry-mock': 4.5.0
+  '@pnpm/registry-mock': 4.6.0
   '@pnpm/semver-diff': ^1.1.0
   '@pnpm/tabtab': ^0.5.4
   '@pnpm/util.lex-comparator': ^3.0.2

--- a/pnpm/test/hooks.ts
+++ b/pnpm/test/hooks.ts
@@ -367,3 +367,14 @@ module.exports = {
   expect(nodeModulesFiles).toContain('is-number')
   expect(nodeModulesFiles).toContain('is-even')
 })
+
+test('automatically loading pnpmfile from a config dependency that has a name that starts with "@pnpm/plugin-"', async () => {
+  prepare()
+
+  await execPnpm(['add', '--config', '@pnpm/plugin-pnpmfile'])
+  await execPnpm(['add', 'is-odd@1.0.0'])
+
+  const nodeModulesFiles = fs.readdirSync('node_modules')
+  expect(nodeModulesFiles).toContain('kind-of')
+  expect(nodeModulesFiles).toContain('is-number')
+})


### PR DESCRIPTION
We have a couple of official pnpm config dependencies that work via pnpmfiles: `@pnpm/better-defaults`, `@pnpm/types-fixer`, `@pnpm/node-path-for-esm`. Currently, we have to instruct users to add a reference to the pnpmfiles in these config dependencies. With this change, it will be enough to name the config dependency following a convention, it should start with either `@pnpm/plugin-` or `pnpm-plugin-`. If the config dependency will be named this way, pnpm will automatically load the `pnpmfile.cjs` from it. This is now easier to implement since I added support for multiple pnpmfiles via https://github.com/pnpm/pnpm/pull/9702

I was considering loading esm files from these plugins but looks like they don't work well with all the Node.js versions that we currently support: https://github.com/pnpm/pnpm/pull/9730

An alternative solution could be to automatically update the pnpmfile config settings of the projects where such dependencies are installed.