### PR TITLE
feat(add): update devEngines.runtime with a Node.js entry

### DIFF
--- a/pkg-manifest/read-project-manifest/src/index.ts
+++ b/pkg-manifest/read-project-manifest/src/index.ts
@@ -240,6 +240,39 @@ function convertManifestAfterRead (manifest: ProjectManifest): ProjectManifest {
 
 function convertManifestBeforeWrite (manifest: ProjectManifest): ProjectManifest {
   if (manifest.devDependencies?.['node']?.startsWith('runtime:')) {
+    manifest.devEngines ??= {}
+    const version = manifest.devDependencies['node'].replace(/^runtime:/, '')
+    if (!manifest.devEngines.runtime) {
+      manifest.devEngines.runtime = {
+        name: 'node',
+        version,
+        onFail: 'download',
+      }
+    } else if (Array.isArray(manifest.devEngines.runtime)) {
+      const existing = manifest.devEngines.runtime.find(({ name }) => name === 'node')
+      if (existing) {
+        existing.version = version
+        existing.onFail = 'download'
+      } else {
+        manifest.devEngines.runtime.push({
+          name: 'node',
+          version,
+          onFail: 'download',
+        })
+      }
+    } else if (manifest.devEngines.runtime.name === 'node') {
+      manifest.devEngines.runtime.version = version
+      manifest.devEngines.runtime.onFail = 'download'
+    } else {
+      manifest.devEngines.runtime = [
+        manifest.devEngines.runtime,
+        {
+          name: 'node',
+          version,
+          onFail: 'download',
+        },
+      ]
+    }
     delete manifest.devDependencies['node']
   }
   return manifest

--- a/pkg-manifest/read-project-manifest/test/index.ts
+++ b/pkg-manifest/read-project-manifest/test/index.ts
@@ -169,10 +169,8 @@ test.each([
 
   const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
 
-  // We can't use a simple `toStrictEqual` because we need to ignore the `devDependencies` field
-  // and only check the `devEngines` field.
-  expect(pkgJson.devEngines).toEqual(expected)
-  expect(pkgJson.devDependencies).toEqual({})
+  expect(pkgJson.devEngines).toStrictEqual(expected)
+  expect(pkgJson.devDependencies).toStrictEqual({})
 })
 
 test('preserve tab indentation in json file', async () => {

--- a/pkg-manifest/read-project-manifest/test/index.ts
+++ b/pkg-manifest/read-project-manifest/test/index.ts
@@ -62,6 +62,124 @@ test('readProjectManifest() converts devEngines runtime to devDependencies', asy
   })
 })
 
+test('readProjectManifest() converts devDependencies to devEngines', async () => {
+  const dir = f.prepare('package-json')
+  let { manifest, writeProjectManifest } = await tryReadProjectManifest(dir)
+  manifest ??= {}
+  manifest.devDependencies = {
+    node: 'runtime:22',
+  }
+  await writeProjectManifest(manifest!)
+  {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+    expect(pkgJson).toStrictEqual({
+      ...manifest,
+      devDependencies: {},
+      devEngines: {
+        runtime: {
+          name: 'node',
+          version: '22',
+          onFail: 'download',
+        },
+      },
+    })
+  }
+
+  manifest.devEngines = {
+    runtime: {
+      name: 'node',
+      version: '16',
+    },
+  }
+  manifest.devDependencies = {
+    node: 'runtime:22',
+  }
+  await writeProjectManifest(manifest!)
+  {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+    expect(pkgJson).toStrictEqual({
+      ...manifest,
+      devDependencies: {},
+      devEngines: {
+        runtime: {
+          name: 'node',
+          version: '22',
+          onFail: 'download',
+        },
+      },
+    })
+  }
+
+  manifest.devEngines = {
+    runtime: {
+      name: 'deno',
+      version: '1',
+    },
+  }
+  manifest.devDependencies = {
+    node: 'runtime:22',
+  }
+  await writeProjectManifest(manifest!)
+  {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+    expect(pkgJson).toStrictEqual({
+      ...manifest,
+      devDependencies: {},
+      devEngines: {
+        runtime: [
+          {
+            name: 'deno',
+            version: '1',
+          },
+          {
+            name: 'node',
+            version: '22',
+            onFail: 'download',
+          },
+        ],
+      },
+    })
+  }
+
+  manifest.devEngines = {
+    runtime: [
+      {
+        name: 'deno',
+        version: '1',
+      },
+      {
+        name: 'node',
+        version: '16',
+        onFail: 'download',
+      },
+    ],
+  }
+  manifest.devDependencies = {
+    node: 'runtime:22',
+  }
+  await writeProjectManifest(manifest!)
+  {
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
+    expect(pkgJson).toStrictEqual({
+      ...manifest,
+      devDependencies: {},
+      devEngines: {
+        runtime: [
+          {
+            name: 'deno',
+            version: '1',
+          },
+          {
+            name: 'node',
+            version: '22',
+            onFail: 'download',
+          },
+        ],
+      },
+    })
+  }
+})
+
 test('preserve tab indentation in json file', async () => {
   process.chdir(tempy.directory())
 


### PR DESCRIPTION
Running `pnpm add -D node@runtime:24` adds a new runtime entry to `devEngines`.