### PR TITLE
feat: check the engine when excute the create command

### DIFF
--- a/.changeset/huge-apples-hang.md
+++ b/.changeset/huge-apples-hang.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+---
+
+When executing the `pnpm create` command, must verify whether the node version is supported even if a cache already exists.

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -70,7 +70,8 @@
     "write-json-file": "catalog:"
   },
   "peerDependencies": {
-    "@pnpm/logger": "catalog:"
+    "@pnpm/logger": "catalog:",
+    "@pnpm/package-is-installable": "workspace:*"
   },
   "devDependencies": {
     "@pnpm/filter-workspace-packages": "workspace:*",

--- a/exec/plugin-commands-script-runners/tsconfig.json
+++ b/exec/plugin-commands-script-runners/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../config/config"
     },
     {
+      "path": "../../config/package-is-installable"
+    },
+    {
       "path": "../../crypto/hash"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2701,6 +2701,9 @@ importers:
       '@pnpm/package-bins':
         specifier: workspace:*
         version: link:../../pkg-manager/package-bins
+      '@pnpm/package-is-installable':
+        specifier: workspace:*
+        version: link:../../config/package-is-installable
       '@pnpm/parse-wanted-dependency':
         specifier: workspace:*
         version: link:../../packages/parse-wanted-dependency


### PR DESCRIPTION
When executing the `pnpm create` command, you must verify whether the node version is supported even if a cache already exists.