### PR TITLE
fix: address pnpm failing to prune hoisted dev dependencies

### DIFF
--- a/.changeset/upset-ends-yell.md
+++ b/.changeset/upset-ends-yell.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/modules-cleaner": patch
+"pnpm": patch
+---
+
+`pnpm install --prod` should removing hoisted dev dependencies [#9782](https://github.com/pnpm/pnpm/issues/9782).

--- a/pkg-manager/modules-cleaner/src/prune.ts
+++ b/pkg-manager/modules-cleaner/src/prune.ts
@@ -241,7 +241,7 @@ function getPkgsDepPaths (
 ): Record<DepPath, string> {
   const acc: Record<DepPath, string> = {}
   for (const [depPath, pkg] of Object.entries(packages)) {
-    if (skipped.has(depPath)) return acc
+    if (skipped.has(depPath)) continue
     acc[depPath as DepPath] = packageIdFromSnapshot(depPath as DepPath, pkg)
   }
   return acc


### PR DESCRIPTION
This PR introduced a bug where it switched out a reduce for a for loop. I'm not sure where to write tests here but I'm happy to if you could point me to where I could.

Tested this against my bug reproduction.

https://github.com/pnpm/pnpm/pull/8537/files#diff-494d01d2e936696b2af0a7338260c27cbc5fb00345ee2506a086d38f974b8365R242-R247

Resolves: https://github.com/pnpm/pnpm/issues/9782