### PR TITLE
revert: there's no need to pass the packageId to the fetcher

### DIFF
--- a/.changeset/twenty-lions-rush.md
+++ b/.changeset/twenty-lions-rush.md
@@ -1,6 +1,0 @@
----
-"@pnpm/fetcher-base": major
-"@pnpm/tarball-fetcher": major
----
-
-Added a new required field for the fetcher function.

--- a/env/node.fetcher/src/index.ts
+++ b/env/node.fetcher/src/index.ts
@@ -243,9 +243,7 @@ async function downloadAndUnpackTarballToDir (
   }, {
     filesIndexFile,
     lockfileDir: process.cwd(),
-    pkg: {
-      id: '',
-    },
+    pkg: {},
   })
 
   cafs.importPackage(targetDir, {
@@ -278,9 +276,7 @@ async function downloadAndUnpackTarball (
   }, {
     filesIndexFile: opts.filesIndexFile,
     lockfileDir: process.cwd(),
-    pkg: {
-      id: '',
-    },
+    pkg: {},
   })
 }
 

--- a/fetching/fetcher-base/src/index.ts
+++ b/fetching/fetcher-base/src/index.ts
@@ -10,7 +10,6 @@ import { type DependencyManifest } from '@pnpm/types'
 export interface PkgNameVersion {
   name?: string
   version?: string
-  id: string
 }
 
 export interface FetchOptions {

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -46,7 +46,7 @@ const fetch = createTarballFetcher(fetchFromRegistry, getAuthHeader, {
     retries: 1,
   },
 })
-const pkg = { id: '' }
+const pkg = {}
 
 test('fail when tarball size does not match content-length', async () => {
   const scope = nock(registry)

--- a/pkg-manager/package-requester/src/packageRequester.ts
+++ b/pkg-manager/package-requester/src/packageRequester.ts
@@ -354,6 +354,7 @@ function fetchToStore (
       readManifest?: boolean
     ) => Promise<{ verified: boolean, pkgFilesIndex: PackageFilesIndex, manifest?: DependencyManifest, requiresBuild: boolean }>
     fetch: (
+      packageId: string,
       resolution: Resolution,
       opts: FetchOptions
     ) => Promise<FetchResult>
@@ -552,6 +553,7 @@ Actual package in the store with the given integrity: ${pkgFilesIndex.name}@${pk
       const priority = (++ctx.requestsQueue.counter % ctx.requestsQueue.concurrency === 0 ? -1 : 1) * 1000
 
       const fetchedPackage = await ctx.requestsQueue.add(async () => ctx.fetch(
+        opts.pkg.id,
         opts.pkg.resolution,
         {
           filesIndexFile,
@@ -575,7 +577,6 @@ Actual package in the store with the given integrity: ${pkgFilesIndex.name}@${pk
           pkg: {
             name: opts.pkg.name,
             version: opts.pkg.version,
-            id: opts.pkg.id,
           },
         }
       ), { priority })
@@ -633,6 +634,7 @@ async function tarballIsUpToDate (
 async function fetcher (
   fetcherByHostingType: Fetchers,
   cafs: Cafs,
+  packageId: string,
   resolution: Resolution,
   opts: FetchOptions
 ): Promise<FetchResult> {
@@ -641,7 +643,7 @@ async function fetcher (
     return await fetch(cafs, resolution as any, opts) // eslint-disable-line @typescript-eslint/no-explicit-any
   } catch (err: any) { // eslint-disable-line
     packageRequestLogger.warn({
-      message: `Fetching ${opts.pkg.id} failed!`,
+      message: `Fetching ${packageId} failed!`,
       prefix: opts.lockfileDir,
     })
     throw err


### PR DESCRIPTION
Reverts a change introduced via #9755