### PR TITLE
feat: remove the corresponding catalog configuration when catalogMode is strict

### DIFF
--- a/.changeset/large-ducks-wear.md
+++ b/.changeset/large-ducks-wear.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/workspace.manifest-writer": patch
+---
+
+When `catalogMode` is `strict`, the corresponding catalog configuration is deleted when the dependent package is removed.

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -9,6 +9,7 @@ import { type Config, getOptionsFromRootManifest, types as allTypes } from '@pnp
 import { PnpmError } from '@pnpm/error'
 import { arrayOfWorkspacePackagesToMap } from '@pnpm/get-context'
 import { findWorkspacePackages } from '@pnpm/workspace.find-packages'
+import { removePackagesFromWorkspaceCatalog } from '@pnpm/workspace.manifest-writer'
 import { getAllDependenciesFromManifest } from '@pnpm/manifest-utils'
 import { createOrConnectStoreController, type CreateStoreControllerOptions } from '@pnpm/store-connection-manager'
 import { type DependenciesField, type ProjectRootDir } from '@pnpm/types'
@@ -150,6 +151,7 @@ export async function handler (
   | 'workspaceDir'
   | 'workspacePackagePatterns'
   | 'sharedWorkspaceLockfile'
+  | 'catalogMode'
   > & {
     recursive?: boolean
     pnpmfile: string[]
@@ -215,4 +217,8 @@ export async function handler (
     removeOpts
   )
   await writeProjectManifest(mutationResult.updatedProject.manifest)
+
+  if (opts.catalogMode === 'strict' && opts.workspaceDir) {
+    await removePackagesFromWorkspaceCatalog(opts.workspaceDir, params)
+  }
 }

--- a/workspace/manifest-writer/src/index.ts
+++ b/workspace/manifest-writer/src/index.ts
@@ -89,3 +89,46 @@ export async function addCatalogs (workspaceDir: string, newCatalogs: Catalogs):
     await writeManifestFile(workspaceDir, manifest)
   }
 }
+
+// when catalogMode is strict, we cannot remove dependencies from the catalog after the package is removed
+export async function removePackagesFromWorkspaceCatalog (workspaceDir: string, packages: string[]): Promise<void> {
+  const manifest: Partial<WorkspaceManifest> = await readWorkspaceManifest(workspaceDir) ?? {}
+  let shouldBeUpdated = false
+
+  if (manifest.catalog == null && manifest.catalogs == null) return
+
+  if (manifest.catalog != null) {
+    for (const pkg of packages) {
+      if (manifest.catalog[pkg] != null) {
+        delete manifest.catalog[pkg]
+        shouldBeUpdated = true
+      }
+    }
+    if (Object.keys(manifest.catalog).length === 0) {
+      delete manifest.catalog
+      shouldBeUpdated = true
+    }
+  }
+
+  for (const catalogName in manifest.catalogs) {
+    const catalog = manifest.catalogs[catalogName]
+    for (const pkg of packages) {
+      if (catalog[pkg] != null) {
+        delete catalog[pkg]
+        shouldBeUpdated = true
+      }
+    }
+    if (Object.keys(catalog).length === 0) {
+      delete manifest.catalogs[catalogName]
+      shouldBeUpdated = true
+    }
+  }
+  if (Object.keys(manifest.catalogs ?? {}).length === 0) {
+    delete manifest.catalogs
+    shouldBeUpdated = true
+  }
+
+  if (shouldBeUpdated) {
+    await writeManifestFile(workspaceDir, manifest)
+  }
+}

--- a/workspace/manifest-writer/test/removeCatalogs.test.ts
+++ b/workspace/manifest-writer/test/removeCatalogs.test.ts
@@ -1,0 +1,169 @@
+import path from 'path'
+import { WORKSPACE_MANIFEST_FILENAME } from '@pnpm/constants'
+import { tempDir } from '@pnpm/prepare-temp-dir'
+import { addCatalogs, removePackagesFromWorkspaceCatalog } from '@pnpm/workspace.manifest-writer'
+import { sync as readYamlFile } from 'read-yaml-file'
+import { sync as writeYamlFile } from 'write-yaml-file'
+
+test('addCatalogs adds `default` catalogs to the `catalog` object by default and remove `default` catalogs if they are empty', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  await addCatalogs(dir, {
+    default: {
+      foo: '^0.1.2',
+    },
+  })
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalog: {
+      foo: '^0.1.2',
+    },
+  })
+
+  await removePackagesFromWorkspaceCatalog(dir, ['foo'])
+  expect(readYamlFile(filePath)).toStrictEqual({})
+})
+
+test('addCatalogs adds `default` catalogs to the `catalog` object if it exists and remove catalog', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  writeYamlFile(filePath, {
+    catalog: {
+      bar: '3.2.1',
+    },
+  })
+  await addCatalogs(dir, {
+    default: {
+      foo: '^0.1.2',
+    },
+  })
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalog: {
+      bar: '3.2.1',
+      foo: '^0.1.2',
+    },
+  })
+
+  await removePackagesFromWorkspaceCatalog(dir, ['foo'])
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalog: {
+      bar: '3.2.1',
+    },
+  })
+})
+
+test('addCatalogs adds `default` catalogs to the `catalogs.default` object if it exists and remove catalog', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  writeYamlFile(filePath, {
+    catalogs: {
+      default: {
+        bar: '3.2.1',
+      },
+    },
+  })
+  await addCatalogs(dir, {
+    default: {
+      foo: '^0.1.2',
+    },
+  })
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      default: {
+        bar: '3.2.1',
+        foo: '^0.1.2',
+      },
+    },
+  })
+  await removePackagesFromWorkspaceCatalog(dir, ['foo'])
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      default: {
+        bar: '3.2.1',
+      },
+    },
+  })
+})
+
+test('addCatalogs creates a `catalogs` object for any-named catalogs and remove catalog', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  await addCatalogs(dir, {
+    foo: {
+      abc: '0.1.2',
+    },
+    bar: {
+      def: '3.2.1',
+    },
+  })
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      foo: {
+        abc: '0.1.2',
+      },
+      bar: {
+        def: '3.2.1',
+      },
+    },
+  })
+  await removePackagesFromWorkspaceCatalog(dir, ['abc'])
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      bar: {
+        def: '3.2.1',
+      },
+    },
+  })
+})
+
+test('addCatalogs add any-named catalogs to the `catalogs` object if it already exists and remove catalog', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  writeYamlFile(filePath, {
+    catalogs: {
+      foo: {
+        ghi: '7.8.9',
+      },
+    },
+  })
+  await addCatalogs(dir, {
+    foo: {
+      abc: '0.1.2',
+    },
+    bar: {
+      def: '3.2.1',
+    },
+  })
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      foo: {
+        abc: '0.1.2',
+        ghi: '7.8.9',
+      },
+      bar: {
+        def: '3.2.1',
+      },
+    },
+  })
+
+  await removePackagesFromWorkspaceCatalog(dir, ['abc'])
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      bar: {
+        def: '3.2.1',
+      },
+      foo: {
+        ghi: '7.8.9',
+      },
+    },
+  })
+  await removePackagesFromWorkspaceCatalog(dir, ['def'])
+  expect(readYamlFile(filePath)).toStrictEqual({
+    catalogs: {
+      foo: {
+        ghi: '7.8.9',
+      },
+    },
+  })
+  await removePackagesFromWorkspaceCatalog(dir, ['ghi'])
+  expect(readYamlFile(filePath)).toStrictEqual({})
+})


### PR DESCRIPTION
`strict - only allows dependency versions from the catalog.` 

When deleting a dependency, the corresponding catalog configuration should be removed.