### PR TITLE
fix: re-link local tarball when contents change (without rename) during filtered install

### DIFF
--- a/.changeset/beige-camels-post.md
+++ b/.changeset/beige-camels-post.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/headless": patch
+"@pnpm/deps.graph-builder": patch
+"@pnpm/core": patch
+pnpm: patch
+---
+
+Fix an edge case bug causing local tarballs to not re-link into the virtual store. This bug would happen when changing the contents of the tarball without renaming the file and running a filtered install.

--- a/deps/graph-builder/src/lockfileToDepGraph.ts
+++ b/deps/graph-builder/src/lockfileToDepGraph.ts
@@ -33,6 +33,7 @@ export interface DependenciesGraphNode {
   modules: string
   name: string
   fetching?: () => Promise<PkgRequestFetchResult>
+  forceImportPackage?: boolean // Used to force re-imports from the store of local tarballs that have changed.
   dir: string
   children: Record<string, string>
   optionalDependencies: Set<string>
@@ -186,6 +187,8 @@ async function buildGraphFromPackages (
         currentPackages[depPath] &&
         equals(currentPackages[depPath].dependencies, pkgSnapshot.dependencies)
 
+      const depIntegrityIsUnchanged = isIntegrityEqual(pkgSnapshot.resolution, currentPackages[depPath]?.resolution)
+
       const modules = path.join(opts.virtualStoreDir, dirNameInVirtualStore, 'node_modules')
       const dir = path.join(modules, pkgName)
       locationByDepPath[depPath] = dir
@@ -193,6 +196,7 @@ async function buildGraphFromPackages (
       let dirExists: boolean | undefined
       if (
         depIsPresent &&
+        depIntegrityIsUnchanged &&
         isEmpty(currentPackages[depPath].optionalDependencies ?? {}) &&
         isEmpty(pkgSnapshot.optionalDependencies ?? {}) &&
         !opts.includeUnchangedDeps
@@ -203,7 +207,7 @@ async function buildGraphFromPackages (
       }
 
       let fetchResponse!: Partial<FetchResponse>
-      if (depIsPresent && equals(currentPackages[depPath].optionalDependencies, pkgSnapshot.optionalDependencies)) {
+      if (depIsPresent && depIntegrityIsUnchanged && equals(currentPackages[depPath].optionalDependencies, pkgSnapshot.optionalDependencies)) {
         if (dirExists ?? await pathExists(dir)) {
           fetchResponse = {}
         } else {
@@ -236,6 +240,7 @@ async function buildGraphFromPackages (
         dir,
         fetching: fetchResponse.fetching,
         filesIndexFile: fetchResponse.filesIndexFile,
+        forceImportPackage: !depIntegrityIsUnchanged,
         hasBin: pkgSnapshot.hasBin === true,
         hasBundledDependencies: pkgSnapshot.bundledDependencies != null,
         modules,
@@ -289,4 +294,14 @@ function getChildrenPaths (
     }
   }
   return children
+}
+
+function isIntegrityEqual (resolutionA?: LockfileResolution, resolutionB?: LockfileResolution) {
+  // The LockfileResolution type is a union, but it doesn't have a "tag"
+  // field to perform a discriminant match on. Using a type assertion is
+  // required to get the integrity field.
+  const integrityA = (resolutionA as ({ integrity?: string } | undefined))?.integrity
+  const integrityB = (resolutionB as ({ integrity?: string } | undefined))?.integrity
+
+  return integrityA === integrityB
 }

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -886,7 +886,7 @@ async function linkAllPkgs (
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {
         filesResponse,
-        force: opts.force,
+        force: depNode.forceImportPackage ?? opts.force,
         disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
         requiresBuild: depNode.patch != null || depNode.requiresBuild,
         sideEffectsCacheKey,


### PR DESCRIPTION
## Problem

When using the file protocol on a local tarball:

```json
{
  "dependencies": {
    "bar": "file:../../bar.tgz"
  }
}
```

I observed pnpm not re-link `node_modules/bar` when changing `bar.tgz`. This only happened when running a filtered install. (The filter does include the package above.) Example:

```console
pnpm install --filter ./packages/foo
```

## Repro

Here's a minimal repro of the above: https://github.com/gluxon/pnpm-pull-9805-repro

## Cause

This is due to a common assumption across the codebase. We assume the path for a virtual store directory uniquely identifies its contents. In this case, pnpm is seeing that `node_modules/.pnpm/bar@file+bar.tgz` already exists and doesn't re-link it.

https://github.com/pnpm/pnpm/blob/10195e4857d29ca2de5023d213478b9a94ec4d3f/deps/graph-builder/src/lockfileToDepGraph.ts#L193-L203

## Potential Fixes

I thought through a few ways this could be fixed:

1. Update the check in `lockfileToDepGraph` to also check if the integrity hashes are the same.
2. Include the integrity hash for tarballs in the virtual store path. For example, `node_modules/.pnpm/bar@file+bar.tgz` would be renamed to a path that includes a short hash of the tarball: `node_modules/.pnpm/bar@file+1DWk8c6Pt0ELS` 

## Changes

I went with approach 1 in this PR, but let me know if we should switch approaches and do 2.