### PR TITLE
chore: remove `--quiet` from `pnpm lint` in `test-main` and `test-branch` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "pretest": "pnpm run compile-only && pnpm --dir=__fixtures__ run prepareFixtures",
     "lint": "pnpm run spellcheck && pnpm lint:meta && pnpm run lint:ts",
     "spellcheck": "cspell \"**/*.ts\" \"**/README.md\" \".changeset/*.md\" --no-progress",
-    "lint:ts": "eslint \"**/src/**/*.ts\" \"**/test/**/*.ts\" --quiet",
+    "lint:ts": "eslint \"**/src/**/*.ts\" \"**/test/**/*.ts\"",
     "test-main": "pnpm pretest && pnpm lint && pnpm run test-pkgs-main",
     "remove-temp-dir": "shx rm -rf ../pnpm_tmp",
     "test-pkgs-main": "pnpm remove-temp-dir && pnpm run --no-sort --workspace-concurrency=1 -r _test",


### PR DESCRIPTION
<img width="1078" height="160" alt="image" src="https://github.com/user-attachments/assets/610c71b9-1e98-40af-8a15-c7c98a2521c1" />
