### PR TITLE
perf: replace startsWith with strict equality

### DIFF
--- a/__utils__/test-fixtures/src/index.ts
+++ b/__utils__/test-fixtures/src/index.ts
@@ -40,7 +40,7 @@ function copyAndRename (src: string, dest: string): void {
 
   for (const entry of entries) {
     const srcPath = path.join(src, entry)
-    const destPath = path.join(dest, entry.startsWith('_') ? entry.substring(1) : entry)
+    const destPath = path.join(dest, entry[0] === '_' ? entry.substring(1) : entry)
     const stats = fs.statSync(srcPath)
 
     if (stats.isDirectory()) {

--- a/cli/cli-utils/src/getConfig.ts
+++ b/cli/cli-utils/src/getConfig.ts
@@ -79,6 +79,6 @@ function * calcPnpmfilePathsOfPluginDeps (configModulesDir: string, configDepend
 
 function isPluginName (configDepName: string): boolean {
   if (configDepName.startsWith('pnpm-plugin-')) return true
-  if (!configDepName.startsWith('@')) return false
+  if (configDepName[0] !== '@') return false
   return configDepName.startsWith('@pnpm/plugin-') || configDepName.includes('/pnpm-plugin-')
 }

--- a/completion/plugin-commands-completion/src/getOptionType.ts
+++ b/completion/plugin-commands-completion/src/getOptionType.ts
@@ -56,10 +56,10 @@ export function getLastOption (completionCtx: CompletionCtx): string | null {
 
 function isOption (word: string): boolean {
   return word.startsWith('--') && word.length >= 3 ||
-    word.startsWith('-') && word.length >= 2
+    word[0] === '-' && word.length >= 2
 }
 
 export function currentTypedWordType (completionCtx: CompletionCtx): 'option' | 'value' | null {
   if (completionCtx.partial.endsWith(' ')) return null
-  return completionCtx.lastPartial.startsWith('-') ? 'option' : 'value'
+  return completionCtx.lastPartial[0] === '-' ? 'option' : 'value'
 }

--- a/config/matcher/src/index.ts
+++ b/config/matcher/src/index.ts
@@ -80,7 +80,7 @@ function matcherFromPattern (pattern: string): Matcher {
 }
 
 function isIgnorePattern (pattern: string): boolean {
-  return pattern.startsWith('!')
+  return pattern[0] === '!'
 }
 
 function matcherWhenOnlyOnePatternWithIndex (pattern: string): MatcherWithIndex {

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -233,7 +233,7 @@ export async function handler (
     if (opts.fallbackCommandUsed) {
       if (opts.argv == null) throw new Error('Could not fallback because opts.argv.original was not passed to the script runner')
       const params = opts.argv.original.slice(1)
-      while (params.length > 0 && params[0].startsWith('-') && params[0] !== '--') {
+      while (params.length > 0 && params[0][0] === '-' && params[0] !== '--') {
         params.shift()
       }
       if (params.length > 0 && params[0] === '--') {

--- a/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -21,7 +21,7 @@ export function pkgSnapshotToResolution (
   const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
   let registry: string = ''
   if (name != null) {
-    if (name.startsWith('@')) {
+    if (name[0] === '@') {
       registry = registries[name.split('/')[0]]
     }
   }

--- a/object/property-path/src/token/StringLiteral.ts
+++ b/object/property-path/src/token/StringLiteral.ts
@@ -37,9 +37,9 @@ export class IncompleteStringLiteralError extends ParseErrorBase {
 
 export const parseStringLiteral: Tokenize<StringLiteral> = source => {
   let quote: StringLiteralQuote
-  if (source.startsWith('"')) {
+  if (source[0] === '"') {
     quote = '"'
-  } else if (source.startsWith("'")) {
+  } else if (source[0] === "'") {
     quote = "'"
   } else {
     return undefined

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -103,7 +103,7 @@ export function refToRelative (
   if (reference.startsWith('link:')) {
     return null
   }
-  if (reference.startsWith('@')) return reference as DepPath
+  if (reference[0] === '@') return reference as DepPath
   const atIndex = reference.indexOf('@')
   if (atIndex === -1) return `${pkgName}@${reference}` as DepPath
   const colonIndex = reference.indexOf(':')
@@ -203,7 +203,7 @@ export function createPeerDepGraphHash (peerIds: PeerId[], maxLength: number = 1
       if (typeof peerId !== 'string') {
         return `${peerId.name}@${peerId.version}`
       }
-      if (peerId.startsWith('/')) {
+      if (peerId[0] === '/') {
         return peerId.substring(1)
       }
       return peerId

--- a/pkg-manager/core/src/install/validateModules.ts
+++ b/pkg-manager/core/src/install/validateModules.ts
@@ -182,7 +182,7 @@ async function removeContentsOfDir (dir: string, virtualStoreDir: string): Promi
   await Promise.all(items.map(async (item) => {
     // The non-pnpm related hidden files are kept
     if (
-      item.startsWith('.') &&
+      item[0] === '.' &&
       item !== '.bin' &&
       item !== '.modules.yaml' &&
       !dirsAreEqual(path.join(dir, item), virtualStoreDir)

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -199,7 +199,7 @@ Do you want to continue?`,
   if (index !== -1) {
     // If --publish-branch follows with another cli option, only remove this argument
     // otherwise remove the following argument as well
-    if (args[index + 1]?.startsWith('-')) {
+    if (args[index + 1]?.[0] === '-') {
       args.splice(index, 1)
     } else {
       args.splice(index, 2)

--- a/resolving/jsr-specifier-parser/src/index.ts
+++ b/resolving/jsr-specifier-parser/src/index.ts
@@ -13,7 +13,7 @@ export function parseJsrSpecifier (rawSpecifier: string, alias?: string): JsrSpe
   rawSpecifier = rawSpecifier.substring('jsr:'.length)
 
   // syntax: jsr:@<scope>/<name>[@<version_selector>]
-  if (rawSpecifier.startsWith('@')) {
+  if (rawSpecifier[0] === '@') {
     const index = rawSpecifier.lastIndexOf('@')
 
     // syntax: jsr:@<scope>/<name>
@@ -51,7 +51,7 @@ export function parseJsrSpecifier (rawSpecifier: string, alias?: string): JsrSpe
 }
 
 function jsrToNpmPackageName (jsrPkgName: string): string {
-  if (!jsrPkgName.startsWith('@')) {
+  if (jsrPkgName[0] !== '@') {
     throw new PnpmError('MISSING_JSR_PACKAGE_SCOPE', 'Package names from JSR must have a scope')
   }
   const sepIndex = jsrPkgName.indexOf('/')

--- a/text/comments-parser/src/insertComments.ts
+++ b/text/comments-parser/src/insertComments.ts
@@ -46,7 +46,7 @@ export function insertComments (json: string, comments: CommentSpecifier[]): str
       if (jsonPrefix[location]) {
         jsonPrefix[location] += ' ' + comment.content
       } else {
-        const inlineWhitespace = comment.whitespace.startsWith('\n')
+        const inlineWhitespace = comment.whitespace[0] === '\n'
           ? comment.whitespace.slice(1)
           : comment.whitespace
         jsonPrefix[location] = inlineWhitespace + comment.content

--- a/workspace/filter-workspace-packages/src/parsePackageSelector.ts
+++ b/workspace/filter-workspace-packages/src/parsePackageSelector.ts
@@ -29,7 +29,7 @@ export function parsePackageSelector (rawSelector: string, prefix: string): Pack
   const includeDependents = rawSelector.startsWith('...')
   if (includeDependents) {
     rawSelector = rawSelector.substring(3)
-    if (rawSelector.startsWith('^')) {
+    if (rawSelector[0] === '^') {
       excludeSelf = true
       rawSelector = rawSelector.slice(1)
     }


### PR DESCRIPTION
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)