### PR TITLE
fix: install absolute path pkg failed

### DIFF
--- a/.changeset/afraid-mammals-battle.md
+++ b/.changeset/afraid-mammals-battle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/headless": patch
+---
+
+Failed to install dependency packages under absolute paths on different disk paths.

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -793,7 +793,8 @@ async function getRootPackagesToLink (
         if (ref.startsWith('link:')) {
           const isDev = Boolean(projectSnapshot.devDependencies?.[alias])
           const isOptional = Boolean(projectSnapshot.optionalDependencies?.[alias])
-          const packageDir = path.join(opts.projectDir, ref.slice(5))
+          ref = ref.slice(5)
+          const packageDir = path.isAbsolute(ref) ? ref : path.join(opts.projectDir, ref)
           const linkedPackage = await (async () => {
             const importerId = getLockfileImporterId(opts.lockfileDir, packageDir)
             if (opts.importerManifestsByImporterId[importerId]) {


### PR DESCRIPTION
When a project has a `pnpm-workspace.yaml` file that contains the "packages" field, and I try to install dependencies locally on a disk that is located on another disk, the installation fails because the obtained path is incorrect.

For example, if I install `E:/test/b` in the `a` directory of the `D` drive, the final path is `D:\a\E:\test\b\`. (windows)