### PR TITLE
perf: replace indexOf with startsWith

### DIFF
--- a/deps/graph-builder/src/lockfileToDepGraph.ts
+++ b/deps/graph-builder/src/lockfileToDepGraph.ts
@@ -297,7 +297,7 @@ function getChildrenPaths (
       children[alias] = ctx.locationByDepPath[childRelDepPath]
     } else if (ctx.graph[childRelDepPath]) {
       children[alias] = ctx.graph[childRelDepPath].dir
-    } else if (ref.indexOf('file:') === 0) {
+    } else if (ref.startsWith('file:')) {
       children[alias] = path.resolve(ctx.lockfileDir, ref.slice(5))
     } else if (!ctx.skipped.has(childRelDepPath) && ((peerDeps == null) || !peerDeps.has(alias))) {
       throw new Error(`${childRelDepPath} not found in ${WANTED_LOCKFILE}`)

--- a/packages/dependency-path/src/index.ts
+++ b/packages/dependency-path/src/index.ts
@@ -183,7 +183,7 @@ export function depPathToFilename (depPath: string, maxLengthWithoutHash: number
 }
 
 function depPathToFilenameUnescaped (depPath: string): string {
-  if (depPath.indexOf('file:') !== 0) {
+  if (!depPath.startsWith('file:')) {
     if (depPath[0] === '/') {
       depPath = depPath.substring(1)
     }

--- a/store/store-path/src/index.ts
+++ b/store/store-path/src/index.ts
@@ -112,5 +112,5 @@ function getHomedir (): string {
 }
 
 function isHomepath (filepath: string): boolean {
-  return filepath.indexOf('~/') === 0 || filepath.indexOf('~\\') === 0
+  return filepath.startsWith('~/') || filepath.startsWith('~\\')
 }


### PR DESCRIPTION
Using startswith is more efficient than using indexOf to determine whether the subscript is 0. [link](https://perf.link/#eyJpZCI6Imd2dGtvM3AwaWoyIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnZmlsZTonKSkiLCJydW5zIjpbMTAwMCwwLDExMDAwLDEwMDAsOTAwMCwxMTAwMCwxMjAwMCw3MDAwLDMyMDAwLDMwMDAsODAwMCwyMDAwLDEyMDAwLDIwMDAsMTYwMDAsMTAwMCwzMDAwLDIwMDAsMTkwMDAsNTAwMCw5MDAwLDUwMDAsODAwMCwxMDAwMCwyMDAwLDEwMDAsODAwMCwxNzAwMCwxMDAwLDIwMDAsMTIwMDAsMTAwMCwxMzAwMCw0MDAwLDEwMDAsMjAwMCwyMTAwMCwxMTAwMCw3MDAwLDEwMDAsNzAwMCwxNjAwMCwxMDAwLDQwMDAsMTEwMDAsMTAwMCwxMTAwMCwxMjAwMCwxMDAwLDcwMDAsODAwMCw3MDAwLDQwMDAsMjAwMCwxNDAwMCwxMDAwLDkwMDAsNTAwMCwzMDAwLDIwMDAsMTIwMDAsMTMwMDAsOTAwMCwyMDAwLDE2MDAwLDE1MDAwLDkwMDAsMzAwMCwxMDAwMCwxNDAwMCw1MDAwLDcwMDAsMTAwMDAsMTYwMDAsNTAwMCwzMDAwLDYwMDAsNDAwMCwyMjAwMCwxMDAwLDEyMDAwLDgwMDAsMTEwMDAsMjAwMCwxMDAwLDI1MDAwLDI5MDAwLDcwMDAsNTAwMCw3MDAwLDYwMDAsMzAwMCwxMDAwLDEwMDAsMTAwMCwxMTAwMCw2MDAwLDIxMDAwLDEwMDAsOTAwMF0sIm9wcyI6NzY4MH0seyJuYW1lIjoiRmluZCBpdGVtIDIwMCIsImNvZGUiOiJkYXRhLmZpbmQoeCA9PiB4LmluZGV4T2YoJ2ZpbGU6JykgPT09ICcuJykiLCJydW5zIjpbMjAwMCw0MDAwLDMwMDAsMjAwMCwxMDAwLDcwMDAsMzAwMCw3MDAwLDIwMDAsMjAwMCwzMDAwLDYwMDAsMjAwMCwxMTAwMCwxMDAwLDMwMDAsMTAwMCwxMDAwLDkwMDAsNTAwMCw0MDAwLDEwMDAsNjAwMCwxMTAwMCwzMDAwLDcwMDAsMTAwMCwyMDAwLDQwMDAsNzAwMCwxMDAwLDcwMDAsMjAwMCwxMDAwLDIwMDAsNjAwMCwxMDAwLDMwMDAsMzAwMCwxMDAwLDYwMDAsNTAwMCw3MDAwLDEwMDAsMzAwMCw4MDAwLDMwMDAsMjAwMCwyMDAwLDEwMDAsMTAwMCw1MDAwLDEwMDAsMTAwMCw5MDAwLDEzMDAwLDUwMDAsMTAwMDAsNDAwMCwzMDAwLDIwMDAsNjAwMCw2MDAwLDYwMDAsNzAwMCwxMDAwLDE1MDAwLDQwMDAsMzAwMCwxMDAwLDIwMDAsMjAwMCwzMDAwLDMwMDAsNjAwMCw0MDAwLDYwMDAsMTAwMCwxMDAwLDEwMDAsNzAwMCw1MDAwLDEwMDAsMTAwMCw3MDAwLDIwMDAsMzAwMCwzMDAwLDYwMDAsMzAwMCwxMDAwLDMwMDAsNDAwMCwyMDAwLDEwMDAsODAwMCwyMDAwLDEwMDAsMzAwMCwzMDAwXSwib3BzIjozODQwfV0sInVwZGF0ZWQiOiIyMDI1LTA4LTI2VDAxOjIxOjIxLjgwNFoifQ%3D%3D)