### PR TITLE
fix(lockfile-to-pnp): ensure packageLocation ends in trailing slash

### DIFF
--- a/.changeset/good-llamas-dream.md
+++ b/.changeset/good-llamas-dream.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/lockfile-to-pnp": patch
+---
+
+Fix .pnp.cjs crash when importing subpath
+
+See https://github.com/pnpm/pnpm/issues/9904

--- a/.changeset/good-llamas-dream.md
+++ b/.changeset/good-llamas-dream.md
@@ -1,7 +1,7 @@
 ---
 "@pnpm/lockfile-to-pnp": patch
+"pnpm": patch
 ---
 
-Fix .pnp.cjs crash when importing subpath
+Fix `.pnp.cjs` crash when importing subpath [#9904](https://github.com/pnpm/pnpm/issues/9904).
 
-See https://github.com/pnpm/pnpm/issues/9904

--- a/lockfile/lockfile-to-pnp/src/index.ts
+++ b/lockfile/lockfile-to-pnp/src/index.ts
@@ -95,6 +95,9 @@ export function lockfileToPackageRegistry (
     if (!packageLocation.startsWith('../')) {
       packageLocation = `./${packageLocation}`
     }
+    if (!packageLocation.endsWith('/')) {
+      packageLocation += '/'
+    }
     packageStore.set(pnpVersion, {
       packageDependencies: new Map([
         [name, pnpVersion],

--- a/lockfile/lockfile-to-pnp/test/index.ts
+++ b/lockfile/lockfile-to-pnp/test/index.ts
@@ -129,7 +129,7 @@ test('lockfileToPackageRegistry', () => {
               ['dep1', '1.0.0'],
               ['dep2', ['foo', '2.0.0']],
             ],
-            packageLocation: './node_modules/.pnpm/dep1@1.0.0/node_modules/dep1',
+            packageLocation: './node_modules/.pnpm/dep1@1.0.0/node_modules/dep1/',
           },
         ],
       ],
@@ -144,7 +144,7 @@ test('lockfileToPackageRegistry', () => {
               ['foo', '2.0.0'],
               ['qar', '3.0.0'],
             ],
-            packageLocation: './node_modules/.pnpm/foo@2.0.0/node_modules/foo',
+            packageLocation: './node_modules/.pnpm/foo@2.0.0/node_modules/foo/',
           },
         ],
       ],
@@ -158,7 +158,7 @@ test('lockfileToPackageRegistry', () => {
             packageDependencies: [
               ['qar', '2.0.0'],
             ],
-            packageLocation: './node_modules/.pnpm/qar@2.0.0/node_modules/qar',
+            packageLocation: './node_modules/.pnpm/qar@2.0.0/node_modules/qar/',
           },
         ],
         [
@@ -167,7 +167,7 @@ test('lockfileToPackageRegistry', () => {
             packageDependencies: [
               ['qar', '3.0.0'],
             ],
-            packageLocation: './node_modules/.pnpm/qar@3.0.0/node_modules/qar',
+            packageLocation: './node_modules/.pnpm/qar@3.0.0/node_modules/qar/',
           },
         ],
       ],
@@ -265,7 +265,7 @@ test('lockfileToPackageRegistry packages that have peer deps', () => {
               ['haspeer', 'virtual:2.0.0(peer@1.0.0)#2.0.0'],
               ['peer', '1.0.0'],
             ],
-            packageLocation: './node_modules/.pnpm/haspeer@2.0.0_peer@1.0.0/node_modules/haspeer',
+            packageLocation: './node_modules/.pnpm/haspeer@2.0.0_peer@1.0.0/node_modules/haspeer/',
           },
         ],
       ],
@@ -279,7 +279,7 @@ test('lockfileToPackageRegistry packages that have peer deps', () => {
             packageDependencies: [
               ['peer', '1.0.0'],
             ],
-            packageLocation: './node_modules/.pnpm/peer@1.0.0/node_modules/peer',
+            packageLocation: './node_modules/.pnpm/peer@1.0.0/node_modules/peer/',
           },
         ],
       ],


### PR DESCRIPTION
I compared PNPM's `.pnp.cjs` with the one generated by Yarn Berry, and it turned out that Yarn normalises `packageLocation` to always end in a trailing slash:
Here's where they ensure this when writing `.pnp.cjs`: https://github.com/yarnpkg/berry/blob/f6a58c2803d6572af28e118eecd10c795e1228b1/packages/plugin-pnp/sources/PnpLinker.ts#L492
And here's where they normalise at read-time: https://github.com/yarnpkg/berry/blob/f6a58c2803d6572af28e118eecd10c795e1228b1/packages/yarnpkg-pnp/sources/loader/makeApi.ts#L511-L512

This PR makes PNPM adhere to this behaviour.

I verified that it resolves https://github.com/pnpm/pnpm/issues/9904 by manually updating the paths in `.pnp.cjs`.