### PR TITLE
perf(link-bins): replace `p-settle` with builtin `Promise.allSettled`

### DIFF
--- a/.changeset/tiny-terms-stop.md
+++ b/.changeset/tiny-terms-stop.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/link-bins": patch
+---
+
+Replace `p-settle` with the builtin `Promise.allSettled`

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -47,7 +47,6 @@
     "is-subdir": "catalog:",
     "is-windows": "catalog:",
     "normalize-path": "catalog:",
-    "p-settle": "catalog:",
     "ramda": "catalog:",
     "semver": "catalog:",
     "symlink-dir": "catalog:"

--- a/pkg-manager/link-bins/src/index.ts
+++ b/pkg-manager/link-bins/src/index.ts
@@ -15,7 +15,6 @@ import rimraf from '@zkochan/rimraf'
 import isSubdir from 'is-subdir'
 import isWindows from 'is-windows'
 import normalizePath from 'normalize-path'
-import pSettle from 'p-settle'
 import isEmpty from 'ramda/src/isEmpty'
 import unnest from 'ramda/src/unnest'
 import groupBy from 'ramda/src/groupBy'
@@ -143,11 +142,11 @@ async function _linkBins (
 
   await fs.mkdir(binsDir, { recursive: true })
 
-  const results = await pSettle(allCmds.map(async cmd => linkBin(cmd, binsDir, opts)))
+  const results = await Promise.allSettled(allCmds.map(async cmd => linkBin(cmd, binsDir, opts)))
 
   // We want to create all commands that we can create before throwing an exception
   for (const result of results) {
-    if (result.isRejected) {
+    if (result.status === 'rejected') {
       throw result.reason
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,9 +561,6 @@ catalogs:
     p-queue:
       specifier: ^6.6.2
       version: 6.6.2
-    p-settle:
-      specifier: ^4.1.1
-      version: 4.1.1
     parse-json:
       specifier: ^5.2.0
       version: 5.2.0
@@ -5399,9 +5396,6 @@ importers:
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
-      p-settle:
-        specifier: 'catalog:'
-        version: 4.1.1
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'


### PR DESCRIPTION
`Promise.allSettled` has been available since Node 12.9.