### PR TITLE
fix(patch): forcibly disable ANSI color codes when generating patch diff

### DIFF
--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -151,7 +151,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
   let stderr!: string
 
   try {
-    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', folderAN, folderBN], {
+    const result = await execa('git', ['-c', 'core.safecrlf=false', 'diff', '--src-prefix=a/', '--dst-prefix=b/', '--ignore-cr-at-eol', '--irreversible-delete', '--full-index', '--no-index', '--text', '--no-ext-diff', '--no-color', folderAN, folderBN], {
       cwd: process.cwd(),
       env: {
         ...process.env,


### PR DESCRIPTION
When working inside of a Git repository that includes `color.diff = always` in its local (repository-level) config, the `pnpm patch-commit` command outputs invalid `.diff` files that include ANSI color codes.

To work around this scenario, we need to pass `--no-color` to the `git diff` command that `pnpm patch-commit` runs, to forcibly override the repository's local color preferences.