### PR TITLE
fix(deploy): hint "pnpm run deploy" for "pnpm deploy" outside a workspace

### DIFF
--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -82,9 +82,11 @@ export type DeployOptions =
 
 export async function handler (opts: DeployOptions, params: string[]): Promise<void> {
   if (!opts.workspaceDir) {
-    throw new PnpmError('CANNOT_DEPLOY', 'A deploy is only possible from inside a workspace', {
-      hint: 'Maybe you wanted to invoke "pnpm run deploy"'
-    })
+    let hint: string | undefined
+    if (opts.rootProjectManifest?.scripts?.['deploy'] != null) {
+      hint = 'Maybe you wanted to invoke "pnpm run deploy"'
+    }
+    throw new PnpmError('CANNOT_DEPLOY', 'A deploy is only possible from inside a workspace', { hint })
   }
   const selectedProjects = Object.values(opts.selectedProjectsGraph ?? {})
   if (selectedProjects.length === 0) {

--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -82,7 +82,9 @@ export type DeployOptions =
 
 export async function handler (opts: DeployOptions, params: string[]): Promise<void> {
   if (!opts.workspaceDir) {
-    throw new PnpmError('CANNOT_DEPLOY', 'A deploy is only possible from inside a workspace')
+    throw new PnpmError('CANNOT_DEPLOY', 'A deploy is only possible from inside a workspace', {
+      hint: 'Maybe you wanted to invoke "pnpm run deploy"'
+    })
   }
   const selectedProjects = Object.values(opts.selectedProjectsGraph ?? {})
   if (selectedProjects.length === 0) {


### PR DESCRIPTION
This makes the experience better for those who have a script named "deploy", and may potentially get confused why "pnpm deploy" doesn't work.

Related to #9475 but doesn't actually fix it.

PS: Not sure if `docs(deploy)` is correct. Feel free to change the title.