### PR TITLE
fix: resolve peer dependencies not updated with `pnpm upgrade --latest`

### DIFF
--- a/.changeset/quiet-zebras-repeat.md
+++ b/.changeset/quiet-zebras-repeat.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Fix peer dependencies not being upgraded with `pnpm upgrade --latest` [#9900](https://github.com/pnpm/pnpm/issues/9900).

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -681,7 +681,9 @@ export async function mutateModules (
     >
 
     async function installSome (project: InstallSomeProject) {
-      const currentBareSpecifiers = opts.ignoreCurrentSpecifiers ? {} : getAllDependenciesFromManifest(project.manifest)
+      const currentBareSpecifiers = opts.ignoreCurrentSpecifiers
+        ? {}
+        : getAllDependenciesFromManifest(project.manifest, { autoInstallPeers: opts.autoInstallPeers })
       const optionalDependencies = project.targetDependenciesField ? {} : project.manifest.optionalDependencies ?? {}
       const devDependencies = project.targetDependenciesField ? {} : project.manifest.devDependencies ?? {}
       if (preferredSpecs == null) {

--- a/installing/deps-installer/test/install/update.ts
+++ b/installing/deps-installer/test/install/update.ts
@@ -263,3 +263,36 @@ test('peer dependency is not added to prod deps on update', async () => {
     },
   })
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/9900
+test('peer dependencies are updated with pnpm upgrade --latest when autoInstallPeers is true', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '1.0.0', distTag: 'latest' })
+
+  const project = prepareEmpty()
+
+  const manifest = {
+    name: 'test-pkg',
+    version: '1.0.0',
+    peerDependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+    },
+  }
+
+  await install(manifest, testDefaults({ autoInstallPeers: true }))
+
+  let lockfile = project.readLockfile()
+  expect(lockfile.importers?.['.']?.dependencies?.['@pnpm.e2e/foo'].version).toBe('1.0.0')
+
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '1.3.0', distTag: 'latest' })
+
+  await addDependenciesToPackage(manifest, ['@pnpm.e2e/foo'], testDefaults({
+    allowNew: false,
+    autoInstallPeers: true,
+    update: true,
+    updateToLatest: true,
+  }))
+
+  lockfile = project.readLockfile()
+
+  expect(lockfile.importers?.['.']?.dependencies?.['@pnpm.e2e/foo'].version).toBe('1.3.0')
+})

--- a/pkg-manifest/utils/src/getAllDependenciesFromManifest.ts
+++ b/pkg-manifest/utils/src/getAllDependenciesFromManifest.ts
@@ -1,11 +1,13 @@
 import type { Dependencies, DependenciesField, ProjectManifest } from '@pnpm/types'
 
 export function getAllDependenciesFromManifest (
-  pkg: Pick<ProjectManifest, DependenciesField>
+  pkg: Pick<ProjectManifest, DependenciesField | 'peerDependencies'>,
+  opts?: { autoInstallPeers?: boolean }
 ): Dependencies {
   return {
     ...pkg.devDependencies,
     ...pkg.dependencies,
     ...pkg.optionalDependencies,
+    ...(opts?.autoInstallPeers ? pkg.peerDependencies : {}),
   } as Dependencies
 }

--- a/pkg-manifest/utils/src/index.ts
+++ b/pkg-manifest/utils/src/index.ts
@@ -25,11 +25,13 @@ export function filterDependenciesByType (
 }
 
 export function getAllDependenciesFromManifest (
-  manifest: Pick<ProjectManifest, 'devDependencies' | 'dependencies' | 'optionalDependencies'>
+  manifest: Pick<ProjectManifest, 'devDependencies' | 'dependencies' | 'optionalDependencies' | 'peerDependencies'>,
+  opts?: { autoInstallPeers?: boolean }
 ): Dependencies {
   return {
     ...manifest.devDependencies,
     ...manifest.dependencies,
     ...manifest.optionalDependencies,
+    ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
   }
 }


### PR DESCRIPTION
fixes #9900

Fix peer dependencies not being upgraded when using `pnpm upgrade --latest`.

## Problem

In monorepos, peer dependencies (both catalog-based and regular) were not being upgraded when running `pnpm upgrade --latest`, while regular dependencies updated correctly.

**Root cause**: The `--latest` flag triggers the `installSome` code path, which uses `getAllDependenciesFromManifest()` to build `currentBareSpecifiers`. Unlike `installCase` which uses `getWantedDependencies()` and includes peer dependencies, `getAllDependenciesFromManifest()` was excluding them entirely.

## Solution

Added an optional `autoInstallPeers` parameter to `getAllDependenciesFromManifest` to make it behave consistently with `getWantedDependencies`:

  ```typescript
  export function getAllDependenciesFromManifest (
    manifest: Pick<ProjectManifest, DependenciesField | 'peerDependencies'>,
    opts?: { autoInstallPeers?: boolean }
  ): Dependencies {
    return {
      ...manifest.devDependencies,
      ...manifest.dependencies,
      ...manifest.optionalDependencies,
      ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
    }
  }
```

Now installSome and installCase handle peer dependencies consistently.

## Key Changes

1) Modified getAllDependenciesFromManifest to accept autoInstallPeers option
2)  Updated installSome to pass autoInstallPeers when calling getAllDependenciesFromManifest
3) Added test for peer dependency upgrades in install/update.ts