### PR TITLE
fix: remove pkg apply cleanupUnusedCatalogs

### DIFF
--- a/.changeset/every-walls-search.md
+++ b/.changeset/every-walls-search.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+`cleanupUnusedCatalogs` configuration should be applied when removing a dependency package.

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -217,8 +217,8 @@ export async function handler (
     removeOpts
   )
   await writeProjectManifest(mutationResult.updatedProject.manifest)
-  updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+  await updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
     cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
-    allProjects: opts.allProjects
+    allProjects: opts.allProjects,
   })
 }

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -9,6 +9,7 @@ import { type Config, getOptionsFromRootManifest, types as allTypes } from '@pnp
 import { PnpmError } from '@pnpm/error'
 import { arrayOfWorkspacePackagesToMap } from '@pnpm/get-context'
 import { findWorkspacePackages } from '@pnpm/workspace.find-packages'
+import { updateWorkspaceManifest } from '@pnpm/workspace.manifest-writer'
 import { getAllDependenciesFromManifest } from '@pnpm/manifest-utils'
 import { createOrConnectStoreController, type CreateStoreControllerOptions } from '@pnpm/store-connection-manager'
 import { type DependenciesField, type ProjectRootDir } from '@pnpm/types'
@@ -150,6 +151,7 @@ export async function handler (
   | 'workspaceDir'
   | 'workspacePackagePatterns'
   | 'sharedWorkspaceLockfile'
+  | 'cleanupUnusedCatalogs'
   > & {
     recursive?: boolean
     pnpmfile: string[]
@@ -215,4 +217,8 @@ export async function handler (
     removeOpts
   )
   await writeProjectManifest(mutationResult.updatedProject.manifest)
+  updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+    cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
+    allProjects: opts.allProjects
+  })
 }


### PR DESCRIPTION
When removing a dependency, we should also execute `cleanupUnusedCatalogs` configuration related logic.