### PR TITLE
feat: add `NoMatchingVersionWithMinimumReleaseAgeError`

### DIFF
--- a/.changeset/chubby-trees-notice.md
+++ b/.changeset/chubby-trees-notice.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/npm-resolver": patch
+"@pnpm/default-reporter": patch
+---
+
+Added `NoMatchingVersionWithMinimumReleaseAgeError` class to describe the error message when the installation dependency package matching fails when `minimumReleaseAge` is set.

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -71,6 +71,8 @@ function getErrorInfo (logObj: Log, config?: Config): ErrorInfo | null {
       return { title: err.message, body: 'If you cannot fix this registry issue, then set "resolution-mode" to "highest".' }
     case 'ERR_PNPM_NO_MATCHING_VERSION':
       return formatNoMatchingVersion(err, logObj as unknown as { packageMeta: PackageMeta })
+    case 'ERR_PNPM_NO_MATCHING_VERSION_WITH_MINIMUM_RELEASE_AGE':
+      return formatNoMatchingVersionWithMinimumReleaseAge(err, logObj as unknown as { packageMeta: PackageMeta })
     case 'ERR_PNPM_RECURSIVE_FAIL':
       return formatRecursiveCommandSummary(logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
     case 'ERR_PNPM_BAD_TARBALL_SIZE':
@@ -145,6 +147,18 @@ function formatNoMatchingVersion (err: Error, msg: { packageMeta: PackageMeta })
   }
 
   output += `${EOL}If you need the full list of all ${Object.keys(meta.versions).length} published versions run "$ pnpm view ${meta.name} versions".`
+
+  return {
+    title: err.message,
+    body: output,
+  }
+}
+
+function formatNoMatchingVersionWithMinimumReleaseAge (err: Error, msg: { packageMeta: PackageMeta }) {
+  const meta: PackageMeta = msg.packageMeta
+  let output = `The latest release of ${meta.name} is "${meta['dist-tags'].latest}".${EOL}`
+
+  output += `${EOL}It seems that you set "minimumReleaseAge" which caused the installation to fail. Please refer to the documentation for more information. https://pnpm.io/blog/releases/10.16#new-setting-for-delayed-dependency-updates`
 
   return {
     title: err.message,

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -55,6 +55,17 @@ export class NoMatchingVersionError extends PnpmError {
   }
 }
 
+export class NoMatchingVersionWithMinimumReleaseAgeError extends PnpmError {
+  public readonly packageMeta: PackageMeta
+  constructor (opts: { wantedDependency: WantedDependency, packageMeta: PackageMeta, registry: string }) {
+    const dep = opts.wantedDependency.alias
+      ? `${opts.wantedDependency.alias}@${opts.wantedDependency.bareSpecifier ?? ''}`
+      : opts.wantedDependency.bareSpecifier!
+    super('NO_MATCHING_VERSION_WITH_MINIMUM_RELEASE_AGE', `No matching version found for ${dep} while fetching it from ${opts.registry}`)
+    this.packageMeta = opts.packageMeta
+  }
+}
+
 export {
   parseBareSpecifier,
   workspacePrefToNpm,
@@ -257,6 +268,10 @@ async function resolveNpm (
       } catch {
         // ignore
       }
+    }
+
+    if (opts.publishedBy) {
+      throw new NoMatchingVersionWithMinimumReleaseAgeError({ wantedDependency, packageMeta: meta, registry })
     }
     throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry })
   }


### PR DESCRIPTION
When `minimumReleaseAge` is configured, if the installation dependencies do not match, the error message below may appear confusing.

<img width="1188" height="222" alt="image" src="https://github.com/user-attachments/assets/a89e091f-a319-471b-96d3-dfb808dc436a" />
