### PR TITLE
fix: only show save catalog skip warning when using `pnpm add --save-catalog`

### DIFF
--- a/.changeset/three-islands-juggle.md
+++ b/.changeset/three-islands-juggle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+pnpm: patch
+---
+
+When using pnpm catalogs and running a normal `pnpm install`, pnpm produced false positive warnings for "_skip adding to the default catalog because it already exists_". This warning now only prints when using `pnpm add --save-catalog` as originally intended.

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -245,6 +245,11 @@ export async function resolveDependencyTree<T> (
   for (const directDependencies of pkgAddressesByImporters) {
     for (const directDep of directDependencies as PkgAddress[]) {
       const { alias, normalizedBareSpecifier, version, saveCatalogName } = directDep
+
+      if (saveCatalogName == null) {
+        continue
+      }
+
       const existingCatalog = opts.catalogs?.default?.[alias]
       if (existingCatalog != null) {
         if (existingCatalog !== normalizedBareSpecifier) {
@@ -252,7 +257,7 @@ export async function resolveDependencyTree<T> (
             `Skip adding ${alias} to the default catalog because it already exists as ${existingCatalog}. Please use \`pnpm update\` to update the catalogs.`
           )
         }
-      } else if (saveCatalogName != null && normalizedBareSpecifier != null && version != null) {
+      } else if (normalizedBareSpecifier != null && version != null) {
         const userSpecifiedBareSpecifier = `catalog:${saveCatalogName === 'default' ? '' : saveCatalogName}`
 
         // Attach metadata about how this new catalog dependency should be


### PR DESCRIPTION
## Context

Fixes https://github.com/pnpm/pnpm/issues/9662.

This warning was originally added in:

- https://github.com/pnpm/pnpm/pull/9484

Looking through the original PR, I think the intention of this warning was to only print when running `pnpm add --save-catalog`.

## Changes

Let's gate this warning around `saveCatalogName != null`. I suspect this was the original intention in https://github.com/pnpm/pnpm/pull/9484. CC @KSXGitHub to confirm.

## Why did this false positive?

This warning prints whenever:

https://github.com/pnpm/pnpm/blob/904ae1a87589e755a7a4c13f3b083ac244bb406e/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts#L255

I noticed a few cases when `normalizedBareSpecifier` will be different than the specifier defined in `pnpm-workspace.yaml`.

- When there's no `pnpm-lock.yaml` file, `normalizedBareSpecifier` will be the latest version of the package. (Originally noted by @zkochan here:
  - https://github.com/pnpm/pnpm/issues/9662#issuecomment-3364790040)
- The `normalizedBareSpecifier` value can also be `undefined`. For example, when resolution is skipped, this value will never be set.
  - https://github.com/pnpm/pnpm/blob/bdbd31aa4fa6546d65b6eee50a79b51879340d40/pkg-manager/package-requester/src/packageRequester.ts#L191

