### PR TITLE
chore: add GHSA-ffrw-9mx8-89p8 to `ignoreGhsas` config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ packages:
 auditConfig:
   ignoreGhsas:
     - GHSA-76c9-3jph-rj3q
+    - GHSA-ffrw-9mx8-89p8
 
 catalog:
   '@babel/core': ^7.26.10


### PR DESCRIPTION
This is a quick fix for a recent `fast-redact` vulnerability. There's no fix available yet.

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ low                 │ fast-redact vulnerable to prototype pollution          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ fast-redact                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=3.5.0                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ <0.0.0                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>verdaccio>pino>fast-redact                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-ffrw-9mx8-89p8      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```