### PR TITLE
fix: handle EPIPE errors when piping output

### DIFF
--- a/.changeset/wet-ducks-admire.md
+++ b/.changeset/wet-ducks-admire.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fix `EPIPE` errors when piping output to other commands [#10027](https://github.com/pnpm/pnpm/issues/10027).

--- a/cspell.json
+++ b/cspell.json
@@ -66,6 +66,7 @@
     "enoent",
     "enten",
     "eperm",
+    "epipe",
     "etamponi",
     "exdev",
     "execa",

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -33,6 +33,15 @@ export const REPORTER_INITIALIZED = Symbol('reporterInitialized')
 
 loudRejection()
 
+// This prevents the program from crashing when the pipe's read side closes early
+// (e.g., when running `pnpm config list | head`)
+process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') {
+    process.exit(0)
+  }
+  throw err
+})
+
 const DEPRECATED_OPTIONS = new Set([
   'independent-leaves',
   'lock',


### PR DESCRIPTION
Fixes #10027 

Handle EPIPE errors when piping pnpm output to other commands.