### PR TITLE
fix: correct path parsing for projects in ancestor directories while calculating the repo root

### DIFF
--- a/.changeset/old-vans-feel.md
+++ b/.changeset/old-vans-feel.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-installation": patch
+---
+
+During installation, use a correct regex to parse paths of projects in ancestor directories when calculating the repo root.

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -479,7 +479,7 @@ function calculateRepositoryRoot (
   // assume repo root is workspace dir
   let relativeRepoRoot = '.'
   for (const rootDir of projectDirs) {
-    const relativePartRegExp = new RegExp(`^(\\.\\.\\${path.sep})+`)
+    const relativePartRegExp = new RegExp(`^(\\.\\.\\${path.sep})*\\.\\.(\\${path.sep})?`)
     const relativePartMatch = relativePartRegExp.exec(path.relative(workspaceDir, rootDir))
     if (relativePartMatch != null) {
       const relativePart = relativePartMatch[0]

--- a/pkg-manager/plugin-commands-installation/test/miscRecursive.ts
+++ b/pkg-manager/plugin-commands-installation/test/miscRecursive.ts
@@ -756,3 +756,29 @@ test('installing in monorepo with shared lockfile should work on virtual drives'
 
   projects['project-1'].has('is-positive')
 })
+
+test('install with package in the parent folder', async () => {
+  const projects = preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    },
+  ])
+
+  writeYamlFile('project-1/workspace/pnpm-workspace.yaml', { packages: ['..'] })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    ...await filterPackagesFromDir(process.cwd(), []),
+    dir: path.join(process.cwd(), 'project-1', 'workspace'),
+    lockfileDir: path.join(process.cwd(), 'project-1', 'workspace'),
+    recursive: true,
+    workspaceDir: path.join(process.cwd(), 'project-1', 'workspace'),
+  })
+
+  projects['project-1'].has('is-positive')
+})


### PR DESCRIPTION
fix #10096

During installation, the regex for parsing relative package paths does not work correctly for projects in ancestor directories:
```typescript
const relativePartRegExp = new RegExp(`^(\\.\\.\\${path.sep})+`)
```
For example, given the path `../..`, this regex extracts `../`, whereas the expected result is `'../..'`.