### PR TITLE
fix: skip time field validation for packages excluded by `minimumReleaseAgeExclude`

### DIFF
--- a/.changeset/all-jobs-lose.md
+++ b/.changeset/all-jobs-lose.md
@@ -1,0 +1,5 @@
+---
+'@pnpm/npm-resolver': patch
+---
+
+Skip time field validation for packages excluded by `minimumReleaseAgeExclude` (allows packages that would otherwise throw `ERR_PNPM_MISSING_TIME`).

--- a/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -33,9 +33,9 @@ export function pickPackageFromMeta (
   meta: PackageMeta
 ): PackageInRegistry | null {
   if (publishedBy) {
-    assertMetaHasTime(meta)
     const excludeResult = publishedByExclude?.(meta.name) ?? false
     if (excludeResult !== true) {
+      assertMetaHasTime(meta)
       const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
       meta = filterPkgMetadataByPublishDate(meta, publishedBy, trustedVersions)
     }


### PR DESCRIPTION
I noticed this regression in 10.9 when running `pnpm update -i`. Packages excluded by `minimumReleaseAgeExclude` started to throw `ERR_PNPM_MISSING_TIME` again.