### PR TITLE
fix: update import in `@pnpm/patching.apply-patch` for ESM compatibility

### DIFF
--- a/.changeset/odd-keys-judge.md
+++ b/.changeset/odd-keys-judge.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/patching.apply-patch": patch
+---
+
+Import `@pnpm/patch-package/dist/applyPatches` using `.js` extension for ESM compatibility. This fixes an `ERR_MODULE_NOT_FOUND` error.

--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -113,7 +113,7 @@ declare module 'yaml-tag' {
   export = anything
 }
 
-declare module '@pnpm/patch-package/dist/applyPatches' {
+declare module '@pnpm/patch-package/dist/applyPatches.js' {
   export function applyPatch (opts: any): boolean
 }
 

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -1,5 +1,5 @@
 import { PnpmError } from '@pnpm/error'
-import { applyPatch } from '@pnpm/patch-package/dist/applyPatches'
+import { applyPatch } from '@pnpm/patch-package/dist/applyPatches.js'
 import { globalWarn } from '@pnpm/logger'
 
 export interface ApplyPatchToDirOpts {


### PR DESCRIPTION
The `@pnpm/patching.apply-patch` package is now an ESM package as of https://github.com/pnpm/pnpm/pull/9870, but it contains an import that's missing a file extension.

It seems like Jest doesn't catch this. They're tracking at https://github.com/jestjs/jest/issues/9885.

```
~/Developer/pnpm/patching/apply-patch
❯ node .
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/gluxon/Developer/pnpm/patching/apply-patch/node_modules/@pnpm/patch-package/dist/applyPatches' imported from /Users/gluxon/Developer/pnpm/patching/apply-patch/lib/index.js
Did you mean to import "@pnpm/patch-package/dist/applyPatches.js"?
    at finalizeResolution (node:internal/modules/esm/resolve:274:11)
    at moduleResolve (node:internal/modules/esm/resolve:864:10)
    at defaultResolve (node:internal/modules/esm/resolve:990:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:712:20)
    at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:729:38)
    at ModuleLoader.resolveSync (node:internal/modules/esm/loader:758:52)
    at #resolve (node:internal/modules/esm/loader:694:17)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:614:35)
    at ModuleJob.syncLink (node:internal/modules/esm/module_job:143:33)
    at ModuleJob.link (node:internal/modules/esm/module_job:228:17) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///Users/gluxon/Developer/pnpm/patching/apply-patch/node_modules/@pnpm/patch-package/dist/applyPatches'
}

Node.js v25.2.0
```