### PR TITLE
chore: ignore GHSA-mh29-5h37-fv8m

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,6 +50,7 @@ auditConfig:
   ignoreGhsas:
     - GHSA-76c9-3jph-rj3q
     - GHSA-ffrw-9mx8-89p8
+    - GHSA-mh29-5h37-fv8m
 
 catalog:
   '@babel/core': ^7.28.3


### PR DESCRIPTION
The `pnpm audit` command is failing due to a new security advisory from 2 days ago. The fix relevant for pnpm is tracked in https://github.com/changesets/changesets/issues/1762. We can remove this ignore after once changesets releases a fix.

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ js-yaml has prototype pollution in merge (<<)          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ js-yaml                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <4.1.1                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.1.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@changesets/cli>@changesets/read>@changesets/        │
│                     │ parse>js-yaml                                          │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mh29-5h37-fv8m      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```