### PR TITLE
fix: store prune should not fail if the store contains Node.js

### DIFF
--- a/.changeset/tidy-teeth-accept.md
+++ b/.changeset/tidy-teeth-accept.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/package-store": patch
+"pnpm": patch
+---
+
+`pnpm store prune` should not fail if the store contains Node.js packages [#10131](https://github.com/pnpm/pnpm/issues/10131).

--- a/store/package-store/src/storeController/prune.ts
+++ b/store/package-store/src/storeController/prune.ts
@@ -75,7 +75,8 @@ export async function prune ({ cacheDir, storeDir }: PruneOptions, removeAlienFi
   let pkgCounter = 0
   await Promise.all(pkgIndexFiles.map(async (pkgIndexFilePath) => {
     const { files: pkgFilesIndex } = await readV8FileStrictAsync<PackageFilesIndex>(pkgIndexFilePath)
-    if (removedHashes.has(pkgFilesIndex['package.json'].integrity)) {
+    // TODO: implement prune of Node.js packages, they don't have a package.json file
+    if (pkgFilesIndex['package.json'] && removedHashes.has(pkgFilesIndex['package.json'].integrity)) {
       await fs.unlink(pkgIndexFilePath)
       pkgCounter++
     }


### PR DESCRIPTION
close #10131