### PR TITLE
fix: outdated send warning messages to stderr

### DIFF
--- a/.changeset/slick-bananas-make.md
+++ b/.changeset/slick-bananas-make.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed outdated command to send logs to stderr [#10200](https://github.com/pnpm/pnpm/issues/10200).

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -123,7 +123,7 @@ export async function main (inputArgv: string[]): Promise<void> {
         checkPackageManager(config.wantedPackageManager, config)
       }
     }
-    if (isDlxOrCreateCommand) {
+    if (isDlxOrCreateCommand || cmd === 'outdated') {
       config.useStderr = true
     }
     config.argv = argv


### PR DESCRIPTION
Fixes #10200

Warning messages were corrupting stdout output. 
Now logs are  sent to stderr for the `outdated` command.