### PR TITLE
Fix usage example in `@pnpm/read-package-json` README

### DIFF
--- a/pkg-manifest/read-package-json/README.md
+++ b/pkg-manifest/read-package-json/README.md
@@ -15,7 +15,7 @@ pnpm add @pnpm/read-package-json
 ## Usage
 
 ```ts
-import readPackageJson from '@pnpm/read-package-json'
+import { readPackageJson } from '@pnpm/read-package-json'
 
 const pkgJson = await readPackageJson('package.json')
 ```


### PR DESCRIPTION
This module has no default export.