### PR TITLE
fix: allow env vars and updateConfig hook to override frozen-lockfile in CI

### DIFF
--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -361,8 +361,8 @@ export async function handler (opts: InstallCommandOptions): Promise<void> {
     ...opts,
     frozenLockfileIfExists: opts.frozenLockfileIfExists ?? (
       opts.ci && !opts.lockfileOnly &&
-      typeof opts.rawLocalConfig['frozen-lockfile'] === 'undefined' &&
-      typeof opts.rawLocalConfig['prefer-frozen-lockfile'] === 'undefined'
+      typeof opts.frozenLockfile === 'undefined' &&
+      typeof opts.preferFrozenLockfile === 'undefined'
     ),
     include,
     includeDirect: include,


### PR DESCRIPTION
When `CI=true`, pnpm automatically enables frozen-lockfile mode. Previously, this could only be overridden via `.npmrc` files or CLI flags because the code checked `rawLocalConfig` (which excludes env vars and hook changes).

This PR makes pnpm check the fully resolved config values instead of `rawLocalConfig`.

Fixes #9861