### PR TITLE
fix: trustPolicy should ignore trust evidences of prerelease versions

### DIFF
--- a/.changeset/many-showers-beg.md
+++ b/.changeset/many-showers-beg.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/npm-resolver": patch
+"pnpm": patch
+---
+
+`trustPolicy` should ignore the trust evidences of prerelease versions, when installing a non-prerelease version.

--- a/resolving/npm-resolver/test/trustChecks.test.ts
+++ b/resolving/npm-resolver/test/trustChecks.test.ts
@@ -210,6 +210,52 @@ describe('failIfTrustDowngraded', () => {
     }).toThrow('High-risk trust downgrade')
   })
 
+  test('does not throw an error when only prerelease versions had provenance', () => {
+    const meta: PackageMetaWithTime = {
+      name: 'foo',
+      'dist-tags': { latest: '3.0.0' },
+      versions: {
+        '1.0.0': {
+          name: 'foo',
+          version: '1.0.0',
+          dist: {
+            shasum: 'abc123',
+            tarball: 'https://registry.example.com/foo/-/foo-1.0.0.tgz',
+          },
+        },
+        '2.0.0-0': {
+          name: 'foo',
+          version: '2.0.0-0',
+          dist: {
+            shasum: 'def456',
+            tarball: 'https://registry.example.com/foo/-/foo-2.0.0-0.tgz',
+            attestations: {
+              provenance: {
+                predicateType: 'https://slsa.dev/provenance/v1',
+              },
+            },
+          },
+        },
+        '3.0.0': {
+          name: 'foo',
+          version: '3.0.0',
+          dist: {
+            shasum: 'ghi789',
+            tarball: 'https://registry.example.com/foo/-/foo-3.0.0.tgz',
+          },
+        },
+      },
+      time: {
+        '1.0.0': '2025-01-01T00:00:00.000Z',
+        '2.0.0-0': '2025-02-01T00:00:00.000Z',
+        '3.0.0': '2025-03-01T00:00:00.000Z',
+      },
+    }
+    expect(() => {
+      failIfTrustDowngraded(meta, '3.0.0')
+    }).not.toThrow()
+  })
+
   test('throws an error when downgrading from trustedPublisher to provenance', () => {
     const meta: PackageMetaWithTime = {
       name: 'foo',


### PR DESCRIPTION
Many packages only use provenance for prerelease versions.