### PR TITLE
fix: add CommonJS shims for compatibility with older Corepack versions

### DIFF
--- a/pnpm/bin/pnpm.cjs
+++ b/pnpm/bin/pnpm.cjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 // CommonJS shim for compatibility with older Corepack versions
-import("./pnpm.mjs");
+import('./pnpm.mjs')

--- a/pnpm/bin/pnpx.cjs
+++ b/pnpm/bin/pnpx.cjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 // CommonJS shim for compatibility with older Corepack versions
-import("./pnpx.mjs");
+import('./pnpx.mjs')


### PR DESCRIPTION
Fixes #10242

As described on that ticket, attempting to use pnpm v11 with corepack < 0.34.5 fails because earlier versions of corepack hard-coded the `pnpm.cjs` path, which v11 replaces with `pnpm.mjs`.

This PR fixes the issue by adding `pnpm.cjs` (and `pnpx.cjs`) modules that simply load the ESM modules. This should provided compatibility with older corepack versions.

## Testing

I've tested this change by copying these files into my corepack cache dir and running `pnpm` under corepack 0.33.0. It works smoothly.