### PR TITLE
fix: unsupported env fallbacks in .npmrc when publishing

### DIFF
--- a/.changeset/tall-hornets-tickle.md
+++ b/.changeset/tall-hornets-tickle.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-publishing": patch
+---
+
+pnpm uses npm under the hood when publishing, and npm doesn't support the `:-fallback` syntax, resulting in npm not reading any envs specified with a fallback. For example, if the npmrc contains `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN-fallback}`, all publish commands fails even if the NODE_AUTH_TOKEN env is set. The fallbacks are now stripped before publishing, i.e. the line becomes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7095,6 +7095,9 @@ importers:
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
+      read-ini-file:
+        specifier: 'catalog:'
+        version: 4.0.0
       realpath-missing:
         specifier: 'catalog:'
         version: 1.1.0
@@ -7113,6 +7116,9 @@ importers:
       validate-npm-package-name:
         specifier: 'catalog:'
         version: 6.0.2
+      write-ini-file:
+        specifier: 'catalog:'
+        version: 4.0.1
       write-json-file:
         specifier: 'catalog:'
         version: 6.0.0

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -59,12 +59,14 @@
     "p-filter": "catalog:",
     "p-limit": "catalog:",
     "ramda": "catalog:",
+    "read-ini-file": "catalog:",
     "realpath-missing": "catalog:",
     "render-help": "catalog:",
     "tar-stream": "catalog:",
     "tempy": "catalog:",
     "tinyglobby": "catalog:",
     "validate-npm-package-name": "catalog:",
+    "write-ini-file": "catalog:",
     "write-json-file": "catalog:"
   },
   "peerDependencies": {

--- a/releasing/plugin-commands-publishing/src/publish.ts
+++ b/releasing/plugin-commands-publishing/src/publish.ts
@@ -1,4 +1,4 @@
-import { promises as fs, existsSync } from 'fs'
+import { existsSync } from 'fs'
 import path from 'path'
 import { docsUrl, readProjectManifest } from '@pnpm/cli-utils'
 import { FILTERING } from '@pnpm/common-cli-options-help'
@@ -16,8 +16,32 @@ import { pick } from 'ramda'
 import realpathMissing from 'realpath-missing'
 import renderHelp from 'render-help'
 import { temporaryDirectory } from 'tempy'
+import { readIniFile } from 'read-ini-file'
+import { writeIniFile } from 'write-ini-file'
 import * as pack from './pack.js'
 import { recursivePublish, type PublishRecursiveOpts } from './recursivePublish.js'
+
+// TODO: import from @pnpm/config.env-replace once https://github.com/pnpm/components/pull/25 is merged
+const ENV_EXPR = /(?<!\\)(\\*)\$\{([^${}]+)\}/g
+const ENV_VALUE = /([^:-]+)(:?)-(.+)/
+export function stripEnvFallback (settingValue: string): string {
+  return settingValue.replace(ENV_EXPR, replaceEnvMatchForStrip)
+}
+
+function replaceEnvMatchForStrip (orig: string, escape: string, name: string): string {
+  if (escape.length % 2) {
+    return orig.slice((escape.length + 1) / 2)
+  }
+  const strippedName = getStrippedEnvName(name)
+  return `${escape.slice(escape.length / 2)}\${${strippedName}}`
+}
+
+function getStrippedEnvName (name: string): string {
+  const matched = name.match(ENV_VALUE)
+  if (!matched) return name
+  const [, variableName] = matched
+  return variableName
+}
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
@@ -325,15 +349,36 @@ async function copyNpmrc (
   }
 ): Promise<void> {
   const localNpmrc = path.join(dir, '.npmrc')
+  const destPath = path.join(packDestination, '.npmrc')
   if (existsSync(localNpmrc)) {
-    await fs.copyFile(localNpmrc, path.join(packDestination, '.npmrc'))
+    const npmrc = await readIniFile(localNpmrc)
+    const strippedNpmrc = stripNpmrcFallbacks(npmrc)
+    await writeIniFile(destPath, strippedNpmrc)
     return
   }
   if (!workspaceDir) return
   const workspaceNpmrc = path.join(workspaceDir, '.npmrc')
   if (existsSync(workspaceNpmrc)) {
-    await fs.copyFile(workspaceNpmrc, path.join(packDestination, '.npmrc'))
+    const npmrc = await readIniFile(workspaceNpmrc)
+    const strippedNpmrc = stripNpmrcFallbacks(npmrc)
+    await writeIniFile(destPath, strippedNpmrc)
   }
+}
+
+export function stripNpmrcFallbacks (
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  npmrc: Object
+): Record<string, unknown> {
+  const strippedNpmrc: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(npmrc)) {
+    if (typeof value === 'string') {
+      strippedNpmrc[key] = stripEnvFallback(value)
+    } else {
+      strippedNpmrc[key] = value
+    }
+  }
+
+  return strippedNpmrc
 }
 
 export async function runScriptsIfPresent (

--- a/releasing/plugin-commands-publishing/test/stripNpmrcFallbacks.test.ts
+++ b/releasing/plugin-commands-publishing/test/stripNpmrcFallbacks.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-template-curly-in-string */
+import { stripNpmrcFallbacks } from '../lib/publish.js'
+
+describe('stripNpmrcFallbacks', () => {
+  it('should strip fallback values from environment variables in string values', () => {
+    const npmrc = {
+      registry: 'https://${REGISTRY:-registry.npmjs.org}',
+      '//registry.npmjs.org/:_authToken': '${NPM_TOKEN:-default-token}',
+    }
+
+    const result = stripNpmrcFallbacks(npmrc)
+
+    expect(result).toEqual({
+      registry: 'https://${REGISTRY}',
+      '//registry.npmjs.org/:_authToken': '${NPM_TOKEN}',
+    })
+  })
+
+  it('should preserve non-string values unchanged', () => {
+    const npmrc = {
+      'strict-ssl': false,
+      timeout: 60000,
+      registry: '${REGISTRY:-https://registry.npmjs.org}',
+    }
+
+    const result = stripNpmrcFallbacks(npmrc)
+
+    expect(result).toEqual({
+      'strict-ssl': false,
+      timeout: 60000,
+      registry: '${REGISTRY}',
+    })
+  })
+
+  it('should handle empty object', () => {
+    const npmrc = {}
+
+    const result = stripNpmrcFallbacks(npmrc)
+
+    expect(result).toEqual({})
+  })
+
+  it('should handle real-world npmrc configuration', () => {
+    const npmrc = {
+      registry: '${NPM_REGISTRY:-https://registry.npmjs.org}',
+      '//registry.npmjs.org/:_authToken': '${NPM_TOKEN:-fallback}',
+      'strict-ssl': true,
+      'save-exact': true,
+      '//custom-registry.com/:_authToken': '${CUSTOM_TOKEN:-fallback-value}',
+    }
+
+    const result = stripNpmrcFallbacks(npmrc)
+
+    expect(result).toEqual({
+      registry: '${NPM_REGISTRY}',
+      '//registry.npmjs.org/:_authToken': '${NPM_TOKEN}',
+      'strict-ssl': true,
+      'save-exact': true,
+      '//custom-registry.com/:_authToken': '${CUSTOM_TOKEN}',
+    })
+  })
+})


### PR DESCRIPTION
WIP until https://github.com/pnpm/components/pull/25 is merged.

As mentioned in the changeset, `pnpm publish` doesn't work if any of the .npmrc settings that are required to publish, uses an env fallback, since the syntax isn't supported by npm.

Any use of the `:-fallback` syntax in .npmrc files is now stripped before publishing, using the new `stripEnvFallback` function from `@pnpm/config.env-replace`.

I opted to create `stripEnvFallback` since using the existing `envReplace` would place the actual env value in the .npmrc file, which is not desirable for security reasons, even if pnpm attempts to delete the temp npmrc after publishing.
