### PR TITLE
feat: use npm bulk audit endpoint

### DIFF
--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -122,5 +122,16 @@ declare module 'ramda/src/map' {
   export = map
 }
 
+// cspell:disable-next-line
+declare module '@npmcli/metavuln-calculator' {
+  class Calculator {
+    constructor (options?: Record<string, any>)
+    get cache (): string;
+    get options (): Record<string, any>;
+    calculate (name: string, source: Record<string, any>): Promise<unknown>;
+  }
+  export = Calculator
+}
+
 declare module '@yarnpkg/core/semverUtils'
 declare module '@yarnpkg/core/structUtils'

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -32,6 +32,8 @@
     "compile": "tsc --build && pnpm run lint --fix"
   },
   "dependencies": {
+    "@npmcli/metavuln-calculator": "catalog:",
+    "@pnpm/dependency-path": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/fetch": "workspace:*",
     "@pnpm/fetching-types": "workspace:*",
@@ -39,9 +41,17 @@
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/lockfile.utils": "workspace:*",
     "@pnpm/lockfile.walker": "workspace:*",
+    "@pnpm/manifest-utils": "workspace:*",
+    "@pnpm/npm-package-arg": "catalog:",
+    "@pnpm/npm-resolver": "workspace:*",
+    "@pnpm/read-package-json": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
+    "@pnpm/registry.types": "workspace:*",
+    "@pnpm/resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "ramda": "catalog:"
+    "normalize-path": "catalog:",
+    "ramda": "catalog:",
+    "semver": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"
@@ -52,7 +62,9 @@
     "@pnpm/lockfile.fs": "workspace:*",
     "@pnpm/logger": "workspace:*",
     "@pnpm/test-fixtures": "workspace:*",
+    "@types/normalize-path": "catalog:",
     "@types/ramda": "catalog:",
+    "@types/semver": "catalog:",
     "nock": "catalog:"
   },
   "engines": {

--- a/lockfile/audit/src/bulkAudit.ts
+++ b/lockfile/audit/src/bulkAudit.ts
@@ -1,0 +1,468 @@
+// cspell:ignore metavuln
+// cspell:ignore metavulns
+// cspell:ignore vulns
+import path from 'path'
+import { satisfies } from 'semver'
+import Calculator from '@npmcli/metavuln-calculator'
+import type { BulkAuditTree, BulkAuditNode } from './lockfileToBulkAuditTree.js'
+import type { DepPath, PackageManifest } from '@pnpm/types'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
+import { depPathToFilename } from '@pnpm/dependency-path'
+import { safeReadPackageJsonFromDir } from '@pnpm/read-package-json'
+import { getSpecFromPackageManifest } from '@pnpm/manifest-utils'
+import { pickPackageFromMeta, pickVersionByVersionRange } from '@pnpm/npm-resolver/pickPackageFromMeta'
+import { parseBareSpecifier, type PackageMeta } from '@pnpm/npm-resolver'
+import type { VersionSelectors } from '@pnpm/resolver-base'
+import normalizePath from 'normalize-path'
+
+export type BulkAuditReport = Record<string, BulkAuditAdvisory[]>
+
+export interface BulkAuditAdvisory {
+  id: number
+  url: string
+  title: string
+  severity: string
+  vulnerable_versions: string
+  cwe: string[]
+  cvss: {
+    score: number
+    vectorString: string | null
+  }
+}
+
+const semverOpt = { loose: true, includePrerelease: true }
+
+declare class Advisory {
+  source: number
+  name: string
+  dependency: string
+  title: string
+  url: string
+  severity: string
+  versions: string[]
+  vulnerableVersions: string[]
+  cwe: string[]
+  cvss: {
+    score: number
+    vectorString: string | null
+  }
+
+  range: string | null
+  id: string
+
+  get updated (): boolean
+  get type (): 'advisory' | 'metavuln'
+  get packument (): PackageMeta | null
+
+  testVersion (version: string, spec?: string): boolean
+  testSpec (spec: string): boolean
+}
+
+export type VulnFixAvailable = boolean | { name: string, version: string, isSemVerMajor?: boolean }
+
+export class Vuln {
+  readonly name: string
+  readonly packument: PackageMeta | null
+  readonly versions: string[]
+  readonly via = new Set<Vuln>()
+  readonly advisories = new Set<Advisory>()
+  readonly effects = new Set<Vuln>()
+  readonly nodes = new Set<BulkAuditNode>()
+  readonly topNodes = new Set<BulkAuditNode>()
+  #fixAvailable: VulnFixAvailable = true
+
+  constructor (options: { name: string, advisory: Advisory }) {
+    this.name = options.name
+    this.addAdvisory(options.advisory)
+    this.packument = options.advisory.packument
+    this.versions = options.advisory.versions
+  }
+
+  get fixAvailable (): VulnFixAvailable {
+    return this.#fixAvailable
+  }
+
+  set fixAvailable (f: VulnFixAvailable) {
+    this.#fixAvailable = f
+    // if there's a fix available for this at the top level, it means that
+    // it will also fix the vulns that led to it being there.  to get there,
+    // we set the vias to the most "strict" of fix available.
+    // - false: no fix is available
+    // - {name, version, isSemVerMajor} fix requires -f, is semver major
+    // - {name, version} fix requires -f, not semver major
+    // - true: fix does not require -f
+    // TODO: duped entries may require different fixes but the current
+    // structure does not support this, so the case were a top level fix
+    // corrects a duped entry may mean you have to run fix more than once
+    for (const v of this.via) {
+      // don't blow up on loops
+      if (v.fixAvailable === f) {
+        continue
+      }
+
+      if (f === false) {
+        v.fixAvailable = f
+      } else if (v.fixAvailable === true) {
+        v.fixAvailable = f
+      } else if (typeof f === 'object' && (
+        typeof v.fixAvailable !== 'object' || !v.fixAvailable.isSemVerMajor)) {
+        v.fixAvailable = f
+      }
+    }
+  }
+
+  testSpec (spec: string): boolean {
+    // TODO:
+    // const specObj = npa(spec)
+    // if (!specObj.registry) {
+    //   return true
+    // }
+
+    // if (specObj.subSpec) {
+    //   spec = specObj.subSpec.rawSpec
+    // }
+    for (const v of this.versions) {
+      if (satisfies(v, spec) && !satisfies(v, this.range, semverOpt)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  addVia (v: Vuln): void {
+    this.via.add(v)
+    this.effects.add(v)
+    // TODO: // call the setter since we might add vias _after_ setting fixAvailable
+    // this.fixAvailable = this.fixAvailable
+  }
+
+  deleteVia (v: Vuln): void {
+    this.via.delete(v)
+    v.effects.delete(this)
+  }
+
+  deleteAdvisory (advisory: Advisory): void {
+    this.advisories.delete(advisory)
+    // // make sure we have the max severity of all the vulns causing this one
+    // this.severity = null
+    // this.#range = null
+    // this.#simpleRange = null
+    // // refresh severity
+    // for (const advisory of this.advisories) {
+    //   this.addAdvisory(advisory)
+    // }
+
+    // remove any effects that are no longer relevant
+    const vias = new Set([...this.advisories].map(a => a.dependency))
+    for (const via of this.via) {
+      if (!vias.has(via.name)) {
+        this.deleteVia(via)
+      }
+    }
+
+    // TODO: update versions
+  }
+
+  addAdvisory (advisory: Advisory): void {
+    this.advisories.add(advisory)
+    // const sev = severities.get(advisory.severity)
+    // this.#range = null
+    // this.#simpleRange = null
+    // if (sev > severities.get(this.severity)) {
+    //   this.severity = advisory.severity
+    // }
+
+    // TODO: update versions
+  }
+
+  get range (): string {
+    return [...this.advisories].map(v => v.range).join(' || ')
+  }
+}
+
+export class BulkProcessedAuditReport {
+  public readonly report = new Map<string, Vuln>()
+  public readonly topVulns = new Map<string, Vuln>()
+}
+
+export async function performBulkAudit (
+  report: BulkAuditReport,
+  auditTree: BulkAuditTree,
+  lockfile: LockfileObject,
+  opts: {
+    lockfileDir: string
+    virtualStoreDir: string
+    virtualStoreDirMaxLength: number
+  }
+): Promise<BulkProcessedAuditReport> {
+  const calculator = new Calculator()
+
+  const promises: Array<Promise<unknown>> = []
+  for (const [name, advisories] of Object.entries(report)) {
+    for (const advisory of advisories) {
+      promises.push(calculator.calculate(name, advisory))
+    }
+  }
+
+  // now the advisories are calculated with a set of versions
+  // and the packument.  turn them into our style of vuln objects
+  // which also have the affected nodes, and also create entries
+  // for all the metavulns that we find from dependents.
+  const advisories = new Set((await Promise.all(promises)) as Advisory[])
+  const auditReport = new BulkProcessedAuditReport()
+
+  const specLoader = new PackageSpecLoader(
+    lockfile,
+    {
+      lockfileDir: opts.lockfileDir,
+      virtualStoreDir: opts.virtualStoreDir,
+      virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+    }
+  )
+
+  const seen = new Set<string>()
+  for (const advisory of advisories) {
+    const { name, range } = advisory
+    const k = `${name}@${range}`
+
+    let vuln = auditReport.report.get(name)
+    if (vuln) {
+      vuln.addAdvisory(advisory)
+    } else {
+      vuln = new Vuln({ name, advisory })
+      auditReport.report.set(name, vuln)
+    }
+
+    // don't flag the exact same name/range more than once
+    // adding multiple advisories with the same range is fine, but no
+    // need to search for nodes we already would have added.
+    if (!seen.has(k)) {
+      const p: Array<Promise<void>> = []
+      for (const node of auditTree.allNodesByPackageName.get(name) ?? []) {
+        if (!shouldAudit(node)) {
+          continue
+        }
+
+        // if not vulnerable by this advisory, keep searching
+        if (!advisory.testVersion(node.version)) {
+          continue
+        }
+
+        // we will have loaded the source already if this is a metavuln
+        if (advisory.type === 'metavuln') {
+          vuln.addVia(auditReport.report.get(advisory.dependency)!)
+        }
+
+        // already marked this one, no need to do it again
+        if (vuln.nodes.has(node)) {
+          continue
+        }
+
+        // haven't marked this one yet.  get its dependents.
+        vuln.nodes.add(node)
+        for (const dep of node.dependents) {
+          if (dep.isImporter) {
+            // Nothing to do if this is an importer
+            continue
+          }
+          // eslint-disable-next-line no-await-in-loop
+          const spec = await specLoader.getSpecForDependencyRelationship(dep, node)
+          if (spec === null) {
+            // TODO: spec isn't available or dep is a top level package
+            continue
+          }
+          if (dep.isDirect && !vuln.topNodes.has(dep)) {
+            vuln.fixAvailable = fixAvailable(vuln, spec)
+            if (vuln.fixAvailable !== true) {
+              // now we know the top node is vulnerable, and cannot be
+              // upgraded out of the bad place without --force.  But, there's
+              // no need to add it to the actual vulns list, because nothing
+              // depends on root.
+              auditReport.topVulns.set(vuln.name, vuln)
+              vuln.topNodes.add(dep)
+            }
+          } else {
+          // calculate a metavuln, if necessary
+            const calc = calculator.calculate(dep.name, advisory) as Promise<Advisory>
+
+            p.push(calc.then(meta => {
+              if (meta.testVersion(dep.version, spec)) {
+                advisories.add(meta)
+              }
+            }))
+          }
+        }
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.all(p)
+      seen.add(k)
+    }
+
+    // make sure we actually got something.  if not, remove it
+    // this can happen if you are loading from a lockfile created by
+    // npm v5, since it lists the current version of all deps,
+    // rather than the range that is actually depended upon,
+    // or if using --omit with the older audit endpoint.
+    if (auditReport.report.get(name)!.nodes.size === 0) {
+      auditReport.report.delete(name)
+      continue
+    }
+
+    // if the vuln is valid, but THIS advisory doesn't apply to any of
+    // the nodes it references, then remove it from the advisory list.
+    // happens when using omit with old audit endpoint.
+    for (const advisory of vuln.advisories) {
+      const relevant = [...vuln.nodes]
+        .some(n => advisory.testVersion(n.version))
+      if (!relevant) {
+        vuln.deleteAdvisory(advisory)
+      }
+    }
+  }
+
+  return auditReport
+}
+
+function shouldAudit (node: BulkAuditNode): boolean {
+  if (!node.version || node.isImporter) {
+    return false
+  }
+  return true
+}
+// given the spec, see if there is a fix available at all, and note whether or not it's a semver major fix or not (i.e. will need --force)
+function fixAvailable (vuln: Vuln, spec: string): VulnFixAvailable {
+  // TODO we return true, false, OR an object here. this is probably a bad pattern.
+  if (!vuln.testSpec(spec)) {
+    return true
+  }
+
+  if (!vuln.packument) {
+    return false
+  }
+
+  // TODO: replace registry url
+  const specObj = parseBareSpecifier(spec, vuln.name, 'latest', 'https://registry.npmjs.org/')
+  if (!specObj) {
+    return false
+  }
+
+  // // even if we HAVE a packument, if we're looking for it somewhere other than the registry and we have something vulnerable then we're stuck with it.
+  // const specObj = npa(spec)
+  // if (!specObj.registry) {
+  //   return false
+  // }
+
+  // if (specObj.subSpec) {
+  //   spec = specObj.subSpec.rawSpec
+  // }
+
+  // TODO: From npm-pick-manifest:
+  // // we don't provide fixes for top nodes other than root, but we still check to see if the node is fixable with a different version, and note if that is a semver major bump.
+  // try {
+  //   const {
+  //     _isSemVerMajor: isSemVerMajor,
+  //     version,
+  //     name,
+  //   } = pickManifest(vuln.packument, spec, {
+  //     ...this.options,
+  //     before: null,
+  //     avoid: vuln.range,
+  //     avoidStrict: true,
+  //   })
+  //   return { name, version, isSemVerMajor }
+  // } catch (er) {
+  //   return false
+  // }
+  const versionSelectors: VersionSelectors = {}
+  for (const version of Object.keys(vuln.packument.versions)) {
+    versionSelectors[version] = { selectorType: 'version', weight: 0 }
+  }
+  versionSelectors[vuln.range] = { selectorType: 'range', weight: -1 }
+  const chosenPackage = pickPackageFromMeta(pickVersionByVersionRange, {
+    preferredVersionSelectors: versionSelectors,
+  }, specObj, vuln.packument)
+  if (!chosenPackage) {
+    return false
+  }
+  // TODO: this won't work as-is because pickPackageFromMeta will never return a package outside of the given spec
+  return {
+    name: chosenPackage.name,
+    version: chosenPackage.version,
+    isSemVerMajor: false, // TODO: assume false for now
+  }
+}
+
+class PackageSpecLoader {
+  manifestCache = new Map<string, PackageManifest | null>()
+
+  constructor (
+    private readonly lockfile: LockfileObject,
+    private readonly opts: {
+      lockfileDir: string
+      virtualStoreDir: string
+      virtualStoreDirMaxLength: number
+    }
+  ) { }
+
+  async getPackageManifest (depPath: DepPath): Promise<PackageManifest | null> {
+    if (this.manifestCache.has(depPath)) {
+      return this.manifestCache.get(depPath)!
+    }
+
+    const pkgLocation = lockfileToPackageLocation(depPath, this.lockfile, this.opts)
+    if (!pkgLocation) {
+      return null
+    }
+    const manifest = await safeReadPackageJsonFromDir(pkgLocation)
+    this.manifestCache.set(depPath, manifest)
+    return manifest
+  }
+
+  async getSpecForDependencyRelationship (parent: BulkAuditNode, child: BulkAuditNode): Promise<string | null> {
+    if (!parent.depPath) {
+      return null
+    }
+    const manifest = await this.getPackageManifest(parent.depPath)
+    if (!manifest) {
+      return null
+    }
+    const spec = getSpecFromPackageManifest(manifest, child.name)
+    if (spec === '') {
+      return null
+    }
+    return spec
+  }
+}
+
+function lockfileToPackageLocation (
+  depPath: DepPath,
+  lockfile: LockfileObject,
+  opts: {
+    lockfileDir: string
+    virtualStoreDir: string
+    virtualStoreDirMaxLength: number
+  }
+): string | undefined {
+  const pkgSnapshot = lockfile.packages?.[depPath]
+  if (!pkgSnapshot) {
+    return undefined
+  }
+
+  const { name } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+
+  // Seems like this field should always contain a relative path
+  let packageLocation = normalizePath(path.join(
+    opts.virtualStoreDir,
+    depPathToFilename(depPath, opts.virtualStoreDirMaxLength),
+    'node_modules',
+    name
+  ))
+  if (!packageLocation.startsWith('../') && !path.isAbsolute(packageLocation)) {
+    packageLocation = `./${packageLocation}`
+  }
+  if (!packageLocation.endsWith('/')) {
+    packageLocation += '/'
+  }
+  return packageLocation
+}

--- a/lockfile/audit/src/lockfileToBulkAuditTree.ts
+++ b/lockfile/audit/src/lockfileToBulkAuditTree.ts
@@ -1,0 +1,93 @@
+import path from 'path'
+import { type LockfileObject, type TarballResolution } from '@pnpm/lockfile.types'
+import { nameVerFromPkgSnapshot } from '@pnpm/lockfile.utils'
+import { lockfileWalkerGroupImporterSteps, type LockfileWalkerStep } from '@pnpm/lockfile.walker'
+import { detectDepTypes, type DepTypes, DepType } from '@pnpm/lockfile.detect-dep-types'
+import { type DependenciesField, type ProjectId, type DepPath } from '@pnpm/types'
+import { safeReadProjectManifestOnly } from '@pnpm/read-project-manifest'
+
+export interface BulkAuditNode {
+  isImporter?: true
+  isDirect: boolean
+  name: string
+  depPath?: DepPath
+  version: string
+  integrity?: string
+  dependencies?: { [name: string]: BulkAuditNode }
+  dependents: Set<BulkAuditNode>
+  dev: boolean
+}
+
+export interface BulkAuditTree {
+  importers: Map<string, BulkAuditNode>
+  allNodesByPackageName: Map<string, Set<BulkAuditNode>>
+}
+
+export async function lockfileToBulkAuditTree (
+  lockfile: LockfileObject,
+  opts: {
+    include?: { [dependenciesField in DependenciesField]: boolean }
+    lockfileDir: string
+  }
+): Promise<BulkAuditTree> {
+  const importerWalkers = lockfileWalkerGroupImporterSteps(lockfile, Object.keys(lockfile.importers) as ProjectId[], { include: opts?.include })
+  const importerNodes = new Map<string, BulkAuditNode>()
+  const depTypes = detectDepTypes(lockfile)
+  const allNodesByPackageName = new Map<string, Set<BulkAuditNode>>()
+  await Promise.all(
+    importerWalkers.map(async (importerWalker) => {
+      const importerDeps = lockfileToBulkAuditNode(depTypes, importerWalker.step, true, allNodesByPackageName)
+      const manifest = await safeReadProjectManifestOnly(path.join(opts.lockfileDir, importerWalker.importerId))
+      const importerNode: BulkAuditNode = {
+        name: importerWalker.importerId,
+        isImporter: true,
+        isDirect: true,
+        dependencies: importerDeps,
+        dev: false,
+        version: manifest?.version ?? '0.0.0',
+        dependents: new Set(),
+      }
+      for (const dep of Object.values(importerDeps)) {
+        dep.dependents.add(importerNode)
+      }
+      importerNodes.set(importerWalker.importerId, importerNode)
+    })
+  )
+  const auditTree: BulkAuditTree = {
+    importers: importerNodes,
+    allNodesByPackageName,
+  }
+  return auditTree
+}
+
+function lockfileToBulkAuditNode (depTypes: DepTypes, step: LockfileWalkerStep, isDirect: boolean, allNodesByPackageName: Map<string, Set<BulkAuditNode>>): Record<string, BulkAuditNode> {
+  const dependencies: Record<string, BulkAuditNode> = {}
+  for (const { depPath, pkgSnapshot, next } of step.dependencies) {
+    const { name, version } = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
+    const subdeps = lockfileToBulkAuditNode(depTypes, next(), false, allNodesByPackageName)
+    const dep: BulkAuditNode = {
+      isDirect,
+      name,
+      depPath,
+      dev: depTypes[depPath] === DepType.DevOnly,
+      integrity: (pkgSnapshot.resolution as TarballResolution).integrity,
+      version,
+      dependents: new Set(),
+    }
+    if (Object.keys(subdeps).length > 0) {
+      dep.dependencies = subdeps
+      for (const subdep of Object.values(subdeps)) {
+        subdep.dependents.add(dep)
+      }
+    }
+    dependencies[name] = dep
+    let nodesByName = allNodesByPackageName.get(name)
+    if (nodesByName) {
+      nodesByName.add(dep)
+    } else {
+      nodesByName = new Set([dep])
+      allNodesByPackageName.set(name, nodesByName)
+    }
+  }
+  return dependencies
+}

--- a/lockfile/audit/test/__fixtures__/bulkAudit-1/package.json
+++ b/lockfile/audit/test/__fixtures__/bulkAudit-1/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-pnpm-proj",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.19.0",
+  "dependencies": {
+    "is-bigint": "1.0.3"
+  }
+}

--- a/lockfile/audit/test/__fixtures__/bulkAudit-1/pnpm-lock.yaml
+++ b/lockfile/audit/test/__fixtures__/bulkAudit-1/pnpm-lock.yaml
@@ -1,0 +1,22 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-bigint:
+        specifier: 1.0.3
+        version: 1.0.3
+
+packages:
+
+  is-bigint@1.0.3:
+    resolution: {integrity: sha512-ZU538ajmYJmzysE5yU4Y7uIrPQ2j704u+hXFiIPQExpqzzUbpe5jCPdTfmz7jXRxZdvjY3KZ3ZNenoXQovX+Dg==}
+
+snapshots:
+
+  is-bigint@1.0.3: {}

--- a/lockfile/audit/test/__fixtures__/bulkAudit-2/package.json
+++ b/lockfile/audit/test/__fixtures__/bulkAudit-2/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-pnpm-proj",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.19.0",
+  "dependencies": {
+    "dockerode": "4.0.7"
+  }
+}

--- a/lockfile/audit/test/__fixtures__/bulkAudit-2/pnpm-lock.yaml
+++ b/lockfile/audit/test/__fixtures__/bulkAudit-2/pnpm-lock.yaml
@@ -1,0 +1,514 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dockerode:
+        specifier: 4.0.7
+        version: 4.0.7
+
+packages:
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@types/node@25.0.2':
+    resolution: {integrity: sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  docker-modem@5.0.6:
+    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.7:
+    resolution: {integrity: sha512-R+rgrSRTRdU5mH14PZTCPZtW/zw3HDWNTS/1ZAQpL/5Upe/ye5K9WQkIysu4wBoiMwKynsz0a8qWuGsHgEvSAA==}
+    engines: {node: '>= 8.0'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.24.0:
+    resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  tar-fs@2.1.2:
+    resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@balena/dockerignore@1.0.2': {}
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
+
+  '@types/node@25.0.2':
+    dependencies:
+      undici-types: 7.16.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  base64-js@1.5.1: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
+
+  chownr@1.1.4: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.24.0
+    optional: true
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  docker-modem@5.0.6:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.7:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.6
+      protobufjs: 7.5.4
+      tar-fs: 2.1.2
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  escalade@3.2.0: {}
+
+  fs-constants@1.0.0: {}
+
+  get-caller-file@2.0.5: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  lodash.camelcase@4.3.0: {}
+
+  long@5.3.2: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  ms@2.1.3: {}
+
+  nan@2.24.0:
+    optional: true
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.0.2
+      long: 5.3.2
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  require-directory@2.1.1: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  split-ca@1.0.1: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.24.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  tar-fs@2.1.2:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tweetnacl@0.14.5: {}
+
+  undici-types@7.16.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/lockfile/audit/test/index.ts
+++ b/lockfile/audit/test/index.ts
@@ -1,10 +1,14 @@
-import { audit } from '@pnpm/audit'
+import path from 'path'
+import { audit, bulkAudit } from '@pnpm/audit'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import { type PnpmError } from '@pnpm/error'
 import { fixtures } from '@pnpm/test-fixtures'
 import { type DepPath, type ProjectId } from '@pnpm/types'
 import nock from 'nock'
 import { lockfileToAuditTree } from '../lib/lockfileToAuditTree.js'
+import { lockfileToBulkAuditTree, type BulkAuditNode, type BulkAuditTree } from '../lib/lockfileToBulkAuditTree.js'
+import { lockfileToPackageMap } from '../lib/lockfileToPackageMap.js'
+import { readWantedLockfile } from '@pnpm/lockfile.fs'
 
 const f = fixtures(import.meta.dirname)
 
@@ -143,6 +147,121 @@ describe('audit', () => {
     })
   })
 
+  test('lockfileToBulkAuditTree()', async () => {
+    const actual = await lockfileToBulkAuditTree({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: {
+            foo: '1.0.0',
+          },
+          specifiers: {
+            foo: '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['bar@1.0.0' as DepPath]: {
+          resolution: {
+            integrity: 'bar-integrity',
+          },
+        },
+        ['foo@1.0.0' as DepPath]: {
+          dependencies: {
+            bar: '1.0.0',
+          },
+          resolution: {
+            integrity: 'foo-integrity',
+          },
+        },
+      },
+    }, { lockfileDir: f.find('one-project') })
+
+    const barNode: BulkAuditNode = {
+      isDirect: false,
+      name: 'bar',
+      depPath: 'bar@1.0.0' as DepPath,
+      version: '1.0.0',
+      integrity: 'bar-integrity',
+      dev: false,
+      dependents: new Set(),
+    }
+    const fooNode: BulkAuditNode = {
+      isDirect: true,
+      name: 'foo',
+      depPath: 'foo@1.0.0' as DepPath,
+      version: '1.0.0',
+      integrity: 'foo-integrity',
+      dev: false,
+      dependencies: {
+        bar: barNode,
+      },
+      dependents: new Set(),
+    }
+    barNode.dependents.add(fooNode)
+    const topLevelNode: BulkAuditNode = {
+      name: '.',
+      isImporter: true,
+      isDirect: true,
+      version: '1.0.0',
+      dev: false,
+      dependencies: {
+        foo: fooNode,
+      },
+      dependents: new Set(),
+    }
+    fooNode.dependents.add(topLevelNode)
+    const expected: BulkAuditTree = {
+      importers: new Map<string, BulkAuditNode>([
+        ['.', topLevelNode],
+      ]),
+      allNodesByPackageName: new Map<string, Set<BulkAuditNode>>([
+        ['foo', new Set([fooNode])],
+        ['bar', new Set([barNode])],
+      ]),
+    }
+
+    // TODO: can't compare nodes directly because of circular references with dependents
+    expect(new Set(actual.importers.keys())).toEqual(new Set(expected.importers.keys()))
+    expect(new Set(actual.allNodesByPackageName.keys())).toEqual(new Set(expected.allNodesByPackageName.keys()))
+  })
+
+  test('lockfileToPackageMap()', () => {
+    expect(lockfileToPackageMap({
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: {
+            foo: '1.0.0',
+          },
+          specifiers: {
+            foo: '^1.0.0',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['bar@1.0.0' as DepPath]: {
+          resolution: {
+            integrity: 'bar-integrity',
+          },
+        },
+        ['foo@1.0.0' as DepPath]: {
+          dependencies: {
+            bar: '1.0.0',
+          },
+          resolution: {
+            integrity: 'foo-integrity',
+          },
+        },
+      },
+    }, {})).toEqual(
+      new Map<string, Set<string>>([
+        ['foo', new Set(['1.0.0'])],
+        ['bar', new Set(['1.0.0'])],
+      ])
+    )
+  })
+
   test('an error is thrown if the audit endpoint responds with a non-OK code', async () => {
     const registry = 'http://registry.registry/'
     const getAuthHeader = () => undefined
@@ -174,5 +293,113 @@ describe('audit', () => {
     expect(err).toBeDefined()
     expect(err.code).toBe('ERR_PNPM_AUDIT_BAD_RESPONSE')
     expect(err.message).toBe('The audit endpoint (at http://registry.registry/-/npm/v1/security/audits) responded with 500: {"message":"Something bad happened"}')
+  })
+
+  test('bulkAudit error', async () => {
+    const registry = 'http://registry.registry/'
+    const getAuthHeader = () => undefined
+    nock(registry, {
+      badheaders: ['authorization'],
+    })
+      .post('/-/npm/v1/security/advisories/bulk')
+      .reply(500, { message: 'Something bad happened' })
+
+    let err!: PnpmError
+    try {
+      await bulkAudit({
+        importers: {},
+        lockfileVersion: LOCKFILE_VERSION,
+      },
+      getAuthHeader,
+      {
+        lockfileDir: f.find('one-project'),
+        registry,
+        retry: {
+          retries: 0,
+        },
+        virtualStoreDir: 'node_modules/.pnpm',
+        virtualStoreDirMaxLength: 120,
+      })
+    } catch (_err: any) { // eslint-disable-line
+      err = _err
+    }
+
+    expect(err).toBeDefined()
+    expect(err.code).toBe('ERR_PNPM_AUDIT_BAD_RESPONSE')
+    expect(err.message).toBe('The audit endpoint (at http://registry.registry/-/npm/v1/security/advisories/bulk) responded with 500: {"message":"Something bad happened"}')
+  })
+
+  test('bulkAudit-1', async () => {
+    const registry = 'http://registry.registry/'
+    const getAuthHeader = () => undefined
+    nock(registry, {
+      badheaders: ['authorization'],
+    })
+      .post('/-/npm/v1/security/advisories/bulk')
+      .reply(200, {
+        'is-bigint': [
+          { id: 123, url: 'https://example.com/vuln', title: 'vuln title', severity: 'critical', vulnerable_versions: '>=1.0.2 <1.0.4', cwe: ['CWE-330'], cvss: { score: 0, vectorString: null } },
+        ],
+      })
+
+    const fixturePath = f.find('bulkAudit-1')
+
+    const lockfile = await readWantedLockfile(fixturePath, {
+      ignoreIncompatible: false,
+    })
+    expect(lockfile).not.toBeNull()
+
+    const report = await bulkAudit(lockfile!,
+      getAuthHeader,
+      {
+        lockfileDir: fixturePath,
+        registry,
+        retry: {
+          retries: 0,
+        },
+        virtualStoreDir: path.join(fixturePath, 'node_modules/.pnpm'),
+        virtualStoreDirMaxLength: 120,
+      })
+
+    expect(report.report.size).toBe(1)
+    expect(report.report.has('is-bigint')).toBe(true)
+    expect(report.report.get('is-bigint')!.fixAvailable).toBe(true)
+  })
+
+  test('bulkAudit-2', async () => {
+    const registry = 'http://registry.registry/'
+    const getAuthHeader = () => undefined
+    nock(registry, {
+      badheaders: ['authorization'],
+    })
+      .post('/-/npm/v1/security/advisories/bulk')
+      .reply(200, {
+        'tar-fs': [
+          { id: 123, url: 'https://example.com/vuln', title: 'vuln title', severity: 'critical', vulnerable_versions: '>=2.1.0 <2.1.4', cwe: ['CWE-330'], cvss: { score: 0, vectorString: null } },
+        ],
+      })
+
+    const fixturePath = f.find('bulkAudit-2')
+
+    const lockfile = await readWantedLockfile(fixturePath, {
+      ignoreIncompatible: false,
+    })
+    expect(lockfile).not.toBeNull()
+
+    const report = await bulkAudit(lockfile!,
+      getAuthHeader,
+      {
+        lockfileDir: fixturePath,
+        registry,
+        retry: {
+          retries: 0,
+        },
+        virtualStoreDir: path.join(fixturePath, 'node_modules/.pnpm'),
+        virtualStoreDirMaxLength: 120,
+      })
+
+    expect(report.report.size).toBe(1)
+    expect(report.report.has('tar-fs')).toBe(true)
+    expect(report.report.get('tar-fs')!.fixAvailable).toBe(true)
   })
 })

--- a/lockfile/audit/tsconfig.json
+++ b/lockfile/audit/tsconfig.json
@@ -22,6 +22,9 @@
       "path": "../../packages/constants"
     },
     {
+      "path": "../../packages/dependency-path"
+    },
+    {
       "path": "../../packages/error"
     },
     {
@@ -31,7 +34,22 @@
       "path": "../../packages/types"
     },
     {
+      "path": "../../pkg-manifest/manifest-utils"
+    },
+    {
+      "path": "../../pkg-manifest/read-package-json"
+    },
+    {
       "path": "../../pkg-manifest/read-project-manifest"
+    },
+    {
+      "path": "../../registry/types"
+    },
+    {
+      "path": "../../resolving/npm-resolver"
+    },
+    {
+      "path": "../../resolving/resolver-base"
     },
     {
       "path": "../detect-dep-types"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     '@jest/globals':
       specifier: 30.0.5
       version: 30.0.5
+    '@npmcli/metavuln-calculator':
+      specifier: 9.0.3
+      version: 9.0.3
     '@pnpm/byline':
       specifier: ^1.0.0
       version: 1.0.0
@@ -47,7 +50,7 @@ catalogs:
       version: 3.0.2
     '@pnpm/config.nerf-dart':
       specifier: ^1.0.0
-      version: 1.0.0
+      version: 1.0.1
     '@pnpm/exec':
       specifier: ^2.0.0
       version: 2.0.0
@@ -76,7 +79,7 @@ catalogs:
       specifier: ^1001.0.0
       version: 1001.0.0
     '@pnpm/npm-package-arg':
-      specifier: ^2.0.0
+      specifier: 2.0.0
       version: 2.0.0
     '@pnpm/os.env.path-extender':
       specifier: ^2.0.3
@@ -101,10 +104,10 @@ catalogs:
       version: 3.0.2
     '@pnpm/workspace.find-packages':
       specifier: ^1000.0.15
-      version: 1000.0.15
+      version: 1000.0.25
     '@pnpm/workspace.read-manifest':
       specifier: ^1000.1.1
-      version: 1000.1.1
+      version: 1000.1.5
     '@reflink/reflink':
       specifier: 0.1.19
       version: 0.1.19
@@ -163,7 +166,7 @@ catalogs:
       specifier: ^2.4.4
       version: 2.4.4
     '@types/normalize-path':
-      specifier: ^3.0.2
+      specifier: 3.0.2
       version: 3.0.2
     '@types/object-hash':
       specifier: 3.0.6
@@ -251,7 +254,7 @@ catalogs:
       version: 3.0.3
     '@yarnpkg/pnp':
       specifier: ^4.0.8
-      version: 4.0.8
+      version: 4.1.1
     '@zkochan/cmd-shim':
       specifier: ^7.0.0
       version: 7.0.0
@@ -284,7 +287,7 @@ catalogs:
       version: 5.0.0
     bole:
       specifier: ^5.0.17
-      version: 5.0.17
+      version: 5.0.19
     boxen:
       specifier: npm:@zkochan/boxen@5.1.2
       version: 5.1.2
@@ -344,7 +347,7 @@ catalogs:
       version: 7.0.1
     detect-libc:
       specifier: ^2.0.3
-      version: 2.0.3
+      version: 2.0.4
     didyoumean2:
       specifier: ^7.0.4
       version: 7.0.4
@@ -410,7 +413,7 @@ catalogs:
       version: 7.0.0
     fs-extra:
       specifier: ^11.3.1
-      version: 11.3.1
+      version: 11.3.2
     fuse-native:
       specifier: ^2.2.6
       version: 2.2.6
@@ -497,7 +500,7 @@ catalogs:
       version: 2.2.0
     lru-cache:
       specifier: ^11.1.0
-      version: 11.1.0
+      version: 11.2.4
     make-empty-dir:
       specifier: ^3.0.2
       version: 3.0.2
@@ -523,7 +526,7 @@ catalogs:
       specifier: ^8.0.0
       version: 8.0.0
     normalize-path:
-      specifier: ^3.0.0
+      specifier: 3.0.0
       version: 3.0.0
     normalize-registry-url:
       specifier: 2.0.0
@@ -545,7 +548,7 @@ catalogs:
       version: 4.1.0
     p-limit:
       specifier: ^7.1.0
-      version: 7.1.0
+      version: 7.2.0
     p-map-values:
       specifier: ^1.0.0
       version: 1.0.0
@@ -623,7 +626,7 @@ catalogs:
       version: 9.0.1
     rename-overwrite:
       specifier: ^6.0.2
-      version: 6.0.2
+      version: 6.0.3
     render-help:
       specifier: ^1.0.3
       version: 1.0.3
@@ -655,7 +658,7 @@ catalogs:
       specifier: ^1.6.3
       version: 1.6.3
     semver:
-      specifier: ^7.7.2
+      specifier: 7.7.2
       version: 7.7.2
     semver-range-intersect:
       specifier: ^0.3.1
@@ -803,7 +806,7 @@ overrides:
   path-to-regexp@>=4.0.0 <6.3.0: '>=6.3.0'
   path-to-regexp@>=7.0.0 <8.0.0: '>=8.0.0'
   request: npm:postman-request@2.88.1-postman.40
-  semver@<7.5.2: ^7.7.2
+  semver@<7.5.2: 7.7.2
   send@<0.19.0: ^0.19.0
   serve-static@<1.16.0: ^1.16.0
   socks@2: ^2.8.1
@@ -1179,10 +1182,10 @@ importers:
     dependencies:
       '@pnpm/workspace.find-packages':
         specifier: 'catalog:'
-        version: 1000.0.15(@pnpm/logger@1001.0.0)
+        version: 1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
       '@pnpm/workspace.read-manifest':
         specifier: 'catalog:'
-        version: 1000.1.1
+        version: 1000.1.5
       execa:
         specifier: 'catalog:'
         version: safe-execa@0.2.0
@@ -1213,7 +1216,7 @@ importers:
         version: link:../prepare-temp-dir
       fs-extra:
         specifier: 'catalog:'
-        version: 11.3.1
+        version: 11.3.2
     devDependencies:
       '@pnpm/test-fixtures':
         specifier: workspace:*
@@ -1893,7 +1896,7 @@ importers:
         version: link:../../packages/types
       detect-libc:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       execa:
         specifier: 'catalog:'
         version: safe-execa@0.2.0
@@ -2301,7 +2304,7 @@ importers:
         version: link:../../fetching/tarball-fetcher
       detect-libc:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -2808,7 +2811,7 @@ importers:
         version: 10.0.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -2959,7 +2962,7 @@ importers:
         version: safe-execa@0.2.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -3113,7 +3116,7 @@ importers:
         version: 0.5.16
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       ssri:
         specifier: 'catalog:'
         version: 12.0.0
@@ -3319,7 +3322,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -3412,7 +3415,7 @@ importers:
         version: 2.1.0
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
     devDependencies:
       '@pnpm/fs.hard-link-dir':
         specifier: workspace:*
@@ -3443,19 +3446,19 @@ importers:
         version: 3.0.2
       fs-extra:
         specifier: 'catalog:'
-        version: 11.3.1
+        version: 11.3.2
       make-empty-dir:
         specifier: 'catalog:'
         version: 3.0.2
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       path-temp:
         specifier: 'catalog:'
         version: 2.1.0
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       sanitize-filename:
         specifier: 'catalog:'
         version: 1.6.3
@@ -3655,6 +3658,12 @@ importers:
 
   lockfile/audit:
     dependencies:
+      '@npmcli/metavuln-calculator':
+        specifier: 'catalog:'
+        version: 9.0.3
+      '@pnpm/dependency-path':
+        specifier: workspace:*
+        version: link:../../packages/dependency-path
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -3676,15 +3685,39 @@ importers:
       '@pnpm/lockfile.walker':
         specifier: workspace:*
         version: link:../walker
+      '@pnpm/manifest-utils':
+        specifier: workspace:*
+        version: link:../../pkg-manifest/manifest-utils
+      '@pnpm/npm-package-arg':
+        specifier: 'catalog:'
+        version: 2.0.0
+      '@pnpm/npm-resolver':
+        specifier: workspace:*
+        version: link:../../resolving/npm-resolver
+      '@pnpm/read-package-json':
+        specifier: workspace:*
+        version: link:../../pkg-manifest/read-package-json
       '@pnpm/read-project-manifest':
         specifier: workspace:*
         version: link:../../pkg-manifest/read-project-manifest
+      '@pnpm/registry.types':
+        specifier: workspace:*
+        version: link:../../registry/types
+      '@pnpm/resolver-base':
+        specifier: workspace:*
+        version: link:../../resolving/resolver-base
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      normalize-path:
+        specifier: 'catalog:'
+        version: 3.0.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.2
     devDependencies:
       '@pnpm/audit':
         specifier: workspace:*
@@ -3701,9 +3734,15 @@ importers:
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
+      '@types/normalize-path':
+        specifier: 'catalog:'
+        version: 3.0.2
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.29.12
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.5.3
       nock:
         specifier: 'catalog:'
         version: 13.3.4
@@ -3771,7 +3810,7 @@ importers:
         version: 0.29.12
       detect-libc:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       tempy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -3886,7 +3925,7 @@ importers:
         version: link:../../packages/types
       '@yarnpkg/pnp':
         specifier: 'catalog:'
-        version: 4.0.8
+        version: 4.1.1
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
@@ -4303,7 +4342,7 @@ importers:
     dependencies:
       '@pnpm/config.nerf-dart':
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 1.0.1
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../packages/error
@@ -4475,7 +4514,7 @@ importers:
     dependencies:
       bole:
         specifier: 'catalog:'
-        version: 5.0.17
+        version: 5.0.19
       split2:
         specifier: 'catalog:'
         version: 4.2.0
@@ -4518,7 +4557,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
     devDependencies:
       '@pnpm/make-dedicated-lockfile':
         specifier: workspace:*
@@ -5122,7 +5161,7 @@ importers:
         version: 4.1.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       path-exists:
         specifier: 'catalog:'
         version: 5.0.0
@@ -5407,7 +5446,7 @@ importers:
         version: 3.0.2
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       path-absolute:
         specifier: 'catalog:'
         version: 1.0.1
@@ -5767,13 +5806,13 @@ importers:
         version: link:../../worker
       detect-libc:
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       p-defer:
         specifier: 'catalog:'
         version: 4.0.1
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       p-queue:
         specifier: 'catalog:'
         version: 8.1.0
@@ -6005,7 +6044,7 @@ importers:
         version: 4.1.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -6309,7 +6348,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       safe-promise-defer:
         specifier: 'catalog:'
         version: 1.0.1
@@ -7108,7 +7147,7 @@ importers:
         version: 4.1.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -7502,13 +7541,13 @@ importers:
         version: 3.0.1
       lru-cache:
         specifier: 'catalog:'
-        version: 11.1.0
+        version: 11.2.4
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       p-memoize:
         specifier: 'catalog:'
         version: 8.0.0
@@ -7523,7 +7562,7 @@ importers:
         version: '@pnpm/ramda@0.28.1'
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       semver:
         specifier: 'catalog:'
         version: 7.7.2
@@ -7707,7 +7746,7 @@ importers:
         version: link:../../packages/types
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       path-absolute:
         specifier: 'catalog:'
         version: 1.0.1
@@ -7762,7 +7801,7 @@ importers:
         version: 4.0.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -8113,10 +8152,10 @@ importers:
         version: 2.0.0
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       rename-overwrite:
         specifier: 'catalog:'
-        version: 6.0.2
+        version: 6.0.3
       ssri:
         specifier: 'catalog:'
         version: 12.0.0
@@ -8518,7 +8557,7 @@ importers:
         version: link:../../packages/types
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
       promise-share:
         specifier: 'catalog:'
         version: 1.0.0
@@ -8828,7 +8867,7 @@ importers:
         version: 1.0.2
       p-limit:
         specifier: 'catalog:'
-        version: 7.1.0
+        version: 7.2.0
     devDependencies:
       '@pnpm/logger':
         specifier: workspace:*
@@ -10135,9 +10174,50 @@ packages:
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/git@7.0.1':
+    resolution: {integrity: sha512-+XTFxK2jJF/EJJ5SoAzXk3qwIDfvFc5/g+bD274LZ7uY7LE8sTfG6Z8rOanPl2ZEvZWqNvmEdtXC25cE54VcoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/installed-package-contents@4.0.0':
+    resolution: {integrity: sha512-yNyAdkBxB72gtZ4GrwXCM0ZUedo9nIbOMKfGjt6Cu6DXf0p8y1PViZAKDC8q8kv/fufx0WTjRBdSlyrvnP7hmA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  '@npmcli/metavuln-calculator@9.0.3':
+    resolution: {integrity: sha512-94GLSYhLXF2t2LAC7pDwLaM4uCARzxShyAQKsirmlNcpidH89VA4/+K1LbJmRMgz5gy65E/QBBWQdUvGLe2Frg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/node-gyp@5.0.0':
+    resolution: {integrity: sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/package-json@7.0.4':
+    resolution: {integrity: sha512-0wInJG3j/K40OJt/33ax47WfWMzZTm6OQxB9cDhTt5huCP2a9g2GnlsxmfN+PulItNPIpPrZ+kfwwUil7eHcZQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/promise-spawn@9.0.1':
+    resolution: {integrity: sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/run-script@10.0.3':
+    resolution: {integrity: sha512-ER2N6itRkzWbbtVmZ9WKaWxVlKlOeBFF1/7xx+KA5J1xKa4JjUwBdb6tDpk0v1qA+d+VDwHI9qmLcXSWcmi+Rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
@@ -10155,31 +10235,13 @@ packages:
     resolution: {integrity: sha512-2GCYZwxmgw6w0bpB71VbbXapgIcSSFOF9vnS+YLyTdy8JaIYoag2XkhXP1cMu24THPRXeo/zKTyziEsqgr1u8w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/catalogs.protocol-parser@1000.0.0':
-    resolution: {integrity: sha512-8eC25RAiu8BTaEseQmbo5xemlSwl06pMsUVORiYGX7JZEDb0UQVXOnbqFFJMPe/dyO8uwGXnDb350nauMzaraA==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/catalogs.resolver@1000.0.2':
-    resolution: {integrity: sha512-5xp3InFRgl6YzovSYoKs0NTalcVKRj4KkD/d0zIBsKp2cae0G/t2ZZVq3J5rS1Ytf4qkv4oe5SZWpd1oV7Hkew==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/catalogs.types@1000.0.0':
     resolution: {integrity: sha512-xRf72lk7xHNvbenA4sp4Of/90QDdRW0CRYT+V+EbqpUXu1xsXtedHai34cTU6VGe7C1hUukxxE9eYTtIpYrx5g==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/cli-meta@1000.0.4':
-    resolution: {integrity: sha512-zjWK2LNlXGzWIBdpuuVJ51V0xu5uTydbmUM2YwmfMrQyC+rll5izu6PEMsi+B9EguOycynSMZ4PF6Bq4AubuDw==}
     engines: {node: '>=18.12'}
 
   '@pnpm/cli-meta@1000.0.8':
     resolution: {integrity: sha512-THA7cPwxqPAu07pgvvTLhM1AXdYE9+ZCWjT68abQZGL1cpOll9wHChDaB5TLlTkRkbvFzLC9ABr3x/F7873/rg==}
     engines: {node: '>=18.12'}
-
-  '@pnpm/cli-utils@1000.0.15':
-    resolution: {integrity: sha512-0U/ioez/PXcE3RpYU6e6MrrKzA2lYA3T51fSGoi3Y7K+8suxYOGworaJz2BagfEynSB3ftlNJeOvVqlzcf8YWg==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
 
   '@pnpm/cli-utils@1000.1.5':
     resolution: {integrity: sha512-vQiPYyw8RnG/rmbHMC/ajFcHshMTj4Hf6JNmGHizkMdD1EWEWi7G7FoXRGStfHm6hD8HUTtCPZ4o4ceES92q6w==}
@@ -10209,24 +10271,12 @@ packages:
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
 
-  '@pnpm/config.env-replace@3.0.1':
-    resolution: {integrity: sha512-/raU9tmnv1wEw1LdTTCvopwjUMXlLvGP5214sKSpIFC6w41hPS4f1oODDy0nNVteXwa8ewu85xpHQeMFgXdmxQ==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/config.env-replace@3.0.2':
     resolution: {integrity: sha512-GD6nKLyKF+ev15Tj3pS8y6cTVPIuAqTyhPrUFMfmodFvhEDdYKN/gdGimkc9GJLfHVC/SuCVFg49YNJyoW7niA==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/config.nerf-dart@1.0.0':
-    resolution: {integrity: sha512-/jnjwmeLVEXzfk+za2qJams03KtFe4C5s2fT623SZ6UxhYqzHd+Zin/NzrCFY1/IHMHMP1ScFDDgAd36GrKxEA==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/config.nerf-dart@1.0.1':
     resolution: {integrity: sha512-03d2l21gAyzGVr9SR6rS5pvCTnZ4HaNdi8jB2Y/UGvszzrNbA+AJVObVw6SulNQ1Eah3SHB9wCezJwtP+jYIcA==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/config@1002.5.2':
-    resolution: {integrity: sha512-VLo2C/bDoXTla8b/EIrbQoUoETvgGXWnpF/Zl72Qc/m7rZ4UI8J5UC6TraGEjG24dSPqdrjrHv7TvkJfmEVlYQ==}
     engines: {node: '>=18.12'}
 
   '@pnpm/config@1003.1.1':
@@ -10239,15 +10289,9 @@ packages:
     resolution: {integrity: sha512-xb9dfSGi1qfUKY3r4Zy9JdC9+ZeaDxwfE7HrrGIEsBVY1hvIn6ntbR7A97z3nk44yX7vwbINNf9sizTp0WEtEw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/constants@1001.3.0':
-    resolution: {integrity: sha512-ZFRekNHbDlu//67Byg+mG8zmtmCsfBhNsg1wKBLRtF7VjH+Q5TDGMX0+8aJYSikQDuzM2FOhvQcDwyjILKshJQ==}
+  '@pnpm/constants@1001.3.1':
+    resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
     engines: {node: '>=18.12'}
-
-  '@pnpm/core-loggers@1000.1.4':
-    resolution: {integrity: sha512-cmmEk1YuqCfF1RWqHyEDczp2RSd/Sn4np/9iaSd5TISlY0lFCc8A2CKQvkOf2E7N2kpXf/dS7W0Vb3PzW/5w2Q==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
 
   '@pnpm/core-loggers@1001.0.1':
     resolution: {integrity: sha512-U/hqSHo6AJJqBkTvtGbSMcmutINNTfARXqtw9c9PrIwqYbUZPJZAX+c2NNTLzKtv6ywxb8hcC1MKc+PpACPSng==}
@@ -10255,8 +10299,20 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
+  '@pnpm/core-loggers@1001.0.4':
+    resolution: {integrity: sha512-WzdXlK0GEKAmm+d7/QJKrgnfLxcmTrM62lVUIl5994IYbBwl65h0KAX9h0wXi2L7BK6uVDUxrwFWSPcmdT5Buw==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
   '@pnpm/create-cafs-store@1000.0.14':
     resolution: {integrity: sha512-95OczT9/zsJea3Nm6x9ovUD04GoLKYHnSCKUhe5VFx7ckUxW8DUrFJynl94Tx+kdf7u7zXBIlwhhHJEplDaNTg==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/create-cafs-store@1000.0.20':
+    resolution: {integrity: sha512-HLONtwQnBQIUaIxf3htTFItcMnyqZwHSa7gZjmHeJ+UBWKTFznAaXa6IPjm4vLm0vhiIj9htzNQzzDtSYeyBJA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
@@ -10276,12 +10332,6 @@ packages:
   '@pnpm/dedupe.types@1000.0.0':
     resolution: {integrity: sha512-+d8Q576BxRZgt03O+JZXK3C1xVJeAr4Hs35Y8SCl01KpQ0Z7xzfJWahpee7iFc5jELiwjCQg2sISTwtZZQFltA==}
     engines: {node: '>=18.12'}
-
-  '@pnpm/default-reporter@1001.3.6':
-    resolution: {integrity: sha512-eqjwOBOLxG+by5f6SpRy0Zpvf3/SClRP+vLxXKd60cHtMhiQo9cnkKDC3f8ihm9j7wPAEESvsOTqSVzvFY4sKA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
 
   '@pnpm/default-reporter@1002.0.1':
     resolution: {integrity: sha512-d0P2Issm09xMkv2RsQROBk3XDo/Bgq1cMECaufuwdPjJ+tAzV/kQx2weG+FU0XXaKs/7bpfliqUatuiWlTDxQg==}
@@ -10303,10 +10353,6 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/env.system-node-version@1000.0.4':
-    resolution: {integrity: sha512-tqP2AZzJup42KMblzGdtcnhCKO/VaJS1vJeIrl3HAA5HlM40Z8OSkYzIgdtm6O8lc2r1QXRw6XxgI7CcE831dA==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/env.system-node-version@1000.0.8':
     resolution: {integrity: sha512-vK1qrDrY+Y9FPAY3hDNbCK2wUdQHQRaM359Zlpr6BaUvb7WlHYHEbvpom7rEwKbNZQ6uPUcFbSIAiX+PCeF+SA==}
     engines: {node: '>=18.12'}
@@ -10315,8 +10361,12 @@ packages:
     resolution: {integrity: sha512-2SfE4FFL73rE1WVIoESbqlj4sLy5nWW4M/RVdHvCRJPjlQHa9MH7m7CVJM204lz6I+eHoB+E7rL3zmpJR5wYnQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/error@1000.0.4':
-    resolution: {integrity: sha512-22mG/Mq4u2r7gr2+XY5j4GlN7J4Mg4WiCfT9flvsUc1uZecShocv6WkyoA20qs14M64f6I+aaWB6b6xsDiITlg==}
+  '@pnpm/error@1000.0.5':
+    resolution: {integrity: sha512-GjH0TPjbVNrPnl/BAGoFuBLJ2sFfXNKbS33lll/Ehe9yw0fyc8Kdw7kO9if37yQqn6vaa4dAHKkPllum7f/IPQ==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/exec.pkg-requires-build@1000.0.11':
+    resolution: {integrity: sha512-6cV8WWS5/bTEwkk2RF9WF/QeRxDqsN2rJ+b6OnQYT3jiUqWlAjdESu0EzOX4LkGQiJTOQS4k34axM3FcUKdIaw==}
     engines: {node: '>=18.12'}
 
   '@pnpm/exec.pkg-requires-build@1000.0.8':
@@ -10337,8 +10387,8 @@ packages:
     resolution: {integrity: sha512-QcHArZSCNGJZBlBc0dG4NvfL1vWt7SE+qHALJm/mp2kQ7HBODXwp95xgNB1JTx29AbJ8c4tpybq73ZQ6Vdsw+A==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/fetcher-base@1000.0.5':
-    resolution: {integrity: sha512-pRYA6OzGnhll7nmS/KfTcQy/bcnF5R5ueDtpGqek2nO9zbSSZKAUIX/igOg3Dju4Vb0NQV/d6OAYLWTuVMTOGg==}
+  '@pnpm/fetcher-base@1001.0.2':
+    resolution: {integrity: sha512-+oL/a1no20hJvfEX4y4NSPufULLSLvSS9m+rG3qmVCXZ9q8izOKUaHVnPgfRSFC4LoN1N+lewBmp5MTKALoy0A==}
     engines: {node: '>=18.12'}
 
   '@pnpm/fetching-types@1000.1.0':
@@ -10353,12 +10403,20 @@ packages:
     resolution: {integrity: sha512-vI3+bu6CrI/42hDUjtsKtSGaHlp8XHdmywtrc3HQYQrihzoaswjQW3dXAfG9x4bZy6vuGwmzXkberI1Z81QYUQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/fs.find-packages@1000.0.7':
-    resolution: {integrity: sha512-QV/FsqXU4pT6UDSUFgMAGeDgqoTwHh3dIjZfur+8GONBZJGqkA8TU27rysrUIHO5xGwOy5e64m/oSB9zeK6/vA==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/fs.hard-link-dir@1000.0.1':
     resolution: {integrity: sha512-P+nAsqQR5ksBwXSVBpeAJLNP8BvD3pRbeAbMvwZ0stuw+t1krkFkbEHkEtBBvX9vFeO2bxi8JXo3SnD/fD3KfA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/fs.hard-link-dir@1000.0.2':
+    resolution: {integrity: sha512-h3MYlT9Wogg6nuXTf7sGTNbz8j0DgERa0lvfxICFZFdhNT2nx1nc+FX56IsGLxLkMHQdmK6GaPPTjfvGwLgdFw==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/fs.indexed-pkg-importer@1000.1.14':
+    resolution: {integrity: sha512-sInsw499KKeuirsv8U4jnUIGPaOqsiO9lYgiyEKKmYnDyEVb4m1XENCOc9sC0/z3Pubz3cfTf0rUje6wXzSKCQ==}
     engines: {node: '>=18.12'}
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
@@ -10396,8 +10454,8 @@ packages:
     resolution: {integrity: sha512-RvMEliAmcfd/4UoaYQ93DLQcFeqit78jhYmeJJVPxqFGmj0jEcb9Tu0eAOXr7tGP3eJHpgvPbTU4o6pZ1bJhxg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/hooks.types@1001.0.4':
-    resolution: {integrity: sha512-HHS4K2m7j2PllnvUkHIFCkvfV1AkG8kxu9tyi9FJzRVFflQHO2iUGeKx2p2Zl60YFTtwpjoEJ/BE1yrimNYb+Q==}
+  '@pnpm/graceful-fs@1000.0.1':
+    resolution: {integrity: sha512-JnzaAVFJIEgwTcB55eww8N3h5B6qJdZqDA2wYkSK+OcTvvMSQb9c2STMhBP6GfkWygG1fs3w8D7JRx9SPZnxJg==}
     engines: {node: '>=18.12'}
 
   '@pnpm/hooks.types@1001.0.8':
@@ -10426,10 +10484,6 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/lockfile.types@1001.0.4':
-    resolution: {integrity: sha512-J0tem8YlKFByW9q6CqQmhg9tb8GV2Aoz/28/HqLpX6KDYB6bG7iP1+g14VSV6mhuSn8qtdh8sSv3Li3mMrMOvQ==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/lockfile.types@1001.0.8':
     resolution: {integrity: sha512-rKecvWutX7aZPFNyXGnGtiwfmnPRiQyG6AWQ1Ad0djWKbPeccg0s9B7cJqCJ4nEnwzhEvw9UtuofBkU/O0L+bQ==}
     engines: {node: '>=18.12'}
@@ -10440,10 +10494,6 @@ packages:
 
   '@pnpm/logger@1001.0.0':
     resolution: {integrity: sha512-nj80XtTHHt7T+b5stLWszzd166MbGx4eTOu9+6h6RdelKMlSWhrb7KUb0j90tYk+yoGx8TeMVdJCaoBnkLp8xw==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/manifest-utils@1000.0.6':
-    resolution: {integrity: sha512-hHRb0HJQ6VgknkEgEs4FDho69QRETn64QurXm75i+pPuoYkI12vDPXkBmoJQfdHSsA23uGvtadjBueHLx608GQ==}
     engines: {node: '>=18.12'}
 
   '@pnpm/manifest-utils@1001.0.1':
@@ -10540,12 +10590,6 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/package-is-installable@1000.0.6':
-    resolution: {integrity: sha512-8Y5fcJTiVpf70oISzvliKZhXH2U9SHhdfWuDuVd46k2sSRVmu0iF27OE2ZePD+rOY1LNRHnfqQCvbCYtvaYHlw==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
-
   '@pnpm/package-requester@1004.0.2':
     resolution: {integrity: sha512-laowhyIIol+9AIimxq73tcxTWD5nUVvyfKA1YKysPP1+coq/4tPHqOlK2S5Z4FgPj496Eew7Dg7cEu4K4QBUOg==}
     engines: {node: '>=18.12'}
@@ -10560,14 +10604,6 @@ packages:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
       '@pnpm/worker': ^1000.1.7
 
-  '@pnpm/parse-overrides@1000.0.2':
-    resolution: {integrity: sha512-NII/zHEDIqtSNkDS39TD0r6ukKdZaQPwn6EjDEHYFacgbHN2d3i261paQvm0Pm0oX4svV+5x5YWHUTIbQJItDg==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/parse-wanted-dependency@1000.0.0':
-    resolution: {integrity: sha512-SKK9m7leIQ0u6S+/LXREF0wTrFnyKiirLza6Dt0l7CL9pZdZtuI3mMvz6gNBFnIjTKJPwacdqRywT3bfK8W+FQ==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/parse-wanted-dependency@1001.0.0':
     resolution: {integrity: sha512-cIZao+Jdu/4znu76d3ttAWBycDj6GWKiDVNlx1GVgqYgS/Qn7ak3Lm0FGIMAIHr5oOnX63jwzKIhW35AHNaTjQ==}
     engines: {node: '>=18.12'}
@@ -10576,10 +10612,6 @@ packages:
     resolution: {integrity: sha512-AEgJoZH2goHdGWlyQ1cOMlgmjGLCqk88IFcbAolxWqlhawa3bSL1jLHnjwQc1XBwxeeUltL7mNmPR23q+VZTWQ==}
     engines: {node: '>=14', npm: '>5'}
     hasBin: true
-
-  '@pnpm/patching.types@1000.0.0':
-    resolution: {integrity: sha512-IzNrirYIcquD0tRGKkzj8q5eKh0zOVDL6rOu/sQSrlF6qWTu8YaWCI5LQoZPa1B5IGQTCJwhcoZlnGBHZyEXAg==}
-    engines: {node: '>=18.12'}
 
   '@pnpm/patching.types@1000.1.0':
     resolution: {integrity: sha512-Zib2ysLctRnWM4KXXlljR44qSKwyEqYmLk+8VPBDBEK3l5Gp5mT3N4ix9E4qjYynvFqahumsxzOfxOYQhUGMGw==}
@@ -10592,12 +10624,6 @@ packages:
   '@pnpm/pick-registry-for-package@1000.0.8':
     resolution: {integrity: sha512-d72n9tHyw0oOFzay+7/pd/94OMXCJmuuaTRbnNmUIDrwdPXtJ0B4ACCe87+LxtCvTO0LArG3yCDKxq7mK5VLUg==}
     engines: {node: '>=18.12'}
-
-  '@pnpm/pnpmfile@1001.0.7':
-    resolution: {integrity: sha512-aGG1826DgwvnkIEVf7r6IGeXS/VLm+oTF6M3WHxLyKNj35AHYRHIRK8sQZ652WbyzxYHJi2dX5PqYnnR+ROScA==}
-    engines: {node: '>=18.12'}
-    peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
 
   '@pnpm/pnpmfile@1001.2.2':
     resolution: {integrity: sha512-274P1OPhrbt7JezKBbWWKSYxMeAY6oYUcqQxBg7Abv7lUXMsxE4F0njmKv3gkK0Tc6UrM6qJEXdMqeLGLtL8pg==}
@@ -10624,20 +10650,12 @@ packages:
     resolution: {integrity: sha512-uPl5tkXullEQa+WOZDIhp7jb1UlGg8vVjnOLZmv6oJltEfMzOlDryu0awYJB5QVj1twKuxevjH6Zaq/mdVn4dw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/read-project-manifest@1000.0.7':
-    resolution: {integrity: sha512-UY5ZFl8jTgWpPMp3qwVt1z455gDLGh4aAna7ufqsJP9qhI6lr9scFpnEamjpA51Y3MJMBtnML8KATmH6RY+NHQ==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/registry-mock@5.2.0':
     resolution: {integrity: sha512-6zAH9cNXB1wh91CvOA92iZytHOebGOFTVt2k3VURhjRtoTuPiyEtpcu/3TdNkZW3ZkCLCwjw/Z1zNK3SvQ+J4w==}
     engines: {node: '>=18.12'}
     hasBin: true
     peerDependencies:
       verdaccio: ^5.20.1 || ^6.1.6
-
-  '@pnpm/render-peer-issues@1000.0.6':
-    resolution: {integrity: sha512-Iwebi2PTsmbfldJliu3ev1BdqZO2KC6HDheKbbPnxwhl3RTrH3C95dwBU/lITwxM2yO+ekosn4yU+rGcGGjmCw==}
-    engines: {node: '>=18.12'}
 
   '@pnpm/render-peer-issues@1002.0.0':
     resolution: {integrity: sha512-KYx8cqr7HRS6eAENDbXF4q2A4zt5aeUkZprp3KXz76JGEK0IkyDJjlHhWPJZa3bEKnLzgG2T4Kd3dkJ2h3GlZw==}
@@ -10647,12 +10665,12 @@ packages:
     resolution: {integrity: sha512-NO0Rz4MEOVvGsMBR7AGqqQ5zgHMQ0fpRE01iYKUKfxJ42AVP6slka4GF2rpEZISfgq8HeSdSnKL9oul3+V/2jA==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/resolver-base@1000.1.4':
-    resolution: {integrity: sha512-0tKdZD4v6Q3TqmZfuwF24r8CNrN31UScR5mBYwV8foLrGpcRZEEBPvApDjShL7r8QbD7F6eVfXL4f8T2pm0R+A==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/resolver-base@1003.0.1':
     resolution: {integrity: sha512-QdkoHw3Bk/pLfdmhWttBZP5DVOcYTvli6zjt9Pk3A8gIhVMw1QBRbdhhvEmPgKwDh6DxD7jFrh8daTkF7OK1cw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/resolver-base@1005.1.0':
+    resolution: {integrity: sha512-7JljhfFFf/qUVi/Nzfq4stBpfSt/JJp5xYx0nAJ6/cagAqiVeYP/chawj7iT3jhhpESclAToTi0NjyiTTzK4VQ==}
     engines: {node: '>=18.12'}
 
   '@pnpm/resolving.jsr-specifier-parser@1000.0.0':
@@ -10683,12 +10701,12 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/store-controller-types@1001.0.3':
-    resolution: {integrity: sha512-Y/rM9+sfNKFdxbK+2nnEwTiicThyEIwvPOUDG+a1ZLdTNybTvBy52FgtZgLgy0l1wC7htFJfssg/FWa0osyCGg==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/store-controller-types@1003.0.2':
     resolution: {integrity: sha512-YT9o5KBagNBzzKLX2GtLoamFPl6I6beg/pencHMzAR6yDCE4hicvymvK1ahtl/ntCaWdxaj5+DtTED0UaqimGA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/store-controller-types@1004.1.0':
+    resolution: {integrity: sha512-8wk06DIwhTf16SRJ51PKuWzu/Cm8KuLopQmx+aIUkoCGS+EjaeVtX8oG8lI+MfgSrsHStczRozb3WLI9m/BPTA==}
     engines: {node: '>=18.12'}
 
   '@pnpm/store-path@1000.0.2':
@@ -10698,6 +10716,16 @@ packages:
   '@pnpm/store.cafs@1000.0.13':
     resolution: {integrity: sha512-WhYfU77DdOIrIXHJ3uNPs39J87CLDaV6WV7SgqoZAkhWSIja6qTgOirDlhqj6FSRuKSKNwbYEMitd4BX0ZA8BA==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/store.cafs@1000.0.19':
+    resolution: {integrity: sha512-q/NUuyBVF4PopTdwtttoPOPEq8LOuTLkRV13jvrJ/+DaorebJjoKQPduVwIP6DxArzgrkpM2XyGgYC7WN/xhpg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/symlink-dependency@1000.0.12':
+    resolution: {integrity: sha512-/rQJ7VpZwPnlj72FQ6UuZyGJJrcwbRAkEE4WqW+Bpw9vHPGGE6KXm8aHnTC3JFhdoQ22ekEL7/2tgMJ7e/D4iQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
   '@pnpm/symlink-dependency@1000.0.9':
     resolution: {integrity: sha512-yI4nFQuI6lBzP/hUJ6L0te1TT+LVwr8LzA4E5acyrjQy/LOoRlIMykVP1nPagS/h4E2lDXo1LlARvSt1Ibe1LA==}
@@ -10727,20 +10755,12 @@ packages:
   '@pnpm/tgz-fixtures@0.0.0':
     resolution: {integrity: sha512-6YlfA/aWpeYbX9ADtSv3kKJYjTUE8rXw3gKzLPuO8hc4S7fP6sZwQXaYP7uwyWieU45TR3u0V/g8esQQYZrGMA==}
 
-  '@pnpm/types@1000.2.1':
-    resolution: {integrity: sha512-8bgr9zjlwBO53mfqv3IzaJsl5r+dwFKVhCMuxcsZ8JzsK66XHCBZz5SLkKFhu6XJtdfL+GtLUkhgl4O1xBIt7g==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/types@1000.6.0':
     resolution: {integrity: sha512-6PsMNe98VKPGcg6LnXSW/LE3YfJ77nj+bPKiRjYRWAQLZ+xXjEQRaR0dAuyjCmchlv4wR/hpnMVRS21/fCod5w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/util.lex-comparator@3.0.0':
-    resolution: {integrity: sha512-ead+l3IiuVXwKDf/QJPX6G93cwhXki3yOVEA/VdAO7AhZ5vUuSBxHe6gQKEbB0QacJ4H5VsYxeM1xUgwjjOO/Q==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/util.lex-comparator@3.0.1':
-    resolution: {integrity: sha512-jUR0XFKlYcwexqNl+Qbkw8XqQw3+wjwKz72uREqVf4OiV9Hi67IoVu8q1gz0LvHgZmqruisiar+873HcJW9dHw==}
+  '@pnpm/types@1000.9.0':
+    resolution: {integrity: sha512-UvDTCxnbyqkTg2X0dBOuZ4IdFJ8g4UFu0Ybv/5/cZAxCWVhNl1hC/Xc9hR4tZrlBL0NRFePLRhO/iw9LmA1lbw==}
     engines: {node: '>=18.12'}
 
   '@pnpm/util.lex-comparator@3.0.2':
@@ -10758,11 +10778,11 @@ packages:
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/workspace.find-packages@1000.0.15':
-    resolution: {integrity: sha512-cmDt4TbGOS309/CLRKuI6Uh4aWBLriqhmszStdJNF37+MRWSirgXPGYtgRzRmvJUiE+MUUBF/VmrEFHbHbK4kg==}
+  '@pnpm/worker@1000.3.0':
+    resolution: {integrity: sha512-xSWB/LWjTfW+Vm6BhVObXJrSAUNIxQelrX4ry+ni0ogYj/i6BlO6Tv0t83opnJ5fwqQUi3n3DwehnzbVYIn8xw==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      '@pnpm/logger': '>=5.1.0 <1001.0.0'
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
   '@pnpm/workspace.find-packages@1000.0.25':
     resolution: {integrity: sha512-dKXeM46nSXKOzIIvofAhrcZqivxeJIqG27MX2nQoYYtccdJw6IBWozPqDJIPw0V3WLt9DAEQOqooEasbBmB5wg==}
@@ -10774,20 +10794,12 @@ packages:
     resolution: {integrity: sha512-muGVZ4LWmdUoLNE7+sv6D9OnKY/PO4xzXvcA5r2t9HFnxibd9DBjPg51K62e7euif8v6fDNx18soh1GmVxqKOg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/workspace.read-manifest@1000.1.1':
-    resolution: {integrity: sha512-2Y4em+kU+dHVp+WndpZsYUBO2Euwi+kOAaUN6nwMhTjFOgzs3SW725i5VUFdDqw+U4qcvFcWNsuv8SWGODn06Q==}
-    engines: {node: '>=18.12'}
-
   '@pnpm/workspace.read-manifest@1000.1.5':
     resolution: {integrity: sha512-2oSdHnL1n9SCAsGySFFbQeLSydv5KA87781ifS17/uY7c9eEd8vMIpjcXG4Mws1ri+B+1rSCy/1T3gfdLGgOsQ==}
     engines: {node: '>=18.12'}
 
   '@pnpm/workspace.spec-parser@1000.0.0':
     resolution: {integrity: sha512-uiCSwv0vRldMhkYRN1BDMLxn1g9KWku8lq8WutybWvKPvYg/xvHHX3s2LiVOerCP45Kys5o8DILSENQc+uaF+w==}
-    engines: {node: '>=18.12'}
-
-  '@pnpm/write-project-manifest@1000.0.4':
-    resolution: {integrity: sha512-U/vWmJgjDvyGcuw86qCY31rjZHhjHbqKKRY0RvFlS4Rt/Xv8q93Hal7+VKZ/08nCbMdzoTOX4ploMqgUVXCB6Q==}
     engines: {node: '>=18.12'}
 
   '@pnpm/write-project-manifest@1000.0.8':
@@ -10855,6 +10867,30 @@ packages:
       '@types/node':
         optional: true
 
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.0.0':
+    resolution: {integrity: sha512-NgbJ+aW9gQl/25+GIEGYcCyi8M+ng2/5X04BMuIgoDfgvp18vDcoNHOQjQsG9418HGNYRxG3vfEXaR1ayD37gg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.0':
+    resolution: {integrity: sha512-MM8XIwUjN2bwvCg1QvrMtbBmpcSHrkhFSCu1D11NyPvDQ25HEc4oG5/OcQfd/Tlf/OxmKWERDj0zGE23jQaMwA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@4.0.1':
+    resolution: {integrity: sha512-KFNGy01gx9Y3IBPG/CergxR9RZpN43N+lt3EozEfeoyqm8vEiLxwRl3ZO5sPx3Obv1ix/p7FWOlPc2Jgwfp9PA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/tuf@4.0.0':
+    resolution: {integrity: sha512-0QFuWDHOQmz7t66gfpfNO6aEjoFrdhkJaej/AOqb4kqWZVbPWFZifXZzkxyQBB1OwTbkhdT3LNpMFxwkTvf+2w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/verify@3.0.0':
+    resolution: {integrity: sha512-moXtHH33AobOhTZF8xcX1MpOFqdvfCk7v6+teJL8zymBiDXwEsQH6XG9HGx2VIxnJZNm4cNSzflTLDnQLmIdmw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -10898,6 +10934,14 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@4.0.0':
+    resolution: {integrity: sha512-h5x5ga/hh82COe+GoD4+gKUeV4T3iaYOxqLt41GRKApinPI7DMidhCmNVTjKfhCWFJIGXaFJee07XczdT4jdZQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
@@ -11440,10 +11484,6 @@ packages:
     resolution: {integrity: sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==}
     engines: {node: '>=18.12.0'}
 
-  '@yarnpkg/pnp@4.0.8':
-    resolution: {integrity: sha512-D0hcRPYgYlp4W98tWYG4tCNEyenL6yxazWCxzxdnKF1r9rauDMImtAR5Sh0ERSrTf3lHKXAz8Jy7S+ztOxf7yQ==}
-    engines: {node: '>=18.12.0'}
-
   '@yarnpkg/pnp@4.1.1':
     resolution: {integrity: sha512-IDI3dBnxOY/JEyNn3rg9UD0Zw8R1oX8uc4XIa+qoE0duvEqNaNBhpZTlgf11alYf2sTanIg4R/FQsmgmMR0oOA==}
     engines: {node: '>=18.12.0'}
@@ -11504,6 +11544,10 @@ packages:
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -11799,15 +11843,8 @@ packages:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
-  bole@5.0.17:
-    resolution: {integrity: sha512-q6F82qEcUQTP178ZEY4WI1zdVzxy+fOnSF1dOMyC16u1fc0c24YrDPbgxA6N5wGHayCUdSBWsF8Oy7r2AKtQdA==}
-
   bole@5.0.19:
     resolution: {integrity: sha512-OgMuI8erST2t4K/Y+tSsn4SOxlKj4JR2wluQgLYadQFPIhj0r3jcmnp0OthgiyNO91CnxR8woKeLQmnMPgl1Ug==}
-
-  boxen@5.1.2:
-    resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
-    engines: {node: '>=10'}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -11879,6 +11916,10 @@ packages:
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  cacache@20.0.3:
+    resolution: {integrity: sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -12463,10 +12504,6 @@ packages:
   detect-indent@7.0.1:
     resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
     engines: {node: '>=12.20'}
-
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -13063,10 +13100,6 @@ packages:
     resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.1:
-    resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.3.2:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
@@ -13223,6 +13256,10 @@ packages:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -13461,6 +13498,10 @@ packages:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  ignore-walk@8.0.0:
+    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -13517,6 +13558,10 @@ packages:
   ini@5.0.0:
     resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   inquirer@9.3.7:
     resolution: {integrity: sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==}
@@ -14036,6 +14081,10 @@ packages:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  json-parse-even-better-errors@5.0.0:
+    resolution: {integrity: sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -14254,8 +14303,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.1.0:
-    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+  lru-cache@11.2.4:
+    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -14291,6 +14340,10 @@ packages:
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  make-fetch-happen@15.0.3:
+    resolution: {integrity: sha512-iyyEpDty1mwW3dGlYXAJqC/azFn5PPvgKVwXayOGBSmKLxhKZ9fg4qIan2ePpp1vJIwfFiO34LAPZgq9SZW9Aw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -14482,6 +14535,10 @@ packages:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  minipass-fetch@5.0.0:
+    resolution: {integrity: sha512-fiCdUALipqgPWrOVTz9fw0XhcazULXOSU6ie40DDbX1F49p1dBrSRBuswndTx1x3vEb/g0FT7vC4c4C2u/mh3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
@@ -14514,8 +14571,8 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
-  minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
@@ -14523,11 +14580,6 @@ packages:
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -14649,6 +14701,11 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
+  node-gyp@12.1.0:
+    resolution: {integrity: sha512-W+RYA8jBnhSr2vrTtlPYPc1K+CSjGpVDRZxcqJcERZ8ND3A1ThWPHRwctTx3qC3oW99jt726jhdz3Y6ky87J4g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -14662,6 +14719,11 @@ packages:
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   normalize-newline@4.1.0:
@@ -14714,6 +14776,14 @@ packages:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  npm-bundled@5.0.0:
+    resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-install-checks@8.0.0:
+    resolution: {integrity: sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-normalize-package-bin@2.0.0:
     resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -14726,14 +14796,34 @@ packages:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-package-arg@13.0.2:
+    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-package-arg@8.1.5:
     resolution: {integrity: sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==}
     engines: {node: '>=10'}
+
+  npm-packlist@10.0.3:
+    resolution: {integrity: sha512-zPukTwJMOu5X5uvm0fztwS5Zxyvmk38H/LfidkOMt3gbZVCyro2cD/ETzwzVPcWZA3JOyPznfUN/nkyFiyUbxg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-packlist@5.1.3:
     resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     hasBin: true
+
+  npm-pick-manifest@11.0.3:
+    resolution: {integrity: sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  npm-registry-fetch@19.1.1:
+    resolution: {integrity: sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -14879,10 +14969,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-limit@7.1.0:
-    resolution: {integrity: sha512-7LbrpOjbzBWFHFgRtVrIAwBwW1bB7c7n914Q2+CXr1TvOfbTrVHAEH1Ya9PwDwAoKLeiRrczymYWPwaHNOQ0vA==}
-    engines: {node: '>=20'}
-
   p-limit@7.2.0:
     resolution: {integrity: sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==}
     engines: {node: '>=20'}
@@ -14956,6 +15042,11 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  pacote@21.0.4:
+    resolution: {integrity: sha512-RplP/pDW0NNNDh3pnaoIWYPvNenS7UqMbXyvMqJczosiFWTeGGwJC2NQBLqKf4rGLFfwCOnntw1aEp9Jiqm1MA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -15179,6 +15270,10 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   proc-output@1.0.9:
     resolution: {integrity: sha512-XARWwM2pPNU/U8V4OuQNQLyjFqvHk1FRB5sFd1CCyT2vLLfDlLRLE4f6njcvm4Kyek1VzvF8MQRAYK1uLOlZmw==}
@@ -15416,10 +15511,6 @@ packages:
   remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
 
-  rename-overwrite@6.0.2:
-    resolution: {integrity: sha512-AOnE/H23f7tVoozuBs/PtKX7qy92T1RQZOhofr1d6iey0qUrUH1VJoZZUctCXi1AXqQqHwje2ybtC/LHeXy6NQ==}
-    engines: {node: '>=18'}
-
   rename-overwrite@6.0.3:
     resolution: {integrity: sha512-Daqe51STnrCUq/t4dbzCtfNBLElrqVpCtuWK0MuPrzUi6K/13E98y3E8/kzuMZt6IEmghMnF41J0AidrFqjZUA==}
     engines: {node: '>=18'}
@@ -15656,6 +15747,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  shlex@2.1.2:
+    resolution: {integrity: sha512-Nz6gtibMVgYeMEhUjp2KuwAgqaJA1K155dU/HuDaEJUGgnmYfVtVZah+uerVWdH8UGnyahhDCgABbYTbs254+w==}
+
   shlex@3.0.0:
     resolution: {integrity: sha512-jHPXQQk9d/QXCvJuLPYMOYWez3c43sORAgcIEoV7bFv5AJSJRAOyw5lQO12PMfd385qiLRCaDt7OtEzgrIGZUA==}
 
@@ -15693,6 +15787,10 @@ packages:
 
   signed-varint@2.0.1:
     resolution: {integrity: sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==}
+
+  sigstore@4.0.0:
+    resolution: {integrity: sha512-Gw/FgHtrLM9WP8P5lLcSGh9OQcrTruWCELAiS48ik1QbL0cH+dfjomiRTUE9zzz+D1N6rOLkwXUvVmXZAsNE0Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -15823,6 +15921,10 @@ packages:
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  ssri@13.0.0:
+    resolution: {integrity: sha512-yizwGBpbCn4YomB2lzhZqrHLJoqFGXihNbib3ozhqF/cIp5ue+xSmOQrjNasEE62hFxsCcg/V/z23t4n8jMEng==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
@@ -16007,8 +16109,8 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
 
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
 
   temp-dir@2.0.0:
@@ -16198,6 +16300,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tuf-js@4.0.0:
+    resolution: {integrity: sha512-Lq7ieeGvXDXwpoSmOSgLWVdsGGV9J4a77oDTAPe/Ltrqnnm/ETaRlBAQTH5JatEh8KXuE6sddf9qAv1Q2282Hg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -16342,9 +16448,17 @@ packages:
     resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  unique-filename@5.0.0:
+    resolution: {integrity: sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   unique-slug@5.0.0:
     resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  unique-slug@6.0.0:
+    resolution: {integrity: sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   unique-stream@2.3.1:
     resolution: {integrity: sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==}
@@ -16446,6 +16560,10 @@ packages:
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  validate-npm-package-name@7.0.0:
+    resolution: {integrity: sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   validator@13.15.23:
     resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
@@ -16559,6 +16677,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  which@6.0.0:
+    resolution: {integrity: sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
   wide-align@1.1.5:
@@ -16741,7 +16864,7 @@ snapshots:
       '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.2
@@ -16974,7 +17097,7 @@ snapshots:
       '@babel/parser': 7.28.3(@babel/types@7.28.2)
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17601,7 +17724,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -17615,7 +17738,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -17635,7 +17758,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17943,9 +18066,78 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@npmcli/agent@4.0.0':
+    dependencies:
+      agent-base: 7.1.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.2.4
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@npmcli/fs@4.0.0':
     dependencies:
       semver: 7.7.2
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.7.2
+
+  '@npmcli/git@7.0.1':
+    dependencies:
+      '@npmcli/promise-spawn': 9.0.1
+      ini: 6.0.0
+      lru-cache: 11.2.4
+      npm-pick-manifest: 11.0.3
+      proc-log: 6.1.0
+      promise-retry: 2.0.1
+      semver: 7.7.2
+      which: 6.0.0
+
+  '@npmcli/installed-package-contents@4.0.0':
+    dependencies:
+      npm-bundled: 5.0.0
+      npm-normalize-package-bin: 5.0.0
+
+  '@npmcli/metavuln-calculator@9.0.3':
+    dependencies:
+      cacache: 20.0.3
+      json-parse-even-better-errors: 5.0.0
+      pacote: 21.0.4
+      proc-log: 6.1.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/node-gyp@5.0.0': {}
+
+  '@npmcli/package-json@7.0.4':
+    dependencies:
+      '@npmcli/git': 7.0.1
+      glob: 13.0.0
+      hosted-git-info: 9.0.0
+      json-parse-even-better-errors: 5.0.0
+      proc-log: 6.1.0
+      semver: 7.7.2
+      validate-npm-package-license: 3.0.4
+
+  '@npmcli/promise-spawn@9.0.1':
+    dependencies:
+      which: 6.0.0
+
+  '@npmcli/redact@4.0.0': {}
+
+  '@npmcli/run-script@10.0.3':
+    dependencies:
+      '@npmcli/node-gyp': 5.0.0
+      '@npmcli/package-json': 7.0.4
+      '@npmcli/promise-spawn': 9.0.1
+      node-gyp: 12.1.0
+      proc-log: 6.1.0
+      which: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@pkgr/core@0.2.9': {}
 
@@ -17957,37 +18149,11 @@ snapshots:
     dependencies:
       '@pnpm/error': 1000.0.2
 
-  '@pnpm/catalogs.protocol-parser@1000.0.0': {}
-
-  '@pnpm/catalogs.resolver@1000.0.2':
-    dependencies:
-      '@pnpm/catalogs.protocol-parser': 1000.0.0
-      '@pnpm/error': 1000.0.4
-
   '@pnpm/catalogs.types@1000.0.0': {}
-
-  '@pnpm/cli-meta@1000.0.4':
-    dependencies:
-      '@pnpm/types': 1000.2.1
-      load-json-file: 6.2.0
 
   '@pnpm/cli-meta@1000.0.8':
     dependencies:
       '@pnpm/types': 1000.6.0
-      load-json-file: 6.2.0
-
-  '@pnpm/cli-utils@1000.0.15(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.4
-      '@pnpm/config': 1002.5.2(@pnpm/logger@1001.0.0)
-      '@pnpm/default-reporter': 1001.3.6(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/manifest-utils': 1000.0.6(@pnpm/logger@1001.0.0)
-      '@pnpm/package-is-installable': 1000.0.6(@pnpm/logger@1001.0.0)
-      '@pnpm/read-project-manifest': 1000.0.7
-      '@pnpm/types': 1000.2.1
-      chalk: 4.1.2
       load-json-file: 6.2.0
 
   '@pnpm/cli-utils@1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
@@ -18012,6 +18178,28 @@ snapshots:
       - supports-color
       - typanion
 
+  '@pnpm/cli-utils@1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/cli-meta': 1000.0.8
+      '@pnpm/config': 1003.1.1(@pnpm/logger@1001.0.0)
+      '@pnpm/config.deps-installer': 1000.0.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))
+      '@pnpm/default-reporter': 1002.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/error': 1000.0.2
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/manifest-utils': 1001.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/package-is-installable': 1000.0.10(@pnpm/logger@1001.0.0)
+      '@pnpm/pnpmfile': 1001.2.2(@pnpm/logger@1001.0.0)
+      '@pnpm/read-project-manifest': 1000.0.11
+      '@pnpm/store-connection-manager': 1002.0.3(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
+      '@pnpm/types': 1000.6.0
+      chalk: 4.1.2
+      load-json-file: 6.2.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - domexception
+      - supports-color
+      - typanion
+
   '@pnpm/client@1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
     dependencies:
       '@pnpm/default-resolver': 1002.0.2(@pnpm/logger@1001.0.0)
@@ -18022,6 +18210,25 @@ snapshots:
       '@pnpm/network.auth-header': 1000.0.3
       '@pnpm/resolver-base': 1003.0.1
       '@pnpm/tarball-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
+      '@pnpm/types': 1000.6.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - '@pnpm/worker'
+      - domexception
+      - supports-color
+      - typanion
+
+  '@pnpm/client@1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/default-resolver': 1002.0.2(@pnpm/logger@1001.0.0)
+      '@pnpm/directory-fetcher': 1000.1.7(@pnpm/logger@1001.0.0)
+      '@pnpm/fetch': 1000.2.2(@pnpm/logger@1001.0.0)
+      '@pnpm/fetching-types': 1000.1.0
+      '@pnpm/git-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
+      '@pnpm/network.auth-header': 1000.0.3
+      '@pnpm/resolver-base': 1003.0.1
+      '@pnpm/tarball-fetcher': 1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
       '@pnpm/types': 1000.6.0
       ramda: '@pnpm/ramda@0.28.1'
     transitivePeerDependencies:
@@ -18064,45 +18271,33 @@ snapshots:
       - domexception
       - supports-color
 
-  '@pnpm/config.env-replace@1.1.0': {}
+  '@pnpm/config.deps-installer@1000.0.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))':
+    dependencies:
+      '@pnpm/config.config-writer': 1000.0.5
+      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/error': 1000.0.2
+      '@pnpm/fetch': 1000.2.2(@pnpm/logger@1001.0.0)
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/network.auth-header': 1000.0.3
+      '@pnpm/npm-resolver': 1004.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/package-store': 1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))
+      '@pnpm/parse-wanted-dependency': 1001.0.0
+      '@pnpm/pick-registry-for-package': 1000.0.8
+      '@pnpm/read-modules-dir': 1000.0.0
+      '@pnpm/read-package-json': 1000.0.9
+      '@pnpm/types': 1000.6.0
+      '@zkochan/rimraf': 3.0.2
+      get-npm-tarball-url: 2.1.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - domexception
+      - supports-color
 
-  '@pnpm/config.env-replace@3.0.1': {}
+  '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/config.env-replace@3.0.2': {}
 
-  '@pnpm/config.nerf-dart@1.0.0': {}
-
   '@pnpm/config.nerf-dart@1.0.1': {}
-
-  '@pnpm/config@1002.5.2(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/catalogs.config': 1000.0.2
-      '@pnpm/catalogs.types': 1000.0.0
-      '@pnpm/config.env-replace': 3.0.1
-      '@pnpm/constants': 1001.1.0
-      '@pnpm/error': 1000.0.2
-      '@pnpm/git-utils': 1000.0.0
-      '@pnpm/matcher': 1000.0.0
-      '@pnpm/npm-conf': 3.0.0
-      '@pnpm/pnpmfile': 1001.0.7(@pnpm/logger@1001.0.0)
-      '@pnpm/read-project-manifest': 1000.0.7
-      '@pnpm/types': 1000.2.1
-      '@pnpm/workspace.read-manifest': 1000.1.1
-      better-path-resolve: 1.0.0
-      camelcase: 6.3.0
-      camelcase-keys: 6.2.2
-      can-write-to-dir: 1.1.1
-      is-subdir: 1.2.0
-      is-windows: 1.0.2
-      normalize-registry-url: 2.0.0
-      path-absolute: 1.0.1
-      path-name: 1.0.0
-      ramda: '@pnpm/ramda@0.28.1'
-      read-ini-file: 4.0.0
-      realpath-missing: 1.1.0
-      which: '@pnpm/which@3.0.1'
-    transitivePeerDependencies:
-      - '@pnpm/logger'
 
   '@pnpm/config@1003.1.1(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18136,17 +18331,17 @@ snapshots:
 
   '@pnpm/constants@1001.1.0': {}
 
-  '@pnpm/constants@1001.3.0': {}
-
-  '@pnpm/core-loggers@1000.1.4(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/types': 1000.2.1
+  '@pnpm/constants@1001.3.1': {}
 
   '@pnpm/core-loggers@1001.0.1(@pnpm/logger@1001.0.0)':
     dependencies:
       '@pnpm/logger': 1001.0.0
       '@pnpm/types': 1000.6.0
+
+  '@pnpm/core-loggers@1001.0.4(@pnpm/logger@1001.0.0)':
+    dependencies:
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/types': 1000.9.0
 
   '@pnpm/create-cafs-store@1000.0.14(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18156,6 +18351,18 @@ snapshots:
       '@pnpm/logger': 1001.0.0
       '@pnpm/store-controller-types': 1003.0.2
       '@pnpm/store.cafs': 1000.0.13
+      mem: 8.1.1
+      path-temp: 2.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/create-cafs-store@1000.0.20(@pnpm/logger@1001.0.0)':
+    dependencies:
+      '@pnpm/exec.pkg-requires-build': 1000.0.11
+      '@pnpm/fetcher-base': 1001.0.2
+      '@pnpm/fs.indexed-pkg-importer': 1000.1.14(@pnpm/logger@1001.0.0)
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/store-controller-types': 1004.1.0
+      '@pnpm/store.cafs': 1000.0.19
       mem: 8.1.1
       path-temp: 2.1.0
       ramda: '@pnpm/ramda@0.28.1'
@@ -18175,31 +18382,6 @@ snapshots:
       chalk: 4.1.2
 
   '@pnpm/dedupe.types@1000.0.0': {}
-
-  '@pnpm/default-reporter@1001.3.6(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.4
-      '@pnpm/config': 1002.5.2(@pnpm/logger@1001.0.0)
-      '@pnpm/core-loggers': 1000.1.4(@pnpm/logger@1001.0.0)
-      '@pnpm/dedupe.issues-renderer': 1000.0.1
-      '@pnpm/dedupe.types': 1000.0.0
-      '@pnpm/error': 1000.0.2
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/render-peer-issues': 1000.0.6
-      '@pnpm/types': 1000.2.1
-      '@pnpm/util.lex-comparator': 3.0.1
-      ansi-diff: 1.2.0
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-truncate: 2.1.0
-      normalize-path: 3.0.0
-      pretty-bytes: 5.6.0
-      pretty-ms: 7.0.1
-      ramda: '@pnpm/ramda@0.28.1'
-      rxjs: 7.8.2
-      semver: 7.7.2
-      stacktracey: 2.1.8
-      string-length: 4.0.2
 
   '@pnpm/default-reporter@1002.0.1(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18256,12 +18438,6 @@ snapshots:
       '@pnpm/resolver-base': 1003.0.1
       '@pnpm/types': 1000.6.0
 
-  '@pnpm/env.system-node-version@1000.0.4':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.4
-      execa: safe-execa@0.1.2
-      mem: 8.1.1
-
   '@pnpm/env.system-node-version@1000.0.8':
     dependencies:
       '@pnpm/cli-meta': 1000.0.8
@@ -18272,9 +18448,13 @@ snapshots:
     dependencies:
       '@pnpm/constants': 1001.1.0
 
-  '@pnpm/error@1000.0.4':
+  '@pnpm/error@1000.0.5':
     dependencies:
-      '@pnpm/constants': 1001.3.0
+      '@pnpm/constants': 1001.3.1
+
+  '@pnpm/exec.pkg-requires-build@1000.0.11':
+    dependencies:
+      '@pnpm/types': 1000.9.0
 
   '@pnpm/exec.pkg-requires-build@1000.0.8':
     dependencies:
@@ -18305,10 +18485,10 @@ snapshots:
       '@pnpm/types': 1000.6.0
       '@types/ssri': 7.1.5
 
-  '@pnpm/fetcher-base@1000.0.5':
+  '@pnpm/fetcher-base@1001.0.2':
     dependencies:
-      '@pnpm/resolver-base': 1000.1.4
-      '@pnpm/types': 1000.2.1
+      '@pnpm/resolver-base': 1005.1.0
+      '@pnpm/types': 1000.9.0
       '@types/ssri': 7.1.5
 
   '@pnpm/fetching-types@1000.1.0':
@@ -18331,17 +18511,29 @@ snapshots:
       p-filter: 2.1.0
       tinyglobby: 0.2.14
 
-  '@pnpm/fs.find-packages@1000.0.7':
-    dependencies:
-      '@pnpm/read-project-manifest': 1000.0.7
-      '@pnpm/types': 1000.2.1
-      '@pnpm/util.lex-comparator': 3.0.0
-      p-filter: 2.1.0
-      tinyglobby: 0.2.14
-
   '@pnpm/fs.hard-link-dir@1000.0.1(@pnpm/logger@1001.0.0)':
     dependencies:
       '@pnpm/logger': 1001.0.0
+
+  '@pnpm/fs.hard-link-dir@1000.0.2(@pnpm/logger@1001.0.0)':
+    dependencies:
+      '@pnpm/graceful-fs': 1000.0.1
+      '@pnpm/logger': 1001.0.0
+
+  '@pnpm/fs.indexed-pkg-importer@1000.1.14(@pnpm/logger@1001.0.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1001.0.4(@pnpm/logger@1001.0.0)
+      '@pnpm/graceful-fs': 1000.0.1
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/store-controller-types': 1004.1.0
+      '@reflink/reflink': 0.1.19
+      '@zkochan/rimraf': 3.0.2
+      fs-extra: 11.3.2
+      make-empty-dir: 3.0.2
+      p-limit: 3.1.0
+      path-temp: 2.1.0
+      rename-overwrite: 6.0.3
+      sanitize-filename: 1.6.3
 
   '@pnpm/fs.indexed-pkg-importer@1000.1.8(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18372,7 +18564,20 @@ snapshots:
       '@pnpm/fs.packlist': 2.0.0
       '@pnpm/logger': 1001.0.0
       '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)
+      '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
+      '@zkochan/rimraf': 3.0.2
+      execa: safe-execa@0.1.2
+    transitivePeerDependencies:
+      - supports-color
+      - typanion
+
+  '@pnpm/git-fetcher@1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/fetcher-base': 1000.0.11
+      '@pnpm/fs.packlist': 2.0.0
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
+      '@pnpm/worker': 1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
       '@zkochan/rimraf': 3.0.2
       execa: safe-execa@0.1.2
     transitivePeerDependencies:
@@ -18399,10 +18604,9 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
 
-  '@pnpm/hooks.types@1001.0.4':
+  '@pnpm/graceful-fs@1000.0.1':
     dependencies:
-      '@pnpm/lockfile.types': 1001.0.4
-      '@pnpm/types': 1000.2.1
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
 
   '@pnpm/hooks.types@1001.0.8':
     dependencies:
@@ -18463,11 +18667,6 @@ snapshots:
       '@pnpm/types': 1000.6.0
       normalize-path: 3.0.0
 
-  '@pnpm/lockfile.types@1001.0.4':
-    dependencies:
-      '@pnpm/patching.types': 1000.0.0
-      '@pnpm/types': 1000.2.1
-
   '@pnpm/lockfile.types@1001.0.8':
     dependencies:
       '@pnpm/patching.types': 1000.1.0
@@ -18481,14 +18680,6 @@ snapshots:
     dependencies:
       bole: 5.0.19
       ndjson: 2.0.0
-
-  '@pnpm/manifest-utils@1000.0.6(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/core-loggers': 1000.1.4(@pnpm/logger@1001.0.0)
-      '@pnpm/error': 1000.0.2
-      '@pnpm/types': 1000.2.1
-    transitivePeerDependencies:
-      - '@pnpm/logger'
 
   '@pnpm/manifest-utils@1001.0.1(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18507,7 +18698,7 @@ snapshots:
       '@pnpm/find-workspace-dir': 1000.1.0
       '@pnpm/logger': 1001.0.0
       '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)
+      '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
       '@pnpm/workspace.find-packages': 1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
       '@pnpm/workspace.read-manifest': 1000.1.5
       load-json-file: 7.0.1
@@ -18544,7 +18735,7 @@ snapshots:
 
   '@pnpm/network.proxy-agent@2.0.3':
     dependencies:
-      '@pnpm/error': 1000.0.4
+      '@pnpm/error': 1000.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -18578,7 +18769,7 @@ snapshots:
   '@pnpm/npm-lifecycle@1000.0.4(patch_hash=9ca23edf604c5e8ff290e3c0a5443646b5f9865624042a5c41d9b2beb8f98972)(typanion@3.14.0)':
     dependencies:
       '@pnpm/byline': 1.0.0
-      '@pnpm/error': 1000.0.4
+      '@pnpm/error': 1000.0.5
       '@yarnpkg/fslib': 3.1.2
       '@yarnpkg/shell': 4.0.0(typanion@3.14.0)
       node-gyp: 11.4.2
@@ -18594,7 +18785,7 @@ snapshots:
   '@pnpm/npm-lifecycle@1001.0.0(patch_hash=9ca23edf604c5e8ff290e3c0a5443646b5f9865624042a5c41d9b2beb8f98972)(typanion@3.14.0)':
     dependencies:
       '@pnpm/byline': 1.0.0
-      '@pnpm/error': 1000.0.4
+      '@pnpm/error': 1000.0.5
       '@yarnpkg/fslib': 3.1.2
       '@yarnpkg/shell': 4.0.0(typanion@3.14.0)
       node-gyp: 11.4.2
@@ -18653,11 +18844,11 @@ snapshots:
 
   '@pnpm/os.env.path-extender-posix@2.1.0':
     dependencies:
-      '@pnpm/error': 1000.0.4
+      '@pnpm/error': 1000.0.5
 
   '@pnpm/os.env.path-extender-windows@2.0.3':
     dependencies:
-      '@pnpm/error': 1000.0.4
+      '@pnpm/error': 1000.0.5
       safe-execa: 0.1.4
       string.prototype.matchall: 4.0.12
 
@@ -18685,19 +18876,6 @@ snapshots:
       mem: 8.1.1
       semver: 7.7.2
 
-  '@pnpm/package-is-installable@1000.0.6(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/cli-meta': 1000.0.4
-      '@pnpm/core-loggers': 1000.1.4(@pnpm/logger@1001.0.0)
-      '@pnpm/env.system-node-version': 1000.0.4
-      '@pnpm/error': 1000.0.2
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/types': 1000.2.1
-      detect-libc: 2.0.4
-      execa: safe-execa@0.1.2
-      mem: 8.1.1
-      semver: 7.7.2
-
   '@pnpm/package-requester@1004.0.2(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))':
     dependencies:
       '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
@@ -18713,7 +18891,31 @@ snapshots:
       '@pnpm/store-controller-types': 1003.0.2
       '@pnpm/store.cafs': 1000.0.13
       '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)
+      '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
+      p-defer: 3.0.0
+      p-limit: 3.1.0
+      p-queue: 6.6.2
+      promise-share: 1.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+      ssri: 10.0.5
+
+  '@pnpm/package-requester@1004.0.2(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))':
+    dependencies:
+      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/dependency-path': 1000.0.9
+      '@pnpm/error': 1000.0.2
+      '@pnpm/fetcher-base': 1000.0.11
+      '@pnpm/graceful-fs': 1000.0.0
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/package-is-installable': 1000.0.10(@pnpm/logger@1001.0.0)
+      '@pnpm/pick-fetcher': 1000.0.0
+      '@pnpm/read-package-json': 1000.0.9
+      '@pnpm/resolver-base': 1003.0.1
+      '@pnpm/store-controller-types': 1003.0.2
+      '@pnpm/store.cafs': 1000.0.13
+      '@pnpm/types': 1000.6.0
+      '@pnpm/worker': 1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
       p-defer: 3.0.0
       p-limit: 3.1.0
       p-queue: 6.6.2
@@ -18732,22 +18934,27 @@ snapshots:
       '@pnpm/store-controller-types': 1003.0.2
       '@pnpm/store.cafs': 1000.0.13
       '@pnpm/types': 1000.6.0
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)
+      '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
       '@zkochan/rimraf': 3.0.2
       load-json-file: 6.2.0
       ramda: '@pnpm/ramda@0.28.1'
       ssri: 10.0.5
 
-  '@pnpm/parse-overrides@1000.0.2':
+  '@pnpm/package-store@1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))':
     dependencies:
-      '@pnpm/catalogs.resolver': 1000.0.2
-      '@pnpm/catalogs.types': 1000.0.0
-      '@pnpm/error': 1000.0.2
-      '@pnpm/parse-wanted-dependency': 1000.0.0
-
-  '@pnpm/parse-wanted-dependency@1000.0.0':
-    dependencies:
-      validate-npm-package-name: 5.0.0
+      '@pnpm/create-cafs-store': 1000.0.14(@pnpm/logger@1001.0.0)
+      '@pnpm/fetcher-base': 1000.0.11
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/package-requester': 1004.0.2(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))
+      '@pnpm/resolver-base': 1003.0.1
+      '@pnpm/store-controller-types': 1003.0.2
+      '@pnpm/store.cafs': 1000.0.13
+      '@pnpm/types': 1000.6.0
+      '@pnpm/worker': 1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
+      '@zkochan/rimraf': 3.0.2
+      load-json-file: 6.2.0
+      ramda: '@pnpm/ramda@0.28.1'
+      ssri: 10.0.5
 
   '@pnpm/parse-wanted-dependency@1001.0.0':
     dependencies:
@@ -18760,7 +18967,7 @@ snapshots:
       ci-info: 3.9.0
       cross-spawn: 7.0.6
       find-yarn-workspace-root: 2.0.0
-      fs-extra: 11.3.1
+      fs-extra: 11.3.2
       klaw-sync: 6.0.0
       minimist: 1.2.8
       open: 7.4.2
@@ -18770,8 +18977,6 @@ snapshots:
       tmp: 0.2.5
       yaml: 2.8.1
 
-  '@pnpm/patching.types@1000.0.0': {}
-
   '@pnpm/patching.types@1000.1.0': {}
 
   '@pnpm/pick-fetcher@1000.0.0': {}
@@ -18779,19 +18984,6 @@ snapshots:
   '@pnpm/pick-registry-for-package@1000.0.8':
     dependencies:
       '@pnpm/types': 1000.6.0
-
-  '@pnpm/pnpmfile@1001.0.7(@pnpm/logger@1001.0.0)':
-    dependencies:
-      '@pnpm/core-loggers': 1000.1.4(@pnpm/logger@1001.0.0)
-      '@pnpm/crypto.hash': 1000.1.1
-      '@pnpm/error': 1000.0.2
-      '@pnpm/hooks.types': 1001.0.4
-      '@pnpm/lockfile.types': 1001.0.4
-      '@pnpm/logger': 1001.0.0
-      '@pnpm/store-controller-types': 1001.0.3
-      '@pnpm/types': 1000.2.1
-      chalk: 4.1.2
-      path-absolute: 1.0.1
 
   '@pnpm/pnpmfile@1001.2.2(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -18849,21 +19041,6 @@ snapshots:
       read-yaml-file: 2.1.0
       strip-bom: 4.0.0
 
-  '@pnpm/read-project-manifest@1000.0.7':
-    dependencies:
-      '@gwhitney/detect-indent': 7.0.1
-      '@pnpm/error': 1000.0.2
-      '@pnpm/graceful-fs': 1000.0.0
-      '@pnpm/text.comments-parser': 1000.0.0
-      '@pnpm/types': 1000.2.1
-      '@pnpm/write-project-manifest': 1000.0.4
-      fast-deep-equal: 3.1.3
-      is-windows: 1.0.2
-      json5: 2.2.3
-      parse-json: 5.2.0
-      read-yaml-file: 2.1.0
-      strip-bom: 4.0.0
-
   '@pnpm/registry-mock@5.2.0(verdaccio@6.1.6(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       anonymous-npm-registry-client: 0.3.2
@@ -18874,17 +19051,6 @@ snapshots:
       tempy: 1.0.1
       verdaccio: 6.1.6(encoding@0.1.13)(typanion@3.14.0)
       write-yaml-file: 4.2.0
-
-  '@pnpm/render-peer-issues@1000.0.6':
-    dependencies:
-      '@pnpm/error': 1000.0.2
-      '@pnpm/matcher': 1000.0.0
-      '@pnpm/parse-overrides': 1000.0.2
-      '@pnpm/types': 1000.2.1
-      archy: 1.0.0
-      chalk: 4.1.2
-      cli-columns: 4.0.0
-      semver: 7.7.2
 
   '@pnpm/render-peer-issues@1002.0.0':
     dependencies:
@@ -18898,13 +19064,13 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  '@pnpm/resolver-base@1000.1.4':
-    dependencies:
-      '@pnpm/types': 1000.2.1
-
   '@pnpm/resolver-base@1003.0.1':
     dependencies:
       '@pnpm/types': 1000.6.0
+
+  '@pnpm/resolver-base@1005.1.0':
+    dependencies:
+      '@pnpm/types': 1000.9.0
 
   '@pnpm/resolving.jsr-specifier-parser@1000.0.0':
     dependencies:
@@ -18950,17 +19116,36 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/store-controller-types@1001.0.3':
+  '@pnpm/store-connection-manager@1002.0.3(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
     dependencies:
-      '@pnpm/fetcher-base': 1000.0.5
-      '@pnpm/resolver-base': 1000.1.4
-      '@pnpm/types': 1000.2.1
+      '@pnpm/cli-meta': 1000.0.8
+      '@pnpm/client': 1000.0.19(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
+      '@pnpm/config': 1003.1.1(@pnpm/logger@1001.0.0)
+      '@pnpm/error': 1000.0.2
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/package-store': 1002.0.4(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))
+      '@pnpm/server': 1001.0.4(@pnpm/logger@1001.0.0)
+      '@pnpm/store-path': 1000.0.2
+      '@zkochan/diable': 1.0.2
+      delay: 5.0.0
+      dir-is-case-sensitive: 2.0.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - domexception
+      - supports-color
+      - typanion
 
   '@pnpm/store-controller-types@1003.0.2':
     dependencies:
       '@pnpm/fetcher-base': 1000.0.11
       '@pnpm/resolver-base': 1003.0.1
       '@pnpm/types': 1000.6.0
+
+  '@pnpm/store-controller-types@1004.1.0':
+    dependencies:
+      '@pnpm/fetcher-base': 1001.0.2
+      '@pnpm/resolver-base': 1005.1.0
+      '@pnpm/types': 1000.9.0
 
   '@pnpm/store-path@1000.0.2':
     dependencies:
@@ -18985,6 +19170,25 @@ snapshots:
       ssri: 10.0.5
       strip-bom: 4.0.0
 
+  '@pnpm/store.cafs@1000.0.19':
+    dependencies:
+      '@pnpm/fetcher-base': 1001.0.2
+      '@pnpm/graceful-fs': 1000.0.1
+      '@pnpm/store-controller-types': 1004.1.0
+      '@zkochan/rimraf': 3.0.2
+      is-gzip: 2.0.0
+      p-limit: 3.1.0
+      rename-overwrite: 6.0.3
+      ssri: 10.0.5
+      strip-bom: 4.0.0
+
+  '@pnpm/symlink-dependency@1000.0.12(@pnpm/logger@1001.0.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1001.0.4(@pnpm/logger@1001.0.0)
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/types': 1000.9.0
+      symlink-dir: 6.0.5
+
   '@pnpm/symlink-dependency@1000.0.9(@pnpm/logger@1001.0.0)':
     dependencies:
       '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
@@ -18994,7 +19198,7 @@ snapshots:
 
   '@pnpm/tabtab@0.5.4':
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       enquirer: 2.4.1
       minimist: 1.2.8
       untildify: 4.0.0
@@ -19011,7 +19215,29 @@ snapshots:
       '@pnpm/graceful-fs': 1000.0.0
       '@pnpm/logger': 1001.0.0
       '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
-      '@pnpm/worker': 1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)
+      '@pnpm/worker': 1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
+      '@zkochan/retry': 0.2.0
+      lodash.throttle: 4.1.1
+      p-map-values: 1.0.0
+      path-temp: 2.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+      rename-overwrite: 6.0.3
+    transitivePeerDependencies:
+      - domexception
+      - supports-color
+      - typanion
+
+  '@pnpm/tarball-fetcher@1001.0.8(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1001.0.1(@pnpm/logger@1001.0.0)
+      '@pnpm/error': 1000.0.2
+      '@pnpm/fetcher-base': 1000.0.11
+      '@pnpm/fetching-types': 1000.1.0
+      '@pnpm/fs.packlist': 2.0.0
+      '@pnpm/graceful-fs': 1000.0.0
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/prepare-package': 1000.0.16(@pnpm/logger@1001.0.0)(typanion@3.14.0)
+      '@pnpm/worker': 1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30)
       '@zkochan/retry': 0.2.0
       lodash.throttle: 4.1.1
       p-map-values: 1.0.0
@@ -19036,13 +19262,9 @@ snapshots:
 
   '@pnpm/tgz-fixtures@0.0.0': {}
 
-  '@pnpm/types@1000.2.1': {}
-
   '@pnpm/types@1000.6.0': {}
 
-  '@pnpm/util.lex-comparator@3.0.0': {}
-
-  '@pnpm/util.lex-comparator@3.0.1': {}
+  '@pnpm/types@1000.9.0': {}
 
   '@pnpm/util.lex-comparator@3.0.2': {}
 
@@ -19050,7 +19272,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  '@pnpm/worker@1000.1.7(@pnpm/logger@packages+logger)(@types/node@22.15.30)':
+  '@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30)':
     dependencies:
       '@pnpm/cafs-types': 1000.0.0
       '@pnpm/create-cafs-store': 1000.0.14(@pnpm/logger@1001.0.0)
@@ -19059,7 +19281,7 @@ snapshots:
       '@pnpm/exec.pkg-requires-build': 1000.0.8
       '@pnpm/fs.hard-link-dir': 1000.0.1(@pnpm/logger@1001.0.0)
       '@pnpm/graceful-fs': 1000.0.0
-      '@pnpm/logger': link:packages/logger
+      '@pnpm/logger': 1001.0.0
       '@pnpm/store.cafs': 1000.0.13
       '@pnpm/symlink-dependency': 1000.0.9(@pnpm/logger@1001.0.0)
       '@rushstack/worker-pool': 0.4.9(@types/node@22.15.30)
@@ -19070,18 +19292,43 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@pnpm/workspace.find-packages@1000.0.15(@pnpm/logger@1001.0.0)':
+  '@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30)':
     dependencies:
-      '@pnpm/cli-utils': 1000.0.15(@pnpm/logger@1001.0.0)
-      '@pnpm/constants': 1001.1.0
-      '@pnpm/fs.find-packages': 1000.0.7
+      '@pnpm/cafs-types': 1000.0.0
+      '@pnpm/create-cafs-store': 1000.0.20(@pnpm/logger@1001.0.0)
+      '@pnpm/crypto.polyfill': 1000.1.0
+      '@pnpm/error': 1000.0.5
+      '@pnpm/exec.pkg-requires-build': 1000.0.11
+      '@pnpm/fs.hard-link-dir': 1000.0.2(@pnpm/logger@1001.0.0)
+      '@pnpm/graceful-fs': 1000.0.1
       '@pnpm/logger': 1001.0.0
-      '@pnpm/types': 1000.2.1
-      '@pnpm/util.lex-comparator': 3.0.1
+      '@pnpm/store.cafs': 1000.0.19
+      '@pnpm/symlink-dependency': 1000.0.12(@pnpm/logger@1001.0.0)
+      '@rushstack/worker-pool': 0.4.9(@types/node@22.15.30)
+      is-windows: 1.0.2
+      load-json-file: 6.2.0
+      p-limit: 3.1.0
+      shlex: 2.1.2
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@pnpm/workspace.find-packages@1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
     dependencies:
       '@pnpm/cli-utils': 1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.1.7(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
+      '@pnpm/constants': 1001.1.0
+      '@pnpm/fs.find-packages': 1000.0.11
+      '@pnpm/logger': 1001.0.0
+      '@pnpm/types': 1000.6.0
+      '@pnpm/util.lex-comparator': 3.0.2
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - domexception
+      - supports-color
+      - typanion
+
+  '@pnpm/workspace.find-packages@1000.0.25(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/cli-utils': 1000.1.5(@pnpm/logger@1001.0.0)(@pnpm/worker@1000.3.0(@pnpm/logger@1001.0.0)(@types/node@22.15.30))(typanion@3.14.0)
       '@pnpm/constants': 1001.1.0
       '@pnpm/fs.find-packages': 1000.0.11
       '@pnpm/logger': 1001.0.0
@@ -19101,13 +19348,6 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       write-yaml-file: 5.0.0
 
-  '@pnpm/workspace.read-manifest@1000.1.1':
-    dependencies:
-      '@pnpm/constants': 1001.1.0
-      '@pnpm/error': 1000.0.2
-      '@pnpm/types': 1000.2.1
-      read-yaml-file: 2.1.0
-
   '@pnpm/workspace.read-manifest@1000.1.5':
     dependencies:
       '@pnpm/constants': 1001.1.0
@@ -19116,14 +19356,6 @@ snapshots:
       read-yaml-file: 2.1.0
 
   '@pnpm/workspace.spec-parser@1000.0.0': {}
-
-  '@pnpm/write-project-manifest@1000.0.4':
-    dependencies:
-      '@pnpm/text.comments-parser': 1000.0.0
-      '@pnpm/types': 1000.2.1
-      json5: 2.2.3
-      write-file-atomic: 5.0.1
-      write-yaml-file: 5.0.0
 
   '@pnpm/write-project-manifest@1000.0.8':
     dependencies:
@@ -19181,6 +19413,38 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.15.30
 
+  '@sigstore/bundle@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.0
+
+  '@sigstore/core@3.0.0': {}
+
+  '@sigstore/protobuf-specs@0.5.0': {}
+
+  '@sigstore/sign@4.0.1':
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.0.0
+      '@sigstore/protobuf-specs': 0.5.0
+      make-fetch-happen: 15.0.3
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/tuf@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.0
+      tuf-js: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@3.0.0':
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.0.0
+      '@sigstore/protobuf-specs': 0.5.0
+
   '@sinclair/typebox@0.27.8': {}
 
   '@sinclair/typebox@0.34.40': {}
@@ -19222,6 +19486,13 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@4.0.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 9.0.5
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -19462,7 +19733,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.18.1(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/utils': 6.18.1(eslint@8.57.1)(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 6.18.1
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -19480,7 +19751,7 @@ snapshots:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 6.18.1
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.9.2
@@ -19491,7 +19762,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.40.0
-      debug: 4.4.1
+      debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -19514,7 +19785,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.18.1(typescript@5.9.2)
       '@typescript-eslint/utils': 6.18.1(eslint@8.57.1)(typescript@5.9.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@5.9.2)
     optionalDependencies:
@@ -19530,7 +19801,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.18.1
       '@typescript-eslint/visitor-keys': 6.18.1
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -19547,7 +19818,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.40.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.40.0
       '@typescript-eslint/visitor-keys': 8.40.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -19825,7 +20096,7 @@ snapshots:
       prebuild-install: 7.1.1
       resolve: 1.22.10
       stream-meter: 1.0.4
-      tar: 7.4.3
+      tar: 7.5.2
       tinyglobby: 0.2.14
       unzipper: 0.12.3
     transitivePeerDependencies:
@@ -19923,11 +20194,6 @@ snapshots:
       js-yaml: 3.14.2
       tslib: 2.8.1
 
-  '@yarnpkg/pnp@4.0.8':
-    dependencies:
-      '@types/node': 18.19.110
-      '@yarnpkg/fslib': 3.1.2
-
   '@yarnpkg/pnp@4.1.1':
     dependencies:
       '@types/node': 18.19.110
@@ -20014,6 +20280,8 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  abbrev@4.0.0: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -20037,7 +20305,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -20365,26 +20633,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bole@5.0.17:
-    dependencies:
-      fast-safe-stringify: 2.1.1
-      individual: 3.0.0
-
   bole@5.0.19:
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
-
-  boxen@5.1.2:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 6.3.0
-      chalk: 4.1.2
-      cli-boxes: 2.2.1
-      string-width: 4.2.3
-      type-fest: 0.20.2
-      widest-line: 3.1.0
-      wrap-ansi: 7.0.0
 
   brace-expansion@1.1.12:
     dependencies:
@@ -20477,8 +20729,22 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.3
       ssri: 12.0.0
-      tar: 7.4.3
+      tar: 7.5.2
       unique-filename: 4.0.0
+
+  cacache@20.0.3:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.0
+      lru-cache: 11.2.4
+      minipass: 7.1.2
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.3
+      ssri: 13.0.0
+      unique-filename: 5.0.0
 
   cacheable-lookup@5.0.4: {}
 
@@ -20715,7 +20981,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 4.4.1
+      debug: 4.4.3
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -21047,8 +21313,6 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-indent@7.0.1: {}
-
-  detect-libc@2.0.3: {}
 
   detect-libc@2.0.4: {}
 
@@ -21455,7 +21719,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -21785,12 +22049,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.1:
-    dependencies:
-      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fs-extra@11.3.2:
     dependencies:
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -21992,6 +22250,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -22144,7 +22408,7 @@ snapshots:
 
   hosted-git-info@9.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.2.4
 
   html-escaper@2.0.2: {}
 
@@ -22169,7 +22433,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22215,14 +22479,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -22267,6 +22531,10 @@ snapshots:
     dependencies:
       minimatch: 5.1.6
 
+  ignore-walk@8.0.0:
+    dependencies:
+      minimatch: 10.1.1
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -22305,6 +22573,8 @@ snapshots:
   ini@4.1.1: {}
 
   ini@5.0.0: {}
+
+  ini@6.0.0: {}
 
   inquirer@9.3.7:
     dependencies:
@@ -22590,7 +22860,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.30
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -23008,6 +23278,8 @@ snapshots:
 
   json-parse-even-better-errors@3.0.2: {}
 
+  json-parse-even-better-errors@5.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -23213,7 +23485,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.1.0: {}
+  lru-cache@11.2.4: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -23257,6 +23529,22 @@ snapshots:
       proc-log: 5.0.0
       promise-retry: 2.0.1
       ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  make-fetch-happen@15.0.3:
+    dependencies:
+      '@npmcli/agent': 4.0.0
+      cacache: 20.0.3
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.2
+      minipass-fetch: 5.0.0
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      promise-retry: 2.0.1
+      ssri: 13.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23360,7 +23648,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -23446,7 +23734,15 @@ snapshots:
     dependencies:
       minipass: 7.1.2
       minipass-sized: 1.0.3
-      minizlib: 3.0.2
+      minizlib: 3.1.0
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-fetch@5.0.0:
+    dependencies:
+      minipass: 7.1.2
+      minipass-sized: 1.0.3
+      minizlib: 3.1.0
     optionalDependencies:
       encoding: 0.1.13
 
@@ -23477,15 +23773,13 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  minizlib@3.0.2:
+  minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
 
   mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
-
-  mkdirp@3.0.1: {}
 
   module-not-found-error@1.0.1: {}
 
@@ -23553,7 +23847,7 @@ snapshots:
 
   nock@13.3.4:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -23597,7 +23891,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.2
-      tar: 7.4.3
+      tar: 7.5.2
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
@@ -23612,9 +23906,24 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.2
-      tar: 7.4.3
+      tar: 7.5.2
       tinyglobby: 0.2.14
       which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  node-gyp@12.1.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.2
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      make-fetch-happen: 15.0.3
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.2
+      tar: 7.5.2
+      tinyglobby: 0.2.14
+      which: 6.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -23629,6 +23938,10 @@ snapshots:
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   normalize-newline@4.1.0:
     dependencies:
@@ -23692,11 +24005,28 @@ snapshots:
     dependencies:
       npm-normalize-package-bin: 2.0.0
 
+  npm-bundled@5.0.0:
+    dependencies:
+      npm-normalize-package-bin: 5.0.0
+
+  npm-install-checks@8.0.0:
+    dependencies:
+      semver: 7.7.2
+
   npm-normalize-package-bin@2.0.0: {}
 
   npm-normalize-package-bin@3.0.1: {}
 
   npm-normalize-package-bin@4.0.0: {}
+
+  npm-normalize-package-bin@5.0.0: {}
+
+  npm-package-arg@13.0.2:
+    dependencies:
+      hosted-git-info: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.2
+      validate-npm-package-name: 7.0.0
 
   npm-package-arg@8.1.5:
     dependencies:
@@ -23704,12 +24034,37 @@ snapshots:
       semver: 7.7.2
       validate-npm-package-name: 3.0.0
 
+  npm-packlist@10.0.3:
+    dependencies:
+      ignore-walk: 8.0.0
+      proc-log: 6.1.0
+
   npm-packlist@5.1.3:
     dependencies:
       glob: 8.1.0
       ignore-walk: 5.0.1
       npm-bundled: 2.0.1
       npm-normalize-package-bin: 2.0.0
+
+  npm-pick-manifest@11.0.3:
+    dependencies:
+      npm-install-checks: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      npm-package-arg: 13.0.2
+      semver: 7.7.2
+
+  npm-registry-fetch@19.1.1:
+    dependencies:
+      '@npmcli/redact': 4.0.0
+      jsonparse: 1.3.1
+      make-fetch-happen: 15.0.3
+      minipass: 7.1.2
+      minipass-fetch: 5.0.0
+      minizlib: 3.1.0
+      npm-package-arg: 13.0.2
+      proc-log: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   npm-run-path@2.0.2:
     dependencies:
@@ -23866,10 +24221,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.1
 
-  p-limit@7.1.0:
-    dependencies:
-      yocto-queue: 1.2.1
-
   p-limit@7.2.0:
     dependencies:
       yocto-queue: 1.2.1
@@ -23936,6 +24287,28 @@ snapshots:
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
+
+  pacote@21.0.4:
+    dependencies:
+      '@npmcli/git': 7.0.1
+      '@npmcli/installed-package-contents': 4.0.0
+      '@npmcli/package-json': 7.0.4
+      '@npmcli/promise-spawn': 9.0.1
+      '@npmcli/run-script': 10.0.3
+      cacache: 20.0.3
+      fs-minipass: 3.0.3
+      minipass: 7.1.2
+      npm-package-arg: 13.0.2
+      npm-packlist: 10.0.3
+      npm-pick-manifest: 11.0.3
+      npm-registry-fetch: 19.1.1
+      proc-log: 6.1.0
+      promise-retry: 2.0.1
+      sigstore: 4.0.0
+      ssri: 13.0.0
+      tar: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
 
   pako@0.2.9: {}
 
@@ -24011,7 +24384,7 @@ snapshots:
 
   path-scurry@2.0.0:
     dependencies:
-      lru-cache: 11.1.0
+      lru-cache: 11.2.4
       minipass: 7.1.2
 
   path-temp@2.0.0:
@@ -24167,6 +24540,8 @@ snapshots:
   printable-characters@1.0.42: {}
 
   proc-log@5.0.0: {}
+
+  proc-log@6.1.0: {}
 
   proc-output@1.0.9: {}
 
@@ -24442,11 +24817,6 @@ snapshots:
 
   remove-trailing-separator@1.1.0: {}
 
-  rename-overwrite@6.0.2:
-    dependencies:
-      '@zkochan/rimraf': 3.0.2
-      fs-extra: 11.3.0
-
   rename-overwrite@6.0.3:
     dependencies:
       '@zkochan/rimraf': 3.0.2
@@ -24692,6 +25062,8 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
+  shlex@2.1.2: {}
+
   shlex@3.0.0: {}
 
   short-tree@3.0.0:
@@ -24740,6 +25112,17 @@ snapshots:
     dependencies:
       varint: 5.0.0
 
+  sigstore@4.0.0:
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.0.0
+      '@sigstore/protobuf-specs': 0.5.0
+      '@sigstore/sign': 4.0.1
+      '@sigstore/tuf': 4.0.0
+      '@sigstore/verify': 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -24787,7 +25170,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -24884,6 +25267,10 @@ snapshots:
       minipass: 7.1.2
 
   ssri@12.0.0:
+    dependencies:
+      minipass: 7.1.2
+
+  ssri@13.0.0:
     dependencies:
       minipass: 7.1.2
 
@@ -25115,13 +25502,12 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.4.3:
+  tar@7.5.2:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
       minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
+      minizlib: 3.1.0
       yallist: 5.0.0
 
   temp-dir@2.0.0: {}
@@ -25301,6 +25687,14 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tuf-js@4.0.0:
+    dependencies:
+      '@tufjs/models': 4.0.0
+      debug: 4.4.3
+      make-fetch-happen: 15.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -25433,7 +25827,15 @@ snapshots:
     dependencies:
       unique-slug: 5.0.0
 
+  unique-filename@5.0.0:
+    dependencies:
+      unique-slug: 6.0.0
+
   unique-slug@5.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+
+  unique-slug@6.0.0:
     dependencies:
       imurmurhash: 0.1.4
 
@@ -25551,6 +25953,8 @@ snapshots:
       builtins: 5.1.0
 
   validate-npm-package-name@6.0.2: {}
+
+  validate-npm-package-name@7.0.0: {}
 
   validator@13.15.23: {}
 
@@ -25767,6 +26171,10 @@ snapshots:
       isexe: 3.1.1
 
   which@5.0.0:
+    dependencies:
+      isexe: 3.1.1
+
+  which@6.0.0:
     dependencies:
       isexe: 3.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,6 +63,7 @@ catalog:
   '@eslint/eslintrc': 3.1.0
   '@eslint/js': 9.9.1
   '@jest/globals': 30.0.5
+  '@npmcli/metavuln-calculator': 9.0.3
   '@pnpm/byline': ^1.0.0
   '@pnpm/colorize-semver-diff': ^1.0.1
   '@pnpm/config.env-replace': ^3.0.2
@@ -76,7 +77,7 @@ catalog:
   '@pnpm/nopt': ^0.3.1
   '@pnpm/npm-conf': 3.0.1
   '@pnpm/npm-lifecycle': ^1001.0.0
-  '@pnpm/npm-package-arg': ^2.0.0
+  '@pnpm/npm-package-arg': 2.0.0
   '@pnpm/os.env.path-extender': ^2.0.3
   '@pnpm/patch-package': 0.0.1
   '@pnpm/registry-mock': 5.2.0
@@ -105,7 +106,7 @@ catalog:
   '@types/micromatch': ^4.0.9
   '@types/node': ^22.15.30
   '@types/normalize-package-data': ^2.4.4
-  '@types/normalize-path': ^3.0.2
+  '@types/normalize-path': 3.0.2
   '@types/object-hash': 3.0.6
   '@types/parse-json': ^4.0.2
   '@types/pnpm__byline': npm:@types/byline@^4.2.36
@@ -225,7 +226,7 @@ catalog:
   node-fetch: ^3.3.2
   normalize-newline: 4.1.0
   normalize-package-data: ^8.0.0
-  normalize-path: ^3.0.0
+  normalize-path: 3.0.0
   normalize-registry-url: 2.0.0
   npm-packlist: 5.1.3
   object-hash: 3.0.0
@@ -269,7 +270,7 @@ catalog:
   safe-execa: ^0.2.0
   safe-promise-defer: ^1.0.1
   sanitize-filename: ^1.6.3
-  semver: ^7.7.2
+  semver: 7.7.2
   semver-range-intersect: ^0.3.1
   semver-utils: ^1.1.4
   shlex: ^3.0.0
@@ -356,7 +357,7 @@ optimisticRepeatInstall: true
 
 overrides:
   '@yarnpkg/fslib@2': '3'
-  body-parser@<2.2.1: '^2.2.1'
+  body-parser@<2.2.1: ^2.2.1
   clipanion: 3.2.0-rc.6
   cookie@<0.7.0: '>=0.7.0'
   cross-spawn@<7.0.5: '>=7.0.5'
@@ -364,15 +365,15 @@ overrides:
   express@<4.22.1: ^4.22.1
   follow-redirects@<=1.15.5: '>=1.15.6'
   glob-parent@<5.1.2: '>=5.1.2'
-  glob@>=10.3.7 <=11.0.3: '^11.1.0'
+  glob@>=10.3.7 <=11.0.3: ^11.1.0
   hosted-git-info@1: 'catalog:'
   http-proxy-middleware@<2.0.7: ^2.0.7
   istanbul-reports: npm:@zkochan/istanbul-reports
-  js-yaml@<3.14.2: '^3.14.2'
+  js-yaml@<3.14.2: ^3.14.2
   js-yaml@^4.0.0: 'catalog:'
   json5@<2.2.2: 'catalog:'
   jsonwebtoken@<=8.5.1: '>=9.0.0'
-  jws@<3.2.3: '^3.2.3'
+  jws@<3.2.3: ^3.2.3
   nopt@5: npm:@pnpm/nopt@^0.2.1
   on-headers@<1.1.0: '>=1.1.0'
   path-to-regexp@<0.1.12: ^0.1.12

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -207,7 +207,7 @@
       "path-to-regexp@>=4.0.0 <6.3.0": ">=6.3.0",
       "path-to-regexp@>=7.0.0 <8.0.0": ">=8.0.0",
       "request": "npm:postman-request@2.88.1-postman.40",
-      "semver@<7.5.2": "^7.7.2",
+      "semver@<7.5.2": "7.7.2",
       "send@<0.19.0": "^0.19.0",
       "serve-static@<1.16.0": "^1.16.0",
       "socks@2": "^2.8.1",


### PR DESCRIPTION
Update `@pnpm/audit` to use the npm bulk audit endpoint. Additionally, use the package `@npmcli/metavuln-calculator` to calculate meta-vulnerabilities similar to how `npm audit` behaves [ref](https://docs.npmjs.com/cli/v10/commands/npm-audit?v=true#calculating-meta-vulnerabilities-and-remediations).

This will enable pnpm to automatically fix vulnerable dependencies similar to `npm audit fix`.

Work needed:
- [x] Call bulk audit endpoint instead of quick audit endpoint
- [x] Return the results in a format similar to `AuditReport` from the `@npmcli/arborist` `Arborist.audit()` method
- [ ] Support for identifying force fixing opportunities, where updating a top-level dependency to a higher semver major version would resolve the vulnerability
- [ ] Use the report to make changes to the lockfile dependency tree to fix the vulnerabilities
- [ ] More testing