### PR TITLE
fix: accept annotated tag object SHAs (#10335)

### DIFF
--- a/.changeset/four-meals-remain.md
+++ b/.changeset/four-meals-remain.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/git-fetcher": major
+---
+
+`pnpm` now correctly handles git dependencies pinned to an annotated tag by resolving them to the underlying commit before validation.
+
+This prevents false `GIT_CHECKOUT_FAILED` errors while preserving strict checks for partial or invalid commit hashes.


### PR DESCRIPTION
This change fixes a false `GIT_CHECKOUT_FAILED` error when git dependencies are resolved via annotated tag.

`pnpm` now resolves an annotated tag object to its underlying commits before validation, while still rejecting partial or invalid commit hashes.

Closes #10335.