### PR TITLE
fix: ensure custom resolver resolve() is called when shouldForceResolve returns true

### DIFF
--- a/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencies.ts
@@ -150,6 +150,7 @@ export interface ResolutionContext {
   appliedPatches: Set<string>
   updatedSet: Set<string>
   catalogResolver: CatalogResolver
+  customResolverForceResolveDeps: Set<string>
   defaultTag: string
   dryRun: boolean
   forceFullResolution: boolean
@@ -1352,6 +1353,7 @@ async function resolveDependency (
       trustPolicyExclude: ctx.trustPolicyExclude,
       trustPolicyIgnoreAfter: ctx.trustPolicyIgnoreAfter,
       update: options.update,
+      forceResolve: ctx.customResolverForceResolveDeps.has(wantedDependency.alias),
       workspacePackages: ctx.workspacePackages,
       supportedArchitectures: options.supportedArchitectures,
       onFetchError: (err: any) => { // eslint-disable-line

--- a/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
+++ b/pkg-manager/resolve-dependencies/src/resolveDependencyTree.ts
@@ -110,6 +110,7 @@ export interface ResolveDependenciesOptions {
   allowUnusedPatches: boolean
   catalogs?: Catalogs
   currentLockfile: LockfileObject
+  customResolverForceResolveDeps?: Set<string>
   dedupePeerDependents?: boolean
   dryRun: boolean
   engineStrict: boolean
@@ -174,6 +175,7 @@ export async function resolveDependencyTree<T> (
     catalogResolver: resolveFromCatalog.bind(null, opts.catalogs ?? {}),
     childrenByParentId: {} as ChildrenByParentId,
     currentLockfile: opts.currentLockfile,
+    customResolverForceResolveDeps: opts.customResolverForceResolveDeps ?? new Set(),
     defaultTag: opts.tag,
     dependenciesTree: new Map() as DependenciesTree<ResolvedPackage>,
     dryRun: opts.dryRun,


### PR DESCRIPTION
This PR is a follow-up for the new custom resolvers and fetchers feature added by #10246.

When trying to integrate that feature (newly released in [v11.0.0-alpha.2](https://github.com/pnpm/pnpm/releases/tag/v11.0.0-alpha.2)) into one of my projects, I was surprised to find that:

1. My custom resolver's `resolve` function wasn't running if there was a matching lockfile entry for the dependency, even when `shouldForceResolve` returned `true`. (The install process would say "Already up to date".)
2. If I returned a new custom resolution from `resolve` with the same ID as the existing resolution, my custom fetcher wouldn't run, even if I changed the `integrity` field.

This PR fixes both issues by treating `custom:` dependencies as potentially mutable, just like `file:` dependencies. Specific changes:

- Never skip resolution for dependencies with custom resolution type (type: 'custom:*') if the custom resolver's `shouldForceResolve` returns `true`
- Force re-fetch when a custom dependency's `integrity` changes
- Fix `checkCustomResolverForceResolve` to read manifest when `allProjects` is empty