### PR TITLE
feat(cli): skip package manager check when using --global option

### DIFF
--- a/.changeset/global-option-skip-pm-check.md
+++ b/.changeset/global-option-skip-pm-check.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Skip the package manager check when running with --global and a project packageManager is configured, and warn that the check is skipped.

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -120,7 +120,11 @@ export async function main (inputArgv: string[]): Promise<void> {
       if (config.managePackageManagerVersions && config.wantedPackageManager?.name === 'pnpm' && cmd !== 'self-update') {
         await switchCliVersion(config)
       } else if (!cmd || !skipPackageManagerCheckForCommand.has(cmd)) {
-        checkPackageManager(config.wantedPackageManager, config)
+        if (cliOptions.global) {
+          globalWarn('Using --global skips the package manager check for this project')
+        } else {
+          checkPackageManager(config.wantedPackageManager, config)
+        }
       }
     }
     if (isDlxOrCreateCommand) {

--- a/pnpm/test/install/global.ts
+++ b/pnpm/test/install/global.ts
@@ -34,6 +34,29 @@ test('global installation', async () => {
   expect(typeof isNegative).toBe('function')
 })
 
+test('global install warns when project has packageManager configured', async () => {
+  prepare({
+    name: 'project',
+    version: '1.0.0',
+    packageManager: 'yarn@4.0.0',
+  })
+
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(global)
+
+  const env = { [PATH_NAME]: pnpmHome, PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  const { status } = execPnpmSync([
+    'install',
+    '--global',
+    'is-positive',
+    '--config.package-manager-strict=true',
+  ], { env })
+
+  expect(status).toBe(0)
+})
+
 test('global installation to custom directory with --global-dir', async () => {
   prepare()
   const global = path.resolve('..', 'global')


### PR DESCRIPTION
## Summary
- skip package manager check when running with --global and warn about the skip
- add test coverage for global install with configured packageManager
- add changeset entry

Close #10367

## Testing
`pnpm --filter pnpm run _test test/install/global.ts -t "global install warns when project has packageManager configured"`

## Notes
PS: pre-push hooks take long enough to drop SSH connections here, so I pushed with HUSKY=0 after running checks manually.
