### PR TITLE
refactor: factor out a `unwrapPackageName` function

### DIFF
--- a/pkg-manager/resolve-dependencies/src/toResolveImporter.ts
+++ b/pkg-manager/resolve-dependencies/src/toResolveImporter.ts
@@ -10,6 +10,7 @@ import { type ImporterToResolve } from './index.js'
 import { getWantedDependencies, type WantedDependency } from './getWantedDependencies.js'
 import { type ImporterToResolveGeneric } from './resolveDependencyTree.js'
 import { safeIsInnerLink } from './safeIsInnerLink.js'
+import { unwrapPackageName } from './unwrapPackageName.js'
 import { validatePeerDependencies } from './validatePeerDependencies.js'
 
 export interface ResolveImporter extends ImporterToResolve, ImporterToResolveGeneric<{ isNew?: boolean }> {
@@ -149,22 +150,18 @@ function getVersionSpecsByRealNames (deps: Dependencies): VersionSpecsByRealName
   const acc: VersionSpecsByRealNames = {}
   for (const depName in deps) {
     const currentBareSpecifier = deps[depName]
-    if (currentBareSpecifier.startsWith('npm:')) {
-      const bareSpecifier = currentBareSpecifier.slice(4)
-      const index = bareSpecifier.lastIndexOf('@')
-      const spec = bareSpecifier.slice(index + 1)
-      const selector = getVerSelType(spec)
-      if (selector != null) {
-        const pkgName = bareSpecifier.substring(0, index)
-        acc[pkgName] = acc[pkgName] || {}
-        acc[pkgName][selector.normalized] = selector.type
-      }
-    } else if (!currentBareSpecifier.includes(':')) { // we really care only about semver specs
-      const selector = getVerSelType(currentBareSpecifier)
-      if (selector != null) {
-        acc[depName] = acc[depName] || {}
-        acc[depName][selector.normalized] = selector.type
-      }
+
+    const { pkgName, bareSpecifier } = unwrapPackageName(depName, currentBareSpecifier)
+
+    // we really care only about semver specs
+    if (bareSpecifier.includes(':')) {
+      continue
+    }
+
+    const selector = getVerSelType(bareSpecifier)
+    if (selector != null) {
+      acc[pkgName] = acc[pkgName] || {}
+      acc[pkgName][selector.normalized] = selector.type
     }
   }
   return acc

--- a/pkg-manager/resolve-dependencies/src/unwrapPackageName.ts
+++ b/pkg-manager/resolve-dependencies/src/unwrapPackageName.ts
@@ -1,0 +1,38 @@
+export interface UnwrappedPackageInfo {
+  readonly pkgName: string
+  readonly bareSpecifier: string
+}
+
+/**
+ * When declaring dependencies in a package.json file, it's possible to specify
+ * an "alias".
+ *
+ * An example of this would be:
+ *
+ * @example
+ * ```json
+ * {
+ *   "dependencies": {
+ *     "my-alias": "npm:is-positive@^1.0.0"
+ *   }
+ * }
+ * ```
+ *
+ * This function normalizes out the alias and returns the real package name
+ * (i.e. "is-positive" for this example) if "npm:" is used.
+ */
+export function unwrapPackageName (alias: string, originalBareSpecifier: string): UnwrappedPackageInfo {
+  // If the specifier doesn't start with "npm:", there's no more work to do. The
+  // "alias" argument is just the real package's name.
+  if (!originalBareSpecifier.startsWith('npm:')) {
+    return { pkgName: alias, bareSpecifier: originalBareSpecifier }
+  }
+
+  const npmAliasSpecifierValue = originalBareSpecifier.slice(4)
+
+  const index = npmAliasSpecifierValue.lastIndexOf('@')
+  const bareSpecifier = npmAliasSpecifierValue.slice(index + 1)
+  const pkgName = npmAliasSpecifierValue.substring(0, index)
+
+  return { pkgName, bareSpecifier }
+}


### PR DESCRIPTION
## PR Stack

- https://github.com/pnpm/pnpm/pull/10369
- https://github.com/pnpm/pnpm/pull/10370

## Changes

This factors out a new `unwrapPackageName` function from the existing `getVersionSpecsByRealNames` function.

The new `unwrapPackageName` function is used in the next PR. If we prefer merging this all together instead of separately, I can close this PR though. I usually like separate PRs for independent refactors since it allows reviewers to double check that the refactor is correct without worrying about bug fixes or new features.