### PR TITLE
fix: frozen lockfile installs in pnpm repo

### DIFF
--- a/__utils__/jest-config/package.json
+++ b/__utils__/jest-config/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@pnpm/jest-config": "workspace:*",
-    "pnpm": "workspace:",
+    "pnpm": "workspace:*",
     "ts-jest-resolver": "catalog:"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,7 +1135,7 @@ importers:
         specifier: workspace:*
         version: 'link:'
       pnpm:
-        specifier: 'workspace:'
+        specifier: workspace:*
         version: link:../../pnpm
       ts-jest-resolver:
         specifier: 'catalog:'


### PR DESCRIPTION
## Problem

I noticed frozen lockfile installs stopped working in this repo recently. The lockfile is always seen as out of date and `pnpm install` always performs an installation.

https://github.com/pnpm/pnpm/blob/24da84c19d97e07863ef3b4345c4c59018a6d27f/lockfile/verification/src/linkedPackagesAreUpToDate.ts#L86-L87

The failing check is:

```ts
semver.satisfies(linkedPkg.version, availableRange, { loose: true })
```

In this case `linkedPkg.version` was `11.0.0-alpha.2` and `availableRange` is an empty string. The `availableRange` value was an empty string since there was nothing after the `workspace:` protocol here.

## Changes

Fixing this by modifying `workspace:` to `workspace:*` so it passes the `semver.satisfies` call above.

## Question

Is `workspace:` valid? Should we throw an error if we encounter this case?

I think the answer is yes.

I double checked what happens if you run `pnpm pack` on `__utils__/jest-config`, and the `pnpm` dependency becomes an empty string. It's not a problem in this specific case since `@pnpm/jest-config` is a private package, but I think we should consider throwing an error to prevent real users from hitting this problem.

```json
{
  "name": "@pnpm/jest-config",
  "version": "1000.0.5",
  "private": true,
  "main": "jest-preset.js",
  "type": "module",
  "dependencies": {
    "@pnpm/registry-mock": "5.2.0",
    "get-port": "^7.1.0",
    "tree-kill": "^1.2.2",
    "@pnpm/worker": "1000.3.0"
  },
  "devDependencies": {
    "pnpm": "",
    "ts-jest-resolver": "2.0.1",
    "@pnpm/jest-config": "1000.0.5"
  },
  "keywords": [
    "pnpm",
    "pnpm11"
  ],
  "repository": "https://github.com/pnpm/pnpm/tree/main/__utils__/jest-config"
}
```