### PR TITLE
chore: print type checking errors relative to user's working directory

### DIFF
--- a/__utils__/scripts/src/typecheck-only.ts
+++ b/__utils__/scripts/src/typecheck-only.ts
@@ -53,8 +53,18 @@ async function main (): Promise<void> {
     JSON.stringify(typeCheckTSConfig, undefined, 2)
   )
 
-  execa('tsc', ['--build'], {
-    cwd: typeCheckDir,
+  execa('tsc', ['--build', typeCheckDir], {
+    // The INIT_CWD variable is populated by package managers and points towards
+    // the user's original working directory. It's more useful to run TypeScript
+    // from the user's actual working directory so any type checking errors can
+    // reference files relative to the real CWD. This allows better integration
+    // with terminals. For example, most terminals support Ctrl+Click or
+    // Cmd+Click on file paths printed to directly open them.
+    //
+    // There's intentionally no fallback if INIT_CWD is undefined. In that case,
+    // this script isn't run through a package manager and we can allow the
+    // current working directory used to be the user's real one.
+    cwd: process.env.INIT_CWD,
     stdio: 'inherit',
   })
 }


### PR DESCRIPTION
This makes it so developers can Ctrl+Click or Cmd+Click into errors.

https://github.com/user-attachments/assets/b9fcbca4-1e66-49f1-bbc9-0971486e5186

Before this change these file paths couldn't be clicked on in most terminals since we were printing errors relative to the `__typecheck__` directory.