### PR TITLE
chore: upgrade qs to 6.14.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,6 +780,7 @@ catalogs:
 
 overrides:
   '@yarnpkg/fslib@2': '3'
+  '@cypress/request@3.0.9>qs': ^6.14.1
   body-parser@<2.2.1: ^2.2.1
   clipanion: 3.2.0-rc.6
   cookie@<0.7.0: '>=0.7.0'
@@ -802,6 +803,7 @@ overrides:
   path-to-regexp@<0.1.12: ^0.1.12
   path-to-regexp@>=4.0.0 <6.3.0: '>=6.3.0'
   path-to-regexp@>=7.0.0 <8.0.0: '>=8.0.0'
+  postman-request>qs: ^6.14.1
   request: npm:postman-request@2.88.1-postman.40
   semver@<7.5.2: ^7.7.2
   send@<0.19.0: ^0.19.0
@@ -15285,12 +15287,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -17521,7 +17519,7 @@ snapshots:
       json-stringify-safe: 5.0.1
       mime-types: 2.1.35
       performance-now: 2.1.0
-      qs: 6.14.0
+      qs: 6.14.1
       safe-buffer: 5.2.1
       tough-cookie: 5.1.2
       tunnel-agent: 0.6.0
@@ -20397,7 +20395,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.0
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -21625,7 +21623,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -24132,7 +24130,7 @@ snapshots:
       mime-types: 2.1.35
       oauth-sign: 0.9.0
       performance-now: 2.1.0
-      qs: 6.5.3
+      qs: 6.14.1
       safe-buffer: 5.2.1
       stream-length: 1.0.2
       uuid: 8.3.2
@@ -24281,11 +24279,9 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.5.3: {}
 
   quansync@0.2.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -354,6 +354,7 @@ optimisticRepeatInstall: true
 
 overrides:
   '@yarnpkg/fslib@2': '3'
+  '@cypress/request@3.0.9>qs': ^6.14.1
   body-parser@<2.2.1: '^2.2.1'
   clipanion: 3.2.0-rc.6
   cookie@<0.7.0: '>=0.7.0'
@@ -376,6 +377,7 @@ overrides:
   path-to-regexp@<0.1.12: ^0.1.12
   path-to-regexp@>=4.0.0 <6.3.0: '>=6.3.0'
   path-to-regexp@>=7.0.0 <8.0.0: '>=8.0.0'
+  postman-request>qs: ^6.14.1
   request: npm:postman-request@2.88.1-postman.40
   semver@<7.5.2: 'catalog:'
   send@<0.19.0: ^0.19.0

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -184,6 +184,7 @@
   "pnpm": {
     "overrides": {
       "@yarnpkg/fslib@2": "3",
+      "@cypress/request@3.0.9>qs": "^6.14.1",
       "body-parser@<2.2.1": "^2.2.1",
       "clipanion": "3.2.0-rc.6",
       "cookie@<0.7.0": ">=0.7.0",
@@ -206,6 +207,7 @@
       "path-to-regexp@<0.1.12": "^0.1.12",
       "path-to-regexp@>=4.0.0 <6.3.0": ">=6.3.0",
       "path-to-regexp@>=7.0.0 <8.0.0": ">=8.0.0",
+      "postman-request>qs": "^6.14.1",
       "request": "npm:postman-request@2.88.1-postman.40",
       "semver@<7.5.2": "^7.7.2",
       "send@<0.19.0": "^0.19.0",


### PR DESCRIPTION
Updating `qs` to address a security advisory: https://github.com/advisories/GHSA-6rw7-vpxm-498p