### PR TITLE
chore: disable optimistic repeat install in the pnpm repo

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -350,8 +350,6 @@ minimumReleaseAgeExclude:
 
 nodeVersion: 20.19.4
 
-optimisticRepeatInstall: true
-
 overrides:
   '@yarnpkg/fslib@2': '3'
   '@cypress/request@3.0.9>qs': ^6.14.1


### PR DESCRIPTION
I understand the value of dog fooding features, but this feature seems to have a lot of issues still. I run into a no-op `pnpm install` probably more than 30 times a day as I'm working in this repo.

Examples:

- https://github.com/pnpm/pnpm/issues/10393

Could we disable optimistic repeat install in this repo for now?