### PR TITLE
refactor: use `yaml` instead of `@yarnpkg/parsers` for `pnpm import`

### DIFF
--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -73,7 +73,6 @@
     "@pnpm/write-project-manifest": "workspace:*",
     "@yarnpkg/core": "catalog:",
     "@yarnpkg/lockfile": "catalog:",
-    "@yarnpkg/parsers": "catalog:",
     "@zkochan/rimraf": "catalog:",
     "@zkochan/table": "catalog:",
     "chalk": "catalog:",
@@ -87,7 +86,8 @@
     "ramda": "catalog:",
     "render-help": "catalog:",
     "version-selector-type": "catalog:",
-    "which": "catalog:"
+    "which": "catalog:",
+    "yaml": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -22,9 +22,9 @@ import renderHelp from 'render-help'
 import yarnLockfileLib from '@yarnpkg/lockfile'
 import { type LockFileObject } from '@yarnpkg/lockfile'
 import * as structUtils from '@yarnpkg/core/structUtils'
-import { parseSyml } from '@yarnpkg/parsers'
 import { recursive } from '../recursive.js'
 import { yarnLockFileKeyNormalizer } from './yarnUtil.js'
+import yaml from 'yaml'
 
 interface NpmPackageLock {
   dependencies: LockedPackagesMap
@@ -212,7 +212,7 @@ async function readYarnLockFile (dir: string): Promise<LockFileObject> {
 }
 
 function parseYarn2Lock (lockFileContents: string): YarnLock2Struct {
-  const parseYarnLock = parseSyml(lockFileContents)
+  const parseYarnLock = yaml.parse(lockFileContents)
 
   delete parseYarnLock.__metadata
   const dependencies: YarnPackageLock = {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,9 +249,6 @@ catalogs:
     '@yarnpkg/nm':
       specifier: 4.0.5
       version: 4.0.5
-    '@yarnpkg/parsers':
-      specifier: 3.0.3
-      version: 3.0.3
     '@yarnpkg/pnp':
       specifier: ^4.0.8
       version: 4.0.8
@@ -5987,9 +5984,6 @@ importers:
       '@yarnpkg/lockfile':
         specifier: 'catalog:'
         version: 1.1.0
-      '@yarnpkg/parsers':
-        specifier: 'catalog:'
-        version: 3.0.3
       '@zkochan/rimraf':
         specifier: 'catalog:'
         version: 3.0.2
@@ -6032,6 +6026,9 @@ importers:
       which:
         specifier: 'catalog:'
         version: '@pnpm/which@3.0.1'
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.1
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -141,7 +141,6 @@ catalog:
   '@yarnpkg/extensions': 2.0.3
   '@yarnpkg/lockfile': ^1.1.0
   '@yarnpkg/nm': 4.0.5
-  '@yarnpkg/parsers': 3.0.3
   '@yarnpkg/pnp': ^4.0.8
   '@zkochan/cmd-shim': ^7.0.0
   '@zkochan/diable': ^1.0.2
@@ -315,6 +314,7 @@ catalog:
   write-json5-file: ^3.1.0
   write-package: 7.2.0
   write-yaml-file: ^5.0.0
+  yaml: ^2.8.1
   yaml-tag: 1.1.0
   yazl: ^3.3.1
 


### PR DESCRIPTION
## Context

This PR supports a large migration to `js-yaml` and will merge into the feature branch here:

- https://github.com/pnpm/pnpm/pull/10392

## Changes

The `pnpm import` command currently calls `parseSyml` from `@yarnpkg/parsers`. I believe this function can be switched over to `yaml.parse` in a straightforward way.

The `parseSyml` function is a minimal wrapper around `js-yaml`'s `safeLoad` function.

https://github.com/yarnpkg/berry/blob/571363e6d64044b85a1f8885491c7f3b84c09f4b/packages/yarnpkg-parsers/sources/syml.ts#L138-L163

## Downsides

The downside is `@yarnpkg/parsers`'s functionality could change upstream in the future and we wouldn't be able to pick up that change as easily. However, I suspect breaks would only happen in a new `yarn.lock` format and we'd have to write new code to support that anyway.