### PR TITLE
build: patch out `@yarnpkg/parsers` export for yaml parsing

### DIFF
--- a/__patches__/@yarnpkg__parsers.patch
+++ b/__patches__/@yarnpkg__parsers.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/index.d.ts b/lib/index.d.ts
+index 40c8d389c5f81f60a496ce9792626b42c5bb06db..04103ca6f1b872804f8b1ec781cf251e96e70dac 100644
+--- a/lib/index.d.ts
++++ b/lib/index.d.ts
+@@ -3,4 +3,3 @@ export type { ArithmeticExpression, ArithmeticPrimary } from './grammars/shell';
+ export { parseShell, stringifyShell, stringifyArgument, stringifyArgumentSegment, stringifyArithmeticExpression, stringifyCommand, stringifyCommandChain, stringifyCommandChainThen, stringifyCommandLine, stringifyCommandLineThen, stringifyEnvSegment, stringifyRedirectArgument, stringifyShellLine, stringifyValueArgument, } from './shell';
+ export { parseResolution, stringifyResolution } from './resolution';
+ export type { Resolution } from './resolution';
+-export { parseSyml, stringifySyml } from './syml';
+diff --git a/lib/index.js b/lib/index.js
+index c2088ed779fcf248b5d0bc54a827c6a478d00696..3af5791f99545582caa10f20d7396a6d79a8ae8c 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -19,6 +19,3 @@ Object.defineProperty(exports, "stringifyValueArgument", { enumerable: true, get
+ var resolution_1 = require("./resolution");
+ Object.defineProperty(exports, "parseResolution", { enumerable: true, get: function () { return resolution_1.parseResolution; } });
+ Object.defineProperty(exports, "stringifyResolution", { enumerable: true, get: function () { return resolution_1.stringifyResolution; } });
+-var syml_1 = require("./syml");
+-Object.defineProperty(exports, "parseSyml", { enumerable: true, get: function () { return syml_1.parseSyml; } });
+-Object.defineProperty(exports, "stringifySyml", { enumerable: true, get: function () { return syml_1.stringifySyml; } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,6 +822,9 @@ patchedDependencies:
   '@yao-pkg/pkg':
     hash: ab0601976c8cb8df34650a3e9cb6bf5789ed5c381e473dcbda313b2511aa560e
     path: __patches__/pkg.patch
+  '@yarnpkg/parsers':
+    hash: 48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff
+    path: __patches__/@yarnpkg__parsers.patch
   graceful-fs@4.2.11:
     hash: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
     path: __patches__/graceful-fs@4.2.11.patch
@@ -19879,7 +19882,7 @@ snapshots:
       '@types/treeify': 1.0.3
       '@yarnpkg/fslib': 3.1.2
       '@yarnpkg/libzip': 3.2.1(@yarnpkg/fslib@3.1.2)
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.0.3(patch_hash=48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff)
       '@yarnpkg/shell': 4.1.2(typanion@3.14.0)
       camelcase: 5.3.1
       chalk: 3.0.0
@@ -19910,7 +19913,7 @@ snapshots:
       '@types/treeify': 1.0.3
       '@yarnpkg/fslib': 3.1.2
       '@yarnpkg/libzip': 3.2.1(@yarnpkg/fslib@3.1.2)
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.0.3(patch_hash=48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff)
       '@yarnpkg/shell': 4.1.2(typanion@3.14.0)
       camelcase: 5.3.1
       chalk: 3.0.0
@@ -19958,7 +19961,7 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/parsers@3.0.3':
+  '@yarnpkg/parsers@3.0.3(patch_hash=48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff)':
     dependencies:
       js-yaml: 3.14.2
       tslib: 2.8.1
@@ -19976,7 +19979,7 @@ snapshots:
   '@yarnpkg/shell@4.0.0(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/fslib': 3.1.2
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.0.3(patch_hash=48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff)
       chalk: 3.0.0
       clipanion: 3.2.0-rc.6(typanion@3.14.0)
       cross-spawn: 7.0.6
@@ -19989,7 +19992,7 @@ snapshots:
   '@yarnpkg/shell@4.1.2(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/fslib': 3.1.2
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.0.3(patch_hash=48d06b9f0cd769c001fc975241c4c4573d0cbe84df362f8ac6885d1c5019eaff)
       chalk: 3.0.0
       clipanion: 3.2.0-rc.6(typanion@3.14.0)
       cross-spawn: 7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -408,6 +408,7 @@ packageExtensions:
 patchedDependencies:
   '@pnpm/npm-lifecycle': __patches__/@pnpm__npm-lifecycle.patch
   '@yao-pkg/pkg': __patches__/pkg.patch
+  '@yarnpkg/parsers': __patches__/@yarnpkg__parsers.patch
   graceful-fs@4.2.11: __patches__/graceful-fs@4.2.11.patch
   mdast-util-to-string@2.0.0: __patches__/mdast-util-to-string@2.0.0.patch
 


### PR DESCRIPTION
## Context

This PR supports a large migration to `js-yaml` and will merge into the feature branch here:

- https://github.com/pnpm/pnpm/pull/10392

## Motivation

The `@yarnpkg/parsers` package introduces a dependency on `js-yaml` that's no longer needed with the changes in https://github.com/pnpm/pnpm/pull/10396.

Unfortunately it still gets included through the `./syml.js` file exported by the `index.js` of this package because esbuild doesn't tree-shake CommonJS modules.

## Changes

To prevent two copies of yaml libraries in pnpm's distribution, let's patch out this unused export.