### PR TITLE
feat: pass currentPkg to custom resolvers

### DIFF
--- a/hooks/types/src/index.ts
+++ b/hooks/types/src/index.ts
@@ -32,6 +32,12 @@ export interface ResolveOptions {
   lockfileDir: string
   projectDir: string
   preferredVersions: Record<string, string>
+  currentPkg?: {
+    id: string
+    resolution: Resolution
+    name?: string
+    version?: string
+  }
 }
 
 export interface ResolveResult {

--- a/pkg-manager/core/src/install/checkCustomResolverForceResolve.ts
+++ b/pkg-manager/core/src/install/checkCustomResolverForceResolve.ts
@@ -1,64 +1,33 @@
-import { type ProjectId, type ProjectManifest } from '@pnpm/types'
+import { parse as parseDepPath } from '@pnpm/dependency-path'
 import { type LockfileObject } from '@pnpm/lockfile.types'
 import { type CustomResolver, type WantedDependency, checkCustomResolverCanResolve } from '@pnpm/hooks.types'
 
-export interface ProjectWithManifest {
-  id: ProjectId
-  manifest: ProjectManifest
-}
-
-/**
- * Check if any custom resolver requires force re-resolution for dependencies in the lockfile.
- * This is a pure function extracted from the install flow for testability.
- *
- * @param customResolvers - Array of custom resolvers to check
- * @param wantedLockfile - Current lockfile
- * @param projects - Projects with their manifests
- * @returns Promise<boolean> - true if any custom resolver requires force re-resolution
- */
 export async function checkCustomResolverForceResolve (
   customResolvers: CustomResolver[],
-  wantedLockfile: LockfileObject,
-  projects: ProjectWithManifest[]
+  wantedLockfile: LockfileObject
 ): Promise<boolean> {
-  for (const project of projects) {
-    const allDeps = getAllDependenciesFromManifest(project.manifest)
+  if (!wantedLockfile.packages) return false
 
-    for (const [depName, bareSpec] of Object.entries(allDeps)) {
-      const wantedDependency: WantedDependency = {
-        alias: depName,
-        bareSpecifier: bareSpec,
-      }
+  for (const depPath of Object.keys(wantedLockfile.packages)) {
+    const { name: alias, version, nonSemverVersion } = parseDepPath(depPath)
+    if (!alias) continue
 
-      for (const customResolver of customResolvers) {
+    const wantedDependency: WantedDependency = {
+      alias,
+      bareSpecifier: version ?? nonSemverVersion,
+    }
+
+    for (const customResolver of customResolvers) {
+      // eslint-disable-next-line no-await-in-loop
+      const canResolve = await checkCustomResolverCanResolve(customResolver, wantedDependency)
+      if (canResolve && customResolver.shouldForceResolve) {
         // eslint-disable-next-line no-await-in-loop
-        const canResolve = await checkCustomResolverCanResolve(customResolver, wantedDependency)
-
-        if (canResolve && customResolver.shouldForceResolve) {
-          // eslint-disable-next-line no-await-in-loop
-          const shouldForce = await customResolver.shouldForceResolve(wantedDependency, wantedLockfile)
-
-          if (shouldForce) {
-            return true
-          }
+        if (await customResolver.shouldForceResolve(wantedDependency, wantedLockfile)) {
+          return true
         }
       }
     }
   }
 
   return false
-}
-
-function getAllDependenciesFromManifest (manifest: {
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  optionalDependencies?: Record<string, string>
-  peerDependencies?: Record<string, string>
-}): Record<string, string> {
-  return {
-    ...manifest.dependencies,
-    ...manifest.devDependencies,
-    ...manifest.optionalDependencies,
-    ...manifest.peerDependencies,
-  }
 }

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -334,11 +334,9 @@ export async function mutateModules (
     !opts.frozenLockfile &&
     opts.saveLockfile
   if (shouldCheckCustomResolverForceResolve) {
-    const projects = Object.values(ctx.projects).map(({ id, manifest }) => ({ id, manifest }))
     forceResolutionFromHook = await checkCustomResolverForceResolve(
       opts.hooks.customResolvers!,
-      ctx.wantedLockfile,
-      projects
+      ctx.wantedLockfile
     )
   }
 

--- a/pkg-manager/core/test/install/checkCustomResolverForceResolve.test.ts
+++ b/pkg-manager/core/test/install/checkCustomResolverForceResolve.test.ts
@@ -1,7 +1,6 @@
-import { checkCustomResolverForceResolve, type ProjectWithManifest } from '../../src/install/checkCustomResolverForceResolve.js'
+import { checkCustomResolverForceResolve } from '../../src/install/checkCustomResolverForceResolve.js'
 import { type CustomResolver } from '@pnpm/hooks.types'
 import { type LockfileObject } from '@pnpm/lockfile.types'
-import { type ProjectId } from '@pnpm/types'
 
 describe('checkCustomResolverForceResolve', () => {
   test('returns false when no custom resolvers provided', async () => {
@@ -9,14 +8,13 @@ describe('checkCustomResolverForceResolve', () => {
       lockfileVersion: '9.0',
       importers: {},
     }
-    const projects: ProjectWithManifest[] = []
 
-    const result = await checkCustomResolverForceResolve([], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([], lockfile)
 
     expect(result).toBe(false)
   })
 
-  test('returns false when no projects provided', async () => {
+  test('returns false when lockfile has no packages', async () => {
     const resolver: CustomResolver = {
       canResolve: () => true,
       shouldForceResolve: () => true,
@@ -26,7 +24,7 @@ describe('checkCustomResolverForceResolve', () => {
       importers: {},
     }
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, [])
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(false)
   })
@@ -38,31 +36,15 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(false)
   })
@@ -74,31 +56,15 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(false)
   })
@@ -110,31 +76,15 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(false)
   })
@@ -146,254 +96,35 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(true)
   })
 
-  test('checks devDependencies', async () => {
+  test('checks scoped packages', async () => {
     const resolver: CustomResolver = {
-      canResolve: (wantedDependency) => wantedDependency.alias === 'dev-pkg',
+      canResolve: (wantedDependency) => wantedDependency.alias === '@scope/pkg',
       shouldForceResolve: () => true,
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          devDependencies: {
-            'dev-pkg': '/dev-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/dev-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/dev-pkg-1.0.0.tgz', integrity: 'sha512-test' },
+        '@scope/pkg@1.0.0': {
+          resolution: { tarball: 'http://example.com/pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          devDependencies: {
-            'dev-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
-
-    expect(result).toBe(true)
-  })
-
-  test('checks optionalDependencies', async () => {
-    const resolver: CustomResolver = {
-      canResolve: (wantedDependency) => wantedDependency.alias === 'opt-pkg',
-      shouldForceResolve: () => true,
-    }
-    const lockfile: LockfileObject = {
-      lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          optionalDependencies: {
-            'opt-pkg': '/opt-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      packages: {
-        '/opt-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/opt-pkg-1.0.0.tgz', integrity: 'sha512-test' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          optionalDependencies: {
-            'opt-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    ]
-
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
-
-    expect(result).toBe(true)
-  })
-
-  test('checks peerDependencies', async () => {
-    const resolver: CustomResolver = {
-      canResolve: (wantedDependency) => wantedDependency.alias === 'peer-pkg',
-      shouldForceResolve: () => true,
-    }
-    const lockfile: LockfileObject = {
-      lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          peerDependencies: {
-            'peer-pkg': '/peer-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      packages: {
-        '/peer-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/peer-pkg-1.0.0.tgz', integrity: 'sha512-test' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          peerDependencies: {
-            'peer-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    ]
-
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
-
-    expect(result).toBe(true)
-  })
-
-  test('checks all dependency types together', async () => {
-    const resolver: CustomResolver = {
-      canResolve: () => true,
-      shouldForceResolve: (wantedDependency) => wantedDependency.alias === 'peer-pkg',
-    }
-    const lockfile: LockfileObject = {
-      lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'reg-pkg': '/reg-pkg@1.0.0',
-          },
-          devDependencies: {
-            'dev-pkg': '/dev-pkg@1.0.0',
-          },
-          optionalDependencies: {
-            'opt-pkg': '/opt-pkg@1.0.0',
-          },
-          peerDependencies: {
-            'peer-pkg': '/peer-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      packages: {
-        '/reg-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/reg-pkg@1.0.0.tgz', integrity: 'sha512-test1' },
-        },
-        '/dev-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/dev-pkg-1.0.0.tgz', integrity: 'sha512-test2' },
-        },
-        '/opt-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/opt-pkg-1.0.0.tgz', integrity: 'sha512-test3' },
-        },
-        '/peer-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/peer-pkg-1.0.0.tgz', integrity: 'sha512-test4' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'reg-pkg': '1.0.0',
-          },
-          devDependencies: {
-            'dev-pkg': '1.0.0',
-          },
-          optionalDependencies: {
-            'opt-pkg': '1.0.0',
-          },
-          peerDependencies: {
-            'peer-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    ]
-
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
-
-    expect(result).toBe(true)
-  })
-
-  test('handles multiple projects', async () => {
-    const resolver: CustomResolver = {
-      canResolve: (wantedDependency) => wantedDependency.alias === 'pkg-b',
-      shouldForceResolve: () => true,
-    }
-    const lockfile: LockfileObject = {
-      lockfileVersion: '9.0',
-      importers: {
-        'project-a': {
-          dependencies: {
-            'pkg-a': '/pkg-a@1.0.0',
-          },
-        },
-        'project-b': {
-          dependencies: {
-            'pkg-b': '/pkg-b@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      packages: {
-        '/pkg-a@1.0.0': {
-          resolution: { tarball: 'http://example.com/pkg-a-1.0.0.tgz', integrity: 'sha512-test1' },
-        },
-        '/pkg-b@1.0.0': {
-          resolution: { tarball: 'http://example.com/pkg-b-1.0.0.tgz', integrity: 'sha512-test2' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: 'project-a' as ProjectId,
-        manifest: {
-          dependencies: {
-            'pkg-a': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      {
-        id: 'project-b' as ProjectId,
-        manifest: {
-          dependencies: {
-            'pkg-b': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    ]
-
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(true)
   })
@@ -409,31 +140,15 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver1, resolver2], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver1, resolver2], lockfile)
 
     expect(result).toBe(true)
   })
@@ -448,31 +163,15 @@ describe('checkCustomResolverForceResolve', () => {
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(true)
   })
@@ -483,99 +182,38 @@ describe('checkCustomResolverForceResolve', () => {
       canResolve: () => true,
       shouldForceResolve: () => {
         callCount++
-        return callCount === 1 // First call returns true
+        return true // Always returns true
       },
     }
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            pkg1: '/pkg1@1.0.0',
-            pkg2: '/pkg2@1.0.0',
-            pkg3: '/pkg3@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/pkg1@1.0.0': {
+        'pkg1@1.0.0': {
           resolution: { tarball: 'http://example.com/pkg1-1.0.0.tgz', integrity: 'sha512-test1' },
         },
-        '/pkg2@1.0.0': {
+        'pkg2@1.0.0': {
           resolution: { tarball: 'http://example.com/pkg2-1.0.0.tgz', integrity: 'sha512-test2' },
         },
-        '/pkg3@1.0.0': {
+        'pkg3@1.0.0': {
           resolution: { tarball: 'http://example.com/pkg3-1.0.0.tgz', integrity: 'sha512-test3' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            pkg1: '1.0.0',
-            pkg2: '1.0.0',
-            pkg3: '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(result).toBe(true)
     expect(callCount).toBe(1) // Should stop after first true
-  })
-
-  test('returns false when custom resolver has no canResolve method', async () => {
-    const resolver: CustomResolver = {
-      // No canResolve method at all
-      shouldForceResolve: () => true,
-    }
-    const lockfile: LockfileObject = {
-      lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          dependencies: {
-            'test-pkg': '/test-pkg@1.0.0',
-          },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      packages: {
-        '/test-pkg@1.0.0': {
-          resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: {
-            'test-pkg': '1.0.0',
-          },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
-
-    const result = await checkCustomResolverForceResolve([resolver], lockfile, projects)
-
-    expect(result).toBe(false)
   })
 
   test('passes lockfile to shouldForceResolve', async () => {
     let receivedLockfile: LockfileObject | undefined
     const lockfile: LockfileObject = {
       lockfileVersion: '9.0',
-      importers: {
-        '.': {
-          specifiers: { 'test-pkg': '1.0.0' },
-          dependencies: { 'test-pkg': '1.0.0' },
-        },
-      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      importers: {},
       packages: {
-        '/test-pkg@1.0.0': {
+        'test-pkg@1.0.0': {
           resolution: { tarball: 'http://example.com/test-pkg-1.0.0.tgz', integrity: 'sha512-test' },
         },
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -587,17 +225,38 @@ describe('checkCustomResolverForceResolve', () => {
         return false
       },
     }
-    const projects: ProjectWithManifest[] = [
-      {
-        id: '.' as ProjectId,
-        manifest: {
-          dependencies: { 'test-pkg': '1.0.0' },
-        } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      },
-    ]
 
-    await checkCustomResolverForceResolve([resolver], lockfile, projects)
+    await checkCustomResolverForceResolve([resolver], lockfile)
 
     expect(receivedLockfile).toBe(lockfile)
+  })
+
+  test('checks indirect (transitive) dependencies', async () => {
+    const resolver: CustomResolver = {
+      canResolve: (wantedDependency) => wantedDependency.alias === 'indirect-pkg',
+      shouldForceResolve: () => true,
+    }
+    const lockfile: LockfileObject = {
+      lockfileVersion: '9.0',
+      importers: {
+        '.': {
+          specifiers: { 'direct-pkg': '1.0.0' },
+          dependencies: { 'direct-pkg': '1.0.0' },
+        },
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      packages: {
+        'direct-pkg@1.0.0': {
+          resolution: { tarball: 'http://example.com/direct-pkg-1.0.0.tgz', integrity: 'sha512-test1' },
+          dependencies: { 'indirect-pkg': '2.0.0' },
+        },
+        'indirect-pkg@2.0.0': {
+          resolution: { tarball: 'http://example.com/indirect-pkg-2.0.0.tgz', integrity: 'sha512-test2' },
+        },
+      } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+
+    const result = await checkCustomResolverForceResolve([resolver], lockfile)
+
+    expect(result).toBe(true)
   })
 })

--- a/pkg-manager/core/test/install/customResolvers.ts
+++ b/pkg-manager/core/test/install/customResolvers.ts
@@ -4,33 +4,28 @@ import { type CustomResolver } from '@pnpm/hooks.types'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import { testDefaults } from '../utils/index.js'
 
-// Test 1: Validate custom metadata flows through resolve() → lockfile
-// TODO: Unskip when fixed - tests timeout with "Jest environment has been torn down" errors during dependency resolution
-test.skip('custom resolver: metadata from resolve() is persisted to lockfile', async () => {
-  const project = prepareEmpty()
+// Integration tests for custom resolvers
+// These tests verify that custom resolvers work correctly in the full install flow
 
-  const resolveCallCount = { count: 0 }
-  const shouldForceResolveCallCount = { count: 0 }
-  let savedCachedAt: number | undefined
+// Test: Custom resolver is called during install
+test('custom resolver is called during install', async () => {
+  prepareEmpty()
 
-  // Custom resolver that wraps @pnpm.e2e/dep-of-pkg-with-1-dep and adds custom metadata
-  const timestampResolver: CustomResolver = {
+  let resolveCallCount = 0
+
+  const trackingResolver: CustomResolver = {
     canResolve: (descriptor) => {
       return descriptor.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep'
     },
 
-    resolve: async (descriptor, opts) => {
-      resolveCallCount.count++
-      const now = Date.now()
-      savedCachedAt = now
-
-      // Use standard npm resolution but add custom metadata
+    resolve: async () => {
+      resolveCallCount++
+      // Use the correct integrity for the actual package
       return {
         id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
         resolution: {
-          integrity: 'sha512-jPYrv4nLDd6nHrJWCAddqh+R+7WsbsU/lZ3tpDBQpjteXJVbSGSaicpkVQJp7lbVSvBJzdF+GKmqXvQXLv4rIg==',
+          integrity: 'sha512-atUXGBNAbym4OioYcKt1qTjiH23CSfZ1K2N8JgCUewSE5gY/i9YoK7Ez6+CuEZbH+O3R+HKNrRIaZfnkv/93tg==',
           tarball: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/dep-of-pkg-with-1-dep/-/dep-of-pkg-with-1-dep-100.0.0.tgz`,
-          cachedAt: now, // Custom metadata
         },
         manifest: {
           name: '@pnpm.e2e/dep-of-pkg-with-1-dep',
@@ -38,203 +33,80 @@ test.skip('custom resolver: metadata from resolve() is persisted to lockfile', a
         },
       }
     },
-
-    shouldForceResolve: (descriptor) => {
-      shouldForceResolveCallCount.count++
-      // Don't force re-resolution in this test
-      return false
-    },
   }
 
-  // First install - creates lockfile with custom metadata
-  const { updatedManifest: manifest } = await addDependenciesToPackage(
+  await addDependenciesToPackage(
     {},
     ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'],
     testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
+      customResolvers: [trackingResolver],
     })
   )
 
-  expect(resolveCallCount.count).toBe(1)
-  expect(shouldForceResolveCallCount.count).toBe(0) // Not called on first install
-
-  // Read lockfile to verify custom metadata was persisted
-  const lockfile = project.readLockfile()
-  const depPath = Object.keys(lockfile.packages ?? {})[0]
-  expect(depPath).toBeTruthy()
-  const pkgSnapshot = lockfile.packages?.[depPath]
-  expect((pkgSnapshot?.resolution as any)?.cachedAt).toBe(savedCachedAt) // eslint-disable-line @typescript-eslint/no-explicit-any
-
-  // Second install - reads from lockfile and calls shouldForceResolve
-  await addDependenciesToPackage(
-    manifest,
-    [],
-    testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
-    })
-  )
-
-  // On second install, shouldForceResolve should be called
-  expect(shouldForceResolveCallCount.count).toBe(1)
-  // resolve() should not be called again since shouldForceResolve returned false
-  expect(resolveCallCount.count).toBe(1)
-
-  // Verify custom metadata still in lockfile after second install
-  const lockfile2 = project.readLockfile()
-  const depPath2 = Object.keys(lockfile2.packages ?? {})[0]
-  const pkgSnapshot2 = lockfile2.packages?.[depPath2]
-  expect((pkgSnapshot2?.resolution as any)?.cachedAt).toBe(savedCachedAt) // eslint-disable-line @typescript-eslint/no-explicit-any
-})
-
-// Test 2: Validate custom resolver works for both fresh and cached installs
-// TODO: Unskip when fixed - tests timeout with "Jest environment has been torn down" errors during dependency resolution
-test.skip('custom resolver: works for fresh resolve() and lockfile resolutions', async () => {
-  const project = prepareEmpty()
-
-  let resolveCallCount = 0
-
-  // Custom resolver that wraps standard resolution but tracks calls
-  const timestampResolver: CustomResolver = {
-    canResolve: (descriptor) => {
-      return descriptor.alias === '@pnpm.e2e/pkg-with-1-dep'
-    },
-
-    resolve: async (descriptor, _opts) => {
-      resolveCallCount++
-      // Use standard npm resolution
-      return {
-        id: '@pnpm.e2e/pkg-with-1-dep@100.0.0',
-        resolution: {
-          integrity: 'sha512-1MYbHCSEbOwCLN6cERxVQcVH/W0dXIz9YSv6dBdq3CaWVqx11tMwFt6o7gPBs/r2eDxPEz+CDNT/ZFNYNt78wg==',
-          tarball: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/pkg-with-1-dep/-/pkg-with-1-dep-100.0.0.tgz`,
-        },
-        manifest: {
-          name: '@pnpm.e2e/pkg-with-1-dep',
-          version: '100.0.0',
-        },
-      }
-    },
-  }
-
-  // First install - fresh resolution, custom resolver should be used
-  const { updatedManifest: manifest } = await addDependenciesToPackage(
-    {},
-    ['@pnpm.e2e/pkg-with-1-dep@100.0.0'],
-    testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
-    })
-  )
-
-  // Verify custom resolver resolve was called for fresh resolution
   expect(resolveCallCount).toBe(1)
-
-  project.has('@pnpm.e2e/pkg-with-1-dep')
-
-  // Second install - should read from lockfile
-  resolveCallCount = 0
-  await addDependenciesToPackage(
-    manifest,
-    [],
-    testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
-    })
-  )
-
-  // Verify custom resolver resolve was not called again (using cached lockfile)
-  expect(resolveCallCount).toBe(0)
-
-  project.has('@pnpm.e2e/pkg-with-1-dep')
 })
 
-// Test 3: Validate shouldForceResolve can trigger re-resolution
-// TODO: Unskip when fixed - tests timeout with "Jest environment has been torn down" errors during dependency resolution
-test.skip('custom resolver: shouldForceResolve=true triggers re-resolution', async () => {
-  const project = prepareEmpty()
+// Test: Custom resolver receives currentPkg on subsequent installs
+test('custom resolver receives currentPkg on subsequent installs', async () => {
+  prepareEmpty()
 
   let resolveCallCount = 0
-  let shouldForceReturn = false
+  let receivedCurrentPkg: unknown = null
 
-  const timestampResolver: CustomResolver = {
+  const trackingResolver: CustomResolver = {
     canResolve: (descriptor) => {
-      return descriptor.alias === '@pnpm.e2e/foo'
+      return descriptor.alias === '@pnpm.e2e/dep-of-pkg-with-1-dep'
     },
 
-    resolve: async (descriptor, _opts) => {
+    resolve: async (_descriptor, opts) => {
       resolveCallCount++
+      receivedCurrentPkg = opts.currentPkg
+
+      // If we have currentPkg, return the existing resolution
+      if (opts.currentPkg) {
+        return {
+          id: opts.currentPkg.id,
+          resolution: opts.currentPkg.resolution,
+        }
+      }
 
       return {
-        id: `@pnpm.e2e/foo@100.${resolveCallCount}.0`,
+        id: '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
         resolution: {
-          integrity: 'sha512-c3bT3gLTuSRfC0pbs4TgMGjeN1t7eJGwb2vWVx/zUYJp+CsVj3cMNWPanEjahorIUXpW/senCGjMHfyFWLiM4Q==',
-          tarball: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/foo/-/foo-100.0.0.tgz`,
-          resolveCount: resolveCallCount, // Track how many times resolve was called
+          integrity: 'sha512-atUXGBNAbym4OioYcKt1qTjiH23CSfZ1K2N8JgCUewSE5gY/i9YoK7Ez6+CuEZbH+O3R+HKNrRIaZfnkv/93tg==',
+          tarball: `http://localhost:${REGISTRY_MOCK_PORT}/@pnpm.e2e/dep-of-pkg-with-1-dep/-/dep-of-pkg-with-1-dep-100.0.0.tgz`,
         },
         manifest: {
-          name: '@pnpm.e2e/foo',
+          name: '@pnpm.e2e/dep-of-pkg-with-1-dep',
           version: '100.0.0',
         },
       }
-    },
-
-    shouldForceResolve: () => {
-      return shouldForceReturn
     },
   }
 
   // First install
-  const { updatedManifest: manifest1 } = await addDependenciesToPackage(
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
     {},
-    ['@pnpm.e2e/foo@100.0.0'],
+    ['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'],
     testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
+      customResolvers: [trackingResolver],
     })
   )
 
   expect(resolveCallCount).toBe(1)
+  expect(receivedCurrentPkg).toBeUndefined()
 
-  // Second install with shouldForceResolve returning false
-  shouldForceReturn = false
-  const { updatedManifest: manifest2 } = await addDependenciesToPackage(
-    manifest1,
-    [],
-    testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
-    })
-  )
-
-  // resolve() should not be called again
-  expect(resolveCallCount).toBe(1)
-
-  // Third install with shouldForceResolve returning true
-  shouldForceReturn = true
+  // Second install - should receive currentPkg
+  receivedCurrentPkg = null
   await addDependenciesToPackage(
-    manifest2,
+    manifest,
     [],
     testDefaults({
-      hooks: {
-        customResolvers: [timestampResolver],
-      },
+      customResolvers: [trackingResolver],
     })
   )
 
-  // resolve() should be called again due to forced re-resolution
   expect(resolveCallCount).toBe(2)
-
-  // Verify lockfile was updated with new resolveCount
-  const lockfile = project.readLockfile()
-  const depPath = Object.keys(lockfile.packages ?? {})[0]
-  const pkgSnapshot = lockfile.packages?.[depPath]
-  expect((pkgSnapshot?.resolution as any)?.resolveCount).toBe(2) // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(receivedCurrentPkg).toBeTruthy()
+  expect((receivedCurrentPkg as any).id).toBe('@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0') // eslint-disable-line @typescript-eslint/no-explicit-any
 })

--- a/pkg-manager/core/test/utils/testDefaults.ts
+++ b/pkg-manager/core/test/utils/testDefaults.ts
@@ -3,6 +3,7 @@ import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import { type StoreController } from '@pnpm/store-controller-types'
 import { type Registries } from '@pnpm/types'
 import { type InstallOptions } from '@pnpm/core'
+import { type CustomResolver } from '@pnpm/hooks.types'
 
 const registry = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
@@ -12,6 +13,7 @@ export function testDefaults<T> (
     storeDir?: string
     prefix?: string
     registries?: Registries
+    customResolvers?: CustomResolver[]
   },
   resolveOpts?: any, // eslint-disable-line
   fetchOpts?: any, // eslint-disable-line
@@ -28,6 +30,7 @@ export function testDefaults<T> (
     ...opts,
     clientOptions: {
       ...(opts?.registries != null ? { registries: opts.registries } : {}),
+      customResolvers: opts?.customResolvers,
       ...resolveOpts,
       ...fetchOpts,
     },

--- a/resolving/default-resolver/src/index.ts
+++ b/resolving/default-resolver/src/index.ts
@@ -71,6 +71,7 @@ async function resolveFromCustomResolvers (
         lockfileDir: opts.lockfileDir,
         projectDir: opts.projectDir,
         preferredVersions: (opts.preferredVersions ?? {}) as unknown as Record<string, string>,
+        currentPkg: opts.currentPkg,
       })
       return {
         ...result,


### PR DESCRIPTION
Previous discussion: #10342

This PR builds on the approach in #10439 of moving the skip resolution logic from the package requester into the resolvers themselves. The main difference is that `checkCustomResolverForceResolve` iterates over the lockfile, not the package manifests, so that the custom resolvers for subdependencies have the option to force full resolution.