### PR TITLE
fix: remove redundant ports from registry URL during normalization

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,8 +520,8 @@ catalogs:
       specifier: ^3.0.0
       version: 3.0.0
     normalize-registry-url:
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 2.0.1
+      version: 2.0.1
     npm-packlist:
       specifier: 5.1.3
       version: 5.1.3
@@ -1708,7 +1708,7 @@ importers:
         version: 4.1.1
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       path-absolute:
         specifier: 'catalog:'
         version: 1.0.1
@@ -1865,7 +1865,7 @@ importers:
         version: link:../../packages/types
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -14650,6 +14650,9 @@ packages:
   normalize-registry-url@2.0.0:
     resolution: {integrity: sha512-3e9FwDyRAhbxXw4slm4Tjv40u78yPwMc/WZkACpqNQOs5sM7wic853AeTLkMFEVhivZkclGYlse8iYsklz0Yvg==}
 
+  normalize-registry-url@2.0.1:
+    resolution: {integrity: sha512-Ad5kiOvJFA62l6bkzuekf3AbEyCPweePeGIfU9iHtqem68EVKu2Tr6YM+xmO1dkwTzKgTCqzb3NqfIEtWWbQBg==}
+
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
@@ -23811,6 +23814,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-registry-url@2.0.0: {}
+
+  normalize-registry-url@2.0.1: {}
 
   normalize-url@6.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -232,7 +232,7 @@ catalog:
   normalize-newline: 4.1.0
   normalize-package-data: ^8.0.0
   normalize-path: ^3.0.0
-  normalize-registry-url: 2.0.0
+  normalize-registry-url: 2.0.1
   npm-packlist: 5.1.3
   object-hash: 3.0.0
   p-defer: ^4.0.1
@@ -334,14 +334,15 @@ managePackageManagerVersions: true
 minimumReleaseAge: 1440 # At least a day
 
 minimumReleaseAgeExclude:
+  - '@pnpm/*'
   - body-parser@2.2.1
   - express@4.22.1
-  - pnpm
-  - '@pnpm/*'
-  - parse-npm-tarball-url@4.0.0
-  - publish-packed@5.0.0
   - glob@11.1.0
   - jws@3.2.3
+  - normalize-registry-url
+  - parse-npm-tarball-url@4.0.0
+  - pnpm
+  - publish-packed@5.0.0
   - run-groups@4.0.0
 
 nodeVersion: 20.19.4


### PR DESCRIPTION
Related fix: https://github.com/pnpm/normalize-registry-url/commit/805484aaddd2e711764fb43c7b3db0b4db48b883