### PR TITLE
fix(config): do not crash when env variable is not defined in pnpm-workspace.yaml

### DIFF
--- a/.changeset/friendly-waves-smile.md
+++ b/.changeset/friendly-waves-smile.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config": patch
+---
+
+Do not crash when an environment variable referenced in `pnpm-workspace.yaml` is not defined. Instead, a warning is logged and the original value is preserved.

--- a/config/config/src/getOptionsFromRootManifest.ts
+++ b/config/config/src/getOptionsFromRootManifest.ts
@@ -87,10 +87,23 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
 function replaceEnvInSettings (settings: PnpmSettings): PnpmSettings {
   const newSettings: PnpmSettings = {}
   for (const [key, value] of Object.entries(settings)) {
-    const newKey = envReplace(key, process.env)
+    let newKey: string
+    try {
+      newKey = envReplace(key, process.env)
+    } catch (err) {
+      globalWarn((err as Error).message)
+      newKey = key
+    }
     if (typeof value === 'string') {
+      let newValue: string
+      try {
+        newValue = envReplace(value, process.env)
+      } catch (err) {
+        globalWarn((err as Error).message)
+        newValue = value
+      }
       // @ts-expect-error
-      newSettings[newKey as keyof PnpmSettings] = envReplace(value, process.env)
+      newSettings[newKey as keyof PnpmSettings] = newValue
     } else {
       newSettings[newKey as keyof PnpmSettings] = value
     }

--- a/config/config/test/getOptionsFromRootManifest.test.ts
+++ b/config/config/test/getOptionsFromRootManifest.test.ts
@@ -193,3 +193,23 @@ test('getOptionsFromRootManifest() converts allowBuilds', () => {
     },
   })
 })
+
+test('getOptionsFromPnpmSettings() warns and keeps original value when env variable is not defined', () => {
+  delete process.env.UNDEFINED_TEST_VAR
+
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    ignoreScripts: '${UNDEFINED_TEST_VAR}', // eslint-disable-line
+  } as any) as any // eslint-disable-line
+
+  expect(options.ignoreScripts).toBe('${UNDEFINED_TEST_VAR}') // eslint-disable-line
+})
+
+test('getOptionsFromPnpmSettings() supports env variable default value syntax', () => {
+  delete process.env.UNDEFINED_TEST_VAR_WITH_DEFAULT
+
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    ignoreScripts: '${UNDEFINED_TEST_VAR_WITH_DEFAULT:-false}', // eslint-disable-line
+  } as any) as any // eslint-disable-line
+
+  expect(options.ignoreScripts).toBe('false')
+})


### PR DESCRIPTION
## Summary                                                                                                         
                                                                                                                       
This PR fixes #10300.                                                                                               
                                                                                                                   
When an environment variable referenced in `pnpm-workspace.yaml` is not defined 
(e.g., `ignoreScripts: ${MEND_HOSTED}`), pnpm previously crashed with an error:                                                            
                                                                                                                   
```                                                                                                                 
ERROR  Failed to replace env in config: ${MEND_HOSTED}                                                              
For help, run: pnpm help install                                                                                    
```                                                                                                                 
                                                                                                                   
This was problematic because even `pnpm help` would crash, leaving users in a deadlock situation where they         
couldn't even access help documentation.                                                                            
                                                                                                                   
## Changes                                                                                                          
                                                                                                                   
- Modified `replaceEnvInSettings` function in `config/config/src/getOptionsFromRootManifest.ts`                     
- Added try-catch around `envReplace` calls to gracefully handle undefined environment variables                    
- When an env variable is not found, a warning is logged (instead of throwing an error) and the original value is   
preserved                                                                                                          
- Added test cases to verify the fix                                                                                
                                                                                                                   
## Before & After                                                                                                   
                                                                                                                   
| Command | Before | After |                                                                                        
|---------|--------|-------|                                                                                        
| `pnpm install` | ❌ `ERROR` + crash | ✅ `WARN` + continues |                                                     
| `pnpm help` | ❌ `ERROR` + crash | ✅ `WARN` + shows help |         


 #### After fix - `pnpm install`                                                                                      
                                                                                                                       
```                                                                                                                 
WARN  Failed to replace env in config: ${MEND_HOSTED}                                                              
No projects found in "/private/tmp/pnpm-test-10300"                                                                 
```                                                                                                                 
                                                                                                                       
 #### After fix - `pnpm help`                                                                                         
                                                                                                                     
```                                                                                                                 
WARN  Failed to replace env in config: ${MEND_HOSTED}                                                              
Version 11.0.0-alpha.2 (compiled to binary; bundled Node.js v22.20.0)                                               
Usage: pnpm [command] [flags]                                                                                       
      pnpm [ -h | --help | -v | --version ]                                                                        
                                                                                                                     
These are common pnpm commands used in various situations...                                                        
```                                                                                                           
                                                                                                                   
## Test plan                                                                                                        
                                                                                                                   
- [x] Added unit tests for undefined env variable handling                                                          
- [x] Added unit tests for `${VAR:-default}` fallback syntax (already supported by `@pnpm/config.env-replace`)      
- [x] Verified manually that `pnpm install` and `pnpm help` work with undefined env variables                       
                                                                                                                   
## Notes                                                                                                            
                                                                                                                   
- The `${VAR:-default}` fallback syntax was already supported by the `@pnpm/config.env-replace` package             
- This fix aligns the behavior of `pnpm-workspace.yaml` with `.npmrc`, which already handles undefined env          
variables 


closes #10300                                                                                               
                                                                                                                   
Thank you for reviewing! 🙏                        