### PR TITLE
ci: cancel outdated PR CI runs to reduce redundant matrix executions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,9 @@ jobs:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.platform }}
       cancel-in-progress: true
-
-
+      
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What
- Scope CI concurrency to PRs instead of individual matrix jobs

### Why
- Prevents redundant matrix executions when PRs are updated
- Ensures only the latest commit is tested
- Reduces CI load without changing test behavior
