### PR TITLE
fix(global): preserve build approvals and dlx behavior

### DIFF
--- a/.changeset/tiny-shoes-fold.md
+++ b/.changeset/tiny-shoes-fold.md
@@ -1,7 +1,9 @@
 ---
 "@pnpm/plugin-commands-installation": patch
 "@pnpm/plugin-commands-script-runners": patch
+"@pnpm/core": patch
 "pnpm": patch
 ---
 
-Fix global build approvals persistence and allow `pnpm dlx` to run when `dangerouslyAllowAllBuilds` is enabled.
+Fix global build approvals persistence, improve the approve-builds hint for global installs,
+and allow `pnpm dlx` to run when `dangerouslyAllowAllBuilds` is enabled.

--- a/.changeset/tiny-shoes-fold.md
+++ b/.changeset/tiny-shoes-fold.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+Fix global build approvals persistence and allow `pnpm dlx` to run when `dangerouslyAllowAllBuilds` is enabled.

--- a/exec/plugin-commands-script-runners/test/utils/index.ts
+++ b/exec/plugin-commands-script-runners/test/utils/index.ts
@@ -68,6 +68,7 @@ export const DLX_DEFAULT_OPTS = {
   bail: false,
   bin: 'node_modules/.bin',
   cacheDir: path.join(tmp, 'cache'),
+  dangerouslyAllowAllBuilds: false,
   excludeLinksFromLockfile: false,
   extraEnv: {},
   extraBinPaths: [],

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1731,10 +1731,11 @@ async function linkAllBins (
 }
 
 export class IgnoredBuildsError extends PnpmError {
-  constructor (ignoredBuilds: IgnoredBuilds) {
+  constructor (ignoredBuilds: IgnoredBuilds, opts?: { global?: boolean }) {
     const packageNames = dedupePackageNamesFromIgnoredBuilds(ignoredBuilds)
+    const globalFlag = opts?.global ? ' -g' : ''
     super('IGNORED_BUILDS', `Ignored build scripts: ${packageNames.join(', ')}`, {
-      hint: 'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.',
+      hint: `Run "pnpm approve-builds${globalFlag}" to pick which dependencies should be allowed to run scripts.`,
     })
   }
 }

--- a/pkg-manager/core/test/install/ignoredBuildsHint.ts
+++ b/pkg-manager/core/test/install/ignoredBuildsHint.ts
@@ -1,0 +1,20 @@
+import { type DepPath } from '@pnpm/types'
+import { IgnoredBuildsError } from '../../src/install/index.js'
+
+test('ignored builds hint includes -g for global installs', () => {
+  const ignoredBuilds = new Set<DepPath>(['esbuild@0.27.2' as DepPath])
+  const error = new IgnoredBuildsError(ignoredBuilds, { global: true })
+
+  expect(error.hint).toBe(
+    'Run "pnpm approve-builds -g" to pick which dependencies should be allowed to run scripts.'
+  )
+})
+
+test('ignored builds hint omits -g for non-global installs', () => {
+  const ignoredBuilds = new Set<DepPath>(['esbuild@0.27.2' as DepPath])
+  const error = new IgnoredBuildsError(ignoredBuilds)
+
+  expect(error.hint).toBe(
+    'Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.'
+  )
+})

--- a/pkg-manager/plugin-commands-installation/src/add.ts
+++ b/pkg-manager/plugin-commands-installation/src/add.ts
@@ -271,7 +271,9 @@ export async function handler (
         })
       }
     }
-    const allowBuilds: Record<string, boolean> = {}
+    const allowBuilds: Record<string, boolean | string> = {
+      ...opts.allowBuilds,
+    }
     for (const pkg of opts.allowBuild) {
       allowBuilds[pkg] = true
     }

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -358,7 +358,7 @@ when running add/update with the --workspace option')
       })
     }
     if (opts.strictDepBuilds && ignoredBuilds?.size) {
-      throw new IgnoredBuildsError(ignoredBuilds)
+      throw new IgnoredBuildsError(ignoredBuilds, { global: opts.global })
     }
     return
   }
@@ -383,7 +383,7 @@ when running add/update with the --workspace option')
     ])
   }
   if (opts.strictDepBuilds && ignoredBuilds?.size) {
-    throw new IgnoredBuildsError(ignoredBuilds)
+    throw new IgnoredBuildsError(ignoredBuilds, { global: opts.global })
   }
 
   if (opts.linkWorkspacePackages && opts.workspaceDir) {

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -334,13 +334,17 @@ when running add/update with the --workspace option')
     }
     const { updatedCatalogs, updatedProject, ignoredBuilds } = await mutateModulesInSingleProject(mutatedProject, installOpts)
     if (opts.save !== false) {
-      await Promise.all([
-        writeProjectManifest(updatedProject.manifest),
-        updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+      const shouldUpdateWorkspaceManifest = opts.workspaceDir != null || !opts.global
+      const updateWorkspaceManifestPromise = shouldUpdateWorkspaceManifest
+        ? updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
           updatedCatalogs,
           cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
           allProjects: opts.allProjects,
-        }),
+        })
+        : Promise.resolve()
+      await Promise.all([
+        writeProjectManifest(updatedProject.manifest),
+        updateWorkspaceManifestPromise,
       ])
     }
     if (!opts.lockfileOnly) {
@@ -365,13 +369,17 @@ when running add/update with the --workspace option')
     updateMatching,
   })
   if (opts.update === true && opts.save !== false) {
-    await Promise.all([
-      writeProjectManifest(updatedManifest),
-      updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+    const shouldUpdateWorkspaceManifest = opts.workspaceDir != null || !opts.global
+    const updateWorkspaceManifestPromise = shouldUpdateWorkspaceManifest
+      ? updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
         updatedCatalogs,
         cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
         allProjects,
-      }),
+      })
+      : Promise.resolve()
+    await Promise.all([
+      writeProjectManifest(updatedManifest),
+      updateWorkspaceManifestPromise,
     ])
   }
   if (opts.strictDepBuilds && ignoredBuilds?.size) {

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -58,6 +58,7 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'configDependencies'
 | 'dedupePeerDependents'
 | 'depth'
+| 'global'
 | 'globalPnpmfile'
 | 'hoistPattern'
 | 'hooks'
@@ -307,7 +308,7 @@ export async function recursive (
       await Promise.all(promises)
     }
     if (opts.strictDepBuilds && ignoredBuilds?.size) {
-      throw new IgnoredBuildsError(ignoredBuilds)
+      throw new IgnoredBuildsError(ignoredBuilds, { global: opts.global })
     }
     return true
   }
@@ -427,7 +428,7 @@ export async function recursive (
           }
         }
         if (opts.strictDepBuilds && ignoredBuilds?.size) {
-          throw new IgnoredBuildsError(ignoredBuilds)
+          throw new IgnoredBuildsError(ignoredBuilds, { global: opts.global })
         }
         result[rootDir].status = 'passed'
       } catch (err: any) { // eslint-disable-line

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -132,6 +132,7 @@ export async function handler (
   | 'configDependencies'
   | 'dev'
   | 'engineStrict'
+  | 'global'
   | 'globalPnpmfile'
   | 'hooks'
   | 'ignorePnpmfile'
@@ -235,8 +236,10 @@ export async function handler (
       }
     }
   }
-  await updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
-    cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
-    allProjects: updatedProjects,
-  })
+  if (opts.workspaceDir != null || !opts.global) {
+    await updateWorkspaceManifest(opts.workspaceDir ?? opts.dir, {
+      cleanupUnusedCatalogs: opts.cleanupUnusedCatalogs,
+      allProjects: updatedProjects,
+    })
+  }
 }

--- a/pnpm/test/dlx.ts
+++ b/pnpm/test/dlx.ts
@@ -79,6 +79,29 @@ test('dlx ignores configuration in current project package.json', async () => {
   })
 })
 
+test('dlx does not fail when dangerouslyAllowAllBuilds is true', async () => {
+  prepareEmpty()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(global)
+
+  const env = {
+    [PATH_NAME]: `${pnpmHome}${path.delimiter}${process.env[PATH_NAME]}`,
+    PNPM_HOME: pnpmHome,
+    XDG_DATA_HOME: global,
+  }
+
+  const result = execPnpmSync([
+    '--config.dangerously-allow-all-builds=true',
+    'dlx',
+    'shx@0.3.4',
+    'echo',
+    'hi',
+  ], { env, expectSuccess: true })
+
+  expect(result.stdout.toString().trim()).toBe('hi')
+})
+
 test('dlx should work with npm_config_save_dev env variable', async () => {
   prepareEmpty()
   execPnpmSync(['dlx', '@foo/touch-file-one-bin@latest'], {


### PR DESCRIPTION
> [!IMPORTANT]  
> **Full disclosure** : Most of the code here has been written by GPT 5.2 Codex.  
> Please review the changes to see if there is any glaring mistake or flaw in the implementation 🙏

## Summary
- preserve global build approvals and avoid rewriting global workspace manifests
- allow `pnpm dlx` when `dangerouslyAllowAllBuilds` is enabled
- improve global ignored-builds hint and add tests for that

## Details
1. When running `pnpm approve-builds -g` (after a `pnpm up -L -g` for instance), any existing entry in `allowBuilds` won't be overwritten or just removed from either the global `pnpm-workspace.yaml` or `pnpm` key in the global `package.json`
2. When running `pnpm config set dangerouslyAllowAllBuilds true` followed by a `pnpm dlx` command, we will no longer see the `CONFIG_CONFLICT_BUILT_DEPENDENCIES` error
3. When installing/updating a global dependency, the message thrown by `IgnoredBuildsError` will indicate to run `pnpm approve-builds` with the `-g` flag (was that a regression of v11 ? I believe it was present before in v10 iirc)

## Issues
Closes pnpm/pnpm#10121
Closes pnpm/pnpm#8891
