### PR TITLE
fix: prevent path traversal in `directories.bin`

### DIFF
--- a/.changeset/fix-directories-bin-path-traversal.md
+++ b/.changeset/fix-directories-bin-path-traversal.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/package-bins": patch
+"pnpm": patch
+---
+
+Security fix: prevent path traversal in `directories.bin` field.

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "@pnpm/package-bins": "workspace:*",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "tempy": "catalog:"
   },
   "engines": {
     "node": ">=20.19"

--- a/pkg-manager/package-bins/src/index.ts
+++ b/pkg-manager/package-bins/src/index.ts
@@ -14,6 +14,10 @@ export async function getBinsFromPackageManifest (manifest: DependencyManifest, 
   }
   if (manifest.directories?.bin) {
     const binDir = path.join(pkgPath, manifest.directories.bin)
+    // Validate: directories.bin must be within the package root
+    if (!isSubdir(pkgPath, binDir)) {
+      return []
+    }
     const files = await findFiles(binDir)
     return files.map((file) => ({
       name: path.basename(file),

--- a/pkg-manager/package-bins/test/index.ts
+++ b/pkg-manager/package-bins/test/index.ts
@@ -144,3 +144,25 @@ test('skip scoped bin names with path traversal', async () => {
     },
   ])
 })
+
+test('skip directories.bin with path traversal', async () => {
+  // Security test: malicious packages can try to escape the package root
+  // using directories.bin to chmod files at arbitrary locations
+  expect(
+    await getBinsFromPackageManifest({
+      name: 'malicious',
+      version: '1.0.0',
+      directories: {
+        bin: '../../../../tmp/target',
+      },
+    }, process.cwd())).toStrictEqual([])
+
+  expect(
+    await getBinsFromPackageManifest({
+      name: 'malicious',
+      version: '1.0.0',
+      directories: {
+        bin: '../../../etc',
+      },
+    }, process.cwd())).toStrictEqual([])
+})

--- a/pkg-manager/package-bins/test/path-traversal.test.ts
+++ b/pkg-manager/package-bins/test/path-traversal.test.ts
@@ -1,0 +1,32 @@
+
+import fs from 'fs'
+import path from 'path'
+import { getBinsFromPackageManifest } from '@pnpm/package-bins'
+import { temporaryDirectory } from 'tempy'
+
+test('skip directories.bin with real path traversal', async () => {
+  // Create a secret file outside the package directory
+  const tempDir = temporaryDirectory()
+  const secretDir = path.join(tempDir, 'secret')
+  fs.mkdirSync(secretDir)
+  fs.writeFileSync(path.join(secretDir, 'secret.sh'), 'echo secret')
+
+  // Create a package directory
+  const pkgDir = path.join(tempDir, 'pkg')
+  fs.mkdirSync(pkgDir)
+
+  // Calculate relative path from pkgDir to secretDir
+  const relativePath = path.relative(pkgDir, secretDir)
+
+  // Attempt path traversal
+  const bins = await getBinsFromPackageManifest({
+    name: 'malicious',
+    version: '1.0.0',
+    directories: {
+      bin: relativePath,
+    },
+  }, pkgDir)
+
+  // Should be empty because it escaped pkgDir
+  expect(bins).toStrictEqual([])
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,7 +428,7 @@ catalogs:
       version: 2.0.0
     ini:
       specifier: 6.0.0
-      version: 5.0.0
+      version: 6.0.0
     is-gzip:
       specifier: 2.0.0
       version: 2.0.0
@@ -659,7 +659,7 @@ catalogs:
       version: 4.2.0
     ssri:
       specifier: 13.0.0
-      version: 12.0.0
+      version: 13.0.0
     stacktracey:
       specifier: ^2.1.8
       version: 2.1.8
@@ -3366,7 +3366,7 @@ importers:
         version: 13.3.4
       ssri:
         specifier: 'catalog:'
-        version: 12.0.0
+        version: 13.0.0
       tempy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -5235,7 +5235,7 @@ importers:
         version: 7.0.0
       write-json-file:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 7.0.0
       write-yaml-file:
         specifier: 'catalog:'
         version: 5.0.0
@@ -5487,7 +5487,7 @@ importers:
         version: 3.0.0
       write-json-file:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 7.0.0
 
   pkg-manager/hoist:
     dependencies:
@@ -5715,6 +5715,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.15.30
+      tempy:
+        specifier: 'catalog:'
+        version: 3.0.0
 
   pkg-manager/package-requester:
     dependencies:
@@ -6088,7 +6091,7 @@ importers:
         version: 3.0.0
       write-json-file:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 7.0.0
       write-package:
         specifier: 'catalog:'
         version: 7.2.0
@@ -6767,7 +6770,7 @@ importers:
         version: 7.1.0
       ini:
         specifier: 'catalog:'
-        version: 5.0.0
+        version: 6.0.0
       is-windows:
         specifier: 'catalog:'
         version: 1.0.2
@@ -6818,7 +6821,7 @@ importers:
         version: 1.2.2
       write-json-file:
         specifier: 'catalog:'
-        version: 6.0.0
+        version: 7.0.0
       write-package:
         specifier: 'catalog:'
         version: 7.2.0
@@ -8397,7 +8400,7 @@ importers:
         version: safe-execa@0.2.0
       ssri:
         specifier: 'catalog:'
-        version: 12.0.0
+        version: 13.0.0
       tempy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -13354,10 +13357,6 @@ packages:
   ini@4.1.1:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  ini@5.0.0:
-    resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   ini@6.0.0:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
@@ -22134,8 +22133,6 @@ snapshots:
   ini@3.0.1: {}
 
   ini@4.1.1: {}
-
-  ini@5.0.0: {}
 
   ini@6.0.0: {}
 


### PR DESCRIPTION
by validating the bin directory is a subdirectory of the package root and adding relevant tests.