### PR TITLE
fix: remove the prefix for view version info

### DIFF
--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -158,7 +158,7 @@ function formatNoMatchingVersion (err: Error, msg: { packageMeta: PackageMeta, i
     }
   }
 
-  output += `${EOL}If you need the full list of all ${Object.keys(meta.versions).length} published versions run "$ pnpm view ${meta.name} versions".`
+  output += `${EOL}If you need the full list of all ${Object.keys(meta.versions).length} published versions run "pnpm view ${meta.name} versions".`
 
   if (msg.immatureVersion) {
     output += `${EOL}${EOL}If you want to install the matched version ignoring the time it was published, you can add the package name to the minimumReleaseAgeExclude setting. Read more about it: https://pnpm.io/settings#minimumreleaseageexclude`

--- a/cli/default-reporter/test/reportingErrors.ts
+++ b/cli/default-reporter/test/reportingErrors.ts
@@ -82,7 +82,7 @@ ${ERROR_PAD}  * stable: 2.2.2
 ${ERROR_PAD}  * next: 2.4.0
 ${ERROR_PAD}  * latest-1: 1.43.1
 ${ERROR_PAD}
-${ERROR_PAD}If you need the full list of all 281 published versions run "$ pnpm view pnpm versions".`)
+${ERROR_PAD}If you need the full list of all 281 published versions run "pnpm view pnpm versions".`)
 })
 
 test('prints no matching version error when only the latest dist-tag exists', async () => {
@@ -103,7 +103,7 @@ test('prints no matching version error when only the latest dist-tag exists', as
 ${ERROR_PAD}
 ${ERROR_PAD}The latest release of is-positive is "3.1.0".
 ${ERROR_PAD}
-${ERROR_PAD}If you need the full list of all 4 published versions run "$ pnpm view is-positive versions".`)
+${ERROR_PAD}If you need the full list of all 4 published versions run "pnpm view is-positive versions".`)
 })
 
 test('prints suggestions when an internet-connection related error happens', async () => {


### PR DESCRIPTION
Consistent with other prompt commands, remove `$`.