### PR TITLE
fix: pass storeDir to createClient to fix resolution skipping

### DIFF
--- a/store/store-connection-manager/src/createNewStoreController.ts
+++ b/store/store-connection-manager/src/createNewStoreController.ts
@@ -72,6 +72,7 @@ export async function createNewStoreController (
     authConfig: opts.rawConfig,
     ca: opts.ca,
     cacheDir: opts.cacheDir,
+    storeDir: opts.storeDir,
     cert: opts.cert,
     fetchWarnTimeoutMs: opts.fetchWarnTimeoutMs,
     fetchMinSpeedKiBps: opts.fetchMinSpeedKiBps,


### PR DESCRIPTION
Prior discussion: https://github.com/pnpm/pnpm/issues/10409#issuecomment-3786766907

When running `pnpm install` with minor changes to a `package.json` file, I'm seeing a performance regression due `storeDir` being `undefined` below. This causes `peekManifestFromStore` to never be initialized.

https://github.com/pnpm/pnpm/blob/29a3151b60d2a459a9daff738fc4dfb327940c7b/resolving/npm-resolver/src/index.ts#L187-L188

I tested this PR and passing through `storeDir` here fixes the performance issue!