### PR TITLE
fix(completion): correct documentation URL in help output

### DIFF
--- a/.changeset/fix-completion-help-url.md
+++ b/.changeset/fix-completion-help-url.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-completion": patch
+"pnpm": patch
+---
+
+Fixed the documentation URL shown in `pnpm completion --help` to point to the correct page at https://pnpm.io/completion [#10281](https://github.com/pnpm/pnpm/issues/10281).

--- a/completion/plugin-commands-completion/src/generateCompletion.ts
+++ b/completion/plugin-commands-completion/src/generateCompletion.ts
@@ -1,5 +1,4 @@
 import renderHelp from 'render-help'
-import { docsUrl } from '@pnpm/cli-utils'
 import { getCompletionScript, SUPPORTED_SHELLS } from '@pnpm/tabtab'
 import { getShellFromParams } from './getShell.js'
 
@@ -14,7 +13,7 @@ export const cliOptionsTypes = (): Record<string, unknown> => ({})
 export function help (): string {
   return renderHelp({
     description: 'Print shell completion code to stdout',
-    url: docsUrl('completion'),
+    url: 'https://pnpm.io/completion',
     usages: SUPPORTED_SHELLS.map(shell => `pnpm completion ${shell}`),
   })
 }


### PR DESCRIPTION
The completion command's help text was showing a URL that redirects to a 404 page (https://pnpm.io/10.x/cli/completion\). This changes it to the correct URL (https://pnpm.io/completion\) where the documentation actually exists.

Fixes #10281