### PR TITLE
fix: check `updateSpec` correctly when updating catalog snapshots

### DIFF
--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -285,7 +285,8 @@ export async function resolveDependencies (
     if (!project.updatePackageManifest) continue
     const resolvedImporter = resolvedImporters[project.id]
     for (let i = 0; i < resolvedImporter.directDependencies.length; i++) {
-      if (project.wantedDependencies[i]?.updateSpec == null) continue
+      const updateSpec = project.wantedDependencies[i]?.updateSpec ?? false
+      if (!updateSpec) continue
       const dep = resolvedImporter.directDependencies[i]
       if (dep.catalogLookup == null) continue
       updatedCatalogs ??= {}


### PR DESCRIPTION
## Context

This bug was found in a separate PR by @m2na7.

- https://github.com/pnpm/pnpm/pull/9928#discussion_r2648571072

## Problem

The original check doesn't correctly handle `updateSpec` when it's `false`. We got a bit lucky since this field is only ever `undefined` or set to `true`.

<img width="495" height="447" alt="Screenshot 2026-01-25 at 4 40 42 PM" src="https://github.com/user-attachments/assets/42150517-f292-42c6-8d67-af8c6653da73" />

## Changes

Let's future-proof this check in case the codebase ever sets `updateSpec` to `false` in the future.