### PR TITLE
feat(find-workspace-dir): warn for dot-prefixed workspace manifest files

### DIFF
--- a/.changeset/warn-dotted-workspace-files.md
+++ b/.changeset/warn-dotted-workspace-files.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/find-workspace-dir": patch
+"pnpm": patch
+---
+
+Added `.pnpm-workspace.yaml` and `.pnpm-workspace.yml` to the list of invalid workspace manifest filenames that trigger a helpful error message [#10313](https://github.com/pnpm/pnpm/issues/10313).

--- a/workspace/find-workspace-dir/src/index.ts
+++ b/workspace/find-workspace-dir/src/index.ts
@@ -5,7 +5,13 @@ import { findUp } from 'find-up'
 
 const WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR'
 const WORKSPACE_MANIFEST_FILENAME = 'pnpm-workspace.yaml'
-const INVALID_WORKSPACE_MANIFEST_FILENAME = ['pnpm-workspaces.yaml', 'pnpm-workspaces.yml', 'pnpm-workspace.yml']
+const INVALID_WORKSPACE_MANIFEST_FILENAME = [
+  'pnpm-workspaces.yaml',
+  'pnpm-workspaces.yml',
+  'pnpm-workspace.yml',
+  '.pnpm-workspace.yaml',
+  '.pnpm-workspace.yml',
+]
 
 export async function findWorkspaceDir (cwd: string): Promise<string | undefined> {
   const workspaceManifestDirEnvVar = process.env[WORKSPACE_DIR_ENV_VAR] ?? process.env[WORKSPACE_DIR_ENV_VAR.toLowerCase()]

--- a/workspace/find-workspace-dir/test/index.ts
+++ b/workspace/find-workspace-dir/test/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
-import path from 'path'
 import fs from 'fs'
+import path from 'path'
 import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
 
 const NPM_CONFIG_WORKSPACE_DIR_ENV_VAR = 'NPM_CONFIG_WORKSPACE_DIR'

--- a/workspace/find-workspace-dir/test/invalidFilenames.ts
+++ b/workspace/find-workspace-dir/test/invalidFilenames.ts
@@ -1,0 +1,31 @@
+/// <reference path="../../../__typings__/index.d.ts"/>
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir'
+
+describe('invalid workspace manifest filenames', () => {
+  const invalidFilenames = [
+    'pnpm-workspaces.yaml',
+    'pnpm-workspaces.yml',
+    'pnpm-workspace.yml',
+    '.pnpm-workspace.yaml',
+    '.pnpm-workspace.yml',
+  ]
+
+  for (const filename of invalidFilenames) {
+    test(`throws error for ${filename}`, async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-test-'))
+      fs.writeFileSync(path.join(tempDir, filename), '')
+
+      try {
+        await expect(findWorkspaceDir(tempDir)).rejects.toMatchObject({
+          code: 'ERR_PNPM_BAD_WORKSPACE_MANIFEST_NAME',
+          message: expect.stringContaining('The workspace manifest file should be named "pnpm-workspace.yaml"'),
+        })
+      } finally {
+        fs.rmSync(tempDir, { recursive: true })
+      }
+    })
+  }
+})


### PR DESCRIPTION
Fixes #10313

### Problem

Users familiar with tools like Prettier and ESLint (which use dot-prefixed config files like `.prettierrc` and `.eslintrc`) may mistakenly create `.pnpm-workspace.yaml` instead of `pnpm-workspace.yaml`. Currently, pnpm silently ignores these files, leaving users confused about why their workspace configuration isn't being applied.

### Solution

Added `.pnpm-workspace.yaml` and `.pnpm-workspace.yml` to the existing list of invalid workspace manifest filenames that trigger a helpful error message:

```
The workspace manifest file should be named "pnpm-workspace.yaml". File found: /path/to/.pnpm-workspace.yaml
```

This matches the existing behavior for other common mistakes like `pnpm-workspaces.yaml` (plural) and `pnpm-workspace.yml` (wrong extension).

### Testing

- Added tests for all invalid filename variants including the new dot-prefixed ones
