### PR TITLE
fix: auto-switch Node version based on devEngines.runtime

### DIFF
--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -5,7 +5,11 @@ process.setMaxListeners(0)
 
 const argv = process.argv.slice(2)
 
-; (async () => {
+
+  ; (async () => {
+  const { switchNodeBasedOnDevEngine } = await import('./switchNodeBasedOnDevEngine.js');
+  if (await switchNodeBasedOnDevEngine()) return;
+
   switch (argv[0]) {
   // commands that are passed through to npm:
   case 'access':

--- a/pnpm/src/switchNodeBasedOnDevEngine.ts
+++ b/pnpm/src/switchNodeBasedOnDevEngine.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import semver from 'semver'
+import { spawn } from 'node:child_process'
+import { DevEngines } from '@pnpm/types'
+import { getNodeExecPathInBinDir } from '../../env/plugin-commands-env/src/utils.js'
+import { getNodeBinDir } from '../../env/plugin-commands-env/src/node.js'
+import { getConfig } from '@pnpm/config'
+import { packageManager } from '@pnpm/cli-meta'
+
+/**
+ * Switches the Node runtime to the version specified in `devEngines.runtime` of package.json.
+ * Spawns a child process if a switch is needed.
+ *
+ * @returns {Promise<boolean>} - true if a switch occurred and the current process will exit
+ */
+export async function switchNodeBasedOnDevEngine (): Promise<boolean> {
+  const pkgPath = path.resolve(process.cwd(), 'package.json')
+  if (!fs.existsSync(pkgPath)) return false
+
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as { devEngines?: DevEngines }
+  const runtime = pkg.devEngines?.runtime
+  if (!runtime) return false
+
+  const wantedNodeVersion = (Array.isArray(runtime) ? runtime : [runtime])
+    .find(rt => rt.name === 'node')?.version
+  if (!wantedNodeVersion) return false
+  if (process.env.PNPM_NODE_SWITCHED) return false
+  if (semver.satisfies(process.version.slice(1), wantedNodeVersion)) return false
+
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager,
+  })
+
+  const nodeBinDir = await getNodeBinDir({
+    useNodeVersion: wantedNodeVersion,
+    global: true,
+    pnpmHomeDir: config.pnpmHomeDir,
+    bin: path.join(config.pnpmHomeDir, 'bin'),
+    rawConfig: {},
+  })
+
+  const nodeExecPath = getNodeExecPathInBinDir(nodeBinDir)
+
+  const child = spawn(nodeExecPath, process.argv.slice(1), {
+    stdio: 'inherit',
+    env: { ...process.env, PNPM_NODE_SWITCHED: '1' },
+  })
+
+  child.on('exit', code => process.exit(code ?? 0))
+  child.on('error', err => {
+    console.error('Failed to spawn Node process:', err)
+    process.exit(1)
+  })
+
+  return true
+}

--- a/pnpm/test/verifyNodeSwitchBasedOnDevEngine/install.ts
+++ b/pnpm/test/verifyNodeSwitchBasedOnDevEngine/install.ts
@@ -1,0 +1,32 @@
+import { prepare } from '@pnpm/prepare'
+import { execPnpmSync } from '../utils/index.js'
+
+const scenarios = [
+  { nodeVersion: '22.20.0', pkg: 'is-positive', pkgVersion: '1.0.0' },
+  { nodeVersion: '22.18.0', pkg: 'is-negative', pkgVersion: '1.0.0' },
+]
+
+test.each(scenarios)(
+  'pnpm respects devEngines on install with Node %s',
+  ({ nodeVersion, pkg, pkgVersion }) => {
+    const project = prepare({
+      name: 'engine-test',
+      private: true,
+      devEngines: {
+        runtime: { name: 'node', version: nodeVersion, onFail: 'download' },
+      },
+      dependencies: {
+        [pkg]: pkgVersion,
+      },
+    })
+
+    const { stdout, stderr } = execPnpmSync(['install'], { expectSuccess: true })
+    const log = stdout.toString() + stderr.toString()
+
+    expect(log).toMatch(new RegExp(`node ${nodeVersion.replace(/\./g, '\\.')}`))
+
+    project.has(pkg)
+    const module = project.requireModule(pkg)
+    expect(typeof module).toBe('function')
+  }
+)


### PR DESCRIPTION
This PR implements automatic Node version switching based on the
`devEngines.runtime` field in package.json, addressing https://github.com/pnpm/pnpm/issues/10033.

- [x] Spawns a child Node process if the current version does not satisfy the specified runtime.
- [x] Sets `PNPM_NODE_SWITCHED=1` to avoid recursive switching.
- [x] Uses `getNodeBinDir` and `getNodeExecPathInBinDir` from pnpm internal utils.
