### PR TITLE
fix(deploy): update hints for `deploy` command

### DIFF
--- a/.changeset/update-deploy-hints.md
+++ b/.changeset/update-deploy-hints.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-deploy": patch
+pnpm: patch
+---
+
+updated hints for `deploy` command

--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -92,13 +92,19 @@ export async function handler (opts: DeployOptions, params: string[]): Promise<v
   }
   const selectedProjects = Object.values(opts.selectedProjectsGraph ?? {})
   if (selectedProjects.length === 0) {
-    throw new PnpmError('NOTHING_TO_DEPLOY', 'No project was selected for deployment')
+    let hint = 'Use --filter to select a project to deploy.'
+    if (opts.dir === opts.workspaceDir && opts.rootProjectManifest?.scripts?.['deploy'] != null) {
+      hint += '\nIn case you want to run the custom "deploy" script in the root manifest, try "pnpm run deploy"'
+    }
+    throw new PnpmError('NOTHING_TO_DEPLOY', 'No project was selected for deployment', { hint })
   }
   if (selectedProjects.length > 1) {
     throw new PnpmError('CANNOT_DEPLOY_MANY', 'Cannot deploy more than 1 project')
   }
   if (params.length !== 1) {
-    throw new PnpmError('INVALID_DEPLOY_TARGET', 'This command requires one parameter')
+    throw new PnpmError('INVALID_DEPLOY_TARGET', 'This command requires one parameter', {
+      hint: 'Provide the parameter with "pnpm deploy <target-directory>"',
+    })
   }
   const selectedProject = selectedProjects[0].package
   const deployDirParam = params[0]


### PR DESCRIPTION
people migrating from `yarn deploy` usually try to run `pnpm deploy` and end up with an ambiguous error like
`ERR_PNPM_NOTHING_TO_DEPLOY: No project was selected for deployment` (related issue https://github.com/pnpm/pnpm/issues/5163)

=> improve the hints by adding some actionable instructions

---

I also update docs with missing options https://github.com/pnpm/pnpm.io/pull/750