### PR TITLE
fix: pnpm help should correctly show if pnpm is bundled with Node.js

### DIFF
--- a/.changeset/solid-memes-punch.md
+++ b/.changeset/solid-memes-punch.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+`pnpm help` should correctly report if the currently running pnpm CLI is bundled with Node.js [#10561](https://github.com/pnpm/pnpm/issues/10561).

--- a/pnpm/src/cmd/help.ts
+++ b/pnpm/src/cmd/help.ts
@@ -50,7 +50,7 @@ function handler (helpByCommandName: HelpByCommandName, opts: { all?: boolean },
     helpText = `No results for "${params[0]}"`
   }
   return `Version ${packageManager.version}\
-${detectIfCurrentPkgIsExecutable() != null ? ` (compiled to binary; bundled Node.js ${process.version})` : ''}\
+${detectIfCurrentPkgIsExecutable() ? ` (compiled to binary; bundled Node.js ${process.version})` : ''}\
 \n${helpText}\n`
 }
 


### PR DESCRIPTION
close #10561