### PR TITLE
feat!: drop Node.js 20 and 21 support

### DIFF
--- a/.changeset/polite-carpets-relax.md
+++ b/.changeset/polite-carpets-relax.md
@@ -171,4 +171,4 @@
 "pnpm": major
 ---
 
-Node.js v18 and 19 support discontinued.
+Node.js v18, 19, 20, and 21 support discontinued.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - [20, 19, 4]
           - [22, 12, 0]
           - [24, 0, 0]
           - [25, 0, 0]

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ RELEASE.md
 .verdaccio-cache
 .turbo
 .eslintcache
+.claude
 
 ## custom modules-dir fixture
 __fixtures__/custom-modules-dir/**/fake_modules/

--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -391,7 +391,7 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
     bugs: {
       url: 'https://github.com/pnpm/pnpm/issues',
     },
-    engines: { node: '>=20.19' },
+    engines: { node: '>=22.12' },
     files,
     funding: 'https://opencollective.com/pnpm',
     homepage,

--- a/builder/policy/package.json
+++ b/builder/policy/package.json
@@ -38,7 +38,7 @@
     "@pnpm/builder.policy": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cache/api/package.json
+++ b/cache/api/package.json
@@ -47,7 +47,7 @@
     "@pnpm/logger": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cache/commands/package.json
+++ b/cache/commands/package.json
@@ -54,7 +54,7 @@
     "execa": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/catalogs/config/package.json
+++ b/catalogs/config/package.json
@@ -40,7 +40,7 @@
     "@pnpm/workspace.read-manifest": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/catalogs/protocol-parser/package.json
+++ b/catalogs/protocol-parser/package.json
@@ -35,7 +35,7 @@
     "@pnpm/catalogs.protocol-parser": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/catalogs/resolver/package.json
+++ b/catalogs/resolver/package.json
@@ -41,7 +41,7 @@
     "@pnpm/catalogs.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/catalogs/types/package.json
+++ b/catalogs/types/package.json
@@ -34,7 +34,7 @@
     "@pnpm/catalogs.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/cli-meta/package.json
+++ b/cli/cli-meta/package.json
@@ -38,7 +38,7 @@
     "@pnpm/cli-meta": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/cli-utils/package.json
+++ b/cli/cli-utils/package.json
@@ -57,7 +57,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/command/package.json
+++ b/cli/command/package.json
@@ -36,7 +36,7 @@
     "@pnpm/command": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/common-cli-options-help/package.json
+++ b/cli/common-cli-options-help/package.json
@@ -33,7 +33,7 @@
     "@pnpm/common-cli-options-help": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -69,7 +69,7 @@
     "normalize-newline": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/cli/parse-cli-args/package.json
+++ b/cli/parse-cli-args/package.json
@@ -42,7 +42,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/completion/plugin-commands-completion/package.json
+++ b/completion/plugin-commands-completion/package.json
@@ -51,7 +51,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/config-writer/package.json
+++ b/config/config-writer/package.json
@@ -42,7 +42,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/config/package.json
+++ b/config/config/package.json
@@ -78,7 +78,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/deps-installer/package.json
+++ b/config/deps-installer/package.json
@@ -60,7 +60,7 @@
     "read-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/config/matcher/package.json
+++ b/config/matcher/package.json
@@ -40,7 +40,7 @@
     "@pnpm/matcher": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/normalize-registries/package.json
+++ b/config/normalize-registries/package.json
@@ -39,7 +39,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/package-is-installable/package.json
+++ b/config/package-is-installable/package.json
@@ -52,7 +52,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/parse-overrides/package.json
+++ b/config/parse-overrides/package.json
@@ -40,7 +40,7 @@
     "@pnpm/parse-overrides": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/pick-registry-for-package/package.json
+++ b/config/pick-registry-for-package/package.json
@@ -37,7 +37,7 @@
     "@pnpm/pick-registry-for-package": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/plugin-commands-config/package.json
+++ b/config/plugin-commands-config/package.json
@@ -62,7 +62,7 @@
     "read-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/config/version-policy/package.json
+++ b/config/version-policy/package.json
@@ -41,7 +41,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/crypto/hash/package.json
+++ b/crypto/hash/package.json
@@ -44,7 +44,7 @@
     "tar-stream": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/crypto/integrity/package.json
+++ b/crypto/integrity/package.json
@@ -39,7 +39,7 @@
     "@pnpm/crypto.integrity": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/crypto/object-hasher/package.json
+++ b/crypto/object-hasher/package.json
@@ -42,7 +42,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/crypto/shasums-file/package.json
+++ b/crypto/shasums-file/package.json
@@ -41,7 +41,7 @@
     "@pnpm/crypto.shasums-file": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/dedupe/check/package.json
+++ b/dedupe/check/package.json
@@ -40,7 +40,7 @@
     "@pnpm/dedupe.check": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/dedupe/issues-renderer/package.json
+++ b/dedupe/issues-renderer/package.json
@@ -40,7 +40,7 @@
     "@types/archy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/dedupe/types/package.json
+++ b/dedupe/types/package.json
@@ -33,7 +33,7 @@
     "@pnpm/dedupe.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/deps/graph-builder/package.json
+++ b/deps/graph-builder/package.json
@@ -55,7 +55,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/deps/graph-sequencer/package.json
+++ b/deps/graph-sequencer/package.json
@@ -35,7 +35,7 @@
     "@pnpm/deps.graph-sequencer": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/deps/status/package.json
+++ b/deps/status/package.json
@@ -60,7 +60,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/env/node.fetcher/package.json
+++ b/env/node.fetcher/package.json
@@ -52,7 +52,7 @@
     "node-fetch": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/env/node.resolver/package.json
+++ b/env/node.resolver/package.json
@@ -49,7 +49,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/env/path/package.json
+++ b/env/path/package.json
@@ -38,7 +38,7 @@
     "@pnpm/env.path": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/env/plugin-commands-env/package.json
+++ b/env/plugin-commands-env/package.json
@@ -73,7 +73,7 @@
     "yazl": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/env/system-node-version/package.json
+++ b/env/system-node-version/package.json
@@ -41,7 +41,7 @@
     "@pnpm/env.system-node-version": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/build-commands/package.json
+++ b/exec/build-commands/package.json
@@ -61,7 +61,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/exec/build-modules/package.json
+++ b/exec/build-modules/package.json
@@ -60,7 +60,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/lifecycle/package.json
+++ b/exec/lifecycle/package.json
@@ -62,7 +62,7 @@
     "load-json-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/pkg-requires-build/package.json
+++ b/exec/pkg-requires-build/package.json
@@ -37,7 +37,7 @@
     "@pnpm/exec.pkg-requires-build": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/plugin-commands-rebuild/package.json
+++ b/exec/plugin-commands-rebuild/package.json
@@ -90,7 +90,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/exec/plugin-commands-script-runners/package.json
+++ b/exec/plugin-commands-script-runners/package.json
@@ -90,7 +90,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/exec/pnpm-cli-runner/package.json
+++ b/exec/pnpm-cli-runner/package.json
@@ -36,7 +36,7 @@
     "@pnpm/exec.pnpm-cli-runner": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/prepare-package/package.json
+++ b/exec/prepare-package/package.json
@@ -49,7 +49,7 @@
     "load-json-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/exec/run-npm/package.json
+++ b/exec/run-npm/package.json
@@ -38,7 +38,7 @@
     "@types/cross-spawn": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/binary-fetcher/package.json
+++ b/fetching/binary-fetcher/package.json
@@ -51,7 +51,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/directory-fetcher/package.json
+++ b/fetching/directory-fetcher/package.json
@@ -52,7 +52,7 @@
     "@zkochan/rimraf": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/fetcher-base/package.json
+++ b/fetching/fetcher-base/package.json
@@ -41,7 +41,7 @@
     "@pnpm/fetcher-base": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/git-fetcher/package.json
+++ b/fetching/git-fetcher/package.json
@@ -54,7 +54,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/pick-fetcher/package.json
+++ b/fetching/pick-fetcher/package.json
@@ -48,7 +48,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fetching/tarball-fetcher/package.json
+++ b/fetching/tarball-fetcher/package.json
@@ -71,7 +71,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/find-packages/package.json
+++ b/fs/find-packages/package.json
@@ -44,7 +44,7 @@
     "@pnpm/fs.find-packages": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/graceful-fs/package.json
+++ b/fs/graceful-fs/package.json
@@ -37,7 +37,7 @@
     "@types/graceful-fs": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/hard-link-dir/package.json
+++ b/fs/hard-link-dir/package.json
@@ -46,7 +46,7 @@
     "@pnpm/prepare": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/indexed-pkg-importer/package.json
+++ b/fs/indexed-pkg-importer/package.json
@@ -67,7 +67,7 @@
     "@types/fs-extra": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/is-empty-dir-or-nothing/package.json
+++ b/fs/is-empty-dir-or-nothing/package.json
@@ -34,7 +34,7 @@
     "@pnpm/fs.is-empty-dir-or-nothing": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/msgpack-file/package.json
+++ b/fs/msgpack-file/package.json
@@ -40,7 +40,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/packlist/package.json
+++ b/fs/packlist/package.json
@@ -36,7 +36,7 @@
     "@pnpm/fs.packlist": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/read-modules-dir/package.json
+++ b/fs/read-modules-dir/package.json
@@ -38,7 +38,7 @@
     "@types/graceful-fs": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/fs/symlink-dependency/package.json
+++ b/fs/symlink-dependency/package.json
@@ -48,7 +48,7 @@
     "@pnpm/symlink-dependency": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/hooks/pnpmfile/package.json
+++ b/hooks/pnpmfile/package.json
@@ -51,7 +51,7 @@
     "@pnpm/test-fixtures": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/hooks/read-package-hook/package.json
+++ b/hooks/read-package-hook/package.json
@@ -51,7 +51,7 @@
     "@yarnpkg/core": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/hooks/types/package.json
+++ b/hooks/types/package.json
@@ -42,7 +42,7 @@
     "@pnpm/hooks.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/audit/package.json
+++ b/lockfile/audit/package.json
@@ -56,7 +56,7 @@
     "nock": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/detect-dep-types/package.json
+++ b/lockfile/detect-dep-types/package.json
@@ -41,7 +41,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/filtering/package.json
+++ b/lockfile/filtering/package.json
@@ -57,7 +57,7 @@
     "yaml-tag": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/fs/package.json
+++ b/lockfile/fs/package.json
@@ -69,7 +69,7 @@
     "yaml-tag": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/lockfile-to-pnp/package.json
+++ b/lockfile/lockfile-to-pnp/package.json
@@ -51,7 +51,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/merger/package.json
+++ b/lockfile/merger/package.json
@@ -45,7 +45,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/plugin-commands-audit/package.json
+++ b/lockfile/plugin-commands-audit/package.json
@@ -61,7 +61,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/preferred-versions/package.json
+++ b/lockfile/preferred-versions/package.json
@@ -42,7 +42,7 @@
     "@pnpm/lockfile.preferred-versions": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/pruner/package.json
+++ b/lockfile/pruner/package.json
@@ -45,7 +45,7 @@
     "yaml-tag": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/settings-checker/package.json
+++ b/lockfile/settings-checker/package.json
@@ -47,7 +47,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/types/package.json
+++ b/lockfile/types/package.json
@@ -39,6 +39,6 @@
     "@pnpm/lockfile.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   }
 }

--- a/lockfile/utils/package.json
+++ b/lockfile/utils/package.json
@@ -51,7 +51,7 @@
     "yaml-tag": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/verification/package.json
+++ b/lockfile/verification/package.json
@@ -60,7 +60,7 @@
     "tar-stream": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/lockfile/walker/package.json
+++ b/lockfile/walker/package.json
@@ -41,7 +41,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/modules-mounter/daemon/package.json
+++ b/modules-mounter/daemon/package.json
@@ -63,7 +63,7 @@
     "rimraf": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/network/auth-header/package.json
+++ b/network/auth-header/package.json
@@ -40,7 +40,7 @@
     "safe-buffer": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/network/fetch/package.json
+++ b/network/fetch/package.json
@@ -50,7 +50,7 @@
     "nock": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/network/fetching-types/package.json
+++ b/network/fetching-types/package.json
@@ -38,7 +38,7 @@
     "@pnpm/fetching-types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/object/key-sorting/package.json
+++ b/object/key-sorting/package.json
@@ -39,7 +39,7 @@
     "@pnpm/object.key-sorting": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/object/property-path/package.json
+++ b/object/property-path/package.json
@@ -38,7 +38,7 @@
     "@pnpm/object.property-path": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/calc-dep-state/package.json
+++ b/packages/calc-dep-state/package.json
@@ -42,7 +42,7 @@
     "@pnpm/calc-dep-state": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -34,7 +34,7 @@
     "@pnpm/constants": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/core-loggers/package.json
+++ b/packages/core-loggers/package.json
@@ -44,7 +44,7 @@
     "@pnpm/logger": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/dependency-path/package.json
+++ b/packages/dependency-path/package.json
@@ -42,7 +42,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -38,7 +38,7 @@
     "@pnpm/error": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/git-utils/package.json
+++ b/packages/git-utils/package.json
@@ -42,7 +42,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -39,7 +39,7 @@
     "@pnpm/logger": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/make-dedicated-lockfile/package.json
+++ b/packages/make-dedicated-lockfile/package.json
@@ -53,7 +53,7 @@
     "execa": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/naming-cases/package.json
+++ b/packages/naming-cases/package.json
@@ -35,7 +35,7 @@
     "@pnpm/naming-cases": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/parse-wanted-dependency/package.json
+++ b/packages/parse-wanted-dependency/package.json
@@ -37,7 +37,7 @@
     "@types/validate-npm-package-name": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/plugin-commands-doctor/package.json
+++ b/packages/plugin-commands-doctor/package.json
@@ -45,7 +45,7 @@
     "@pnpm/plugin-commands-doctor": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/plugin-commands-init/package.json
+++ b/packages/plugin-commands-init/package.json
@@ -51,7 +51,7 @@
     "load-json-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/plugin-commands-setup/package.json
+++ b/packages/plugin-commands-setup/package.json
@@ -50,7 +50,7 @@
     "@pnpm/prepare": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/render-peer-issues/package.json
+++ b/packages/render-peer-issues/package.json
@@ -42,7 +42,7 @@
     "@types/archy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,7 +34,7 @@
     "@pnpm/types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/patching/apply-patch/package.json
+++ b/patching/apply-patch/package.json
@@ -46,7 +46,7 @@
     "@pnpm/test-fixtures": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/patching/config/package.json
+++ b/patching/config/package.json
@@ -45,7 +45,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/patching/plugin-commands-patching/package.json
+++ b/patching/plugin-commands-patching/package.json
@@ -86,7 +86,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/patching/types/package.json
+++ b/patching/types/package.json
@@ -34,7 +34,7 @@
     "@pnpm/patching.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/client/package.json
+++ b/pkg-manager/client/package.json
@@ -53,7 +53,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/core/package.json
+++ b/pkg-manager/core/package.json
@@ -162,7 +162,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/pkg-manager/direct-dep-linker/package.json
+++ b/pkg-manager/direct-dep-linker/package.json
@@ -46,7 +46,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/get-context/package.json
+++ b/pkg-manager/get-context/package.json
@@ -52,7 +52,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/headless/package.json
+++ b/pkg-manager/headless/package.json
@@ -103,7 +103,7 @@
     "write-json-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/pkg-manager/hoist/package.json
+++ b/pkg-manager/hoist/package.json
@@ -54,7 +54,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/link-bins/package.json
+++ b/pkg-manager/link-bins/package.json
@@ -68,7 +68,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/modules-cleaner/package.json
+++ b/pkg-manager/modules-cleaner/package.json
@@ -52,7 +52,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/modules-yaml/package.json
+++ b/pkg-manager/modules-yaml/package.json
@@ -46,7 +46,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/package-bins/package.json
+++ b/pkg-manager/package-bins/package.json
@@ -43,7 +43,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/package-requester/package.json
+++ b/pkg-manager/package-requester/package.json
@@ -81,7 +81,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -124,7 +124,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/pkg-manager/read-projects-context/package.json
+++ b/pkg-manager/read-projects-context/package.json
@@ -45,7 +45,7 @@
     "@pnpm/read-projects-context": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/real-hoist/package.json
+++ b/pkg-manager/real-hoist/package.json
@@ -44,7 +44,7 @@
     "@pnpm/types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/remove-bins/package.json
+++ b/pkg-manager/remove-bins/package.json
@@ -49,7 +49,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -85,7 +85,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manifest/exportable-manifest/package.json
+++ b/pkg-manifest/exportable-manifest/package.json
@@ -51,7 +51,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manifest/manifest-utils/package.json
+++ b/pkg-manifest/manifest-utils/package.json
@@ -47,7 +47,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manifest/read-package-json/package.json
+++ b/pkg-manifest/read-package-json/package.json
@@ -42,7 +42,7 @@
     "@types/normalize-package-data": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manifest/read-project-manifest/package.json
+++ b/pkg-manifest/read-project-manifest/package.json
@@ -56,7 +56,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pkg-manifest/write-project-manifest/package.json
+++ b/pkg-manifest/write-project-manifest/package.json
@@ -43,7 +43,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -345,7 +345,7 @@ minimumReleaseAgeExclude:
   - tar@7.5.7
   - lodash@4.17.23
 
-nodeVersion: 20.19.4
+nodeVersion: 22.12.0
 
 optimisticRepeatInstall: true
 

--- a/pnpm/bin/pnpm.mjs
+++ b/pnpm/bin/pnpm.mjs
@@ -5,8 +5,8 @@ const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past
 // We don't use the semver library here because:
 //  1. it is already bundled to dist/pnpm.mjs, so we would load it twice
 //  2. we want this file to support potentially older Node.js versions than what semver supports
-if (major < 20 || major == 20 && minor < 19) {
-  console.error(`ERROR: This version of pnpm requires at least Node.js v20.19
+if (major < 22 || major == 22 && minor < 12) {
+  console.error(`ERROR: This version of pnpm requires at least Node.js v22.12
 The current version of Node.js is ${process.version}
 ${COMPATIBILITY_PAGE}`)
   process.exit(1)

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -180,7 +180,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "pnpm": {
     "overrides": {

--- a/registry/pkg-metadata-filter/package.json
+++ b/registry/pkg-metadata-filter/package.json
@@ -45,7 +45,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/registry/types/package.json
+++ b/registry/types/package.json
@@ -37,7 +37,7 @@
     "@pnpm/registry.types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/releasing/plugin-commands-deploy/package.json
+++ b/releasing/plugin-commands-deploy/package.json
@@ -67,7 +67,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/releasing/plugin-commands-publishing/package.json
+++ b/releasing/plugin-commands-publishing/package.json
@@ -96,7 +96,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/resolving/bun-resolver/package.json
+++ b/resolving/bun-resolver/package.json
@@ -54,7 +54,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/default-resolver/package.json
+++ b/resolving/default-resolver/package.json
@@ -56,7 +56,7 @@
     "node-fetch": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/deno-resolver/package.json
+++ b/resolving/deno-resolver/package.json
@@ -53,7 +53,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/git-resolver/package.json
+++ b/resolving/git-resolver/package.json
@@ -51,7 +51,7 @@
     "is-windows": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/jsr-specifier-parser/package.json
+++ b/resolving/jsr-specifier-parser/package.json
@@ -38,7 +38,7 @@
     "@pnpm/resolving.jsr-specifier-parser": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/local-resolver/package.json
+++ b/resolving/local-resolver/package.json
@@ -51,7 +51,7 @@
     "@types/normalize-path": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/npm-resolver/package.json
+++ b/resolving/npm-resolver/package.json
@@ -83,7 +83,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/resolver-base/package.json
+++ b/resolving/resolver-base/package.json
@@ -38,7 +38,7 @@
     "@pnpm/resolver-base": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/resolving/tarball-resolver/package.json
+++ b/resolving/tarball-resolver/package.json
@@ -40,7 +40,7 @@
     "@pnpm/tarball-resolver": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/reviewing/dependencies-hierarchy/package.json
+++ b/reviewing/dependencies-hierarchy/package.json
@@ -58,7 +58,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/reviewing/license-scanner/package.json
+++ b/reviewing/license-scanner/package.json
@@ -62,7 +62,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/reviewing/list/package.json
+++ b/reviewing/list/package.json
@@ -53,7 +53,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/reviewing/outdated/package.json
+++ b/reviewing/outdated/package.json
@@ -63,7 +63,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/reviewing/plugin-commands-licenses/package.json
+++ b/reviewing/plugin-commands-licenses/package.json
@@ -61,7 +61,7 @@
     "@types/zkochan__table": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/reviewing/plugin-commands-listing/package.json
+++ b/reviewing/plugin-commands-listing/package.json
@@ -58,7 +58,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/reviewing/plugin-commands-outdated/package.json
+++ b/reviewing/plugin-commands-outdated/package.json
@@ -63,7 +63,7 @@
     "@types/zkochan__table": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/semver/peer-range/package.json
+++ b/semver/peer-range/package.json
@@ -39,7 +39,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/cafs-types/package.json
+++ b/store/cafs-types/package.json
@@ -36,7 +36,7 @@
     "@types/ssri": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/cafs/package.json
+++ b/store/cafs/package.json
@@ -54,7 +54,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/create-cafs-store/package.json
+++ b/store/create-cafs-store/package.json
@@ -62,7 +62,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/package-store/package.json
+++ b/store/package-store/package.json
@@ -75,7 +75,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/plugin-commands-store-inspecting/package.json
+++ b/store/plugin-commands-store-inspecting/package.json
@@ -54,7 +54,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/plugin-commands-store/package.json
+++ b/store/plugin-commands-store/package.json
@@ -76,7 +76,7 @@
     "tempy": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config/with-registry"

--- a/store/store-connection-manager/package.json
+++ b/store/store-connection-manager/package.json
@@ -46,7 +46,7 @@
     "@pnpm/store-connection-manager": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/store-controller-types/package.json
+++ b/store/store-controller-types/package.json
@@ -40,7 +40,7 @@
     "@pnpm/store-controller-types": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/store/store-path/package.json
+++ b/store/store-path/package.json
@@ -50,7 +50,7 @@
     "rimraf": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/testing/temp-store/package.json
+++ b/testing/temp-store/package.json
@@ -41,7 +41,7 @@
     "@pnpm/testing.temp-store": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/text/comments-parser/package.json
+++ b/text/comments-parser/package.json
@@ -38,7 +38,7 @@
     "@pnpm/text.comments-parser": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/tools/path/package.json
+++ b/tools/path/package.json
@@ -33,7 +33,7 @@
     "@pnpm/tools.path": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/tools/plugin-commands-self-updater/package.json
+++ b/tools/plugin-commands-self-updater/package.json
@@ -62,7 +62,7 @@
     "nock": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/worker/package.json
+++ b/worker/package.json
@@ -59,7 +59,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/filter-packages-from-dir/package.json
+++ b/workspace/filter-packages-from-dir/package.json
@@ -39,7 +39,7 @@
     "@pnpm/workspace.filter-packages-from-dir": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -54,7 +54,7 @@
     "touch": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/find-packages/package.json
+++ b/workspace/find-packages/package.json
@@ -47,7 +47,7 @@
     "@pnpm/workspace.read-manifest": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/find-workspace-dir/package.json
+++ b/workspace/find-workspace-dir/package.json
@@ -38,7 +38,7 @@
     "@pnpm/find-workspace-dir": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/injected-deps-syncer/package.json
+++ b/workspace/injected-deps-syncer/package.json
@@ -52,7 +52,7 @@
     "@pnpm/workspace.injected-deps-syncer": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/manifest-writer/package.json
+++ b/workspace/manifest-writer/package.json
@@ -53,7 +53,7 @@
     "write-yaml-file": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/pkgs-graph/package.json
+++ b/workspace/pkgs-graph/package.json
@@ -43,7 +43,7 @@
     "better-path-resolve": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/read-manifest/package.json
+++ b/workspace/read-manifest/package.json
@@ -40,7 +40,7 @@
     "@pnpm/workspace.read-manifest": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/resolve-workspace-range/package.json
+++ b/workspace/resolve-workspace-range/package.json
@@ -39,7 +39,7 @@
     "@types/semver": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/sort-packages/package.json
+++ b/workspace/sort-packages/package.json
@@ -37,7 +37,7 @@
     "@pnpm/sort-packages": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/spec-parser/package.json
+++ b/workspace/spec-parser/package.json
@@ -34,7 +34,7 @@
     "@pnpm/workspace.spec-parser": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/workspace/state/package.json
+++ b/workspace/state/package.json
@@ -48,7 +48,7 @@
     "@types/ramda": "catalog:"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/yaml/document-sync/package.json
+++ b/yaml/document-sync/package.json
@@ -39,7 +39,7 @@
     "@pnpm/yaml.document-sync": "workspace:*"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.12"
   },
   "jest": {
     "preset": "@pnpm/jest-config"


### PR DESCRIPTION
EOL for Node.js 20 is April 2026, so I don't think we should support it in pnpm v11.