### PR TITLE
fix: restore default workspace pattern when packages field is missing

### DIFF
--- a/.changeset/petite-laws-share.md
+++ b/.changeset/petite-laws-share.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config": patch
+"pnpm": patch
+---
+
+Fixed `--frozen-lockfile` failing in projects with a `pnpm-workspace.yaml` that has no `packages` field [#10571](https://github.com/pnpm/pnpm/issues/10571).

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -411,7 +411,7 @@ export async function getConfig (opts: {
     if (pnpmConfig.workspaceDir != null) {
       const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
 
-      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages
+      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages ?? (workspaceManifest ? ['.'] : undefined)
       if (workspaceManifest) {
         addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
           configFromCliOpts,

--- a/pnpm/test/recursive/misc.ts
+++ b/pnpm/test/recursive/misc.ts
@@ -284,6 +284,7 @@ test('recursive command with filter from config', async () => {
 
   fs.writeFileSync('package.json', '{}', 'utf8')
   writeYamlFile('pnpm-workspace.yaml', {
+    packages: ['project-1', 'project-2', 'project-3'],
     filter: ['project-1', 'project-2'],
   })
   await execPnpm(['recursive', 'install'])


### PR DESCRIPTION
Closes #10571

Restore the `['.']` fallback for `workspacePackagePatterns` when `pnpm-workspace.yaml` exists but has no `packages` field. Without this, `findPackages` defaults to `['.', '**']` and scans all subdirectories, breaking `--frozen-lockfile`.

The fallback is only applied when the manifest is not `null`, to keep #10520 working.