### PR TITLE
fix: disable global virtual store during `pnpm deploy`

### DIFF
--- a/.changeset/bold-words-give.md
+++ b/.changeset/bold-words-give.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"@pnpm/plugin-commands-deploy": patch
+pnpm: patch
+---
+
+When the [`enableGlobalVirtualStore`](https://pnpm.io/settings#enableglobalvirtualstore) option is set, the `pnpm deploy` command would incorrectly create symlinks to the global virtual store. To keep the deploy directory self-contained, `pnpm deploy` now ignores this setting and always creates a localized virtual store within the deploy directory.
+

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -274,6 +274,7 @@ export type InstallCommandOptions = Pick<Config,
 | 'deployAllFiles'
 | 'depth'
 | 'dev'
+| 'enableGlobalVirtualStore'
 | 'engineStrict'
 | 'excludeLinksFromLockfile'
 | 'frozenLockfile'

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -57,6 +57,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'dedupePeerDependents'
 | 'depth'
 | 'dev'
+| 'enableGlobalVirtualStore'
 | 'engineStrict'
 | 'excludeLinksFromLockfile'
 | 'global'

--- a/releasing/plugin-commands-deploy/src/deploy.ts
+++ b/releasing/plugin-commands-deploy/src/deploy.ts
@@ -170,6 +170,9 @@ export async function handler (opts: DeployOptions, params: string[]): Promise<v
     // the deploy directory. It's also just weird to include empty importers
     // that don't matter to the filtered lockfile generated for pnpm deploy.
     pruneLockfileImporters: true,
+    // The node_modules for a pnpm deploy should be self-contained. The global
+    // virtual store would create symlinks outside of the deploy directory.
+    enableGlobalVirtualStore: false,
     depth: Infinity,
     hooks: {
       ...opts.hooks,
@@ -266,6 +269,9 @@ async function deployFromSharedLockfile (
       allProjectsGraph: undefined,
       selectedProjectsGraph: undefined,
       rootProjectManifest: deployFiles.manifest,
+      // The node_modules for a pnpm deploy should be self-contained. The global
+      // virtual store would create symlinks outside of the deploy directory.
+      enableGlobalVirtualStore: false,
       rootProjectManifestDir: deployDir,
       dir: deployDir,
       lockfileDir: deployDir,


### PR DESCRIPTION
## Problem

The deploy directory from `pnpm deploy` should ideally be self-contained. This isn't true when `enableGlobalVirtualStore` is set. Symlinks are created in the deploy directory that reference the global store.

## Changes

Let's override `enableGlobalVirtualStore` to always be `false`.

## Testing

I tested this manually and verified the output.

I can write a new test for this specific scenario if desired, but I think the existing unit tests cover this well. We have tests for `pnpm deploy` and `enableGlobalVirtualStore` already. I personally don't think we need tests to cover every command and option combination.