### PR TITLE
fix: skip catalogs mismatch check when no pnpm-workspace.yaml exists

### DIFF
--- a/.changeset/fix-catalogs-mismatch-without-workspace.md
+++ b/.changeset/fix-catalogs-mismatch-without-workspace.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.settings-checker": patch
+"pnpm": patch
+---
+
+Fixed `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` error when the lockfile contains a `catalogs` section but no `pnpm-workspace.yaml` exists [#10551](https://github.com/pnpm/pnpm/issues/10551).

--- a/lockfile/settings-checker/package.json
+++ b/lockfile/settings-checker/package.json
@@ -27,10 +27,11 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pnpm run compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pnpm run compile && pnpm run _test",
     "prepublishOnly": "pnpm run compile",
-    "compile": "tsgo --build && pnpm run lint --fix"
+    "compile": "tsgo --build && pnpm run lint --fix",
+    "_test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest"
   },
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",

--- a/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -41,7 +41,8 @@ export function getOutdatedLockfileSetting (
     injectWorkspacePackages?: boolean
   }
 ): ChangedField | null {
-  if (catalogs != null && !allCatalogsAreUpToDate(catalogs, lockfile.catalogs)) {
+  const catalogsConfig = catalogs ?? {}
+  if (Object.keys(catalogsConfig).length > 0 && !allCatalogsAreUpToDate(catalogsConfig, lockfile.catalogs)) {
     return 'catalogs'
   }
   if (!equals(lockfile.overrides ?? {}, overrides ?? {})) {

--- a/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -41,7 +41,7 @@ export function getOutdatedLockfileSetting (
     injectWorkspacePackages?: boolean
   }
 ): ChangedField | null {
-  if (!allCatalogsAreUpToDate(catalogs ?? {}, lockfile.catalogs)) {
+  if (catalogs != null && !allCatalogsAreUpToDate(catalogs, lockfile.catalogs)) {
     return 'catalogs'
   }
   if (!equals(lockfile.overrides ?? {}, overrides ?? {})) {

--- a/lockfile/settings-checker/test/getOutdatedLockfileSetting.test.ts
+++ b/lockfile/settings-checker/test/getOutdatedLockfileSetting.test.ts
@@ -1,0 +1,75 @@
+import { type LockfileObject } from '@pnpm/lockfile.types'
+import { getOutdatedLockfileSetting } from '@pnpm/lockfile.settings-checker'
+
+const DEFAULT_OPTS = {
+  autoInstallPeers: true,
+  excludeLinksFromLockfile: false,
+  peersSuffixMaxLength: 1000,
+}
+
+function createLockfile (overrides?: Partial<LockfileObject>): LockfileObject {
+  return {
+    lockfileVersion: '9.0',
+    importers: {},
+    settings: {
+      autoInstallPeers: true,
+      excludeLinksFromLockfile: false,
+      peersSuffixMaxLength: 1000,
+    },
+    ...overrides,
+  }
+}
+
+describe('getOutdatedLockfileSetting', () => {
+  describe('catalogs', () => {
+    test('returns null when catalogs is undefined and lockfile has catalogs (no workspace)', () => {
+      const lockfile = createLockfile({
+        catalogs: {
+          default: {
+            'is-odd': { specifier: '^3.0.1', version: '3.0.1' },
+          },
+        },
+      })
+      expect(getOutdatedLockfileSetting(lockfile, {
+        ...DEFAULT_OPTS,
+        catalogs: undefined,
+      })).toBeNull()
+    })
+
+    test('returns null when catalogs match', () => {
+      const lockfile = createLockfile({
+        catalogs: {
+          default: {
+            'is-odd': { specifier: '^3.0.1', version: '3.0.1' },
+          },
+        },
+      })
+      expect(getOutdatedLockfileSetting(lockfile, {
+        ...DEFAULT_OPTS,
+        catalogs: { default: { 'is-odd': '^3.0.1' } },
+      })).toBeNull()
+    })
+
+    test('returns "catalogs" when catalogs do not match', () => {
+      const lockfile = createLockfile({
+        catalogs: {
+          default: {
+            'is-odd': { specifier: '^3.0.1', version: '3.0.1' },
+          },
+        },
+      })
+      expect(getOutdatedLockfileSetting(lockfile, {
+        ...DEFAULT_OPTS,
+        catalogs: { default: { 'is-odd': '^4.0.0' } },
+      })).toBe('catalogs')
+    })
+
+    test('returns null when both catalogs and lockfile catalogs are empty', () => {
+      const lockfile = createLockfile()
+      expect(getOutdatedLockfileSetting(lockfile, {
+        ...DEFAULT_OPTS,
+        catalogs: {},
+      })).toBeNull()
+    })
+  })
+})

--- a/lockfile/settings-checker/test/tsconfig.json
+++ b/lockfile/settings-checker/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #10551

Fix `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` error when the lockfile contains a `catalogs` section but no `pnpm-workspace.yaml` exists.