### PR TITLE
refactor: simplify dependenciesHierarchyForPackage by delegating to getTree

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -41,6 +41,7 @@
     "cves",
     "cwsay",
     "deburr",
+    "dedup",
     "denoland",
     "denolib",
     "deptype",


### PR DESCRIPTION
Instead of manually iterating over top-level dependencies, calling getPkgInfo/getTreeNodeChildId/getTree per dependency, and handling dedup/search logic in parallel with materializeChildren, delegate entirely to a single getTree call with the importer as root.

The returned PackageNode[] are then post-categorized into their dependency fields (dependencies, devDependencies, optionalDependencies) using a fieldMap built from the lockfile importer snapshot.

This eliminates the duplicated dedup/search handling between dependenciesHierarchyForPackage and materializeChildren, and removes the GetTreeResult wrapper type from getTree (now returns PackageNode[] directly). The materializeChildren cache is now the sole mechanism for cross-importer deduplication.