### PR TITLE
feat(approve-builds): add --all flag to skip interactive prompts

### DIFF
--- a/.changeset/approve-builds-all-flag.md
+++ b/.changeset/approve-builds-all-flag.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.build-commands": minor
+"pnpm": minor
+---
+
+Added `--all` flag to `pnpm approve-builds` that approves all pending builds without interactive prompts [#10136](https://github.com/pnpm/pnpm/issues/10136).


### PR DESCRIPTION
## Summary
- Added `--all` flag to `pnpm approve-builds` that approves all pending build dependencies at once without interactive selection
- Useful for CI/CD pipelines and project bootstrapping scenarios (e.g., `npm create nuxt@latest`) where interactive prompts are not feasible

Closes #10136

## Test plan
- [x] Added unit test: `approve all builds with --all flag`
- [x] Verified `enquirer.prompt` is not called when `--all` is passed
- [x] Verified all packages are written to `pnpm-workspace.yaml` with `allowBuilds: true`
- [x] Verified build artifacts are generated for all approved packages
- [x] All existing tests still pass

> [!NOTE]
> 🤖 This PR was generated with the assistance of an AI coding agent (Claude Code by Anthropic). All code changes have been reviewed and tested by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)