### PR TITLE
fix: remove misleading `maxAge` argument to `pMemoize`

### DIFF
--- a/.changeset/deep-eggs-cry.md
+++ b/.changeset/deep-eggs-cry.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": patch
+---
+
+An internal refactor was performed to remove a misleading usage of `pMemoize`. Previously the `maxAge` argument was passed, but this field is ignored by the `p-memoize` NPM package.

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -173,7 +173,6 @@ export function createNpmResolver (
   }
   const fetch = pMemoize(fetchMetadataFromFromRegistry.bind(null, fetchOpts), {
     cacheKey: (...args) => JSON.stringify(args),
-    maxAge: 1000 * 20, // 20 seconds
   })
   const metaCache = new LRUCache<string, PackageMeta>({
     max: 10000,


### PR DESCRIPTION
## Changes

The `pMemoize` function has never accepted a `maxAge` argument. The docs previously mentioned it as a copy + paste mistake from another package.

- https://github.com/sindresorhus/p-memoize/issues/40
- https://github.com/sindresorhus/p-memoize/pull/44

Here's the implementation of the function, which I double checked to see doesn't read `options.maxAge` or pass down the `options` argument to anything else.

https://github.com/sindresorhus/p-memoize/blob/a006ac3224bbeb344cb62976e7f18bbc5ad61d14/index.ts#L125

Let's remove this to prevent future confusion. This PR should be a no-op.

## Context

I was debugging a test that should have loaded new package metadata but wasn't. It turns out this cached `pMemoize` function never expired.