### PR TITLE
fix: regenerate global bin scripts on pnpm update --global

### DIFF
--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1425,6 +1425,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           projectManifest: project.manifest,
           extraNodePaths: ctx.extraNodePaths,
           warn: binWarn.bind(null, project.rootDir),
+          global: opts.global,
         })
       } else {
         const directPkgs = [
@@ -1454,6 +1455,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           {
             extraNodePaths: ctx.extraNodePaths,
             preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+            global: opts.global,
           }
         )
       }

--- a/pkg-manager/link-bins/src/index.ts
+++ b/pkg-manager/link-bins/src/index.ts
@@ -278,10 +278,26 @@ function runtimeHasNodeDownloaded (runtime: EngineDependency | EngineDependency[
 export interface LinkBinOptions {
   extraNodePaths?: string[]
   preferSymlinkedExecutables?: boolean
+  /**
+   * When true, forces regeneration of bin scripts even if they already exist.
+   * This is needed for global installations to ensure bin scripts point to the
+   * correct version after updating. See: https://github.com/pnpm/pnpm/issues/10517
+   */
+  global?: boolean
 }
 
 async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions): Promise<void> {
   const externalBinPath = path.join(binsDir, cmd.name)
+
+  // For global installations, remove existing bin scripts to force regeneration.
+  // This fixes https://github.com/pnpm/pnpm/issues/10517 where bin scripts
+  // contain hardcoded version paths that become stale after updating.
+  if (opts?.global && !IS_WINDOWS) {
+    if (existsSync(externalBinPath)) {
+      await rimraf(externalBinPath)
+    }
+  }
+
   if (IS_WINDOWS) {
     const exePath = path.join(binsDir, `${cmd.name}${getExeExtension()}`)
     if (existsSync(exePath)) {


### PR DESCRIPTION
# Fix: Regenerate global bin scripts on `pnpm update --global`

Fixes #10517

## Problem

When running `pnpm update --global`, the bin scripts in the global bin directory are not regenerated. The bin scripts contain hardcoded version-specific paths (e.g., `openclaw@2026.2.9/...`), and after updating to a new version, these paths become stale, pointing to the old version.

### Reproduction

1. Install a package globally: `pnpm add -g openclaw@2026.2.9`
2. Update it: `pnpm up -g openclaw`
3. Try to run the command: `openclaw`
4. Error: Cannot find module '...openclaw@2026.2.9...' (old version path)

## Root Cause

The `linkBin` function in `@pnpm/link-bins` uses `cmdShim` to create bin scripts. When the bin script already exists, `cmdShim` may not update it, leaving the old hardcoded version paths in place.

## Solution

For global installations, force regeneration of bin scripts by removing the existing bin before creating a new one. This ensures the bin script always contains the correct version-specific paths.

## Changes

- Modified `linkBin` function in `pkg-manager/link-bins/src/index.ts`
- For global installations (detected by `opts.global` flag), remove existing bin scripts before creating new ones

## Testing

- [ ] Added test case in `pkg-manager/link-bins/test/index.ts`
- [ ] Manually tested with `pnpm update --global`

## Checklist

- [ ] Code follows the style guidelines
- [ ] Self-review completed
- [ ] Changes are well-documented
- [ ] Tests added/updated
