### PR TITLE
fix: retry existence check in global virtual store race condition handler

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -244,6 +244,7 @@
     "relinks",
     "renderable",
     "reqheaders",
+    "rimrafed",
     "rmgr",
     "rpmdevtools",
     "rpmlint",


### PR DESCRIPTION
When 3+ threads/processes concurrently import the same package to the global virtual store, a third party can rimraf the target between another thread's failed rename and its existence check. Retry the check up to 4 times with 50ms delays to let the competing operation complete.