### PR TITLE
fix: show warning instead of crashing when running on Node.js 20

### DIFF
--- a/pnpm/bin/pnpm.mjs
+++ b/pnpm/bin/pnpm.mjs
@@ -5,7 +5,11 @@ const COMPATIBILITY_PAGE = `Visit https://r.pnpm.io/comp to see the list of past
 // We don't use the semver library here because:
 //  1. it is already bundled to dist/pnpm.mjs, so we would load it twice
 //  2. we want this file to support potentially older Node.js versions than what semver supports
-if (major < 22 || major == 22 && minor < 12) {
+if (major == 20) {
+  console.warn(`warn: This version of pnpm requires at least Node.js v22.12
+warn: The current version of Node.js is ${process.version}
+warn: ${COMPATIBILITY_PAGE}`)
+} else if (major < 22 || major == 22 && minor < 12) {
   console.error(`ERROR: This version of pnpm requires at least Node.js v22.12
 The current version of Node.js is ${process.version}
 ${COMPATIBILITY_PAGE}`)


### PR DESCRIPTION
Looks like Github actions don't yet come with images on Node.js 24 (Node.js 22 will be skipped). So, we need a workaround for now.