### PR TITLE
test: fix several flaky tests in pkg-manager

### DIFF
--- a/.changeset/giant-shoes-smell.md
+++ b/.changeset/giant-shoes-smell.md
@@ -1,5 +1,0 @@
----
-"@pnpm/jest-config": minor
----
-
-Add retries for failed tests during CI testing

--- a/__utils__/jest-config/package.json
+++ b/__utils__/jest-config/package.json
@@ -7,10 +7,8 @@
   "dependencies": {
     "@babel/core": "catalog:",
     "@babel/plugin-transform-explicit-resource-management": "catalog:",
-    "@jest/globals": "catalog:",
     "@pnpm/registry-mock": "catalog:",
     "@pnpm/worker": "workspace:*",
-    "ci-info": "catalog:",
     "get-port": "catalog:",
     "tree-kill": "catalog:"
   },

--- a/__utils__/jest-config/setupFilesAfterEnv.js
+++ b/__utils__/jest-config/setupFilesAfterEnv.js
@@ -1,7 +1,5 @@
 import path from 'path'
 import { finishWorkers } from '@pnpm/worker'
-import { isCI } from 'ci-info'
-import { jest } from '@jest/globals';
 
 const pnpmBinDir = path.join(import.meta.dirname, 'node_modules/.bin')
 process.env.PATH = `${pnpmBinDir}${path.delimiter}${process.env.PATH}`
@@ -9,8 +7,3 @@ process.env.PATH = `${pnpmBinDir}${path.delimiter}${process.env.PATH}`
 afterAll(async () => {
   await finishWorkers()
 })
-
-if (isCI) {
-  // In CI, retry failed tests up to 2 times to mitigate flakiness, and log errors before retrying for better debugging
-  jest.retryTimes(2, { logErrorsBeforeRetry: true })
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,18 +1090,12 @@ importers:
       '@babel/plugin-transform-explicit-resource-management':
         specifier: 'catalog:'
         version: 7.28.6(@babel/core@7.29.0)
-      '@jest/globals':
-        specifier: 'catalog:'
-        version: 30.0.5
       '@pnpm/registry-mock':
         specifier: 'catalog:'
         version: 5.2.1(verdaccio@6.2.5(encoding@0.1.13)(typanion@3.14.0))
       '@pnpm/worker':
         specifier: workspace:*
         version: link:../../worker
-      ci-info:
-        specifier: 'catalog:'
-        version: 4.4.0
       get-port:
         specifier: 'catalog:'
         version: 7.1.0


### PR DESCRIPTION
Fix several flaky tests I observed while working on #10341.

Related flaky test fix: https://github.com/pnpm/registry-mock/pull/30