### PR TITLE
fix(audit): fallback to quick audit endpoint

### DIFF
--- a/.changeset/audit-quick-fallback.md
+++ b/.changeset/audit-quick-fallback.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fallback to the `/-/npm/v1/security/audits/quick` endpoint when the default `/-/npm/v1/security/audits` endpoint fails. This fixes `pnpm audit` failures caused by registry 5xx responses from the primary audit endpoint [#10649](https://github.com/pnpm/pnpm/issues/10649).
+Use the `/-/npm/v1/security/audits/quick` endpoint as the primary audit endpoint, falling back to `/-/npm/v1/security/audits` when it fails [#10649](https://github.com/pnpm/pnpm/issues/10649).

--- a/lockfile/audit/src/index.ts
+++ b/lockfile/audit/src/index.ts
@@ -40,22 +40,22 @@ export async function audit (
     timeout: opts.timeout,
   }
 
-  const res = await fetchWithAgent(auditUrl, requestOptions)
-
-  if (res.status === 200) {
-    return (res.json() as Promise<AuditReport>)
-  }
-
   const quickRes = await fetchWithAgent(quickAuditUrl, requestOptions)
+
   if (quickRes.status === 200) {
     return (quickRes.json() as Promise<AuditReport>)
   }
 
-  if (res.status === 404 && quickRes.status === 404) {
-    throw new AuditEndpointNotExistsError(auditUrl)
+  const res = await fetchWithAgent(auditUrl, requestOptions)
+  if (res.status === 200) {
+    return (res.json() as Promise<AuditReport>)
   }
 
-  throw new PnpmError('AUDIT_BAD_RESPONSE', `The audit endpoint (at ${auditUrl}) responded with ${res.status}: ${await res.text()}. Fallback endpoint (at ${quickAuditUrl}) responded with ${quickRes.status}: ${await quickRes.text()}`)
+  if (quickRes.status === 404 && res.status === 404) {
+    throw new AuditEndpointNotExistsError(quickAuditUrl)
+  }
+
+  throw new PnpmError('AUDIT_BAD_RESPONSE', `The audit endpoint (at ${quickAuditUrl}) responded with ${quickRes.status}: ${await quickRes.text()}. Fallback endpoint (at ${auditUrl}) responded with ${res.status}: ${await res.text()}`)
 }
 
 interface AuthHeaders {

--- a/lockfile/audit/test/index.ts
+++ b/lockfile/audit/test/index.ts
@@ -149,12 +149,12 @@ describe('audit', () => {
     nock(registry, {
       badheaders: ['authorization'],
     })
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(500, { message: 'Something bad happened' })
     nock(registry, {
       badheaders: ['authorization'],
     })
-      .post('/-/npm/v1/security/audits/quick')
+      .post('/-/npm/v1/security/audits')
       .reply(500, { message: 'Fallback failed too' })
 
     let err!: PnpmError
@@ -178,21 +178,21 @@ describe('audit', () => {
 
     expect(err).toBeDefined()
     expect(err.code).toBe('ERR_PNPM_AUDIT_BAD_RESPONSE')
-    expect(err.message).toBe('The audit endpoint (at http://registry.registry/-/npm/v1/security/audits) responded with 500: {"message":"Something bad happened"}. Fallback endpoint (at http://registry.registry/-/npm/v1/security/audits/quick) responded with 500: {"message":"Fallback failed too"}')
+    expect(err.message).toBe('The audit endpoint (at http://registry.registry/-/npm/v1/security/audits/quick) responded with 500: {"message":"Something bad happened"}. Fallback endpoint (at http://registry.registry/-/npm/v1/security/audits) responded with 500: {"message":"Fallback failed too"}')
   })
 
-  test('falls back to /audits/quick if /audits fails', async () => {
+  test('falls back to /audits if /audits/quick fails', async () => {
     const registry = 'http://registry.registry/'
     const getAuthHeader = () => undefined
     nock(registry, {
       badheaders: ['authorization'],
     })
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(500, { message: 'Something bad happened' })
     nock(registry, {
       badheaders: ['authorization'],
     })
-      .post('/-/npm/v1/security/audits/quick')
+      .post('/-/npm/v1/security/audits')
       .reply(200, {
         actions: [],
         advisories: {},

--- a/lockfile/plugin-commands-audit/test/fix.ts
+++ b/lockfile/plugin-commands-audit/test/fix.ts
@@ -17,7 +17,7 @@ test('overrides are added for vulnerable dependencies', async () => {
   const tmp = f.prepare('has-vulnerabilities')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({
@@ -43,7 +43,7 @@ test('no overrides are added if no vulnerabilities are found', async () => {
   const tmp = f.prepare('fixture')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.NO_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({
@@ -65,7 +65,7 @@ test('CVEs found in the allow list are not added as overrides', async () => {
   const tmp = f.prepare('has-vulnerabilities')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({

--- a/lockfile/plugin-commands-audit/test/ignore.ts
+++ b/lockfile/plugin-commands-audit/test/ignore.ts
@@ -17,7 +17,7 @@ test('ignores are added for vulnerable dependencies with no resolutions', async 
   const tmp = f.prepare('has-vulnerabilities')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({
@@ -45,7 +45,7 @@ test('the specified vulnerabilities are ignored', async () => {
   const tmp = f.prepare('has-vulnerabilities')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({
@@ -71,7 +71,7 @@ test('no ignores are added if no vulnerabilities are found', async () => {
   const tmp = f.prepare('fixture')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.NO_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({
@@ -100,7 +100,7 @@ test('ignored CVEs are not duplicated', async () => {
   ]
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { exitCode, output } = await audit.handler({

--- a/lockfile/plugin-commands-audit/test/index.ts
+++ b/lockfile/plugin-commands-audit/test/index.ts
@@ -77,7 +77,7 @@ describe('plugin-commands-audit', () => {
   })
   test('audit', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -94,7 +94,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit --dev', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.DEV_VULN_ONLY_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -114,7 +114,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit --audit-level', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -133,7 +133,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit: no vulnerabilities', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.NO_VULN_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -151,7 +151,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit --json', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -171,7 +171,7 @@ describe('plugin-commands-audit', () => {
 
   test.skip('audit does not exit with code 1 if the found vulnerabilities are having lower severity then what we asked for', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.DEV_VULN_ONLY_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -192,7 +192,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit --json respects audit-level', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.DEV_VULN_ONLY_RESP)
 
     const { exitCode, output } = await audit.handler({
@@ -214,7 +214,7 @@ describe('plugin-commands-audit', () => {
 
   test('audit --json filters advisories by audit-level', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.DEV_VULN_ONLY_RESP)
 
     const { exitCode, output } = await audit.handler({
@@ -241,10 +241,10 @@ describe('plugin-commands-audit', () => {
 
   test('audit does not exit with code 1 if the registry responds with a non-200 response and ignoreRegistryErrors is used', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(500, { message: 'Something bad happened' })
     nock(registries.default)
-      .post('/-/npm/v1/security/audits/quick')
+      .post('/-/npm/v1/security/audits')
       .reply(500, { message: 'Fallback failed too' })
     const { output, exitCode } = await audit.handler({
       dir: hasVulnerabilitiesDir,
@@ -260,14 +260,14 @@ describe('plugin-commands-audit', () => {
     })
 
     expect(exitCode).toBe(0)
-    expect(stripAnsi(output)).toBe(`The audit endpoint (at ${registries.default}-/npm/v1/security/audits) responded with 500: {"message":"Something bad happened"}. Fallback endpoint (at ${registries.default}-/npm/v1/security/audits/quick) responded with 500: {"message":"Fallback failed too"}`)
+    expect(stripAnsi(output)).toBe(`The audit endpoint (at ${registries.default}-/npm/v1/security/audits/quick) responded with 500: {"message":"Something bad happened"}. Fallback endpoint (at ${registries.default}-/npm/v1/security/audits) responded with 500: {"message":"Fallback failed too"}`)
   })
 
   test('audit sends authToken', async () => {
     nock(registries.default, {
       reqheaders: { authorization: 'Bearer 123' },
     })
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.NO_VULN_RESP)
 
     const { output, exitCode } = await audit.handler({
@@ -288,10 +288,10 @@ describe('plugin-commands-audit', () => {
 
   test('audit endpoint does not exist', async () => {
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(404, {})
     nock(registries.default)
-      .post('/-/npm/v1/security/audits/quick')
+      .post('/-/npm/v1/security/audits')
       .reply(404, {})
 
     await expect(audit.handler({
@@ -312,7 +312,7 @@ describe('plugin-commands-audit', () => {
     const tmp = f.prepare('has-vulnerabilities')
 
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { exitCode, output } = await audit.handler({
@@ -342,7 +342,7 @@ describe('plugin-commands-audit', () => {
     const tmp = f.prepare('has-vulnerabilities')
 
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { exitCode, output } = await audit.handler({
@@ -372,7 +372,7 @@ describe('plugin-commands-audit', () => {
     const tmp = f.prepare('has-vulnerabilities')
 
     nock(registries.default)
-      .post('/-/npm/v1/security/audits')
+      .post('/-/npm/v1/security/audits/quick')
       .reply(200, responses.ALL_VULN_RESP)
 
     const { exitCode, output } = await audit.handler({

--- a/lockfile/plugin-commands-audit/test/preserveReferenceOverrides.ts
+++ b/lockfile/plugin-commands-audit/test/preserveReferenceOverrides.ts
@@ -18,7 +18,7 @@ test('overrides with references (via $) are preserved during audit --fix', async
   const tmp = f.prepare('preserve-reference-overrides')
 
   nock(registries.default)
-    .post('/-/npm/v1/security/audits')
+    .post('/-/npm/v1/security/audits/quick')
     .reply(200, responses.ALL_VULN_RESP)
 
   const { manifest: initialManifest } = await readProjectManifest(tmp)


### PR DESCRIPTION
## Summary
- retry pnpm audit via /-/npm/v1/security/audits/quick when /-/npm/v1/security/audits returns non-200
- preserve existing behavior when the primary endpoint succeeds
- include both endpoint responses in the error when both fail
- add regression tests for quick fallback and dual-404 behavior
- add a changeset for @pnpm/audit and pnpm

## Testing
- pnpm --filter @pnpm/audit test
- pnpm --filter @pnpm/plugin-commands-audit test test/index.ts

Closes #10649