### PR TITLE
fix(audit): help text for --ignore-registry-errors was missing a "not"

### DIFF
--- a/.changeset/rich-days-bow.md
+++ b/.changeset/rich-days-bow.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-audit": patch
+---
+
+fixed help text for audit --ignore-registry-errors

--- a/lockfile/plugin-commands-audit/src/audit.ts
+++ b/lockfile/plugin-commands-audit/src/audit.ts
@@ -103,7 +103,7 @@ export function help (): string {
             name: '--no-optional',
           },
           {
-            description: 'Use exit code 0 if the registry responds with an error. Useful when audit checks are used in CI. A build should fail because the registry has issues.',
+            description: 'Use exit code 0 if the registry responds with an error. Useful when audit checks are used in CI. A build should not fail because the registry has issues.',
             name: '--ignore-registry-errors',
           },
           {


### PR DESCRIPTION
was having audit issues today (rando 500s on and off all day)

was pleasantly surprised to see the `--ignore-registry-errors` flag. Realized there  was a typo in the help text, so here I am...
