### PR TITLE
fix: audit fix should respect ignoreGhsas config

### DIFF
--- a/.changeset/silly-birds-mate.md
+++ b/.changeset/silly-birds-mate.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+`pnpm audit --fix` should respect the ignoreGhsas configuration.

--- a/deps/compliance/commands/src/audit/fix.ts
+++ b/deps/compliance/commands/src/audit/fix.ts
@@ -11,7 +11,7 @@ export interface FixResult {
 }
 
 export async function fix (auditReport: AuditReport, opts: AuditOptions): Promise<FixResult> {
-  const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreCves)
+  const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreCves, opts.auditConfig?.ignoreGhsas)
   const vulnOverrides = createOverrides(fixableAdvisories)
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
@@ -25,9 +25,12 @@ export async function fix (auditReport: AuditReport, opts: AuditOptions): Promis
   return { vulnOverrides, addedAgeExcludes }
 }
 
-function getFixableAdvisories (advisories: AuditAdvisory[], ignoreCves?: string[]): AuditAdvisory[] {
+function getFixableAdvisories (advisories: AuditAdvisory[], ignoreCves?: string[], ignoreGhsas?: string[]): AuditAdvisory[] {
   if (ignoreCves) {
     advisories = advisories.filter(({ cves }) => difference(cves, ignoreCves).length > 0)
+  }
+  if (ignoreGhsas) {
+    advisories = advisories.filter(({ github_advisory_id: ghsaId }) => difference([ghsaId], ignoreGhsas).length > 0)
   }
   return advisories
     .filter(({ vulnerable_versions: vulnerableVersions, patched_versions: patchedVersions }) => vulnerableVersions !== '>=0.0.0' && patchedVersions !== '<0.0.0')

--- a/deps/compliance/commands/test/audit/fix.ts
+++ b/deps/compliance/commands/test/audit/fix.ts
@@ -101,3 +101,36 @@ test('CVEs found in the allow list are not added as overrides', async () => {
   expect(manifest.overrides?.['minimist@<0.2.1']).toBeFalsy()
   expect(manifest.overrides?.['url-parse@<1.5.6']).toBeTruthy()
 })
+
+test('GHSAs found in the allow list are not added as overrides', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/audits/quick', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    auditConfig: {
+      ignoreGhsas: [
+        'GHSA-42xw-2xvc-qx8m', // axios CVE-2019-10742
+        'GHSA-4w2v-q235-vp99', // axios CVE-2020-28168
+        'GHSA-cph5-m8f7-6c5x', // axios CVE-2021-3749
+        'GHSA-vh95-rmgr-6w4m', // minimist CVE-2020-7598
+      ],
+    },
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+  })
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBeFalsy()
+  expect(manifest.overrides?.['axios@<0.21.1']).toBeFalsy()
+  expect(manifest.overrides?.['axios@<=0.21.1']).toBeFalsy()
+  expect(manifest.overrides?.['minimist@<0.2.1']).toBeFalsy()
+  expect(manifest.overrides?.['url-parse@<1.5.6']).toBeTruthy()
+})


### PR DESCRIPTION
`pnpm audit --fix` should not add dependencies in the ignoreGhsas configuration to overrides.