### PR TITLE
feat: install all matching Node.js runtime variants for multiple architectures

### DIFF
--- a/.changeset/node-runtime-multi-arch.md
+++ b/.changeset/node-runtime-multi-arch.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/package-requester": minor
+"@pnpm/deps.graph-builder": minor
+"@pnpm/headless": minor
+"@pnpm/core": minor
+"pnpm": minor
+---
+
+When `supportedArchitectures` specifies multiple os/cpu combinations, all matching Node.js runtime variants are now automatically installed alongside the primary one. Each extra variant is installed into `node_modules/node-<os>-<cpu>[-musl]/`.

--- a/deps/graph-builder/package.json
+++ b/deps/graph-builder/package.json
@@ -39,6 +39,7 @@
     "@pnpm/lockfile.utils": "workspace:*",
     "@pnpm/modules-yaml": "workspace:*",
     "@pnpm/package-is-installable": "workspace:*",
+    "@pnpm/package-requester": "workspace:*",
     "@pnpm/patching.config": "workspace:*",
     "@pnpm/patching.types": "workspace:*",
     "@pnpm/store-controller-types": "workspace:*",

--- a/deps/graph-builder/tsconfig.json
+++ b/deps/graph-builder/tsconfig.json
@@ -49,6 +49,9 @@
       "path": "../../pkg-manager/modules-yaml"
     },
     {
+      "path": "../../pkg-manager/package-requester"
+    },
+    {
       "path": "../../store/store-controller-types"
     }
   ]

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -1327,6 +1327,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         symlink: opts.symlink,
         skipped: ctx.skipped,
         storeController: opts.storeController,
+        supportedArchitectures: opts.supportedArchitectures,
         virtualStoreDir: ctx.virtualStoreDir,
         virtualStoreDirMaxLength: ctx.virtualStoreDirMaxLength,
         wantedLockfile: newLockfile,

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -339,6 +339,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
   } as LockfileToDepGraphOptions
   const {
     directDependenciesByImporterId,
+    extraVariantLinks,
     graph,
     hierarchy,
     hoistedLocations,
@@ -495,6 +496,18 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         registries: opts.registries,
         symlink: opts.symlink,
       })
+
+      if (opts.symlink !== false && extraVariantLinks.length > 0) {
+        const modulesDirByImporterId = Object.fromEntries(selectedProjects.map((p) => [p.id, p.modulesDir]))
+        await Promise.all(
+          extraVariantLinks.flatMap(({ alias, dir, importerIds: variantImporterIds }) =>
+            variantImporterIds
+              .map((importerId) => modulesDirByImporterId[importerId])
+              .filter(Boolean)
+              .map((modulesDir) => symlinkDependency(dir, modulesDir, alias))
+          )
+        )
+      }
     }
   }
 

--- a/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
+++ b/pkg-manager/headless/src/lockfileToHoistedDepGraph.ts
@@ -126,6 +126,7 @@ async function _lockfileToHoistedDepGraph (
   )
   return {
     directDependenciesByImporterId,
+    extraVariantLinks: [],
     graph,
     hierarchy,
     symlinkedDirectDependenciesByImporterId,

--- a/pkg-manager/package-requester/src/index.ts
+++ b/pkg-manager/package-requester/src/index.ts
@@ -1,3 +1,5 @@
-export { createPackageRequester } from './packageRequester.js'
+export { createPackageRequester, getExtraVariantDescriptors } from './packageRequester.js'
+
+export type { ExtraVariantDescriptor } from './packageRequester.js'
 
 export type { PackageResponse } from '@pnpm/store-controller-types'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2153,6 +2153,9 @@ importers:
       '@pnpm/package-is-installable':
         specifier: workspace:*
         version: link:../../config/package-is-installable
+      '@pnpm/package-requester':
+        specifier: workspace:*
+        version: link:../../pkg-manager/package-requester
       '@pnpm/patching.config':
         specifier: workspace:*
         version: link:../../patching/config


### PR DESCRIPTION
When `supportedArchitectures` specifies multiple os/cpu values and a `node@runtime:*` dependency exists, pnpm now automatically installs all matching platform variants alongside the primary one. Each extra variant is installed into `node_modules/node-<os>-<cpu>[-musl]/` with a corresponding top-level symlink.