### PR TITLE
fix: merge workspace overrides with package.json resolutions

### DIFF
--- a/.changeset/fix-overrides-merge.md
+++ b/.changeset/fix-overrides-merge.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/config": patch
+"pnpm": patch
+---
+
+Fix overrides from package.json resolutions being lost when pnpm-workspace.yaml has overrides [#10675](https://github.com/pnpm/pnpm/issues/10675)
+
+When both `package.json` has a `resolutions` field and `pnpm-workspace.yaml` has an `overrides` field, the overrides are now properly merged instead of the workspace overrides replacing the package.json ones.

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -654,7 +654,14 @@ function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config, {
   workspaceDir: string | undefined
   workspaceManifest: WorkspaceManifest
 }): void {
-  const newSettings = Object.assign(getOptionsFromPnpmSettings(workspaceDir, workspaceManifest, projectManifest), configFromCliOpts)
+  const workspaceSettings = getOptionsFromPnpmSettings(workspaceDir, workspaceManifest, projectManifest)
+  // Merge workspace overrides with existing package.json overrides
+  // Package.json overrides (from resolutions/pnpm.overrides) should be merged with workspace overrides
+  // Workspace overrides take precedence when there's a conflict
+  if (workspaceSettings.overrides != null && pnpmConfig.overrides != null) {
+    workspaceSettings.overrides = { ...pnpmConfig.overrides, ...workspaceSettings.overrides }
+  }
+  const newSettings = Object.assign(workspaceSettings, configFromCliOpts)
   for (const [key, value] of Object.entries(newSettings)) {
     if (!isCamelCase(key)) continue
 

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -1500,4 +1500,39 @@ describe('global config.yaml', () => {
       'baz': '3.0.0',
     })
   })
+
+  test('workspace-only overrides should be applied even when package.json has resolutions', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('package.json', JSON.stringify({
+      name: 'test-project',
+      resolutions: {
+        'foo': '1.0.0',
+      },
+    }, null, 2))
+
+    writeYamlFile('pnpm-workspace.yaml', {
+      packages: [],
+      overrides: {
+        'bar': '2.0.0', // This is ONLY in workspace, should still be applied
+      },
+    })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    // Both overrides should be present:
+    // - 'foo' from package.json resolutions
+    // - 'bar' from workspace overrides
+    expect(config.overrides).toStrictEqual({
+      'foo': '1.0.0',
+      'bar': '2.0.0',
+    })
+  })
 })

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -1422,6 +1422,75 @@ test.each([
   expect(config.autoConfirmAllPrompts).toBe(expectedValue)
 })
 
+describe('workspace overrides', () => {
+  test('overrides from package.json resolutions and pnpm-workspace.yaml should be merged', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('package.json', JSON.stringify({
+      name: 'test-project',
+      resolutions: {
+        'foo': '1.0.0',
+        'bar': '2.0.0',
+      },
+    }, null, 2))
+
+    writeYamlFile('pnpm-workspace.yaml', {
+      packages: [],
+      overrides: {
+        'baz': '3.0.0',
+        'bar': '2.5.0',
+      },
+    })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.overrides).toStrictEqual({
+      'foo': '1.0.0',
+      'bar': '2.5.0',
+      'baz': '3.0.0',
+    })
+  })
+
+  test('workspace-only overrides should be applied even when package.json has resolutions', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('package.json', JSON.stringify({
+      name: 'test-project',
+      resolutions: {
+        'foo': '1.0.0',
+      },
+    }, null, 2))
+
+    writeYamlFile('pnpm-workspace.yaml', {
+      packages: [],
+      overrides: {
+        'bar': '2.0.0',
+      },
+    })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.overrides).toStrictEqual({
+      'foo': '1.0.0',
+      'bar': '2.0.0',
+    })
+  })
+})
+
 describe('global config.yaml', () => {
   let XDG_CONFIG_HOME: string | undefined
 
@@ -1460,79 +1529,5 @@ describe('global config.yaml', () => {
     //       `pnpm config list` would convert them to camelCase.
     // TODO: switch to camelCase entirely later.
     expect(config.rawConfig).toHaveProperty(['dangerously-allow-all-builds'])
-  })
-
-  test('overrides from package.json resolutions and pnpm-workspace.yaml should be merged', async () => {
-    prepareEmpty()
-
-    fs.writeFileSync('package.json', JSON.stringify({
-      name: 'test-project',
-      resolutions: {
-        'foo': '1.0.0',
-        'bar': '2.0.0',
-      },
-    }, null, 2))
-
-    writeYamlFile('pnpm-workspace.yaml', {
-      packages: [],
-      overrides: {
-        'baz': '3.0.0',
-        'bar': '2.5.0', // This should override package.json's bar
-      },
-    })
-
-    const { config } = await getConfig({
-      cliOptions: {},
-      packageManager: {
-        name: 'pnpm',
-        version: '1.0.0',
-      },
-      workspaceDir: process.cwd(),
-    })
-
-    // All overrides should be merged:
-    // - 'foo' from package.json resolutions
-    // - 'bar' from workspace (overriding package.json's version)
-    // - 'baz' from workspace overrides
-    expect(config.overrides).toStrictEqual({
-      'foo': '1.0.0',
-      'bar': '2.5.0',
-      'baz': '3.0.0',
-    })
-  })
-
-  test('workspace-only overrides should be applied even when package.json has resolutions', async () => {
-    prepareEmpty()
-
-    fs.writeFileSync('package.json', JSON.stringify({
-      name: 'test-project',
-      resolutions: {
-        'foo': '1.0.0',
-      },
-    }, null, 2))
-
-    writeYamlFile('pnpm-workspace.yaml', {
-      packages: [],
-      overrides: {
-        'bar': '2.0.0', // This is ONLY in workspace, should still be applied
-      },
-    })
-
-    const { config } = await getConfig({
-      cliOptions: {},
-      packageManager: {
-        name: 'pnpm',
-        version: '1.0.0',
-      },
-      workspaceDir: process.cwd(),
-    })
-
-    // Both overrides should be present:
-    // - 'foo' from package.json resolutions
-    // - 'bar' from workspace overrides
-    expect(config.overrides).toStrictEqual({
-      'foo': '1.0.0',
-      'bar': '2.0.0',
-    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes #10675

When both `package.json` has a `resolutions` field and `pnpm-workspace.yaml` has an `overrides` field, the overrides are now properly merged instead of the workspace overrides completely replacing the package.json ones.

## Problem

Previously, when a project had:
- `package.json` with `resolutions: { "foo": "1.0.0" }`
- `pnpm-workspace.yaml` with `overrides: { "bar": "2.0.0" }`

Only the workspace override (`bar`) would be applied. The `foo` override from `package.json` was lost.

## Solution

Modified `addSettingsFromWorkspaceManifestToConfig` in `config/config/src/index.ts` to merge workspace overrides with existing package.json overrides, with workspace overrides taking precedence when there's a conflict.

## Test Plan

Added tests that verify:
- `foo` from `package.json` resolutions is preserved
- `bar` from workspace overrides overrides `package.json`'s `bar`
- `baz` from workspace overrides is included

```typescript
// package.json resolutions: { foo: '1.0.0', bar: '2.0.0' }
// pnpm-workspace.yaml overrides: { baz: '3.0.0', bar: '2.5.0' }
// Expected result: { foo: '1.0.0', bar: '2.5.0', baz: '3.0.0' }
```