### PR TITLE
ci: skip update-lockfile on forks

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update-lockfile:
-    if : github.repository == 'pnpm/pnpm' #Only run on the main repository, not forks
+    if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Commit


### PR DESCRIPTION
To prevent frequent error emails from being received due to the failure of scheduled workflow execution when forking the repository.