### PR TITLE
fix(config): handle configDependencies fetch during config commands

### DIFF
--- a/.changeset/major-hats-press.md
+++ b/.changeset/major-hats-press.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli-utils": patch
+"pnpm": patch
+---
+
+fix(config): prevent crashes by ignoring `configDependencies` fetch errors

--- a/cli/cli-utils/test/getConfig.test.ts
+++ b/cli/cli-utils/test/getConfig.test.ts
@@ -1,8 +1,44 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import fs from 'fs'
-import { getConfig } from '@pnpm/cli-utils'
-import { prepare } from '@pnpm/prepare'
 import { jest } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+jest.unstable_mockModule('@pnpm/config.deps-installer', () => ({
+  installConfigDeps: jest.fn(),
+}))
+
+jest.unstable_mockModule('@pnpm/logger', () => {
+  const mockMethods = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const logger = Object.assign(
+    jest.fn().mockReturnValue(mockMethods),
+    mockMethods
+  )
+
+  return {
+    logger,
+    globalWarn: jest.fn(),
+    globalInfo: jest.fn(),
+    globalError: jest.fn(),
+  }
+})
+
+jest.unstable_mockModule('@pnpm/store-connection-manager', () => ({
+  createStoreController: jest.fn().mockImplementation(async () => ({
+    ctrl: {
+      close: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    },
+  })),
+}))
+
+const { installConfigDeps } = await import('@pnpm/config.deps-installer')
+const { logger } = await import('@pnpm/logger')
+const { getConfig } = await import('@pnpm/cli-utils')
 
 beforeEach(() => {
   jest.spyOn(console, 'warn')
@@ -41,4 +77,69 @@ test('hoist: false removes hoistPattern', async () => {
 
   expect(config.hoist).toBe(false)
   expect(config.hoistPattern).toBeUndefined()
+})
+
+test('proceeds normally when configDependencies install successfully', async () => {
+  prepare()
+  fs.writeFileSync('pnpm-workspace.yaml', 'configDependencies:\n  some-helper-pkg: "1.0.0"', 'utf8')
+
+  jest.mocked(installConfigDeps).mockResolvedValueOnce(undefined)
+
+  const config = await getConfig({
+    json: false,
+  }, {
+    workspaceDir: '.',
+    excludeReporter: false,
+    rcOptionsTypes: {},
+  })
+
+  expect(config).toBeDefined()
+  expect(installConfigDeps).toHaveBeenCalled()
+})
+
+test('does not crash when configDependencies fail to install (e.g. missing auth token)', async () => {
+  prepare()
+  fs.writeFileSync('pnpm-workspace.yaml', 'configDependencies:\n  some-helper-pkg: "1.0.0"', 'utf8')
+
+  const simulatedError = new Error('401 Unauthorized: missing auth token')
+
+  jest.mocked(installConfigDeps).mockRejectedValueOnce(simulatedError)
+
+  const config = await getConfig({
+    json: false,
+  }, {
+    workspaceDir: '.',
+    excludeReporter: false,
+    rcOptionsTypes: {},
+    catchConfigDependenciesErrors: true,
+  })
+
+  expect(config).toBeDefined()
+  expect(installConfigDeps).toHaveBeenCalled()
+  expect(logger.debug).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: expect.stringContaining('Failed to install configDependencies'),
+      err: simulatedError,
+    })
+  )
+})
+
+test('throws error when configDependencies fail and catchConfigDependenciesErrors is false (default)', async () => {
+  prepare()
+  fs.writeFileSync('pnpm-workspace.yaml', 'configDependencies:\n  some-helper-pkg: "1.0.0"', 'utf8')
+
+  const simulatedError = new Error('401 Unauthorized: missing auth token')
+  jest.mocked(installConfigDeps).mockRejectedValueOnce(simulatedError)
+
+  await expect(
+    getConfig({
+      json: false,
+    }, {
+      workspaceDir: '.',
+      excludeReporter: false,
+      rcOptionsTypes: {},
+    })
+  ).rejects.toThrow('401 Unauthorized: missing auth token')
+
+  expect(installConfigDeps).toHaveBeenCalled()
 })

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -110,6 +110,7 @@ export async function main (inputArgv: string[]): Promise<void> {
       workspaceDir,
       checkUnknownSetting: false,
       ignoreNonAuthSettingsFromLocal: isDlxOrCreateCommand,
+      catchConfigDependenciesErrors: cmd === 'config' || cmd === 'set' || cmd === 'get',
     }) as typeof config
     if (!isExecutedByCorepack() && cmd !== 'setup' && config.wantedPackageManager != null) {
       if (config.managePackageManagerVersions && config.wantedPackageManager?.name === 'pnpm' && cmd !== 'self-update') {


### PR DESCRIPTION
Running pnpm config set with configDependencies triggers installConfigDeps before saving
the new config, causing a crash as it tries to download dependencies before auth token is
written to .npmrc.

This PR adds an catchConfigDependenciesErrors flag to getConfig. During config commands
(config, set, get), if an error occurs, catches and logs it and proceeds.

Fixes #10684