### PR TITLE
feat: allow enableGlobalVirtualStore in CI

### DIFF
--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -607,12 +607,6 @@ export async function getConfig (opts: {
     pnpmConfig.dev = true
   }
 
-  if (pnpmConfig.ci) {
-    // Using a global virtual store in CI makes little sense,
-    // as there is never a warm cache in that environment.
-    pnpmConfig.enableGlobalVirtualStore = false
-  }
-
   // The yes option is only meant to be a CLI option. Remove it from the
   // returned pnpm config.
   delete (pnpmConfig as { yes?: boolean }).yes

--- a/pnpm/test/install/globalVirtualStore.ts
+++ b/pnpm/test/install/globalVirtualStore.ts
@@ -13,7 +13,6 @@ test('using a global virtual store', async () => {
   const storeDir = path.resolve('store')
   const globalVirtualStoreDir = path.join(storeDir, 'v11/links')
   writeYamlFile(path.resolve('pnpm-workspace.yaml'), {
-    ci: false, // We force CI=false because enableGlobalVirtualStore is always disabled in CI
     enableGlobalVirtualStore: true,
     storeDir,
     privateHoistPattern: '*',

--- a/pnpm/test/list.ts
+++ b/pnpm/test/list.ts
@@ -50,7 +50,6 @@ test('pnpm list returns correct paths with global virtual store', async () => {
     },
   })
   writeYamlFile('pnpm-workspace.yaml', {
-    ci: false, // enableGlobalVirtualStore is always disabled in CI
     enableGlobalVirtualStore: true,
     storeDir: path.resolve('store'),
     privateHoistPattern: '*',

--- a/store/plugin-commands-store/test/storePrune.ts
+++ b/store/plugin-commands-store/test/storePrune.ts
@@ -440,7 +440,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false', // This is needed because enableGlobalVirtualStore is set to fails in CI
     ])
 
     // Verify the links directory was created
@@ -456,7 +455,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ])
 
     // Run prune - should remove the now-unreferenced package
@@ -498,7 +496,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ], { cwd: project1Dir })
 
     // Create second project with the same dependency
@@ -515,7 +512,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ], { cwd: project2Dir })
 
     // Delete project1
@@ -567,7 +563,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ], { cwd: project1Dir })
 
     // Create second project with a different package (so it stays)
@@ -584,7 +579,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ], { cwd: project2Dir })
 
     // Verify both packages exist in links/@/ directory
@@ -647,7 +641,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ])
 
     // Verify all packages exist in links directory
@@ -679,7 +672,6 @@ describe('global virtual store prune', () => {
       `--cache-dir=${cacheDir}`,
       `--registry=${REGISTRY}`,
       '--config.enableGlobalVirtualStore=true',
-      '--config.ci=false',
     ])
 
     // Run prune


### PR DESCRIPTION
## Description
This PR allows the use of \enableGlobalVirtualStore\ in CI environments. Previously, this feature was explicitly disabled when \ci\ was detected as true.

## Why
Using a global virtual store in CI is beneficial when the store directory is cached across runs (e.g., using GitHub Actions cache). It avoids redundant link creation and speeds up builds.

## Changes
- Removed the block in \config/config/src/index.ts\ that forced \enableGlobalVirtualStore\ to false in CI.
- Updated unit tests to remove \ci: false\ overrides that were previously necessary to test this feature.

## Verification
Ran relevant unit tests:
- \pnpm\test\install\globalVirtualStore.ts\
- \pnpm\test\list.ts\
- \store\plugin-commands-store\test\storePrune.ts\
All passed successfully.

Fixes #10681