### PR TITLE
fix(patching): ignore GIT_CONFIG_GLOBAL during patch-commit git diff

### DIFF
--- a/.changeset/clever-lines-rule.md
+++ b/.changeset/clever-lines-rule.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-patching": patch
+---
+
+ignore GIT_CONFIG_GLOBAL during patch-commit git diff

--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -158,6 +158,7 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
         // These variables aim to ignore the global git config so we get predictable output
         // https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGNOSYSTEMcode
         GIT_CONFIG_NOSYSTEM: '1',
+        GIT_CONFIG_GLOBAL: '',
         HOME: '',
         XDG_CONFIG_HOME: '',
         USERPROFILE: '',


### PR DESCRIPTION
pnpm patch-commit overrides HOME and XDG_CONFIG_HOME on running git diff to an empty string. If a user exports GIT_CONFIG_GLOBAL in their environment to point to a config with includeIf directive referencing '~/', git tries to resolve home dir, and since HOME is overridden, it throws a fatal error.

This PR explicitly appends GIT_CONFIG_GLOBAL: '' to the env object when execa is called. Hence, global user configs are ignored. Also added a test that ensures no problems in the presence of broken GIT_CONFIG_GLOBAL env variable.

Fixes #10689