### PR TITLE
fix(patch): use '/dev/null' instead of os.devNull for GIT_CONFIG_GLOBAL

### DIFF
--- a/patching/plugin-commands-patching/src/patchCommit.ts
+++ b/patching/plugin-commands-patching/src/patchCommit.ts
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import os from 'os'
 import path from 'path'
 import { docsUrl } from '@pnpm/cli-utils'
 import { type Config, types as allTypes } from '@pnpm/config'
@@ -159,14 +158,18 @@ async function diffFolders (folderA: string, folderB: string): Promise<string> {
         // These variables aim to ignore the global git config so we get predictable output
         // https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGNOSYSTEMcode
         GIT_CONFIG_NOSYSTEM: '1',
-        // Redirect the global git config to the null device instead of setting
+        // Redirect the global git config to /dev/null instead of setting
         // HOME to an empty string. An empty HOME causes git to resolve '~' as
         // '/' (root), which triggers a "Permission denied" warning when git
         // tries to access '/.config/git/attributes', making pnpm throw an
         // error because any stderr output is treated as a failure.
         // We do not set XDG_CONFIG_HOME to avoid the same issue: an empty
         // value would make git resolve paths like /git/config and /git/attributes.
-        GIT_CONFIG_GLOBAL: os.devNull,
+        // We use '/dev/null' literally instead of os.devNull because on Windows
+        // os.devNull is '\\.\nul', which git cannot open as a config file path
+        // (fatal: unable to access '\\.\nul': Invalid argument). Git for Windows
+        // translates '/dev/null' correctly via its MSYS2 layer.
+        GIT_CONFIG_GLOBAL: '/dev/null',
         // #endregion
       },
       stripFinalNewline: false,


### PR DESCRIPTION
On Windows, os.devNull is '\\.\nul', which git cannot open as a config file path (fatal: unable to access '\\.\nul': Invalid argument). Git for Windows translates the literal '/dev/null' correctly via its MSYS2 layer, fixing patch-commit on Windows.

Followup to https://github.com/pnpm/pnpm/pull/10640