### PR TITLE
fix(audit): correctly count ignored vulnerabilities on the basis of o…

### DIFF
--- a/.changeset/dull-moments-cross.md
+++ b/.changeset/dull-moments-cross.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/plugin-commands-audit": patch
+---
+
+fix(audit): correctly count ignored vulnerabilities on the basis of occurrence paths

--- a/lockfile/plugin-commands-audit/src/audit.ts
+++ b/lockfile/plugin-commands-audit/src/audit.ts
@@ -258,21 +258,27 @@ ${newIgnores.join('\n')}`,
     .reduce((sum: number, vulnerabilitiesCount: number) => sum + vulnerabilitiesCount, 0)
   const ignoreGhsas = opts.auditConfig?.ignoreGhsas
   if (ignoreGhsas) {
-    auditReport.advisories = pickBy(({ github_advisory_id: githubAdvisoryId, severity }) => {
+    auditReport.advisories = pickBy(({ github_advisory_id: githubAdvisoryId, severity, findings }) => {
       if (!ignoreGhsas.includes(githubAdvisoryId)) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+
+      const occurrences = (findings || []).reduce((acc: number, finding: { paths?: string[] }) => acc + (finding.paths?.length || 0), 0)
+      ignoredVulnerabilities[severity as AuditLevelString] += occurrences
+
       return false
     }, auditReport.advisories)
   }
   const ignoreCves = opts.auditConfig?.ignoreCves
   if (ignoreCves) {
-    auditReport.advisories = pickBy(({ cves, severity }) => {
+    auditReport.advisories = pickBy(({ cves, severity, findings }) => {
       if (cves.length === 0 || difference(cves, ignoreCves).length > 0) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+
+      const occurrences = (findings || []).reduce((acc: number, finding: { paths?: string[] }) => acc + (finding.paths?.length || 0), 0)
+      ignoredVulnerabilities[severity as AuditLevelString] += occurrences
+
       return false
     }, auditReport.advisories)
   }

--- a/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
+++ b/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
@@ -1681,7 +1681,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;
 
 exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSON output is used 1`] = `
@@ -3865,5 +3865,5 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;

--- a/lockfile/plugin-commands-audit/test/index.ts
+++ b/lockfile/plugin-commands-audit/test/index.ts
@@ -6,7 +6,6 @@ import { AuditEndpointNotExistsError } from '@pnpm/audit'
 import nock from 'nock'
 import { stripVTControlCharacters as stripAnsi } from 'util'
 import * as responses from './utils/responses/index.js'
-
 const f = fixtures(path.join(import.meta.dirname, 'fixtures'))
 const registries = {
   default: 'https://registry.npmjs.org/',


### PR DESCRIPTION
…ccurrence paths

The `pnpm audit` command counted ignored vulnerabilities by the number of unique advisories, which caused confusing CLI output where the total ignored count did not match the actual number of vulnerable packages bypassed.

This PR updates GHSA and CVE ignore logic to sum the length of `finding.paths`, so the ignored count correctly reflects the dependency tree usage. Also, updated existing snapshot tests.

Fixes #10646