### PR TITLE
fix(self-updater): bypass minimumReleaseAge for standalone binary bootstrap

### DIFF
--- a/.changeset/some-ends-thank.md
+++ b/.changeset/some-ends-thank.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/tools.plugin-commands-self-updater": patch
+---
+
+Fix standalone binary bootstrap failing due to minimumReleaseAge constraint.

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -49,6 +49,7 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
       // which breaks the junctions on Windows.
       '--config.node-linker=hoisted',
       '--config.bin=bin',
+      '--config.minimum-release-age=0',
     ], { cwd: stage })
     // We need the operation of installing pnpm to be atomic.
     // However, we cannot use a rename as that breaks the command shim created for pnpm.

--- a/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
+++ b/tools/plugin-commands-self-updater/test/installPnpmToTools.test.ts
@@ -1,0 +1,49 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+jest.unstable_mockModule('@pnpm/exec.pnpm-cli-runner', () => ({
+  runPnpmCli: jest.fn(),
+}))
+
+jest.unstable_mockModule('symlink-dir', () => ({
+  default: { sync: jest.fn() },
+}))
+
+const { installPnpmToTools } = await import('../src/installPnpmToTools.js')
+const { runPnpmCli } = await import('@pnpm/exec.pnpm-cli-runner')
+
+type InstallOptions = Parameters<typeof installPnpmToTools>[1]
+
+describe('installPnpmToTools', () => {
+  let tempPnpmHome: string
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    tempPnpmHome = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-test-home-'))
+  })
+
+  afterEach(() => {
+    if (tempPnpmHome) {
+      fs.rmSync(tempPnpmHome, { recursive: true, force: true })
+    }
+  })
+
+  it('should include --config.minimum-release-age=0 to bypass age constraints for standalone binaries', async () => {
+    const targetVersion = '10.30.1'
+
+    await installPnpmToTools(targetVersion, {
+      pnpmHomeDir: tempPnpmHome,
+    } as InstallOptions)
+
+    expect(runPnpmCli).toHaveBeenCalledTimes(1)
+
+    const calledArgs = (runPnpmCli as jest.Mock).mock.calls[0][0]
+
+    expect(calledArgs).toContain('--config.minimum-release-age=0')
+    expect(calledArgs).toContain('--allow-build=@pnpm/exe')
+    expect(calledArgs).toContain('--no-dangerously-allow-all-builds')
+    expect(calledArgs).toContain('--config.node-linker=hoisted')
+  })
+})


### PR DESCRIPTION
When a user installs or runs a standalone pnpm binary, installPnpmToTools dynamically fetches the executable using `pnpm add`. It relies on the global resolver and hence is subjected to minimumReleaseAge configuration. This blocks the fetch and crashes the binary with ERR_PNPM_NO_MATURE_MATCHING_VERSION for new versions of pnpm.

This PR injects --config.minimum-release-age=0 into the arguments passed to runPnpmCli, bypassing the maturity check for pnpm executable internal bootstrapping. Also, adds tests.

Fixes #10699