### PR TITLE
docs: fix duplicated word in DirPatcher comment

### DIFF
--- a/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -6,7 +6,7 @@ import { PnpmError } from '@pnpm/error'
 
 export const DIR: unique symbol = Symbol('Path is a directory')
 
-// symbols and and numbers are used instead of discriminated union because
+// symbols and numbers are used instead of discriminated union because
 // it's faster and simpler to compare primitives than to deep compare objects
 export type File = number // representing the file's inode, which is sufficient for hardlinks
 export type Dir = typeof DIR


### PR DESCRIPTION
## Summary
- fix duplicated wording in `workspace/injected-deps-syncer/src/DirPatcher.ts`
- changed `and and numbers are used instead of discriminated union because` -> `and numbers are used instead of discriminated union because`

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- guideline reference: https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md
- trivial docs/comment wording fix only
- no behavior or API changes

## Validation
- single-file text/comment/docs change