### PR TITLE
fix(npm-resolver): consider only cached versions in offline mode

### DIFF
--- a/.changeset/shaky-facts-prove.md
+++ b/.changeset/shaky-facts-prove.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/npm-resolver": patch
+---
+
+Offline mode should only resolve to versions present in the local cache, preventing ERR_PNPM_NO_OFFLINE_TARBALL when uncached versions exist in the metadata.


### PR DESCRIPTION
When running `pnpm install --offline`, the semver resolver evaluated ranges against all versions in the metadata cache, including those without downloaded tarballs. This caused `ERR_PNPM_NO_OFFLINE_TARBALL` when an uncached version was picked over a cached version.

This PR adds a fix that filters out versions and dist-tags not present in `cachedVersions` in offline mode. Hence, only cached versions are picked.

Fixes #10715