### PR TITLE
fix(headless): populate GVS links/ when enableModulesDir is false

### DIFF
--- a/.changeset/gvs-enable-modules-dir-false.md
+++ b/.changeset/gvs-enable-modules-dir-false.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/headless": patch
+"pnpm": patch
+---
+
+Fixed a bug where `enableModulesDir: false` prevented the Global Virtual Store `links/` directory from being populated. The `links/` directory is part of the store, not the project's `node_modules/`, so it should be written regardless of the `enableModulesDir` setting when GVS is enabled.

--- a/pkg-manager/core/test/install/globalVirtualStore.ts
+++ b/pkg-manager/core/test/install/globalVirtualStore.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { assertProject } from '@pnpm/assert-project'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
-import { install, type MutatedProject, mutateModules, type ProjectOptions } from '@pnpm/core'
+import { install, mutateModulesInSingleProject, type MutatedProject, mutateModules, type ProjectOptions } from '@pnpm/core'
 import { type ProjectRootDir } from '@pnpm/types'
 import { sync as rimraf } from '@zkochan/rimraf'
 import { testDefaults } from '../utils/index.js'
@@ -194,4 +194,45 @@ test('injected local packages work with global virtual store', async () => {
   const injectedDepLocation = modulesState?.injectedDeps?.['project-1'][0]
   expect(injectedDepLocation).toContain('links')
   expect(fs.existsSync(path.join(injectedDepLocation!, 'foo.js'))).toBeTruthy()
+})
+
+test('global virtual store links/ is populated when enableModulesDir is false', async () => {
+  prepareEmpty()
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+
+  // First install to generate lockfile
+  await install(manifest, testDefaults({
+    enableGlobalVirtualStore: true,
+    virtualStoreDir: globalVirtualStoreDir,
+  }))
+
+  // Clean up and re-install with enableModulesDir: false (simulates pnpm fetch)
+  rimraf('node_modules')
+  rimraf(globalVirtualStoreDir)
+
+  await mutateModulesInSingleProject({
+    manifest: {},
+    mutation: 'install',
+    pruneDirectDependencies: true,
+    rootDir: process.cwd() as ProjectRootDir,
+  }, testDefaults({
+    enableGlobalVirtualStore: true,
+    enableModulesDir: false,
+    virtualStoreDir: globalVirtualStoreDir,
+    ignorePackageManifest: true,
+    frozenLockfile: true,
+  }))
+
+  // GVS links/ should be populated even though enableModulesDir is false
+  const hashDirs = fs.readdirSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0'))
+  expect(hashDirs).toHaveLength(1)
+  expect(fs.existsSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0', hashDirs[0], 'node_modules/@pnpm.e2e/pkg-with-1-dep/package.json'))).toBeTruthy()
+
+  // Project node_modules/ should NOT exist
+  expect(fs.existsSync(path.resolve('node_modules'))).toBeFalsy()
 })

--- a/pkg-manager/headless/src/index.ts
+++ b/pkg-manager/headless/src/index.ts
@@ -412,15 +412,33 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
       registries: opts.registries,
       symlink: opts.symlink,
     })
-  } else if (opts.enableModulesDir !== false) {
-    await Promise.all(depNodes.map(async (depNode) => fs.mkdir(depNode.modules, { recursive: true })))
-    await Promise.all([
-      opts.symlink === false
-        ? Promise.resolve()
-        : linkAllModules(depNodes, {
-          optional: opts.include.optionalDependencies,
+  } else {
+    // Import packages from CAS into their target directories.
+    // When GVS is enabled, depNode.dir is inside {storeDir}/v11/links/ (store-level),
+    // so this must run even when enableModulesDir is false.
+    // When GVS is not enabled, depNode.dir is inside node_modules/.pnpm/ (project-level),
+    // so it should only run when enableModulesDir is true.
+    if (opts.enableModulesDir !== false) {
+      await Promise.all(depNodes.map(async (depNode) => fs.mkdir(depNode.modules, { recursive: true })))
+      await Promise.all([
+        opts.symlink === false
+          ? Promise.resolve()
+          : linkAllModules(depNodes, {
+            optional: opts.include.optionalDependencies,
+          }),
+        linkAllPkgs(opts.storeController, depNodes, {
+          allowBuild,
+          force: opts.force,
+          disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
+          depGraph: graph,
+          depsStateCache,
+          ignoreScripts: opts.ignoreScripts,
+          lockfileDir: opts.lockfileDir,
+          sideEffectsCacheRead: opts.sideEffectsCacheRead,
         }),
-      linkAllPkgs(opts.storeController, depNodes, {
+      ])
+    } else if (opts.enableGlobalVirtualStore) {
+      await linkAllPkgs(opts.storeController, depNodes, {
         allowBuild,
         force: opts.force,
         disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
@@ -429,72 +447,75 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         ignoreScripts: opts.ignoreScripts,
         lockfileDir: opts.lockfileDir,
         sideEffectsCacheRead: opts.sideEffectsCacheRead,
-      }),
-    ])
+      })
+    }
 
     stageLogger.debug({
       prefix: lockfileDir,
       stage: 'importing_done',
     })
 
-    if (opts.ignorePackageManifest !== true && (opts.hoistPattern != null || opts.publicHoistPattern != null)) {
-      newHoistedDependencies = {
-        ...opts.hoistedDependencies,
-        ...await hoist({
-          extraNodePath: opts.extraNodePaths,
-          graph,
-          directDepsByImporterId: Object.fromEntries(Object.entries(directDependenciesByImporterId).map(([projectId, deps]) => [
-            projectId,
-            new Map(Object.entries(deps)),
-          ])),
-          importerIds,
-          preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
-          privateHoistedModulesDir: hoistedModulesDir,
-          privateHoistPattern: opts.hoistPattern ?? [],
-          publicHoistedModulesDir,
-          publicHoistPattern: opts.publicHoistPattern ?? [],
-          virtualStoreDir,
-          virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
-          hoistedWorkspacePackages: opts.hoistWorkspacePackages
-            ? Object.values(opts.allProjects).reduce((hoistedWorkspacePackages, project) => {
-              if (project.manifest.name && project.id !== '.') {
-                hoistedWorkspacePackages[project.id] = {
-                  dir: project.rootDir,
-                  name: project.manifest.name,
+    if (opts.enableModulesDir !== false) {
+
+      if (opts.ignorePackageManifest !== true && (opts.hoistPattern != null || opts.publicHoistPattern != null)) {
+        newHoistedDependencies = {
+          ...opts.hoistedDependencies,
+          ...await hoist({
+            extraNodePath: opts.extraNodePaths,
+            graph,
+            directDepsByImporterId: Object.fromEntries(Object.entries(directDependenciesByImporterId).map(([projectId, deps]) => [
+              projectId,
+              new Map(Object.entries(deps)),
+            ])),
+            importerIds,
+            preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+            privateHoistedModulesDir: hoistedModulesDir,
+            privateHoistPattern: opts.hoistPattern ?? [],
+            publicHoistedModulesDir,
+            publicHoistPattern: opts.publicHoistPattern ?? [],
+            virtualStoreDir,
+            virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+            hoistedWorkspacePackages: opts.hoistWorkspacePackages
+              ? Object.values(opts.allProjects).reduce((hoistedWorkspacePackages, project) => {
+                if (project.manifest.name && project.id !== '.') {
+                  hoistedWorkspacePackages[project.id] = {
+                    dir: project.rootDir,
+                    name: project.manifest.name,
+                  }
                 }
-              }
-              return hoistedWorkspacePackages
-            }, {} as Record<string, HoistedWorkspaceProject>)
-            : undefined,
-          skipped: opts.skipped,
-        }),
+                return hoistedWorkspacePackages
+              }, {} as Record<string, HoistedWorkspaceProject>)
+              : undefined,
+            skipped: opts.skipped,
+          }),
+        }
+      } else {
+        newHoistedDependencies = {}
       }
-    } else {
-      newHoistedDependencies = {}
-    }
 
-    await linkAllBins(graph, {
-      extraNodePaths: opts.extraNodePaths,
-      optional: opts.include.optionalDependencies,
-      preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
-      warn,
-    })
-
-    if ((currentLockfile != null) && !equals(importerIds.sort(), Object.keys(filteredLockfile.importers).sort())) {
-      Object.assign(filteredLockfile.packages!, currentLockfile.packages)
-    }
-
-    /** Skip linking and due to no project manifest */
-    if (!opts.ignorePackageManifest) {
-      linkedToRoot = await symlinkDirectDependencies({
-        dedupe: Boolean(opts.dedupeDirectDeps),
-        directDependenciesByImporterId,
-        filteredLockfile,
-        lockfileDir,
-        projects: selectedProjects,
-        registries: opts.registries,
-        symlink: opts.symlink,
+      await linkAllBins(graph, {
+        extraNodePaths: opts.extraNodePaths,
+        optional: opts.include.optionalDependencies,
+        preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+        warn,
       })
+
+      if ((currentLockfile != null) && !equals(importerIds.sort(), Object.keys(filteredLockfile.importers).sort())) {
+        Object.assign(filteredLockfile.packages!, currentLockfile.packages)
+      }
+
+      /** Skip linking and due to no project manifest */
+      if (!opts.ignorePackageManifest) {
+        linkedToRoot = await symlinkDirectDependencies({
+          dedupe: Boolean(opts.dedupeDirectDeps),
+          directDependenciesByImporterId,
+          filteredLockfile,
+          lockfileDir,
+          projects: selectedProjects,
+          registries: opts.registries,
+          symlink: opts.symlink,
+        })
+      }
     }
   }
 


### PR DESCRIPTION
close #10840

## What

`linkAllPkgs` (which calls `storeController.importPackage`) was inside the `enableModulesDir !== false` guard in the headless install path. When GVS is enabled, `depNode.dir` points to `{storeDir}/v11/links/` (store-level), not to project `node_modules/`. Skipping `linkAllPkgs` when `enableModulesDir` is `false` incorrectly prevented GVS store materialization.

## Why

Tools that pre-build the store (Nix, Docker multistage builds) use `pnpm fetch` with `enableGlobalVirtualStore: true` and `enableModulesDir: false` to populate the CAS + GVS without creating unnecessary project-level `node_modules/`. With this bug, `links/` was never populated, breaking the GVS zero-fetch fast path (`lockfileToDepGraph.ts:259-263`).

## How

Hoist `linkAllPkgs` out of the `enableModulesDir` conditional so it runs when either GVS is enabled or `enableModulesDir` is `true`:

```typescript
// Before: linkAllPkgs only ran when enableModulesDir !== false
} else if (opts.enableModulesDir !== false) {
    mkdir(depNode.modules)
    linkAllModules(...)
    linkAllPkgs(...)   // <-- store-level operation, incorrectly guarded
}

// After: linkAllPkgs runs when GVS is enabled OR enableModulesDir is true
} else {
    if (opts.enableGlobalVirtualStore || opts.enableModulesDir !== false) {
        linkAllPkgs(...)   // <-- store-level: always runs for GVS
    }
    if (opts.enableModulesDir !== false) {
        mkdir(depNode.modules)
        linkAllModules(...)   // <-- project-level: correctly guarded
        // ... hoist, linkAllBins, symlinkDirectDependencies
    }
}
```

The `importPackage` implementation (`tryImportIndexedDir` in `fs/indexed-pkg-importer`) already creates the target directory via `makeEmptyDir(newDir, { recursive: true })`, so the `mkdir(depNode.modules)` at the top of the block is only needed for project-level `node_modules/` structure, not for GVS paths.

## Tests

Added a test to `pkg-manager/core/test/install/globalVirtualStore.ts` that verifies GVS `links/` is populated when `enableModulesDir: false` and `enableGlobalVirtualStore: true`. All 5 GVS tests pass.