### PR TITLE
fix: handle Windows SQLite concurrency errors during StoreIndex init

### DIFF
--- a/store/index/src/index.ts
+++ b/store/index/src/index.ts
@@ -1,3 +1,4 @@
+// cspell:ignore IOERR CANTOPEN
 import { createRequire } from 'module'
 import fs from 'fs'
 import type { DatabaseSync as DatabaseSyncType, StatementSync } from 'node:sqlite'
@@ -14,6 +15,10 @@ const packr = new Packr({
 })
 
 const SQLITE_BUSY = 5
+const SQLITE_LOCKED = 6
+const SQLITE_IOERR = 10
+const SQLITE_CANTOPEN = 14
+const SQLITE_PROTOCOL = 15
 const RETRY_DELAY_MS = 50
 const MAX_RETRIES = 100 // ~5 seconds total
 
@@ -31,10 +36,41 @@ function sqliteRetry<T> (fn: () => T): T {
   }
 }
 
+/**
+ * Retry on any transient SQLite error, not just SQLITE_BUSY.
+ * On Windows, concurrent file operations can produce SQLITE_IOERR_LOCK,
+ * SQLITE_CANTOPEN, or SQLITE_PROTOCOL instead of SQLITE_BUSY.
+ * Use this only for idempotent operations (e.g. initialization).
+ */
+function sqliteRetryInit<T> (fn: () => T): T {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return fn()
+    } catch (err: unknown) {
+      if (isSqliteRetryable(err) && attempt < MAX_RETRIES) {
+        sleepSync(RETRY_DELAY_MS)
+        continue
+      }
+      throw err
+    }
+  }
+}
+
 function isSqliteBusy (err: any): boolean { // eslint-disable-line @typescript-eslint/no-explicit-any
   // errcode may be an extended error code (e.g. SQLITE_BUSY_RECOVERY = 261),
   // so mask off the upper bits to get the primary error code.
   return (err?.errcode & 0xFF) === SQLITE_BUSY
+}
+
+export function isSqliteRetryable (err: unknown): boolean {
+  const code = (err as { errcode?: unknown })?.errcode
+  if (typeof code !== 'number') return false
+  const primary = code & 0xFF
+  return primary === SQLITE_BUSY
+    || primary === SQLITE_LOCKED   // another connection in the same process
+    || primary === SQLITE_IOERR    // includes SQLITE_IOERR_LOCK on Windows
+    || primary === SQLITE_CANTOPEN // file being created by another process
+    || primary === SQLITE_PROTOCOL // WAL recovery contention
 }
 
 const sleepBuffer = new Int32Array(new SharedArrayBuffer(4))
@@ -82,22 +118,24 @@ export class StoreIndex {
   private closed = false
   private pendingWrites: Array<{ key: string, buffer: Uint8Array }> = []
   private flushScheduled = false
-  private stmtGet: StatementSync
-  private stmtSet: StatementSync
-  private stmtDel: StatementSync
-  private stmtHas: StatementSync
-  private stmtAll: StatementSync
+  private stmtGet!: StatementSync
+  private stmtSet!: StatementSync
+  private stmtDel!: StatementSync
+  private stmtHas!: StatementSync
+  private stmtAll!: StatementSync
   private readonly exitHandler: () => void
 
   constructor (storeDir: string) {
     const dbPath = `${storeDir}/index.db`
     fs.mkdirSync(storeDir, { recursive: true })
-    this.db = new DatabaseSync(dbPath)
-    // Set busy_timeout FIRST so SQLite's internal busy handler is active
-    // during all subsequent operations. On Windows, file locking is mandatory
-    // and concurrent processes (e.g. parallel dlx calls) will contend.
-    this.db.exec('PRAGMA busy_timeout=5000')
-    sqliteRetry(() => {
+    // Use sqliteRetryInit for the entire init sequence. On Windows,
+    // concurrent processes opening the same database can produce
+    // SQLITE_IOERR_LOCK or SQLITE_CANTOPEN, not just SQLITE_BUSY.
+    this.db = sqliteRetryInit(() => new DatabaseSync(dbPath))
+    sqliteRetryInit(() => {
+      // Set busy_timeout FIRST so SQLite's internal busy handler is active
+      // during all subsequent operations.
+      this.db.exec('PRAGMA busy_timeout=5000')
       this.db.exec('PRAGMA journal_mode=WAL')
       this.db.exec('PRAGMA synchronous=NORMAL')
       // Increase memory map size to 512MB
@@ -114,11 +152,13 @@ export class StoreIndex {
         ) WITHOUT ROWID
       `)
     })
-    this.stmtGet = this.db.prepare('SELECT data FROM package_index WHERE key = ?')
-    this.stmtSet = this.db.prepare('INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)')
-    this.stmtDel = this.db.prepare('DELETE FROM package_index WHERE key = ?')
-    this.stmtHas = this.db.prepare('SELECT 1 FROM package_index WHERE key = ?')
-    this.stmtAll = this.db.prepare('SELECT key, data FROM package_index')
+    sqliteRetryInit(() => {
+      this.stmtGet = this.db.prepare('SELECT data FROM package_index WHERE key = ?')
+      this.stmtSet = this.db.prepare('INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)')
+      this.stmtDel = this.db.prepare('DELETE FROM package_index WHERE key = ?')
+      this.stmtHas = this.db.prepare('SELECT 1 FROM package_index WHERE key = ?')
+      this.stmtAll = this.db.prepare('SELECT key, data FROM package_index')
+    })
     this.exitHandler = () => this.close()
     process.on('exit', this.exitHandler)
     openInstances.add(this)

--- a/store/index/test/index.ts
+++ b/store/index/test/index.ts
@@ -1,4 +1,5 @@
-import { StoreIndex, storeIndexKey } from '@pnpm/store.index'
+// cspell:ignore IOERR CANTOPEN
+import { StoreIndex, storeIndexKey, isSqliteRetryable } from '@pnpm/store.index'
 import path from 'path'
 import { temporaryDirectory } from 'tempy'
 
@@ -24,6 +25,31 @@ test('StoreIndex round-trips data via SQLite key', () => {
   } finally {
     idx.close()
   }
+})
+
+describe('isSqliteRetryable', () => {
+  test.each([
+    ['SQLITE_BUSY', 5, true],
+    ['SQLITE_BUSY_RECOVERY', 261, true], // extended: 5 | (1 << 8)
+    ['SQLITE_LOCKED', 6, true],
+    ['SQLITE_IOERR', 10, true],
+    ['SQLITE_IOERR_LOCK', 3850, true], // extended: 10 | (15 << 8)
+    ['SQLITE_CANTOPEN', 14, true],
+    ['SQLITE_PROTOCOL', 15, true],
+    ['SQLITE_ERROR', 1, false],
+    ['SQLITE_PERM', 3, false],
+    ['SQLITE_CORRUPT', 11, false],
+    ['SQLITE_NOTFOUND', 12, false],
+  ])('%s (errcode %i) → %s', (_name, errcode, expected) => {
+    expect(isSqliteRetryable({ errcode })).toBe(expected)
+  })
+
+  test('returns false for non-SQLite errors', () => {
+    expect(isSqliteRetryable(new Error('random'))).toBe(false)
+    expect(isSqliteRetryable(null)).toBe(false)
+    expect(isSqliteRetryable(undefined)).toBe(false)
+    expect(isSqliteRetryable({ errcode: 'not-a-number' })).toBe(false)
+  })
 })
 
 test('StoreIndex entries() iterates all SQLite entries', () => {


### PR DESCRIPTION
On Windows, concurrent processes opening the same index.db (e.g. parallel dlx calls) can produce SQLITE_IOERR_LOCK, SQLITE_CANTOPEN, or SQLITE_PROTOCOL instead of SQLITE_BUSY. The existing sqliteRetry only caught SQLITE_BUSY, so these errors crashed the process.

- Add sqliteRetryInit that retries on all transient SQLite errors (BUSY, LOCKED, IOERR, CANTOPEN, PROTOCOL) for idempotent init operations
- Set busy_timeout before all other PRAGMAs so SQLite's internal busy handler is active from the start
- Wrap new DatabaseSync(), PRAGMAs, CREATE TABLE, and prepare statements in sqliteRetryInit