### PR TITLE
fix: show linked path instead of ??? in global install output

### DIFF
--- a/.changeset/fix-global-link-output.md
+++ b/.changeset/fix-global-link-output.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/default-reporter": patch
+"pnpm": patch
+---
+
+Fixed global install output showing `???` instead of the linked package path when linking from the current directory.

--- a/cli/default-reporter/src/reporterForClient/reportSummary.ts
+++ b/cli/default-reporter/src/reporterForClient/reportSummary.ts
@@ -118,7 +118,7 @@ function printDiffs (
       result += ` ${chalk.red('deprecated')}`
     }
     if (pkg.from) {
-      result += ` ${chalk.grey(`<- ${pkg.from && path.relative(opts.prefix, pkg.from) || '???'}`)}`
+      result += ` ${chalk.grey(`<- ${path.relative(opts.prefix, pkg.from) || pkg.from}`)}`
     }
     if (pkg.added && depType === 'dev' && opts.pnpmConfig?.saveDev === false && opts.cmd === 'add') {
       result += `${chalk.yellow(' already in devDependencies, was not moved to dependencies.')}`


### PR DESCRIPTION
## Summary
- When running `pnpm add -g .`, the output showed `???` instead of the linked package path
- This happened because `path.relative(cwd, cwd)` returns `''` (falsy), triggering the `|| '???'` fallback
- Fixed by falling back to the absolute path (`pkg.from`) instead of `???`

## Test plan
- [x] Existing tests pass (the test fixtures use different paths so `path.relative` doesn't return empty)
- [x] Manual: run `pnpm add -g .` in a local package and verify the output shows the absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)