### PR TITLE
fix: handle Ctrl+C gracefully during verifyDepsBeforeRun prompt

### DIFF
--- a/.changeset/fix-prompt-ctrl-c.md
+++ b/.changeset/fix-prompt-ctrl-c.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/plugin-commands-script-runners": patch
+"pnpm": patch
+---
+
+Handle Ctrl+C gracefully during the `verifyDepsBeforeRun: prompt` confirmation dialog.
+
+Previously, pressing Ctrl+C during the prompt would crash pnpm with an `ERR_USE_AFTER_CLOSE` error and show a stack trace. Now it exits cleanly with exit code 1.
+
+Fixes #10888

--- a/exec/plugin-commands-script-runners/src/runDepsStatusCheck.ts
+++ b/exec/plugin-commands-script-runners/src/runDepsStatusCheck.ts
@@ -27,16 +27,24 @@ export async function runDepsStatusCheck (opts: RunDepsStatusCheckOptions): Prom
     install()
     break
   case 'prompt': {
-    const confirmed = await enquirer.prompt<{ runInstall: boolean }>({
-      type: 'confirm',
-      name: 'runInstall',
-      message: `Your "node_modules" directory is out of sync with the "pnpm-lock.yaml" file. This can lead to issues during scripts execution.
+    try {
+      const confirmed = await enquirer.prompt<{ runInstall: boolean }>({
+        type: 'confirm',
+        name: 'runInstall',
+        message: `Your "node_modules" directory is out of sync with the "pnpm-lock.yaml" file. This can lead to issues during scripts execution.
 
 Would you like to run "pnpm ${command.join(' ')}" to update your "node_modules"?`,
-      initial: true,
-    })
-    if (confirmed.runInstall) {
-      install()
+        initial: true,
+      })
+      if (confirmed.runInstall) {
+        install()
+      }
+    } catch (err) {
+      // Handle Ctrl+C gracefully - user cancelled the prompt
+      if ((err as NodeJS.ErrnoException).code === 'ERR_USE_AFTER_CLOSE') {
+        process.exit(1)
+      }
+      throw err
     }
     break
   }


### PR DESCRIPTION
## Summary

Fixes #10888

When using `verifyDepsBeforeRun: 'prompt'` and pressing Ctrl+C during the confirmation dialog, pnpm would crash with an `ERR_USE_AFTER_CLOSE` error and show a stack trace.

This PR catches the error and exits cleanly with exit code 1.

## Changes

- Wrapped the enquirer prompt in a try-catch block
- Handle `ERR_USE_AFTER_CLOSE` error by calling `process.exit(1)`
- Re-throw any other errors

## Testing

- Existing tests pass
- Manual testing confirms Ctrl+C now exits cleanly without stack trace