### PR TITLE
fix: prevent double-loading config error in nested pnpm invocations

### DIFF
--- a/.changeset/fix-nested-pnpm-double-loading.md
+++ b/.changeset/fix-nested-pnpm-double-loading.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/run-npm": patch
+"pnpm": patch
+---
+
+Fixed nested `pnpm` invocations under `pnpm run` failing with "double-loading config" error when commands like `pnpm view` are passed through to npm [#10914](https://github.com/pnpm/pnpm/issues/10914).

--- a/exec/run-npm/src/index.ts
+++ b/exec/run-npm/src/index.ts
@@ -74,6 +74,12 @@ function createEnv (
 
   if (opts.userConfigPath) {
     env.npm_config_userconfig = opts.userConfigPath
+    // Remove globalconfig from the environment to prevent npm from loading
+    // the same file as both "user" and "global" config. The npm_config_globalconfig
+    // env var may be inherited from a parent pnpm process (set by npm-lifecycle
+    // from pnpm's rawConfig), and it points to pnpm's own config file which
+    // conflicts with the userconfig we're explicitly setting here.
+    delete env.npm_config_globalconfig
   }
 
   return env


### PR DESCRIPTION
## Summary

- Fixes nested `pnpm` invocations under `pnpm run` failing with `double-loading config "/home/runner/.config/pnpm/rc" as "global", previously loaded as "user"` error
- When `pnpm run` spawns a script that invokes `pnpm view` (or other npm-passthrough commands), the child npm process inherits `npm_config_globalconfig` pointing to pnpm's config file from the parent env, while pnpm also sets `npm_config_userconfig` to the same file — causing npm's `@npmcli/config` to throw a duplicate detection error
- Fix: delete inherited `npm_config_globalconfig` from the env when explicitly setting `npm_config_userconfig`, so npm falls back to its default global config path

Closes #10914

## Test plan

- [ ] Verify `pnpm run <script>` where the script spawns `pnpm view` no longer fails with "double-loading config" error
- [ ] Verify `pnpm config set` / `pnpm config get` still work correctly (they also use `runNpm` with `userConfigPath`)
- [ ] Verify direct `pnpm view` (not nested) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)