### PR TITLE
chore: fix after-install warning typo

### DIFF
--- a/building/after-install/src/index.ts
+++ b/building/after-install/src/index.ts
@@ -67,7 +67,7 @@ function findPackages (
       if (!pkgInfo.name) {
         logger.warn({
           message: `Skipping ${relativeDepPath} because cannot get the package name from ${WANTED_LOCKFILE}.
-            Try to run run \`pnpm update --depth 100\` to create a new ${WANTED_LOCKFILE} with all the necessary info.`,
+            Try to run \`pnpm update --depth 100\` to create a new ${WANTED_LOCKFILE} with all the necessary info.`,
           prefix: opts.prefix,
         })
         return false


### PR DESCRIPTION
## Summary

- Fixes a duplicate word in the after-install warning message by changing `run run` to `run`.

## Related issue

- N/A (minor wording fix)

## Guideline alignment

- https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md

## Validation

- `git diff --check`
- No tests added; one-line wording-only change.
