### PR TITLE
fix: don't run pnpm install in the fixture dir, use a temp copy instead

### DIFF
--- a/__utils__/test-fixtures/src/index.ts
+++ b/__utils__/test-fixtures/src/index.ts
@@ -44,15 +44,7 @@ function copyAndRename (src: string, dest: string): void {
     // Use lstatSync to avoid following symlinks - this prevents ENOENT errors
     // when symlink targets haven't been copied yet (e.g., when copying directories
     // in alphabetical order where a symlink points to a directory that comes later)
-    let stats: fs.Stats
-    try {
-      stats = fs.lstatSync(srcPath)
-    } catch (err: unknown) {
-      // The entry may disappear between readdirSync and lstatSync (e.g. temp
-      // files created by antivirus or another process on Windows CI)
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue
-      throw err
-    }
+    const stats = fs.lstatSync(srcPath)
 
     if (stats.isSymbolicLink()) {
       // Recreate symlinks to preserve the pnpm node_modules structure

--- a/lockfile/plugin-commands-audit/test/index.ts
+++ b/lockfile/plugin-commands-audit/test/index.ts
@@ -67,7 +67,7 @@ export const DEFAULT_OPTS = {
 }
 
 describe('plugin-commands-audit', () => {
-  const hasVulnerabilitiesDir = f.find('has-vulnerabilities')
+  const hasVulnerabilitiesDir = f.prepare('has-vulnerabilities')
   beforeAll(async () => {
     await install.handler({
       ...DEFAULT_OPTS,


### PR DESCRIPTION
## Summary

- `test/index.ts` in `plugin-commands-audit` used `f.find('has-vulnerabilities')` and then ran `pnpm install` directly in the committed fixture directory
- On Windows CI, `pnpm install` uses `rename-overwrite` for atomic renames, which creates temp files like `type-is_tmp_3788_1` inside the fixture's `node_modules`
- `fix.ts` runs concurrently and calls `f.prepare('has-vulnerabilities')`, which copies the fixture — it sees these temp files via `readdirSync` then fails with `ENOENT` when `lstatSync`-ing them (they've already been renamed away)
- Fix: use `f.prepare` in `index.ts` too so `pnpm install` runs in a temp copy and never writes into the committed fixture directory
- Also reverts the earlier incorrect workaround that caught `ENOENT` in `@pnpm/test-fixtures`