### PR TITLE
chore: add Husky hooks to prevent Claude Code from bad git practices

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Prevent Claude Code from committing directly on the main branch.
 
-if [ -n "$CLAUDE_CODE" ] && [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
+if [ -n "$CLAUDECODE" ] && [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ]; then
   echo "error: Committing directly to the main branch is not allowed. Create a new branch and open a pull request instead." >&2
   exit 1
 fi

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -2,7 +2,7 @@
 # Prevent Claude Code from amending commits.
 # The prepare-commit-msg hook receives "commit" as $2 when --amend is used.
 
-if [ "$2" = "commit" ] && [ -n "$CLAUDE_CODE" ]; then
+if [ "$2" = "commit" ] && [ -n "$CLAUDECODE" ]; then
   echo "error: Amending commits is not allowed. Create a new commit instead." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Adds two Husky hooks to prevent Claude Code from bad git practices:
  - \`prepare-commit-msg\`: blocks \`git commit --amend\` (detected via the \`commit\` source argument)
  - \`pre-commit\`: blocks committing directly to \`main\`
- Both hooks detect Claude Code sessions via the \`CLAUDECODE\` environment variable, so regular users are unaffected
- Error messages explicitly tell Claude what to do instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)