### PR TITLE
fix: handle 400 responses as HTTP errors in npm resolver fetch

### DIFF
--- a/.changeset/fix-npm-resolver-400-status.md
+++ b/.changeset/fix-npm-resolver-400-status.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/npm-resolver": patch
+"pnpm": patch
+---
+
+fix: treat HTTP 400 responses as errors in the npm resolver fetch
+
+The status check used `> 400` instead of `>= 400`, causing 400 Bad Request responses to bypass the error path and fall into JSON parse/retry logic instead.

--- a/resolving/npm-resolver/src/fetch.ts
+++ b/resolving/npm-resolver/src/fetch.ts
@@ -88,7 +88,7 @@ export async function fetchMetadataFromFromRegistry (
         reject(new PnpmError('META_FETCH_FAIL', `GET ${uri}: ${error.message as string}`, { attempts: attempt }))
         return
       }
-      if (response.status > 400) {
+      if (response.status >= 400) {
         const request = {
           authHeaderValue,
           url: uri,

--- a/resolving/npm-resolver/test/index.ts
+++ b/resolving/npm-resolver/test/index.ts
@@ -916,6 +916,31 @@ test('error is thrown when package needs authorization', async () => {
     )
 })
 
+test('error is thrown when registry returns 400 Bad Request', async () => {
+  nock(registries.default)
+    .get('/bad-pkg')
+    .reply(400)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+  await expect(resolveFromNpm({ alias: 'bad-pkg', bareSpecifier: '1.0.0' }, {})).rejects
+    .toThrow(
+      new RegistryResponseError(
+        {
+          url: `${registries.default}bad-pkg`,
+        },
+        {
+          status: 400,
+          statusText: '',
+        },
+        'bad-pkg'
+      )
+    )
+})
+
 test('error is thrown when there is no package found for the requested range', async () => {
   nock(registries.default)
     .get('/is-positive')


### PR DESCRIPTION
## Summary

Treat HTTP 400 responses as errors in the npm resolver fetch path.

## Problem

The current status check uses `> 400`, which allows `400 Bad Request` to fall through the non-error path.

Since 400 is a client error, this can route the response into the wrong handling flow and lead to misleading JSON parse/retry behavior.

## Fix

Change the status check from `> 400` to `>= 400`.

## Test

Added a targeted test covering a 400 response.  
The test fails on the old code and passes with the fix.