### PR TITLE
refactor: synchronous `generateQrCode`

### DIFF
--- a/releasing/plugin-commands-publishing/src/otp.ts
+++ b/releasing/plugin-commands-publishing/src/otp.ts
@@ -188,22 +188,21 @@ export async function publishWithOtpHandling ({
  * If the OTP error contains npm-notice headers with URLs, display the
  * notice messages and a QR code for each URL.
  */
-async function displayNpmNotice (error: OtpError, context: OtpContext): Promise<void> {
+function displayNpmNotice (error: OtpError, context: OtpContext): void {
   const notices = error.headers?.['npm-notice']
   if (!notices?.length) return
 
   for (const notice of notices) {
     context.globalInfo(notice)
     for (const url of extractUrlsFromString(notice)) {
-      // eslint-disable-next-line no-await-in-loop
-      const qrCode = await generateQrCode(url)
+      const qrCode = generateQrCode(url)
       context.globalInfo(`\n${qrCode}\n`)
     }
   }
 }
 
 async function webAuthOtp (authUrl: string, doneUrl: string, context: OtpContext, fetchOptions: OtpWebAuthFetchOptions): Promise<string> {
-  const qrCode = await generateQrCode(authUrl)
+  const qrCode = generateQrCode(authUrl)
   context.globalInfo(`Authenticate your account at:\n${authUrl}\n\n${qrCode}`)
   const startTime = context.Date.now()
   const timeout = 5 * 60 * 1000 // 5 minutes
@@ -256,10 +255,13 @@ async function webAuthOtp (authUrl: string, doneUrl: string, context: OtpContext
   }
 }
 
-function generateQrCode (url: string): Promise<string> {
-  return new Promise(resolve => {
-    qrcodeTerminal.generate(url, { small: true }, resolve)
+function generateQrCode (text: string): string {
+  let qrCode: string | undefined
+  qrcodeTerminal.generate(text, { small: true }, (code: string) => {
+    qrCode = code
   })
+  if (qrCode != null) return qrCode
+  throw new Error('we were expecting qrcode-terminal to be fully synchronous, but it fails to execute the callback')
 }
 
 export class OtpWebAuthTimeoutError extends PnpmError {


### PR DESCRIPTION
## Summary
Refactored QR code generation to be synchronous instead of asynchronous, removing unnecessary async/await patterns and improving code simplicity.

## Key Changes
- Changed `generateQrCode()` function from returning `Promise<string>` to returning `string`
- Removed `async`/`await` keywords from `displayNpmNotice()` function since it no longer needs to await QR code generation
- Updated `webAuthOtp()` to call `generateQrCode()` synchronously instead of awaiting it
- Removed `no-await-in-loop` eslint disable comment that is no longer needed
- Added error handling in `generateQrCode()` to validate that the callback is executed synchronously

## Implementation Details
The `qrcodeTerminal.generate()` library appears to execute its callback synchronously, so wrapping it in a Promise was unnecessary. The refactored implementation captures the generated QR code in a variable and validates that the callback was invoked before returning, throwing an error if the callback execution is delayed or fails to occur.

https://claude.ai/code/session_01HNVRLzLoxwsH17ESvU37Zt