### PR TITLE
refactor: destructure `context`

### DIFF
--- a/releasing/plugin-commands-publishing/src/otp.ts
+++ b/releasing/plugin-commands-publishing/src/otp.ts
@@ -223,8 +223,9 @@ async function webAuthOtp (
   const pollIntervalMs = 1000
 
   while (true) {
-    if (Date.now() - startTime > timeout) {
-      throw new OtpWebAuthTimeoutError(Date.now(), startTime, timeout)
+    const now = Date.now()
+    if (now - startTime > timeout) {
+      throw new OtpWebAuthTimeoutError(now, startTime, timeout)
     }
     // eslint-disable-next-line no-await-in-loop
     await new Promise<void>(resolve => setTimeout(resolve, pollIntervalMs))


### PR DESCRIPTION
## Summary
Refactored the OTP handling functions to destructure context parameters at the function signature level rather than accessing them through a context object. This improves code clarity and makes dependencies more explicit.

## Key Changes
- **`publishWithOtpHandling`**: Changed the `context` parameter from a single object to destructured parameters (`Date`, `setTimeout`, `enquirer`, `fetch`, `globalInfo`, `process`, `publish`), making dependencies explicit and improving readability
- **`displayNpmNotice`**: Simplified to accept only the `globalInfo` function instead of the entire context object, reducing unnecessary dependencies
- **`webAuthOtp`**: Updated to accept a destructured subset of context properties (`Date`, `setTimeout`, `fetch`, `globalInfo`) instead of the full context object
- Updated all internal function calls to pass individual parameters instead of the context object
- Maintained backward compatibility by keeping `SHARED_CONTEXT` as the default value
- **`Date.now()`**: Fix a subtle [double-calling bug](https://github.com/pnpm/pnpm/pull/10950#discussion_r2928391089). The Copilot reviewer previously missed this behind the `context.` qualification — illustrating why destructuring is preferable.

## Implementation Details
- The refactoring follows the principle of dependency injection by making function dependencies explicit in their signatures
- Each function now only receives the specific context properties it actually uses, reducing coupling
- The `SHARED_CONTEXT` object is still used as the default parameter value, ensuring no breaking changes for callers
- All references to `context.property` have been replaced with direct parameter usage (e.g., `context.publish()` → `publish()`)

https://claude.ai/code/session_01UTfDyCyFbD897P4HK93wFs