### PR TITLE
chore: add script to clean up worktrees with merged PRs

### DIFF
--- a/shell/cleanup-worktrees.sh
+++ b/shell/cleanup-worktrees.sh
@@ -44,7 +44,7 @@ while IFS= read -r line; do
   case "$branch" in
     main|master|v[0-9]*)
       echo "SKIP (protected branch): $worktree_path [$branch]"
-      ((skipped++))
+      skipped=$((skipped + 1))
       continue
       ;;
   esac
@@ -53,7 +53,7 @@ while IFS= read -r line; do
   real_wt="$(cd "$worktree_path" 2>/dev/null && pwd -P)" || continue
   if [[ "$real_wt" == "$CURRENT_WORKTREE" ]]; then
     echo "SKIP (current worktree): $worktree_path [$branch]"
-    ((skipped++))
+    skipped=$((skipped + 1))
     continue
   fi
 
@@ -84,10 +84,10 @@ while IFS= read -r line; do
       echo "  -> Would remove worktree and delete branch"
     fi
     echo
-    ((removed++))
+    removed=$((removed + 1))
   else
     echo "SKIP (no merged PR): $worktree_path [$branch]"
-    ((skipped++))
+    skipped=$((skipped + 1))
   fi
 done < <(git worktree list)
 


### PR DESCRIPTION
## Summary
- Adds `shell/cleanup-worktrees.sh` that finds git worktrees whose branches have merged PRs on GitHub and removes them
- Supports `--dry-run` mode to preview what would be removed
- Protects long-lived branches (`main`, `v10`, `v11`, etc.) and the current worktree from removal

## Test plan
- [x] Verified with `--dry-run` that it correctly identifies merged PRs and skips protected/unrelated branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)