### PR TITLE
ci: only run Windows tests with lowest Node.js on branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
         exclude:
           - node: '24.0.0'
             platform: ubuntu-latest
+          # On branches, only run Windows with the lowest supported Node.js
+          - node: ${{ github.ref != 'refs/heads/main' && '24.0.0' || 'none' }}
+            platform: windows-latest
+          - node: ${{ github.ref != 'refs/heads/main' && '25.0.0' || 'none' }}
+            platform: windows-latest
     uses: ./.github/workflows/test.yml
     with:
       node: ${{ matrix.node }}


### PR DESCRIPTION
## Summary
- On non-main branches, run Windows tests only with Node.js 22.13.0 (the lowest supported version), skipping 24.0.0 and 25.0.0
- The full Windows matrix (all Node.js versions) still runs on `main`
- Reduces CI time and resource usage for feature branches and PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)