### PR TITLE
fix: throw ERR_PNPM_CONFIG_UNRESOLVED_ENV_VAR for undefined env vars in config

### DIFF
--- a/config/config/src/getOptionsFromRootManifest.ts
+++ b/config/config/src/getOptionsFromRootManifest.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import util from 'node:util'
 
 import { envReplace } from '@pnpm/config.env-replace'
 import { PnpmError } from '@pnpm/error'
@@ -76,15 +77,26 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
 function replaceEnvInSettings (settings: PnpmSettings): PnpmSettings {
   const newSettings: PnpmSettings = {}
   for (const [key, value] of Object.entries(settings)) {
-    const newKey = envReplace(key, process.env)
+    const newKey = safeEnvReplace(key)
     if (typeof value === 'string') {
       // @ts-expect-error
-      newSettings[newKey as keyof PnpmSettings] = envReplace(value, process.env)
+      newSettings[newKey as keyof PnpmSettings] = safeEnvReplace(value)
     } else {
       newSettings[newKey as keyof PnpmSettings] = value
     }
   }
   return newSettings
+}
+
+function safeEnvReplace (str: string): string {
+  try {
+    return envReplace(str, process.env)
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err)) {
+      throw new PnpmError('CONFIG_UNRESOLVED_ENV_VAR', err.message)
+    }
+    throw err
+  }
 }
 
 function createVersionReferencesReplacer (manifest: ProjectManifest): (spec: string) => string {

--- a/config/config/test/getOptionsFromRootManifest.test.ts
+++ b/config/config/test/getOptionsFromRootManifest.test.ts
@@ -1,5 +1,7 @@
 import path from 'node:path'
 
+import type { PnpmSettings } from '@pnpm/types'
+
 import { getOptionsFromPnpmSettings, getOptionsFromRootManifest } from '../lib/getOptionsFromRootManifest.js'
 
 const ORIGINAL_ENV = process.env
@@ -118,6 +120,18 @@ test('getOptionsFromPnpmSettings() replaces env variables in settings', () => {
     '${PNPM_TEST_KEY}': '${PNPM_TEST_VALUE}',
   } as any) as any // eslint-disable-line
   expect(options.foo).toBe('bar')
+})
+
+test('getOptionsFromPnpmSettings() throws a PnpmError when a string config value has an undefined env variable', () => {
+  // Simulates runtime behavior when pnpm-workspace.yaml or config.yaml has a
+  // string-valued setting referencing an env variable that is not defined.
+  // The TypeScript type doesn't include all valid config keys, so we cast.
+  const settings = { nodeLinker: '${PNPM_TEST_UNDEFINED_ENV_VAR_82645}' } as unknown as PnpmSettings
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), settings)).toThrow(
+    expect.objectContaining({
+      code: 'ERR_PNPM_CONFIG_UNRESOLVED_ENV_VAR',
+    })
+  )
 })
 
 test('getOptionsFromRootManifest() converts allowBuilds', () => {

--- a/config/config/test/getOptionsFromRootManifest.test.ts
+++ b/config/config/test/getOptionsFromRootManifest.test.ts
@@ -126,6 +126,8 @@ test('getOptionsFromPnpmSettings() throws a PnpmError when a string config value
   // Simulates runtime behavior when pnpm-workspace.yaml or config.yaml has a
   // string-valued setting referencing an env variable that is not defined.
   // The TypeScript type doesn't include all valid config keys, so we cast.
+  delete process.env.PNPM_TEST_UNDEFINED_ENV_VAR_82645
+  expect(process.env.PNPM_TEST_UNDEFINED_ENV_VAR_82645).toBeUndefined()
   const settings = { nodeLinker: '${PNPM_TEST_UNDEFINED_ENV_VAR_82645}' } as unknown as PnpmSettings
   expect(() => getOptionsFromPnpmSettings(process.cwd(), settings)).toThrow(
     expect.objectContaining({


### PR DESCRIPTION
## Summary

Throw a controlled pnpm error when a config value in `pnpm-workspace.yaml` or `config.yaml`
references an undefined environment variable.

## Problem

`envReplace()` could throw a plain error while replacing env vars in workspace/config
settings, which bubbled up as an uncontrolled exception instead of a pnpm error.

The `.npmrc` path already handles this case more gracefully, but the workspace/config
path did not.

## Fix

- wrap env replacement in a helper (`safeEnvReplace`)
- convert native errors from `envReplace()` into
  `PnpmError('CONFIG_UNRESOLVED_ENV_VAR', ...)`

## Test

Added a regression test confirming that undefined env vars in string config values throw:

`ERR_PNPM_CONFIG_UNRESOLVED_ENV_VAR`