### PR TITLE
fix(audit): count ignored vulnerabilities by affected paths

### DIFF
--- a/.changeset/fix-audit-ignored-counts.md
+++ b/.changeset/fix-audit-ignored-counts.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/plugin-commands-audit": patch
+"pnpm": patch
+---
+
+Fix `pnpm audit` ignored vulnerability counts to include all ignored occurrences in dependency paths.
+
+Previously, ignored advisories were counted once per advisory, which could under-report ignored counts when a single advisory appeared in multiple paths. The summary now reports ignored counts based on all affected paths.
+
+Fixes #10646

--- a/lockfile/plugin-commands-audit/src/audit.ts
+++ b/lockfile/plugin-commands-audit/src/audit.ts
@@ -291,21 +291,21 @@ ${newIgnores.join('\n')}`,
     .reduce((sum: number, vulnerabilitiesCount: number) => sum + vulnerabilitiesCount, 0)
   const ignoreGhsas = opts.auditConfig?.ignoreGhsas
   if (ignoreGhsas) {
-    auditReport.advisories = pickBy(({ github_advisory_id: githubAdvisoryId, severity }) => {
-      if (!ignoreGhsas.includes(githubAdvisoryId)) {
+    auditReport.advisories = pickBy((advisory) => {
+      if (!ignoreGhsas.includes(advisory.github_advisory_id)) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+      ignoredVulnerabilities[advisory.severity as AuditLevelString] += getIgnoredVulnerabilityCount(advisory)
       return false
     }, auditReport.advisories)
   }
   const ignoreCves = opts.auditConfig?.ignoreCves
   if (ignoreCves) {
-    auditReport.advisories = pickBy(({ cves, severity }) => {
-      if (cves.length === 0 || difference(cves, ignoreCves).length > 0) {
+    auditReport.advisories = pickBy((advisory) => {
+      if (advisory.cves.length === 0 || difference(advisory.cves, ignoreCves).length > 0) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+      ignoredVulnerabilities[advisory.severity as AuditLevelString] += getIgnoredVulnerabilityCount(advisory)
       return false
     }, auditReport.advisories)
   }
@@ -411,4 +411,9 @@ export function formatFixWithUpdateOutput (result: FixWithUpdateResult, auditRep
   // Add trailing newline
   output.push('')
   return output.join('\n')
+}
+
+function getIgnoredVulnerabilityCount (advisory: AuditAdvisory): number {
+  const affectedPathsCount = advisory.findings.reduce((count, finding) => count + finding.paths.length, 0)
+  return affectedPathsCount > 0 ? affectedPathsCount : 1
 }

--- a/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
+++ b/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
@@ -1681,7 +1681,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;
 
 exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSON output is used 1`] = `
@@ -3865,5 +3865,5 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;

--- a/lockfile/plugin-commands-audit/test/index.ts
+++ b/lockfile/plugin-commands-audit/test/index.ts
@@ -252,6 +252,87 @@ describe('plugin-commands-audit', () => {
     expect(stripAnsi(output)).toMatchSnapshot()
   })
 
+  test('audit: ignored vulnerabilities count reflects all ignored paths', async () => {
+    const tmp = f.prepare('has-vulnerabilities')
+
+    nock(AUDIT_REGISTRY)
+      .post('/-/npm/v1/security/audits/quick')
+      .reply(200, {
+        actions: [],
+        advisories: {
+          '999999': {
+            findings: [
+              {
+                version: '1.0.0',
+                paths: [
+                  'a>pkg',
+                  'b>pkg',
+                  'c>pkg',
+                  'd>pkg',
+                  'e>pkg',
+                  'f>pkg',
+                  'g>pkg',
+                ],
+                dev: false,
+                optional: false,
+                bundled: false,
+              },
+            ],
+            id: 999999,
+            created: '2026-01-01T00:00:00.000Z',
+            updated: '2026-01-01T00:00:00.000Z',
+            title: 'Test advisory',
+            found_by: { name: 'test' },
+            reported_by: { name: 'test' },
+            module_name: 'test-package',
+            cves: ['CVE-TEST-123'],
+            vulnerable_versions: '<2.0.0',
+            patched_versions: '>=2.0.0',
+            overview: 'test',
+            recommendation: 'upgrade',
+            references: 'test',
+            access: 'public',
+            severity: 'high',
+            cwe: 'CWE-79',
+            github_advisory_id: 'GHSA-test-1234',
+            metadata: {
+              module_type: 'package',
+              exploitability: 1,
+              affected_components: 'test',
+            },
+            url: 'https://example.com',
+          },
+        },
+        muted: [],
+        metadata: {
+          vulnerabilities: {
+            info: 0,
+            low: 0,
+            moderate: 0,
+            high: 7,
+            critical: 0,
+          },
+          dependencies: 1,
+          devDependencies: 0,
+          optionalDependencies: 0,
+          totalDependencies: 1,
+        },
+      })
+
+    const { output } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      auditLevel: 'low',
+      dir: tmp,
+      rootProjectManifestDir: tmp,
+      rootProjectManifest: {},
+      auditConfig: {
+        ignoreCves: ['CVE-TEST-123'],
+      },
+    })
+
+    expect(stripAnsi(output)).toContain('Severity: 7 high (7 ignored)')
+  })
+
   test('audit: CVEs in ignoreGhsas do not show up', async () => {
     const tmp = f.prepare('has-vulnerabilities')
 


### PR DESCRIPTION
## Summary

Fixes #10646

┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ node-tar Symlink Path Traversal via Drive-Relative     │
│                     │ Linkpath                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ tar                                                    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=7.5.10                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=7.5.11                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ __utils____scripts>tar                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-9ppj-qmqm-q256      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ flatted vulnerable to unbounded recursion DoS in       │
│                     │ parse() revive phase                                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ flatted                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <3.4.0                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.4.0                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>cspell>flatted                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-25h7-pfq9-p65f      │
└─────────────────────┴────────────────────────────────────────────────────────┘
3 vulnerabilities found
Severity: 1 moderate (1 ignored) | 2 high was under-reporting ignored vulnerability counts when a single ignored advisory appeared in multiple dependency paths.

Previously, ignored counts were incremented once per advisory. This PR updates counting to use all affected paths from advisory findings.

## Changes

- Count ignored vulnerabilities by total number of affected paths in 
- Add regression test that verifies an ignored advisory with 7 paths is reported as 
- Update snapshots for existing ignore tests

## Validation

- 
> @pnpm/plugin-commands-audit@1002.1.19 lint /Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit
> eslint "src/**/*.ts" "test/**/*.ts"


/Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit/test/index.ts
  172:3  warning  Tests should not be skipped  jest/no-disabled-tests

✖ 1 problem (0 errors, 1 warning)
- 
> @pnpm/plugin-commands-audit@1002.1.19 test /Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit
> pnpm run compile && pnpm run _test test/index.ts


> @pnpm/plugin-commands-audit@1002.1.19 compile /Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit
> tsgo --build && pnpm run lint --fix


> @pnpm/plugin-commands-audit@1002.1.19 lint /Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit
> eslint "src/**/*.ts" "test/**/*.ts" --fix


/Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit/test/index.ts
  172:3  warning  Tests should not be skipped  jest/no-disabled-tests

✖ 1 problem (0 errors, 1 warning)


> @pnpm/plugin-commands-audit@1002.1.19 _test /Users/zybo/jotform-contributions/pnpm/lockfile/plugin-commands-audit
> cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" jest test/index.ts

----------------------|---------|----------|---------|---------|---------------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s         
----------------------|---------|----------|---------|---------|---------------------------
All files             |   62.62 |       55 |      48 |   64.13 |                           
 lib                  |   61.45 |       55 |      48 |   62.92 |                           
  audit.js            |   84.28 |       75 |   85.71 |   83.58 | 41,63,118,164-171,181-197 
  fix.js              |       0 |        0 |       0 |       0 | 6-23                      
  ignore.js           |       0 |        0 |       0 |       0 | 6-31                      
  index.js            |       0 |        0 |       0 |       0 |                           
 test/utils/responses |     100 |      100 |     100 |     100 |                           
  index.ts            |     100 |      100 |     100 |     100 |                           
----------------------|---------|----------|---------|---------|---------------------------