### PR TITLE
feat: add --raw alias for recursive run

### DIFF
--- a/.changeset/raw-option-recursive-run.md
+++ b/.changeset/raw-option-recursive-run.md
@@ -1,0 +1,6 @@
+---
+'@pnpm/plugin-commands-script-runners': patch
+pnpm: patch
+---
+
+Add a new `--raw` (`-R`) option to recursive run as a shorthand for `--stream --reporter-hide-prefix`.

--- a/exec/plugin-commands-script-runners/src/run.ts
+++ b/exec/plugin-commands-script-runners/src/run.ts
@@ -71,12 +71,23 @@ export const REPORTER_HIDE_PREFIX_HELP: DescriptionItem = {
   name: '--reporter-hide-prefix',
 }
 
+export const RAW_OPTION_HELP: DescriptionItem = {
+  description: 'Print raw output for recursive run by enabling --stream and --reporter-hide-prefix.',
+  name: '--raw',
+  shortAlias: '-R',
+}
+
 export const shorthands: Record<string, string[]> = {
+  R: ['--raw'],
   parallel: [
     '--workspace-concurrency=Infinity',
     '--no-sort',
     '--stream',
     '--recursive',
+  ],
+  raw: [
+    '--stream',
+    '--reporter-hide-prefix',
   ],
   sequential: [
     '--workspace-concurrency=1',
@@ -103,6 +114,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
     ...IF_PRESENT_OPTION,
     recursive: Boolean,
     reverse: Boolean,
+    raw: Boolean,
     'resume-from': String,
     'report-summary': Boolean,
     'reporter-hide-prefix': Boolean,
@@ -145,6 +157,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           ...UNIVERSAL_OPTIONS,
           SEQUENTIAL_OPTION_HELP,
           REPORT_SUMMARY_OPTION_HELP,
+          RAW_OPTION_HELP,
           REPORTER_HIDE_PREFIX_HELP,
         ],
       },
@@ -157,7 +170,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
 
 export type RunOpts =
   & Omit<RecursiveRunOpts, 'allProjects' | 'selectedProjectsGraph' | 'workspaceDir'>
-  & { recursive?: boolean }
+  & { recursive?: boolean, raw?: boolean }
   & Pick<Config,
   | 'bin'
   | 'cliOptions'
@@ -207,6 +220,10 @@ export async function handler (
       ...opts.extraEnv,
       NODE_OPTIONS: opts.nodeOptions,
     }
+  }
+
+  if (opts.raw) {
+    opts.stream = true
   }
 
   if (opts.recursive) {

--- a/exec/plugin-commands-script-runners/test/index.ts
+++ b/exec/plugin-commands-script-runners/test/index.ts
@@ -21,6 +21,14 @@ const pnpmBin = path.join(import.meta.dirname, '../../../pnpm/bin/pnpm.mjs')
 const skipOnWindows = isWindows() ? test.skip : test
 const onlyOnWindows = !isWindows() ? test.skip : test
 
+test('run command defines --raw option and shorthand mappings', () => {
+  expect(run.cliOptionsTypes()).toMatchObject({
+    raw: Boolean,
+  })
+  expect(run.shorthands.raw).toStrictEqual(['--stream', '--reporter-hide-prefix'])
+  expect(run.shorthands.R).toStrictEqual(['--raw'])
+})
+
 test('pnpm run: returns correct exit code', async () => {
   prepare({
     scripts: {


### PR DESCRIPTION
## Summary\n- add a new `--raw` option with short alias `-R` to the run command\n- map `--raw` to existing behavior: `--stream --reporter-hide-prefix`\n- add unit coverage for raw option and shorthand mappings\n\n## Motivation\nCloses #1677\n\n## Testing\n- pnpm --filter @pnpm/plugin-commands-script-runners run lint\n- pre-push repo lint hooks passed (spellcheck/meta-updater/lint:ts)\n- note: direct package jest run in local environment currently fails with existing workspace module-resolution issue (missing @pnpm/plugin-commands-rebuild in local lib state), unrelated to this change