### PR TITLE
fix: fix install summary in workspace

### DIFF
--- a/.changeset/fix-install-summary.md
+++ b/.changeset/fix-install-summary.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolve-dependencies": patch
+"pnpm": patch
+---
+
+Fixed the install summary in workspaces by setting recursive config before reporter initialization and skipping manifest logging during dry runs.

--- a/cli/default-reporter/test/index.ts
+++ b/cli/default-reporter/test/index.ts
@@ -38,6 +38,54 @@ const h1 = chalk.cyanBright
 
 const EOL = '\n'
 
+test('does not show false dependency changes when updated manifest is not logged', async () => {
+  const prefix = '/home/jane/project'
+  const output$ = toOutput$({
+    context: {
+      argv: ['install'],
+      config: { dir: prefix } as Config,
+    },
+    streamParser: createStreamParser(),
+  })
+
+  // During a dry run, only the initial manifest is logged (no updated manifest).
+  // The summary should only show root-level added packages, not false dependency type changes.
+  packageManifestLogger.debug({
+    initial: {
+      name: 'foo',
+      version: '1.0.0',
+
+      dependencies: {
+        'is-positive': '^1.0.0',
+      },
+      devDependencies: {
+        'is-negative': '^1.0.0',
+      },
+    },
+    prefix,
+  })
+  rootLogger.debug({
+    added: {
+      dependencyType: 'prod',
+      id: 'registry.npmjs.org/is-positive/1.0.0',
+      name: 'is-positive',
+      realName: 'is-positive',
+      version: '1.0.0',
+    },
+    prefix,
+  })
+  summaryLogger.debug({ prefix })
+
+  expect.assertions(1)
+
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  // Should only show the added package, not re-list existing deps as added/removed
+  expect(output).toBe(EOL + `\
+${h1('dependencies:')}
+${ADD} is-positive ${versionColor('1.0.0')}
+`)
+})
+
 test('prints summary (of current package only)', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({

--- a/pkg-manager/resolve-dependencies/src/index.ts
+++ b/pkg-manager/resolve-dependencies/src/index.ts
@@ -235,10 +235,12 @@ export async function resolveDependencies (
     } else {
       updatedManifest = project.manifest
       updatedOriginalManifest = project.originalManifest
-      packageManifestLogger.debug({
-        prefix: project.rootDir,
-        updated: project.manifest,
-      })
+      if (!opts.dryRun) {
+        packageManifestLogger.debug({
+          prefix: project.rootDir,
+          updated: project.manifest,
+        })
+      }
     }
 
     if (updatedManifest != null) {

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -169,6 +169,18 @@ export async function main (inputArgv: string[]): Promise<void> {
     write = (text) => process.stdout.write(stripAnsi(text))
   }
 
+  if (
+    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe' || cmd === 'patch-commit' || cmd === 'patch' || cmd === 'patch-remove' || cmd === 'approve-builds' || cmd === 'audit') &&
+    typeof workspaceDir === 'string'
+  ) {
+    cliOptions['recursive'] = true
+    config.recursive = true
+
+    if (!config.recursiveInstall && !config.filter && !config.filterProd) {
+      config.filter = ['{.}...']
+    }
+  }
+
   const reporterType: ReporterType = (() => {
     if (config.loglevel === 'silent') return 'silent'
     if (config.reporter) return config.reporter as ReporterType
@@ -183,18 +195,6 @@ export async function main (inputArgv: string[]): Promise<void> {
       config,
     })
     global[REPORTER_INITIALIZED] = reporterType
-  }
-
-  if (
-    (cmd === 'install' || cmd === 'import' || cmd === 'dedupe' || cmd === 'patch-commit' || cmd === 'patch' || cmd === 'patch-remove' || cmd === 'approve-builds' || cmd === 'audit') &&
-    typeof workspaceDir === 'string'
-  ) {
-    cliOptions['recursive'] = true
-    config.recursive = true
-
-    if (!config.recursiveInstall && !config.filter && !config.filterProd) {
-      config.filter = ['{.}...']
-    }
   }
 
   if (cliOptions['recursive']) {


### PR DESCRIPTION
## Summary
- Move workspace recursive detection block before reporter initialization in `pnpm/src/main.ts`, so the reporter has the correct recursive config when it starts
- Skip `packageManifestLogger.debug` during dry runs in `pkg-manager/resolve-dependencies/src/index.ts` to prevent incorrect install summary output

## Test plan
- [ ] Run `pnpm install` in a workspace and verify the install summary is correct
- [ ] Run `pnpm install --dry-run` and verify no incorrect manifest updates are logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)