### PR TITLE
fix(audit): correctly report ignored vulnerabilities count

### DIFF
--- a/.changeset/audit-ignored-vulnerabilities.md
+++ b/.changeset/audit-ignored-vulnerabilities.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-audit": patch
+"pnpm": patch
+---
+
+Fixed an issue where `pnpm audit` incorrectly reported the number of ignored vulnerabilities when a vulnerable dependency with multiple occurrences was ignored.

--- a/lockfile/plugin-commands-audit/src/audit.ts
+++ b/lockfile/plugin-commands-audit/src/audit.ts
@@ -291,21 +291,21 @@ ${newIgnores.join('\n')}`,
     .reduce((sum: number, vulnerabilitiesCount: number) => sum + vulnerabilitiesCount, 0)
   const ignoreGhsas = opts.auditConfig?.ignoreGhsas
   if (ignoreGhsas) {
-    auditReport.advisories = pickBy(({ github_advisory_id: githubAdvisoryId, severity }) => {
+    auditReport.advisories = pickBy(({ github_advisory_id: githubAdvisoryId, severity, findings }: AuditAdvisory) => {
       if (!ignoreGhsas.includes(githubAdvisoryId)) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+      ignoredVulnerabilities[severity as AuditLevelString] += findings.reduce((count: number, finding: { paths: string[] }) => count + finding.paths.length, 0)
       return false
     }, auditReport.advisories)
   }
   const ignoreCves = opts.auditConfig?.ignoreCves
   if (ignoreCves) {
-    auditReport.advisories = pickBy(({ cves, severity }) => {
+    auditReport.advisories = pickBy(({ cves, severity, findings }: AuditAdvisory) => {
       if (cves.length === 0 || difference(cves, ignoreCves).length > 0) {
         return true
       }
-      ignoredVulnerabilities[severity as AuditLevelString] += 1
+      ignoredVulnerabilities[severity as AuditLevelString] += findings.reduce((count: number, finding: { paths: string[] }) => count + finding.paths.length, 0)
       return false
     }, auditReport.advisories)
   }

--- a/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
+++ b/lockfile/plugin-commands-audit/test/__snapshots__/index.ts.snap
@@ -1681,7 +1681,7 @@ exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;
 
 exports[`plugin-commands-audit audit: CVEs in ignoreCves do not show up when JSON output is used 1`] = `
@@ -3865,5 +3865,5 @@ exports[`plugin-commands-audit audit: CVEs in ignoreGhsas do not show up 1`] = `
 │ More info           │ https://github.com/advisories/GHSA-pw2r-vq6v-hr8c      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 46 vulnerabilities found
-Severity: 4 low | 17 moderate (1 ignored) | 21 high (3 ignored) | 4 critical"
+Severity: 4 low | 17 moderate (2 ignored) | 21 high (3 ignored) | 4 critical"
 `;


### PR DESCRIPTION
## Description

When 1 vulnerabilities found
Severity: 1 moderate (1 ignored) found an ignored vulnerability that was present multiple times in the dependency tree (multiple paths), it was only incrementing the ignored count by 1 per advisory. 

This PR updates the filtering logic to accumulate the total count of all finding paths instead of just adding 1 for each advisory.

## Changes:
- Updated `lockfile/plugin-commands-audit/src/audit.ts` to correctly sum finding paths lengths.
- Added type annotations to fix implicit any TS errors in the modified code.
- Updated test snapshots for `@pnpm/plugin-commands-audit`.
- Added a changeset for versioning.