### PR TITLE
chore: fix pnpm audit fix update command in changelog

### DIFF
--- a/pnpm/CHANGELOG.md
+++ b/pnpm/CHANGELOG.md
@@ -186,7 +186,7 @@
 - Added `-F` as a short alias for the `--filter` option.
 - When the global virtual store is enabled, packages that are not allowed to build (and don't transitively depend on packages that are) now get hashes that don't include the engine name (platform, architecture, Node.js major version). This means ~95% of packages in the GVS survive Node.js upgrades and architecture changes without re-import [#10837](https://github.com/pnpm/pnpm/issues/10837).
 - Support specifying the pnpm version via `devEngines.packageManager` in `package.json`. Unlike the `packageManager` field, this supports version ranges. The resolved version is stored in `pnpm-lock.yaml` and reused if it still satisfies the range [#10932](https://github.com/pnpm/pnpm/pull/10932).
-- Add the ability to fix vulnerabilities by updating packages in the lockfile instead of adding overrides. Use `pnpm audit --fix --fix-mode=update` [#10341](https://github.com/pnpm/pnpm/pull/10341).
+- Add the ability to fix vulnerabilities by updating packages in the lockfile instead of adding overrides. Use `pnpm audit --fix=update` [#10341](https://github.com/pnpm/pnpm/pull/10341).
 
 ### Patch Changes
 


### PR DESCRIPTION
I noticed the changelog & release notes have a different command than what #10341 adds for updating vulnerabilities in the lockfile. The PR adds `--fix=update`, not `--fix-mode=update`.

If you would prefer to update the code to use `--fix-mode` instead, let me know and I can make that change.