### PR TITLE
fix: show available workspace versions in resolution errors

### DIFF
--- a/.changeset/clever-hats-sparkle.md
+++ b/.changeset/clever-hats-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/default-reporter": patch
+"@pnpm/npm-resolver": patch
+"pnpm": patch
+---
+
+Include available workspace versions in resolver errors when the registry cannot satisfy a requested dependency [#1379](https://github.com/pnpm/pnpm/issues/1379).

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -72,7 +72,7 @@ function getErrorInfo (logObj: Log, config?: Config): ErrorInfo | null {
         return { title: err.message, body: 'If you cannot fix this registry issue, then set "resolution-mode" to "highest".' }
       case 'ERR_PNPM_NO_MATCHING_VERSION':
       case 'ERR_PNPM_NO_MATURE_MATCHING_VERSION':
-        return formatNoMatchingVersion(err, logObj as unknown as { packageMeta: PackageMeta, immatureVersion?: string })
+        return formatNoMatchingVersion(err, logObj as unknown as { packageMeta: PackageMeta, immatureVersion?: string, hint?: string })
       case 'ERR_PNPM_RECURSIVE_FAIL':
         return formatRecursiveCommandSummary(logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
       case 'ERR_PNPM_BAD_TARBALL_SIZE':
@@ -134,7 +134,7 @@ interface PackageMeta {
   time?: Record<string, string>
 }
 
-function formatNoMatchingVersion (err: Error, msg: { packageMeta: PackageMeta, immatureVersion?: string }) {
+function formatNoMatchingVersion (err: Error & { hint?: string }, msg: { packageMeta: PackageMeta, immatureVersion?: string, hint?: string }) {
   const meta: PackageMeta = msg.packageMeta
   const latestVersion = meta['dist-tags'].latest
   let output = `The latest release of ${meta.name} is "${latestVersion}".`
@@ -163,6 +163,9 @@ function formatNoMatchingVersion (err: Error, msg: { packageMeta: PackageMeta, i
 
   if (msg.immatureVersion) {
     output += `${EOL}${EOL}If you want to install the matched version ignoring the time it was published, you can add the package name to the minimumReleaseAgeExclude setting. Read more about it: https://pnpm.io/settings#minimumreleaseageexclude`
+  }
+  if (msg.hint ?? err.hint) {
+    output += `${EOL}${EOL}${msg.hint ?? err.hint}`
   }
 
   return {

--- a/cli/default-reporter/test/reportingErrors.ts
+++ b/cli/default-reporter/test/reportingErrors.ts
@@ -107,6 +107,31 @@ ${ERROR_PAD}
 ${ERROR_PAD}If you need the full list of all 4 published versions run "pnpm view is-positive versions".`)
 })
 
+test('prints no matching version error hint', async () => {
+  const output$ = toOutput$({
+    context: { argv: ['install'] },
+    streamParser: createStreamParser(),
+  })
+
+  expect.assertions(1)
+
+  const err = Object.assign(new PnpmError('NO_MATCHING_VERSION', 'No matching version found for is-positive@1000.0.0', {
+    hint: 'Available workspace versions for "is-positive": 1.0.0',
+  }), {
+    packageMeta: loadJsonFileSync(path.join(import.meta.dirname, 'is-positive-meta.json')),
+  })
+  logger.error(err, err)
+
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(`${formatError('ERR_PNPM_NO_MATCHING_VERSION', 'No matching version found for is-positive@1000.0.0')}
+${ERROR_PAD}
+${ERROR_PAD}The latest release of is-positive is "3.1.0".
+${ERROR_PAD}
+${ERROR_PAD}If you need the full list of all 4 published versions run "pnpm view is-positive versions".
+${ERROR_PAD}
+${ERROR_PAD}Available workspace versions for "is-positive": 1.0.0`)
+})
+
 test('prints suggestions when an internet-connection related error happens', async () => {
   const output$ = toOutput$({
     context: { argv: ['install'] },

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -61,6 +61,7 @@ export interface NoMatchingVersionErrorOptions {
   wantedDependency: WantedDependency
   packageMeta: PackageMeta
   registry: string
+  hint?: string
   immatureVersion?: string
   publishedBy?: Date
 }
@@ -81,7 +82,7 @@ export class NoMatchingVersionError extends PnpmError {
     } else {
       errorMessage = `No matching version found for ${dep} while fetching it from ${opts.registry}`
     }
-    super(opts.publishedBy ? 'NO_MATURE_MATCHING_VERSION' : 'NO_MATCHING_VERSION', errorMessage)
+    super(opts.publishedBy ? 'NO_MATURE_MATCHING_VERSION' : 'NO_MATCHING_VERSION', errorMessage, { hint: opts.hint })
     this.packageMeta = opts.packageMeta
     this.immatureVersion = opts.immatureVersion
   }
@@ -372,6 +373,10 @@ async function resolveNpm (
       } catch {
         // ignore
       }
+      const workspaceHint = getWorkspaceVersionsHint(workspacePackages, spec)
+      if (workspaceHint) {
+        appendHint(err, workspaceHint)
+      }
     }
     throw err
   }
@@ -394,6 +399,9 @@ async function resolveNpm (
         // ignore
       }
     }
+    const workspaceHint = workspacePackages != null
+      ? getWorkspaceVersionsHint(workspacePackages, spec)
+      : undefined
 
     if (opts.publishedBy) {
       const immatureVersion = pickVersionByVersionRange({
@@ -406,12 +414,13 @@ async function resolveNpm (
           wantedDependency,
           packageMeta: meta,
           registry,
+          hint: workspaceHint,
           immatureVersion,
           publishedBy: opts.publishedBy,
         })
       }
     }
-    throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry })
+    throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry, hint: workspaceHint })
   } else if (opts.trustPolicy === 'no-downgrade') {
     failIfTrustDowngraded(meta, pickedPackage.version, opts)
   }
@@ -640,7 +649,7 @@ function tryResolveFromWorkspacePackages (
     opts.update ? { name: spec.name, fetchSpec: '*', type: 'range' } : spec
   )
   if (!localVersion) {
-    const availableVersions = Array.from(workspacePkgsMatchingName.keys()).sort((a, b) => semver.rcompare(a, b))
+    const availableVersions = getAvailableWorkspaceVersions(workspacePkgsMatchingName)
     throw new PnpmError(
       'NO_MATCHING_VERSION_INSIDE_WORKSPACE',
       `In ${path.relative(process.cwd(), opts.projectDir)}: No matching version found for ${opts.wantedDependency.alias ?? ''}@${opts.wantedDependency.bareSpecifier ?? ''} inside the workspace` +
@@ -653,6 +662,29 @@ function tryResolveFromWorkspacePackages (
     )
   }
   return resolveFromLocalPackage(workspacePkgsMatchingName.get(localVersion)!, spec, opts)
+}
+
+function appendHint (err: Error, hint: string): void {
+  const errorWithHint = err as Error & { hint?: string }
+  errorWithHint.hint = errorWithHint.hint
+    ? `${errorWithHint.hint}\n\n${hint}`
+    : hint
+}
+
+function getWorkspaceVersionsHint (
+  workspacePackages: WorkspacePackages,
+  spec: RegistryPackageSpec
+): string | undefined {
+  const workspacePkgsMatchingName = workspacePackages.get(spec.name)
+  if (!workspacePkgsMatchingName) return undefined
+  if (pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)) return undefined
+  const availableVersions = getAvailableWorkspaceVersions(workspacePkgsMatchingName)
+  if (availableVersions.length === 0) return undefined
+  return `Available workspace versions for "${spec.name}": ${availableVersions.join(', ')}`
+}
+
+function getAvailableWorkspaceVersions (workspacePkgsMatchingName: WorkspacePackagesByVersion): string[] {
+  return Array.from(workspacePkgsMatchingName.keys()).sort((a, b) => semver.rcompare(a, b))
 }
 
 function pickMatchingLocalVersionOrNull (

--- a/resolving/npm-resolver/test/index.ts
+++ b/resolving/npm-resolver/test/index.ts
@@ -2081,8 +2081,9 @@ test('throws when workspace package version does not match and package is not fo
     registries,
   })
 
-  await expect(
-    resolveFromNpm({ alias: 'is-positive', bareSpecifier: '2.0.0' }, {
+  let err!: Error & { code: string, hint?: string }
+  try {
+    await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '2.0.0' }, {
       projectDir: '/home/istvan/src',
       update: 'compatible',
       workspacePackages: new Map([
@@ -2097,7 +2098,13 @@ test('throws when workspace package version does not match and package is not fo
         ])],
       ]),
     })
-  ).rejects.toThrow()
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err).toBeTruthy()
+  expect(err.code).toBe('ERR_PNPM_FETCH_404')
+  expect(err.hint).toContain('Available workspace versions for "is-positive": 1.0.0')
 })
 
 test('throws NoMatchingVersionError when workspace package version does not match and registry has no matching version', async () => {
@@ -2112,8 +2119,9 @@ test('throws NoMatchingVersionError when workspace package version does not matc
     registries,
   })
 
-  await expect(
-    resolveFromNpm({ alias: 'is-positive', bareSpecifier: '99.0.0' }, {
+  let err!: Error & { code: string, hint?: string }
+  try {
+    await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '99.0.0' }, {
       projectDir: '/home/istvan/src',
       update: 'compatible',
       workspacePackages: new Map([
@@ -2128,7 +2136,14 @@ test('throws NoMatchingVersionError when workspace package version does not matc
         ])],
       ]),
     })
-  ).rejects.toThrow(NoMatchingVersionError)
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err).toBeTruthy()
+  expect(err.code).toBe('ERR_PNPM_NO_MATCHING_VERSION')
+  expect(err).toBeInstanceOf(NoMatchingVersionError)
+  expect(err.hint).toBe('Available workspace versions for "is-positive": 1.0.0')
 })
 
 test('resolve from registry when workspace package version does not match the requested version', async () => {


### PR DESCRIPTION
Closes #1379

## Summary
- preserve the available workspace versions hint when registry resolution falls back to an error
- surface the same hint for no-matching-version errors in the default reporter
- add resolver and reporter regression coverage for the mismatched workspace version flow

## Testing
- corepack pnpm --filter @pnpm/npm-resolver run test test/index.ts -t "workspace package version does not match"
- corepack pnpm --filter @pnpm/default-reporter run test test/reportingErrors.ts -t "no matching version error"