### PR TITLE
feat: warn when optimistic-repeat-install skips shouldRefreshResolution hooks

### DIFF
--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -164,7 +164,7 @@ export async function installDeps (
     if (upToDate) {
       if (opts.hooks?.customResolvers?.some(r => r.shouldRefreshResolution)) {
         logger.warn({
-          message: 'shouldRefreshResolution hooks were skipped because optimistic-repeat-install is enabled.',
+          message: 'shouldRefreshResolution hooks were skipped because optimisticRepeatInstall is enabled.',
           prefix: opts.dir,
         })
       }


### PR DESCRIPTION
Per [previous discussion](https://github.com/pnpm/pnpm/pull/10342#discussion_r2663082951), `optimisticRepeatInstall` (which is enabled by default in pnpm 11) prevents the new `shouldRefreshResolution` hook from performing its main function: If the lockfile is up-to-date, the optimistic repeat install skips resolution without even calling the hook.

That's reasonable as an optimization (calling the hook for every resolved dependency would be potentially expensive), but it's quite confusing if you're trying to use the `shouldRefreshResolution` hook. This PR adds a warning in that scenario:

> shouldRefreshResolution hooks were skipped because optimistic-repeat-install is enabled.