### PR TITLE
fix: use ENOENT check instead of which.sync for command-not-found on Windows

### DIFF
--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -68,6 +68,7 @@
     "realpath-missing": "catalog:",
     "render-help": "catalog:",
     "symlink-dir": "catalog:",
+    "which": "catalog:",
     "write-json-file": "catalog:"
   },
   "peerDependencies": {

--- a/exec/commands/src/exec.ts
+++ b/exec/commands/src/exec.ts
@@ -8,6 +8,7 @@ import type { CheckDepsStatusOptions } from '@pnpm/deps.status'
 import { PnpmError } from '@pnpm/error'
 import { makeNodeRequireOption } from '@pnpm/exec.lifecycle'
 import { logger } from '@pnpm/logger'
+import { prependDirsToPath } from '@pnpm/shell.path'
 import type { Project, ProjectRootDir, ProjectRootDirRealPath, ProjectsGraph } from '@pnpm/types'
 import { tryReadProjectManifest } from '@pnpm/workspace.project-manifest-reader'
 import { sortPackages } from '@pnpm/workspace.projects-sorter'
@@ -15,6 +16,7 @@ import { safeExeca as execa } from 'execa'
 import pLimit from 'p-limit'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
+import which from 'which'
 import { writeJsonFile } from 'write-json-file'
 
 import { getNearestProgram, getNearestScript } from './buildCommandNotFoundHint.js'
@@ -294,7 +296,7 @@ export async function handler (
           result[prefix].status = 'passed'
           result[prefix].duration = getExecutionDuration(startTime)
         } catch (err: any) { // eslint-disable-line
-          if (isErrorCommandNotFound(params[0], err)) {
+          if (isErrorCommandNotFound(params[0], err, prefix, prependPaths)) {
             err.message = `Command "${params[0]}" not found`
             err.hint = await createExecCommandNotFoundHint(params[0], {
               implicitlyFellbackFromRun: opts.implicitlyFellbackFromRun ?? false,
@@ -392,6 +394,21 @@ interface CommandError extends Error {
   shortMessage: string
 }
 
-function isErrorCommandNotFound (command: string, error: CommandError): boolean {
-  return error.originalMessage === `spawn ${command} ENOENT`
+function isErrorCommandNotFound (command: string, error: CommandError, prefix: string, prependPaths: string[]): boolean {
+  if (error.originalMessage === `spawn ${command} ENOENT`) {
+    return true
+  }
+
+  // On Windows, execa 9.x uses cross-spawn only for command parsing (not spawning),
+  // so cross-spawn's ENOENT hook never fires. Non-existent commands get wrapped as
+  // `cmd.exe /c <command>` which exits with code 1 instead of emitting ENOENT.
+  // Fall back to checking if the command exists in PATH, resolving relative paths
+  // against the exec prefix to correctly handle --filter contexts.
+  if (process.platform === 'win32') {
+    const absolutePrependPaths = prependPaths.map(p => path.resolve(prefix, p))
+    const { value: searchPath } = prependDirsToPath(absolutePrependPaths)
+    return !which.sync(command, { nothrow: true, path: searchPath })
+  }
+
+  return false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3976,6 +3976,9 @@ importers:
       symlink-dir:
         specifier: 'catalog:'
         version: 7.1.0
+      which:
+        specifier: 'catalog:'
+        version: '@pnpm/which@3.0.1'
       write-json-file:
         specifier: 'catalog:'
         version: 7.0.0


### PR DESCRIPTION
## Summary

Fixes #11000

On Windows, `pnpm exec` (with `--filter`) falsely reports **"Command not found"** when the command actually exists but exits with a non-zero exit code. For example, running `pnpm --filter sub-package exec prettier --check test.js` where Prettier finds formatting issues reports `Command "prettier" not found` instead of the actual exit code error.

## Root Cause

The `isErrorCommandNotFound()` function in `exec/commands/src/exec.ts` had a flawed Windows implementation:

- **Linux/macOS**: Correctly checked `error.originalMessage === 'spawn ${command} ENOENT'` — the standard Node.js error when a binary cannot be found.
- **Windows**: Used `which.sync()` to check if the command exists in PATH, but resolved relative paths (like `./node_modules/.bin`) against `process.cwd()` instead of the exec prefix directory. In `--filter` contexts where the command runs in a different package directory, this caused `which.sync` to look in the wrong `node_modules/.bin`, failing to find the command and incorrectly reporting "Command not found".

## Fix

Two changes to `isErrorCommandNotFound()`:

1. **Unified ENOENT check first** (all platforms): `error.originalMessage === 'spawn ${command} ENOENT'` — this handles the common case on Linux/macOS where Node.js spawn directly emits ENOENT.

2. **Fixed Windows fallback**: `which.sync` is still needed on Windows because execa 9.x uses `cross-spawn` only for command parsing (`crossSpawn._parse()`), not for spawning — it calls `node:child_process.spawn()` directly. This means cross-spawn's `hookChildProcess` ENOENT detection never fires, and non-existent commands wrapped as `cmd.exe /c <command>` exit with code 1 instead of emitting ENOENT. The fix resolves relative `prependPaths` against the exec `prefix` directory (using `path.resolve(prefix, p)`) so `which.sync` correctly searches in the right `node_modules/.bin`.

## Test plan

- [x] Compile passes (`pnpm --filter @pnpm/exec.commands run compile`)
- [x] Lint passes (pre-push hook)
- [ ] CI: Verify Windows `exec.e2e.ts` command-not-found tests pass
- [ ] CI: Verify Linux/macOS tests still pass