### PR TITLE
fix(deploy): prevent extra directories when using relative deploy path

### DIFF
--- a/.changeset/fix-deploy-extra-directories.md
+++ b/.changeset/fix-deploy-extra-directories.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm deploy` creating extra directories inside the deploy target and breaking the project's own `node_modules` when using a relative deploy path [#10981](https://github.com/pnpm/pnpm/issues/10981).

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -130,9 +130,16 @@ export async function handler (opts: DeployOptions, params: string[]): Promise<v
     }
   }
 
-  const deployedProject = opts.allProjects?.find(({ rootDir }) => rootDir === selectedProject.rootDir)
-  if (deployedProject) {
-    deployedProject.modulesDir = path.relative(selectedProject.rootDir, path.join(deployDir, 'node_modules'))
+  const deployNodeModules = path.join(deployDir, 'node_modules')
+  // Set modulesDir for ALL workspace projects to point to the deploy directory's
+  // node_modules. Without this, non-deployed projects fall back to the relative
+  // modulesDir from opts, which gets incorrectly joined with each project's
+  // rootDir, creating extraneous directories (e.g., project-2/foo/node_modules
+  // when deploying to ./foo).
+  if (opts.allProjects) {
+    for (const project of opts.allProjects) {
+      project.modulesDir = path.relative(project.rootDir, deployNodeModules)
+    }
   }
   await install.handler({
     ...opts,

--- a/releasing/commands/test/deploy/deploy.test.ts
+++ b/releasing/commands/test/deploy/deploy.test.ts
@@ -251,6 +251,69 @@ test('deploy with node-linker=hoisted', async () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBeFalsy() // no changes to the lockfile are written
 })
 
+// Regression test for https://github.com/pnpm/pnpm/issues/10981
+// pnpm deploy should not create extra directories inside the deploy target
+// or inside other workspace project directories.
+test('deploy with node-linker=hoisted does not create extra directories', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+      },
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      files: ['index.js'],
+      dependencies: {
+        'project-2': 'workspace:*',
+        'is-positive': '1.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '2.0.0',
+      files: ['index.js'],
+      dependencies: {
+        'is-odd': '1.0.0',
+      },
+    },
+  ])
+
+  ;['project-1', 'project-2'].forEach(name => {
+    fs.writeFileSync(`${name}/index.js`, '', 'utf8')
+  })
+
+  const { allProjects, selectedProjectsGraph } = await filterPkgsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'project-1' }])
+
+  await deploy.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    dir: process.cwd(),
+    dev: false,
+    production: true,
+    recursive: true,
+    selectedProjectsGraph,
+    nodeLinker: 'hoisted',
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  }, ['some/nested/path'])
+
+  const project = assertProject(path.resolve('some/nested/path'))
+  project.has('project-2')
+  project.has('is-positive')
+  expect(fs.existsSync('some/nested/path/index.js')).toBeTruthy()
+  expect(fs.existsSync('some/nested/path/node_modules/.modules.yaml')).toBeTruthy()
+
+  // The deploy should NOT create extra directories inside the deploy target
+  expect(fs.existsSync('some/nested/path/some')).toBeFalsy()
+  // The deploy should NOT create directories inside other workspace projects
+  expect(fs.existsSync('project-1/some')).toBeFalsy()
+  expect(fs.existsSync('project-2/some')).toBeFalsy()
+})
+
 // Similar to the test above making sure pnpm deploy works with
 // node-linker=hoisted, but we should also make sure not to link projects not in
 // the dependency graph of the deployed package.


### PR DESCRIPTION
## Summary

Fixes #10981

`pnpm deploy` with a relative path (e.g., `pnpm --filter=my-pkg deploy ./foo`) creates extraneous nested directories inside the deploy target (`foo/foo/...`) and corrupts workspace projects' `node_modules`. This happens in the legacy deploy path (used when shared lockfile is unavailable or `node-linker=hoisted` without pre-existing lockfile).

## Root Cause

In the legacy deploy path (`deploy.ts`), only the **deployed project's** `modulesDir` was updated to point to the deploy directory's `node_modules` (line 135):

```typescript
deployedProject.modulesDir = path.relative(selectedProject.rootDir, path.join(deployDir, 'node_modules'))
```

The `modulesDir` option passed to `install.handler` (line 193) was a relative path from `workspaceDir`:

```typescript
modulesDir: path.relative(opts.workspaceDir, path.join(deployDir, 'node_modules'))
// e.g., 'foo/node_modules' when deploying to ./foo
```

In `read-projects-context`, this relative `modulesDir` is used as a fallback for **all** workspace projects that don't have an explicit `modulesDir`:

```typescript
// read-projects-context/src/index.ts:61
const modulesDir = path.join(project.rootDir, project.modulesDir ?? relativeModulesDir)
```

For non-deployed projects, this produced wrong paths like `project-2/foo/node_modules` instead of `foo/node_modules`, creating extra directories inside workspace projects and inside the deploy target.

## Fix

Set `modulesDir` for **all** workspace projects in `allProjects` to point to the deploy directory's `node_modules`, not just the deployed project:

```typescript
const deployNodeModules = path.join(deployDir, 'node_modules')
if (opts.allProjects) {
  for (const project of opts.allProjects) {
    project.modulesDir = path.relative(project.rootDir, deployNodeModules)
  }
}
```

This ensures that no matter which code path is taken downstream, all `modulesDir` references resolve to the deploy directory.

## Test plan

- [x] All 11 deploy tests pass (including new regression test)
- [x] All 9 shared lockfile deploy tests pass
- [x] Added regression test: deploy with `node-linker=hoisted` to a nested relative path (`some/nested/path`) verifies no extra directories are created inside deploy target or workspace projects
- [x] Compile and lint pass
