### PR TITLE
fix(test): wait for verdaccio registry readiness before running tests

### DIFF
--- a/__utils__/jest-config/with-registry/globalSetup.js
+++ b/__utils__/jest-config/with-registry/globalSetup.js
@@ -1,3 +1,4 @@
+import http from 'node:http'
 import getPort from 'get-port'
 import { promisify } from 'util'
 import treeKill from 'tree-kill'
@@ -31,4 +32,27 @@ export default async () => {
     killed = true
     return kill(server.pid)
   }
+  await waitForRegistry(`http://localhost:${process.env.PNPM_REGISTRY_MOCK_PORT}`)
+}
+
+function waitForRegistry (url, { maxRetries = 60, interval = 500 } = {}) {
+  return new Promise((resolve, reject) => {
+    let attempts = 0
+    const check = () => {
+      attempts++
+      const req = http.get(url, (res) => {
+        res.resume()
+        resolve()
+      })
+      req.on('error', () => {
+        if (attempts >= maxRetries) {
+          reject(new Error(`Verdaccio registry at ${url} did not become ready after ${maxRetries * interval}ms`))
+          return
+        }
+        setTimeout(check, interval)
+      })
+      req.end()
+    }
+    check()
+  })
 }


### PR DESCRIPTION
## Summary
- Add a readiness check in Jest `globalSetup` that polls the verdaccio registry URL until it responds before allowing tests to proceed
- Fixes intermittent `META_FETCH_FAIL` errors caused by tests running before the registry server is ready to accept connections

## Problem
The Jest `globalSetup` in `@pnpm/jest-config/with-registry` spawns a verdaccio server via `execa()` but never waits for it to be ready. This race condition causes flaky test failures across multiple packages (`@pnpm/deps.inspection.commands`, `@pnpm/deps.compliance.commands`, etc.) with `META_FETCH_FAIL` errors, affecting unrelated PRs.

## Solution
Added a `waitForRegistry()` function that sends HTTP GET requests to the registry URL with retry logic (up to 60 attempts, 500ms interval = 30s max wait). Tests only proceed once the registry responds successfully.

## Test plan
- [x] `@pnpm/deps.inspection.commands` tests pass consistently (7/7 suites, 48/48 tests)
- [x] `@pnpm/deps.compliance.commands` tests pass consistently (7/7 suites, 52/52 tests)
- [x] Multiple consecutive runs show no flaky failures

Closes #11005
