### PR TITLE
fix(exec): avoid false "command not found" on Windows recursive exec

### DIFF
--- a/exec/commands/src/exec.ts
+++ b/exec/commands/src/exec.ts
@@ -1,89 +1,113 @@
-import path from 'node:path'
+import path from "node:path";
 
-import { FILTERING, UNIVERSAL_OPTIONS } from '@pnpm/cli.common-cli-options-help'
-import { docsUrl, readProjectManifestOnly, type RecursiveSummary, throwOnCommandFail } from '@pnpm/cli.utils'
-import { type Config, getWorkspaceConcurrency, types } from '@pnpm/config.reader'
-import { lifecycleLogger, type LifecycleMessage } from '@pnpm/core-loggers'
-import type { CheckDepsStatusOptions } from '@pnpm/deps.status'
-import { PnpmError } from '@pnpm/error'
-import { makeNodeRequireOption } from '@pnpm/exec.lifecycle'
-import { logger } from '@pnpm/logger'
-import { prependDirsToPath } from '@pnpm/shell.path'
-import type { Project, ProjectRootDir, ProjectRootDirRealPath, ProjectsGraph } from '@pnpm/types'
-import { tryReadProjectManifest } from '@pnpm/workspace.project-manifest-reader'
-import { sortPackages } from '@pnpm/workspace.projects-sorter'
-import { safeExeca as execa } from 'execa'
-import pLimit from 'p-limit'
-import { pick } from 'ramda'
-import { renderHelp } from 'render-help'
-import which from 'which'
-import { writeJsonFile } from 'write-json-file'
+import {
+  FILTERING,
+  UNIVERSAL_OPTIONS,
+} from "@pnpm/cli.common-cli-options-help";
+import {
+  docsUrl,
+  readProjectManifestOnly,
+  type RecursiveSummary,
+  throwOnCommandFail,
+} from "@pnpm/cli.utils";
+import {
+  type Config,
+  getWorkspaceConcurrency,
+  types,
+} from "@pnpm/config.reader";
+import { lifecycleLogger, type LifecycleMessage } from "@pnpm/core-loggers";
+import type { CheckDepsStatusOptions } from "@pnpm/deps.status";
+import { PnpmError } from "@pnpm/error";
+import { makeNodeRequireOption } from "@pnpm/exec.lifecycle";
+import { logger } from "@pnpm/logger";
+import type {
+  Project,
+  ProjectRootDir,
+  ProjectRootDirRealPath,
+  ProjectsGraph,
+} from "@pnpm/types";
+import { tryReadProjectManifest } from "@pnpm/workspace.project-manifest-reader";
+import { sortPackages } from "@pnpm/workspace.projects-sorter";
+import { safeExeca as execa } from "execa";
+import pLimit from "p-limit";
+import { pick } from "ramda";
+import { renderHelp } from "render-help";
+import { writeJsonFile } from "write-json-file";
 
-import { getNearestProgram, getNearestScript } from './buildCommandNotFoundHint.js'
-import { existsInDir } from './existsInDir.js'
-import { makeEnv } from './makeEnv.js'
+import {
+  getNearestProgram,
+  getNearestScript,
+} from "./buildCommandNotFoundHint.js";
+import { existsInDir } from "./existsInDir.js";
+import { makeEnv } from "./makeEnv.js";
 import {
   PARALLEL_OPTION_HELP,
   REPORT_SUMMARY_OPTION_HELP,
   RESUME_FROM_OPTION_HELP,
   shorthands as runShorthands,
-} from './run.js'
-import { runDepsStatusCheck } from './runDepsStatusCheck.js'
+} from "./run.js";
+import { runDepsStatusCheck } from "./runDepsStatusCheck.js";
 
 export const shorthands: Record<string, string | string[]> = {
   parallel: runShorthands.parallel,
-  c: '--shell-mode',
-}
+  c: "--shell-mode",
+};
 
-export const commandNames = ['exec']
+export const commandNames = ["exec"];
 
-export function rcOptionsTypes (): Record<string, unknown> {
+export function rcOptionsTypes(): Record<string, unknown> {
   return {
-    ...pick([
-      'bail',
-      'sort',
-      'unsafe-perm',
-      'workspace-concurrency',
-      'reporter-hide-prefix',
-    ], types),
-    'shell-mode': Boolean,
-    'resume-from': String,
-    'report-summary': Boolean,
-  }
+    ...pick(
+      [
+        "bail",
+        "sort",
+        "unsafe-perm",
+        "workspace-concurrency",
+        "reporter-hide-prefix",
+      ],
+      types,
+    ),
+    "shell-mode": Boolean,
+    "resume-from": String,
+    "report-summary": Boolean,
+  };
 }
 
 export const cliOptionsTypes = (): Record<string, unknown> => ({
   ...rcOptionsTypes(),
   recursive: Boolean,
   reverse: Boolean,
-})
+});
 
-export function help (): string {
+export function help(): string {
   return renderHelp({
-    description: 'Run a shell command in the context of a project.',
+    description: "Run a shell command in the context of a project.",
     descriptionLists: [
       {
-        title: 'Options',
+        title: "Options",
 
         list: [
           {
-            description: 'Do not hide project name prefix from output of recursively running command.',
-            name: '--no-reporter-hide-prefix',
+            description:
+              "Do not hide project name prefix from output of recursively running command.",
+            name: "--no-reporter-hide-prefix",
           },
           PARALLEL_OPTION_HELP,
           {
-            description: 'Run the shell command in every package found in subdirectories \
+            description:
+              'Run the shell command in every package found in subdirectories \
 or every workspace package, when executed inside a workspace. \
 For options that may be used with `-r`, see "pnpm help recursive"',
-            name: '--recursive',
-            shortAlias: '-r',
+            name: "--recursive",
+            shortAlias: "-r",
           },
           {
-            description: 'If exist, runs file inside of a shell. \
+            description:
+              "If exist, runs file inside of a shell. \
 Uses /bin/sh on UNIX and \\cmd.exe on Windows. \
-The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
-            name: '--shell-mode',
-            shortAlias: '-c',
+The shell should understand the -c switch on UNIX or /d /s /c on Windows.",
+            name: "--shell-mode",
+            shortAlias: "-c",
           },
           RESUME_FROM_OPTION_HELP,
           REPORT_SUMMARY_OPTION_HELP,
@@ -92,106 +116,125 @@ The shell should understand the -c switch on UNIX or /d /s /c on Windows.',
       },
       FILTERING,
     ],
-    url: docsUrl('exec'),
-    usages: ['pnpm [-r] [-c] exec <command> [args...]'],
-  })
+    url: docsUrl("exec"),
+    usages: ["pnpm [-r] [-c] exec <command> [args...]"],
+  });
 }
 
-export function getResumedPackageChunks ({
+export function getResumedPackageChunks({
   resumeFrom,
   chunks,
   selectedProjectsGraph,
 }: {
-  resumeFrom: string
-  chunks: ProjectRootDir[][]
-  selectedProjectsGraph: ProjectsGraph
+  resumeFrom: string;
+  chunks: ProjectRootDir[][];
+  selectedProjectsGraph: ProjectsGraph;
 }): ProjectRootDir[][] {
-  const resumeFromPackagePrefix = (Object.keys(selectedProjectsGraph) as ProjectRootDir[])
-    .find((prefix) => selectedProjectsGraph[prefix]?.package.manifest.name === resumeFrom)
+  const resumeFromPackagePrefix = (
+    Object.keys(selectedProjectsGraph) as ProjectRootDir[]
+  ).find(
+    (prefix) =>
+      selectedProjectsGraph[prefix]?.package.manifest.name === resumeFrom,
+  );
 
   if (!resumeFromPackagePrefix) {
-    throw new PnpmError('RESUME_FROM_NOT_FOUND', `Cannot find package ${resumeFrom}. Could not determine where to resume from.`)
+    throw new PnpmError(
+      "RESUME_FROM_NOT_FOUND",
+      `Cannot find package ${resumeFrom}. Could not determine where to resume from.`,
+    );
   }
 
-  const chunkPosition = chunks.findIndex(chunk => chunk.includes(resumeFromPackagePrefix))
-  return chunks.slice(chunkPosition)
+  const chunkPosition = chunks.findIndex((chunk) =>
+    chunk.includes(resumeFromPackagePrefix),
+  );
+  return chunks.slice(chunkPosition);
 }
 
-export async function writeRecursiveSummary (opts: { dir: string, summary: RecursiveSummary }): Promise<void> {
-  await writeJsonFile(path.join(opts.dir, 'pnpm-exec-summary.json'), {
+export async function writeRecursiveSummary(opts: {
+  dir: string;
+  summary: RecursiveSummary;
+}): Promise<void> {
+  await writeJsonFile(path.join(opts.dir, "pnpm-exec-summary.json"), {
     executionStatus: opts.summary,
-  })
+  });
 }
 
-export function createEmptyRecursiveSummary (chunks: string[][]): RecursiveSummary {
-  const acc: RecursiveSummary = {}
+export function createEmptyRecursiveSummary(
+  chunks: string[][],
+): RecursiveSummary {
+  const acc: RecursiveSummary = {};
   for (const prefix of chunks.flat()) {
-    acc[prefix] = { status: 'queued' }
+    acc[prefix] = { status: "queued" };
   }
-  return acc
+  return acc;
 }
 
-export function getExecutionDuration (start: [number, number]): number {
-  const end = process.hrtime(start)
-  return (end[0] * 1e9 + end[1]) / 1e6
+export function getExecutionDuration(start: [number, number]): number {
+  const end = process.hrtime(start);
+  return (end[0] * 1e9 + end[1]) / 1e6;
 }
 
-export type ExecOpts = Required<Pick<Config, 'selectedProjectsGraph'>> & {
-  bail?: boolean
-  unsafePerm?: boolean
-  reverse?: boolean
-  sort?: boolean
-  workspaceConcurrency?: number
-  shellMode?: boolean
-  resumeFrom?: string
-  reportSummary?: boolean
-  implicitlyFellbackFromRun?: boolean
-} & Pick<Config,
-| 'bin'
-| 'cliOptions'
-| 'dir'
-| 'extraBinPaths'
-| 'extraEnv'
-| 'lockfileDir'
-| 'modulesDir'
-| 'nodeOptions'
-| 'pnpmHomeDir'
-| 'rawConfig'
-| 'recursive'
-| 'reporterHidePrefix'
-| 'userAgent'
-| 'verifyDepsBeforeRun'
-| 'workspaceDir'
-> & CheckDepsStatusOptions
+export type ExecOpts = Required<Pick<Config, "selectedProjectsGraph">> & {
+  bail?: boolean;
+  unsafePerm?: boolean;
+  reverse?: boolean;
+  sort?: boolean;
+  workspaceConcurrency?: number;
+  shellMode?: boolean;
+  resumeFrom?: string;
+  reportSummary?: boolean;
+  implicitlyFellbackFromRun?: boolean;
+} & Pick<
+    Config,
+    | "bin"
+    | "cliOptions"
+    | "dir"
+    | "extraBinPaths"
+    | "extraEnv"
+    | "lockfileDir"
+    | "modulesDir"
+    | "nodeOptions"
+    | "pnpmHomeDir"
+    | "rawConfig"
+    | "recursive"
+    | "reporterHidePrefix"
+    | "userAgent"
+    | "verifyDepsBeforeRun"
+    | "workspaceDir"
+  > &
+  CheckDepsStatusOptions;
 
-export async function handler (
+export async function handler(
   opts: ExecOpts,
-  params: string[]
+  params: string[],
 ): Promise<{ exitCode: number }> {
   // For backward compatibility
-  if (params[0] === '--') {
-    params.shift()
+  if (params[0] === "--") {
+    params.shift();
   }
   if (!params[0]) {
-    throw new PnpmError('EXEC_MISSING_COMMAND', '\'pnpm exec\' requires a command to run')
+    throw new PnpmError(
+      "EXEC_MISSING_COMMAND",
+      "'pnpm exec' requires a command to run",
+    );
   }
-  const limitRun = pLimit(getWorkspaceConcurrency(opts.workspaceConcurrency))
+  const limitRun = pLimit(getWorkspaceConcurrency(opts.workspaceConcurrency));
 
   if (opts.verifyDepsBeforeRun) {
-    await runDepsStatusCheck(opts)
+    await runDepsStatusCheck(opts);
   }
 
-  let chunks!: ProjectRootDir[][]
+  let chunks!: ProjectRootDir[][];
   if (opts.recursive) {
     chunks = opts.sort
       ? sortPackages(opts.selectedProjectsGraph)
-      : [(Object.keys(opts.selectedProjectsGraph) as ProjectRootDir[]).sort()]
+      : [(Object.keys(opts.selectedProjectsGraph) as ProjectRootDir[]).sort()];
     if (opts.reverse) {
-      chunks = chunks.reverse()
+      chunks = chunks.reverse();
     }
   } else {
-    chunks = [[(opts.cliOptions.dir ?? process.cwd()) as ProjectRootDir]]
-    const project = await tryReadProjectManifest(opts.dir)
+    chunks = [[(opts.cliOptions.dir ?? process.cwd()) as ProjectRootDir]];
+    const project = await tryReadProjectManifest(opts.dir);
     if (project.manifest != null) {
       opts.selectedProjectsGraph = {
         [opts.dir]: {
@@ -202,12 +245,15 @@ export async function handler (
             rootDirRealPath: opts.dir as ProjectRootDirRealPath,
           } as Project,
         },
-      }
+      };
     }
   }
 
   if (!opts.selectedProjectsGraph) {
-    throw new PnpmError('RECURSIVE_EXEC_NO_PACKAGE', 'No package found in this workspace')
+    throw new PnpmError(
+      "RECURSIVE_EXEC_NO_PACKAGE",
+      "No package found in this workspace",
+    );
   }
 
   if (opts.resumeFrom) {
@@ -215,199 +261,213 @@ export async function handler (
       resumeFrom: opts.resumeFrom,
       chunks,
       selectedProjectsGraph: opts.selectedProjectsGraph,
-    })
+    });
   }
 
-  const result = createEmptyRecursiveSummary(chunks)
-  const existsPnp = existsInDir.bind(null, '.pnp.cjs')
-  const workspacePnpPath = opts.workspaceDir && existsPnp(opts.workspaceDir)
+  const result = createEmptyRecursiveSummary(chunks);
+  const existsPnp = existsInDir.bind(null, ".pnp.cjs");
+  const workspacePnpPath = opts.workspaceDir && existsPnp(opts.workspaceDir);
 
-  let exitCode = 0
-  const prependPaths = [
-    './node_modules/.bin',
-    ...(opts.extraBinPaths ?? []),
-  ]
-  const reporterShowPrefix = opts.recursive && opts.reporterHidePrefix === false
+  let exitCode = 0;
+  const prependPaths = ["./node_modules/.bin", ...(opts.extraBinPaths ?? [])];
+  const reporterShowPrefix =
+    opts.recursive && opts.reporterHidePrefix === false;
   for (const chunk of chunks) {
     // eslint-disable-next-line no-await-in-loop
-    await Promise.all(chunk.map(async (prefix) =>
-      limitRun(async () => {
-        result[prefix].status = 'running'
-        const startTime = process.hrtime()
-        try {
-          const pnpPath = workspacePnpPath ?? existsPnp(prefix)
-          const extraEnv = {
-            ...opts.extraEnv,
-            ...(pnpPath ? makeNodeRequireOption(pnpPath) : {}),
-          }
-          const env = makeEnv({
-            extraEnv: {
-              ...extraEnv,
-              PNPM_PACKAGE_NAME: opts.selectedProjectsGraph[prefix]?.package.manifest.name,
-              ...(opts.nodeOptions ? { NODE_OPTIONS: opts.nodeOptions } : {}),
-            },
-            prependPaths,
-            userAgent: opts.userAgent,
-          })
-          const [cmd, ...args] = params
-          if (reporterShowPrefix) {
-            const manifest = await readProjectManifestOnly(prefix)
-            const child = execa(cmd, args, {
-              cwd: prefix,
-              env,
-              stdio: 'pipe',
-              shell: opts.shellMode ?? false,
-            })
-            const lifecycleOpts = {
-              wd: prefix,
-              depPath: manifest.name ?? path.relative(opts.dir, prefix),
-              stage: '(exec)',
-            } satisfies Partial<LifecycleMessage>
-            const logFn = (stdio: 'stdout' | 'stderr') => (data: unknown): void => {
-              for (const line of String(data).split('\n')) {
-                lifecycleLogger.debug({
-                  ...lifecycleOpts,
-                  stdio,
-                  line,
-                })
-              }
+    await Promise.all(
+      chunk.map(async (prefix) =>
+        limitRun(async () => {
+          result[prefix].status = "running";
+          const startTime = process.hrtime();
+          try {
+            const pnpPath = workspacePnpPath ?? existsPnp(prefix);
+            const extraEnv = {
+              ...opts.extraEnv,
+              ...(pnpPath ? makeNodeRequireOption(pnpPath) : {}),
+            };
+            const env = makeEnv({
+              extraEnv: {
+                ...extraEnv,
+                PNPM_PACKAGE_NAME:
+                  opts.selectedProjectsGraph[prefix]?.package.manifest.name,
+                ...(opts.nodeOptions ? { NODE_OPTIONS: opts.nodeOptions } : {}),
+              },
+              prependPaths,
+              userAgent: opts.userAgent,
+            });
+            const [cmd, ...args] = params;
+            if (reporterShowPrefix) {
+              const manifest = await readProjectManifestOnly(prefix);
+              const child = execa(cmd, args, {
+                cwd: prefix,
+                env,
+                stdio: "pipe",
+                shell: opts.shellMode ?? false,
+              });
+              const lifecycleOpts = {
+                wd: prefix,
+                depPath: manifest.name ?? path.relative(opts.dir, prefix),
+                stage: "(exec)",
+              } satisfies Partial<LifecycleMessage>;
+              const logFn =
+                (stdio: "stdout" | "stderr") =>
+                (data: unknown): void => {
+                  for (const line of String(data).split("\n")) {
+                    lifecycleLogger.debug({
+                      ...lifecycleOpts,
+                      stdio,
+                      line,
+                    });
+                  }
+                };
+              child.stdout!.on("data", logFn("stdout"));
+              child.stderr!.on("data", logFn("stderr"));
+              await new Promise<void>((resolve) => {
+                void child.once("close", (exitCode) => {
+                  lifecycleLogger.debug({
+                    ...lifecycleOpts,
+                    exitCode: exitCode ?? 1,
+                    optional: false,
+                  });
+                  resolve();
+                });
+              });
+              await child;
+            } else {
+              await execa(cmd, args, {
+                cwd: prefix,
+                env,
+                stdio: "inherit",
+                shell: opts.shellMode ?? false,
+              });
             }
-            child.stdout!.on('data', logFn('stdout'))
-            child.stderr!.on('data', logFn('stderr'))
-            await new Promise<void>((resolve) => {
-              void child.once('close', exitCode => {
-                lifecycleLogger.debug({
-                  ...lifecycleOpts,
-                  exitCode: exitCode ?? 1,
-                  optional: false,
-                })
-                resolve()
-              })
-            })
-            await child
-          } else {
-            await execa(cmd, args, {
-              cwd: prefix,
-              env,
-              stdio: 'inherit',
-              shell: opts.shellMode ?? false,
-            })
-          }
-          result[prefix].status = 'passed'
-          result[prefix].duration = getExecutionDuration(startTime)
-        } catch (err: any) { // eslint-disable-line
-          if (isErrorCommandNotFound(params[0], err, prependPaths)) {
-            err.message = `Command "${params[0]}" not found`
-            err.hint = await createExecCommandNotFoundHint(params[0], {
-              implicitlyFellbackFromRun: opts.implicitlyFellbackFromRun ?? false,
-              dir: opts.dir,
-              workspaceDir: opts.workspaceDir,
-              modulesDir: opts.modulesDir ?? 'node_modules',
-            })
-          } else if (!opts.recursive && typeof err.exitCode === 'number') {
-            exitCode = err.exitCode
-            return
-          }
-          logger.info(err)
+            result[prefix].status = "passed";
+            result[prefix].duration = getExecutionDuration(startTime);
+          } catch (err: any) {
+            // eslint-disable-line
+            if (isErrorCommandNotFound(params[0], err, prependPaths)) {
+              err.message = `Command "${params[0]}" not found`;
+              err.hint = await createExecCommandNotFoundHint(params[0], {
+                implicitlyFellbackFromRun:
+                  opts.implicitlyFellbackFromRun ?? false,
+                dir: opts.dir,
+                workspaceDir: opts.workspaceDir,
+                modulesDir: opts.modulesDir ?? "node_modules",
+              });
+            } else if (!opts.recursive && typeof err.exitCode === "number") {
+              exitCode = err.exitCode;
+              return;
+            }
+            logger.info(err);
 
-          result[prefix] = {
-            status: 'failure',
-            duration: getExecutionDuration(startTime),
-            error: err,
-            message: err.message,
-            prefix,
-          }
+            result[prefix] = {
+              status: "failure",
+              duration: getExecutionDuration(startTime),
+              error: err,
+              message: err.message,
+              prefix,
+            };
 
-          if (!opts.bail) {
-            return
-          }
+            if (!opts.bail) {
+              return;
+            }
 
-          if (!err['code']?.startsWith('ERR_PNPM_')) {
-            err['code'] = 'ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL'
-          }
-          err['prefix'] = prefix
-          if (opts.reportSummary) {
-            await writeRecursiveSummary({
-              dir: opts.lockfileDir ?? opts.dir,
-              summary: result,
-            })
-          }
+            if (!err["code"]?.startsWith("ERR_PNPM_")) {
+              err["code"] = "ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL";
+            }
+            err["prefix"] = prefix;
+            if (opts.reportSummary) {
+              await writeRecursiveSummary({
+                dir: opts.lockfileDir ?? opts.dir,
+                summary: result,
+              });
+            }
 
-          throw err
-        }
-      }
-      )))
+            throw err;
+          }
+        }),
+      ),
+    );
   }
 
   if (opts.reportSummary) {
     await writeRecursiveSummary({
       dir: opts.lockfileDir ?? opts.dir,
       summary: result,
-    })
+    });
   }
-  throwOnCommandFail('pnpm recursive exec', result)
-  return { exitCode }
+  throwOnCommandFail("pnpm recursive exec", result);
+  return { exitCode };
 }
 
-async function createExecCommandNotFoundHint (
+async function createExecCommandNotFoundHint(
   programName: string,
   opts: {
-    dir: string
-    implicitlyFellbackFromRun: boolean
-    workspaceDir?: string
-    modulesDir: string
-  }
+    dir: string;
+    implicitlyFellbackFromRun: boolean;
+    workspaceDir?: string;
+    modulesDir: string;
+  },
 ): Promise<string | undefined> {
   if (opts.implicitlyFellbackFromRun) {
-    let nearestScript: string | null | undefined
+    let nearestScript: string | null | undefined;
     try {
-      nearestScript = getNearestScript(programName, (await readProjectManifestOnly(opts.dir)).scripts)
+      nearestScript = getNearestScript(
+        programName,
+        (await readProjectManifestOnly(opts.dir)).scripts,
+      );
     } catch {}
     if (nearestScript) {
-      return `Did you mean "pnpm ${nearestScript}"?`
+      return `Did you mean "pnpm ${nearestScript}"?`;
     }
     const nearestProgram = getNearestProgram({
       programName,
       dir: opts.dir,
       workspaceDir: opts.workspaceDir,
       modulesDir: opts.modulesDir,
-    })
+    });
     if (nearestProgram) {
-      return `Did you mean "pnpm ${nearestProgram}"?`
+      return `Did you mean "pnpm ${nearestProgram}"?`;
     }
-    return undefined
+    return undefined;
   }
   const nearestProgram = getNearestProgram({
     programName,
     dir: opts.dir,
     workspaceDir: opts.workspaceDir,
     modulesDir: opts.modulesDir,
-  })
+  });
   if (nearestProgram) {
-    return `Did you mean "pnpm exec ${nearestProgram}"?`
+    return `Did you mean "pnpm exec ${nearestProgram}"?`;
   }
-  return undefined
+  return undefined;
 }
 
 interface CommandError extends Error {
-  originalMessage: string
-  shortMessage: string
+  originalMessage: string;
+  shortMessage: string;
 }
 
-function isErrorCommandNotFound (command: string, error: CommandError, prependPaths: string[]): boolean {
+function isErrorCommandNotFound(
+  command: string,
+  error: CommandError,
+  _prependPaths: string[],
+): boolean {
   // Mac/Linux
-  if (process.platform === 'linux' || process.platform === 'darwin') {
-    return error.originalMessage === `spawn ${command} ENOENT`
+  if (process.platform === "linux" || process.platform === "darwin") {
+    return error.originalMessage === `spawn ${command} ENOENT`;
   }
 
   // Windows
-  if (process.platform === 'win32') {
-    const { value: path } = prependDirsToPath(prependPaths)
-    return !which.sync(command, {
-      nothrow: true,
-      path,
-    })
+  if (process.platform === "win32") {
+    const commandNotFoundMessage =
+      /is not recognized as an internal or external command/i;
+    return (
+      error.originalMessage === `spawn ${command} ENOENT` ||
+      commandNotFoundMessage.test(error.originalMessage) ||
+      commandNotFoundMessage.test(error.shortMessage)
+    );
   }
 
-  return false
+  return false;
 }


### PR DESCRIPTION
- Updated Windows detection logic in [isErrorCommandNotFound] to use actual process error output patterns
- Removed the which-based check from this path.
- Kept macOS/Linux behavior unchanged.