### PR TITLE
fix(link-bins,headless): scope GVS read-only error suppression

### DIFF
--- a/.changeset/fix-gvs-readonly-error-handling.md
+++ b/.changeset/fix-gvs-readonly-error-handling.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"@pnpm/bins.linker": patch
+"pnpm": patch
+---
+
+Scope GVS read-only error suppression to Global Virtual Store code paths only. Non-GVS installs now correctly throw on permission errors instead of silently skipping bin linking and self-dep symlinking.

--- a/bins/linker/src/index.ts
+++ b/bins/linker/src/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, promises as fs } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
+import util from 'node:util'
 
 import { type Command, getBinsFromPackageManifest } from '@pnpm/bins.resolver'
 import { getBunBinLocationForCurrentOS, getDenoBinLocationForCurrentOS, getNodeBinLocationForCurrentOS } from '@pnpm/constants'
@@ -140,7 +141,16 @@ async function _linkBins (
   // deduplicate bin names to prevent race conditions (multiple writers for the same file)
   allCmds = deduplicateCommands(allCmds, binsDir)
 
-  await fs.mkdir(binsDir, { recursive: true })
+  try {
+    await fs.mkdir(binsDir, { recursive: true })
+  } catch (err: unknown) {
+    // When the GVS entry is a symlink to a read-only store (e.g. Nix),
+    // mkdir inside it fails with EACCES/EROFS/EPERM. Skip bin linking
+    // for this entry — the bins were either pre-linked by the store
+    // builder or are not critical for frozen-lockfile installs.
+    if (opts.allowReadonlyErrors && isReadonlyError(err)) return []
+    throw err
+  }
 
   const results = await Promise.allSettled(allCmds.map(async cmd => linkBin(cmd, binsDir, opts)))
 
@@ -152,6 +162,12 @@ async function _linkBins (
   }
 
   return allCmds.map(cmd => cmd.pkgName)
+}
+
+function isReadonlyError (err: unknown): boolean {
+  if (!util.types.isNativeError(err) || !('code' in err)) return false
+  const { code } = err as { code: string }
+  return code === 'EACCES' || code === 'EROFS' || code === 'EPERM'
 }
 
 function deduplicateCommands (commands: CommandInfo[], binsDir: string): CommandInfo[] {
@@ -285,6 +301,8 @@ function runtimeHasNodeDownloaded (runtime: EngineDependency | EngineDependency[
 export interface LinkBinOptions {
   extraNodePaths?: string[]
   preferSymlinkedExecutables?: boolean
+  /** When true, silently skip EACCES/EROFS/EPERM from mkdir when creating the bins directory (e.g. GVS read-only store). */
+  allowReadonlyErrors?: boolean
 }
 
 async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions): Promise<void> {

--- a/bins/linker/test/index.ts
+++ b/bins/linker/test/index.ts
@@ -697,3 +697,81 @@ describe('node binary linking', () => {
     expect(fs.existsSync(path.join(binTarget, `node${CMD_EXTENSION}`))).toBe(false)
   })
 })
+
+describe('allowReadonlyErrors', () => {
+  // Skip on Windows — chmod 0o444 does not prevent mkdir on NTFS
+  const testOnPosix = IS_WINDOWS ? test.skip : test
+
+  testOnPosix('returns empty when mkdir fails with EACCES and allowReadonlyErrors is true', async () => {
+    const simpleFixture = f.prepare('simple-fixture')
+    const readonlyDir = temporaryDirectory()
+    // Create a read-only parent so mkdir of the child fails with EACCES
+    fs.chmodSync(readonlyDir, 0o444)
+    const binsDir = path.join(readonlyDir, 'bin')
+
+    try {
+      const result = await linkBinsOfPackages(
+        [
+          {
+            location: path.join(simpleFixture, 'node_modules/simple'),
+            manifest: (await import(path.join(simpleFixture, 'node_modules/simple/package.json'))).default,
+          },
+        ],
+        binsDir,
+        { allowReadonlyErrors: true }
+      )
+      expect(result).toEqual([])
+    } finally {
+      fs.chmodSync(readonlyDir, 0o755)
+    }
+  })
+
+  testOnPosix('throws when mkdir fails with EACCES and allowReadonlyErrors is not set', async () => {
+    const simpleFixture = f.prepare('simple-fixture')
+    const readonlyDir = temporaryDirectory()
+    fs.chmodSync(readonlyDir, 0o444)
+    const binsDir = path.join(readonlyDir, 'bin')
+
+    try {
+      await expect(
+        linkBinsOfPackages(
+          [
+            {
+              location: path.join(simpleFixture, 'node_modules/simple'),
+              manifest: (await import(path.join(simpleFixture, 'node_modules/simple/package.json'))).default,
+            },
+          ],
+          binsDir
+        )
+      ).rejects.toMatchObject({ code: 'EACCES' })
+    } finally {
+      fs.chmodSync(readonlyDir, 0o755)
+    }
+  })
+
+  test('re-throws non-readonly errors even when allowReadonlyErrors is true', async () => {
+    // Point to a non-existent fixture location so getPackageBinsFromManifest
+    // produces a cmd, but binsDir path traverses a file (not a dir) → ENOTDIR
+    const tmpDir = temporaryDirectory()
+    const filePath = path.join(tmpDir, 'not-a-dir')
+    fs.writeFileSync(filePath, '')
+    const binsDir = path.join(filePath, 'bin')
+
+    await expect(
+      linkBinsOfPackages(
+        [
+          {
+            location: tmpDir,
+            manifest: {
+              name: 'fake',
+              version: '1.0.0',
+              bin: { fake: 'index.js' },
+            },
+          },
+        ],
+        binsDir,
+        { allowReadonlyErrors: true }
+      )
+    ).rejects.toMatchObject({ code: 'ENOTDIR' })
+  })
+})

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
 import { buildModules } from '@pnpm/building.during-install'
@@ -492,6 +493,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
 
     if (!skipPostImportLinking) {
       await linkAllBins(graph, {
+        enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
         extraNodePaths: opts.extraNodePaths,
         optional: opts.include.optionalDependencies,
         preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
@@ -955,7 +957,18 @@ async function linkAllPkgs (
         const pkg = opts.depGraph[selfDep]
         if (!pkg) return
         const targetModulesDir = path.join(depNode.modules, depNode.name, 'node_modules')
-        await limitLinking(async () => symlinkDependency(pkg.dir, targetModulesDir, depNode.name))
+        if (opts.enableGlobalVirtualStore) {
+          try {
+            await limitLinking(async () => symlinkDependency(pkg.dir, targetModulesDir, depNode.name))
+          } catch (err: unknown) {
+            // GVS entry may be a symlink to a read-only store; skip self-dep linking
+            if (!util.types.isNativeError(err) || !('code' in err)) throw err
+            const { code } = err as { code: string }
+            if (code !== 'EACCES' && code !== 'EROFS' && code !== 'EPERM') throw err
+          }
+        } else {
+          await limitLinking(async () => symlinkDependency(pkg.dir, targetModulesDir, depNode.name))
+        }
       }
     })
   )
@@ -964,6 +977,7 @@ async function linkAllPkgs (
 async function linkAllBins (
   depGraph: DependenciesGraph,
   opts: {
+    enableGlobalVirtualStore?: boolean
     extraNodePaths?: string[]
     optional: boolean
     preferSymlinkedExecutables?: boolean
@@ -982,6 +996,7 @@ async function linkAllBins (
 
         if (pkgSnapshots.includes(undefined as any)) { // eslint-disable-line
           await linkBins(depNode.modules, binPath, {
+            allowReadonlyErrors: opts.enableGlobalVirtualStore,
             extraNodePaths: opts.extraNodePaths,
             preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
             warn: opts.warn,
@@ -997,6 +1012,7 @@ async function linkAllBins (
           )
 
           await linkBinsOfPackages(pkgs, binPath, {
+            allowReadonlyErrors: opts.enableGlobalVirtualStore,
             extraNodePaths: opts.extraNodePaths,
             preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
           })
@@ -1006,6 +1022,7 @@ async function linkAllBins (
         if (depNode.hasBundledDependencies) {
           const bundledModules = path.join(depNode.dir, 'node_modules')
           await linkBins(bundledModules, binPath, {
+            allowReadonlyErrors: opts.enableGlobalVirtualStore,
             extraNodePaths: opts.extraNodePaths,
             preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
             warn: opts.warn,


### PR DESCRIPTION
## Context

Part of the ongoing work to make the Global Virtual Store (GVS) work with read-only content-addressable stores (e.g. Nix). When `enableGlobalVirtualStore` is active and the store is read-only, post-import linking operations (`symlinkDependency` for self-deps, `fs.mkdir` for bin directories) fail with `EACCES`/`EROFS`/`EPERM` because the target lives inside an immutable store path.

This PR suppresses those errors for GVS installs only, so non-GVS installs still get clear errors on genuine permission problems.

Follows #10965 (`virtualStoreOnly`), #10709 (GVS warm reattach), #10836 (CI GVS config).

## What changed

**`@pnpm/link-bins`**
- Add `allowReadonlyErrors?: boolean` to `LinkBinOptions`
- `_linkBins` only suppresses `mkdir` errors when the flag is set
- Extract `isReadonlyError()` helper using `util.types.isNativeError()` (per codebase convention, matching `read-projects-context` and `plugin-commands-installation`)

**`@pnpm/headless`**
- Thread `enableGlobalVirtualStore` through `linkAllBins` → all three `linkBins`/`linkBinsOfPackages` call sites as `allowReadonlyErrors`
- Guard the self-dep symlink catch with `if (opts.enableGlobalVirtualStore)`; non-GVS path has no try/catch overhead
- Use `util.types.isNativeError()` instead of duck-typing

**Tests** (3 new in `@pnpm/link-bins`)
- EACCES + `allowReadonlyErrors: true` → returns `[]` (suppressed)
- EACCES + no flag → throws (not suppressed)
- ENOTDIR + `allowReadonlyErrors: true` → throws (non-readonly errors always re-thrown)

## Verification

- `pnpm --filter @pnpm/link-bins test`: 36/36 pass
- `pnpm --filter @pnpm/headless compile`: clean (1 pre-existing lint warning)
- Pre-push hooks (spellcheck, meta-updater, eslint): all pass