### PR TITLE
docs: fix --force help text grammar

### DIFF
--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -237,7 +237,7 @@ by any dependencies, so it is an emulation of a flat node_modules',
           {
             description: 'Force reinstall dependencies: refetch packages modified in store, \
 recreate a lockfile and/or modules directory created by a non-compatible version of pnpm. \
-Install all optionalDependencies even they don\'t satisfy the current environment(cpu, os, arch)',
+Install all optionalDependencies even when they don\'t satisfy the current environment(cpu, os, arch)',
             name: '--force',
           },
           {


### PR DESCRIPTION
Summary

Fix the --force help text by changing "even they don't satisfy" to "even when they don't satisfy".

Related issue

N/A

Guideline alignment

Single-file, non-behavioral copy change from main.

Validation/testing

Not run locally; help-text-only change.