### PR TITLE
build: use `stripTypeScriptTypes` transform mode for source map support

### DIFF
--- a/__utils__/jest-config/jest.transform.js
+++ b/__utils__/jest-config/jest.transform.js
@@ -7,7 +7,18 @@ import { transformSync } from '@babel/core'
 
 export default {
   process(sourceText, sourcePath) {
-    const code = stripTypeScriptTypes(sourceText, { mode: 'strip' })
+    const code = stripTypeScriptTypes(sourceText, {
+      // The stripTypeScriptTypes function supports a lightweight 'strip' mode.
+      // Unfortunately 'strip' doesn't support source map generation. Use
+      // 'transform' instead to generate inline source maps.
+      //
+      // Source maps are important for enabling interactive debuggers to match
+      // type-stripped test files to their location on disk. For details, see:
+      // https://github.com/pnpm/pnpm/pull/11024
+      mode: 'transform',
+      sourceMap: true,
+      sourceUrl: sourcePath
+    })
 
     // Using the presence of the DisposableStack global to feature detect
     // whether the current Node.js runtime supports explicit resource


### PR DESCRIPTION
## Problem

After https://github.com/pnpm/pnpm/pull/10579, I noticed VS Code would sometimes open a new read-only tab for an already open file when binding a breakpoint in a Jest test. I found this a bit annoying since the read-only tabs accumulate over time and make it harder to keep track of where I am as I rerun tests.

In the example below, I added a breakpoint to `installing/deps-installer/test/brokenLockfileIntegrity.ts`. Instead of binding to that breakpoint, VS Code kept opening a new file (shown on right) with the blank space stripped types.

<img width="1937" height="1101" alt="Screenshot 2026-03-19 at 2 43 20 AM" src="https://github.com/user-attachments/assets/5ce18a92-483c-41f3-80f8-f3a8e70cda3e" />

## Explanation

It turns out this is because of [vscode-js-debug](https://github.com/microsoft/vscode-js-debug)'s default-enabled `enableContentValidation` config. When disabling this config, breakpoints bind in already open files.

<img width="1514" height="1101" alt="Screenshot 2026-03-19 at 2 44 08 AM" src="https://github.com/user-attachments/assets/d0b3a70c-3096-4c31-bfc7-347f6805d963" />

## Changes

I think `enableContentValidation` is a good setting. Instead of turning this off in VS Code, I'd like to go back to generating source maps for TypeScript files running in Jest. These source maps allow vscode-js-debug to realize that the original file on disk and the type-stripped file are the same, passing content validation.