### PR TITLE
fix: reuse sortLockfileKeys for env lockfile sorting

### DIFF
--- a/lockfile/fs/src/envLockfile.ts
+++ b/lockfile/fs/src/envLockfile.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
-import type { EnvLockfile, LockfileFile } from '@pnpm/lockfile.types'
+import type { EnvLockfile } from '@pnpm/lockfile.types'
 import yaml from 'js-yaml'
 import writeFileAtomic from 'write-file-atomic'
 
@@ -58,7 +58,7 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
 
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)
-  const sorted = sortLockfileKeys(lockfile as unknown as LockfileFile)
+  const sorted = sortLockfileKeys(lockfile)
   const envYaml = lockfileYamlDump(sorted)
 
   // Read existing main lockfile document to preserve it

--- a/lockfile/fs/src/sortLockfileKeys.ts
+++ b/lockfile/fs/src/sortLockfileKeys.ts
@@ -1,4 +1,4 @@
-import type { LockfileFile } from '@pnpm/lockfile.types'
+import type { EnvLockfile, LockfileFile } from '@pnpm/lockfile.types'
 import { sortDeepKeys, sortDirectKeys, sortKeysByPriority } from '@pnpm/object.key-sorting'
 
 const ORDERED_KEYS = {
@@ -44,7 +44,9 @@ const ROOT_KEYS: readonly RootKey[] = [
 ]
 const ROOT_KEYS_ORDER = Object.fromEntries(ROOT_KEYS.map((key, index) => [key, index]))
 
-export function sortLockfileKeys (lockfile: LockfileFile): LockfileFile {
+export function sortLockfileKeys (lockfile: LockfileFile): LockfileFile
+export function sortLockfileKeys (lockfile: EnvLockfile): EnvLockfile
+export function sortLockfileKeys (lockfile: LockfileFile | EnvLockfile): LockfileFile | EnvLockfile {
   if (lockfile.importers != null) {
     lockfile.importers = sortDirectKeys(lockfile.importers)
     for (const [importerId, importer] of Object.entries(lockfile.importers)) {
@@ -72,15 +74,17 @@ export function sortLockfileKeys (lockfile: LockfileFile): LockfileFile {
       }, pkg)
     }
   }
-  if (lockfile.catalogs != null) {
+  if ('catalogs' in lockfile && lockfile.catalogs != null) {
     lockfile.catalogs = sortDirectKeys(lockfile.catalogs)
     for (const [catalogName, catalog] of Object.entries(lockfile.catalogs)) {
       lockfile.catalogs[catalogName] = sortDeepKeys(catalog)
     }
   }
-  for (const key of ['time', 'patchedDependencies'] as const) {
-    if (!lockfile[key]) continue
-    lockfile[key] = sortDirectKeys<any>(lockfile[key]) // eslint-disable-line @typescript-eslint/no-explicit-any
+  if ('time' in lockfile && lockfile.time != null) {
+    lockfile.time = sortDirectKeys(lockfile.time)
+  }
+  if ('patchedDependencies' in lockfile && lockfile.patchedDependencies != null) {
+    lockfile.patchedDependencies = sortDirectKeys(lockfile.patchedDependencies)
   }
   return sortKeysByPriority({ priority: ROOT_KEYS_ORDER }, lockfile)
 }

--- a/lockfile/types/src/index.ts
+++ b/lockfile/types/src/index.ts
@@ -165,13 +165,15 @@ export type PackageBin = string | { [name: string]: string }
  */
 export type ResolvedDependencies = Record<string, string>
 
+export interface EnvImporterSnapshot {
+  configDependencies: Record<string, SpecifierAndResolution>
+  packageManagerDependencies?: Record<string, SpecifierAndResolution>
+}
+
 export interface EnvLockfile {
   lockfileVersion: string
-  importers: {
-    '.': {
-      configDependencies: Record<string, SpecifierAndResolution>
-      packageManagerDependencies?: Record<string, SpecifierAndResolution>
-    }
+  importers: Record<string, EnvImporterSnapshot> & {
+    '.': EnvImporterSnapshot
   }
   packages: Record<string, LockfilePackageInfo>
   snapshots: Record<string, LockfilePackageSnapshot>


### PR DESCRIPTION
## Summary
- Replace the custom `sortEnvLockfile` function with the shared `sortLockfileKeys`, ensuring env lockfile fields (including package/snapshot entry keys like `resolution`, `name`, `version`, `dependencies`, `optionalDependencies`, etc.) are sorted consistently with the main lockfile document.

## Test plan
- [x] Existing `sortLockfileKeys` tests pass
- [x] Existing `write` tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)