### PR TITLE
chore: remove npm_config_verify_deps_before_run from extraEnv

### DIFF
--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -508,7 +508,6 @@ export async function getConfig (opts: {
   }
 
   pnpmConfig.extraEnv = {
-    npm_config_verify_deps_before_run: 'false', // This should be removed in pnpm v11
     pnpm_config_verify_deps_before_run: 'false',
   }
   if (pnpmConfig.preferSymlinkedExecutables && !isWindows()) {


### PR DESCRIPTION
## Summary
- Removes the `npm_config_verify_deps_before_run` env variable from `extraEnv`, which was marked for removal in v11
- Only the `pnpm_config_verify_deps_before_run` prefixed version is kept

## Test plan
- [x] Linting passes (verified by pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)