### PR TITLE
feat(update): add --peer flag to update peerDependencies

### DIFF
--- a/.changeset/update-peer-dependencies.md
+++ b/.changeset/update-peer-dependencies.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/pkg-manifest.utils": minor
+"@pnpm/installing.commands": minor
+"@pnpm/types": patch
+"pnpm": minor
+---
+
+Added `--peer` flag to `pnpm update` command to allow updating packages in `peerDependencies` [#8081](https://github.com/pnpm/pnpm/issues/8081).
+
+Previously, `pnpm up` only updated packages in `dependencies`, `devDependencies`, and `optionalDependencies`. Packages listed in `peerDependencies` were silently skipped, requiring manual version range updates.
+
+Now you can use `pnpm up --peer` or `pnpm up --latest --peer` to also update peer dependency version ranges in `package.json`.

--- a/core/types/src/options.ts
+++ b/core/types/src/options.ts
@@ -11,6 +11,8 @@ export type LogBase = {
 
 export type IncludedDependencies = {
   [dependenciesField in DependenciesField]: boolean
+} & {
+  peerDependencies?: boolean
 }
 
 export type ReadPackageHook = <Pkg extends BaseManifest> (pkg: Pkg, dir?: string) => Pkg | Promise<Pkg>

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -191,6 +191,7 @@ when running add/update with the --workspace option')
     dependencies: true,
     devDependencies: true,
     optionalDependencies: true,
+    peerDependencies: false,
   }
   const forceHoistPattern = typeof opts.rawLocalConfig['hoist-pattern'] !== 'undefined' ||
     typeof opts.rawLocalConfig['hoist'] !== 'undefined'

--- a/installing/commands/src/update/index.ts
+++ b/installing/commands/src/update/index.ts
@@ -79,6 +79,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
     ...rcOptionsTypes(),
     interactive: Boolean,
     latest: Boolean,
+    peer: Boolean,
     recursive: Boolean,
     workspace: Boolean,
   }
@@ -138,6 +139,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           {
             description: 'Don\'t update packages in "optionalDependencies"',
             name: '--no-optional',
+          },
+          {
+            description: 'Also update packages in "peerDependencies"',
+            name: '--peer',
           },
           {
             description: 'Tries to link all packages from the workspace. \
@@ -326,10 +331,12 @@ function makeIncludeDependenciesFromCLI (opts: {
   production?: boolean
   dev?: boolean
   optional?: boolean
+  peer?: boolean
 }): IncludedDependencies {
   return {
     dependencies: opts.production === true || (opts.dev !== true && opts.optional !== true),
     devDependencies: opts.dev === true || (opts.production !== true && opts.optional !== true),
     optionalDependencies: opts.optional === true || (opts.production !== true && opts.dev !== true),
+    peerDependencies: opts.peer === true,
   }
 }

--- a/pkg-manifest/utils/src/filterDependenciesByType.ts
+++ b/pkg-manifest/utils/src/filterDependenciesByType.ts
@@ -8,5 +8,6 @@ export function filterDependenciesByType (
     ...(include.dependencies ? manifest.dependencies : {}),
     ...(include.devDependencies ? manifest.devDependencies : {}),
     ...(include.optionalDependencies ? manifest.optionalDependencies : {}),
+    ...(include.peerDependencies ? manifest.peerDependencies : {}),
   }
 }

--- a/pkg-manifest/utils/src/index.ts
+++ b/pkg-manifest/utils/src/index.ts
@@ -21,6 +21,7 @@ export function filterDependenciesByType (
     ...(include.devDependencies ? manifest.devDependencies : {}),
     ...(include.dependencies ? manifest.dependencies : {}),
     ...(include.optionalDependencies ? manifest.optionalDependencies : {}),
+    ...(include.peerDependencies ? manifest.peerDependencies : {}),
   }
 }
 

--- a/pkg-manifest/utils/src/updateProjectManifestObject.ts
+++ b/pkg-manifest/utils/src/updateProjectManifestObject.ts
@@ -71,7 +71,14 @@ export async function updateProjectManifestObject (
       }
     } else if (packageSpec.bareSpecifier) {
       const usedDepType = guessDependencyType(packageSpec.alias, packageManifest) ?? 'dependencies'
-      if (usedDepType !== 'peerDependencies') {
+      if (usedDepType === 'peerDependencies') {
+        packageManifest.peerDependencies = packageManifest.peerDependencies ?? {}
+        packageManifest.peerDependencies[packageSpec.alias] = getPeerSpecifier(
+          packageSpec.bareSpecifier,
+          packageSpec.resolvedVersion,
+          packageSpec.pinnedVersion
+        )
+      } else {
         packageManifest[usedDepType] = packageManifest[usedDepType] ?? {}
         packageManifest[usedDepType]![packageSpec.alias] = packageSpec.bareSpecifier
       }

--- a/pkg-manifest/utils/test/updateProjectManifestObject.test.ts
+++ b/pkg-manifest/utils/test/updateProjectManifestObject.test.ts
@@ -1,4 +1,4 @@
-import { guessDependencyType, updateProjectManifestObject } from '@pnpm/pkg-manifest.utils'
+import { filterDependenciesByType, guessDependencyType, updateProjectManifestObject } from '@pnpm/pkg-manifest.utils'
 
 test('guessDependencyType()', () => {
   expect(
@@ -136,6 +136,54 @@ test('peer dependencies keep prerelease resolved version without prefix', async 
   expect(manifest.peerDependencies).toStrictEqual({
     foo: '2.1.0-rc.1',
   })
+})
+
+test('update existing peerDependencies version range', async () => {
+  const manifest = await updateProjectManifestObject('/project', {
+    peerDependencies: {
+      foo: '^1.0.0',
+    },
+  }, [
+    {
+      alias: 'foo',
+      bareSpecifier: '^2.0.0',
+      resolvedVersion: '2.0.0',
+    },
+  ])
+
+  expect(manifest.peerDependencies).toStrictEqual({
+    foo: '^2.0.0',
+  })
+  // Should NOT be added to dependencies
+  expect(manifest.dependencies).toBeUndefined()
+})
+
+test('filterDependenciesByType includes peerDependencies when enabled', () => {
+  const manifest = {
+    dependencies: { a: '1.0.0' },
+    devDependencies: { b: '2.0.0' },
+    peerDependencies: { c: '^3.0.0' },
+  }
+  const result = filterDependenciesByType(manifest, {
+    dependencies: true,
+    devDependencies: false,
+    optionalDependencies: false,
+    peerDependencies: true,
+  })
+  expect(result).toStrictEqual({ a: '1.0.0', c: '^3.0.0' })
+})
+
+test('filterDependenciesByType excludes peerDependencies by default', () => {
+  const manifest = {
+    dependencies: { a: '1.0.0' },
+    peerDependencies: { c: '^3.0.0' },
+  }
+  const result = filterDependenciesByType(manifest, {
+    dependencies: true,
+    devDependencies: true,
+    optionalDependencies: true,
+  })
+  expect(result).toStrictEqual({ a: '1.0.0' })
 })
 
 test('peer dependencies respect pinned version "patch" and "none"', async () => {


### PR DESCRIPTION
## Summary

Adds a `--peer` flag to the `pnpm update` command, allowing users to update packages listed in `peerDependencies`.

- `pnpm up --peer` updates peer dependencies within their existing ranges
- `pnpm up --latest --peer` updates peer dependencies to their latest versions, ignoring ranges
- `pnpm up --peer react` updates only specific peer dependencies

Previously, `pnpm up` silently skipped all packages in `peerDependencies`, requiring manual version range edits or workarounds like deleting `node_modules` and `pnpm-lock.yaml`.

Closes #8081

## Changes

- **`core/types/src/options.ts`**: Extended `IncludedDependencies` type with optional `peerDependencies` field
- **`installing/commands/src/update/index.ts`**: Added `--peer` CLI option with help text
- **`pkg-manifest/utils/src/filterDependenciesByType.ts`** + **`index.ts`**: Include `peerDependencies` in dependency filtering when enabled
- **`pkg-manifest/utils/src/updateProjectManifestObject.ts`**: Fixed to update existing `peerDependencies` in-place using proper peer range format (via `getPeerSpecifier`) instead of silently skipping them
- **`installing/commands/src/installDeps.ts`**: Added `peerDependencies: false` default to `includeDirect`

## Design Decisions

- `--peer` is **opt-in** (not included by default) to preserve backward compatibility — existing `pnpm up` behavior is unchanged
- When updating peers, `getPeerSpecifier()` is used to produce proper peer ranges (e.g., `^2.0.0` instead of exact versions)
- Interactive mode (`pnpm up -i --peer`) is not yet supported since the lockfile doesn't store peer dependencies in the importers section — this can be added in a follow-up

## Test plan

- [x] Unit tests for `filterDependenciesByType` with `peerDependencies` enabled/disabled
- [x] Unit test for `updateProjectManifestObject` updating existing peer dependency ranges
- [x] All existing tests pass
- [x] Lint and spellcheck pass
- [ ] Manual testing with a project that has peerDependencies

