### PR TITLE
docs(contributing): fix commit message line-length wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ format that includes a **type**, a **scope** and a **subject**:
 
 The **header** is mandatory and the **scope** of the header is optional.
 
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+Any line of the commit message cannot be longer than 100 characters! This allows the message to be easier
 to read on GitHub as well as in various git tools.
 
 #### Revert


### PR DESCRIPTION
## Summary
- clarify the commit message line-length sentence in `CONTRIBUTING.md`
- keep the change limited to one documentation file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal docs-only change following the repo contribution guidance: https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md

## Validation/testing
- Not run; docs-only change
