### PR TITLE
test: wait for Verdaccio to come online before running tests to fix persistent flakes

### DIFF
--- a/__utils__/jest-config/with-registry/globalSetup.js
+++ b/__utils__/jest-config/with-registry/globalSetup.js
@@ -1,3 +1,4 @@
+import { scheduler } from 'node:timers/promises'
 import getPort from 'get-port'
 import { promisify } from 'util'
 import treeKill from 'tree-kill'
@@ -30,5 +31,48 @@ export default async () => {
   global.killServer = () => {
     killed = true
     return kill(server.pid)
+  }
+
+  // Verdaccio can take a bit of time to come online on Windows and during its
+  // first startup. Some tests will fail immediately if they begin running
+  // before Verdaccio starts. Wait for Verdaccio to become online before running
+  // any tests.
+  await waitForServerOnline()
+}
+
+const UNUSUAL_VERDACCIO_STARTUP_THRESHOLD = 15 // seconds
+
+async function waitForServerOnline () {
+  const start = performance.now()
+
+  for (const delay of exponentialBackoff()) {
+    try {
+      await fetch(`http://localhost:${process.env.PNPM_REGISTRY_MOCK_PORT}`, { method: 'HEAD' })
+
+      const totalWait = (performance.now() - start) / 1000
+      if (totalWait > UNUSUAL_VERDACCIO_STARTUP_THRESHOLD) {
+        console.warn(`Verdaccio required an unusually long amount of time to start: ${totalWait} seconds`)
+      }
+
+      return
+    } catch (err) {
+      // If the Verdaccio process hasn't begun listening yet, attempts to
+      // connect to the unbound port should throw ECONNREFUSED. If a different
+      // error is observed, throw an error.
+      if (err?.cause?.code !== 'ECONNREFUSED') {
+        throw new Error('Failed to bring Verdaccio online:', { cause: err })
+      }
+
+      await scheduler.wait(delay)
+    }
+  }
+
+  const totalWait = (performance.now() - start) / 1000
+  throw new Error(`Verdaccio did not come online after waiting ${totalWait} seconds`)
+}
+
+function *exponentialBackoff (attempts = 15, base = 1.5, initialWait = 100) {
+  for (let i = 0; i < attempts; i++) {
+    yield initialWait * Math.pow(base, i)
   }
 }


### PR DESCRIPTION
## Problem

I've been running into a persistent issue on one of my PRs where only Windows CI job fails . After debugging, I'm confident the problem is:

1. Verdaccio takes longer to start up on Windows (compared to Ubuntu).
3. My PR only touched a few packages, and one package that's particularly sensitive to Verdaccio being online was scheduled to run first.

Here is a repro of the failure above. I opened a PR that modifies the CI config to always run against Windows and start a test in the `deps/compliance/commands` package. No changes to pnpm source code itself:

- https://github.com/pnpm/pnpm/pull/11045

I believe this isn't happening on other CI jobs or PRs because Verdaccio starts up faster after its initial start. Some tests are okay with Verdaccio not being immediately up because they're configured with retries.

## Changes

I think we should add an exponential backoff to the startup of Verdaccio. While this makes tests start a bit slower, it removes a persistent form of CI failure.

## Performance

I created a commit on top of the repro above with this PR and logging. It seems Verdaccio takes about [**26 seconds** to start up](https://github.com/pnpm/pnpm/actions/runs/23368873138/job/67988683784) for the first time on Windows.

```
2026-03-21T01:23:38.5337952Z Starting up Verdaccio and waiting
...
2026-03-21T01:24:04.4221594Z Verdaccio required an unusually long amount of time to start: 25.888396999999998 seconds
2026-03-21T01:24:12.9542602Z PASS test/audit/fixWithUpdate.ts (8.443 s)
```

Testing locally, I see it only takes ~300ms locally on macOS on a warm start.

## Local

The issue does happen to me locally though. If I rerun tests repeatedly, every once in a while the test fails when Verdaccio hasn't started up fast enough.

<img width="1386" height="970" alt="Screenshot 2026-03-20 at 2 52 52 AM" src="https://github.com/user-attachments/assets/4dfbc86c-d0d5-475b-be2b-9d76d0a0b4f0" />

The issue in the screenshot above no longer appear after this PR.