### PR TITLE
fix: suppress warning for unbuilt workspace package bins 

### DIFF
--- a/.changeset/fix-workspace-bin-warn-unbuilt.md
+++ b/.changeset/fix-workspace-bin-warn-unbuilt.md
@@ -1,0 +1,16 @@
+---
+"@pnpm/bins.linker": patch
+"pnpm": patch
+---
+
+fix: suppress false warning when workspace package bin file is not built yet
+
+In a monorepo, a workspace package may declare a `bin` entry (e.g. `dist/cli.js`)
+that is produced by a build step. On a clean `pnpm install` the build has not run
+yet, so the file does not exist. pnpm was emitting a `WARN  Failed to create bin`
+message in this situation even though it is perfectly normal [#10524](https://github.com/pnpm/pnpm/issues/10524).
+
+A new `warnOnMissingBin` option has been added to `LinkBinOptions`. It defaults to
+`true` (existing behaviour preserved everywhere) but is set to `false` at the
+install call-site that links direct dependencies of workspace projects, since only
+that path includes workspace-linked packages whose build artifacts may not yet exist.

--- a/.changeset/fix-workspace-bin-warn-unbuilt.md
+++ b/.changeset/fix-workspace-bin-warn-unbuilt.md
@@ -10,7 +10,11 @@ that is produced by a build step. On a clean `pnpm install` the build has not ru
 yet, so the file does not exist. pnpm was emitting a `WARN  Failed to create bin`
 message in this situation even though it is perfectly normal [#10524](https://github.com/pnpm/pnpm/issues/10524).
 
-A new `warnOnMissingBin` option has been added to `LinkBinOptions`. It defaults to
-`true` (existing behaviour preserved everywhere) but is set to `false` at the
-install call-site that links direct dependencies of workspace projects, since only
-that path includes workspace-linked packages whose build artifacts may not yet exist.
+A `warnOnMissingBin` option has been added to `LinkBinOptions` (global) and to the
+per-package entries accepted by `linkBinsOfPackages` (per-package). The global flag
+defaults to `true` so existing behaviour is preserved everywhere. At the install
+call-site that links direct dependencies of workspace projects, local `link:`
+protocol dependencies (which include workspace packages) get `warnOnMissingBin: false`
+per-package so the warning is suppressed only for them. All packages are processed in
+a single `linkBinsOfPackages` call so cross-package bin conflict resolution still
+works correctly.

--- a/bins/linker/src/index.ts
+++ b/bins/linker/src/index.ts
@@ -101,6 +101,7 @@ export async function linkBinsOfPackages (
   pkgs: Array<{
     manifest: DependencyManifest
     location: string
+    warnOnMissingBin?: boolean
   }>,
   binsTarget: string,
   opts: LinkBinOptions & { excludeBins?: Set<string> } = {}
@@ -111,7 +112,13 @@ export async function linkBinsOfPackages (
   let allCmds = unnest(
     (await Promise.all(
       pkgs
-        .map(async (pkg) => getPackageBinsFromManifest(pkg.manifest, pkg.location))
+        .map(async (pkg) => {
+          const cmds = await getPackageBinsFromManifest(pkg.manifest, pkg.location)
+          if (pkg.warnOnMissingBin !== undefined) {
+            return cmds.map((cmd) => ({ ...cmd, warnOnMissingBin: pkg.warnOnMissingBin }))
+          }
+          return cmds
+        })
     ))
       .filter((cmds: Command[]) => cmds.length)
   )
@@ -129,6 +136,7 @@ interface CommandInfo extends Command {
   pkgVersion: string
   makePowerShellShim: boolean
   nodeExecPath?: string
+  warnOnMissingBin?: boolean
 }
 
 async function _linkBins (
@@ -334,7 +342,7 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
       if (err.code !== 'ENOENT' && err.code !== 'EISDIR') {
         throw err
       }
-      if (opts?.warnOnMissingBin !== false) {
+      if (cmd.warnOnMissingBin !== false && opts?.warnOnMissingBin !== false) {
         globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
       }
     }
@@ -363,7 +371,7 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
     })
   } catch (err: any) { // eslint-disable-line
     if (err.code === 'ENOENT' || err.code === 'EISDIR') {
-      if (opts?.warnOnMissingBin !== false) {
+      if (cmd.warnOnMissingBin !== false && opts?.warnOnMissingBin !== false) {
         globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
       }
       return

--- a/bins/linker/src/index.ts
+++ b/bins/linker/src/index.ts
@@ -105,6 +105,7 @@ export async function linkBinsOfPackages (
   binsTarget: string,
   opts: LinkBinOptions & { excludeBins?: Set<string> } = {}
 ): Promise<string[]> {
+  opts = { warnOnMissingBin: true, ...opts }
   if (pkgs.length === 0) return []
 
   let allCmds = unnest(
@@ -285,6 +286,13 @@ function runtimeHasNodeDownloaded (runtime: EngineDependency | EngineDependency[
 export interface LinkBinOptions {
   extraNodePaths?: string[]
   preferSymlinkedExecutables?: boolean
+  /**
+   * When false, suppresses the globalWarn emitted when a bin target file does
+   * not exist yet. Use this for workspace packages whose bin files are produced
+   * by a build step that has not run yet (e.g. TypeScript output in dist/).
+   * Defaults to true to preserve existing behaviour.
+   */
+  warnOnMissingBin?: boolean
 }
 
 async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions): Promise<void> {
@@ -326,7 +334,9 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
       if (err.code !== 'ENOENT' && err.code !== 'EISDIR') {
         throw err
       }
-      globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
+      if (opts?.warnOnMissingBin !== false) {
+        globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
+      }
     }
     return
   }
@@ -353,7 +363,9 @@ async function linkBin (cmd: CommandInfo, binsDir: string, opts?: LinkBinOptions
     })
   } catch (err: any) { // eslint-disable-line
     if (err.code === 'ENOENT' || err.code === 'EISDIR') {
-      globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
+      if (opts?.warnOnMissingBin !== false) {
+        globalWarn(`Failed to create bin at ${externalBinPath}. ${err.message as string}`)
+      }
       return
     }
     // On Windows, EPERM during bin creation can happen when another process

--- a/bins/linker/test/index.ts
+++ b/bins/linker/test/index.ts
@@ -569,6 +569,38 @@ test("linkBinsOfPackages() does not emit global warning when bin points to path 
   expect(globalWarn).not.toHaveBeenCalled()
 })
 
+test('linkBinsOfPackages() per-package warnOnMissingBin: false suppresses only that package in a mixed call', async () => {
+  const binTarget = temporaryDirectory()
+
+  // Both packages have missing bin targets, but only the second one has the
+  // per-package flag set. The warning should fire once (for the first package)
+  // and not fire for the second, proving per-package scoping in a single call.
+  await linkBinsOfPackages(
+    [
+      {
+        location: path.join(temporaryDirectory(), 'regular-pkg'),
+        manifest: {
+          name: 'regular-pkg',
+          version: '1.0.0',
+          bin: 'dist/cli.js', // missing — should warn
+        },
+      },
+      {
+        location: path.join(temporaryDirectory(), 'link-pkg'),
+        manifest: {
+          name: 'link-pkg',
+          version: '1.0.0',
+          bin: 'dist/cli.js', // missing — should NOT warn
+        },
+        warnOnMissingBin: false,
+      },
+    ],
+    binTarget
+  )
+
+  expect(globalWarn).toHaveBeenCalledTimes(1)
+})
+
 testOnWindows('linkBins() should remove an existing .exe file from the target directory', async () => {
   const binTarget = temporaryDirectory()
   fs.writeFileSync(path.join(binTarget, 'simple.exe'), '', 'utf8')

--- a/bins/linker/test/index.ts
+++ b/bins/linker/test/index.ts
@@ -527,6 +527,48 @@ test("linkBins() emits global warning when bin points to path that doesn't exist
   ).toHaveBeenCalled()
 })
 
+test("linkBinsOfPackages() emits global warning when bin points to path that doesn't exist (default behavior)", async () => {
+  const binTarget = temporaryDirectory()
+  const binNotExistFixture = f.prepare('bin-not-exist')
+
+  await linkBinsOfPackages(
+    [
+      {
+        location: path.join(binNotExistFixture, 'node_modules/foo'),
+        manifest: {
+          name: 'meow',
+          version: '1.0.0',
+          bin: 'dist/not-exist.js',
+        },
+      },
+    ],
+    binTarget
+  )
+
+  expect(globalWarn).toHaveBeenCalled()
+})
+
+test("linkBinsOfPackages() does not emit global warning when bin points to path that doesn't exist and warnOnMissingBin is false", async () => {
+  const binTarget = temporaryDirectory()
+
+  await linkBinsOfPackages(
+    [
+      {
+        location: path.join(temporaryDirectory(), 'my-workspace-pkg'),
+        manifest: {
+          name: 'my-cli',
+          version: '1.0.0',
+          bin: 'dist/cli.js',
+        },
+      },
+    ],
+    binTarget,
+    { warnOnMissingBin: false }
+  )
+
+  expect(globalWarn).not.toHaveBeenCalled()
+})
+
 testOnWindows('linkBins() should remove an existing .exe file from the target directory', async () => {
   const binTarget = temporaryDirectory()
   fs.writeFileSync(path.join(binTarget, 'simple.exe'), '', 'utf8')

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1477,48 +1477,42 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           Array.from(dependenciesByProjectId[project.id].values()).filter((depPath) => !ctx.skipped.has(depPath)),
           dependenciesGraph
         )
-        // Workspace packages linked via the `link:` protocol. Their bin targets
-        // may point to build artifacts (e.g. dist/cli.js) that don't exist yet
-        // on a clean install, so we suppress the missing-bin warning for them.
-        const workspaceLinkedDeps = linkedDependenciesByProjectId[project.id].map(({ pkgId }) => ({
+        // Local link: protocol dependencies (including workspace packages). Their
+        // bin targets may point to build artifacts (e.g. dist/cli.js) that don't
+        // exist yet on a clean install, so we suppress the missing-bin warning for
+        // them via a per-package flag so conflict resolution still works across
+        // both groups in a single linkBinsOfPackages call.
+        const linkedDeps = linkedDependenciesByProjectId[project.id].map(({ pkgId }) => ({
           dir: path.join(project.rootDir, pkgId.substring(5)),
         }))
 
-        const binLinkOpts = {
-          extraNodePaths: ctx.extraNodePaths,
-          preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
-        }
-
-        // Link regular packages with the default warning behavior preserved.
-        const regularLinked = await linkBinsOfPackages(
-          (
+        const directPkgs = [
+          ...(
             await Promise.all(
               regularDeps.map(async (dep) => {
                 const manifest = (await dep.fetching?.())?.bundledManifest ?? await safeReadProjectManifestOnly(dep.dir)
                 return { location: dep.dir, manifest }
               })
             )
-          ).filter(({ manifest }) => manifest != null) as Array<{ location: string, manifest: DependencyManifest }>,
-          project.binsDir,
-          binLinkOpts
-        )
-
-        // Link workspace-linked packages without emitting a warning when the
-        // bin target file is missing — it may simply not have been built yet.
-        const workspaceLinked = await linkBinsOfPackages(
-          (
+          ).filter(({ manifest }) => manifest != null),
+          ...(
             await Promise.all(
-              workspaceLinkedDeps.map(async (dep) => {
+              linkedDeps.map(async (dep) => {
                 const manifest = await safeReadProjectManifestOnly(dep.dir)
-                return { location: dep.dir, manifest }
+                return { location: dep.dir, manifest, warnOnMissingBin: false }
               })
             )
-          ).filter(({ manifest }) => manifest != null) as Array<{ location: string, manifest: DependencyManifest }>,
-          project.binsDir,
-          { ...binLinkOpts, warnOnMissingBin: false }
-        )
+          ).filter(({ manifest }) => manifest != null),
+        ] as Array<{ location: string, manifest: DependencyManifest, warnOnMissingBin?: boolean }>
 
-        linkedPackages = [...regularLinked, ...workspaceLinked]
+        linkedPackages = await linkBinsOfPackages(
+          directPkgs,
+          project.binsDir,
+          {
+            extraNodePaths: ctx.extraNodePaths,
+            preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+          }
+        )
       }
       const projectToInstall = projects[index]
       if (opts.global && projectToInstall.mutation.includes('install')) {

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1472,35 +1472,53 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           warn: binWarn.bind(null, project.rootDir),
         })
       } else {
-        const directPkgs = [
-          ...props<DepPath, DependenciesGraphNode>(
-            Array.from(dependenciesByProjectId[project.id].values()).filter((depPath) => !ctx.skipped.has(depPath)),
-            dependenciesGraph
-          ),
-          ...linkedDependenciesByProjectId[project.id].map(({ pkgId }) => ({
-            dir: path.join(project.rootDir, pkgId.substring(5)),
-            fetching: undefined,
-          })),
-        ]
-        linkedPackages = await linkBinsOfPackages(
+        // Regular npm dependencies resolved from the virtual store.
+        const regularDeps = props<DepPath, DependenciesGraphNode>(
+          Array.from(dependenciesByProjectId[project.id].values()).filter((depPath) => !ctx.skipped.has(depPath)),
+          dependenciesGraph
+        )
+        // Workspace packages linked via the `link:` protocol. Their bin targets
+        // may point to build artifacts (e.g. dist/cli.js) that don't exist yet
+        // on a clean install, so we suppress the missing-bin warning for them.
+        const workspaceLinkedDeps = linkedDependenciesByProjectId[project.id].map(({ pkgId }) => ({
+          dir: path.join(project.rootDir, pkgId.substring(5)),
+        }))
+
+        const binLinkOpts = {
+          extraNodePaths: ctx.extraNodePaths,
+          preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+        }
+
+        // Link regular packages with the default warning behavior preserved.
+        const regularLinked = await linkBinsOfPackages(
           (
             await Promise.all(
-              directPkgs.map(async (dep) => {
+              regularDeps.map(async (dep) => {
                 const manifest = (await dep.fetching?.())?.bundledManifest ?? await safeReadProjectManifestOnly(dep.dir)
-                return {
-                  location: dep.dir,
-                  manifest,
-                }
+                return { location: dep.dir, manifest }
               })
             )
-          )
-            .filter(({ manifest }) => manifest != null) as Array<{ location: string, manifest: DependencyManifest }>,
+          ).filter(({ manifest }) => manifest != null) as Array<{ location: string, manifest: DependencyManifest }>,
           project.binsDir,
-          {
-            extraNodePaths: ctx.extraNodePaths,
-            preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
-          }
+          binLinkOpts
         )
+
+        // Link workspace-linked packages without emitting a warning when the
+        // bin target file is missing — it may simply not have been built yet.
+        const workspaceLinked = await linkBinsOfPackages(
+          (
+            await Promise.all(
+              workspaceLinkedDeps.map(async (dep) => {
+                const manifest = await safeReadProjectManifestOnly(dep.dir)
+                return { location: dep.dir, manifest }
+              })
+            )
+          ).filter(({ manifest }) => manifest != null) as Array<{ location: string, manifest: DependencyManifest }>,
+          project.binsDir,
+          { ...binLinkOpts, warnOnMissingBin: false }
+        )
+
+        linkedPackages = [...regularLinked, ...workspaceLinked]
       }
       const projectToInstall = projects[index]
       if (opts.global && projectToInstall.mutation.includes('install')) {


### PR DESCRIPTION
## Summary

Suppress the missing-bin warning for workspace-linked packages whose bin
targets have not been built yet on a clean install.

Closes #10524

## Problem

In a monorepo, a workspace package may declare a `bin` entry pointing to
a build artifact such as `dist/cli.js`.

On a clean `pnpm install`, that file may not exist yet because the
workspace package has not been built. pnpm still handled this correctly,
but it emitted a warning while linking bins.

## Fix

- add `warnOnMissingBin?: boolean` to `LinkBinOptions`
- preserve the default warning behavior for regular packages
- split the install call-site into:
  - regular dependencies
  - workspace-linked dependencies
- suppress the missing-bin warning only for the workspace-linked group

## Test

Added linker tests confirming that:

- default behavior still warns when a bin target is missing
- `warnOnMissingBin: false` suppresses the warning