### PR TITLE
docs(contributing): improve commit message wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ format that includes a **type**, a **scope** and a **subject**:
 
 The **header** is mandatory and the **scope** of the header is optional.
 
-Any line of the commit message cannot be longer than 100 characters! This allows the message to be easier
+Any line of the commit message cannot be longer than 100 characters! This makes the message easier
 to read on GitHub as well as in various git tools.
 
 #### Revert


### PR DESCRIPTION
## Summary
- improve one sentence in CONTRIBUTING by changing "allows ... easier" to "makes ... easier"

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- CONTRIBUTING: https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md
- PR template: N/A

## Validation
- Not run (docs-only change)
