### PR TITLE
chore: compile pnpm CLI bundle before tests that use it

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -15,6 +15,19 @@ import { writeJsonFile } from 'write-json-file'
 
 const CLI_PKG_NAME = 'pnpm'
 
+// Packages whose tests spawn the local pnpm CLI binary (pnpm/bin/pnpm.mjs)
+// and therefore need the CLI bundle (pnpm/dist/pnpm.mjs) to be built first.
+const PKGS_NEEDING_CLI_COMPILE = new Set([
+  '@pnpm/building.commands',
+  '@pnpm/cache.commands',
+  '@pnpm/deps.inspection.commands',
+  '@pnpm/exec.commands',
+  '@pnpm/lockfile.make-dedicated-lockfile',
+  '@pnpm/releasing.commands',
+  '@pnpm/releasing.exportable-manifest',
+  '@pnpm/store.commands',
+])
+
 export default async (workspaceDir: string) => { // eslint-disable-line
   const workspaceManifest = await readWorkspaceManifest(workspaceDir)!
   const pnpmManifest = loadJsonFileSync<ProjectManifest>(path.join(workspaceDir, 'pnpm/package.json'))
@@ -298,6 +311,9 @@ async function updateManifest (workspaceDir: string, manifest: ProjectManifest, 
         }
       }
       break
+  }
+  if (manifest.name && PKGS_NEEDING_CLI_COMPILE.has(manifest.name)) {
+    scripts.test = 'pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test'
   }
   // Clean up old underscore-prefixed script names
   delete scripts._test

--- a/__utils__/test-ipc-server/package.json
+++ b/__utils__/test-ipc-server/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "compile": "rimraf tsconfig.tsbuildinfo lib && tsc --build",
-    "test": "pnpm run compile && cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "keywords": [
     "pnpm",

--- a/building/commands/package.json
+++ b/building/commands/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/cache/commands/package.json
+++ b/cache/commands/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/deps/inspection/commands/package.json
+++ b/deps/inspection/commands/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "start": "tsgo --watch",
     "compile": "tsgo --build && pnpm run lint --fix",

--- a/lockfile/make-dedicated-lockfile/package.json
+++ b/lockfile/make-dedicated-lockfile/package.json
@@ -28,7 +28,7 @@
   "bin": "./bin/make-dedicated-lockfile.js",
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/releasing/commands/package.json
+++ b/releasing/commands/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "tsgo --watch",
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/releasing/exportable-manifest/package.json
+++ b/releasing/exportable-manifest/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"

--- a/store/commands/package.json
+++ b/store/commands/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "pnpm run compile && pnpm run .test",
+    "test": "pnpm run compile && pnpm --filter pnpm run compile && pnpm run .test",
     "prepublishOnly": "pnpm run compile",
     "compile": "tsgo --build && pnpm run lint --fix",
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"


### PR DESCRIPTION
## Summary

- Packages whose tests spawn the local pnpm CLI (`pnpm/bin/pnpm.mjs`) need the bundle (`pnpm/dist/pnpm.mjs`) to exist. This adds `pnpm --filter pnpm run compile` to their `test` scripts so the bundle is built before tests run.
- Updated `meta-updater` to maintain this for the 8 public packages, and directly edited `@pnpm/test-ipc-server` (private/util, skipped by meta-updater).

**Affected packages:**
`@pnpm/building.commands`, `@pnpm/cache.commands`, `@pnpm/deps.inspection.commands`, `@pnpm/exec.commands`, `@pnpm/lockfile.make-dedicated-lockfile`, `@pnpm/releasing.commands`, `@pnpm/releasing.exportable-manifest`, `@pnpm/store.commands`, `@pnpm/test-ipc-server`

## Test plan

- [x] Run `pnpm run meta-updater --test` — confirms meta-updater produces the expected output
- [x] Run `pnpm --filter @pnpm/cache.commands test` (or any affected package) — verifies the CLI bundle is compiled before tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)