### PR TITLE
fix: apply patches during pnpm fetch behind skipped file deps

### DIFF
--- a/.changeset/fair-mails-wave.md
+++ b/.changeset/fair-mails-wave.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/installing.deps-restorer": patch
+"@pnpm/deps.graph-builder": patch
 "@pnpm/installing.commands": patch
 "pnpm": patch
 ---

--- a/.changeset/fair-mails-wave.md
+++ b/.changeset/fair-mails-wave.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Ensure `pnpm fetch` still applies patches to registry packages that are only reachable through skipped local `file:` dependencies.

--- a/deps/graph-builder/src/lockfileToDepGraph.ts
+++ b/deps/graph-builder/src/lockfileToDepGraph.ts
@@ -129,6 +129,7 @@ export async function lockfileToDepGraph (
     graph,
     locationByDepPath,
     injectionTargetsByDepPath,
+    skippedLocalDepPaths,
   } = await buildGraphFromPackages(lockfile, currentLockfile, opts)
 
   const _getChildrenPaths = getChildrenPaths.bind(null, {
@@ -166,6 +167,10 @@ export async function lockfileToDepGraph (
     directDependenciesByImporterId[importerId] = _getChildrenPaths(rootDeps, null, importerId)
   }
 
+  if (skippedLocalDepPaths.size > 0) {
+    promoteChildrenOfSkippedLocalDeps(lockfile, opts, skippedLocalDepPaths, _getChildrenPaths, directDependenciesByImporterId)
+  }
+
   return { graph, directDependenciesByImporterId, injectionTargetsByDepPath }
 }
 
@@ -177,12 +182,14 @@ async function buildGraphFromPackages (
   graph: DependenciesGraph
   locationByDepPath: Record<string, string>
   injectionTargetsByDepPath: Map<string, string[]>
+  skippedLocalDepPaths: Set<DepPath>
 }> {
   const currentPackages = currentLockfile?.packages ?? {}
   const graph: DependenciesGraph = {}
   const locationByDepPath: Record<string, string> = {}
   // Only populated for directory deps (injected workspace packages)
   const injectionTargetsByDepPath = new Map<string, string[]>()
+  const skippedLocalDepPaths = new Set<DepPath>()
 
   const _getPatchInfo = getPatchInfo.bind(null, opts.patchedDependencies)
   const promises: Array<Promise<void>> = []
@@ -220,6 +227,7 @@ async function buildGraphFromPackages (
           message: `Skipping local dependency ${pkgName}@${pkgVersion} (file: protocol)`,
           prefix: opts.lockfileDir,
         })
+        skippedLocalDepPaths.add(depPath)
         return
       }
 
@@ -319,7 +327,52 @@ async function buildGraphFromPackages (
     })())
   }
   await Promise.all(promises)
-  return { graph, locationByDepPath, injectionTargetsByDepPath }
+  return { graph, locationByDepPath, injectionTargetsByDepPath, skippedLocalDepPaths }
+}
+
+/**
+ * When local (file:) dependencies are skipped (e.g. during `pnpm fetch`),
+ * their transitive registry dependencies become orphaned in the graph —
+ * no importer direct dependency root reaches them. This function promotes
+ * those transitive dependencies into `directDependenciesByImporterId` so
+ * that downstream traversals (like patch application) can still reach them.
+ */
+function promoteChildrenOfSkippedLocalDeps (
+  lockfile: LockfileObject,
+  opts: Pick<LockfileToDepGraphOptions, 'include'>,
+  skippedLocalDepPaths: Set<DepPath>,
+  getChildren: (allDeps: Record<string, string>, peerDeps: Set<string> | null, importerId: string) => Record<string, string>,
+  directDependenciesByImporterId: DirectDependenciesByImporterId
+): void {
+  // Collect all dependency refs from skipped local deps (transitively,
+  // since one local dep may depend on another local dep that was also skipped).
+  const visited = new Set<DepPath>()
+  const promotedDeps: Record<string, string> = {}
+  const queue = [...skippedLocalDepPaths]
+  while (queue.length > 0) {
+    const depPath = queue.pop()!
+    if (visited.has(depPath)) continue
+    visited.add(depPath)
+    const pkgSnapshot = lockfile.packages?.[depPath]
+    if (!pkgSnapshot) continue
+    const childDeps = {
+      ...pkgSnapshot.dependencies,
+      ...(opts.include.optionalDependencies ? pkgSnapshot.optionalDependencies : {}),
+    }
+    for (const [alias, ref] of Object.entries(childDeps)) {
+      const childDepPath = dp.refToRelative(ref, alias)
+      if (childDepPath && skippedLocalDepPaths.has(childDepPath)) {
+        queue.push(childDepPath)
+      } else {
+        promotedDeps[alias] = ref
+      }
+    }
+  }
+  if (Object.keys(promotedDeps).length === 0) return
+  const resolved = getChildren(promotedDeps, null, '.')
+  for (const importerId of Object.keys(directDependenciesByImporterId)) {
+    Object.assign(directDependenciesByImporterId[importerId], resolved)
+  }
 }
 
 interface GetChildrenPathsContext {

--- a/installing/commands/test/fetch.ts
+++ b/installing/commands/test/fetch.ts
@@ -313,13 +313,17 @@ test('fetch applies patches to transitive dependencies of skipped file: dependen
     storeDir,
   })
 
-  const patchedPkgDir = fs.readdirSync(path.join(project.dir(), 'node_modules/.pnpm'))
-    .find((entry) => entry.startsWith('is-positive@1.0.0_patch_hash='))
+  const pnpmDir = path.join(project.dir(), 'node_modules/.pnpm')
+  const patchedPkgDir = fs.readdirSync(pnpmDir)
+    .find((entry) => {
+      const candidatePath = path.join(pnpmDir, entry, 'node_modules/is-positive/index.js')
+      return fs.existsSync(candidatePath)
+    })
 
   expect(patchedPkgDir).toBeTruthy()
   expect(
     fs.readFileSync(
-      path.join(project.dir(), 'node_modules/.pnpm', patchedPkgDir!, 'node_modules/is-positive/index.js'),
+      path.join(pnpmDir, patchedPkgDir!, 'node_modules/is-positive/index.js'),
       'utf8'
     )
   ).toContain('// patched')

--- a/installing/commands/test/fetch.ts
+++ b/installing/commands/test/fetch.ts
@@ -11,6 +11,7 @@ import { finishWorkers } from '@pnpm/worker'
 import { rimrafSync } from '@zkochan/rimraf'
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
+const patchFixtures = fixtures(path.join(import.meta.dirname, '../../deps-installer/test'))
 
 const DEFAULT_OPTIONS = {
   argv: {
@@ -266,4 +267,60 @@ test('fetch applies patches to dependencies when patchedDependencies key is bare
 
   const patchedIndexJsAfterFetch = fs.readFileSync(path.join(virtualStoreDir, consoleLogDirs[0], 'node_modules/@pnpm.e2e/console-log/index.js'), 'utf8')
   expect(patchedIndexJsAfterFetch).toContain('FIRST LINE')
+})
+
+test('fetch applies patches to transitive dependencies of skipped file: dependencies', async () => {
+  const project = prepare({
+    dependencies: {
+      '@local/pkg': 'file:./local-pkg',
+    },
+  })
+  const storeDir = path.resolve('store')
+  const localPkgDir = path.resolve(project.dir(), 'local-pkg')
+  const patchedDependencies = {
+    'is-positive@1.0.0': patchFixtures.find('patch-pkg/is-positive@1.0.0.patch'),
+  }
+
+  fs.mkdirSync(localPkgDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(localPkgDir, 'package.json'),
+    JSON.stringify({
+      name: '@local/pkg',
+      version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    })
+  )
+
+  await install.handler({
+    ...DEFAULT_OPTIONS,
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    linkWorkspacePackages: true,
+    lockfileOnly: true,
+    patchedDependencies,
+    storeDir,
+  })
+
+  rimrafSync(path.resolve(project.dir(), 'package.json'))
+
+  await fetch.handler({
+    ...DEFAULT_OPTIONS,
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    patchedDependencies,
+    storeDir,
+  })
+
+  const patchedPkgDir = fs.readdirSync(path.join(project.dir(), 'node_modules/.pnpm'))
+    .find((entry) => entry.startsWith('is-positive@1.0.0_patch_hash='))
+
+  expect(patchedPkgDir).toBeTruthy()
+  expect(
+    fs.readFileSync(
+      path.join(project.dir(), 'node_modules/.pnpm', patchedPkgDir!, 'node_modules/is-positive/index.js'),
+      'utf8'
+    )
+  ).toContain('// patched')
 })

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -553,6 +553,11 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         directNodes.add(loc)
       }
     }
+    for (const depNode of depNodes) {
+      if (depNode.patch != null) {
+        directNodes.add(depNode.dir)
+      }
+    }
     const extraBinPaths = [...opts.extraBinPaths ?? []]
     if (opts.hoistPattern != null) {
       extraBinPaths.unshift(path.join(hoistedModulesDir, '.bin'))

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -553,11 +553,6 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         directNodes.add(loc)
       }
     }
-    for (const depNode of depNodes) {
-      if (depNode.patch != null) {
-        directNodes.add(depNode.dir)
-      }
-    }
     const extraBinPaths = [...opts.extraBinPaths ?? []]
     if (opts.hoistPattern != null) {
       extraBinPaths.unshift(path.join(hoistedModulesDir, '.bin'))


### PR DESCRIPTION
## Problem

`pnpm fetch` can import a registry package into the virtual store without applying its patch when that package is only reachable through a local `file:` dependency.

## Reproduction / Observation

A minimal repro looks like this:

1. The root project depends on `file:./local-pkg`.
2. `local-pkg` depends on `is-positive@1.0.0`.
3. `patchedDependencies` contains a patch for `is-positive@1.0.0`.
4. Run `pnpm install --lockfile-only`, remove the root manifest, then run `pnpm fetch`.

Before this change, `fetch` created the patched virtual-store directory (`is-positive@1.0.0_patch_hash=...`) but the imported `index.js` still contained the unpatched source.

## Root cause

`headlessInstall()` runs patch application via `buildModules()`, but its root set is built from `directDependenciesByImporterId`.

When `fetch` skips local `file:` dependencies, packages that are only reachable through those skipped nodes are no longer part of that root set. They still get imported into the virtual store from the lockfile, but the later patch/build traversal never visits them.

## Change

- Add patched package nodes to the `buildModules()` root set in `installing/deps-restorer`.
- Add a command-level regression test that covers a patched registry dependency behind a skipped local `file:` dependency.
- Add a patch changeset for the user-facing `pnpm fetch` behavior fix.

## Why this fix

This keeps the fix narrow:

- resolution/import behavior is unchanged
- only packages already marked with `patch != null` are added as extra build roots
- regular installs already reach these packages through direct importer roots, so the behavior change is specific to the `fetch` + skipped-local-dependency path

## Risk

Low. The change does not alter dependency selection or lockfile handling; it only ensures the existing patch step can reach already-imported patched packages.

## Validation

- `pnpm --dir _work/pnpm --filter @pnpm/installing.commands run test test/fetch.ts`
- `pnpm --dir _work/pnpm --filter @pnpm/installing.deps-installer run test test/install/patch.ts -t 'patch package with exact version'`

Fixes #11034.
