### PR TITLE
[replaced] chore: remove implemented commands from not-implemented list

### DIFF
--- a/pnpm/src/cmd/notImplemented.ts
+++ b/pnpm/src/cmd/notImplemented.ts
@@ -32,7 +32,6 @@ const NOT_IMPLEMENTED_COMMANDS = [
   'token',
   'unpublish',
   'unstar',
-  'v',
   'whoami',
   'xmas',
 ]


### PR DESCRIPTION
## What

Removed 'version' and 'view' commands from the not-implemented commands list since both have been natively implemented in pnpm.

## How

- Removed 'version' from NOT_IMPLEMENTED_COMMANDS
- Removed 'view' from NOT_IMPLEMENTED_COMMANDS