### PR TITLE
feat: add dedupePeers option to reduce peer dependency duplication

### DIFF
--- a/.changeset/dedupe-peers-option.md
+++ b/.changeset/dedupe-peers-option.md
@@ -7,4 +7,4 @@
 "pnpm": minor
 ---
 
-Added a new `dedupePeers` setting that reduces peer dependency duplication by using per-project peer deduplication. When enabled, peer dependency suffixes use version-only identifiers (no nested dep paths) and transitive peer propagation is stopped — only directly declared peers appear in a package's suffix. This dramatically reduces the number of package instances in projects with many recursive peer dependencies [#11070](https://github.com/pnpm/pnpm/issues/11070).
+Added a new `dedupePeers` setting that reduces peer dependency duplication. When enabled, peer dependency suffixes use version-only identifiers (`name@version`) instead of full dep paths, eliminating nested suffixes like `(foo@1.0.0(bar@2.0.0))`. This dramatically reduces the number of package instances in projects with many recursive peer dependencies [#11070](https://github.com/pnpm/pnpm/issues/11070).

--- a/.changeset/dedupe-peers-option.md
+++ b/.changeset/dedupe-peers-option.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/installing.deps-resolver": minor
+"@pnpm/installing.deps-installer": minor
+"@pnpm/lockfile.types": minor
+"@pnpm/lockfile.settings-checker": minor
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+Added a new `dedupePeers` setting that reduces peer dependency duplication by using per-project peer deduplication. When enabled, peer dependency suffixes use version-only identifiers (no nested dep paths) and transitive peer propagation is stopped — only directly declared peers appear in a package's suffix. This dramatically reduces the number of package instances in projects with many recursive peer dependencies [#11070](https://github.com/pnpm/pnpm/issues/11070).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -186,6 +186,7 @@ export interface Config extends AuthInfo, OptionsFromRootManifest {
   legacyDirFiltering?: boolean
   allowBuilds?: Record<string, boolean | string>
   dedupePeerDependents?: boolean
+  dedupePeers?: boolean
   patchesDir?: string
   ignoreWorkspaceCycles?: boolean
   disallowWorkspaceCycles?: boolean

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -63,6 +63,7 @@ export const excludedPnpmKeys = [
   'merge-git-branch-lockfiles-branch-pattern',
   'deploy-all-files',
   'dedupe-peer-dependents',
+  'dedupe-peers',
   'dedupe-direct-deps',
   'dedupe-injected-deps',
   'dev',

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -151,6 +151,7 @@ export async function getConfig (opts: {
     'dangerously-allow-all-builds': false,
     'deploy-all-files': false,
     'dedupe-peer-dependents': true,
+    'dedupe-peers': false,
     'dedupe-direct-deps': false,
     'dedupe-injected-deps': true,
     'disallow-workspace-cycles': false,

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -15,6 +15,7 @@ export const pnpmTypes = {
   'dangerously-allow-all-builds': Boolean,
   'deploy-all-files': Boolean,
   'dedupe-peer-dependents': Boolean,
+  'dedupe-peers': Boolean,
   'dedupe-direct-deps': Boolean,
   'dedupe-injected-deps': Boolean,
   dev: [null, true],

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -273,6 +273,7 @@ export type InstallCommandOptions = Pick<Config,
 | 'dedupeInjectedDeps'
 | 'dedupeDirectDeps'
 | 'dedupePeerDependents'
+| 'dedupePeers'
 | 'deployAllFiles'
 | 'depth'
 | 'dev'

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -67,6 +67,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'cleanupUnusedCatalogs'
 | 'cliOptions'
 | 'dedupePeerDependents'
+| 'dedupePeers'
 | 'depth'
 | 'dev'
 | 'enableGlobalVirtualStore'

--- a/installing/commands/src/recursive.ts
+++ b/installing/commands/src/recursive.ts
@@ -59,6 +59,7 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'bail'
 | 'configDependencies'
 | 'dedupePeerDependents'
+| 'dedupePeers'
 | 'depth'
 | 'globalPnpmfile'
 | 'hoistPattern'

--- a/installing/deps-installer/src/getPeerDependencyIssues.ts
+++ b/installing/deps-installer/src/getPeerDependencyIssues.ts
@@ -12,6 +12,7 @@ export type ListMissingPeersOptions = Partial<GetContextOptions>
 & Pick<InstallOptions, 'hooks'
 | 'catalogs'
 | 'dedupePeerDependents'
+| 'dedupePeers'
 | 'ignoreCompatibilityDb'
 | 'linkWorkspacePackagesDepth'
 | 'nodeVersion'

--- a/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -152,6 +152,7 @@ export interface StrictInstallOptions {
   dedupeDirectDeps: boolean
   dedupeInjectedDeps: boolean
   dedupePeerDependents: boolean
+  dedupePeers: boolean
   extendNodePath: boolean
   excludeLinksFromLockfile: boolean
   confirmModulesPurge: boolean
@@ -273,6 +274,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     resolveSymlinksInInjectedDirs: false,
     dedupeDirectDeps: true,
     dedupePeerDependents: true,
+    dedupePeers: false,
     resolvePeersFromWorkspaceRoot: true,
     extendNodePath: true,
     ignoreWorkspaceCycles: false,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -470,7 +470,7 @@ export async function mutateModules (
       const outdatedLockfileSettingName = getOutdatedLockfileSetting(ctx.wantedLockfile, {
         autoInstallPeers: opts.autoInstallPeers,
         catalogs: opts.catalogs,
-        dedupePeers: opts.dedupePeers,
+        dedupePeers: opts.dedupePeers || undefined,
         injectWorkspacePackages: opts.injectWorkspacePackages,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
@@ -495,7 +495,7 @@ export async function mutateModules (
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers,
+        dedupePeers: opts.dedupePeers || undefined,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,
@@ -508,7 +508,7 @@ export async function mutateModules (
     } else if (!frozenLockfile) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers,
+        dedupePeers: opts.dedupePeers || undefined,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -470,6 +470,7 @@ export async function mutateModules (
       const outdatedLockfileSettingName = getOutdatedLockfileSetting(ctx.wantedLockfile, {
         autoInstallPeers: opts.autoInstallPeers,
         catalogs: opts.catalogs,
+        dedupePeers: opts.dedupePeers,
         injectWorkspacePackages: opts.injectWorkspacePackages,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
@@ -494,7 +495,7 @@ export async function mutateModules (
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers || undefined,
+        ...(opts.dedupePeers ? { dedupePeers: true } : {}),
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,
@@ -507,7 +508,7 @@ export async function mutateModules (
     } else if (!frozenLockfile) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        dedupePeers: opts.dedupePeers || undefined,
+        ...(opts.dedupePeers ? { dedupePeers: true } : {}),
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -495,7 +495,7 @@ export async function mutateModules (
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        ...(opts.dedupePeers ? { dedupePeers: true } : {}),
+        dedupePeers: opts.dedupePeers,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,
@@ -508,7 +508,7 @@ export async function mutateModules (
     } else if (!frozenLockfile) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
-        ...(opts.dedupePeers ? { dedupePeers: true } : {}),
+        dedupePeers: opts.dedupePeers,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -494,6 +494,7 @@ export async function mutateModules (
     if (needsFullResolution) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
+        dedupePeers: opts.dedupePeers || undefined,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,
@@ -506,6 +507,7 @@ export async function mutateModules (
     } else if (!frozenLockfile) {
       ctx.wantedLockfile.settings = {
         autoInstallPeers: opts.autoInstallPeers,
+        dedupePeers: opts.dedupePeers || undefined,
         excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
         peersSuffixMaxLength: opts.peersSuffixMaxLength,
         injectWorkspacePackages: opts.injectWorkspacePackages,
@@ -1267,6 +1269,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       dedupeDirectDeps: opts.dedupeDirectDeps,
       dedupeInjectedDeps: opts.dedupeInjectedDeps,
       dedupePeerDependents: opts.dedupePeerDependents,
+      dedupePeers: opts.dedupePeers,
       dryRun: opts.lockfileOnly,
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       engineStrict: opts.engineStrict,

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2063,6 +2063,7 @@ test('detection of circular peer dependencies should not crash with aliased depe
 test('dedupePeers: transitive peers are not propagated to parent suffix', async () => {
   prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
 
   const project = prepareEmpty()
 
@@ -2080,9 +2081,9 @@ test('dedupePeers: transitive peers are not propagated to parent suffix', async 
   expect(Object.keys(lockfile.snapshots).sort()).toStrictEqual([
     '@pnpm.e2e/abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
     '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
-    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
     '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
-    '@pnpm.e2e/peer-a@1.0.1',
+    '@pnpm.e2e/peer-a@1.0.0',
     '@pnpm.e2e/peer-b@1.0.0',
     '@pnpm.e2e/peer-c@1.0.0',
     'is-positive@1.0.0',
@@ -2093,6 +2094,7 @@ test('dedupePeers: transitive peers are not propagated to parent suffix', async 
 // Covers https://github.com/pnpm/pnpm/issues/11070
 test('dedupePeers: workspace projects with different peer versions get different instances', async () => {
   await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
 
   const manifest1 = {
     name: 'project-1',
@@ -2137,10 +2139,10 @@ test('dedupePeers: workspace projects with different peer versions get different
     '@pnpm.e2e/abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@2.0.0)',
     '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
     '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@2.0.0)',
-    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
-    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@2.0.0)',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@2.0.0)',
     '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
-    '@pnpm.e2e/peer-a@1.0.1',
+    '@pnpm.e2e/peer-a@1.0.0',
     '@pnpm.e2e/peer-b@1.0.0',
     '@pnpm.e2e/peer-c@1.0.0',
     '@pnpm.e2e/peer-c@2.0.0',

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2060,7 +2060,7 @@ test('detection of circular peer dependencies should not crash with aliased depe
 })
 
 // Covers https://github.com/pnpm/pnpm/issues/11070
-test('dedupePeers: transitive peers are not propagated to parent suffix', async () => {
+test('dedupePeers: version-only peer suffixes without nested dep paths', async () => {
   prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2074,30 +2074,20 @@ test('dedupePeers: transitive peers are not propagated to parent suffix', async 
   }, testDefaults({ dedupePeers: true, strictPeerDependencies: false }))
 
   const lockfile = project.readLockfile()
-  const snapshotKeys = Object.keys(lockfile.snapshots)
 
-  // abc-grand-parent should NOT have peer-c in its suffix.
-  // It doesn't declare peer-c as its own peer — the transitive propagation is stopped.
-  const grandParentKey = snapshotKeys.find((k) => k.startsWith('@pnpm.e2e/abc-grand-parent@'))!
-  expect(grandParentKey).toBe('@pnpm.e2e/abc-grand-parent@1.0.0')
-  expect(grandParentKey).not.toContain('peer-c')
-
-  // abc (the leaf with direct peer deps) should still have its peers in the suffix,
-  // but using version-only format (no nested dep paths)
-  const abcKey = snapshotKeys.find((k) => k.startsWith('@pnpm.e2e/abc@'))!
-  expect(abcKey).toContain('@pnpm.e2e/peer-a@')
-  expect(abcKey).toContain('@pnpm.e2e/peer-b@')
-  expect(abcKey).toContain('@pnpm.e2e/peer-c@')
-  // No nested parentheses — version-only means no (foo@1(bar@2)) patterns
-  const suffix = abcKey.substring(abcKey.indexOf('('))
-  expect(suffix).not.toMatch(/\([^)]*\(/)
-
-  // The virtual store directory for abc-grand-parent should be short (no peer suffix)
-  expect(
-    fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+abc-grand-parent@1.0.0/node_modules/@pnpm.e2e/abc-grand-parent'))
-  ).toBeTruthy()
-
-  // The lockfile should record dedupePeers in settings
+  // abc-grand-parent and abc-parent-with-ab have no peer suffix —
+  // transitive peers from abc are not propagated up.
+  // abc has version-only suffixes for its direct peers (no nesting).
+  expect(Object.keys(lockfile.snapshots).sort()).toStrictEqual([
+    '@pnpm.e2e/abc-grand-parent@1.0.0',
+    '@pnpm.e2e/abc-parent-with-ab@1.0.0',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
+    '@pnpm.e2e/peer-a@1.0.1',
+    '@pnpm.e2e/peer-b@1.0.0',
+    '@pnpm.e2e/peer-c@1.0.0',
+    'is-positive@1.0.0',
+  ])
   expect(lockfile.settings.dedupePeers).toBe(true)
 })
 

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2075,12 +2075,11 @@ test('dedupePeers: transitive peers are not propagated to parent suffix', async 
 
   const lockfile = project.readLockfile()
 
-  // abc-grand-parent and abc-parent-with-ab have no peer suffix —
-  // transitive peers from abc are not propagated up.
-  // abc has version-only suffixes for its direct peers (no nesting).
+  // Transitive peers are included but with version-only IDs (no nesting).
+  // abc-grand-parent and abc-parent-with-ab get (peer-c@1.0.0) — not the full nested dep path.
   expect(Object.keys(lockfile.snapshots).sort()).toStrictEqual([
-    '@pnpm.e2e/abc-grand-parent@1.0.0',
-    '@pnpm.e2e/abc-parent-with-ab@1.0.0',
+    '@pnpm.e2e/abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
     '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
     '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
     '@pnpm.e2e/peer-a@1.0.1',
@@ -2131,13 +2130,15 @@ test('dedupePeers: workspace projects with different peer versions get different
 
   const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
 
-  // abc-grand-parent and abc-parent-with-ab have NO peer suffix (transitive pruning).
-  // Since they're shared, abc resolves once with the first project's peer-c.
-  // This is the trade-off: packages without declared peers are shared across projects.
+  // Each project gets its own instances differentiated by peer-c version.
+  // Version-only suffixes — no nesting like (@pnpm.e2e/peer-c@1.0.0(@pnpm.e2e/peer-a@...)).
   expect(Object.keys(lockfile.snapshots!).sort()).toStrictEqual([
-    '@pnpm.e2e/abc-grand-parent@1.0.0',
-    '@pnpm.e2e/abc-parent-with-ab@1.0.0',
+    '@pnpm.e2e/abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@2.0.0)',
+    '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@2.0.0)',
     '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@2.0.0)',
     '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
     '@pnpm.e2e/peer-a@1.0.1',
     '@pnpm.e2e/peer-b@1.0.0',
@@ -2146,14 +2147,14 @@ test('dedupePeers: workspace projects with different peer versions get different
     'is-positive@1.0.0',
   ])
 
-  // Both projects use the same abc-grand-parent (no peer suffix)
+  // Each project gets the correct abc-grand-parent instance for its peer-c version
   expect(lockfile.importers?.['project-1']?.dependencies?.['@pnpm.e2e/abc-grand-parent']).toStrictEqual({
     specifier: '1.0.0',
-    version: '1.0.0',
+    version: '1.0.0(@pnpm.e2e/peer-c@1.0.0)',
   })
   expect(lockfile.importers?.['project-2']?.dependencies?.['@pnpm.e2e/abc-grand-parent']).toStrictEqual({
     specifier: '1.0.0',
-    version: '1.0.0',
+    version: '1.0.0(@pnpm.e2e/peer-c@2.0.0)',
   })
 })
 

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2091,6 +2091,72 @@ test('dedupePeers: transitive peers are not propagated to parent suffix', async 
   expect(lockfile.settings.dedupePeers).toBe(true)
 })
 
+// Covers https://github.com/pnpm/pnpm/issues/11070
+test('dedupePeers: workspace projects with different peer versions get different instances', async () => {
+  await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+
+  const manifest1 = {
+    name: 'project-1',
+    dependencies: {
+      '@pnpm.e2e/abc-grand-parent': '1.0.0',
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  const manifest2 = {
+    name: 'project-2',
+    dependencies: {
+      '@pnpm.e2e/abc-grand-parent': '1.0.0',
+      '@pnpm.e2e/peer-c': '2.0.0',
+    },
+  }
+  preparePackages([
+    { location: 'project-1', package: manifest1 },
+    { location: 'project-2', package: manifest2 },
+  ])
+
+  const importers: MutatedProject[] = [
+    { mutation: 'install', rootDir: path.resolve('project-1') as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  const allProjects = [
+    { buildIndex: 0, manifest: manifest1, rootDir: path.resolve('project-1') as ProjectRootDir },
+    { buildIndex: 0, manifest: manifest2, rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  await mutateModules(importers, testDefaults({
+    allProjects,
+    dedupePeers: true,
+    lockfileOnly: true,
+    strictPeerDependencies: false,
+  }))
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+
+  // abc-grand-parent and abc-parent-with-ab have NO peer suffix (transitive pruning).
+  // Since they're shared, abc resolves once with the first project's peer-c.
+  // This is the trade-off: packages without declared peers are shared across projects.
+  expect(Object.keys(lockfile.snapshots!).sort()).toStrictEqual([
+    '@pnpm.e2e/abc-grand-parent@1.0.0',
+    '@pnpm.e2e/abc-parent-with-ab@1.0.0',
+    '@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.1)(@pnpm.e2e/peer-b@1.0.0)(@pnpm.e2e/peer-c@1.0.0)',
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0',
+    '@pnpm.e2e/peer-a@1.0.1',
+    '@pnpm.e2e/peer-b@1.0.0',
+    '@pnpm.e2e/peer-c@1.0.0',
+    '@pnpm.e2e/peer-c@2.0.0',
+    'is-positive@1.0.0',
+  ])
+
+  // Both projects use the same abc-grand-parent (no peer suffix)
+  expect(lockfile.importers?.['project-1']?.dependencies?.['@pnpm.e2e/abc-grand-parent']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+  expect(lockfile.importers?.['project-2']?.dependencies?.['@pnpm.e2e/abc-grand-parent']).toStrictEqual({
+    specifier: '1.0.0',
+    version: '1.0.0',
+  })
+})
+
 // Covers https://github.com/pnpm/pnpm/pull/9673
 test('no deadlock on circular aliased peers', async () => {
   prepareEmpty()

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2059,6 +2059,48 @@ test('detection of circular peer dependencies should not crash with aliased depe
   expect(fs.existsSync(path.resolve(WANTED_LOCKFILE))).toBeTruthy()
 })
 
+// Covers https://github.com/pnpm/pnpm/issues/11070
+test('dedupePeers: transitive peers are not propagated to parent suffix', async () => {
+  prepareEmpty()
+  await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+
+  const project = prepareEmpty()
+
+  await install({
+    dependencies: {
+      '@pnpm.e2e/abc-grand-parent': '1.0.0',
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }, testDefaults({ dedupePeers: true, strictPeerDependencies: false }))
+
+  const lockfile = project.readLockfile()
+  const snapshotKeys = Object.keys(lockfile.snapshots)
+
+  // abc-grand-parent should NOT have peer-c in its suffix.
+  // It doesn't declare peer-c as its own peer — the transitive propagation is stopped.
+  const grandParentKey = snapshotKeys.find((k) => k.startsWith('@pnpm.e2e/abc-grand-parent@'))!
+  expect(grandParentKey).toBe('@pnpm.e2e/abc-grand-parent@1.0.0')
+  expect(grandParentKey).not.toContain('peer-c')
+
+  // abc (the leaf with direct peer deps) should still have its peers in the suffix,
+  // but using version-only format (no nested dep paths)
+  const abcKey = snapshotKeys.find((k) => k.startsWith('@pnpm.e2e/abc@'))!
+  expect(abcKey).toContain('@pnpm.e2e/peer-a@')
+  expect(abcKey).toContain('@pnpm.e2e/peer-b@')
+  expect(abcKey).toContain('@pnpm.e2e/peer-c@')
+  // No nested parentheses — version-only means no (foo@1(bar@2)) patterns
+  const suffix = abcKey.substring(abcKey.indexOf('('))
+  expect(suffix).not.toMatch(/\([^)]*\(/)
+
+  // The virtual store directory for abc-grand-parent should be short (no peer suffix)
+  expect(
+    fs.existsSync(path.resolve('node_modules/.pnpm/@pnpm.e2e+abc-grand-parent@1.0.0/node_modules/@pnpm.e2e/abc-grand-parent'))
+  ).toBeTruthy()
+
+  // The lockfile should record dedupePeers in settings
+  expect(lockfile.settings.dedupePeers).toBe(true)
+})
+
 // Covers https://github.com/pnpm/pnpm/pull/9673
 test('no deadlock on circular aliased peers', async () => {
   prepareEmpty()

--- a/installing/deps-resolver/src/index.ts
+++ b/installing/deps-resolver/src/index.ts
@@ -116,6 +116,7 @@ export async function resolveDependencies (
   opts: ResolveDependenciesOptions & {
     defaultUpdateDepth: number
     dedupePeerDependents?: boolean
+    dedupePeers?: boolean
     dedupeDirectDeps?: boolean
     dedupeInjectedDeps?: boolean
     excludeLinksFromLockfile?: boolean
@@ -209,6 +210,7 @@ export async function resolveDependencies (
     allPeerDepNames,
     dependenciesTree,
     dedupePeerDependents: opts.dedupePeerDependents,
+    dedupePeers: opts.dedupePeers,
     dedupeInjectedDeps: opts.dedupeInjectedDeps,
     lockfileDir: opts.lockfileDir,
     projects: projectsToLink,

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -490,17 +490,11 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       parentNodeIds,
     })
 
-  // allResolvedPeers = transitive peers from children + this node's direct peers
-  // Used for: childrenNodeIds (layout), transitivePeerDependencies tracking
   const allResolvedPeers = unknownResolvedPeersOfChildren
   for (const [k, v] of resolvedPeers) {
     allResolvedPeers.set(k, v)
   }
   allResolvedPeers.delete(node.resolvedPackage.name)
-
-  // When dedupePeers is enabled, the suffix and returned peers use only direct peers.
-  // This prevents transitive peer propagation (Opt 2) and is used with version-only IDs (Opt 1).
-  const suffixPeers = ctx.dedupePeers ? resolvedPeers : allResolvedPeers
 
   const allMissingPeers = new Map<string, MissingPeerInfo>()
   for (const [peer, range] of missingPeersOfChildren.entries()) {
@@ -528,12 +522,12 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 
   let calculateDepPathIfNeeded: CalculateDepPath | undefined
-  if (suffixPeers.size === 0) {
+  if (allResolvedPeers.size === 0) {
     addDepPathToGraph(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
   } else {
     const peerIds: PeerId[] = []
     const pendingPeers: PendingPeer[] = []
-    for (const [alias, peerNodeId] of suffixPeers.entries()) {
+    for (const [alias, peerNodeId] of allResolvedPeers.entries()) {
       if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
         const linkedDir = peerNodeId.slice(5)
         peerIds.push({
@@ -566,13 +560,8 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     }
   }
 
-  // When dedupePeers is enabled, only return direct peers to the parent.
-  // This stops transitive peer propagation — the parent won't include
-  // this node's children's peers in its own suffix.
-  const returnedResolvedPeers = ctx.dedupePeers ? suffixPeers : allResolvedPeers
-
   return {
-    resolvedPeers: returnedResolvedPeers,
+    resolvedPeers: allResolvedPeers,
     missingPeers: allMissingPeers,
     calculateDepPath: calculateDepPathIfNeeded,
     finishing,

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -88,6 +88,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     lockfileDir: string
     resolvePeersFromWorkspaceRoot?: boolean
     dedupePeerDependents?: boolean
+    dedupePeers?: boolean
     dedupeInjectedDeps?: boolean
     resolvedImporters: ResolvedImporters
     peersSuffixMaxLength: number
@@ -136,6 +137,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       peersCache,
       peerDependencyIssues,
       purePkgs,
+      dedupePeers: opts.dedupePeers,
       peersSuffixMaxLength: opts.peersSuffixMaxLength,
       rootDir,
       virtualStoreDir: opts.virtualStoreDir,
@@ -384,6 +386,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'>
     peersCache: PeersCache
     purePkgs: Set<PkgIdWithPatchHash> // pure packages are those that don't rely on externally resolved peers
+    dedupePeers?: boolean
     rootDir: ProjectRootDir
     lockfileDir: string
     peersSuffixMaxLength: number
@@ -487,11 +490,17 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       parentNodeIds,
     })
 
+  // allResolvedPeers = transitive peers from children + this node's direct peers
+  // Used for: childrenNodeIds (layout), transitivePeerDependencies tracking
   const allResolvedPeers = unknownResolvedPeersOfChildren
   for (const [k, v] of resolvedPeers) {
     allResolvedPeers.set(k, v)
   }
   allResolvedPeers.delete(node.resolvedPackage.name)
+
+  // When dedupePeers is enabled, the suffix and returned peers use only direct peers.
+  // This prevents transitive peer propagation (Opt 2) and is used with version-only IDs (Opt 1).
+  const suffixPeers = ctx.dedupePeers ? resolvedPeers : allResolvedPeers
 
   const allMissingPeers = new Map<string, MissingPeerInfo>()
   for (const [peer, range] of missingPeersOfChildren.entries()) {
@@ -519,12 +528,12 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 
   let calculateDepPathIfNeeded: CalculateDepPath | undefined
-  if (allResolvedPeers.size === 0) {
+  if (suffixPeers.size === 0) {
     addDepPathToGraph(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
   } else {
     const peerIds: PeerId[] = []
     const pendingPeers: PendingPeer[] = []
-    for (const [alias, peerNodeId] of allResolvedPeers.entries()) {
+    for (const [alias, peerNodeId] of suffixPeers.entries()) {
       if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
         const linkedDir = peerNodeId.slice(5)
         peerIds.push({
@@ -533,9 +542,18 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         })
         continue
       }
+      if (ctx.dedupePeers) {
+        // Optimization 1: Use version-only peer identifiers instead of full dep paths.
+        // This eliminates nested peer suffixes like (foo@1.0.0(bar@2.0.0)).
+        const peerNode = ctx.dependenciesTree.get(peerNodeId)
+        if (peerNode) {
+          peerIds.push({ name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version })
+          continue
+        }
+      }
       const peerDepPath = ctx.pathsByNodeId.get(peerNodeId)
       if (peerDepPath) {
-        peerIds.push(peerDepPath)
+        peerIds.push(ctx.dedupePeers ? peerDepPathToVersionOnly(peerDepPath) : peerDepPath)
         continue
       }
       pendingPeers.push({ alias, nodeId: peerNodeId })
@@ -548,8 +566,13 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     }
   }
 
+  // When dedupePeers is enabled, only return direct peers to the parent.
+  // This stops transitive peer propagation — the parent won't include
+  // this node's children's peers in its own suffix.
+  const returnedResolvedPeers = ctx.dedupePeers ? suffixPeers : allResolvedPeers
+
   return {
-    resolvedPeers: allResolvedPeers,
+    resolvedPeers: returnedResolvedPeers,
     missingPeers: allMissingPeers,
     calculateDepPath: calculateDepPathIfNeeded,
     finishing,
@@ -577,6 +600,13 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
             const id = `${name}@${version}`
             ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)?.resolve(id as DepPath)
             return id
+          }
+          if (ctx.dedupePeers) {
+            // With dedupePeers, use version-only IDs for pending peers too
+            const peerNode = ctx.dependenciesTree.get(pendingPeer.nodeId)
+            if (peerNode) {
+              return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
+            }
           }
           return ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)!.promise
         })
@@ -785,6 +815,7 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
     virtualStoreDir: string
     virtualStoreDirMaxLength: number
     purePkgs: Set<PkgIdWithPatchHash>
+    dedupePeers?: boolean
     depGraph: GenericDependenciesGraph<T>
     dependenciesTree: DependenciesTree<T>
     rootDir: ProjectRootDir
@@ -962,6 +993,17 @@ function getLocationFromParentNodeIds<T> (
     projectId: '.',
     parents,
   }
+}
+
+// Extracts name@version from a dep path like "foo@1.0.0(bar@2.0.0)" → { name: "foo", version: "1.0.0" }
+function peerDepPathToVersionOnly (depPath: DepPath): PeerId {
+  const atIndex = depPath.indexOf('@', depPath[0] === '@' ? 1 : 0)
+  if (atIndex === -1) return depPath
+  const name = depPath.substring(0, atIndex)
+  const afterAt = depPath.substring(atIndex + 1)
+  const suffixStart = afterAt.indexOf('(')
+  const version = suffixStart === -1 ? afterAt : afterAt.substring(0, suffixStart)
+  return { name, version }
 }
 
 interface ParentRefs {

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -988,11 +988,7 @@ function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
       return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
     }
   }
-  const peerDepPath = ctx.pathsByNodeId.get(peerNodeId)
-  if (peerDepPath) {
-    return peerDepPath
-  }
-  return undefined
+  return ctx.pathsByNodeId.get(peerNodeId)
 }
 
 interface ParentRefs {

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -528,29 +528,12 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     const peerIds: PeerId[] = []
     const pendingPeers: PendingPeer[] = []
     for (const [alias, peerNodeId] of allResolvedPeers.entries()) {
-      if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
-        const linkedDir = peerNodeId.slice(5)
-        peerIds.push({
-          name: alias,
-          version: filenamify(linkedDir, { replacement: '+' }),
-        })
-        continue
+      const peerId = peerNodeIdToPeerId(alias, peerNodeId, ctx)
+      if (peerId != null) {
+        peerIds.push(peerId)
+      } else {
+        pendingPeers.push({ alias, nodeId: peerNodeId })
       }
-      if (ctx.dedupePeers) {
-        // Optimization 1: Use version-only peer identifiers instead of full dep paths.
-        // This eliminates nested peer suffixes like (foo@1.0.0(bar@2.0.0)).
-        const peerNode = ctx.dependenciesTree.get(peerNodeId)
-        if (peerNode) {
-          peerIds.push({ name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version })
-          continue
-        }
-      }
-      const peerDepPath = ctx.pathsByNodeId.get(peerNodeId)
-      if (peerDepPath) {
-        peerIds.push(ctx.dedupePeers ? peerDepPathToVersionOnly(peerDepPath) : peerDepPath)
-        continue
-      }
-      pendingPeers.push({ alias, nodeId: peerNodeId })
     }
     if (pendingPeers.length === 0) {
       const peerDepGraphHash = createPeerDepGraphHash(peerIds, ctx.peersSuffixMaxLength)
@@ -591,7 +574,6 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
             return id
           }
           if (ctx.dedupePeers) {
-            // With dedupePeers, use version-only IDs for pending peers too
             const peerNode = ctx.dependenciesTree.get(pendingPeer.nodeId)
             if (peerNode) {
               return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
@@ -984,15 +966,33 @@ function getLocationFromParentNodeIds<T> (
   }
 }
 
-// Extracts name@version from a dep path like "foo@1.0.0(bar@2.0.0)" → { name: "foo", version: "1.0.0" }
-function peerDepPathToVersionOnly (depPath: DepPath): PeerId {
-  const atIndex = depPath.indexOf('@', depPath[0] === '@' ? 1 : 0)
-  if (atIndex === -1) return depPath
-  const name = depPath.substring(0, atIndex)
-  const afterAt = depPath.substring(atIndex + 1)
-  const suffixStart = afterAt.indexOf('(')
-  const version = suffixStart === -1 ? afterAt : afterAt.substring(0, suffixStart)
-  return { name, version }
+function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
+  alias: string,
+  peerNodeId: NodeId,
+  ctx: ResolvePeersContext & {
+    dedupePeers?: boolean
+    dependenciesTree: DependenciesTree<T>
+  }
+): PeerId | undefined {
+  if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
+    return {
+      name: alias,
+      version: filenamify(peerNodeId.slice(5), { replacement: '+' }),
+    }
+  }
+  if (ctx.dedupePeers) {
+    // Use version-only peer identifiers instead of full dep paths.
+    // This eliminates nested peer suffixes like (foo@1.0.0(bar@2.0.0)).
+    const peerNode = ctx.dependenciesTree.get(peerNodeId)
+    if (peerNode) {
+      return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
+    }
+  }
+  const peerDepPath = ctx.pathsByNodeId.get(peerNodeId)
+  if (peerDepPath) {
+    return peerDepPath
+  }
+  return undefined
 }
 
 interface ParentRefs {

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -675,10 +675,10 @@ test('resolve peer dependencies with npm aliases', async () => {
 })
 
 describe('dedupePeers', () => {
-  test('eliminates transitive peer propagation and uses version-only suffixes', async () => {
+  test('uses version-only peer suffixes without nested dep paths', async () => {
     // Simulates: react@18, @emotion/react@11(peer: react), @emotion/styled@11(peer: react, @emotion/react)
-    // Without dedupePeers: @emotion/styled gets suffix (@emotion/react@11(react@18))(react@18) — nested!
-    // With dedupePeers: @emotion/styled gets suffix (@emotion/react@11)(react@18) — version-only, no nesting
+    // Without dedupePeers: @emotion/styled gets suffix (@emotion/react@11(react@18))(react@18) — nested dep paths
+    // With dedupePeers: @emotion/styled gets suffix (@emotion/react@11.0.0)(react@18.0.0) — version-only, no nesting
     const reactPkg = {
       name: 'react',
       pkgIdWithPatchHash: 'react/18.0.0' as PkgIdWithPatchHash,

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -673,3 +673,270 @@ test('resolve peer dependencies with npm aliases', async () => {
     'foo/2.0.0(bar/2.0.0)',
   ])
 })
+
+describe('dedupePeers', () => {
+  test('eliminates transitive peer propagation and uses version-only suffixes', async () => {
+    // Simulates: react@18, @emotion/react@11(peer: react), @emotion/styled@11(peer: react, @emotion/react)
+    // Without dedupePeers: @emotion/styled gets suffix (@emotion/react@11(react@18))(react@18) — nested!
+    // With dedupePeers: @emotion/styled gets suffix (@emotion/react@11)(react@18) — version-only, no nesting
+    const reactPkg = {
+      name: 'react',
+      pkgIdWithPatchHash: 'react/18.0.0' as PkgIdWithPatchHash,
+      version: '18.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const emotionReactPkg = {
+      name: '@emotion/react',
+      pkgIdWithPatchHash: '@emotion/react/11.0.0' as PkgIdWithPatchHash,
+      version: '11.0.0',
+      peerDependencies: {
+        react: { version: '>=16' },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const emotionStyledPkg = {
+      name: '@emotion/styled',
+      pkgIdWithPatchHash: '@emotion/styled/11.0.0' as PkgIdWithPatchHash,
+      version: '11.0.0',
+      peerDependencies: {
+        react: { version: '>=16' },
+        '@emotion/react': { version: '>=11' },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const { dependenciesGraph } = await resolvePeers({
+      allPeerDepNames: new Set(['react', '@emotion/react', '@emotion/styled']),
+      dedupePeers: true,
+      projects: [
+        {
+          directNodeIdsByAlias: new Map([
+            ['react', '>react/18.0.0>' as NodeId],
+            ['@emotion/react', '>@emotion/react/11.0.0>' as NodeId],
+            ['@emotion/styled', '>@emotion/styled/11.0.0>' as NodeId],
+          ]),
+          topParents: [],
+          rootDir: '' as ProjectRootDir,
+          id: '',
+        },
+      ],
+      resolvedImporters: {},
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        ['>react/18.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: reactPkg,
+          depth: 0,
+        }],
+        ['>@emotion/react/11.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: emotionReactPkg,
+          depth: 0,
+        }],
+        ['>@emotion/styled/11.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: emotionStyledPkg,
+          depth: 0,
+        }],
+      ]),
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set(),
+    })
+    const depPaths = Object.keys(dependenciesGraph).sort()
+    // With dedupePeers: @emotion/react uses version-only react suffix
+    // and @emotion/styled uses version-only suffixes for both peers.
+    // No nested suffixes like (@emotion/react@11.0.0(react@18.0.0))
+    expect(depPaths).toStrictEqual([
+      '@emotion/react/11.0.0(react@18.0.0)',
+      '@emotion/styled/11.0.0(@emotion/react@11.0.0)(react@18.0.0)',
+      'react/18.0.0',
+    ])
+    // Verify no nested parentheses in any dep path (version-only means no nesting)
+    for (const depPath of depPaths) {
+      const openParens = depPath.split('(').length - 1
+      const closeParens = depPath.split(')').length - 1
+      expect(openParens).toBe(closeParens)
+      // No nested parens: between any ( and its matching ), there should be no other (
+      if (openParens > 0) {
+        const suffix = depPath.substring(depPath.indexOf('('))
+        expect(suffix).not.toMatch(/\([^)]*\(/)
+      }
+    }
+  })
+
+  test('packages without direct peers get no suffix even when children have peers', async () => {
+    // A depends on B (peer: C). A has no peers itself.
+    // Without dedupePeers: A gets suffix (C@1.0.0) from transitive propagation
+    // With dedupePeers: A gets no suffix — it doesn't declare any peers
+    const aPkg = {
+      name: 'a',
+      pkgIdWithPatchHash: 'a/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const bPkg = {
+      name: 'b',
+      pkgIdWithPatchHash: 'b/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {
+        c: { version: '1.0.0' },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const cPkg = {
+      name: 'c',
+      pkgIdWithPatchHash: 'c/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const { dependenciesGraph } = await resolvePeers({
+      allPeerDepNames: new Set(['c']),
+      dedupePeers: true,
+      projects: [
+        {
+          directNodeIdsByAlias: new Map([
+            ['a', '>a/1.0.0>' as NodeId],
+            ['c', '>c/1.0.0>' as NodeId],
+          ]),
+          topParents: [],
+          rootDir: '' as ProjectRootDir,
+          id: '',
+        },
+      ],
+      resolvedImporters: {},
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        ['>a/1.0.0>' as NodeId, {
+          children: {
+            b: '>a/1.0.0>b/1.0.0>' as NodeId,
+          },
+          installable: true,
+          resolvedPackage: aPkg,
+          depth: 0,
+        }],
+        ['>a/1.0.0>b/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: bPkg,
+          depth: 1,
+        }],
+        ['>c/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: cPkg,
+          depth: 0,
+        }],
+      ]),
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set(),
+    })
+    expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
+      'a/1.0.0',
+      'b/1.0.0(c@1.0.0)',
+      'c/1.0.0',
+    ])
+  })
+
+  test('multi-project: different peer versions produce different instances', async () => {
+    // project-a has react@17, project-b has react@18
+    // Both have plugin@1 (peer: react)
+    const react17Pkg = {
+      name: 'react',
+      pkgIdWithPatchHash: 'react/17.0.0' as PkgIdWithPatchHash,
+      version: '17.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const react18Pkg = {
+      name: 'react',
+      pkgIdWithPatchHash: 'react/18.0.0' as PkgIdWithPatchHash,
+      version: '18.0.0',
+      peerDependencies: {} as PeerDependencies,
+      id: '' as PkgResolutionId,
+    }
+    const pluginPkg = {
+      name: 'plugin',
+      pkgIdWithPatchHash: 'plugin/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {
+        react: { version: '>=16' },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const { dependenciesGraph, dependenciesByProjectId } = await resolvePeers({
+      allPeerDepNames: new Set(['react']),
+      dedupePeers: true,
+      projects: [
+        {
+          directNodeIdsByAlias: new Map([
+            ['react', '>project-a>react/17.0.0>' as NodeId],
+            ['plugin', '>project-a>plugin/1.0.0>' as NodeId],
+          ]),
+          topParents: [],
+          rootDir: '' as ProjectRootDir,
+          id: 'project-a',
+        },
+        {
+          directNodeIdsByAlias: new Map([
+            ['react', '>project-b>react/18.0.0>' as NodeId],
+            ['plugin', '>project-b>plugin/1.0.0>' as NodeId],
+          ]),
+          topParents: [],
+          rootDir: '' as ProjectRootDir,
+          id: 'project-b',
+        },
+      ],
+      resolvedImporters: {},
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        ['>project-a>react/17.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: react17Pkg,
+          depth: 0,
+        }],
+        ['>project-a>plugin/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: pluginPkg,
+          depth: 0,
+        }],
+        ['>project-b>react/18.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: react18Pkg,
+          depth: 0,
+        }],
+        ['>project-b>plugin/1.0.0>' as NodeId, {
+          children: {},
+          installable: true,
+          resolvedPackage: pluginPkg,
+          depth: 0,
+        }],
+      ]),
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set(),
+    })
+    // Plugin has two instances — one per react version
+    expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
+      'plugin/1.0.0(react@17.0.0)',
+      'plugin/1.0.0(react@18.0.0)',
+      'react/17.0.0',
+      'react/18.0.0',
+    ])
+    // Each project gets the correct instance
+    expect(dependenciesByProjectId['project-a'].get('plugin')).toBe('plugin/1.0.0(react@17.0.0)')
+    expect(dependenciesByProjectId['project-b'].get('plugin')).toBe('plugin/1.0.0(react@18.0.0)')
+  })
+})

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -754,10 +754,10 @@ describe('dedupePeers', () => {
     ])
   })
 
-  test('packages without direct peers get no suffix even when children have peers', async () => {
+  test('transitive peers use version-only suffixes', async () => {
     // A depends on B (peer: C). A has no peers itself.
-    // Without dedupePeers: A gets suffix (C@1.0.0) from transitive propagation
-    // With dedupePeers: A gets no suffix — it doesn't declare any peers
+    // Without dedupePeers: A gets suffix (c/1.0.0) — full dep path
+    // With dedupePeers: A gets suffix (c@1.0.0) — version-only
     const aPkg = {
       name: 'a',
       pkgIdWithPatchHash: 'a/1.0.0' as PkgIdWithPatchHash,
@@ -825,7 +825,7 @@ describe('dedupePeers', () => {
       workspaceProjectIds: new Set(),
     })
     expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
-      'a/1.0.0',
+      'a/1.0.0(c@1.0.0)',
       'b/1.0.0(c@1.0.0)',
       'c/1.0.0',
     ])

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -747,26 +747,11 @@ describe('dedupePeers', () => {
       peersSuffixMaxLength: 1000,
       workspaceProjectIds: new Set(),
     })
-    const depPaths = Object.keys(dependenciesGraph).sort()
-    // With dedupePeers: @emotion/react uses version-only react suffix
-    // and @emotion/styled uses version-only suffixes for both peers.
-    // No nested suffixes like (@emotion/react@11.0.0(react@18.0.0))
-    expect(depPaths).toStrictEqual([
+    expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
       '@emotion/react/11.0.0(react@18.0.0)',
       '@emotion/styled/11.0.0(@emotion/react@11.0.0)(react@18.0.0)',
       'react/18.0.0',
     ])
-    // Verify no nested parentheses in any dep path (version-only means no nesting)
-    for (const depPath of depPaths) {
-      const openParens = depPath.split('(').length - 1
-      const closeParens = depPath.split(')').length - 1
-      expect(openParens).toBe(closeParens)
-      // No nested parens: between any ( and its matching ), there should be no other (
-      if (openParens > 0) {
-        const suffix = depPath.substring(depPath.indexOf('('))
-        expect(suffix).not.toMatch(/\([^)]*\(/)
-      }
-    }
   })
 
   test('packages without direct peers get no suffix even when children have peers', async () => {

--- a/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -62,7 +62,7 @@ export function getOutdatedLockfileSetting (
   if ((lockfile.settings?.autoInstallPeers != null && lockfile.settings.autoInstallPeers !== autoInstallPeers)) {
     return 'settings.autoInstallPeers'
   }
-  if (lockfile.settings?.dedupePeers != null && lockfile.settings.dedupePeers !== dedupePeers) {
+  if (Boolean(lockfile.settings?.dedupePeers) !== Boolean(dedupePeers)) {
     return 'settings.dedupePeers'
   }
   if (lockfile.settings?.excludeLinksFromLockfile != null && lockfile.settings.excludeLinksFromLockfile !== excludeLinksFromLockfile) {

--- a/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -62,7 +62,7 @@ export function getOutdatedLockfileSetting (
   if ((lockfile.settings?.autoInstallPeers != null && lockfile.settings.autoInstallPeers !== autoInstallPeers)) {
     return 'settings.autoInstallPeers'
   }
-  if (Boolean(lockfile.settings?.dedupePeers) !== Boolean(dedupePeers)) {
+  if (lockfile.settings?.dedupePeers != null && lockfile.settings.dedupePeers !== dedupePeers) {
     return 'settings.dedupePeers'
   }
   if (lockfile.settings?.excludeLinksFromLockfile != null && lockfile.settings.excludeLinksFromLockfile !== excludeLinksFromLockfile) {

--- a/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
+++ b/lockfile/settings-checker/src/getOutdatedLockfileSetting.ts
@@ -10,6 +10,7 @@ export type ChangedField =
   | 'packageExtensionsChecksum'
   | 'ignoredOptionalDependencies'
   | 'settings.autoInstallPeers'
+  | 'settings.dedupePeers'
   | 'settings.excludeLinksFromLockfile'
   | 'settings.peersSuffixMaxLength'
   | 'settings.injectWorkspacePackages'
@@ -24,6 +25,7 @@ export function getOutdatedLockfileSetting (
     ignoredOptionalDependencies,
     patchedDependencies,
     autoInstallPeers,
+    dedupePeers,
     excludeLinksFromLockfile,
     peersSuffixMaxLength,
     pnpmfileChecksum,
@@ -35,6 +37,7 @@ export function getOutdatedLockfileSetting (
     patchedDependencies?: Record<string, string>
     ignoredOptionalDependencies?: string[]
     autoInstallPeers?: boolean
+    dedupePeers?: boolean
     excludeLinksFromLockfile?: boolean
     peersSuffixMaxLength?: number
     pnpmfileChecksum?: string
@@ -58,6 +61,9 @@ export function getOutdatedLockfileSetting (
   }
   if ((lockfile.settings?.autoInstallPeers != null && lockfile.settings.autoInstallPeers !== autoInstallPeers)) {
     return 'settings.autoInstallPeers'
+  }
+  if (Boolean(lockfile.settings?.dedupePeers) !== Boolean(dedupePeers)) {
+    return 'settings.dedupePeers'
   }
   if (lockfile.settings?.excludeLinksFromLockfile != null && lockfile.settings.excludeLinksFromLockfile !== excludeLinksFromLockfile) {
     return 'settings.excludeLinksFromLockfile'

--- a/lockfile/types/src/index.ts
+++ b/lockfile/types/src/index.ts
@@ -8,6 +8,7 @@ import type { SpecifierAndResolution } from './lockfileFileTypes.js'
 
 export interface LockfileSettings {
   autoInstallPeers?: boolean
+  dedupePeers?: boolean
   excludeLinksFromLockfile?: boolean
   peersSuffixMaxLength?: number
   injectWorkspacePackages?: boolean

--- a/workspace/state/src/types.ts
+++ b/workspace/state/src/types.ts
@@ -21,6 +21,7 @@ export const WORKSPACE_STATE_SETTING_KEYS = [
   'dedupeDirectDeps',
   'dedupeInjectedDeps',
   'dedupePeerDependents',
+  'dedupePeers',
   'dev',
   'excludeLinksFromLockfile',
   'hoistPattern',


### PR DESCRIPTION
## Summary

- Adds a new opt-in `dedupePeers` setting that reduces peer dependency duplication
- Uses **version-only peer identifiers** (`name@version`) instead of full dep paths when building peer suffixes
- Eliminates nested suffixes like `(@emotion/react@11(react@18))` → `(@emotion/react@11.0.0)`
- Transitive peers are still tracked (per-project isolation preserved), just identified by version instead of full dep path
- Works correctly with `autoInstallPeers`

Closes #11070

## Before/After

**Nested peer suffixes eliminated:**
```
BEFORE: @emotion/styled@11(@emotion/react@11(react@18))(react@18)
AFTER:  @emotion/styled@11(@emotion/react@11.0.0)(react@18.0.0)
```

**Multi-project correctness preserved:**
```
project-1 (peer-c@1.0.0): abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@1.0.0)
project-2 (peer-c@2.0.0): abc-grand-parent@1.0.0(@pnpm.e2e/peer-c@2.0.0)
```

## Test plan

- [x] Unit tests: version-only suffixes, transitive peers with version-only IDs, multi-project isolation
- [x] Integration test: single project with transitive peer chain (abc-grand-parent)
- [x] Integration test: workspace with two projects using different peer-c versions
- [x] All existing tests pass (40/40 in deps-resolver, 67/67 in deps-installer peerDependencies)
- [x] All modified packages compile successfully