### PR TITLE
docs: fix duplicated word in DirPatcher comment

### DIFF
--- a/workspace/injected-deps-syncer/src/DirPatcher.ts
+++ b/workspace/injected-deps-syncer/src/DirPatcher.ts
@@ -6,7 +6,7 @@ import { PnpmError } from '@pnpm/error'
 
 export const DIR: unique symbol = Symbol('Path is a directory')
 
-// symbols and and numbers are used instead of discriminated union because
+// symbols and numbers are used instead of discriminated union because
 // it's faster and simpler to compare primitives than to deep compare objects
 export type File = number // representing the file's inode, which is sufficient for hardlinks
 export type Dir = typeof DIR


### PR DESCRIPTION
## Summary
- fix a duplicated word in the `DirPatcher` comment

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- Read https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md
- one-file comment-only change
- no behavior change
- no changeset added because this change does not affect behavior or release notes

## Validation
- Not run (comment-only change)
