### PR TITLE
fix(exe): hardlink binary as extensionless file on Windows

### DIFF
--- a/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -351,6 +351,7 @@ export function linkExePlatformBinary (installDir: string): void {
     const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
     fs.writeFileSync(path.join(exePkgDir, 'pnpm'), 'This file intentionally left blank')
     exePkg.bin.pnpm = 'pnpm.exe'
+    exePkg.bin.pn = 'pn.exe'
     fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))
   }
 }

--- a/pnpm/artifacts/exe/setup.js
+++ b/pnpm/artifacts/exe/setup.js
@@ -30,10 +30,16 @@ createShellScript(ownDir, 'pnpx', 'pnpm dlx')
 createShellScript(ownDir, 'pnx', 'pnpm dlx')
 
 if (platform === 'win') {
+  // On Windows, also hardlink the binary as 'pnpm' and 'pn' (no .exe
+  // extension). npm's bin shims point to the name from publishConfig.bin,
+  // and npm does NOT re-read package.json after preinstall, so rewriting
+  // the bin entry has no effect on the shims. The file at the original
+  // name must be the real binary so the shim can execute it.
+  linkSync(bin, path.resolve(ownDir, 'pnpm'))
+  linkSync(bin, path.resolve(ownDir, 'pn'))
+
   const pkgJsonPath = path.resolve(ownDir, 'package.json')
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
-  fs.writeFileSync(path.resolve(ownDir, 'pnpm'), 'This file intentionally left blank')
-  fs.writeFileSync(path.resolve(ownDir, 'pn'), 'This file intentionally left blank')
   pkg.bin.pnpm = 'pnpm.exe'
   pkg.bin.pn = 'pn.exe'
   pkg.bin.pnpx = 'pnpx.cmd'


### PR DESCRIPTION
## Summary

- On Windows, npm's `.cmd`/`.ps1` bin shims reference the extensionless `pnpm` file from the published `package.json` bin entry. Previously, `setup.js` and `linkExePlatformBinary` wrote a dummy text file ("This file intentionally left blank") at that path, causing the shim to silently fail — PowerShell's `$LASTEXITCODE` stays `$null`, so `exit $LASTEXITCODE` exits with code 0, making all pnpm commands appear to succeed while doing nothing.
- Fix by hardlinking the real platform binary as both `pnpm.exe` and `pnpm` (no extension), so the shim executes the actual binary.
- Fixes both the published `@pnpm/exe` install script (`setup.js`) and pnpm's internal `linkExePlatformBinary` (used for `manage-package-manager-versions` version switching).

## Test plan

- Windows CI tests should actually execute instead of silently succeeding with no output