### PR TITLE
fix: remove macOS Gatekeeper quarantine xattr from native binaries

### DIFF
--- a/.changeset/fix-macos-gatekeeper-quarantine.md
+++ b/.changeset/fix-macos-gatekeeper-quarantine.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/fs.indexed-pkg-importer": patch
+"pnpm": patch
+---
+
+Fix macOS Gatekeeper blocking native binaries (`.node`, `.dylib`, `.so`) by removing the `com.apple.quarantine` extended attribute after importing them from the store.
+
+When pnpm imports files from its content-addressable store into `node_modules`, macOS preserves extended attributes, including `com.apple.quarantine`. If this xattr is present on a store blob (e.g. it was first written under a Gatekeeper-enabled app such as a Git client), it propagates to `node_modules`, and Gatekeeper blocks the native binary from loading even though pnpm already verified the file's integrity against the lockfile.
+
+After importing a package, pnpm now strips `com.apple.quarantine` from its native binaries, matching Homebrew's behaviour of dropping quarantine from verified downloads. The cleanup is macOS-only, runs in a single batched `xattr` call per package, is restricted to native binaries (other files are untouched), and is non-fatal (it logs a warning on unexpected errors).
+
+Fixes #11056

--- a/cspell.json
+++ b/cspell.json
@@ -417,6 +417,8 @@
     "worktree",
     "worktrees",
     "wrappy",
+    "xattr",
+    "xattrs",
     "xmarw",
     "yazl",
     "zkochan",

--- a/fs/indexed-pkg-importer/src/index.ts
+++ b/fs/indexed-pkg-importer/src/index.ts
@@ -11,6 +11,7 @@ import { fastPathTemp as pathTemp } from 'path-temp'
 import { renameOverwriteSync } from 'rename-overwrite'
 
 import { type Importer, type ImportFile, importIndexedDir } from './importIndexedDir.js'
+import { isNativeBinary, removeQuarantine } from './removeQuarantine.js'
 
 export { type FilesMap, type ImportIndexedPackage, type ImportOptions }
 
@@ -135,6 +136,7 @@ function tryClonePkg (
   if (opts.resolvedFrom !== 'store' || opts.force || !pkgExistsAtTargetDir(to, opts.filesMap)) {
     const clone = createCloneFunction()
     importIndexedDir({ importFile: clone, importFileAtomic: clone }, to, opts.filesMap, opts)
+    removeQuarantineFromNativeBinaries(to, opts)
     return 'clone'
   }
   return undefined
@@ -168,6 +170,7 @@ function createClonePkg (): ImportIndexedPackage {
   return (to: string, opts: ImportOptions) => {
     if (opts.resolvedFrom !== 'store' || opts.force || !pkgExistsAtTargetDir(to, opts.filesMap)) {
       importIndexedDir(importer, to, opts.filesMap, opts)
+      removeQuarantineFromNativeBinaries(to, opts)
       return 'clone'
     }
     return undefined
@@ -229,6 +232,7 @@ function hardlinkPkg (
 ): 'hardlink' | undefined {
   if (opts.force || shouldRelinkPkg(to, opts)) {
     importIndexedDir({ importFile, importFileAtomic: importFile }, to, opts.filesMap, opts)
+    removeQuarantineFromNativeBinaries(to, opts)
     return 'hardlink'
   }
   return undefined
@@ -303,6 +307,7 @@ export function copyPkg (
     // can leave a partially-written file.  package.json is the completion
     // marker, so it must be written atomically via temp file + rename.
     importIndexedDir({ importFile: resilientCopyFileSync, importFileAtomic: atomicCopyFileSync }, to, opts.filesMap, opts)
+    removeQuarantineFromNativeBinaries(to, opts)
     return 'copy'
   }
   return undefined
@@ -319,4 +324,22 @@ function atomicCopyFileSync (src: string, dest: string): void {
     throw err
   }
   renameOverwriteSync(tmp, dest)
+}
+
+// macOS preserves the com.apple.quarantine xattr when files are copied or
+// reflinked out of the store, and for hardlinks the imported file shares the
+// store blob's inode (and thus its xattrs). Either way Gatekeeper can block a
+// native binary from loading. Drop the quarantine once, in a single batched
+// `xattr` call per package, restricted to the few native binaries that
+// Gatekeeper actually guards. Only store imports are cleaned: that's where the
+// quarantine propagation happens and where pnpm has verified file integrity.
+function removeQuarantineFromNativeBinaries (to: string, opts: ImportOptions): void {
+  if (process.platform !== 'darwin' || opts.resolvedFrom !== 'store') return
+  const nativeBinaries: string[] = []
+  for (const file of opts.filesMap.keys()) {
+    if (isNativeBinary(file)) {
+      nativeBinaries.push(path.join(to, file))
+    }
+  }
+  removeQuarantine(nativeBinaries)
 }

--- a/fs/indexed-pkg-importer/src/removeQuarantine.ts
+++ b/fs/indexed-pkg-importer/src/removeQuarantine.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+import { globalWarn } from '@pnpm/logger'
+
+const QUARANTINE_ATTR = 'com.apple.quarantine'
+// Quarantine removal only ever runs on macOS, so the set lists the binary
+// formats Gatekeeper guards there (.dll is Windows-only and never matches).
+const NATIVE_BINARY_EXTENSIONS = new Set(['.node', '.dylib', '.so'])
+// Cap the bytes of file-path arguments per `xattr` call so a package with many
+// (or very long) native-binary paths can't blow past the OS argv limit
+// (ARG_MAX, ~1 MB on macOS). Well under the limit to leave room for argv0 and
+// the environment block.
+const MAX_ARG_BYTES = 100_000
+
+/**
+ * Native binaries are the only files that macOS Gatekeeper blocks for carrying a
+ * quarantine xattr, so removing it from anything else (JavaScript, text, etc.)
+ * just wastes a syscall.
+ */
+export function isNativeBinary (filePath: string): boolean {
+  return NATIVE_BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+}
+
+/**
+ * Remove the macOS Gatekeeper quarantine xattr (com.apple.quarantine) from the
+ * given files using a single `xattr` invocation.
+ *
+ * macOS preserves extended attributes when pnpm copies or reflinks files out of
+ * its content-addressable store. If a store blob carries com.apple.quarantine
+ * (e.g. it was first written under a Gatekeeper-enabled app such as a Git
+ * client), the quarantine propagates to node_modules and Gatekeeper blocks the
+ * native binary from loading, even though pnpm already verified the file's
+ * integrity against the lockfile. This mirrors Homebrew's behaviour of dropping
+ * quarantine from verified downloads.
+ *
+ * File paths are passed as separate arguments rather than interpolated into a
+ * shell command, so package-controlled filenames cannot inject shell commands.
+ * They are split into chunks that stay under the OS argv limit.
+ */
+export function removeQuarantine (filePaths: string[]): void {
+  if (process.platform !== 'darwin') return
+  for (const chunk of chunkByArgSize(filePaths)) {
+    removeQuarantineFromChunk(chunk)
+  }
+}
+
+function removeQuarantineFromChunk (filePaths: string[]): void {
+  try {
+    execFileSync('/usr/bin/xattr', ['-d', QUARANTINE_ATTR, ...filePaths], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+  } catch (err: unknown) {
+    // `xattr -d` exits non-zero when a file simply has no quarantine xattr to
+    // remove ("No such xattr"), which is the common, expected case. It also
+    // reports "No such file" for entries the importer legitimately dropped or
+    // renamed (e.g. case-insensitive filename conflicts). Surface only errors
+    // that are not of those kinds (e.g. permission denied).
+    const realErrors = getStderr(err)
+      .split('\n')
+      .filter((line) => line.trim() !== '' && !line.includes('No such xattr') && !line.includes('No such file'))
+    if (realErrors.length > 0) {
+      globalWarn(`Failed to remove the macOS quarantine attribute:\n${realErrors.join('\n')}`)
+    }
+  }
+}
+
+function chunkByArgSize (filePaths: string[]): string[][] {
+  const chunks: string[][] = []
+  let chunk: string[] = []
+  let chunkBytes = 0
+  for (const filePath of filePaths) {
+    const bytes = Buffer.byteLength(filePath) + 1 // +1 for the argv null terminator
+    if (chunk.length > 0 && chunkBytes + bytes > MAX_ARG_BYTES) {
+      chunks.push(chunk)
+      chunk = []
+      chunkBytes = 0
+    }
+    chunk.push(filePath)
+    chunkBytes += bytes
+  }
+  if (chunk.length > 0) chunks.push(chunk)
+  return chunks
+}
+
+function getStderr (err: unknown): string {
+  if (typeof err === 'object' && err !== null && 'stderr' in err) {
+    const stderr = (err as { stderr?: Buffer | string }).stderr
+    if (stderr != null) return stderr.toString()
+  }
+  return err instanceof Error ? err.message : String(err)
+}

--- a/fs/indexed-pkg-importer/test/removeQuarantine.test.ts
+++ b/fs/indexed-pkg-importer/test/removeQuarantine.test.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, jest, test } from '@jest/globals'
+
+const globalWarn = jest.fn()
+jest.unstable_mockModule('@pnpm/logger', () => ({ globalWarn }))
+
+const { isNativeBinary, removeQuarantine } = await import('../src/removeQuarantine.js')
+
+// Quarantine xattrs only exist on macOS, so these tests are scoped to it.
+const describeOnMacOS = process.platform === 'darwin' ? describe : describe.skip
+
+const QUARANTINE_ATTR = 'com.apple.quarantine'
+
+function setQuarantine (filePath: string): void {
+  execFileSync('/usr/bin/xattr', ['-w', QUARANTINE_ATTR, '0083;00000000;TestApp;', filePath])
+}
+
+function listXattrs (filePath: string): string {
+  return execFileSync('/usr/bin/xattr', ['-l', filePath], { encoding: 'utf8' })
+}
+
+function hasQuarantine (filePath: string): boolean {
+  return listXattrs(filePath).includes(QUARANTINE_ATTR)
+}
+
+test('isNativeBinary matches only native binary extensions handled on macOS', () => {
+  expect(isNativeBinary('rollup.darwin-arm64.node')).toBe(true)
+  expect(isNativeBinary('addon.DYLIB')).toBe(true)
+  expect(isNativeBinary('addon.so')).toBe(true)
+  expect(isNativeBinary('index.js')).toBe(false)
+  expect(isNativeBinary('package.json')).toBe(false)
+  expect(isNativeBinary('README')).toBe(false)
+  // .dll is Windows-only and never relevant on macOS.
+  expect(isNativeBinary('addon.dll')).toBe(false)
+})
+
+describeOnMacOS('removeQuarantine', () => {
+  let testDir: string
+
+  beforeEach(() => {
+    globalWarn.mockClear()
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'quarantine-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('removes the quarantine xattr from a file', () => {
+    const file = path.join(testDir, 'addon.node')
+    fs.writeFileSync(file, 'test content')
+    setQuarantine(file)
+    expect(hasQuarantine(file)).toBe(true)
+
+    removeQuarantine([file])
+
+    expect(hasQuarantine(file)).toBe(false)
+    expect(globalWarn).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the quarantine xattr is absent', () => {
+    const file = path.join(testDir, 'addon.node')
+    fs.writeFileSync(file, 'test content')
+    expect(hasQuarantine(file)).toBe(false)
+
+    expect(() => removeQuarantine([file])).not.toThrow()
+    expect(globalWarn).not.toHaveBeenCalled()
+  })
+
+  it('removes quarantine from a batch of files while preserving other xattrs', () => {
+    const quarantined = path.join(testDir, 'a.node')
+    const clean = path.join(testDir, 'b.node')
+    fs.writeFileSync(quarantined, 'a')
+    fs.writeFileSync(clean, 'b')
+    setQuarantine(quarantined)
+    execFileSync('/usr/bin/xattr', ['-w', 'com.example.custom', 'keep', quarantined])
+
+    removeQuarantine([quarantined, clean])
+
+    expect(hasQuarantine(quarantined)).toBe(false)
+    expect(listXattrs(quarantined)).toContain('com.example.custom')
+    expect(globalWarn).not.toHaveBeenCalled()
+  })
+
+  it('does not warn for missing files (dropped/renamed by the importer)', () => {
+    const quarantined = path.join(testDir, 'real.node')
+    const missing = path.join(testDir, 'dropped.node')
+    fs.writeFileSync(quarantined, 'a')
+    setQuarantine(quarantined)
+
+    removeQuarantine([missing, quarantined])
+
+    expect(hasQuarantine(quarantined)).toBe(false)
+    expect(globalWarn).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when given an empty list', () => {
+    expect(() => removeQuarantine([])).not.toThrow()
+  })
+})

--- a/pacquet/crates/package-manager/src/import_indexed_dir.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir.rs
@@ -1,4 +1,7 @@
-use crate::{LinkFileError, import_into_fresh_target};
+use crate::{
+    LinkFileError, import_into_fresh_target,
+    remove_quarantine::remove_quarantine_from_native_binaries,
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::PackageImportMethod;
@@ -145,10 +148,17 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
         }
     };
 
+    // Drop the macOS quarantine xattr from the package's native binaries after
+    // a populating import, matching pnpm's `removeQuarantineFromNativeBinaries`.
+    // The marker-present short-circuit (and the non-directory dirent left as-is)
+    // import nothing, so they skip the sweep, keeping warm installs free of the
+    // per-install `xattr` cost — exactly pnpm's `!pkgExistsAtTargetDir` gate.
+    let unquarantine = || remove_quarantine_from_native_binaries(dir_path, cas_paths);
     match (existing_kind, opts.force) {
         // Fresh target — populate it. Both linkers take this path on
         // first install.
-        (None, _) => populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths),
+        (None, _) => populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+            .inspect(|()| unquarantine()),
         // Short-circuit only when the completion marker is present
         // (pnpm's `pkgExistsAtTargetDir`, which checks `package.json`),
         // not on mere directory existence. A marker-less directory is a
@@ -159,6 +169,7 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
                 Ok(())
             } else {
                 populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+                    .inspect(|()| unquarantine())
             }
         }
         // A non-directory dirent is left as-is; only force=true clobbers it.
@@ -171,6 +182,7 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
                 ImportIndexedDirError::ClearNonDirEntry { path: dir_path.to_path_buf(), error }
             })?;
             populate_dir::<Reporter>(logged_methods, import_method, dir_path, cas_paths)
+                .inspect(|()| unquarantine())
         }
         // Existing directory with force=true — stage and swap.
         (Some(_), true) => stage_and_swap::<Reporter>(
@@ -179,7 +191,8 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
             dir_path,
             cas_paths,
             opts.keep_modules_dir,
-        ),
+        )
+        .inspect(|()| unquarantine()),
     }
 }
 

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -33,6 +33,7 @@ mod package_extender;
 mod prefetching_resolver;
 mod prune_virtual_store;
 mod remove;
+mod remove_quarantine;
 mod resolution_observer;
 mod resolution_policy;
 mod retry_config;

--- a/pacquet/crates/package-manager/src/remove_quarantine.rs
+++ b/pacquet/crates/package-manager/src/remove_quarantine.rs
@@ -1,0 +1,141 @@
+//! Strip the macOS Gatekeeper quarantine xattr from imported native binaries.
+//!
+//! Ported from pnpm v11's `fs/indexed-pkg-importer/src/removeQuarantine.ts`
+//! and the `removeQuarantineFromNativeBinaries` sweep in
+//! `fs/indexed-pkg-importer/src/index.ts`.
+//!
+//! macOS preserves extended attributes when files are copied, reflinked, or
+//! hardlinked out of the content-addressable store. If a store blob carries
+//! `com.apple.quarantine` (e.g. it was first written under a Gatekeeper-enabled
+//! app such as a Git client), the quarantine propagates into `node_modules` and
+//! Gatekeeper blocks the native binary from loading, even though pacquet has
+//! already verified the file's integrity against the lockfile. Every caller of
+//! [`import_indexed_dir`](crate::import_indexed_dir()) materializes from the
+//! store, which is exactly pnpm's `resolvedFrom === 'store'` gate, so the sweep
+//! runs after any populating import.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+#[cfg(target_os = "macos")]
+use std::{ffi::OsStr, process::Command};
+
+#[cfg(target_os = "macos")]
+const QUARANTINE_ATTR: &str = "com.apple.quarantine";
+
+// Native binaries are the only files macOS Gatekeeper blocks for carrying a
+// quarantine xattr; `.dll` is Windows-only and never relevant here.
+#[cfg(target_os = "macos")]
+const NATIVE_BINARY_EXTENSIONS: [&str; 3] = ["node", "dylib", "so"];
+
+// Cap the bytes of file-path arguments per `xattr` call so a package with many
+// (or very long) native-binary paths can't blow past the OS argv limit
+// (ARG_MAX, ~1 MB on macOS). Well under the limit to leave room for argv0 and
+// the environment block.
+#[cfg(target_os = "macos")]
+const MAX_ARG_BYTES: usize = 100_000;
+
+/// Run a single batched quarantine sweep over the native binaries an import
+/// just placed under `dir_path`. The relative entry paths come from the indexed
+/// `cas_paths`, so the targets are `dir_path.join(entry)`. A no-op off macOS.
+#[cfg(target_os = "macos")]
+pub(crate) fn remove_quarantine_from_native_binaries(
+    dir_path: &Path,
+    cas_paths: &HashMap<String, PathBuf>,
+) {
+    let native_binaries: Vec<PathBuf> = cas_paths
+        .keys()
+        .filter(|entry| is_native_binary(entry))
+        .map(|entry| dir_path.join(entry))
+        .collect();
+    remove_quarantine(&native_binaries);
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn remove_quarantine_from_native_binaries(
+    _dir_path: &Path,
+    _cas_paths: &HashMap<String, PathBuf>,
+) {
+}
+
+#[cfg(target_os = "macos")]
+fn is_native_binary(entry: &str) -> bool {
+    Path::new(entry).extension().and_then(OsStr::to_str).is_some_and(|ext| {
+        NATIVE_BINARY_EXTENSIONS.iter().any(|known| known.eq_ignore_ascii_case(ext))
+    })
+}
+
+/// Remove `com.apple.quarantine` from the given files, split into chunks that
+/// stay under the OS argv limit. Paths are passed as separate arguments (never
+/// interpolated into a shell), so package-controlled filenames cannot inject
+/// shell commands. Non-fatal: errors that aren't a missing xattr or a missing
+/// file are logged and the install continues.
+#[cfg(target_os = "macos")]
+fn remove_quarantine(file_paths: &[PathBuf]) {
+    for chunk in chunk_by_arg_size(file_paths) {
+        remove_quarantine_from_chunk(&chunk);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn remove_quarantine_from_chunk(file_paths: &[&Path]) {
+    let output =
+        Command::new("/usr/bin/xattr").arg("-d").arg(QUARANTINE_ATTR).args(file_paths).output();
+    match output {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            // `xattr -d` exits non-zero when a file simply has no quarantine
+            // xattr ("No such xattr"), the common case, and reports "No such
+            // file" for entries the importer legitimately dropped or renamed.
+            // Surface only errors that are not of those kinds.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let real_errors: Vec<&str> = stderr
+                .lines()
+                .filter(|line| {
+                    !line.trim().is_empty()
+                        && !line.contains("No such xattr")
+                        && !line.contains("No such file")
+                })
+                .collect();
+            if !real_errors.is_empty() {
+                tracing::warn!(
+                    target: "pacquet::remove_quarantine",
+                    errors = real_errors.join("\n"),
+                    "failed to remove the macOS quarantine attribute",
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "pacquet::remove_quarantine",
+                %error,
+                "failed to spawn xattr to remove the macOS quarantine attribute",
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn chunk_by_arg_size(file_paths: &[PathBuf]) -> Vec<Vec<&Path>> {
+    let mut chunks: Vec<Vec<&Path>> = Vec::new();
+    let mut chunk: Vec<&Path> = Vec::new();
+    let mut chunk_bytes = 0;
+    for file_path in file_paths {
+        let bytes = file_path.as_os_str().len() + 1; // +1 for the argv null terminator
+        if !chunk.is_empty() && chunk_bytes + bytes > MAX_ARG_BYTES {
+            chunks.push(std::mem::take(&mut chunk));
+            chunk_bytes = 0;
+        }
+        chunk.push(file_path.as_path());
+        chunk_bytes += bytes;
+    }
+    if !chunk.is_empty() {
+        chunks.push(chunk);
+    }
+    chunks
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/remove_quarantine/tests.rs
+++ b/pacquet/crates/package-manager/src/remove_quarantine/tests.rs
@@ -1,0 +1,127 @@
+// Quarantine xattrs only exist on macOS, so these tests (and the helpers they
+// call) are scoped to it; the whole module compiles to nothing elsewhere.
+#![cfg(target_os = "macos")]
+
+use super::{is_native_binary, remove_quarantine, remove_quarantine_from_native_binaries};
+use std::{collections::HashMap, fs, path::Path, process::Command};
+
+const QUARANTINE_ATTR: &str = "com.apple.quarantine";
+
+fn set_quarantine(path: &Path) {
+    let status = Command::new("/usr/bin/xattr")
+        .arg("-w")
+        .arg(QUARANTINE_ATTR)
+        .arg("0083;00000000;TestApp;")
+        .arg(path)
+        .status()
+        .expect("spawn xattr -w");
+    assert!(status.success(), "failed to set quarantine on {path:?}");
+}
+
+fn list_xattrs(path: &Path) -> String {
+    let output =
+        Command::new("/usr/bin/xattr").arg("-l").arg(path).output().expect("spawn xattr -l");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn has_quarantine(path: &Path) -> bool {
+    list_xattrs(path).contains(QUARANTINE_ATTR)
+}
+
+#[test]
+fn matches_only_native_binary_extensions() {
+    assert!(is_native_binary("rollup.darwin-arm64.node"));
+    assert!(is_native_binary("libfoo.DYLIB"));
+    assert!(is_native_binary("addon.so"));
+    assert!(!is_native_binary("index.js"));
+    assert!(!is_native_binary("package.json"));
+    assert!(!is_native_binary("README"));
+    // `.dll` is Windows-only and never relevant on macOS.
+    assert!(!is_native_binary("addon.dll"));
+}
+
+#[test]
+fn removes_quarantine_from_a_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("addon.node");
+    fs::write(&file, b"test content").unwrap();
+    set_quarantine(&file);
+    assert!(has_quarantine(&file));
+
+    remove_quarantine(std::slice::from_ref(&file));
+
+    assert!(!has_quarantine(&file));
+}
+
+#[test]
+fn does_nothing_when_quarantine_is_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("addon.node");
+    fs::write(&file, b"test content").unwrap();
+    assert!(!has_quarantine(&file));
+
+    remove_quarantine(std::slice::from_ref(&file));
+
+    assert!(!has_quarantine(&file));
+}
+
+#[test]
+fn removes_from_a_batch_while_preserving_other_xattrs() {
+    let dir = tempfile::tempdir().unwrap();
+    let quarantined = dir.path().join("a.node");
+    let clean = dir.path().join("b.node");
+    fs::write(&quarantined, b"a").unwrap();
+    fs::write(&clean, b"b").unwrap();
+    set_quarantine(&quarantined);
+    Command::new("/usr/bin/xattr")
+        .arg("-w")
+        .arg("com.example.custom")
+        .arg("keep")
+        .arg(&quarantined)
+        .status()
+        .expect("spawn xattr -w custom");
+
+    remove_quarantine(&[quarantined.clone(), clean]);
+
+    assert!(!has_quarantine(&quarantined));
+    assert!(list_xattrs(&quarantined).contains("com.example.custom"));
+}
+
+#[test]
+fn tolerates_missing_files_in_the_batch() {
+    let dir = tempfile::tempdir().unwrap();
+    let quarantined = dir.path().join("real.node");
+    let missing = dir.path().join("dropped.node");
+    fs::write(&quarantined, b"a").unwrap();
+    set_quarantine(&quarantined);
+
+    remove_quarantine(&[missing, quarantined.clone()]);
+
+    assert!(!has_quarantine(&quarantined));
+}
+
+#[test]
+fn sweep_targets_only_native_binaries_under_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let native = dir.path().join("lib/addon.node");
+    let script = dir.path().join("index.js");
+    fs::create_dir_all(native.parent().unwrap()).unwrap();
+    fs::write(&native, b"a").unwrap();
+    fs::write(&script, b"b").unwrap();
+    set_quarantine(&native);
+    set_quarantine(&script);
+
+    let cas_paths = HashMap::from([
+        ("lib/addon.node".to_string(), native.clone()),
+        ("index.js".to_string(), script.clone()),
+    ]);
+    remove_quarantine_from_native_binaries(dir.path(), &cas_paths);
+
+    assert!(!has_quarantine(&native), "native binary should be unquarantined");
+    assert!(has_quarantine(&script), "non-binary files must be left untouched");
+}
+
+#[test]
+fn empty_list_is_a_noop() {
+    remove_quarantine(&[]);
+}


### PR DESCRIPTION
Fixes #11056

## Problem

On macOS, pnpm imports files from its content-addressable store into `node_modules` via copy, reflink/clone, or hardlink. All three preserve extended attributes, including `com.apple.quarantine`. If a store blob carries that xattr — e.g. it was first written under a Gatekeeper-enabled app such as a Git client (`LSFileQuarantineEnabled=YES`) — the quarantine propagates into `node_modules`. Gatekeeper then blocks ad-hoc-signed native binaries (`.node`, `.dylib`, `.so`) from loading, even though pnpm has already verified each file's integrity against `pnpm-lock.yaml`.

## Solution

After importing a package from the store, strip `com.apple.quarantine` from its native binaries — mirroring Homebrew's behaviour of dropping quarantine from downloads after checksum verification.

### Implementation (pnpm / TypeScript)

**`fs/indexed-pkg-importer/src/removeQuarantine.ts`**
- `isNativeBinary(path)` — matches the binary formats Gatekeeper guards on macOS (`.node`, `.dylib`, `.so`).
- `removeQuarantine(paths)` — removes the xattr via `execFileSync('/usr/bin/xattr', ['-d', 'com.apple.quarantine', ...paths])`. Paths are passed as argv (never interpolated into a shell) and split into chunks that stay under the OS argv limit.

**`fs/indexed-pkg-importer/src/index.ts`**
- `removeQuarantineFromNativeBinaries(to, opts)` runs once per package after every import path (clone, hardlink, copy), collecting the package's native binaries and removing quarantine in a single batched call.

### Implementation (pacquet / Rust port)

The same behaviour is ported to the Rust CLI so the two stacks stay in sync:

**`pacquet/crates/package-manager/src/remove_quarantine.rs`** — `is_native_binary` + a batched, argv-chunked `xattr -d` invocation via `std::process::Command` (no shell). The whole module is `#[cfg(target_os = "macos")]` with a no-op stub elsewhere.

**`pacquet/crates/package-manager/src/import_indexed_dir.rs`** — sweeps native binaries after each *populating* import branch (`populate_dir` / `stage_and_swap`) and skips the warm short-circuit. Every `import_indexed_dir` caller materializes from the CAS store, which is exactly pnpm's `resolvedFrom === 'store'` gate.

### Design

- **macOS-only** — a no-op on other platforms (compiled out entirely in pacquet).
- **Native binaries only** — other files are never touched, so the overhead is limited to the few files Gatekeeper actually guards.
- **Store imports only** — scoped to `resolvedFrom === 'store'` (pnpm) / populating CAS imports (pacquet), where the propagation happens and where integrity has been verified.
- **Batched** — one `xattr` invocation per package (chunked under the argv limit), not one process per file.
- **Hardlink aware** — for hardlinks the imported file shares the store blob's inode, so the same call clears quarantine there too.
- **Non-fatal** — "No such xattr" (nothing to remove) and "No such file" (entries the importer dropped/renamed) are ignored; any other error logs a warning and installation continues.

### Performance

The sweep is confined to the cold path: it runs only on macOS, only after a *populating* store import (fresh/changed package), and is skipped on warm installs (pnpm's `pkgExistsAtTargetDir` guard / pacquet's marker-present short-circuit). Packages with no native binaries spawn no process. So the cost is one batched `xattr` call per native-binary package on a cold macOS install — not per file, and never on repeat installs or other platforms.

## Security rationale

Removing quarantine after integrity verification is safe: pnpm verifies each file's hash against the lockfile before use, so Gatekeeper's "unverified download" protection is redundant. Only `com.apple.quarantine` is removed; other extended attributes are preserved. This is the same approach [Homebrew](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/artifact/binary.rb) uses for verified downloads.

## Testing

- **pnpm:** `fs/indexed-pkg-importer/test/removeQuarantine.test.ts` covers extension matching, single-file and batch removal, preservation of other xattrs, missing-file tolerance (no spurious warnings), and empty input. The behavioural tests are macOS-scoped.
- **pacquet:** `remove_quarantine` tests cover the same cases plus a directory-level sweep that confirms only native binaries are touched.

## Related

- npm issue: https://github.com/npm/cli/issues/4435

---

_PR title and description updated for accuracy by Claude (Opus 4.8) on behalf of @zkochan, to match the current implementation (pnpm + pacquet)._
