### PR TITLE
feat: add auto-dedupe setting for automatic deduplication after install

### DIFF
--- a/.changeset/auto-dedupe-after-install.md
+++ b/.changeset/auto-dedupe-after-install.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/installing.commands": minor
+"pnpm": minor
+---
+
+Added a new setting `auto-dedupe` that automatically deduplicates dependencies during installation [#7258](https://github.com/pnpm/pnpm/issues/7258).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -26,6 +26,7 @@ export interface Config extends AuthInfo, OptionsFromRootManifest {
 
   allowNew: boolean
   autoConfirmAllPrompts?: boolean
+  autoDedupe?: boolean
   autoInstallPeers?: boolean
   bail: boolean
   color: 'always' | 'auto' | 'never'

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -56,6 +56,7 @@ export type PnpmConfigFileKey = typeof pnpmConfigFileKeys[number]
  * They are usually CLI flags or workspace-only settings.
  */
 export const excludedPnpmKeys = [
+  'auto-dedupe',
   'auto-install-peers',
   'catalog-mode',
   'config-dir',

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -2,6 +2,7 @@ import npmTypes from '@pnpm/npm-conf/lib/types.js'
 import type { TrustPolicy } from '@pnpm/types'
 
 export const pnpmTypes = {
+  'auto-dedupe': Boolean,
   'auto-install-peers': Boolean,
   bail: Boolean,
   ci: Boolean,

--- a/installing/commands/src/add.ts
+++ b/installing/commands/src/add.ts
@@ -176,6 +176,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           OPTIONS.globalDir,
           ...UNIVERSAL_OPTIONS,
           {
+            description: 'Automatically deduplicate dependencies after installation',
+            name: '--auto-dedupe',
+          },
+          {
             description: 'A list of package names that are allowed to run postinstall scripts during installation',
             name: '--allow-build',
           },

--- a/installing/commands/src/add.ts
+++ b/installing/commands/src/add.ts
@@ -24,6 +24,7 @@ export const shorthands: Record<string, string> = {
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
+    'auto-dedupe',
     'cache-dir',
     'cpu',
     'child-concurrency',
@@ -298,6 +299,7 @@ export async function handler (
     return installDeps({
       ...opts,
       allowBuilds: mergedAllowBuilds,
+      dedupe: opts.autoDedupe,
       rebuildHandler: commands?.rebuild,
       fetchFullMetadata: getFetchFullMetadata(opts),
       include,
@@ -306,6 +308,7 @@ export async function handler (
   }
   return installDeps({
     ...opts,
+    dedupe: opts.autoDedupe,
     rebuildHandler: commands?.rebuild,
     fetchFullMetadata: getFetchFullMetadata(opts),
     include,

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -13,6 +13,7 @@ import { installDeps, type InstallDepsOptions } from './installDeps.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
+    'auto-dedupe',
     'cache-dir',
     'child-concurrency',
     'cpu',
@@ -126,6 +127,10 @@ For options that may be used with `-r`, see "pnpm help recursive"',
           {
             description: 'Skip reinstall if the workspace state is up-to-date',
             name: '--optimistic-repeat-install',
+          },
+          {
+            description: 'Automatically deduplicate dependencies after installation',
+            name: '--auto-dedupe',
           },
           {
             description: '`optionalDependencies` are not installed',
@@ -266,6 +271,7 @@ Install all optionalDependencies even when they don\'t satisfy the current envir
 
 export type InstallCommandOptions = Pick<Config,
 | 'allProjects'
+| 'autoDedupe'
 | 'autoInstallPeers'
 | 'bail'
 | 'bin'
@@ -378,6 +384,9 @@ export async function handler (opts: InstallCommandOptions & { _calledFromLink?:
   if (opts.resolutionOnly) {
     installDepsOptions.lockfileOnly = true
     installDepsOptions.forceFullResolution = true
+  }
+  if (opts.autoDedupe) {
+    installDepsOptions.dedupe = true
   }
   return installDeps(installDepsOptions, [])
 }

--- a/installing/commands/test/install.ts
+++ b/installing/commands/test/install.ts
@@ -12,6 +12,38 @@ import { DEFAULT_OPTS } from './utils/index.js'
 
 const describeOnLinuxOnly = process.platform === 'linux' ? describe : describe.skip
 
+describe('auto-dedupe', () => {
+  test('cliOptionsTypes includes auto-dedupe', () => {
+    expect(install.cliOptionsTypes()).toHaveProperty('auto-dedupe')
+  })
+
+  test('install with autoDedupe deduplicates dependencies', async () => {
+    const rootProjectManifest = {
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+    }
+    prepare(rootProjectManifest)
+
+    // First, install normally
+    await install.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      rootProjectManifest,
+    })
+
+    // Then, install with autoDedupe enabled — should not fail
+    await install.handler({
+      ...DEFAULT_OPTS,
+      dir: process.cwd(),
+      rootProjectManifest,
+      autoDedupe: true,
+    })
+
+    expect(fs.existsSync('node_modules/is-positive')).toBeTruthy()
+  })
+})
+
 test('install fails if no package.json is found', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
## Summary
- Added a new `auto-dedupe` setting that automatically deduplicates dependencies during `pnpm install` and `pnpm add`
- When `auto-dedupe=true` is set in `.npmrc`, the install process runs with deduplication enabled, removing older dependency versions when a newer version satisfying all ranges exists
- Supports both `.npmrc` configuration and `--auto-dedupe` CLI flag

## Usage
```ini
# .npmrc
auto-dedupe=true
```
or
```bash
pnpm install --auto-dedupe
```

## How it works
When enabled, the `dedupe: true` flag is passed to the install pipeline — the same mechanism used by `pnpm dedupe`. This triggers `forgetResolutionsOfAllPrevWantedDeps()` during resolution, allowing the resolver to pick deduplicated versions.

Closes https://github.com/pnpm/pnpm/issues/7258

## Test plan
- [ ] Run `pnpm install` with `auto-dedupe=true` in `.npmrc` and verify lockfile has deduplicated dependencies
- [ ] Run `pnpm install --auto-dedupe` and verify same behavior
- [ ] Run `pnpm add <pkg> --auto-dedupe` and verify deduplication occurs
- [ ] Run `pnpm install` without the setting and verify no deduplication (backward compatible)
- [ ] Verify `optimistic-repeat-install` is correctly bypassed when `auto-dedupe` is active
