### PR TITLE
fix(exe): add pn and pnx to BIN_OWNER_OVERRIDES and @pnpm/exe files list

### DIFF
--- a/.changeset/fix-pn-pnx-bin-aliases.md
+++ b/.changeset/fix-pn-pnx-bin-aliases.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/bins.resolver": patch
+"@pnpm/exe": patch
+"pnpm": patch
+---
+
+Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases, and the `@pnpm/exe` package was not including the bin placeholder files in its published tarball.

--- a/.changeset/fix-pn-pnx-bin-aliases.md
+++ b/.changeset/fix-pn-pnx-bin-aliases.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/bins.resolver": patch
+"@pnpm/engine.pm-commands": patch
 "pnpm": patch
 ---
 
-Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases.
+Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases, and `linkExePlatformBinary` in self-update was only creating the `pnpm` binary link without also creating `pn`, `pnpx`, and `pnx`.

--- a/.changeset/fix-pn-pnx-bin-aliases.md
+++ b/.changeset/fix-pn-pnx-bin-aliases.md
@@ -1,7 +1,6 @@
 ---
 "@pnpm/bins.resolver": patch
-"@pnpm/exe": patch
 "pnpm": patch
 ---
 
-Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases, and the `@pnpm/exe` package was not including the bin placeholder files in its published tarball.
+Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases.

--- a/.changeset/fix-pn-pnx-bin-aliases.md
+++ b/.changeset/fix-pn-pnx-bin-aliases.md
@@ -1,7 +1,8 @@
 ---
 "@pnpm/bins.resolver": patch
 "@pnpm/engine.pm-commands": patch
+"@pnpm/exe": patch
 "pnpm": patch
 ---
 
-Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases, and `linkExePlatformBinary` in self-update was only creating the `pnpm` binary link without also creating `pn`, `pnpx`, and `pnx`.
+Fixed `pn` and `pnx` short aliases not working when pnpm is installed via `@pnpm/exe`. The `BIN_OWNER_OVERRIDES` map was missing entries for the new aliases, `linkExePlatformBinary` in self-update was only creating the `pnpm` binary link, and the published `@pnpm/exe` tarball contained dead placeholder files for `pn`/`pnpx`/`pnx` that didn't work when preinstall scripts were skipped.

--- a/bins/resolver/src/index.ts
+++ b/bins/resolver/src/index.ts
@@ -15,8 +15,10 @@ export interface Command {
 // `pnpm` package and the `@pnpm/exe` package.
 export const BIN_OWNER_OVERRIDES: Record<string, string[]> = {
   npx: ['npm'],
+  pn: ['pnpm', '@pnpm/exe'],
   pnpm: ['@pnpm/exe'],
   pnpx: ['pnpm', '@pnpm/exe'],
+  pnx: ['pnpm', '@pnpm/exe'],
 }
 
 export function pkgOwnsBin (binName: string, pkgName: string): boolean {

--- a/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -349,7 +349,7 @@ export function linkExePlatformBinary (installDir: string): void {
   createShellScript(exePkgDir, 'pnx', 'pnpm dlx')
 
   if (platform === 'win') {
-    // On Windows, also hardlink the binary as extensionless files
+    // On Windows, also hardlink the binary without extension
     forceLink(src, path.join(exePkgDir, 'pnpm'))
     forceLink(src, path.join(exePkgDir, 'pn'))
 

--- a/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -318,7 +318,7 @@ async function installFromResolution (
 // @pnpm/exe bundles Node.js via optional platform-specific packages (e.g. @pnpm/macos-arm64).
 // Its postinstall script links the correct binary into the @pnpm/exe package dir.
 // Since scripts are disabled during install (to support systems without Node.js),
-// we replicate that linking here.
+// we replicate that linking here — including the pn alias and pnpx/pnx scripts.
 export function linkExePlatformBinary (installDir: string): void {
   const platform = process.platform === 'win32'
     ? 'win'
@@ -337,6 +337,33 @@ export function linkExePlatformBinary (installDir: string): void {
   const src = path.join(platformPkgDir, executable)
   if (!fs.existsSync(src)) return
   const dest = path.join(exePkgDir, executable)
+  forceLink(src, dest)
+  fs.chmodSync(dest, 0o755)
+
+  // Create pn alias (hardlink to the same binary)
+  const pnExecutable = platform === 'win' ? 'pn.exe' : 'pn'
+  forceLink(src, path.join(exePkgDir, pnExecutable))
+
+  // Create pnpx and pnx scripts
+  createShellScript(exePkgDir, 'pnpx', 'pnpm dlx')
+  createShellScript(exePkgDir, 'pnx', 'pnpm dlx')
+
+  if (platform === 'win') {
+    // On Windows, also hardlink the binary as extensionless files
+    forceLink(src, path.join(exePkgDir, 'pnpm'))
+    forceLink(src, path.join(exePkgDir, 'pn'))
+
+    const exePkgJsonPath = path.join(exePkgDir, 'package.json')
+    const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
+    exePkg.bin.pnpm = 'pnpm.exe'
+    exePkg.bin.pn = 'pn.exe'
+    exePkg.bin.pnpx = 'pnpx.cmd'
+    exePkg.bin.pnx = 'pnx.cmd'
+    fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))
+  }
+}
+
+function forceLink (src: string, dest: string): void {
   try {
     fs.unlinkSync(dest)
   } catch (err: unknown) {
@@ -345,14 +372,14 @@ export function linkExePlatformBinary (installDir: string): void {
     }
   }
   fs.linkSync(src, dest)
-  fs.chmodSync(dest, 0o755)
-  if (platform === 'win') {
-    const exePkgJsonPath = path.join(exePkgDir, 'package.json')
-    const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
-    fs.writeFileSync(path.join(exePkgDir, 'pnpm'), 'This file intentionally left blank')
-    exePkg.bin.pnpm = 'pnpm.exe'
-    exePkg.bin.pn = 'pn.exe'
-    fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))
+}
+
+function createShellScript (dir: string, name: string, command: string): void {
+  fs.writeFileSync(path.join(dir, name), `#!/bin/sh\nexec ${command} "$@"\n`, { mode: 0o755 })
+
+  if (process.platform === 'win32') {
+    fs.writeFileSync(path.join(dir, name + '.cmd'), `@echo off\n${command} %*\n`)
+    fs.writeFileSync(path.join(dir, name + '.ps1'), `${command} @args\n`)
   }
 }
 

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -18,11 +18,7 @@
   "files": [
     "setup.js",
     "prepare.js",
-    "dist/",
-    "pnpm",
-    "pn",
-    "pnpx",
-    "pnx"
+    "dist/"
   ],
   "scripts": {
     "preinstall": "node setup.js",

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -18,7 +18,11 @@
   "files": [
     "setup.js",
     "prepare.js",
-    "dist/"
+    "dist/",
+    "pnpm",
+    "pn",
+    "pnpx",
+    "pnx"
   ],
   "scripts": {
     "preinstall": "node setup.js",

--- a/pnpm/artifacts/exe/prepare.js
+++ b/pnpm/artifacts/exe/prepare.js
@@ -4,12 +4,23 @@ import path from 'path'
 const ownDir = import.meta.dirname
 const placeholder = 'This file intentionally left blank'
 
-for (const name of ['pnpm', 'pn', 'pnpx', 'pnx']) {
+// pnpm is always replaced by setup.js (preinstall) or linkExePlatformBinary,
+// so a dead placeholder is fine.
+writeFile('pnpm', placeholder)
+
+// pn/pnpx/pnx must be functional shell scripts so they work even when
+// preinstall scripts are skipped (e.g. pnpm self-update uses ignoreScripts).
+// setup.js will replace pn with a hardlink for better performance when it runs.
+writeFile('pn', '#!/bin/sh\nexec "$(dirname "$0")/pnpm" "$@"\n', 0o755)
+writeFile('pnpx', '#!/bin/sh\nexec "$(dirname "$0")/pnpm" dlx "$@"\n', 0o755)
+writeFile('pnx', '#!/bin/sh\nexec "$(dirname "$0")/pnpm" dlx "$@"\n', 0o755)
+
+function writeFile (name, content, mode) {
   const file = path.join(ownDir, name)
   try {
     fs.unlinkSync(file)
   } catch (e) {
     if (e.code !== 'ENOENT') throw e
   }
-  fs.writeFileSync(file, placeholder, 'utf8')
+  fs.writeFileSync(file, content, { mode })
 }


### PR DESCRIPTION
## Summary

- Added `pn` and `pnx` entries to `BIN_OWNER_OVERRIDES` in `bins/resolver/src/index.ts` so they are recognized as legitimate bin names owned by `pnpm` and `@pnpm/exe`
- Added `pnpm`, `pn`, `pnpx`, `pnx` placeholder files to the `files` array in `@pnpm/exe`'s `package.json` so they are included in the published tarball and available for bin linking

These were missed when the short aliases were added in #11052, causing `pn` and `pnx` to resolve to placeholder files ("This file intentionally left blank") instead of the actual binary.

## Test plan

- [ ] Verify `pn --version` works after installing `@pnpm/exe` globally
- [ ] Verify `pnpm run` scripts using `pn` work (e.g., `pnpm run lint` in the monorepo root)
- [ ] Verify no bin ownership conflicts when installing `pnpm` or `@pnpm/exe` globally