### PR TITLE
fix(lockfile.merger): preserve dependenciesMeta and publishDirectory of importers

### DIFF
--- a/.changeset/preserve-importer-fields.md
+++ b/.changeset/preserve-importer-fields.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.merger": patch
+"pnpm": patch
+---
+
+Ensure that `dependenciesMeta` and `publishDirectory` are preserved when merging importers in the lockfile.

--- a/lockfile/merger/src/index.ts
+++ b/lockfile/merger/src/index.ts
@@ -25,6 +25,8 @@ export function mergeLockfileChanges (ours: LockfileObject, theirs: LockfileObje
 
   for (const importerId of Array.from(new Set([...Object.keys(ours.importers), ...Object.keys(theirs.importers)] as ProjectId[]))) {
     newLockfile.importers[importerId] = {
+      ...ours.importers[importerId],
+      ...theirs.importers[importerId],
       specifiers: {},
     }
     for (const key of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {

--- a/lockfile/merger/test/index.ts
+++ b/lockfile/merger/test/index.ts
@@ -387,3 +387,36 @@ test('does not crash when merging non-semver versions (link: protocol)', () => {
   // Should not crash and should pick theirs (the incoming change)
   expect(mergedLockfile.packages?.['/a@1.0.0' as DepPath].dependencies?.linked).toBe('link:../pkg2')
 })
+
+test('preserves dependenciesMeta and publishDirectory of importers', () => {
+  const ours: LockfileObject = {
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: { foo: '1.0.0' },
+        specifiers: { foo: '1.0.0' },
+        dependenciesMeta: {
+          foo: { injected: true },
+        },
+        publishDirectory: 'dist',
+      },
+    },
+    lockfileVersion: '6.0',
+  }
+
+  const theirs: LockfileObject = {
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: { foo: '1.1.0' },
+        specifiers: { foo: '1.1.0' },
+      },
+    },
+    lockfileVersion: '6.0',
+  }
+
+  const mergedLockfile = mergeLockfileChanges(ours, theirs)
+
+  expect(mergedLockfile.importers['.' as ProjectId].dependenciesMeta).toStrictEqual({
+    foo: { injected: true },
+  })
+  expect(mergedLockfile.importers['.' as ProjectId].publishDirectory).toBe('dist')
+})


### PR DESCRIPTION
When merging lockfile changes, some fields in the importer snapshots were being dropped (e.g. `dependenciesMeta`, `publishDirectory`). This PR ensures that all fields from original importer snapshots are preserved during the merge process.