### PR TITLE
docs: fix typo in tarball parsing comment

### DIFF
--- a/store/cafs/src/parseTarball.ts
+++ b/store/cafs/src/parseTarball.ts
@@ -120,7 +120,7 @@ export function parseTarball (buffer: Buffer): IParseResult {
       // The file mode is an octal number encoded as UTF-8. It is terminated by a NUL or space. Maximum length 8 characters.
         mode = parseOctal(blockStart + MODE_OFFSET, 8)
 
-        // The TAR format is an append-only data structure; as such later entries with the same name supercede earlier ones.
+        // The TAR format is an append-only data structure; as such later entries with the same name supersede earlier ones.
         files.set(fileName.replaceAll('//', '/'), { offset: blockStart + 512, mode, size: fileSize })
         break
       case FILE_TYPE_DIRECTORY:


### PR DESCRIPTION
## Summary
- fix a typo in the TAR parsing comment in `parseTarball.ts`

## Related issue
- N/A

## Guideline alignment
- Reviewed [CONTRIBUTING.md](https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md)
- Kept this to a single comment-only change in one file with no behavior change

## Validation/testing note
- Not run locally; comment-only change
