### PR TITLE
fix(resolver): resolve bin paths from virtual store layout (#11107)

### DIFF
--- a/bins/linker/test/index.ts
+++ b/bins/linker/test/index.ts
@@ -209,6 +209,36 @@ test('linkBinsOfPackages()', async () => {
   expect(content).toMatch('node_modules/simple/index.js')
 })
 
+testOnWindows('linkBinsOfPackages() resolves node_modules bin paths from the virtual store layout', async () => {
+  const binTarget = temporaryDirectory()
+  const virtualStoreDir = path.join(temporaryDirectory(), 'node_modules', '.pnpm', 'meta-tool@1.0.0', 'node_modules')
+  const metaDir = path.join(virtualStoreDir, 'meta-tool')
+  const depDir = path.join(virtualStoreDir, 'dep-tool')
+  fs.mkdirSync(metaDir, { recursive: true })
+  fs.mkdirSync(depDir, { recursive: true })
+  fs.writeFileSync(path.join(depDir, 'cli.js'), '#!/usr/bin/env node\nconsole.log("dep")\n', 'utf8')
+
+  await linkBinsOfPackages(
+    [
+      {
+        location: metaDir,
+        manifest: {
+          name: 'meta-tool',
+          version: '1.0.0',
+          bin: {
+            'meta-tool': 'node_modules/dep-tool/cli.js',
+          },
+        },
+      },
+    ],
+    binTarget
+  )
+
+  expect(globalWarn).not.toHaveBeenCalled()
+  expect(fs.readdirSync(binTarget)).toEqual(getExpectedBins(['meta-tool']))
+  expect(fs.readFileSync(path.join(binTarget, `meta-tool${CMD_EXTENSION}`), 'utf8')).toMatch(/dep-tool[\\/]+cli\.js/)
+})
+
 test('linkBinsOfPkgsByAliases()', async () => {
   const binTarget = temporaryDirectory()
   const simpleFixture = f.prepare('simple-fixture')

--- a/bins/resolver/src/index.ts
+++ b/bins/resolver/src/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 
 import type { DependencyManifest, PackageBin } from '@pnpm/types'
@@ -70,11 +71,54 @@ function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string): Co
     if (binName !== encodeURIComponent(binName) && binName !== '$') {
       continue
     }
-    const binPath = path.join(pkgPath, binRelativePath)
-    if (!isSubdir(pkgPath, binPath)) {
+    const binPath = resolveBinPath(pkgPath, binRelativePath)
+    if (binPath == null) {
       continue
     }
     cmds.push({ name: binName, path: binPath })
   }
   return cmds
+}
+
+function resolveBinPath (pkgPath: string, binRelativePath: string): string | null {
+  const directBinPath = path.join(pkgPath, binRelativePath)
+  const directBinPathIsSafe = isSubdir(pkgPath, directBinPath)
+  if (!referencesDependencyNodeModules(binRelativePath)) {
+    return directBinPathIsSafe ? directBinPath : null
+  }
+
+  const virtualStoreBinPath = resolveBinPathFromNearestNodeModulesDir(pkgPath, binRelativePath)
+  if (directBinPathIsSafe && existsSync(directBinPath)) {
+    return directBinPath
+  }
+  return virtualStoreBinPath ?? (directBinPathIsSafe ? directBinPath : null)
+}
+
+function referencesDependencyNodeModules (binRelativePath: string): boolean {
+  const normalizedBinRelativePath = binRelativePath.replace(/\\/g, '/')
+  return normalizedBinRelativePath.startsWith('node_modules/') || normalizedBinRelativePath.startsWith('./node_modules/')
+}
+
+function resolveBinPathFromNearestNodeModulesDir (pkgPath: string, binRelativePath: string): string | null {
+  const nearestNodeModulesDir = findNearestNodeModulesDir(pkgPath)
+  if (nearestNodeModulesDir == null) return null
+
+  const normalizedBinRelativePath = binRelativePath.replace(/\\/g, '/')
+  const relativePathFromNodeModules = normalizedBinRelativePath
+    .replace(/^\.\//, '')
+    .slice('node_modules/'.length)
+
+  const binPath = path.join(nearestNodeModulesDir, relativePathFromNodeModules)
+  return isSubdir(nearestNodeModulesDir, binPath) ? binPath : null
+}
+
+function findNearestNodeModulesDir (pkgPath: string): string | null {
+  let currentDir = path.dirname(pkgPath)
+  while (currentDir !== path.dirname(currentDir)) {
+    if (path.basename(currentDir) === 'node_modules') {
+      return currentDir
+    }
+    currentDir = path.dirname(currentDir)
+  }
+  return null
 }


### PR DESCRIPTION
This teaches the resolver to handle package bin entries that point into a dependency under the virtual store layout, and adds coverage for the Windows linker path involved in `#11107`.

Validation:
- `cd bins/resolver && corepack pnpm exec tsgo --build`
- `cd bins/resolver && corepack pnpm exec eslint "src/**/*.ts" "test/**/*.ts" --fix`
- `cd bins/linker && corepack pnpm exec tsgo --build`
- `cd bins/linker && corepack pnpm exec eslint "src/**/*.ts" "test/**/*.ts" --fix`
- `cd worker && corepack pnpm exec tsgo --build`
- `cd worker && corepack pnpm exec eslint "src/**/*.ts" "test/**/*.ts" --fix`
- `cd bins/linker && $env:NODE_OPTIONS = (($env:NODE_OPTIONS, ''--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169'') -join '' '').Trim(); corepack pnpm exec jest test/index.ts --runInBand -t "virtual store layout"`
- `git diff --check`