### PR TITLE
fix(gvs): expose hoisted aliases in package directories

### DIFF
--- a/installing/deps-installer/src/install/link.ts
+++ b/installing/deps-installer/src/install/link.ts
@@ -15,7 +15,7 @@ import type {
 } from '@pnpm/installing.deps-resolver'
 import type { InstallationResultStats } from '@pnpm/installing.deps-restorer'
 import { linkDirectDeps } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune } from '@pnpm/installing.linking.modules-cleaner'
 import type { IncludedDependencies } from '@pnpm/installing.modules-yaml'
 import {
@@ -153,9 +153,11 @@ export async function linkPackages (projects: ImporterToUpdate[], depGraph: Depe
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       force: opts.force,
       depsStateCache: opts.depsStateCache,
+      hoistPattern: opts.hoistPattern,
       ignoreScripts: opts.ignoreScripts,
       lockfileDir: opts.lockfileDir,
       optional: opts.include.optionalDependencies,
+      publicHoistPattern: opts.publicHoistPattern,
       sideEffectsCacheRead: opts.sideEffectsCacheRead,
       symlink: opts.symlink,
       skipped: opts.skipped,
@@ -324,9 +326,11 @@ interface LinkNewPackagesOptions {
   disableRelinkLocalDirDeps?: boolean
   enableGlobalVirtualStore: boolean
   force: boolean
+  hoistPattern?: string[]
   optional: boolean
   ignoreScripts: boolean
   lockfileDir: string
+  publicHoistPattern?: string[]
   sideEffectsCacheRead: boolean
   symlink: boolean
   skipped: Set<DepPath>
@@ -395,8 +399,11 @@ async function linkNewPackages (
     !opts.symlink
       ? Promise.resolve()
       : linkAllModules([...newPkgs, ...existingWithUpdatedDeps], depGraph, {
+        enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
+        hoistPattern: opts.hoistPattern,
         lockfileDir: opts.lockfileDir,
         optional: opts.optional,
+        publicHoistPattern: opts.publicHoistPattern,
       }),
     linkAllPkgs(opts.storeController, newPkgs, {
       allowBuild: opts.allowBuild,
@@ -512,8 +519,11 @@ async function linkAllModules (
   depNodes: DependenciesGraphNode[],
   depGraph: DependenciesGraph,
   opts: {
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     lockfileDir: string
     optional: boolean
+    publicHoistPattern?: string[]
   }
 ): Promise<void> {
   await symlinkAllModules({
@@ -531,6 +541,12 @@ async function linkAllModules (
           childrenPaths[alias] = pkg.dir
         }
       }
+      if (opts.enableGlobalVirtualStore) {
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, depGraph, {
+          hoistPattern: opts.hoistPattern,
+          publicHoistPattern: opts.publicHoistPattern,
+        }))
+      }
       return {
         children: childrenPaths,
         modules: depNode.modules,
@@ -538,4 +554,48 @@ async function linkAllModules (
       }
     }),
   })
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern?: string[]
+    publicHoistPattern?: string[]
+  }
+): Record<string, string> {
+  const hoistPattern = Array.from(new Set([
+    ...(opts.hoistPattern ?? []),
+    ...(opts.publicHoistPattern ?? []),
+  ]))
+  if (hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, DepPath>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath as DepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<DepPath>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: new Set(),
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath as DepPath]
+    if (!pkg || !pkg.installable && pkg.optional) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }

--- a/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { assertProject } from '@pnpm/assert-project'
 import { install, type MutatedProject, mutateModules, type ProjectOptions } from '@pnpm/installing.deps-installer'
@@ -126,6 +127,40 @@ test('modules are correctly updated when using a global virtual store', async ()
     expect(files).toHaveLength(1)
     expect(fs.existsSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/peer-c/2.0.0', files[0], 'node_modules/@pnpm.e2e/peer-c/package.json'))).toBeTruthy()
   }
+})
+
+test('GVS package runtime can resolve hoisted transitive dependencies', async () => {
+  prepareEmpty()
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/abc', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' }),
+  ])
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/abc-parent-with-ab': '1.0.0',
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  await install(manifest, testDefaults({
+    enableGlobalVirtualStore: true,
+    hoistPattern: ['*'],
+    virtualStoreDir: globalVirtualStoreDir,
+  }))
+
+  const pkgVersionDir = path.join(globalVirtualStoreDir, '@pnpm.e2e/abc-parent-with-ab/1.0.0')
+  const [hash] = fs.readdirSync(pkgVersionDir)
+  const gvsModulesDir = path.join(pkgVersionDir, hash, 'node_modules')
+  const pkgDir = path.join(gvsModulesDir, '@pnpm.e2e/abc-parent-with-ab')
+  const probeFile = path.join(pkgDir, 'probe.mjs')
+  fs.writeFileSync(probeFile, "import '@pnpm.e2e/dep-of-pkg-with-1-dep'\n", 'utf8')
+
+  expect(fs.existsSync(path.join(gvsModulesDir, '@pnpm.e2e/dep-of-pkg-with-1-dep/package.json'))).toBeTruthy()
+  await expect(import(pathToFileURL(probeFile).href)).resolves.toBeDefined()
 })
 
 test('GVS hashes are engine-agnostic for packages not in allowBuilds', async () => {

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -31,7 +31,7 @@ import {
 } from '@pnpm/exec.lifecycle'
 import { symlinkDependency } from '@pnpm/fs.symlink-dependency'
 import { linkDirectDeps, type LinkedDirectDep } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune } from '@pnpm/installing.linking.modules-cleaner'
 import type { HoistingLimits } from '@pnpm/installing.linking.real-hoist'
 import {
@@ -438,7 +438,11 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         opts.symlink === false || opts.enableModulesDir === false
           ? Promise.resolve()
           : linkAllModules(depNodes, {
+            depGraph: graph,
+            enableGlobalVirtualStore: Boolean(opts.enableGlobalVirtualStore),
+            hoistPattern: opts.hoistPattern,
             optional: opts.include.optionalDependencies,
+            publicHoistPattern: opts.publicHoistPattern,
           }),
         linkAllPkgs(opts.storeController, depNodes, {
           allowBuild,
@@ -1027,16 +1031,74 @@ async function linkAllBins (
 async function linkAllModules (
   depNodes: Array<Pick<DependenciesGraphNode, 'children' | 'optionalDependencies' | 'modules' | 'name'>>,
   opts: {
+    depGraph: DependenciesGraph
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     optional: boolean
+    publicHoistPattern?: string[]
   }
 ): Promise<void> {
   await symlinkAllModules({
-    deps: depNodes.map((depNode) => ({
-      children: opts.optional
+    deps: depNodes.map((depNode) => {
+      const children = (opts.optional
         ? depNode.children
-        : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), depNode.children),
-      modules: depNode.modules,
-      name: depNode.name,
-    })),
+        : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), depNode.children)) as Record<string, string>
+      const childrenPaths = { ...children }
+      if (opts.enableGlobalVirtualStore) {
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, opts.depGraph, {
+          hoistPattern: opts.hoistPattern,
+          publicHoistPattern: opts.publicHoistPattern,
+        }))
+      }
+      return {
+        children: childrenPaths,
+        modules: depNode.modules,
+        name: depNode.name,
+      }
+    }),
   })
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern?: string[]
+    publicHoistPattern?: string[]
+  }
+): Record<string, string> {
+  const hoistPattern = Array.from(new Set([
+    ...(opts.hoistPattern ?? []),
+    ...(opts.publicHoistPattern ?? []),
+  ]))
+  if (hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, string>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<string>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: new Set(),
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath]
+    if (!pkg) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }


### PR DESCRIPTION
Fixes #9618.

## Summary
- expose hoisted transitive aliases inside global virtual store package directories during linking and restore paths
- add a regression that executes from inside a global virtual store package and proves a hoisted transitive import resolves
- align GVS runtime resolution on Windows more closely with the standard `.pnpm` layout behavior

## Validation
- reproduced the original Windows failure against `maple-font-page` `v7.3.1` with `pnpm@10.12.1`
- `corepack pnpm exec jest test/install/globalVirtualStore.ts --runInBand`
- focused regression passed (`20 passed`)

## Notes
- a broader `tsgo --build installing/deps-restorer installing/deps-installer` run still hits an unrelated existing type error in `lockfile/to-pnp/src/index.ts`