### PR TITLE
fix: allow update --latest to fall back to mature direct versions

### DIFF
--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -290,6 +290,8 @@ export type InstallCommandOptions = Pick<Config,
 | 'ignoreScripts'
 | 'injectWorkspacePackages'
 | 'linkWorkspacePackages'
+| 'minimumReleaseAge'
+| 'minimumReleaseAgeExclude'
 | 'rawLocalConfig'
 | 'lockfileDir'
 | 'lockfileOnly'

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -84,6 +84,8 @@ export type InstallDepsOptions = Pick<Config,
 | 'linkWorkspacePackages'
 | 'lockfileDir'
 | 'lockfileOnly'
+| 'minimumReleaseAge'
+| 'minimumReleaseAgeExclude'
 | 'production'
 | 'preferWorkspacePackages'
 | 'rawLocalConfig'

--- a/installing/commands/src/update/index.ts
+++ b/installing/commands/src/update/index.ts
@@ -5,13 +5,14 @@ import {
   readDepNameCompletions,
   readProjectManifestOnly,
 } from '@pnpm/cli.utils'
-import { createMatcher } from '@pnpm/config.matcher'
+import { createMatcher as createPackageMatcher } from '@pnpm/config.matcher'
 import { types as allTypes } from '@pnpm/config.reader'
 import { outdatedDepsOfProjects } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import { handleGlobalUpdate } from '@pnpm/global.commands'
 import type { UpdateMatchingFunction } from '@pnpm/installing.deps-installer'
 import { globalInfo } from '@pnpm/logger'
+import { filterDependenciesByType } from '@pnpm/pkg-manifest.utils'
 import type { IncludedDependencies, PackageVulnerabilityAudit, ProjectRootDir } from '@pnpm/types'
 import chalk from 'chalk'
 import enquirer from 'enquirer'
@@ -20,8 +21,17 @@ import { renderHelp } from 'render-help'
 
 import type { InstallCommandOptions } from '../install.js'
 import { installDeps } from '../installDeps.js'
-import { parseUpdateParam } from '../recursive.js'
+import {
+  createMatcher as createUpdateMatcher,
+  makeIgnorePatterns,
+  matchDependencies,
+  parseUpdateParam,
+} from '../recursive.js'
 import { type ChoiceRow, getUpdateChoices } from './getUpdateChoices.js'
+
+type UpdateCommandOptionsWithMinimumReleaseAgeExclude = UpdateCommandOptions & {
+  minimumReleaseAgeExclude?: string[]
+}
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
     'cache-dir',
@@ -307,9 +317,9 @@ async function update (
   } else if (
     (dependencies.length > 0) && dependencies.every(dep => !dep.substring(1).includes('@')) && depth > 0 && !opts.latest
   ) {
-    updateMatching = createMatcher(dependencies)
+    updateMatching = createPackageMatcher(dependencies)
   }
-  return installDeps({
+  const installDepsOptions = {
     ...opts,
     rebuildHandler,
     allowNew: false,
@@ -322,7 +332,17 @@ async function update (
     updateMatching,
     updatePackageManifest: opts.save !== false,
     resolutionMode: opts.save === false ? 'highest' : opts.resolutionMode,
-  }, dependencies)
+  } as UpdateCommandOptionsWithMinimumReleaseAgeExclude
+  try {
+    return await installDeps(installDepsOptions, dependencies)
+  } catch (err: any) { // eslint-disable-line
+    const minimumReleaseAgeExclude = await getMinimumReleaseAgeExcludeForRetry(dependencies, installDepsOptions, includeDirect, err)
+    if (minimumReleaseAgeExclude == null) throw err
+    return installDeps({
+      ...installDepsOptions,
+      minimumReleaseAgeExclude,
+    }, dependencies)
+  }
 }
 
 function makeIncludeDependenciesFromCLI (opts: {
@@ -335,4 +355,53 @@ function makeIncludeDependenciesFromCLI (opts: {
     devDependencies: opts.dev === true || (opts.production !== true && opts.optional !== true),
     optionalDependencies: opts.optional === true || (opts.production !== true && opts.dev !== true),
   }
+}
+
+async function getMinimumReleaseAgeExcludeForRetry (
+  dependencies: string[],
+  opts: UpdateCommandOptionsWithMinimumReleaseAgeExclude,
+  includeDirect: IncludedDependencies,
+  err: { code?: string }
+): Promise<string[] | undefined> {
+  if (!opts.latest || err.code !== 'ERR_PNPM_NO_MATURE_MATCHING_VERSION' || !opts.minimumReleaseAgeExclude?.length) {
+    return undefined
+  }
+  const directDependencies = await getDirectDependenciesToUpdate(dependencies, opts, includeDirect)
+  if (directDependencies.length === 0) return undefined
+
+  const retryMinimumReleaseAgeExclude = opts.minimumReleaseAgeExclude.filter((pattern) => {
+    return !directDependencies.some((dependency) => minimumReleaseAgeExcludePatternMatchesDependency(pattern, dependency))
+  })
+  return retryMinimumReleaseAgeExclude.length === opts.minimumReleaseAgeExclude.length
+    ? undefined
+    : retryMinimumReleaseAgeExclude
+}
+
+async function getDirectDependenciesToUpdate (
+  dependencies: string[],
+  opts: UpdateCommandOptions,
+  includeDirect: IncludedDependencies
+): Promise<string[]> {
+  const manifest = await readProjectManifestOnly(opts.dir, opts)
+  const dependenciesToMatch = dependencies.length === 0
+    ? opts.updateConfig?.ignoreDependencies?.length
+      ? makeIgnorePatterns(opts.updateConfig.ignoreDependencies)
+      : []
+    : dependencies
+  if (dependenciesToMatch.length === 0) {
+    return Object.keys(filterDependenciesByType(manifest, includeDirect))
+  }
+  return matchDependencies(createUpdateMatcher(dependenciesToMatch), manifest, includeDirect)
+    .map((dependency) => parseUpdateParam(dependency).pattern)
+}
+
+function minimumReleaseAgeExcludePatternMatchesDependency (pattern: string, dependency: string): boolean {
+  return createPackageMatcher(getPackageNamePatternFromMinimumReleaseAgeExclude(pattern))(dependency)
+}
+
+function getPackageNamePatternFromMinimumReleaseAgeExclude (pattern: string): string {
+  const atIndex = pattern.startsWith('@')
+    ? pattern.indexOf('@', 1)
+    : pattern.indexOf('@')
+  return atIndex === -1 ? pattern : pattern.slice(0, atIndex)
 }

--- a/installing/commands/test/update/minimumReleaseAgeFallback.ts
+++ b/installing/commands/test/update/minimumReleaseAgeFallback.ts
@@ -1,0 +1,69 @@
+import { jest } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+import { DEFAULT_OPTS } from '../utils/index.js'
+
+const installDeps = jest.fn()
+
+jest.unstable_mockModule('../../src/installDeps.js', () => ({
+  installDeps,
+}))
+
+const { handler } = await import('../../src/update/index.js')
+
+beforeEach(() => {
+  installDeps.mockReset()
+})
+
+test('retries latest updates without direct minimumReleaseAgeExclude matches after maturity failure', async () => {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+      '@pnpm.e2e/bar': '^1.0.0',
+    },
+  })
+
+  const err = Object.assign(new Error('maturity failure'), {
+    code: 'ERR_PNPM_NO_MATURE_MATCHING_VERSION',
+  })
+  installDeps.mockRejectedValueOnce(err)
+  installDeps.mockResolvedValueOnce(undefined)
+
+  await handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    latest: true,
+    minimumReleaseAgeExclude: ['@pnpm.e2e/foo', '@pnpm.e2e/bar@1.0.0'],
+  }, ['@pnpm.e2e/foo'])
+
+  expect(installDeps).toHaveBeenCalledTimes(2)
+  expect(installDeps.mock.calls[1][0].minimumReleaseAgeExclude).toEqual(['@pnpm.e2e/bar@1.0.0'])
+})
+
+test('full latest updates keep exclusions for ignored direct dependencies on retry', async () => {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+      '@pnpm.e2e/bar': '^1.0.0',
+    },
+  })
+
+  const err = Object.assign(new Error('maturity failure'), {
+    code: 'ERR_PNPM_NO_MATURE_MATCHING_VERSION',
+  })
+  installDeps.mockRejectedValueOnce(err)
+  installDeps.mockResolvedValueOnce(undefined)
+
+  await handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    latest: true,
+    minimumReleaseAgeExclude: ['@pnpm.e2e/foo', '@pnpm.e2e/bar'],
+    updateConfig: {
+      ignoreDependencies: ['@pnpm.e2e/bar'],
+    },
+  }, [])
+
+  expect(installDeps).toHaveBeenCalledTimes(2)
+  expect(installDeps.mock.calls[1][0].minimumReleaseAgeExclude).toEqual(['@pnpm.e2e/bar'])
+})

--- a/installing/commands/test/update/minimumReleaseAgeFallback.ts
+++ b/installing/commands/test/update/minimumReleaseAgeFallback.ts
@@ -40,6 +40,30 @@ test('retries latest updates without direct minimumReleaseAgeExclude matches aft
   expect(installDeps.mock.calls[1][0].minimumReleaseAgeExclude).toEqual(['@pnpm.e2e/bar@1.0.0'])
 })
 
+test('retries latest updates without scoped version-qualified direct exclusions after maturity failure', async () => {
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+    },
+  })
+
+  const err = Object.assign(new Error('maturity failure'), {
+    code: 'ERR_PNPM_NO_MATURE_MATCHING_VERSION',
+  })
+  installDeps.mockRejectedValueOnce(err)
+  installDeps.mockResolvedValueOnce(undefined)
+
+  await handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    latest: true,
+    minimumReleaseAgeExclude: ['@pnpm.e2e/foo@1.0.0'],
+  }, ['@pnpm.e2e/foo'])
+
+  expect(installDeps).toHaveBeenCalledTimes(2)
+  expect(installDeps.mock.calls[1][0].minimumReleaseAgeExclude).toEqual([])
+})
+
 test('full latest updates keep exclusions for ignored direct dependencies on retry', async () => {
   prepare({
     dependencies: {


### PR DESCRIPTION
Fixes #11068

When `pnpm update --latest` hits `ERR_PNPM_NO_MATURE_MATCHING_VERSION` because the newest matching release is excluded by `minimumReleaseAgeExclude`, pnpm can still have a mature direct version available. This retries resolution once without the direct dependency's exclude match so the command can fall back to that mature direct version instead of aborting.

Tests:
- `corepack pnpm --filter @pnpm/installing.commands run compile`
- `corepack pnpm --filter @pnpm/installing.commands exec cross-env NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/update/minimumReleaseAgeFallback.ts --runInBand`
- `corepack pnpm --filter @pnpm/installing.commands exec cross-env NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/update/update.ts --runInBand`