### PR TITLE
fix(audit): prefer workspace manifest names in audit payload

### DIFF
--- a/.changeset/fix-audit-workspace-importer-names.md
+++ b/.changeset/fix-audit-workspace-importer-names.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.audit": patch
+"pnpm": patch
+---
+
+Fixed `pnpm audit` misreporting advisories for workspace packages whose directory names match a vulnerable package by using the workspace manifest name, rather than the importer path, in the generated audit payload [#11101](https://github.com/pnpm/pnpm/issues/11101).

--- a/deps/compliance/audit/src/lockfileToAuditTree.ts
+++ b/deps/compliance/audit/src/lockfileToAuditTree.ts
@@ -38,10 +38,8 @@ export async function lockfileToAuditTree (
   await Promise.all(
     importerWalkers.map(async (importerWalker) => {
       const importerDeps = lockfileToAuditNode(depTypes, importerWalker.step)
-      // For some reason the registry responds with 500 if the keys in dependencies have slashes
-      // see issue: https://github.com/pnpm/pnpm/issues/2848
-      const depName = importerWalker.importerId.replace(/\//g, '__')
       const manifest = await safeReadProjectManifestOnly(path.join(opts.lockfileDir, importerWalker.importerId))
+      const depName = getAuditImporterName(importerWalker.importerId, manifest?.name)
       dependencies[depName] = {
         dependencies: importerDeps,
         dev: false,
@@ -73,6 +71,13 @@ export async function lockfileToAuditTree (
     requires: toRequires(dependencies),
   }
   return auditTree
+}
+
+function getAuditImporterName (importerId: string, manifestName?: string): string {
+  if (importerId === '.') return '.'
+  // For some reason the registry responds with 500 if the keys in dependencies have slashes.
+  // See: https://github.com/pnpm/pnpm/issues/2848
+  return (manifestName ?? importerId).replace(/\//g, '__')
 }
 
 function lockfileToAuditNode (depTypes: DepTypes, step: LockfileWalkerStep): Record<string, AuditNode> {

--- a/deps/compliance/audit/test/__fixtures__/workspace-importer-name-preferred/playwright/package.json
+++ b/deps/compliance/audit/test/__fixtures__/workspace-importer-name-preferred/playwright/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@sud-fe/playwright",
+  "version": "1.0.0"
+}

--- a/deps/compliance/audit/test/index.ts
+++ b/deps/compliance/audit/test/index.ts
@@ -144,6 +144,55 @@ describe('audit', () => {
     })
   })
 
+  test('lockfileToAuditTree() prefers the workspace manifest name for non-root importers', async () => {
+    expect(await lockfileToAuditTree({
+      importers: {
+        ['playwright' as ProjectId]: {
+          dependencies: {
+            '@playwright/test': '1.58.2',
+          },
+          specifiers: {
+            '@playwright/test': '1.58.2',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['@playwright/test@1.58.2' as DepPath]: {
+          resolution: {
+            integrity: 'playwright-test-integrity',
+          },
+        },
+      },
+    }, { lockfileDir: f.find('workspace-importer-name-preferred') })).toEqual({
+      name: undefined,
+      version: undefined,
+
+      dependencies: {
+        '@sud-fe__playwright': {
+          dependencies: {
+            '@playwright/test': {
+              dev: false,
+              integrity: 'playwright-test-integrity',
+              version: '1.58.2',
+            },
+          },
+          dev: false,
+          requires: {
+            '@playwright/test': '1.58.2',
+          },
+          version: '1.0.0',
+        },
+      },
+      dev: false,
+      install: [],
+      integrity: undefined,
+      metadata: {},
+      remove: [],
+      requires: { '@sud-fe__playwright': '1.0.0' },
+    })
+  })
+
   test('lockfileToAuditTree() includes env lockfile configDependencies and packageManagerDependencies as separate groups', async () => {
     const result = await lockfileToAuditTree({
       importers: {


### PR DESCRIPTION
## Summary
- use non-root workspace manifest names when building the audit payload
- keep the root importer as \\.\\ and continue escaping slashes for the audit registry
- add a regression for a workspace folder named \\playwright\\ with package name \\@sud-fe/playwright\\ so pnpm audit stops matching the wrapper node against Playwright advisories

Closes #11101.

## Testing
- corepack pnpm --filter @pnpm/deps.compliance.audit test