### PR TITLE
fix: resolve symlinked node_modules bin paths

### DIFF
--- a/.changeset/real-node-modules-bin-resolution.md
+++ b/.changeset/real-node-modules-bin-resolution.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/bins.resolver": patch
+"pnpm": patch
+---
+
+Resolve `bin` entries that point into `node_modules/...` from the package's real install location instead of the symlinked package path. This fixes global installs of meta-packages like `sudocode`, where command shims previously failed on Windows by probing non-existent `.../cli.js.EXE` paths [#11107](https://github.com/pnpm/pnpm/issues/11107).

--- a/.changeset/real-node-modules-bin-resolution.md
+++ b/.changeset/real-node-modules-bin-resolution.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Resolve `bin` entries that point into `node_modules/...` from the package's real install location instead of the symlinked package path. This fixes global installs of meta-packages like `sudocode`, where command shims previously failed on Windows by probing non-existent `.../cli.js.EXE` paths [#11107](https://github.com/pnpm/pnpm/issues/11107).
+Resolve `bin` entries that point into `node_modules/...` from the package's real install location instead of the symlinked package path. This fixes global installs of meta-packages whose command shims previously failed on Windows by probing non-existent `.../cli.js.EXE` paths [#11107](https://github.com/pnpm/pnpm/issues/11107).

--- a/bins/resolver/src/index.ts
+++ b/bins/resolver/src/index.ts
@@ -1,8 +1,12 @@
+import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import type { DependencyManifest, PackageBin } from '@pnpm/types'
 import { isSubdir } from 'is-subdir'
 import { glob } from 'tinyglobby'
+
+const require = createRequire(import.meta.dirname)
 
 export interface Command {
   name: string
@@ -60,21 +64,58 @@ async function findFiles (dir: string): Promise<string[]> {
   }
 }
 
-function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string): Command[] {
-  const cmds: Command[] = []
-  for (const [commandName, binRelativePath] of typeof bin === 'string' ? [[pkgName, bin]] : Object.entries(bin)) {
+async function commandsFromBin (bin: PackageBin, pkgName: string, pkgPath: string): Promise<Command[]> {
+  const cmds = await Promise.all((typeof bin === 'string' ? [[pkgName, bin]] : Object.entries(bin)).map(async ([commandName, binRelativePath]) => {
     const binName = commandName[0] === '@'
       ? commandName.slice(commandName.indexOf('/') + 1)
       : commandName
     // Validate: must be safe (no path traversal) - only allow URL-safe chars or $
     if (binName !== encodeURIComponent(binName) && binName !== '$') {
-      continue
+      return null
     }
-    const binPath = path.join(pkgPath, binRelativePath)
-    if (!isSubdir(pkgPath, binPath)) {
-      continue
+    const binPath = await resolveBinPath(binRelativePath, pkgPath)
+    if (binPath == null) {
+      return null
     }
-    cmds.push({ name: binName, path: binPath })
+    return { name: binName, path: binPath }
+  }))
+  return cmds.filter((cmd): cmd is Command => cmd != null)
+}
+
+async function resolveBinPath (binRelativePath: string, pkgPath: string): Promise<string | null> {
+  const binPath = path.join(pkgPath, binRelativePath)
+  if (!isSubdir(pkgPath, binPath)) {
+    return null
   }
-  return cmds
+  const nodeModulesSpecifier = getNodeModulesSpecifier(binRelativePath)
+  if (nodeModulesSpecifier != null) {
+    const resolveFromPath = await fs.realpath(pkgPath).catch(() => pkgPath)
+    try {
+      return require.resolve(nodeModulesSpecifier, { paths: [resolveFromPath] })
+    } catch {}
+  }
+  return binPath
+}
+
+function getNodeModulesSpecifier (binRelativePath: string): string | null {
+  const pathParts = path.normalize(binRelativePath).split(path.sep).filter(Boolean)
+  while (pathParts[0] === '.') {
+    pathParts.shift()
+  }
+  if (pathParts[0] !== 'node_modules') {
+    return null
+  }
+  const specifierParts = pathParts.slice(1)
+  if (
+    specifierParts.length === 0 ||
+    specifierParts.includes('.') ||
+    specifierParts.includes('..') ||
+    specifierParts[0].startsWith('.')
+  ) {
+    return null
+  }
+  if (specifierParts[0].startsWith('@') && specifierParts.length < 2) {
+    return null
+  }
+  return specifierParts.join('/')
 }

--- a/bins/resolver/test/index.ts
+++ b/bins/resolver/test/index.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
@@ -108,6 +110,42 @@ test('skip dangerous bin locations', async () => {
       },
     ]
   )
+})
+
+test('resolve bin paths that point into node_modules using package resolution', async () => {
+  const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-bins-resolver-'))
+  try {
+    const virtualStoreDir = path.join(projectDir, '.pnpm', 'meta-tool@1.0.0', 'node_modules')
+    const realPkgDir = path.join(virtualStoreDir, 'meta-tool')
+    const pkgDir = path.join(projectDir, 'node_modules', 'meta-tool')
+    const cliDir = path.join(virtualStoreDir, '@scope', 'cli')
+    fs.mkdirSync(path.join(cliDir, 'dist'), { recursive: true })
+    fs.mkdirSync(realPkgDir, { recursive: true })
+    fs.mkdirSync(path.dirname(pkgDir), { recursive: true })
+    fs.symlinkSync(realPkgDir, pkgDir, process.platform === 'win32' ? 'junction' : 'dir')
+    fs.writeFileSync(path.join(cliDir, 'package.json'), JSON.stringify({
+      name: '@scope/cli',
+      version: '1.0.0',
+    }))
+    fs.writeFileSync(path.join(cliDir, 'dist', 'cli.js'), '#!/usr/bin/env node\nconsole.log("ok")\n')
+
+    expect(
+      await getBinsFromPackageManifest({
+        name: 'meta-tool',
+        version: '1.0.0',
+        bin: {
+          'meta-tool': 'node_modules/@scope/cli/dist/cli.js',
+        },
+      }, pkgDir)
+    ).toStrictEqual([
+      {
+        name: 'meta-tool',
+        path: path.join(cliDir, 'dist', 'cli.js'),
+      },
+    ])
+  } finally {
+    fs.rmSync(projectDir, { force: true, recursive: true })
+  }
 })
 
 test('get bin from scoped bin name', async () => {


### PR DESCRIPTION
## Summary
- resolve `bin` entries under `node_modules/...` from the package's real install path instead of the symlinked package path
- cover the `.pnpm/.../node_modules/<pkg>` symlink layout in `@pnpm/bins.resolver` tests
- add a patch changeset for the Windows global install bin-linking fix

## Testing
- `corepack pnpm exec tsgo --build` (in `bins/resolver`)
- `corepack pnpm exec eslint "src/**/*.ts" "test/**/*.ts" --fix` (in `bins/resolver`)
- `corepack pnpm exec cross-env NODE_OPTIONS="$env:NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/index.ts -t "resolve bin paths that point into node_modules using package resolution"` (in `bins/resolver`)
- rebuilt the local `pnpm` bundle and verified `node pnpm/bin/pnpm.mjs add -g sudocode --ignore-scripts` created `sudocode`, `sdc`, `sudocode-mcp`, and `sudocode-server` shims without the previous `...cli.js.EXE` warnings

Closes #11107.