### PR TITLE
feat: add confirm-modules-purge setting

### DIFF
--- a/.changeset/confirm-modules-purge-setting.md
+++ b/.changeset/confirm-modules-purge-setting.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+Added a new setting `confirm-modules-purge` that can be set to `false` in `.npmrc` to suppress the "The modules directory will be removed and reinstalled from scratch" confirmation prompt [#7727](https://github.com/pnpm/pnpm/issues/7727).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -30,6 +30,7 @@ export interface Config extends AuthInfo, OptionsFromRootManifest {
   bail: boolean
   color: 'always' | 'auto' | 'never'
   cliOptions: Record<string, any>, // eslint-disable-line
+  confirmModulesPurge?: boolean
   useBetaCli: boolean
   excludeLinksFromLockfile: boolean
   extraBinPaths: string[]

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -59,6 +59,7 @@ export const excludedPnpmKeys = [
   'auto-install-peers',
   'catalog-mode',
   'config-dir',
+  'confirm-modules-purge',
   'merge-git-branch-lockfiles',
   'merge-git-branch-lockfiles-branch-pattern',
   'deploy-all-files',

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -8,6 +8,7 @@ export const pnpmTypes = {
   'cache-dir': String,
   'catalog-mode': ['strict', 'prefer', 'manual'],
   'child-concurrency': Number,
+  'confirm-modules-purge': Boolean,
   'merge-git-branch-lockfiles': Boolean,
   'merge-git-branch-lockfiles-branch-pattern': Array,
   color: ['always', 'auto', 'never'],

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -271,6 +271,7 @@ export type InstallCommandOptions = Pick<Config,
 | 'bin'
 | 'catalogs'
 | 'cliOptions'
+| 'confirmModulesPurge'
 | 'configDependencies'
 | 'dedupeInjectedDeps'
 | 'dedupeDirectDeps'
@@ -349,7 +350,6 @@ export type InstallCommandOptions = Pick<Config,
   saveLockfile?: boolean
   workspace?: boolean
   includeOnlyPackageFiles?: boolean
-  confirmModulesPurge?: boolean
   pnpmfile: string[]
 } & Partial<Pick<Config, 'ci' | 'modulesCacheMaxAge' | 'pnpmHomeDir' | 'preferWorkspacePackages' | 'useLockfile' | 'symlink'>>
 


### PR DESCRIPTION
## Summary
- Adds a new `confirm-modules-purge` setting that can be set to `false` in `.npmrc` to permanently suppress the "The modules directory will be removed and reinstalled from scratch" confirmation prompt
- Previously users had to pass `--yes` or `--force` on every invocation

Closes #7727

## Test plan
- [ ] Set `confirm-modules-purge=false` in `.npmrc` and verify the prompt is suppressed
- [ ] Verify default behavior (prompt shown) is unchanged when setting is not present
- [ ] Verify `--yes` and `--force` flags still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)