### PR TITLE
fix: skip warm global virtual store reimports

### DIFF
--- a/.changeset/soft-plums-search.md
+++ b/.changeset/soft-plums-search.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fs.indexed-pkg-importer": patch
+"pnpm": patch
+---
+
+Skip reimporting packages into the global virtual store when the content-addressed target already has its completion marker. This avoids redundant file work on fresh installs that reuse an already-warm `enableGlobalVirtualStore` links directory [#11112](https://github.com/pnpm/pnpm/issues/11112).

--- a/fs/indexed-pkg-importer/src/importIndexedDir.ts
+++ b/fs/indexed-pkg-importer/src/importIndexedDir.ts
@@ -33,6 +33,10 @@ export function importIndexedDir (
     safeToSkip?: boolean
   }
 ): void {
+  if (opts.safeToSkip && pkgExistsAtTargetDir(newDir, filenames)) {
+    return
+  }
+
   // Fast path: import directly without staging.  Callers already verified
   // the target package is missing (pkgExistsAtTargetDir / pkgLinkedToStore),
   // so we can write straight into newDir and skip the temp dir + rename.
@@ -125,6 +129,20 @@ export function importIndexedDir (
     } catch {} // eslint-disable-line:no-empty
     throw renameErr
   }
+}
+
+function pkgExistsAtTargetDir (targetDir: string, filesMap: Map<string, string>): boolean {
+  return fs.existsSync(path.join(targetDir, pickFileFromFilesMap(filesMap)))
+}
+
+function pickFileFromFilesMap (filesMap: Map<string, string>): string {
+  if (filesMap.has('package.json')) {
+    return 'package.json'
+  }
+  if (filesMap.size === 0) {
+    throw new Error('pickFileFromFilesMap cannot pick a file from an empty FilesMap')
+  }
+  return filesMap.keys().next().value!
 }
 
 function allFilesMatch (dir: string, filenames: Map<string, string>): boolean {

--- a/fs/indexed-pkg-importer/test/importIndexedDir.race.test.ts
+++ b/fs/indexed-pkg-importer/test/importIndexedDir.race.test.ts
@@ -42,6 +42,35 @@ test('safeToSkip skips when target already exists (content-addressed)', () => {
   expect(renameOverwriteSyncMock).not.toHaveBeenCalled()
 })
 
+test('safeToSkip skips importing when the completion marker already exists', () => {
+  const tmp = tempDir()
+  const srcDir = path.join(tmp, 'src')
+  const newDir = path.join(tmp, 'dest')
+  const srcPackageJson = path.join(srcDir, 'package.json')
+  const srcIndexJs = path.join(srcDir, 'index.js')
+
+  fs.mkdirSync(srcDir, { recursive: true })
+  fs.writeFileSync(srcPackageJson, '{"name":"pkg","version":"1.0.0"}')
+  fs.writeFileSync(srcIndexJs, 'module.exports = 1')
+
+  fs.mkdirSync(newDir, { recursive: true })
+  fs.copyFileSync(srcPackageJson, path.join(newDir, 'package.json'))
+  fs.copyFileSync(srcIndexJs, path.join(newDir, 'index.js'))
+
+  const importFileMock = jest.fn(() => {
+    throw new Error('importer should not run when the completion marker already exists')
+  })
+  const filenames = new Map([
+    ['index.js', srcIndexJs],
+    ['package.json', srcPackageJson],
+  ])
+
+  importIndexedDir({ importFile: importFileMock, importFileAtomic: importFileMock }, newDir, filenames, { safeToSkip: true })
+
+  expect(importFileMock).not.toHaveBeenCalled()
+  expect(renameOverwriteSyncMock).not.toHaveBeenCalled()
+})
+
 test('safeToSkip creates dir when target does not exist', () => {
   const tmp = tempDir()
   const srcFile = path.join(tmp, 'src', 'index.js')

--- a/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -103,6 +103,57 @@ test('reinstall from warm global virtual store after deleting node_modules', asy
   expect(fs.existsSync(path.join(globalVirtualStoreDir, '@pnpm.e2e/pkg-with-1-dep/100.0.0', files[0], 'node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json'))).toBeTruthy()
 })
 
+test('fresh install into a second project reuses a warm global virtual store', async () => {
+  const manifest = {
+    name: 'project',
+    version: '1.0.0',
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  }
+  preparePackages([
+    { location: 'project-1', package: manifest },
+    { location: 'project-2', package: manifest },
+  ])
+
+  const cwd = process.cwd()
+  const project1Dir = path.resolve('project-1')
+  const project2Dir = path.resolve('project-2')
+  const globalVirtualStoreDir = path.resolve('links')
+  const opts = testDefaults({
+    enableGlobalVirtualStore: true,
+    virtualStoreDir: globalVirtualStoreDir,
+    hoistPattern: ['*'],
+  })
+
+  try {
+    process.chdir(project1Dir)
+    await install(manifest, opts)
+    fs.copyFileSync(path.join(project1Dir, 'pnpm-lock.yaml'), path.join(project2Dir, 'pnpm-lock.yaml'))
+
+    const originalImportPackage = opts.storeController.importPackage
+    let importCount = 0
+    opts.storeController.importPackage = (async (targetDir, importOpts) => {
+      const result = await originalImportPackage(targetDir, importOpts)
+      if (result.importMethod != null) {
+        importCount++
+      }
+      return result
+    }) as typeof originalImportPackage
+
+    process.chdir(project2Dir)
+    await install(manifest, {
+      ...opts,
+      frozenLockfile: true,
+    })
+
+    expect(importCount).toBe(0)
+    expect(fs.existsSync(path.join(project2Dir, 'node_modules/.pnpm/lock.yaml'))).toBeTruthy()
+  } finally {
+    process.chdir(cwd)
+  }
+})
+
 test('modules are correctly updated when using a global virtual store', async () => {
   prepareEmpty()
   const globalVirtualStoreDir = path.resolve('links')


### PR DESCRIPTION
## Summary
- skip content-addressed GVS reimports as soon as the completion marker already exists
- add a low-level importer regression so safeToSkip never replays file work for an already-complete target
- add a fresh-project global virtual store regression covering reuse of a warm links directory across projects

## Testing
- corepack pnpm --dir fs/indexed-pkg-importer exec tsgo --build
- corepack pnpm --dir worker exec tsgo --build
- corepack pnpm --dir installing/deps-installer exec tsgo --build
- corepack pnpm --dir fs/indexed-pkg-importer exec jest --runInBand test/importIndexedDir.race.test.ts
- corepack pnpm --dir installing/deps-installer exec jest --runInBand test/install/globalVirtualStore.ts -t "fresh install into a second project reuses a warm global virtual store|reinstall from warm global virtual store after deleting node_modules"
- corepack pnpm exec eslint fs/indexed-pkg-importer/src/importIndexedDir.ts fs/indexed-pkg-importer/test/importIndexedDir.race.test.ts installing/deps-installer/test/install/globalVirtualStore.ts
- git diff --check

## Notes
- The focused globalVirtualStore.ts assertions passed on this Windows host, but Jest still hit the repo's existing registry globalTeardown 	askkill timeout after reporting the targeted tests green.

Fixes #11112.