### PR TITLE
fix: rebase bare tarball overrides from the root manifest

### DIFF
--- a/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -42,19 +42,39 @@ interface LocalTarget {
 
 type LocalProtocol = 'link:' | 'file:'
 
+const TARBALL_SPECIFIER_PATTERN = /\.(?:tgz|tar\.gz|tar)$/i
+const NAMED_PROTOCOL_PATTERN = /^[a-z][a-z0-9+.-]*:/i
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[a-z]:[/\\]/i
+
 function createLocalTarget (override: VersionOverrideWithoutRawSelector, rootDir: string): LocalTarget | undefined {
-  let protocol: LocalProtocol | undefined
-  if (override.newBareSpecifier.startsWith('file:')) {
-    protocol = 'file:'
-  } else if (override.newBareSpecifier.startsWith('link:')) {
-    protocol = 'link:'
-  } else {
+  const localSpecifier = parseLocalOverrideSpecifier(override.newBareSpecifier)
+  if (!localSpecifier) {
     return undefined
   }
-  const pkgPath = override.newBareSpecifier.substring(protocol.length)
+  const pkgPath = localSpecifier.path
   const specifiedViaRelativePath = !path.isAbsolute(pkgPath)
   const absolutePath = specifiedViaRelativePath ? path.join(rootDir, pkgPath) : pkgPath
-  return { absolutePath, specifiedViaRelativePath, protocol }
+  return { absolutePath, specifiedViaRelativePath, protocol: localSpecifier.protocol }
+}
+
+function parseLocalOverrideSpecifier (
+  newBareSpecifier: string
+): { protocol: LocalProtocol, path: string } | undefined {
+  if (newBareSpecifier.startsWith('file:')) {
+    return { protocol: 'file:', path: newBareSpecifier.substring('file:'.length) }
+  }
+  if (newBareSpecifier.startsWith('link:')) {
+    return { protocol: 'link:', path: newBareSpecifier.substring('link:'.length) }
+  }
+  if (!isLocalTarballSpecifier(newBareSpecifier)) {
+    return undefined
+  }
+  return { protocol: 'file:', path: newBareSpecifier }
+}
+
+function isLocalTarballSpecifier (specifier: string): boolean {
+  if (!TARBALL_SPECIFIER_PATTERN.test(specifier)) return false
+  return WINDOWS_ABSOLUTE_PATH_PATTERN.test(specifier) || !NAMED_PROTOCOL_PATTERN.test(specifier)
 }
 
 interface VersionOverride extends VersionOverrideBase {

--- a/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -436,6 +436,56 @@ test('createVersionsOverrider() overrides dependencies with file with relative p
   })
 })
 
+test('createVersionsOverrider() overrides dependencies with bare relative tarball path for workspace package', () => {
+  const rootDir = process.cwd()
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: {
+        name: 'qar',
+      },
+      newBareSpecifier: './tarballs/qar-1.0.0.tgz',
+    },
+  ], rootDir)
+  expect(overrider({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: '3.0.0',
+    },
+  }, path.join(rootDir, 'packages', 'pkg'))).toStrictEqual({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: 'file:../../tarballs/qar-1.0.0.tgz',
+    },
+  })
+})
+
+test('createVersionsOverrider() does not rewrite remote tarball URLs', () => {
+  const rootDir = process.cwd()
+  const overrider = createVersionsOverrider([
+    {
+      targetPkg: {
+        name: 'qar',
+      },
+      newBareSpecifier: 'https://example.com/qar-1.0.0.tgz',
+    },
+  ], rootDir)
+  expect(overrider({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: '3.0.0',
+    },
+  }, path.join(rootDir, 'packages', 'pkg'))).toStrictEqual({
+    name: 'foo',
+    version: '1.2.0',
+    dependencies: {
+      qar: 'https://example.com/qar-1.0.0.tgz',
+    },
+  })
+})
+
 test('createVersionsOverrider() overrides dependencies with file specified with absolute path', () => {
   const absolutePath = path.join(import.meta.dirname, 'qar')
   const overrider = createVersionsOverrider([


### PR DESCRIPTION
## Summary
- treat bare local tarball override specs as root-relative local targets before they are applied to workspace packages
- keep remote tarball URLs untouched so only local override paths are rebased
- add focused createVersionsOverrider() coverage for the workspace tarball repro and the remote URL guard

Fixes #11131.

## Validation
- corepack pnpm exec tsgo --build hooks/read-package-hook/tsconfig.json
- 
ode --input-type=module - with a direct createVersionsOverrider() repro asserting ./tarballs/qar-1.0.0.tgz becomes ile:../../tarballs/qar-1.0.0.tgz for packages/pkg, while https://example.com/remote-1.0.0.tgz remains unchanged
- corepack pnpm exec eslint hooks/read-package-hook/src/createVersionsOverrider.ts hooks/read-package-hook/test/createVersionOverrider.test.ts
- corepack pnpm exec cspell hooks/read-package-hook/src/createVersionsOverrider.ts hooks/read-package-hook/test/createVersionOverrider.test.ts --no-progress
- git diff --check

## Notes
- The repo's packaged Jest path is blocked on this Windows host because the checked-in Husky/pn wrapper expects tooling that is not available on PATH here; the hook logic itself was built and exercised directly from the emitted lib/createVersionsOverrider.js output.