### PR TITLE
fix: use process.stderr.write for script logging

### DIFF
--- a/exec/lifecycle/src/runLifecycleHook.ts
+++ b/exec/lifecycle/src/runLifecycleHook.ts
@@ -107,7 +107,7 @@ Please unset the scriptShell option, or configure it to a .exe instead.
       wd: opts.pkgRoot,
     })
   } else if (!opts.silent) {
-    console.error(chalk.dim(`$ ${m.scripts[stage]}`))
+    process.stderr.write(chalk.dim(`$ ${m.scripts[stage]}`) + '\n')
   }
   const logLevel = (opts.stdio !== 'inherit' || opts.silent)
     ? 'silent'


### PR DESCRIPTION
## Summary
- Replace `console.error` with `process.stderr.write` in lifecycle hook script logging
- Prevents Jest from intercepting the output and displaying it with stack traces, which made normal `$ <script>` output look like errors in test results

## Test plan
- Run any test that triggers lifecycle hooks (e.g. `setExtraNodePath.ts`) and verify the `$ <command>` lines no longer appear with stack traces in Jest output