### PR TITLE
fix(exe): make pn a shell script in the tarball like pnpx/pnx

### DIFF
--- a/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -339,15 +339,11 @@ export function linkExePlatformBinary (installDir: string): void {
   const dest = path.join(exePkgDir, executable)
   forceLink(src, dest)
 
-  // Create pn alias (hardlink to the same binary)
-  const pnExecutable = platform === 'win' ? 'pn.exe' : 'pn'
-  forceLink(src, path.join(exePkgDir, pnExecutable))
-
   if (platform === 'win') {
     const exePkgJsonPath = path.join(exePkgDir, 'package.json')
     const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
     exePkg.bin.pnpm = 'pnpm.exe'
-    exePkg.bin.pn = 'pn.exe'
+    exePkg.bin.pn = 'pn.cmd'
     exePkg.bin.pnpx = 'pnpx.cmd'
     exePkg.bin.pnx = 'pnx.cmd'
     fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))

--- a/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -550,10 +550,7 @@ describe('linkExePlatformBinary', () => {
     const result = fs.readFileSync(path.join(topLevelExeDir, executable), 'utf8')
     expect(result).toBe(fakeBinaryContent)
 
-    // pn should be a hardlink to the same binary
-    const pnExecutable = platform === 'win' ? 'pn.exe' : 'pn'
-    const pnResult = fs.readFileSync(path.join(topLevelExeDir, pnExecutable), 'utf8')
-    expect(pnResult).toBe(fakeBinaryContent)
+    // pn is a shell script in the tarball (not created by linkExePlatformBinary)
   })
 
   test('also works with flat node_modules layout', () => {

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -19,6 +19,8 @@
     "setup.js",
     "prepare.js",
     "dist/",
+    "pn.cmd",
+    "pn.ps1",
     "pnpx.cmd",
     "pnpx.ps1",
     "pnx.cmd",

--- a/pnpm/artifacts/exe/prepare.js
+++ b/pnpm/artifacts/exe/prepare.js
@@ -4,8 +4,8 @@ import path from 'path'
 const ownDir = import.meta.dirname
 const placeholder = 'This file intentionally left blank'
 
-// pnpm and pn are placeholders — replaced with hardlinks by setup.js
-for (const name of ['pnpm', 'pn']) {
+// pnpm is a placeholder — replaced with a hardlink to the native binary by setup.js
+for (const name of ['pnpm']) {
   const file = path.join(ownDir, name)
   try {
     fs.unlinkSync(file)
@@ -15,8 +15,8 @@ for (const name of ['pnpm', 'pn']) {
   fs.writeFileSync(file, placeholder, 'utf8')
 }
 
-// pnpx and pnx — write the real shell scripts and Windows wrappers
-for (const [name, command] of [['pnpx', 'pnpm dlx'], ['pnx', 'pnpm dlx']]) {
+// pn, pnpx, and pnx — write the real shell scripts and Windows wrappers
+for (const [name, command] of [['pn', 'pnpm'], ['pnpx', 'pnpm dlx'], ['pnx', 'pnpm dlx']]) {
   const file = path.join(ownDir, name)
   try {
     fs.unlinkSync(file)

--- a/pnpm/artifacts/exe/setup.js
+++ b/pnpm/artifacts/exe/setup.js
@@ -21,23 +21,18 @@ if (!fs.existsSync(bin)) process.exit(0)
 
 linkSync(bin, path.resolve(ownDir, executable))
 
-// Create pn alias (hardlink to the same binary)
-const pnExecutable = platform === 'win' ? 'pn.exe' : 'pn'
-linkSync(bin, path.resolve(ownDir, pnExecutable))
-
 if (platform === 'win') {
-  // On Windows, also hardlink the binary as 'pnpm' and 'pn' (no .exe
-  // extension). npm's bin shims point to the name from publishConfig.bin,
-  // and npm does NOT re-read package.json after preinstall, so rewriting
-  // the bin entry has no effect on the shims. The file at the original
-  // name must be the real binary so the shim can execute it.
+  // On Windows, also hardlink the binary as 'pnpm' (no .exe extension).
+  // npm's bin shims point to the name from publishConfig.bin, and npm
+  // does NOT re-read package.json after preinstall, so rewriting the bin
+  // entry has no effect on the shims. The file at the original name must
+  // be the real binary so the shim can execute it.
   linkSync(bin, path.resolve(ownDir, 'pnpm'))
-  linkSync(bin, path.resolve(ownDir, 'pn'))
 
   const pkgJsonPath = path.resolve(ownDir, 'package.json')
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
   pkg.bin.pnpm = 'pnpm.exe'
-  pkg.bin.pn = 'pn.exe'
+  pkg.bin.pn = 'pn.cmd'
   pkg.bin.pnpx = 'pnpx.cmd'
   pkg.bin.pnx = 'pnx.cmd'
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2))

--- a/pnpm/artifacts/exe/test/setup.test.ts
+++ b/pnpm/artifacts/exe/test/setup.test.ts
@@ -20,35 +20,28 @@ const hasPlatformBinary = fs.existsSync(platformBin)
 test('prepare writes correct content for all bin files', () => {
   execFileSync(process.execPath, [path.join(exeDir, 'prepare.js')], { cwd: exeDir })
 
-  // pnpm and pn should be placeholders (replaced by setup.js with hardlinks)
-  for (const name of ['pnpm', 'pn']) {
-    expect(fs.readFileSync(path.join(exeDir, name), 'utf8')).toBe('This file intentionally left blank')
-  }
+  // pnpm is a placeholder (replaced by setup.js with a hardlink)
+  expect(fs.readFileSync(path.join(exeDir, 'pnpm'), 'utf8')).toBe('This file intentionally left blank')
 
-  // pnpx and pnx should be real shell scripts
-  for (const name of ['pnpx', 'pnx']) {
-    expect(fs.readFileSync(path.join(exeDir, name), 'utf8')).toBe('#!/bin/sh\nexec pnpm dlx "$@"\n')
+  // pn, pnpx, and pnx should be real shell scripts
+  for (const [name, command] of [['pn', 'pnpm'], ['pnpx', 'pnpm dlx'], ['pnx', 'pnpm dlx']]) {
+    expect(fs.readFileSync(path.join(exeDir, name), 'utf8')).toBe(`#!/bin/sh\nexec ${command} "$@"\n`)
     if (!isWindows) {
       expect(fs.statSync(path.join(exeDir, name)).mode & 0o111).not.toBe(0)
     }
   }
 
   // Windows wrappers should exist
-  for (const name of ['pnpx', 'pnx']) {
-    expect(fs.readFileSync(path.join(exeDir, name + '.cmd'), 'utf8')).toBe('@echo off\npnpm dlx %*\n')
-    expect(fs.readFileSync(path.join(exeDir, name + '.ps1'), 'utf8')).toBe('pnpm dlx @args\n')
+  for (const [name, command] of [['pn', 'pnpm'], ['pnpx', 'pnpm dlx'], ['pnx', 'pnpm dlx']]) {
+    expect(fs.readFileSync(path.join(exeDir, name + '.cmd'), 'utf8')).toBe(`@echo off\n${command} %*\n`)
+    expect(fs.readFileSync(path.join(exeDir, name + '.ps1'), 'utf8')).toBe(`${command} @args\n`)
   }
 });
 
-(hasPlatformBinary ? test : test.skip)('setup.js creates hardlinks for pnpm and pn', () => {
-  // Run prepare first to simulate the published tarball state
+(hasPlatformBinary ? test : test.skip)('setup.js creates hardlink for pnpm', () => {
   execFileSync(process.execPath, [path.join(exeDir, 'prepare.js')], { cwd: exeDir })
   execFileSync(process.execPath, [path.join(exeDir, 'setup.js')], { cwd: exeDir })
 
   const pnpmBin = path.join(exeDir, isWindows ? 'pnpm.exe' : 'pnpm')
-  const pnBin = path.join(exeDir, isWindows ? 'pn.exe' : 'pn')
-
-  // pnpm and pn should be hardlinks to the platform binary
   expect(fs.statSync(pnpmBin).ino).toBe(fs.statSync(platformBin).ino)
-  expect(fs.statSync(pnBin).ino).toBe(fs.statSync(platformBin).ino)
 })


### PR DESCRIPTION
## Summary

Follow-up to #11144. The previous fix created `pn` as a hardlink in `linkExePlatformBinary`, but that only works when the *installing* version has the fix. During store installs (auto version management), the bootstrap version's code runs — so an older bootstrap without the fix still leaves `pn` as a placeholder.

This makes `pn` a shell script (`exec pnpm "$@"`) written by `prepare.js`, the same approach that already works for `pnpx`/`pnx`. The tarball contains working scripts regardless of which version does the installing.

### Changes

- **`prepare.js`**: `pn` is now a shell script + `.cmd`/`.ps1`, only `pnpm` remains as a placeholder
- **`setup.js`**: only creates hardlink for `pnpm`, no longer touches `pn`
- **`linkExePlatformBinary`**: same — only `pnpm` hardlink, `pn`/`pnpx`/`pnx` come from the tarball

## Test plan

- [x] Unit tests for `linkExePlatformBinary` pass
- [x] E2E test verifies `prepare.js` writes correct content for all bins
- [ ] CI passes