### PR TITLE
test(deps-resolver): add failing test for autoInstallPeers resolving optional peers

### DIFF
--- a/pnpm/test/monorepo/autoInstallOptionalPeers.test.ts
+++ b/pnpm/test/monorepo/autoInstallOptionalPeers.test.ts
@@ -1,0 +1,112 @@
+import path from 'node:path'
+
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import type { LockfileFile } from '@pnpm/lockfile.types'
+import { preparePackages } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/registry-mock'
+import { readYamlFileSync } from 'read-yaml-file'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpm } from '../utils/index.js'
+
+// Covers https://github.com/pnpm/pnpm/issues/11155
+// autoInstallPeers should NOT install optional peer dependencies.
+// Only non-optional (required) peers should be auto-installed.
+//
+// @pnpm.e2e/abc-optional-peers has:
+//   peerDependencies: { peer-a: ^1, peer-b: ^1, peer-c: ^1 }
+//   peerDependenciesMeta: { peer-b: { optional: true }, peer-c: { optional: true } }
+//
+// So peer-a is required, peer-b and peer-c are optional.
+
+test('autoInstallPeers should not install optional peer dependencies', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+
+  preparePackages([
+    {
+      location: 'project-1',
+      package: {
+        name: 'project-1',
+
+        dependencies: {
+          '@pnpm.e2e/abc-optional-peers': '1.0.0',
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    autoInstallPeers: true,
+  })
+  await execPnpm(['install'])
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+  const project1Deps = lockfile.importers?.['project-1']?.dependencies ?? {}
+
+  // The resolved version string for abc-optional-peers encodes which peers were resolved.
+  // peer-a is required — it SHOULD appear in the resolution
+  const abcVersion = project1Deps['@pnpm.e2e/abc-optional-peers']?.version ?? ''
+  expect(abcVersion).toContain('@pnpm.e2e/peer-a@')
+
+  // peer-b and peer-c are optional (peerDependenciesMeta: { optional: true }) —
+  // they should NOT be resolved since no workspace package depends on them.
+  // BUG: pnpm currently resolves them anyway.
+  expect(abcVersion).not.toContain('@pnpm.e2e/peer-b@')
+  expect(abcVersion).not.toContain('@pnpm.e2e/peer-c@')
+})
+
+test('autoInstallPeers should not install optional peers even when another workspace package provides one', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+
+  preparePackages([
+    {
+      location: 'project-1',
+      package: {
+        name: 'project-1',
+
+        dependencies: {
+          '@pnpm.e2e/abc-optional-peers': '1.0.0',
+        },
+      },
+    },
+    {
+      location: 'project-2',
+      package: {
+        name: 'project-2',
+
+        dependencies: {
+          // project-2 uses peer-b directly, but project-1 does not
+          '@pnpm.e2e/peer-b': '1.0.0',
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    autoInstallPeers: true,
+  })
+  await execPnpm(['install'])
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+  const project1Deps = lockfile.importers?.['project-1']?.dependencies ?? {}
+
+  const abcVersion = project1Deps['@pnpm.e2e/abc-optional-peers']?.version ?? ''
+
+  // peer-a is required — should be resolved for project-1
+  expect(abcVersion).toContain('@pnpm.e2e/peer-a@')
+
+  // peer-b exists in project-2 but is optional for abc-optional-peers —
+  // it should NOT be resolved into project-1's abc-optional-peers just
+  // because it exists somewhere in the workspace.
+  // BUG: pnpm currently resolves it because it's in allPreferredVersions.
+  expect(abcVersion).not.toContain('@pnpm.e2e/peer-b@')
+
+  // peer-c is optional and not depended on by anyone — should not be resolved
+  expect(abcVersion).not.toContain('@pnpm.e2e/peer-c@')
+})


### PR DESCRIPTION
## Human note

Despite the PR and related issue being Claude generated, the actual issue is something that we've been struggling with for quite some time in our pipelines. Claude has just allowed us to finally pin-point the issue.

## Summary

Adds two e2e tests demonstrating that `autoInstallPeers` incorrectly resolves optional peer dependencies (`peerDependenciesMeta: { optional: true }`).

Uses the existing `@pnpm.e2e/abc-optional-peers` test fixture which declares:
- `peer-a` as **required** peer
- `peer-b` and `peer-c` as **optional** peers

### Test 1: Basic case (PASSES)
Optional peers are not auto-installed when no workspace package depends on them.

### Test 2: Cross-workspace contamination (FAILS — reproduces the bug)
When `project-2` depends on `peer-b` directly, pnpm resolves it as an optional peer into `project-1`'s `abc-optional-peers` resolution. The resolved version string becomes `1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-b@1.0.0)` instead of `1.0.0(@pnpm.e2e/peer-a@1.0.0)`.

## Root cause

In `resolveDependencies.ts`, `getHoistableOptionalPeers()` picks up optional peers from `allPreferredVersions` — a global map that includes versions resolved by *any* workspace package. When `project-2` resolves `peer-b`, it enters `allPreferredVersions`, and `getHoistableOptionalPeers` then installs it as an optional dependency for `project-1`'s `abc-optional-peers` even though `project-1` never asked for it.

## Real-world impact

Packages like `typeorm` declare ~17 database drivers as optional peers. In a monorepo where only `pg` and `mongodb` are used, all 17 drivers get installed — including `@sap/hana-client`, `oracledb`, `mssql`, `better-sqlite3`, etc. — resulting in 134+ unnecessary packages with native build steps that can fail on CI.

## References

- Issue: #11155
- Minimal standalone reproduction: https://github.com/macstr1k3r/pnpm-auto-install-peers-optional-repro
- Related: #8142, #10046, #5388, #5152