### PR TITLE
docs: add Discord link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ why it works fine with the Node.js ecosystem, read this small article: [Flat nod
 - [Frequently Asked Questions](https://pnpm.io/faq)
 - [X](https://x.com/pnpmjs)
 - [Bluesky](https://bsky.app/profile/pnpm.io)
+- [Discord](https://bit.ly/pnpm-discord-invite)
 
 ## Benchmark
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ why it works fine with the Node.js ecosystem, read this small article: [Flat nod
 - [Frequently Asked Questions](https://pnpm.io/faq)
 - [X](https://x.com/pnpmjs)
 - [Bluesky](https://bsky.app/profile/pnpm.io)
-- [Discord](https://bit.ly/pnpm-discord-invite)
+- [Discord](https://r.pnpm.io/chat)
 
 ## Benchmark
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -235,6 +235,7 @@ Benchmarks on an app with lots of dependencies:
 - [Frequently Asked Questions](https://pnpm.io/faq)
 - [X](https://x.com/pnpmjs)
 - [Bluesky](https://bsky.app/profile/pnpm.io)
+- [Discord](https://r.pnpm.io/chat)
 
 ## License
 


### PR DESCRIPTION
I was having trouble finding the Discord link (ended up finding it through the issue https://github.com/pnpm/pnpm/issues/3095)

What do you think about including it prominently in the readme?

Companion PR, adding to "Community" in pnpm.io footer:

- https://github.com/pnpm/pnpm.io/pull/769