### PR TITLE
fix: reject falsy non-array packages in workspace manifest

### DIFF
--- a/workspace/workspace-manifest-reader/src/index.ts
+++ b/workspace/workspace-manifest-reader/src/index.ts
@@ -81,7 +81,7 @@ export function validateWorkspaceManifest (manifest: unknown): asserts manifest 
 }
 
 function assertValidWorkspaceManifestPackages (manifest: { packages?: unknown }): asserts manifest is { packages: string[] } {
-  if (!manifest.packages) {
+  if (manifest.packages == null) {
     return
   }
 

--- a/workspace/workspace-manifest-reader/test/__fixtures__/packages-false/pnpm-workspace.yaml
+++ b/workspace/workspace-manifest-reader/test/__fixtures__/packages-false/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+packages: false

--- a/workspace/workspace-manifest-reader/test/index.ts
+++ b/workspace/workspace-manifest-reader/test/index.ts
@@ -34,6 +34,12 @@ test('readWorkspaceManifest() throws on string packages field', async () => {
   ).rejects.toThrow('packages field is not an array')
 })
 
+test('readWorkspaceManifest() throws on false packages field', async () => {
+  await expect(
+    readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/packages-false'))
+  ).rejects.toThrow('packages field is not an array')
+})
+
 test('readWorkspaceManifest() throws on empty package', async () => {
   await expect(
     readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/packages-contains-empty'))


### PR DESCRIPTION
## Summary
Reject falsy non-array `packages` values in `pnpm-workspace.yaml`.

## Problem
`assertValidWorkspaceManifestPackages()` currently uses a truthiness check:

`if (!manifest.packages) return`

This causes falsy non-array values like `false` to be treated as if the field were absent, instead of being rejected as invalid.

The `packages` field is optional, but when present it must be an array.

## Fix
Change the guard to only treat `null` and `undefined` as absent:

`if (manifest.packages == null) return`

## Test
Added a regression fixture and test covering `packages: false`.

The new test fails on the old behavior and passes with the fix.