### PR TITLE
docs(store): fix spelling in parseTarball comment

### DIFF
--- a/store/cafs/src/parseTarball.ts
+++ b/store/cafs/src/parseTarball.ts
@@ -120,7 +120,7 @@ export function parseTarball (buffer: Buffer): IParseResult {
       // The file mode is an octal number encoded as UTF-8. It is terminated by a NUL or space. Maximum length 8 characters.
         mode = parseOctal(blockStart + MODE_OFFSET, 8)
 
-        // The TAR format is an append-only data structure; as such later entries with the same name supercede earlier ones.
+        // The TAR format is an append-only data structure; as such later entries with the same name supersede earlier ones.
         files.set(fileName.replaceAll('//', '/'), { offset: blockStart + 512, mode, size: fileSize })
         break
       case FILE_TYPE_DIRECTORY:


### PR DESCRIPTION
## Summary
- Fix the spelling of `supersede` in the tarball parsing comment.

## Related issue
- N/A; trivial comment-only fix.

## Guideline alignment
- One-file comment change with no behavior impact.
- No release-note or changeset update was added because this does not change runtime behavior.

## Validation
- Not run; comment-only change.