### PR TITLE
fix(test): include LICENSE in case-insensitive filesystem test expectation

### DIFF
--- a/pnpm/test/install/misc.ts
+++ b/pnpm/test/install/misc.ts
@@ -182,7 +182,7 @@ test("don't fail on case insensitive filesystems when package has 2 files with s
   if (await dirIsCaseSensitive(storeDir)) {
     expect([...files].sort(lexCompare)).toStrictEqual(['Foo.js', 'LICENSE', 'foo.js', 'package.json'])
   } else {
-    expect([...files].map((f) => f.toLowerCase()).sort(lexCompare)).toStrictEqual(['foo.js', 'package.json'])
+    expect([...files].map((f) => f.toLowerCase()).sort(lexCompare)).toStrictEqual(['foo.js', 'license', 'package.json'])
   }
 })
 


### PR DESCRIPTION
## Summary
- The test for case-insensitive filesystems expected only `['foo.js', 'package.json']` but `LICENSE` has no case collision with any other file in the package, so it should still be present in `node_modules`
- Fixed the expectation to `['foo.js', 'license', 'package.json']`

## Test plan
- [ ] Verify Windows CI passes for `pnpm/test/install/misc.ts`