### PR TITLE
fix: validate all readPackage dependency maps

### DIFF
--- a/.changeset/kind-peaches-film.md
+++ b/.changeset/kind-peaches-film.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.pnpmfile": patch
+"pnpm": patch
+---
+
+Validate all `readPackage` dependency map fields, including `devDependencies`, and reject falsy non-object invalid values instead of silently accepting them.

--- a/hooks/pnpmfile/src/requirePnpmfile.ts
+++ b/hooks/pnpmfile/src/requirePnpmfile.ts
@@ -75,9 +75,9 @@ export async function requirePnpmfile (pnpmFilePath: string, prefix: string): Pr
         if (!newPkg) {
           throw new BadReadPackageHookError(pnpmFilePath, 'readPackage hook did not return a package manifest object.')
         }
-        const dependencies = ['dependencies', 'optionalDependencies', 'peerDependencies']
+        const dependencies = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const
         for (const dep of dependencies) {
-          if (newPkg[dep] && typeof newPkg[dep] !== 'object') {
+          if (newPkg[dep] != null && (typeof newPkg[dep] !== 'object' || Array.isArray(newPkg[dep]))) {
             throw new BadReadPackageHookError(pnpmFilePath, `readPackage hook returned package manifest object's property '${dep}' must be an object.`)
           }
         }

--- a/hooks/pnpmfile/test/__fixtures__/readPackageArrayPeerDependencies.js
+++ b/hooks/pnpmfile/test/__fixtures__/readPackageArrayPeerDependencies.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: { readPackage },
+}
+
+function readPackage (pkg) {
+  pkg.peerDependencies = []
+  return pkg
+}

--- a/hooks/pnpmfile/test/__fixtures__/readPackageFalsyOptionalDependencies.js
+++ b/hooks/pnpmfile/test/__fixtures__/readPackageFalsyOptionalDependencies.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: { readPackage },
+}
+
+function readPackage (pkg) {
+  pkg.optionalDependencies = false
+  return pkg
+}

--- a/hooks/pnpmfile/test/__fixtures__/readPackageNoObjectDevDependencies.js
+++ b/hooks/pnpmfile/test/__fixtures__/readPackageNoObjectDevDependencies.js
@@ -1,0 +1,8 @@
+module.exports = {
+  hooks: { readPackage },
+}
+
+function readPackage (pkg) {
+  pkg.devDependencies = '@oclif/errors'
+  return pkg
+}

--- a/hooks/pnpmfile/test/index.ts
+++ b/hooks/pnpmfile/test/index.ts
@@ -31,6 +31,30 @@ test('readPackage hook run fails when returned dependencies is not an object', a
   ).rejects.toEqual(new BadReadPackageHookError(pnpmfilePath, 'readPackage hook returned package manifest object\'s property \'dependencies\' must be an object.'))
 })
 
+test('readPackage hook run fails when returned devDependencies is not an object', async () => {
+  const pnpmfilePath = path.join(import.meta.dirname, '__fixtures__/readPackageNoObjectDevDependencies.js')
+  const { pnpmfileModule: pnpmfile } = (await requirePnpmfile(pnpmfilePath, import.meta.dirname))!
+  return expect(
+    pnpmfile!.hooks!.readPackage!({}, defaultHookContext)
+  ).rejects.toEqual(new BadReadPackageHookError(pnpmfilePath, 'readPackage hook returned package manifest object\'s property \'devDependencies\' must be an object.'))
+})
+
+test('readPackage hook run fails when returned optionalDependencies is a falsy non-object value', async () => {
+  const pnpmfilePath = path.join(import.meta.dirname, '__fixtures__/readPackageFalsyOptionalDependencies.js')
+  const { pnpmfileModule: pnpmfile } = (await requirePnpmfile(pnpmfilePath, import.meta.dirname))!
+  return expect(
+    pnpmfile!.hooks!.readPackage!({}, defaultHookContext)
+  ).rejects.toEqual(new BadReadPackageHookError(pnpmfilePath, 'readPackage hook returned package manifest object\'s property \'optionalDependencies\' must be an object.'))
+})
+
+test('readPackage hook run fails when returned peerDependencies is an array', async () => {
+  const pnpmfilePath = path.join(import.meta.dirname, '__fixtures__/readPackageArrayPeerDependencies.js')
+  const { pnpmfileModule: pnpmfile } = (await requirePnpmfile(pnpmfilePath, import.meta.dirname))!
+  return expect(
+    pnpmfile!.hooks!.readPackage!({}, defaultHookContext)
+  ).rejects.toEqual(new BadReadPackageHookError(pnpmfilePath, 'readPackage hook returned package manifest object\'s property \'peerDependencies\' must be an object.'))
+})
+
 test('filterLog hook combines with the global hook', async () => {
   const globalPnpmfile = path.join(import.meta.dirname, '__fixtures__/globalFilterLog.js')
   const pnpmfile = path.join(import.meta.dirname, '__fixtures__/filterLog.js')


### PR DESCRIPTION
## Summary

Fixes validation gaps in the `readPackage` hook wrapper for dependency map
fields.

Previously, only `dependencies`, `optionalDependencies`, and
`peerDependencies` were validated, so `devDependencies` could bypass the
check entirely.

The existing guard also relied on a truthy check, which meant falsy invalid
values like `false` were silently accepted. Arrays were also accepted because
they satisfy `typeof value === 'object'`, even though dependency maps are
expected to be plain objects.

This change validates all dependency map fields consistently and throws
`BadReadPackageHookError` for invalid non-object values.

## Changes

- include `devDependencies` in dependency map validation
- reject falsy non-object invalid values instead of skipping them
- reject arrays for dependency map fields
- add regression coverage for invalid `devDependencies`,
  falsy invalid `optionalDependencies`, and array `peerDependencies`

## Test

- added regression fixtures and tests covering:
  - invalid `devDependencies`
  - falsy invalid `optionalDependencies`
  - array `peerDependencies`
- verified the wrapper now throws `BadReadPackageHookError` for all cases