### PR TITLE
fix: reject null named catalogs in workspace manifest reader

### DIFF
--- a/.changeset/gentle-hats-doubt.md
+++ b/.changeset/gentle-hats-doubt.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.workspace-manifest-reader": patch
+"pnpm": patch
+---
+
+Reject `null` named catalogs in workspace manifests with `InvalidWorkspaceManifestError` instead of crashing with a raw `TypeError`.

--- a/workspace/workspace-manifest-reader/src/catalogs.ts
+++ b/workspace/workspace-manifest-reader/src/catalogs.ts
@@ -46,6 +46,10 @@ export function assertValidWorkspaceManifestCatalogs (manifest: { packages?: rea
       throw new InvalidWorkspaceManifestError(`Expected named catalog ${catalogName} to be an object, but found - array`)
     }
 
+    if (catalog === null) {
+      throw new InvalidWorkspaceManifestError(`Expected named catalog ${catalogName} to be an object, but found - null`)
+    }
+
     if (typeof catalog !== 'object') {
       throw new InvalidWorkspaceManifestError(`Expected named catalog ${catalogName} to be an object, but found - ${typeof catalog}`)
     }

--- a/workspace/workspace-manifest-reader/test/__fixtures__/catalogs-invalid-named-catalog-null/pnpm-workspace.yaml
+++ b/workspace/workspace-manifest-reader/test/__fixtures__/catalogs-invalid-named-catalog-null/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "packages/**"
+  - "types"
+
+catalogs:
+  foo: null

--- a/workspace/workspace-manifest-reader/test/index.ts
+++ b/workspace/workspace-manifest-reader/test/index.ts
@@ -132,6 +132,15 @@ describe('readWorkspaceManifest() catalogs field', () => {
     ).rejects.toThrow('Expected named catalog foo to be an object, but found - number')
   })
 
+  test('throws on null named catalog', async () => {
+    await expect(
+      readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/catalogs-invalid-named-catalog-null'))
+    ).rejects.toMatchObject({
+      code: 'ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION',
+      message: expect.stringContaining('Expected named catalog foo to be an object, but found - null'),
+    })
+  })
+
   test('throws on invalid named catalog specifier', async () => {
     await expect(
       readWorkspaceManifest(path.join(import.meta.dirname, '__fixtures__/catalogs-invalid-named-catalog-specifier'))


### PR DESCRIPTION
## Summary

Fixes a validation gap in the workspace manifest reader where named catalogs
with `null` values were incorrectly accepted.

Due to `typeof null === 'object'`, entries like:

```yaml
catalogs:
  foo: null
``` 

would pass the object check and later crash at `Object.entries()` with a raw
`TypeError`.

This change explicitly rejects null named catalogs during validation and
throws `InvalidWorkspaceManifestError`, aligning with how other invalid
catalog shapes are handled.

## Changes

- Add explicit null check for named catalogs
- Ensure invalid values throw `InvalidWorkspaceManifestError`
- Add regression test for `catalogs: { foo: null }`

## Testing

- Added fixture covering `catalogs: { foo: null }`
- Verified:
  - ✗ fails before fix (raw `TypeError`)
  - ✓ passes after fix (throws `InvalidWorkspaceManifestError`)