### PR TITLE
feat: add minimumReleaseAgeStrict setting

### DIFF
--- a/.changeset/minimum-release-age-loose.md
+++ b/.changeset/minimum-release-age-loose.md
@@ -1,8 +1,0 @@
----
-"@pnpm/config.reader": minor
-"@pnpm/store.connection-manager": minor
-"@pnpm/deps.inspection.outdated": minor
-"pnpm": minor
----
-
-Added a new setting `minimumReleaseAgeLoose` that is `true` by default. When enabled, pnpm falls back to versions that don't meet the `minimumReleaseAge` constraint if no mature versions satisfy the range being resolved.

--- a/.changeset/minimum-release-age-loose.md
+++ b/.changeset/minimum-release-age-loose.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/store.connection-manager": minor
+"@pnpm/deps.inspection.outdated": minor
+"pnpm": minor
+---
+
+Added a new setting `minimumReleaseAgeLoose` that is `true` by default. When enabled, pnpm falls back to versions that don't meet the `minimumReleaseAge` constraint if no mature versions satisfy the range being resolved.

--- a/.changeset/minimum-release-age-strict.md
+++ b/.changeset/minimum-release-age-strict.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/store.connection-manager": minor
+"@pnpm/deps.inspection.outdated": minor
+"pnpm": minor
+---
+
+Added a new setting `minimumReleaseAgeStrict` that is `false` by default. When disabled (the default), pnpm falls back to versions that don't meet the `minimumReleaseAge` constraint if no mature versions satisfy the range being resolved. Set to `true` to fail installation instead.

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -249,7 +249,7 @@ export interface Config extends OptionsFromRootManifest {
   preserveAbsolutePaths?: boolean
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
-  minimumReleaseAgeLoose?: boolean
+  minimumReleaseAgeStrict?: boolean
   fetchWarnTimeoutMs?: number
   fetchMinSpeedKiBps?: number
   trustPolicy?: TrustPolicy

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -249,6 +249,7 @@ export interface Config extends OptionsFromRootManifest {
   preserveAbsolutePaths?: boolean
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeLoose?: boolean
   fetchWarnTimeoutMs?: number
   fetchMinSpeedKiBps?: number
   trustPolicy?: TrustPolicy

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -36,6 +36,7 @@ export const pnpmConfigFileKeys = [
   'dlx-cache-max-age',
   'minimum-release-age',
   'minimum-release-age-exclude',
+  'minimum-release-age-loose',
   'network-concurrency',
   'noproxy',
   'npm-path',

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -36,7 +36,7 @@ export const pnpmConfigFileKeys = [
   'dlx-cache-max-age',
   'minimum-release-age',
   'minimum-release-age-exclude',
-  'minimum-release-age-loose',
+  'minimum-release-age-strict',
   'network-concurrency',
   'noproxy',
   'npm-path',

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -71,6 +71,7 @@ export const pnpmTypes = {
   'dlx-cache-max-age': Number,
   'minimum-release-age': Number,
   'minimum-release-age-exclude': [String, Array],
+  'minimum-release-age-loose': Boolean,
   'modules-dir': String,
   'network-concurrency': Number,
   'node-linker': ['pnp', 'isolated', 'hoisted'],

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -71,7 +71,7 @@ export const pnpmTypes = {
   'dlx-cache-max-age': Number,
   'minimum-release-age': Number,
   'minimum-release-age-exclude': [String, Array],
-  'minimum-release-age-loose': Boolean,
+  'minimum-release-age-strict': Boolean,
   'modules-dir': String,
   'network-concurrency': Number,
   'node-linker': ['pnp', 'isolated', 'hoisted'],

--- a/deps/inspection/outdated/src/createManifestGetter.ts
+++ b/deps/inspection/outdated/src/createManifestGetter.ts
@@ -12,7 +12,7 @@ interface GetManifestOpts {
   configByUri: object
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
-  minimumReleaseAgeLoose?: boolean
+  minimumReleaseAgeStrict?: boolean
 }
 
 export type ManifestGetterOptions = Omit<ClientOptions, 'configByUri' | 'minimumReleaseAgeExclude' | 'storeIndex'>
@@ -30,7 +30,7 @@ export function createManifestGetter (
     ...opts,
     configByUri: opts.configByUri,
     filterMetadata: false, // We need all the data from metadata for "outdated --long" to work.
-    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
   })
 
   const publishedBy = opts.minimumReleaseAge

--- a/deps/inspection/outdated/src/createManifestGetter.ts
+++ b/deps/inspection/outdated/src/createManifestGetter.ts
@@ -12,6 +12,7 @@ interface GetManifestOpts {
   configByUri: object
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeLoose?: boolean
 }
 
 export type ManifestGetterOptions = Omit<ClientOptions, 'configByUri' | 'minimumReleaseAgeExclude' | 'storeIndex'>
@@ -29,7 +30,7 @@ export function createManifestGetter (
     ...opts,
     configByUri: opts.configByUri,
     filterMetadata: false, // We need all the data from metadata for "outdated --long" to work.
-    strictPublishedByCheck: Boolean(opts.minimumReleaseAge),
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
   })
 
   const publishedBy = opts.minimumReleaseAge

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -106,6 +106,7 @@ export async function handler (
     configByUri: opts.configByUri,
     fullMetadata,
     filterMetadata: fullMetadata,
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
     retry: {
       factor: opts.fetchRetryFactor,
       maxTimeout: opts.fetchRetryMaxtimeout,

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -106,7 +106,7 @@ export async function handler (
     configByUri: opts.configByUri,
     fullMetadata,
     filterMetadata: fullMetadata,
-    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
     retry: {
       factor: opts.fetchRetryFactor,
       maxTimeout: opts.fetchRetryMaxtimeout,

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -396,6 +396,7 @@ test('dlx should fail when the requested package does not meet the minimum age r
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       minimumReleaseAge: 60 * 24 * 10000,
+      minimumReleaseAgeLoose: false,
       registries: {
         // We must use the public registry instead of verdaccio here
         // because verdaccio has the "times" field in the abbreviated metadata too.

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -396,7 +396,7 @@ test('dlx should fail when the requested package does not meet the minimum age r
       ...DEFAULT_OPTS,
       dir: path.resolve('project'),
       minimumReleaseAge: 60 * 24 * 10000,
-      minimumReleaseAgeLoose: false,
+      minimumReleaseAgeStrict: true,
       registries: {
         // We must use the public registry instead of verdaccio here
         // because verdaccio has the "times" field in the abbreviated metadata too.

--- a/installing/commands/test/add.ts
+++ b/installing/commands/test/add.ts
@@ -378,6 +378,7 @@ test('minimumReleaseAge makes install fail if there is no version that was publi
     ...DEFAULT_OPTIONS,
     dir: path.resolve('project'),
     minimumReleaseAge,
+    minimumReleaseAgeLoose: false,
     linkWorkspacePackages: false,
   }, ['is-odd@0.1.1'])).rejects.toThrow(/Version 0\.1\.1 \(released .+\) of is-odd does not meet the minimumReleaseAge constraint/)
 })

--- a/installing/commands/test/add.ts
+++ b/installing/commands/test/add.ts
@@ -367,7 +367,7 @@ test('add: fail trying to install @pnpm/exe', async () => {
   expect(err.code).toBe('ERR_PNPM_GLOBAL_PNPM_INSTALL')
 })
 
-test('minimumReleaseAge makes install fail if there is no version that was published before the cutoff', async () => {
+test('minimumReleaseAge with minimumReleaseAgeLoose disabled makes install fail if there is no version that was published before the cutoff', async () => {
   prepareEmpty()
 
   const isOdd011ReleaseDate = new Date(2016, 11, 7 - 2) // 0.1.1 was released at 2016-12-07T07:18:01.205Z

--- a/installing/commands/test/add.ts
+++ b/installing/commands/test/add.ts
@@ -367,7 +367,7 @@ test('add: fail trying to install @pnpm/exe', async () => {
   expect(err.code).toBe('ERR_PNPM_GLOBAL_PNPM_INSTALL')
 })
 
-test('minimumReleaseAge with minimumReleaseAgeLoose disabled makes install fail if there is no version that was published before the cutoff', async () => {
+test('minimumReleaseAge with minimumReleaseAgeStrict enabled makes install fail if there is no version that was published before the cutoff', async () => {
   prepareEmpty()
 
   const isOdd011ReleaseDate = new Date(2016, 11, 7 - 2) // 0.1.1 was released at 2016-12-07T07:18:01.205Z
@@ -378,7 +378,7 @@ test('minimumReleaseAge with minimumReleaseAgeLoose disabled makes install fail 
     ...DEFAULT_OPTIONS,
     dir: path.resolve('project'),
     minimumReleaseAge,
-    minimumReleaseAgeLoose: false,
+    minimumReleaseAgeStrict: true,
     linkWorkspacePackages: false,
   }, ['is-odd@0.1.1'])).rejects.toThrow(/Version 0\.1\.1 \(released .+\) of is-odd does not meet the minimumReleaseAge constraint/)
 })

--- a/installing/deps-installer/test/install/minimumReleaseAge.ts
+++ b/installing/deps-installer/test/install/minimumReleaseAge.ts
@@ -63,10 +63,10 @@ test('minimumReleaseAge applies to versions not in minimumReleaseAgeExclude', as
   expect(manifest.dependencies!['is-odd']).toBe('~0.1.0')
 })
 
-test('minimumReleaseAgeLoose falls back to immature version when no mature version satisfies the range', async () => {
+test('minimumReleaseAge falls back to immature version when no mature version satisfies the range (non-strict mode)', async () => {
   prepareEmpty()
 
-  // With loose mode (default), falls back to installing an immature version.
+  // With non-strict mode (default), falls back to installing an immature version.
   // The fallback picks the lowest matching version (0.1.0), which differs from
   // normal resolution without minimumReleaseAge that would pick the highest (0.1.2).
   const opts = testDefaults({ minimumReleaseAge: allImmatureMinimumReleaseAge })
@@ -75,7 +75,7 @@ test('minimumReleaseAgeLoose falls back to immature version when no mature versi
   expect(manifest.dependencies!['is-odd']).toBe('~0.1.0')
 })
 
-test('minimumReleaseAge throws when no mature version satisfies the range and loose mode is disabled', async () => {
+test('minimumReleaseAge throws when no mature version satisfies the range and strict mode is enabled', async () => {
   prepareEmpty()
 
   await expect(async () => {

--- a/installing/deps-installer/test/install/minimumReleaseAge.ts
+++ b/installing/deps-installer/test/install/minimumReleaseAge.ts
@@ -66,11 +66,13 @@ test('minimumReleaseAge applies to versions not in minimumReleaseAgeExclude', as
 test('minimumReleaseAgeLoose falls back to immature version when no mature version satisfies the range', async () => {
   prepareEmpty()
 
-  // With loose mode (default), falls back to installing an immature version
+  // With loose mode (default), falls back to installing an immature version.
+  // The fallback picks the lowest matching version (0.1.0), which differs from
+  // normal resolution without minimumReleaseAge that would pick the highest (0.1.2).
   const opts = testDefaults({ minimumReleaseAge: allImmatureMinimumReleaseAge })
   const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['is-odd@0.1'], opts)
 
-  expect(manifest.dependencies!['is-odd']).toBeTruthy()
+  expect(manifest.dependencies!['is-odd']).toBe('~0.1.0')
 })
 
 test('minimumReleaseAge throws when no mature version satisfies the range and loose mode is disabled', async () => {

--- a/installing/deps-installer/test/install/minimumReleaseAge.ts
+++ b/installing/deps-installer/test/install/minimumReleaseAge.ts
@@ -7,6 +7,9 @@ const isOdd011ReleaseDate = new Date(2016, 11, 7 - 2) // 0.1.1 was released at 2
 const diff = Date.now() - isOdd011ReleaseDate.getTime()
 const minimumReleaseAge = diff / (60 * 1000) // converting to minutes
 
+// A very high value that makes ALL versions immature (cutoff date would be before any version was published)
+const allImmatureMinimumReleaseAge = Date.now() / (60 * 1000)
+
 test('minimumReleaseAge prevents installation of versions that do not meet the required publish date cutoff', async () => {
   prepareEmpty()
 
@@ -58,6 +61,28 @@ test('minimumReleaseAge applies to versions not in minimumReleaseAgeExclude', as
   // 0.1.2 is NOT excluded (only 0.1.0 is), so minimumReleaseAge applies
   // This should install 0.1.0 which is old enough
   expect(manifest.dependencies!['is-odd']).toBe('~0.1.0')
+})
+
+test('minimumReleaseAgeLoose falls back to immature version when no mature version satisfies the range', async () => {
+  prepareEmpty()
+
+  // With loose mode (default), falls back to installing an immature version
+  const opts = testDefaults({ minimumReleaseAge: allImmatureMinimumReleaseAge })
+  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['is-odd@0.1'], opts)
+
+  expect(manifest.dependencies!['is-odd']).toBeTruthy()
+})
+
+test('minimumReleaseAge throws when no mature version satisfies the range and loose mode is disabled', async () => {
+  prepareEmpty()
+
+  await expect(async () => {
+    const opts = testDefaults(
+      { minimumReleaseAge: allImmatureMinimumReleaseAge },
+      { strictPublishedByCheck: true }
+    )
+    await addDependenciesToPackage({}, ['is-odd@0.1'], opts)
+  }).rejects.toThrow(/does not meet the minimumReleaseAge constraint/)
 })
 
 test('throws error when semver range is used in minimumReleaseAgeExclude', async () => {

--- a/store/connection-manager/src/createNewStoreController.ts
+++ b/store/connection-manager/src/createNewStoreController.ts
@@ -34,7 +34,7 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
 | 'localAddress'
 | 'maxSockets'
 | 'minimumReleaseAge'
-| 'minimumReleaseAgeLoose'
+| 'minimumReleaseAgeStrict'
 | 'networkConcurrency'
 | 'noProxy'
 | 'offline'
@@ -110,7 +110,7 @@ export async function createNewStoreController (
     includeOnlyPackageFiles: !opts.deployAllFiles,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
     preserveAbsolutePaths: opts.preserveAbsolutePaths,
-    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
     storeIndex,
   })
   return {

--- a/store/connection-manager/src/createNewStoreController.ts
+++ b/store/connection-manager/src/createNewStoreController.ts
@@ -34,6 +34,7 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
 | 'localAddress'
 | 'maxSockets'
 | 'minimumReleaseAge'
+| 'minimumReleaseAgeLoose'
 | 'networkConcurrency'
 | 'noProxy'
 | 'offline'
@@ -109,7 +110,7 @@ export async function createNewStoreController (
     includeOnlyPackageFiles: !opts.deployAllFiles,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
     preserveAbsolutePaths: opts.preserveAbsolutePaths,
-    strictPublishedByCheck: Boolean(opts.minimumReleaseAge),
+    strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeLoose === false,
     storeIndex,
   })
   return {


### PR DESCRIPTION
## Summary
- Adds a new `minimumReleaseAgeStrict` setting (default: `false`)
- When `false` (default), pnpm falls back to versions that don't meet the `minimumReleaseAge` constraint if no mature versions satisfy the range being resolved
- Set to `true` to preserve the previous strict behavior (error when no mature version matches)

## Test plan
- [x] Existing `minimumReleaseAge` tests still pass
- [x] New test: non-strict mode (default) falls back to an immature version when no mature version satisfies the range
- [x] New test: strict mode throws when no mature version satisfies the range