### PR TITLE
fix: use satisfiesWithPrereleases for lockfile version verification

### DIFF
--- a/.changeset/fix-lockfile-prerelease-verification.md
+++ b/.changeset/fix-lockfile-prerelease-verification.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.verification": patch
+"pnpm": patch
+---
+
+Fixed lockfile verification to correctly handle pre-release versions. A pre-release version like `1.0.0-alpha` is now recognized as satisfying the `*` range in the lockfile, preventing unnecessary re-resolution.

--- a/lockfile/verification/package.json
+++ b/lockfile/verification/package.json
@@ -41,6 +41,7 @@
     "@pnpm/pkg-manifest.reader": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@yarnpkg/core": "catalog:",
     "p-every": "catalog:",
     "ramda": "catalog:",
     "semver": "catalog:",

--- a/lockfile/verification/src/satisfiesPackageManifest.ts
+++ b/lockfile/verification/src/satisfiesPackageManifest.ts
@@ -4,6 +4,7 @@ import {
   DEPENDENCIES_FIELDS,
   type ProjectManifest,
 } from '@pnpm/types'
+import * as semverUtils from '@yarnpkg/core/semverUtils'
 import { equals, omit, pickBy } from 'ramda'
 import semver from 'semver'
 
@@ -98,7 +99,7 @@ export function satisfiesPackageManifest (
       }
       if (importer?.specifiers[depName] == null || !semver.validRange(importer?.specifiers[depName])) continue
       const version = dp.removeSuffix(importerDeps[depName])
-      if (semver.valid(version) && !semver.satisfies(version, importer.specifiers[depName])) {
+      if (semver.valid(version) && !semverUtils.satisfiesWithPrereleases(version, importer.specifiers[depName])) {
         return {
           satisfies: false,
           detailedReason: `The importer resolution is broken at dependency "${depName}": version "${version}" doesn't satisfy range "${importer.specifiers[depName]}"`,

--- a/lockfile/verification/test/satisfiesPackageManifest.ts
+++ b/lockfile/verification/test/satisfiesPackageManifest.ts
@@ -395,3 +395,56 @@ test('satisfiesPackageManifest()', () => {
     detailedReason: 'The importer resolution is broken at dependency "@apollo/client": version "3.13.8" doesn\'t satisfy range "3.3.7"',
   })
 })
+
+test('satisfiesPackageManifest() with pre-release versions', () => {
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0-alpha' },
+      specifiers: { foo: '*' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '*' },
+    }
+  )).toStrictEqual({ satisfies: true })
+
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '1.0.0-alpha' },
+      specifiers: { foo: '^1.0.0' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^1.0.0' },
+    }
+  )).toStrictEqual({ satisfies: true })
+
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '2.0.0-rc.1' },
+      specifiers: { foo: '>=1.0.0' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '>=1.0.0' },
+    }
+  )).toStrictEqual({ satisfies: true })
+
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { foo: '2.0.0-rc.1' },
+      specifiers: { foo: '^3.0.0' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { foo: '^3.0.0' },
+    }
+  )).toStrictEqual({
+    satisfies: false,
+    detailedReason: 'The importer resolution is broken at dependency "foo": version "2.0.0-rc.1" doesn\'t satisfy range "^3.0.0"',
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1238,7 +1238,7 @@ importers:
         version: 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-jest:
         specifier: 'catalog:'
-        version: 29.15.0(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3)
 
   __utils__/get-release-text:
     dependencies:
@@ -6658,6 +6658,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types
+      '@yarnpkg/core':
+        specifier: 'catalog:'
+        version: 4.5.0(typanion@3.14.0)
       p-every:
         specifier: 'catalog:'
         version: 2.0.0
@@ -11338,14 +11341,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/eslint-plugin@8.57.2':
-    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.57.2
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/parser@8.57.1':
     resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -11387,13 +11382,6 @@ packages:
 
   '@typescript-eslint/type-utils@8.57.1':
     resolution: {integrity: sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.57.2':
-    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -19516,23 +19504,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/type-utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.2
-      eslint: 10.0.3(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
@@ -19592,19 +19563,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/type-utils@8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.0.3(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/types@8.57.1': {}
 
@@ -21361,12 +21319,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.0.3(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       jest: 30.3.0(@babel/types@7.29.0)(@types/node@22.19.15)
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- The lockfile verification added in #9832 used `semver.satisfies` which does not match pre-release versions against ranges like `*` (e.g. `semver.satisfies('1.0.0-alpha', '*')` returns `false`).
- Switched to `satisfiesWithPrereleases` from `@yarnpkg/core/semverUtils`, the same function already used in pnpm's install resolver (`resolvePeers.ts`), which correctly handles pre-release versions. This avoids using `includePrerelease: true` directly, which [has known weird behavior](https://github.com/yarnpkg/berry/issues/575).
- Added tests covering pre-release versions (`*`, `^1.0.0`, `>=1.0.0`) and a negative case (`^3.0.0`).

## Test plan

- [x] Unit tests pass: `satisfiesPackageManifest() with pre-release versions`
- [x] Existing `satisfiesPackageManifest()` tests still pass
- [x] Pre-push hooks (compile, lint, spellcheck) pass