### PR TITLE
feat: add pnpm docs command and home alias

### DIFF
--- a/.changeset/fast-cars-find.md
+++ b/.changeset/fast-cars-find.md
@@ -1,6 +1,11 @@
 ---
 "@pnpm/deps.inspection.commands": minor
+"@pnpm/network.web-auth": major
+"@pnpm/auth.commands": patch
+"@pnpm/releasing.commands": patch
 "pnpm": minor
 ---
 
-Added the `pnpm docs` command and its alias `pnpm home`. This command opens the package documentation or homepage in the browser.
+Added the `pnpm docs` command and its alias `pnpm home`. This command opens the package documentation or homepage in the browser. When the package has no valid homepage, it falls back to `https://npmx.dev/package/<name>`.
+
+Internally, `@pnpm/network.web-auth`'s `promptBrowserOpen` now uses the [`open`](https://www.npmjs.com/package/open) package instead of spawning platform-specific commands. The `execFile` field and `PromptBrowserOpenExecFile` / `PromptBrowserOpenProcess` type exports have been removed from `PromptBrowserOpenContext`.

--- a/.changeset/fast-cars-find.md
+++ b/.changeset/fast-cars-find.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.inspection.commands": minor
+"pnpm": minor
+---
+
+Added the `pnpm docs` command and its alias `pnpm home`. This command opens the package documentation or homepage in the browser.

--- a/auth/commands/src/login.ts
+++ b/auth/commands/src/login.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import path from 'node:path'
 import readline from 'node:readline'
 
@@ -11,7 +10,6 @@ import {
   generateQrCode,
   pollForWebAuthToken,
   promptBrowserOpen,
-  type PromptBrowserOpenExecFile,
   type PromptBrowserOpenReadlineInterface,
   SyntheticOtpError,
   type WebAuthFetchOptions,
@@ -138,7 +136,6 @@ export interface LoginContext {
   setTimeout: (cb: () => void, ms: number) => void
   createReadlineInterface: () => PromptBrowserOpenReadlineInterface
   enquirer: LoginEnquirer
-  execFile: PromptBrowserOpenExecFile
   fetch: (url: string, options?: LoginFetchOptions) => Promise<LoginFetchResponse>
   globalInfo: (message: string) => void
   globalWarn: (message: string) => void
@@ -152,7 +149,6 @@ export const DEFAULT_CONTEXT: LoginContext = {
   setTimeout,
   createReadlineInterface: readline.createInterface.bind(null, { input: process.stdin }),
   enquirer,
-  execFile,
   fetch,
   globalInfo,
   globalWarn,
@@ -212,7 +208,7 @@ export async function login ({ context = DEFAULT_CONTEXT, opts }: LoginParams): 
 }
 
 interface WebLoginParams {
-  context: Pick<LoginContext, 'Date' | 'setTimeout' | 'createReadlineInterface' | 'execFile' | 'fetch' | 'globalInfo' | 'globalWarn' | 'process'>
+  context: Pick<LoginContext, 'Date' | 'setTimeout' | 'createReadlineInterface' | 'fetch' | 'globalInfo' | 'globalWarn' | 'process'>
   fetchOptions: WebAuthFetchOptions
   registry: string
 }
@@ -263,7 +259,7 @@ async function webLogin ({
 }
 
 interface ClassicLoginParams {
-  context: Pick<LoginContext, 'Date' | 'setTimeout' | 'createReadlineInterface' | 'enquirer' | 'execFile' | 'fetch' | 'globalInfo' | 'globalWarn' | 'process'>
+  context: Pick<LoginContext, 'Date' | 'setTimeout' | 'createReadlineInterface' | 'enquirer' | 'fetch' | 'globalInfo' | 'globalWarn' | 'process'>
   fetchOptions: WebAuthFetchOptions
   registry: string
 }

--- a/auth/commands/test/login.test.ts
+++ b/auth/commands/test/login.test.ts
@@ -16,9 +16,6 @@ const TEST_CONTEXT: LoginContext = {
   enquirer: { prompt: async () => {
     throw new Error('Unexpected call to enquirer.prompt')
   } },
-  execFile: () => {
-    throw new Error('Unexpected call to execFile')
-  },
   fetch: async url => {
     throw new Error(`Unexpected call to fetch: ${url}`)
   },

--- a/deps/inspection/commands/package.json
+++ b/deps/inspection/commands/package.json
@@ -57,9 +57,9 @@
     "@pnpm/types": "workspace:*",
     "@zkochan/table": "catalog:",
     "chalk": "catalog:",
+    "open": "catalog:",
     "ramda": "catalog:",
-    "render-help": "catalog:",
-    "open": "^7.4.2"
+    "render-help": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"

--- a/deps/inspection/commands/package.json
+++ b/deps/inspection/commands/package.json
@@ -51,13 +51,15 @@
     "@pnpm/npm-package-arg": "catalog:",
     "@pnpm/resolving.default-resolver": "workspace:*",
     "@pnpm/resolving.npm-resolver": "workspace:*",
+    "@pnpm/resolving.registry.types": "workspace:*",
     "@pnpm/semver-diff": "catalog:",
     "@pnpm/store.path": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@zkochan/table": "catalog:",
     "chalk": "catalog:",
     "ramda": "catalog:",
-    "render-help": "catalog:"
+    "render-help": "catalog:",
+    "open": "^7.4.2"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"

--- a/deps/inspection/commands/src/docs/index.ts
+++ b/deps/inspection/commands/src/docs/index.ts
@@ -39,7 +39,17 @@ export async function handler (
 
   const info = await fetchPackageInfo(opts, packageSpec)
 
-  const url = info.homepage ?? `https://npmx.dev/package/${info.name}`
+  const url = isHttpUrl(info.homepage) ? info.homepage : `https://www.npmjs.com/package/${info.name}`
 
   await open(url)
+}
+
+function isHttpUrl (value: unknown): value is string {
+  if (typeof value !== 'string' || value === '') return false
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
 }

--- a/deps/inspection/commands/src/docs/index.ts
+++ b/deps/inspection/commands/src/docs/index.ts
@@ -1,0 +1,51 @@
+import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
+import { PnpmError } from '@pnpm/error'
+import open from 'open'
+import { pick } from 'ramda'
+import { renderHelp } from 'render-help'
+
+import { fetchPackageInfo } from '../fetchPackageInfo.js'
+
+export function rcOptionsTypes (): Record<string, unknown> {
+  return pick(['registry'], allTypes)
+}
+
+export function cliOptionsTypes (): Record<string, unknown> {
+  return rcOptionsTypes()
+}
+
+export const commandNames = ['docs', 'home']
+
+export function help (): string {
+  return renderHelp({
+    description: 'Open the documentation of a package.',
+    usages: [
+      'pnpm docs <package-name>',
+      'pnpm docs <package-name>@<version>',
+      'pnpm home <package-name>',
+    ],
+  })
+}
+
+export async function handler (
+  opts: Config & ConfigContext,
+  params: string[]
+): Promise<void> {
+  const packageSpec = params[0]
+
+  if (!packageSpec) {
+    throw new PnpmError('MISSING_PACKAGE_NAME', 'Package name is required. Usage: pnpm docs <package-name>')
+  }
+
+  const info = await fetchPackageInfo(opts, packageSpec)
+
+  let url = info.homepage
+  if (!url && info.bugs) {
+    url = typeof info.bugs === 'string' ? info.bugs : info.bugs.url
+  }
+  if (!url) {
+    url = `https://www.npmjs.com/package/${info.name}`
+  }
+
+  await open(url)
+}

--- a/deps/inspection/commands/src/docs/index.ts
+++ b/deps/inspection/commands/src/docs/index.ts
@@ -39,13 +39,7 @@ export async function handler (
 
   const info = await fetchPackageInfo(opts, packageSpec)
 
-  let url = info.homepage
-  if (!url && info.bugs) {
-    url = typeof info.bugs === 'string' ? info.bugs : info.bugs.url
-  }
-  if (!url) {
-    url = `https://www.npmjs.com/package/${info.name}`
-  }
+  const url = info.homepage ?? `https://npmx.dev/package/${info.name}`
 
   await open(url)
 }

--- a/deps/inspection/commands/src/docs/index.ts
+++ b/deps/inspection/commands/src/docs/index.ts
@@ -39,7 +39,7 @@ export async function handler (
 
   const info = await fetchPackageInfo(opts, packageSpec)
 
-  const url = isHttpUrl(info.homepage) ? info.homepage : `https://www.npmjs.com/package/${info.name}`
+  const url = isHttpUrl(info.homepage) ? info.homepage : `https://npmx.dev/package/${info.name}`
 
   await open(url)
 }

--- a/deps/inspection/commands/src/fetchPackageInfo.ts
+++ b/deps/inspection/commands/src/fetchPackageInfo.ts
@@ -1,0 +1,104 @@
+import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+import type { Config, ConfigContext } from '@pnpm/config.reader'
+import { PnpmError } from '@pnpm/error'
+import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+import npa from '@pnpm/npm-package-arg'
+import {
+  fetchMetadataFromFromRegistry,
+  pickPackageFromMeta,
+  pickVersionByVersionRange,
+  type RegistryPackageSpec,
+} from '@pnpm/resolving.npm-resolver'
+import type { PackageInRegistry } from '@pnpm/resolving.registry.types'
+
+export type ExtendedPackageInfo = PackageInRegistry & {
+  author?: string
+  repository?: string
+  versions: string[]
+  versionsCount?: number
+  depsCount?: number
+  distTags: Record<string, string>
+  'dist-tags': Record<string, string>
+  time?: Record<string, string>
+}
+
+export async function fetchPackageInfo (
+  opts: Config & ConfigContext,
+  packageSpec: string
+): Promise<ExtendedPackageInfo> {
+  let parsed: ReturnType<typeof npa>
+  try {
+    parsed = npa(packageSpec)
+  } catch {
+    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}"`)
+  }
+
+  if (!parsed.registry) {
+    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}". This command only supports registry packages.`)
+  }
+
+  const subSpec = parsed.type === 'alias' ? parsed.subSpec : parsed
+  const packageName = subSpec?.name
+  if (!packageName) {
+    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}"`)
+  }
+
+  const specType = (subSpec?.type ?? 'tag') as 'tag' | 'version' | 'range'
+  const spec: RegistryPackageSpec = {
+    name: packageName,
+    fetchSpec: subSpec?.fetchSpec ?? 'latest',
+    type: specType,
+  }
+  const registry = pickRegistryForPackage(opts.registries, packageName)
+  const fetchFromRegistry = createFetchFromRegistry(opts)
+  const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {}, opts.registries?.default)
+  const fetchResult = await fetchMetadataFromFromRegistry(
+    {
+      fetch: fetchFromRegistry,
+      retry: {
+        factor: opts.fetchRetryFactor,
+        maxTimeout: opts.fetchRetryMaxtimeout,
+        minTimeout: opts.fetchRetryMintimeout,
+        retries: opts.fetchRetries,
+      },
+      timeout: opts.fetchTimeout ?? 60000,
+      fetchWarnTimeoutMs: 10000,
+    },
+    packageName,
+    {
+      registry,
+      authHeaderValue: getAuthHeader(registry),
+      fullMetadata: true,
+    }
+  )
+  if (fetchResult.notModified) {
+    throw new PnpmError('UNEXPECTED_304', `Unexpected 304 response for ${packageName}`)
+  }
+  const { meta: metadata } = fetchResult
+  const data = pickPackageFromMeta(
+    pickVersionByVersionRange,
+    { preferredVersionSelectors: undefined },
+    spec,
+    metadata
+  )
+  if (!data) {
+    throw new PnpmError('PACKAGE_NOT_FOUND', `No matching version found for ${packageName}@${spec.fetchSpec}`)
+  }
+
+  const versions = metadata.versions ? Object.keys(metadata.versions) : []
+  const depsCount = data.dependencies ? Object.keys(data.dependencies).length : 0
+  const distTags = metadata['dist-tags']
+
+  return {
+    ...data,
+    author: typeof data.author === 'object' ? (data.author as { name: string }).name : data.author,
+    repository: typeof data.repository === 'object' ? (data.repository as { url: string }).url : data.repository,
+    versions,
+    versionsCount: versions.length > 0 ? versions.length : undefined,
+    depsCount: depsCount > 0 ? depsCount : undefined,
+    distTags,
+    'dist-tags': distTags,
+    time: metadata.time,
+  } as unknown as ExtendedPackageInfo
+}

--- a/deps/inspection/commands/src/index.ts
+++ b/deps/inspection/commands/src/index.ts
@@ -1,3 +1,4 @@
+export * as docs from './docs/index.js'
 export { list, ll, why } from './listing/index.js'
 export { outdated } from './outdated/index.js'
 export * as peers from './peers.js'

--- a/deps/inspection/commands/src/view/index.ts
+++ b/deps/inspection/commands/src/view/index.ts
@@ -1,17 +1,9 @@
-import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
-import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
-import { createFetchFromRegistry } from '@pnpm/network.fetch'
-import npa from '@pnpm/npm-package-arg'
-import {
-  fetchMetadataFromFromRegistry,
-  pickPackageFromMeta,
-  pickVersionByVersionRange,
-  type RegistryPackageSpec,
-} from '@pnpm/resolving.npm-resolver'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
+
+import { fetchPackageInfo } from '../fetchPackageInfo.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick(['registry'], allTypes)
@@ -62,80 +54,7 @@ export async function handler (
 
   const fields = params.slice(1)
 
-  let parsed: ReturnType<typeof npa>
-  try {
-    parsed = npa(packageSpec)
-  } catch {
-    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}"`)
-  }
-
-  if (!parsed.registry) {
-    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}". pnpm view only supports registry packages.`)
-  }
-
-  const subSpec = parsed.type === 'alias' ? parsed.subSpec : parsed
-  const packageName = subSpec?.name
-  if (!packageName) {
-    throw new PnpmError('INVALID_PACKAGE_NAME', `Invalid package name: "${packageSpec}"`)
-  }
-
-  const specType = (subSpec?.type ?? 'tag') as 'tag' | 'version' | 'range'
-  const spec: RegistryPackageSpec = {
-    name: packageName,
-    fetchSpec: subSpec?.fetchSpec ?? 'latest',
-    type: specType,
-  }
-  const registry = pickRegistryForPackage(opts.registries, packageName)
-  const fetchFromRegistry = createFetchFromRegistry(opts)
-  const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {}, opts.registries?.default)
-  const fetchResult = await fetchMetadataFromFromRegistry(
-    {
-      fetch: fetchFromRegistry,
-      retry: {
-        factor: opts.fetchRetryFactor,
-        maxTimeout: opts.fetchRetryMaxtimeout,
-        minTimeout: opts.fetchRetryMintimeout,
-        retries: opts.fetchRetries,
-      },
-      timeout: opts.fetchTimeout ?? 60000,
-      fetchWarnTimeoutMs: 10000,
-    },
-    packageName,
-    {
-      registry,
-      authHeaderValue: getAuthHeader(registry),
-      fullMetadata: true,
-    }
-  )
-  if (fetchResult.notModified) {
-    throw new PnpmError('UNEXPECTED_304', `Unexpected 304 response for ${packageName}`)
-  }
-  const { meta: metadata } = fetchResult
-  const data = pickPackageFromMeta(
-    pickVersionByVersionRange,
-    { preferredVersionSelectors: undefined },
-    spec,
-    metadata
-  )
-  if (!data) {
-    throw new PnpmError('PACKAGE_NOT_FOUND', `No matching version found for ${packageName}@${spec.fetchSpec}`)
-  }
-
-  const versions = metadata.versions ? Object.keys(metadata.versions) : []
-  const depsCount = data.dependencies ? Object.keys(data.dependencies).length : 0
-  const distTags = metadata['dist-tags']
-
-  const info = {
-    ...data,
-    author: typeof data.author === 'object' ? (data.author as { name: string }).name : data.author,
-    repository: typeof data.repository === 'object' ? data.repository.url : data.repository,
-    versions,
-    versionsCount: versions.length > 0 ? versions.length : undefined,
-    depsCount: depsCount > 0 ? depsCount : undefined,
-    distTags,
-    'dist-tags': distTags,
-    time: metadata.time,
-  }
+  const info = await fetchPackageInfo(opts, packageSpec)
 
   // If fields are specified, filter and return only those
   if (fields.length > 0) {

--- a/deps/inspection/commands/test/docs.ts
+++ b/deps/inspection/commands/test/docs.ts
@@ -2,10 +2,12 @@ import { jest } from '@jest/globals'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 
-jest.mock('open', () => jest.fn())
+const mockOpen = jest.fn()
+jest.unstable_mockModule('open', () => ({
+  default: mockOpen,
+}))
 
 const { docs } = await import('@pnpm/deps.inspection.commands')
-const open = (await import('open')).default
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
 
@@ -47,8 +49,9 @@ test('docs: missing package name throws error', async () => {
 })
 
 test('docs: successful lookup of package opens documentation', async () => {
+  mockOpen.mockClear()
   await docs.handler(DOCS_OPTIONS as unknown as Config & ConfigContext, ['is-negative'])
-  expect(open).toHaveBeenCalled()
-  const calledUrl = (open as jest.Mock).mock.calls[0][0]
+  expect(mockOpen).toHaveBeenCalled()
+  const calledUrl = mockOpen.mock.calls[0][0]
   expect(calledUrl).toBe('https://github.com/kevva/is-negative#readme')
 })

--- a/deps/inspection/commands/test/docs.ts
+++ b/deps/inspection/commands/test/docs.ts
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals'
+import type { Config, ConfigContext } from '@pnpm/config.reader'
+import { REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
+
+jest.mock('open', () => jest.fn())
+
+const { docs } = await import('@pnpm/deps.inspection.commands')
+const open = (await import('open')).default
+
+const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
+
+const DOCS_OPTIONS = {
+  registries: { default: REGISTRY_URL },
+}
+
+test('docs: command should be available', () => {
+  expect(docs.handler).toBeDefined()
+  expect(docs.help).toBeDefined()
+  expect(docs.commandNames).toBeDefined()
+  expect(docs.cliOptionsTypes).toBeDefined()
+})
+
+test('docs: command should have correct names', () => {
+  expect(docs.commandNames).toEqual(['docs', 'home'])
+})
+
+test('docs: help should return a string', () => {
+  const help = docs.help()
+  expect(typeof help).toBe('string')
+  expect(help.length).toBeGreaterThan(0)
+})
+
+test('docs: cliOptionsTypes should return object', () => {
+  const types = docs.cliOptionsTypes()
+  expect(typeof types).toBe('object')
+})
+
+test('docs: rcOptionsTypes should return object', () => {
+  const types = docs.rcOptionsTypes()
+  expect(typeof types).toBe('object')
+})
+
+test('docs: missing package name throws error', async () => {
+  await expect(
+    docs.handler(DOCS_OPTIONS as unknown as Config & ConfigContext, [])
+  ).rejects.toMatchObject({ code: 'ERR_PNPM_MISSING_PACKAGE_NAME' })
+})
+
+test('docs: successful lookup of package opens documentation', async () => {
+  await docs.handler(DOCS_OPTIONS as unknown as Config & ConfigContext, ['is-negative'])
+  expect(open).toHaveBeenCalled()
+  const calledUrl = (open as jest.Mock).mock.calls[0][0]
+  expect(calledUrl).toBe('https://github.com/kevva/is-negative#readme')
+})

--- a/deps/inspection/commands/tsconfig.json
+++ b/deps/inspection/commands/tsconfig.json
@@ -70,6 +70,9 @@
       "path": "../../../resolving/npm-resolver"
     },
     {
+      "path": "../../../resolving/registry/types"
+    },
+    {
       "path": "../../../store/path"
     },
     {

--- a/network/web-auth/package.json
+++ b/network/web-auth/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@pnpm/error": "workspace:*",
+    "open": "catalog:",
     "qrcode-terminal": "catalog:"
   },
   "devDependencies": {

--- a/network/web-auth/src/index.ts
+++ b/network/web-auth/src/index.ts
@@ -10,9 +10,7 @@ export {
 export {
   promptBrowserOpen,
   type PromptBrowserOpenContext,
-  type PromptBrowserOpenExecFile,
   type PromptBrowserOpenParams,
-  type PromptBrowserOpenProcess,
   type PromptBrowserOpenReadlineInterface,
 } from './promptBrowserOpen.js'
 export { WebAuthTimeoutError } from './WebAuthTimeoutError.js'

--- a/network/web-auth/src/promptBrowserOpen.ts
+++ b/network/web-auth/src/promptBrowserOpen.ts
@@ -41,6 +41,19 @@ export async function promptBrowserOpen ({
     return pollPromise
   }
 
+  // The authUrl comes from an untrusted registry response, so only allow
+  // http(s) URLs through to `open()`.
+  let canonicalUrl: string
+  try {
+    const parsed = new URL(authUrl)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return pollPromise
+    }
+    canonicalUrl = parsed.href
+  } catch {
+    return pollPromise
+  }
+
   let rl: PromptBrowserOpenReadlineInterface
   try {
     rl = createReadlineInterface()
@@ -52,10 +65,15 @@ export async function promptBrowserOpen ({
   globalInfo('Press ENTER to open the URL in your browser.')
 
   rl.once('line', () => {
-    open(authUrl).catch((err: unknown) => {
+    const handleOpenError = (err: unknown): void => {
       globalWarn(`Could not open browser automatically: ${String(err)}`)
       globalInfo('Please open the URL shown above manually.')
-    })
+    }
+    try {
+      open(canonicalUrl).catch(handleOpenError)
+    } catch (err) {
+      handleOpenError(err)
+    }
   })
 
   // Only await pollPromise — do NOT await the Enter keypress.

--- a/network/web-auth/src/promptBrowserOpen.ts
+++ b/network/web-auth/src/promptBrowserOpen.ts
@@ -1,23 +1,15 @@
+import open from 'open'
+
 export interface PromptBrowserOpenReadlineInterface {
   once: (event: string, listener: () => void) => void
   close: () => void
 }
 
-export interface PromptBrowserOpenExecFile {
-  (file: string, args: readonly string[], callback: (error: Error | null) => void): unknown
-}
-
-export interface PromptBrowserOpenProcess {
-  platform?: NodeJS.Platform
-  stdin: { isTTY?: boolean }
-}
-
 export interface PromptBrowserOpenContext {
   createReadlineInterface?: () => PromptBrowserOpenReadlineInterface
-  execFile?: PromptBrowserOpenExecFile
   globalInfo: (message: string) => void
   globalWarn: (message: string) => void
-  process: PromptBrowserOpenProcess
+  process: { stdin: { isTTY?: boolean } }
 }
 
 export interface PromptBrowserOpenParams {
@@ -43,67 +35,10 @@ export async function promptBrowserOpen ({
   context,
   pollPromise,
 }: PromptBrowserOpenParams): Promise<string> {
-  const { createReadlineInterface, execFile, globalInfo, globalWarn, process } = context
+  const { createReadlineInterface, globalInfo, globalWarn, process } = context
 
-  if (!createReadlineInterface || !execFile || !process.stdin.isTTY) {
+  if (!createReadlineInterface || !process.stdin.isTTY) {
     return pollPromise
-  }
-
-  // Validate the URL before passing it to a shell command. On Windows,
-  // cmd.exe re-parses execFile arguments and would interpret shell
-  // metacharacters (&, |, etc.) in the URL as operators.
-  let parsedUrl: URL
-  try {
-    parsedUrl = new URL(authUrl)
-  } catch {
-    return pollPromise
-  }
-  if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
-    return pollPromise
-  }
-
-  const canonicalUrl = parsedUrl.href
-
-  let cmd: string
-  let args: string[]
-  switch (process.platform) {
-    case 'darwin':
-      cmd = 'open'
-      args = [canonicalUrl]
-      break
-    case 'win32': {
-      cmd = 'cmd'
-      // Windows edge cases for opening URLs from Node.js:
-      //
-      // The clean approach would be calling the Win32 ShellExecuteW API
-      // directly, which is what native Windows programs use. However,
-      // ShellExecuteW is a native API, not an executable — Node.js cannot
-      // call it from child_process without a native addon.
-      //
-      // All process-spawning alternatives have drawbacks:
-      //   - cmd /c start:    cmd.exe re-parses args; special characters in
-      //                      URLs (&, |, ^, %, etc.) are treated as shell
-      //                      operators
-      //   - explorer.exe:    breaks on URLs with query strings (?key=value),
-      //                      opening File Explorer instead of the browser
-      //                      (https://github.com/dotnet/runtime/issues/108817)
-      //   - url.dll:         undocumented, can strip query params on Win 7+
-      //   - PowerShell:      slow startup, own escaping issues
-      //
-      // Since pnpm already ships native addons, a small Rust/N-API addon
-      // calling ShellExecuteW directly could replace this in the future.
-      //
-      // For now, use cmd /c start with ^ escaping for special characters.
-      const escapedUrl = canonicalUrl.replace(/[&|<>^%()!]/g, '^$&')
-      args = ['/c', 'start', '', escapedUrl]
-      break
-    }
-    case 'linux':
-      cmd = 'xdg-open'
-      args = [canonicalUrl]
-      break
-    default:
-      return pollPromise
   }
 
   let rl: PromptBrowserOpenReadlineInterface
@@ -117,7 +52,7 @@ export async function promptBrowserOpen ({
   globalInfo('Press ENTER to open the URL in your browser.')
 
   rl.once('line', () => {
-    runExecFile(execFile, cmd, args).catch((err) => {
+    open(authUrl).catch((err: unknown) => {
       globalWarn(`Could not open browser automatically: ${String(err)}`)
       globalInfo('Please open the URL shown above manually.')
     })
@@ -137,17 +72,4 @@ export async function promptBrowserOpen ({
   } finally {
     rl.close()
   }
-}
-
-function runExecFile (
-  execFile: PromptBrowserOpenExecFile,
-  cmd: string,
-  args: string[]
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    execFile(cmd, args, (err) => {
-      if (err) reject(err)
-      else resolve()
-    })
-  })
 }

--- a/network/web-auth/src/withOtpHandling.ts
+++ b/network/web-auth/src/withOtpHandling.ts
@@ -3,7 +3,7 @@ import { PnpmError } from '@pnpm/error'
 import { generateQrCode } from './generateQrCode.js'
 import type { WebAuthFetchOptions, WebAuthFetchResponse } from './pollForWebAuthToken.js'
 import { pollForWebAuthToken } from './pollForWebAuthToken.js'
-import type { PromptBrowserOpenExecFile, PromptBrowserOpenReadlineInterface } from './promptBrowserOpen.js'
+import type { PromptBrowserOpenReadlineInterface } from './promptBrowserOpen.js'
 import { promptBrowserOpen } from './promptBrowserOpen.js'
 
 export interface OtpEnquirer {
@@ -35,7 +35,6 @@ export interface OtpContext {
   setTimeout: (cb: () => void, ms: number) => void
   createReadlineInterface?: () => PromptBrowserOpenReadlineInterface
   enquirer: OtpEnquirer
-  execFile?: PromptBrowserOpenExecFile
   fetch: (url: string, options: WebAuthFetchOptions) => Promise<WebAuthFetchResponse>
   globalInfo: (message: string) => void
   globalWarn: (message: string) => void

--- a/network/web-auth/test/promptBrowserOpen.test.ts
+++ b/network/web-auth/test/promptBrowserOpen.test.ts
@@ -1,10 +1,15 @@
 import { jest } from '@jest/globals'
-import {
-  promptBrowserOpen,
-  type PromptBrowserOpenContext,
-  type PromptBrowserOpenExecFile,
-  type PromptBrowserOpenReadlineInterface,
+import type {
+  PromptBrowserOpenContext,
+  PromptBrowserOpenReadlineInterface,
 } from '@pnpm/network.web-auth'
+
+const mockOpen = jest.fn<(target: string) => Promise<unknown>>()
+jest.unstable_mockModule('open', () => ({
+  default: mockOpen,
+}))
+
+const { promptBrowserOpen } = await import('@pnpm/network.web-auth')
 
 function createDeferred<T> (): {
   promise: Promise<T>
@@ -44,19 +49,21 @@ const createMockContext = (overrides?: MockContextOverrides): PromptBrowserOpenC
   globalWarn: () => {},
   ...overrides,
   process: {
-    platform: 'linux',
     stdin: { isTTY: true },
     ...overrides?.process,
   },
 })
 
+beforeEach(() => {
+  mockOpen.mockReset()
+  mockOpen.mockResolvedValue(undefined)
+})
+
 describe('promptBrowserOpen', () => {
   it('returns the poll result when poll completes before Enter keypress', async () => {
     const mockRl = createMockReadlineInterface()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>()
     const context = createMockContext({
       createReadlineInterface: () => mockRl,
-      execFile,
     })
 
     const token = await promptBrowserOpen({
@@ -67,18 +74,14 @@ describe('promptBrowserOpen', () => {
 
     expect(token).toBe('my-token')
     expect(mockRl.close).toHaveBeenCalled()
-    expect(execFile).not.toHaveBeenCalled()
+    expect(mockOpen).not.toHaveBeenCalled()
   })
 
-  it('opens browser via execFile when Enter key is pressed before poll completes', async () => {
+  it('opens browser via open package when Enter key is pressed before poll completes', async () => {
     const mockRl = createMockReadlineInterface()
     const pollDeferred = createDeferred<string>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>((_file, _args, cb) => {
-      cb(null)
-    })
     const context = createMockContext({
       createReadlineInterface: () => mockRl,
-      execFile,
     })
 
     const resultPromise = promptBrowserOpen({
@@ -91,7 +94,7 @@ describe('promptBrowserOpen', () => {
 
     await new Promise<void>(resolve => queueMicrotask(resolve))
 
-    expect(execFile).toHaveBeenCalledWith('xdg-open', ['https://example.com/auth'], expect.any(Function))
+    expect(mockOpen).toHaveBeenCalledWith('https://example.com/auth')
 
     pollDeferred.resolve('token-after-enter')
     const token = await resultPromise
@@ -100,136 +103,14 @@ describe('promptBrowserOpen', () => {
     expect(mockRl.close).toHaveBeenCalled()
   })
 
-  it('uses "open" on darwin', async () => {
-    const mockRl = createMockReadlineInterface()
-    const pollDeferred = createDeferred<string>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>((_file, _args, cb) => {
-      cb(null)
-    })
-    const context = createMockContext({
-      createReadlineInterface: () => mockRl,
-      execFile,
-      process: { platform: 'darwin' },
-    })
-
-    const resultPromise = promptBrowserOpen({
-      authUrl: 'https://example.com/auth',
-      context,
-      pollPromise: pollDeferred.promise,
-    })
-
-    mockRl.simulateEnterKeypress()
-    await new Promise<void>(resolve => queueMicrotask(resolve))
-
-    expect(execFile).toHaveBeenCalledWith('open', ['https://example.com/auth'], expect.any(Function))
-
-    pollDeferred.resolve('tok')
-    await resultPromise
-  })
-
-  it('uses "cmd /c start" on win32', async () => {
-    const mockRl = createMockReadlineInterface()
-    const pollDeferred = createDeferred<string>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>((_file, _args, cb) => {
-      cb(null)
-    })
-    const context = createMockContext({
-      createReadlineInterface: () => mockRl,
-      execFile,
-      process: { platform: 'win32' },
-    })
-
-    const resultPromise = promptBrowserOpen({
-      authUrl: 'https://example.com/auth',
-      context,
-      pollPromise: pollDeferred.promise,
-    })
-
-    mockRl.simulateEnterKeypress()
-    await new Promise<void>(resolve => queueMicrotask(resolve))
-
-    expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com/auth'], expect.any(Function))
-
-    pollDeferred.resolve('tok')
-    await resultPromise
-  })
-
-  it('passes URLs with query parameters to execFile on win32', async () => {
-    const mockRl = createMockReadlineInterface()
-    const pollDeferred = createDeferred<string>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>((_file, _args, cb) => {
-      cb(null)
-    })
-    const authUrl = 'https://example.com/auth?token=abc&redirect=https%3A%2F%2Fexample.com'
-    const context = createMockContext({
-      createReadlineInterface: () => mockRl,
-      execFile,
-      process: { platform: 'win32' },
-    })
-
-    const resultPromise = promptBrowserOpen({
-      authUrl,
-      context,
-      pollPromise: pollDeferred.promise,
-    })
-
-    mockRl.simulateEnterKeypress()
-    await new Promise<void>(resolve => queueMicrotask(resolve))
-
-    // & and % are escaped with ^ for cmd.exe
-    expect(execFile).toHaveBeenCalledWith('cmd', ['/c', 'start', '', 'https://example.com/auth?token=abc^&redirect=https^%3A^%2F^%2Fexample.com'], expect.any(Function))
-
-    pollDeferred.resolve('tok')
-    await resultPromise
-  })
-
-  it('skips browser prompt on unsupported platform', async () => {
-    const execFile = jest.fn<PromptBrowserOpenExecFile>()
-    const context = createMockContext({
-      createReadlineInterface: createMockReadlineInterface,
-      execFile,
-      process: { platform: 'freebsd' },
-    })
-
-    const token = await promptBrowserOpen({
-      authUrl: 'https://example.com/auth',
-      context,
-      pollPromise: Promise.resolve('plain-token'),
-    })
-
-    expect(token).toBe('plain-token')
-    expect(execFile).not.toHaveBeenCalled()
-  })
-
-  it('skips browser prompt when platform is undefined', async () => {
-    const execFile = jest.fn<PromptBrowserOpenExecFile>()
-    const context = createMockContext({
-      createReadlineInterface: createMockReadlineInterface,
-      execFile,
-      process: { platform: undefined },
-    })
-
-    const token = await promptBrowserOpen({
-      authUrl: 'https://example.com/auth',
-      context,
-      pollPromise: Promise.resolve('plain-token'),
-    })
-
-    expect(token).toBe('plain-token')
-    expect(execFile).not.toHaveBeenCalled()
-  })
-
-  it('warns and continues polling when execFile fails', async () => {
+  it('warns and continues polling when open fails', async () => {
     const mockRl = createMockReadlineInterface()
     const pollDeferred = createDeferred<string>()
     const globalWarn = jest.fn<(msg: string) => void>()
     const globalInfo = jest.fn<(msg: string) => void>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>((_file, _args, cb) => {
-      cb(new Error('xdg-open not found'))
-    })
+    mockOpen.mockRejectedValue(new Error('xdg-open not found'))
     const context = createMockContext({
       createReadlineInterface: () => mockRl,
-      execFile,
       globalInfo,
       globalWarn,
     })
@@ -254,12 +135,10 @@ describe('promptBrowserOpen', () => {
 
   it('warns and falls back to plain poll when createReadlineInterface throws', async () => {
     const globalWarn = jest.fn<(msg: string) => void>()
-    const execFile = jest.fn<PromptBrowserOpenExecFile>()
     const context = createMockContext({
       createReadlineInterface: () => {
         throw new Error('setRawMode not supported')
       },
-      execFile,
       globalWarn,
     })
 
@@ -271,27 +150,11 @@ describe('promptBrowserOpen', () => {
 
     expect(token).toBe('fallback-token')
     expect(globalWarn).toHaveBeenCalledWith(expect.stringContaining('setRawMode not supported'))
-    expect(execFile).not.toHaveBeenCalled()
+    expect(mockOpen).not.toHaveBeenCalled()
   })
 
   it('falls back to plain poll when createReadlineInterface is not provided', async () => {
-    const context = createMockContext({
-      execFile: jest.fn<PromptBrowserOpenExecFile>(),
-    })
-
-    const token = await promptBrowserOpen({
-      authUrl: 'https://example.com/auth',
-      context,
-      pollPromise: Promise.resolve('plain-token'),
-    })
-
-    expect(token).toBe('plain-token')
-  })
-
-  it('falls back to plain poll when execFile is not provided', async () => {
-    const context = createMockContext({
-      createReadlineInterface: createMockReadlineInterface,
-    })
+    const context = createMockContext()
 
     const token = await promptBrowserOpen({
       authUrl: 'https://example.com/auth',
@@ -305,7 +168,6 @@ describe('promptBrowserOpen', () => {
   it('falls back to plain poll when stdin is not a TTY', async () => {
     const context = createMockContext({
       createReadlineInterface: createMockReadlineInterface,
-      execFile: jest.fn<PromptBrowserOpenExecFile>(),
       process: { stdin: { isTTY: false } },
     })
 
@@ -323,7 +185,6 @@ describe('promptBrowserOpen', () => {
     const globalInfo = jest.fn<(msg: string) => void>()
     const context = createMockContext({
       createReadlineInterface: () => mockRl,
-      execFile: jest.fn<PromptBrowserOpenExecFile>(),
       globalInfo,
     })
 
@@ -340,7 +201,6 @@ describe('promptBrowserOpen', () => {
     const mockRl = createMockReadlineInterface()
     const context = createMockContext({
       createReadlineInterface: () => mockRl,
-      execFile: jest.fn<PromptBrowserOpenExecFile>(),
     })
 
     await expect(promptBrowserOpen({

--- a/network/web-auth/test/promptBrowserOpen.test.ts
+++ b/network/web-auth/test/promptBrowserOpen.test.ts
@@ -197,6 +197,54 @@ describe('promptBrowserOpen', () => {
     expect(globalInfo).toHaveBeenCalledWith('Press ENTER to open the URL in your browser.')
   })
 
+  it.each([
+    ['javascript:alert(1)'],
+    ['file:///etc/passwd'],
+    ['not a url'],
+  ])('does not open browser for non-http(s) authUrl %s', async (authUrl) => {
+    const mockRl = createMockReadlineInterface()
+    const pollDeferred = createDeferred<string>()
+    const context = createMockContext({
+      createReadlineInterface: () => mockRl,
+    })
+
+    const resultPromise = promptBrowserOpen({
+      authUrl,
+      context,
+      pollPromise: pollDeferred.promise,
+    })
+
+    pollDeferred.resolve('tok')
+    expect(await resultPromise).toBe('tok')
+    expect(mockOpen).not.toHaveBeenCalled()
+  })
+
+  it('continues polling when open throws synchronously', async () => {
+    const mockRl = createMockReadlineInterface()
+    const pollDeferred = createDeferred<string>()
+    const globalWarn = jest.fn<(msg: string) => void>()
+    mockOpen.mockImplementation(() => {
+      throw new Error('sync failure')
+    })
+    const context = createMockContext({
+      createReadlineInterface: () => mockRl,
+      globalWarn,
+    })
+
+    const resultPromise = promptBrowserOpen({
+      authUrl: 'https://example.com/auth',
+      context,
+      pollPromise: pollDeferred.promise,
+    })
+
+    mockRl.simulateEnterKeypress()
+
+    expect(globalWarn).toHaveBeenCalledWith(expect.stringContaining('sync failure'))
+
+    pollDeferred.resolve('tok')
+    expect(await resultPromise).toBe('tok')
+  })
+
   it('cleans up when poll rejects', async () => {
     const mockRl = createMockReadlineInterface()
     const context = createMockContext({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,184 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.0.0-rc.0
-        version: 11.0.0-rc.0
-      pnpm:
-        specifier: 11.0.0-rc.0
-        version: 11.0.0-rc.0
-
-packages:
-
-  '@pnpm/exe@11.0.0-rc.0':
-    resolution: {integrity: sha512-lpa3BGQaCvH5BGS256VTyJ4+Ib2PiA5gipTfTs7MTL02utSYXcWarP0OeDhw++Cg/tgrCVRDYWcUjHOy/KNTtA==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.0.0-rc.0':
-    resolution: {integrity: sha512-6JIbPFu8y7RevLIpOH/rhML9JtnLgAa9VVVGl8A02+sRdF415Q3cldz+N9Oh3ZNLi2JZWtvHRa5UE2FRFELOJQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.0.0-rc.0':
-    resolution: {integrity: sha512-5nSOBz07hmznMKJ88LaO/mk6BXCOMs3cA7VkwAz7ehWvtxeT1Dqez2Rnf5nK//BgEF1jQ8cgjff6MWaSmiYY8A==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/macos-arm64@11.0.0-rc.0':
-    resolution: {integrity: sha512-X1KgttzXrspprRU4JV3y1rxraX/H8AzXhuO3tDJj01nbUhps0kkjdfJziLJFFYN74bwSO8DgFWmJ5w5V+Hp0Cg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/macos-x64@11.0.0-rc.0':
-    resolution: {integrity: sha512-Ra/CuHN7hrqScrl9w3zPDcMbY5AjAZMqTDKXL/1qP/GlY4lOJp24sQrH19y3pQGoUKoxlvVo0S4I29ZX2Wsf7A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.0.0-rc.0':
-    resolution: {integrity: sha512-vum6DgUMO6hxYdhJBUkdNpnXW0TU/iKRUuZca6qgn/uckhaobENsuaN0pG1ga49G26I+jL5C8GfVBmdnRenm6w==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.0.0-rc.0':
-    resolution: {integrity: sha512-avY9Gz97pvcWO7nRL1AoJToVwljZIybX9A09buGpgrxTSTGjfs6bbFE+d+576ro02MHqhTn6qUnkCbPyKPcWrA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  pnpm@11.0.0-rc.0:
-    resolution: {integrity: sha512-Hwjq3uoCXpFEjebV3uQqbJR2QlcADAQ6nja4/xKEmnLry5xl/BiFCUdHJJ5S9T2Lc62hGBRGu6gYZoEMik0/bA==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.0.0-rc.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.0-rc.0
-      '@pnpm/linux-x64': 11.0.0-rc.0
-      '@pnpm/macos-arm64': 11.0.0-rc.0
-      '@pnpm/macos-x64': 11.0.0-rc.0
-      '@pnpm/win-arm64': 11.0.0-rc.0
-      '@pnpm/win-x64': 11.0.0-rc.0
-
-  '@pnpm/linux-arm64@11.0.0-rc.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.0.0-rc.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.0.0-rc.0':
-    optional: true
-
-  '@pnpm/macos-x64@11.0.0-rc.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.0.0-rc.0':
-    optional: true
-
-  '@pnpm/win-x64@11.0.0-rc.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  pnpm@11.0.0-rc.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -691,6 +510,9 @@ catalogs:
     object-hash:
       specifier: 3.0.0
       version: 3.0.0
+    open:
+      specifier: ^7.4.2
+      version: 7.4.2
     p-defer:
       specifier: ^4.0.1
       version: 4.0.1
@@ -977,7 +799,9 @@ packageExtensionsChecksum: sha256-87FOGilaYY8gmnjYsryuV/BI3ZuhaaJd/1fN2oxQwzY=
 pnpmfileChecksum: sha256-FyKtfMeHqu9zq1rXAr8P3zdA0NAXUioGdY0esg+SB5s=
 
 patchedDependencies:
-  graceful-fs@4.2.11: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
+  graceful-fs@4.2.11:
+    hash: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
+    path: __patches__/graceful-fs@4.2.11.patch
 
 importers:
 
@@ -3179,7 +3003,7 @@ importers:
         specifier: 'catalog:'
         version: 5.6.2
       open:
-        specifier: ^7.4.2
+        specifier: 'catalog:'
         version: 7.4.2
       ramda:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3160,6 +3160,9 @@ importers:
       '@pnpm/resolving.npm-resolver':
         specifier: workspace:*
         version: link:../../../resolving/npm-resolver
+      '@pnpm/resolving.registry.types':
+        specifier: workspace:*
+        version: link:../../../resolving/registry/types
       '@pnpm/semver-diff':
         specifier: 'catalog:'
         version: 1.1.0
@@ -3175,6 +3178,9 @@ importers:
       chalk:
         specifier: 'catalog:'
         version: 5.6.2
+      open:
+        specifier: ^7.4.2
+        version: 7.4.2
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,184 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.0.0-rc.0
+        version: 11.0.0-rc.0
+      pnpm:
+        specifier: 11.0.0-rc.0
+        version: 11.0.0-rc.0
+
+packages:
+
+  '@pnpm/exe@11.0.0-rc.0':
+    resolution: {integrity: sha512-lpa3BGQaCvH5BGS256VTyJ4+Ib2PiA5gipTfTs7MTL02utSYXcWarP0OeDhw++Cg/tgrCVRDYWcUjHOy/KNTtA==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.0.0-rc.0':
+    resolution: {integrity: sha512-6JIbPFu8y7RevLIpOH/rhML9JtnLgAa9VVVGl8A02+sRdF415Q3cldz+N9Oh3ZNLi2JZWtvHRa5UE2FRFELOJQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.0.0-rc.0':
+    resolution: {integrity: sha512-5nSOBz07hmznMKJ88LaO/mk6BXCOMs3cA7VkwAz7ehWvtxeT1Dqez2Rnf5nK//BgEF1jQ8cgjff6MWaSmiYY8A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/macos-arm64@11.0.0-rc.0':
+    resolution: {integrity: sha512-X1KgttzXrspprRU4JV3y1rxraX/H8AzXhuO3tDJj01nbUhps0kkjdfJziLJFFYN74bwSO8DgFWmJ5w5V+Hp0Cg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/macos-x64@11.0.0-rc.0':
+    resolution: {integrity: sha512-Ra/CuHN7hrqScrl9w3zPDcMbY5AjAZMqTDKXL/1qP/GlY4lOJp24sQrH19y3pQGoUKoxlvVo0S4I29ZX2Wsf7A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.0.0-rc.0':
+    resolution: {integrity: sha512-vum6DgUMO6hxYdhJBUkdNpnXW0TU/iKRUuZca6qgn/uckhaobENsuaN0pG1ga49G26I+jL5C8GfVBmdnRenm6w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.0.0-rc.0':
+    resolution: {integrity: sha512-avY9Gz97pvcWO7nRL1AoJToVwljZIybX9A09buGpgrxTSTGjfs6bbFE+d+576ro02MHqhTn6qUnkCbPyKPcWrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  pnpm@11.0.0-rc.0:
+    resolution: {integrity: sha512-Hwjq3uoCXpFEjebV3uQqbJR2QlcADAQ6nja4/xKEmnLry5xl/BiFCUdHJJ5S9T2Lc62hGBRGu6gYZoEMik0/bA==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.0.0-rc.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.0.0-rc.0
+      '@pnpm/linux-x64': 11.0.0-rc.0
+      '@pnpm/macos-arm64': 11.0.0-rc.0
+      '@pnpm/macos-x64': 11.0.0-rc.0
+      '@pnpm/win-arm64': 11.0.0-rc.0
+      '@pnpm/win-x64': 11.0.0-rc.0
+
+  '@pnpm/linux-arm64@11.0.0-rc.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.0.0-rc.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.0.0-rc.0':
+    optional: true
+
+  '@pnpm/macos-x64@11.0.0-rc.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.0.0-rc.0':
+    optional: true
+
+  '@pnpm/win-x64@11.0.0-rc.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  pnpm@11.0.0-rc.0: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -799,9 +980,7 @@ packageExtensionsChecksum: sha256-87FOGilaYY8gmnjYsryuV/BI3ZuhaaJd/1fN2oxQwzY=
 pnpmfileChecksum: sha256-FyKtfMeHqu9zq1rXAr8P3zdA0NAXUioGdY0esg+SB5s=
 
 patchedDependencies:
-  graceful-fs@4.2.11:
-    hash: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
-    path: __patches__/graceful-fs@4.2.11.patch
+  graceful-fs@4.2.11: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
 
 importers:
 
@@ -1062,7 +1241,7 @@ importers:
         version: 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-jest:
         specifier: 'catalog:'
-        version: 29.15.0(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3)
 
   __utils__/get-release-text:
     dependencies:
@@ -6678,6 +6857,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      open:
+        specifier: 'catalog:'
+        version: 7.4.2
       qrcode-terminal:
         specifier: 'catalog:'
         version: 0.12.0
@@ -11168,14 +11350,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/eslint-plugin@8.57.2':
-    resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^8.57.2
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/parser@8.57.1':
     resolution: {integrity: sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -11217,13 +11391,6 @@ packages:
 
   '@typescript-eslint/type-utils@8.57.1':
     resolution: {integrity: sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.57.2':
-    resolution: {integrity: sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -19346,23 +19513,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.57.2
-      '@typescript-eslint/type-utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.57.2
-      eslint: 10.0.3(jiti@2.6.1)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
@@ -19422,19 +19572,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/type-utils@8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.57.2
-      '@typescript-eslint/typescript-estree': 8.57.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 10.0.3(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/types@8.57.1': {}
 
@@ -21191,12 +21328,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(jest@30.3.0(@babel/types@7.29.0)(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.57.2(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.0.3(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.57.2(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       jest: 30.3.0(@babel/types@7.29.0)(@types/node@22.19.15)
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -241,6 +241,7 @@ catalog:
   normalize-registry-url: 2.0.1
   npm-packlist: 10.0.4
   object-hash: 3.0.0
+  open: ^7.4.2
   p-defer: ^4.0.1
   p-every: ^2.0.0
   p-filter: ^4.1.0

--- a/pnpm/src/cmd/index.ts
+++ b/pnpm/src/cmd/index.ts
@@ -6,7 +6,7 @@ import { createCompletionServer, generateCompletion } from '@pnpm/cli.commands'
 import { config, getCommand, setCommand } from '@pnpm/config.commands'
 import { types as allTypes } from '@pnpm/config.reader'
 import { audit, licenses, sbom } from '@pnpm/deps.compliance.commands'
-import { list, ll, outdated, peers, view, why } from '@pnpm/deps.inspection.commands'
+import { docs, list, ll, outdated, peers, view, why } from '@pnpm/deps.inspection.commands'
 import { selfUpdate, setup } from '@pnpm/engine.pm.commands'
 import { env, runtime } from '@pnpm/engine.runtime.commands'
 import {
@@ -136,6 +136,7 @@ const commands: CommandDefinition[] = [
   deploy,
   distTag,
   dlx,
+  docs,
   env,
   exec,
   runtime,

--- a/pnpm/src/cmd/notImplemented.ts
+++ b/pnpm/src/cmd/notImplemented.ts
@@ -5,10 +5,8 @@ import type { CommandDefinition } from './index.js'
 const NOT_IMPLEMENTED_COMMANDS = [
   'access',
   'bugs',
-  'docs',
   'edit',
   'find',
-  'home',
   'issues',
   'owner',
   'ping',

--- a/releasing/commands/src/publish/utils/shared-context.ts
+++ b/releasing/commands/src/publish/utils/shared-context.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import readline from 'node:readline'
 
 import { globalInfo, globalWarn } from '@pnpm/logger'
@@ -34,7 +33,6 @@ export const SHARED_CONTEXT: SharedContext = {
   createReadlineInterface: readline.createInterface.bind(null, { input: process.stdin }),
   ciInfo,
   enquirer,
-  execFile,
   fetch,
   globalInfo,
   globalWarn,


### PR DESCRIPTION
This PR adds the 'pnpm docs' command and its alias 'pnpm home'. This command fetches package metadata from the registry and opens the homepage or documentation URL in the default browser. When the package has no valid homepage, it falls back to https://npmx.dev/package/<name>.