### PR TITLE
feat(core): add ignoreLockfileSettingsChecks option

### DIFF
--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -50,6 +50,7 @@ export interface StrictInstallOptions {
   dedupe: boolean
   ignoreCompatibilityDb: boolean
   ignoreDepScripts: boolean
+  ignoreLockfileSettingsChecks: boolean
   ignorePackageManifest: boolean
   /**
    * When true, skip fetching local dependencies (file: protocol pointing to directories).
@@ -230,6 +231,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     overrides: {},
     ownLifecycleHooksStdio: 'inherit',
     ignoreCompatibilityDb: false,
+    ignoreLockfileSettingsChecks: false,
     ignorePackageManifest: false,
     ignoreLocalPackages: false,
     packageExtensions: {},

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -426,7 +426,7 @@ export async function mutateModules (
       opts.frozenLockfileIfExists && ctx.existsNonEmptyWantedLockfile
     let outdatedLockfileSettings = false
     const overridesMap = createOverridesMapFromParsed(opts.parsedOverrides)
-    if (!opts.ignorePackageManifest) {
+    if (!opts.ignorePackageManifest && !opts.ignoreLockfileSettingsChecks) {
       const outdatedLockfileSettingName = getOutdatedLockfileSetting(ctx.wantedLockfile, {
         autoInstallPeers: opts.autoInstallPeers,
         catalogs: opts.catalogs,

--- a/pkg-manager/core/test/install/frozenLockfile.ts
+++ b/pkg-manager/core/test/install/frozenLockfile.ts
@@ -303,3 +303,16 @@ test('frozen-lockfile: installation fails if the value of auto-install-peers cha
     install(manifest, testDefaults({ frozenLockfile: true, autoInstallPeers: false }))
   ).rejects.toThrow('Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn\'t match the value found in the lockfile')
 })
+
+test('frozen-lockfile: installation succeeds with mismatched settings when ignoreLockfileSettingsChecks is true', async () => {
+  prepareEmpty()
+  const manifest = {
+    dependencies: {
+      'is-positive': '^3.0.0',
+    },
+  }
+
+  await install(manifest, testDefaults({ autoInstallPeers: true }))
+
+  await install(manifest, testDefaults({ frozenLockfile: true, autoInstallPeers: false, ignoreLockfileSettingsChecks: true }))
+})


### PR DESCRIPTION
## Summary
- Adds `ignoreLockfileSettingsChecks` option to `@pnpm/core` install options
- When enabled, skips the lockfile settings validation during frozen and preferFrozenLockfile installs, allowing pnpm to proceed as if settings are up to date
- Prevents `LOCKFILE_CONFIG_MISMATCH` errors when settings in `pnpm-lock.yaml` don't match current configuration

## Test plan
- [x] Added test: frozen install succeeds with mismatched `autoInstallPeers` when `ignoreLockfileSettingsChecks: true`
- [x] All existing frozen lockfile tests still pass (13/13)
- [x] Compiles and lints cleanly