### PR TITLE
chore: add changeset for ignoreLockfileSettingsChecks option

### DIFF
--- a/.changeset/ignore-lockfile-settings-checks.md
+++ b/.changeset/ignore-lockfile-settings-checks.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/core": minor
+---
+
+Added a new `ignoreLockfileSettingsChecks` option. When enabled, pnpm skips the validation that compares the `settings` section of `pnpm-lock.yaml` with the current configuration during `--frozen-lockfile` and `--prefer-frozen-lockfile` installs, proceeding as if the settings are up to date.


### PR DESCRIPTION
## Summary
- Adds missing changeset for the `ignoreLockfileSettingsChecks` option introduced in #11259

## Test plan
- [x] Changeset file added describing the new `@pnpm/core` option