### PR TITLE
feat(deps-installer): add ignoreLockfileSettingsChecks option

### DIFF
--- a/.changeset/ignore-lockfile-settings-checks.md
+++ b/.changeset/ignore-lockfile-settings-checks.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/installing.deps-installer": minor
+---
+
+Added a new `ignoreLockfileSettingsChecks` option. When enabled, pnpm skips the validation that compares the `settings` section of `pnpm-lock.yaml` with the current configuration during `--frozen-lockfile` and `--prefer-frozen-lockfile` installs, proceeding as if the settings are up to date.

--- a/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -53,6 +53,7 @@ export interface StrictInstallOptions {
   fixLockfile: boolean
   dedupe: boolean
   ignoreCompatibilityDb: boolean
+  ignoreLockfileSettingsChecks: boolean
   ignorePackageManifest: boolean
   /**
    * When true, skip fetching local dependencies (file: protocol pointing to directories).
@@ -228,6 +229,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     overrides: {},
     ownLifecycleHooksStdio: 'inherit',
     ignoreCompatibilityDb: false,
+    ignoreLockfileSettingsChecks: false,
     ignorePackageManifest: false,
     ignoreLocalPackages: false,
     packageExtensions: {},

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -471,7 +471,7 @@ export async function mutateModules (
       opts.frozenLockfileIfExists && ctx.existsNonEmptyWantedLockfile
     let outdatedLockfileSettings = false
     const overridesMap = createOverridesMapFromParsed(opts.parsedOverrides)
-    if (!opts.ignorePackageManifest) {
+    if (!opts.ignorePackageManifest && !opts.ignoreLockfileSettingsChecks) {
       const outdatedLockfileSettingName = getOutdatedLockfileSetting(ctx.wantedLockfile, {
         autoInstallPeers: opts.autoInstallPeers,
         catalogs: opts.catalogs,

--- a/installing/deps-installer/test/install/frozenLockfile.ts
+++ b/installing/deps-installer/test/install/frozenLockfile.ts
@@ -305,3 +305,16 @@ test('frozen-lockfile: installation fails if the value of auto-install-peers cha
     install(manifest, testDefaults({ frozenLockfile: true, autoInstallPeers: false }))
   ).rejects.toThrow('Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn\'t match the value found in the lockfile')
 })
+
+test('frozen-lockfile: installation succeeds with mismatched settings when ignoreLockfileSettingsChecks is true', async () => {
+  prepareEmpty()
+  const manifest = {
+    dependencies: {
+      'is-positive': '^3.0.0',
+    },
+  }
+
+  await install(manifest, testDefaults({ autoInstallPeers: true }))
+
+  await install(manifest, testDefaults({ frozenLockfile: true, autoInstallPeers: false, ignoreLockfileSettingsChecks: true }))
+})


### PR DESCRIPTION
## Summary
- Ports the `ignoreLockfileSettingsChecks` option from v10 (#11259) to main
- When enabled, skips lockfile settings validation during frozen and preferFrozenLockfile installs, allowing pnpm to proceed as if settings are up to date
- Prevents `LOCKFILE_CONFIG_MISMATCH` errors when settings in `pnpm-lock.yaml` don't match current configuration

## Test plan
- [x] Added test: frozen install succeeds with mismatched `autoInstallPeers` when `ignoreLockfileSettingsChecks: true`
- [x] All existing frozen lockfile tests still pass (13/13)
- [x] Compiles and lints cleanly