### PR TITLE
fix: detect unapproved build scripts with sharedWorkspaceLockfile=false

### DIFF
--- a/.changeset/wet-brooms-drive.md
+++ b/.changeset/wet-brooms-drive.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+Fix strictDepBuilds/allowBuilds not detecting unapproved build scripts when sharedWorkspaceLockfile is false. Closes #9082.

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1434,6 +1434,22 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
           .concat(
             result.newDepPaths.filter((depPath) => dependenciesGraph[depPath].requiresBuild)
           )
+        // Even when scripts are not being run (e.g. per-workspace lockfile installs),
+        // check pending builds against allowBuild to detect unapproved packages.
+        // This ensures strictDepBuilds works with sharedWorkspaceLockfile=false.
+        // See: https://github.com/pnpm/pnpm/issues/9082
+        if (opts.allowBuild) {
+          for (const depPath of ctx.pendingBuilds) {
+            const node = dependenciesGraph[depPath as DepPath]
+            if (node?.requiresBuild) {
+              const allowed = opts.allowBuild(node.name, node.version)
+              if (allowed === undefined) {
+                ignoredBuilds ??= new Set()
+                ignoredBuilds.add(depPath as DepPath)
+              }
+            }
+          }
+        }
       }
       if (!opts.ignoreScripts || Object.keys(opts.patchedDependencies ?? {}).length > 0) {
         // postinstall hooks

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -543,6 +543,21 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
       )
   }
   let ignoredBuilds: IgnoredBuilds | undefined
+  // Even when scripts are not being run (e.g. per-workspace lockfile installs),
+  // check pending builds against allowBuild to detect unapproved packages.
+  // This ensures strictDepBuilds works with sharedWorkspaceLockfile=false.
+  // See: https://github.com/pnpm/pnpm/issues/9082
+  if (opts.ignoreScripts && allowBuild) {
+    for (const depNode of depNodes) {
+      if (depNode.requiresBuild) {
+        const allowed = allowBuild(depNode.name, depNode.version)
+        if (allowed === undefined) {
+          ignoredBuilds ??= new Set()
+          ignoredBuilds.add(depNode.depPath)
+        }
+      }
+    }
+  }
   if ((!opts.ignoreScripts || Object.keys(opts.patchedDependencies ?? {}).length > 0) && opts.enableModulesDir !== false) {
     const directNodes = new Set<string>()
     for (const id of union(importerIds, ['.'])) {

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -1357,6 +1357,168 @@ test('strictDepBuilds detects unapproved build scripts with sharedWorkspaceLockf
   }
 })
 
+test('strictDepBuilds detects unapproved build scripts with sharedWorkspaceLockfile=false and frozen lockfile', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  // First install with an allowBuilds entry to produce a valid lockfile
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+    },
+  })
+  expect(execPnpmSync(['install']).status).toBe(0)
+
+  // Now remove allowBuilds and enable strictDepBuilds; the frozen lockfile
+  // path (headlessInstall) should detect the unapproved build script.
+  rimrafSync('node_modules')
+  rimrafSync('project-1/node_modules')
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+  })
+  const result = execPnpmSync(['install', '--frozen-lockfile'])
+  expect(result.status).toBe(1)
+  expect(result.stdout.toString()).toContain('Ignored build scripts:')
+})
+
+test('allowBuilds=false silently skips scripts with sharedWorkspaceLockfile=false', async () => {
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': false,
+    },
+  })
+
+  const result = execPnpmSync(['install'])
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString()).not.toContain('Ignored build scripts:')
+  // The package is installed but the postinstall script was not executed.
+  projects['project-1'].has('@pnpm.e2e/pre-and-postinstall-scripts-example')
+  expect(fs.existsSync(
+    path.join(projects['project-1'].dir(), 'node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')
+  )).toBeFalsy()
+})
+
+test('allowBuilds version pins are respected with sharedWorkspaceLockfile=false', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  // Pin approval to a different version than what's installed.
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example@2.0.0': true,
+    },
+  })
+
+  {
+    const result = execPnpmSync(['install'])
+    expect(result.status).toBe(1)
+    expect(result.stdout.toString()).toContain('Ignored build scripts:')
+  }
+
+  // Pin approval to the installed version.
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0': true,
+    },
+  })
+
+  {
+    const result = execPnpmSync(['install'])
+    expect(result.status).toBe(0)
+  }
+})
+
+test('strictDepBuilds ignores approved workspace packages but reports unapproved ones', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-approved',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/install-script-example': '1.0.0',
+      },
+    },
+    {
+      name: 'project-unapproved',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+    allowBuilds: {
+      '@pnpm.e2e/install-script-example': true,
+    },
+  })
+
+  const result = execPnpmSync(['install'])
+  expect(result.status).toBe(1)
+  expect(result.stdout.toString()).toContain('Ignored build scripts:')
+  expect(result.stdout.toString()).toContain('@pnpm.e2e/pre-and-postinstall-scripts-example')
+})
+
 test("linking the package's bin to another workspace package in a monorepo", async () => {
   const projects = preparePackages([
     {

--- a/pnpm/test/monorepo/index.ts
+++ b/pnpm/test/monorepo/index.ts
@@ -1313,6 +1313,50 @@ test('dependencies of workspace projects are built during headless installation'
   }
 })
 
+test('strictDepBuilds detects unapproved build scripts with sharedWorkspaceLockfile=false', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+  })
+
+  {
+    const result = execPnpmSync(['install'])
+    expect(result.status).toBe(1)
+    expect(result.stdout.toString()).toContain('Ignored build scripts:')
+  }
+
+  // After approving the package, install should succeed
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    strictDepBuilds: true,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+    },
+  })
+
+  {
+    const result = execPnpmSync(['install'])
+    expect(result.status).toBe(0)
+  }
+})
+
 test("linking the package's bin to another workspace package in a monorepo", async () => {
   const projects = preparePackages([
     {


### PR DESCRIPTION
## Summary

Fixes #9082

When `sharedWorkspaceLockfile` is `false`, the per-workspace install path hardcodes `ignoreScripts: true`, which caused `buildModules()` to be skipped entirely. This meant the `allowBuild` check never ran and packages with unapproved postinstall scripts were silently installed without triggering `ERR_PNPM_IGNORED_BUILDS`.

### Root cause

In the per-workspace install path (`recursive.ts:407`), each workspace is installed with `ignoreScripts: true`. This flows through to both install paths:

- **Non-headless** (`deps-installer`): `buildModules()` is gated behind `if (!opts.ignoreScripts || patchedDeps)` — skipped when no patches exist
- **Headless** (`deps-restorer`): Same gate at the `buildModules()` call site

Since `buildModules()` is where the `allowBuild` check runs, `ignoredBuilds` was never populated, and `handleIgnoredBuilds()` had nothing to report.

### Fix

After `pendingBuilds` is collected (which already works with `ignoreScripts: true`), check each pending build against the `allowBuild` policy. This is a pure detection change — no build behavior is modified, no `buildDependency()` is called.

Changes in two files:
- `installing/deps-installer/src/install/index.ts` — non-headless path
- `installing/deps-restorer/src/index.ts` — headless/frozen-lockfile path

### Test plan

Added 5 e2e tests in `pnpm/test/monorepo/index.ts`:
- [ ] Unapproved build scripts detected on fresh install
- [ ] Unapproved build scripts detected with `--frozen-lockfile` (headless path)
- [ ] `allowBuilds: false` silently skips scripts without error
- [ ] Version-pinned `allowBuilds` respected (mismatched version → fails)
- [ ] Mixed workspaces: approved + unapproved packages across projects

Manually verified against a real monorepo with `sharedWorkspaceLockfile: false` and 3500+ packages.