### PR TITLE
feat: pnpm init writes devEngines.packageManager field

### DIFF
--- a/.changeset/init-dev-engines-package-manager.md
+++ b/.changeset/init-dev-engines-package-manager.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.commands": minor
+"pnpm": minor
+---
+
+`pnpm init` now writes a `devEngines.packageManager` field instead of the `packageManager` field when `init-package-manager` is enabled.

--- a/workspace/commands/src/init.ts
+++ b/workspace/commands/src/init.ts
@@ -39,7 +39,7 @@ export function help (): string {
             name: '--init-type <commonjs|module>',
           },
           {
-            description: 'Pin the project to the current pnpm version by adding a "devEngines.packageManager" field to package.json',
+            description: 'Declare a pnpm version range via "devEngines.packageManager" in package.json and auto-download pnpm when it is missing',
             name: '--init-package-manager',
           },
           {

--- a/workspace/commands/src/init.ts
+++ b/workspace/commands/src/init.ts
@@ -39,7 +39,7 @@ export function help (): string {
             name: '--init-type <commonjs|module>',
           },
           {
-            description: 'Pin the project to the current pnpm version by adding a "packageManager" field to package.json',
+            description: 'Pin the project to the current pnpm version by adding a "devEngines.packageManager" field to package.json',
             name: '--init-package-manager',
           },
           {
@@ -103,7 +103,14 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
   const initConfig = getInitConfig(opts)
   const packageJson = { ...manifest, ...initConfig }
   if (opts.initPackageManager) {
-    packageJson.packageManager = `pnpm@${packageManager.version}`
+    packageJson.devEngines = {
+      ...packageJson.devEngines,
+      packageManager: {
+        name: 'pnpm',
+        version: `^${packageManager.version}`,
+        onFail: 'download',
+      },
+    }
   }
   const priority = Object.fromEntries([
     'name',
@@ -115,7 +122,7 @@ export async function handler (opts: InitOptions, params?: string[]): Promise<st
     'keywords',
     'author',
     'license',
-    'packageManager',
+    'devEngines',
   ].map((key, index) => [key, index]))
   const sortedPackageJson = sortKeysByPriority({ priority }, packageJson)
   await writeProjectManifest(manifestPath, sortedPackageJson, {

--- a/workspace/commands/test/init.test.ts
+++ b/workspace/commands/test/init.test.ts
@@ -73,7 +73,12 @@ test('init a new package.json with init-package-manager=true', async () => {
   await init.handler({ cliOptions: {}, initPackageManager: true })
   const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
   expect(manifest).toBeTruthy()
-  expect(manifest.packageManager).toBeTruthy()
+  expect(manifest).not.toHaveProperty('packageManager')
+  expect(manifest.devEngines?.packageManager).toEqual({
+    name: 'pnpm',
+    version: expect.stringMatching(/^\^\d+\.\d+\.\d+/),
+    onFail: 'download',
+  })
 })
 
 test('init a new package.json with init-package-manager=false', async () => {
@@ -82,6 +87,7 @@ test('init a new package.json with init-package-manager=false', async () => {
   const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('package.json'))
   expect(manifest).toBeTruthy()
   expect(manifest).not.toHaveProperty('packageManager')
+  expect(manifest).not.toHaveProperty('devEngines')
 })
 
 test('init a new package.json with init-type=module', async () => {


### PR DESCRIPTION
## Summary
- `pnpm init --init-package-manager` now writes a `devEngines.packageManager` entry instead of the flat `packageManager` string
- Uses a caret range (`^<current-version>`) so the declared version updates with the lockfile rather than pinning to an exact release
- Sets `onFail: "download"` so the declared pnpm version is fetched automatically when it's missing

## Test plan
- [x] `@pnpm/workspace.commands` init tests pass
- [ ] Manual: `pnpm init --init-package-manager` in an empty dir produces the expected `devEngines.packageManager` block