### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Concisely describe what this PR changes and why. Focus on impact and
+urgency. -->
+
+## Details
+
+<!-- Add any extra context and design decisions. Keep it brief but complete. -->
+
+## Related Issues
+
+<!-- Use keywords to auto-close issues (Closes #123, Fixes #456). If this PR is
+only related to an issue or is a partial fix, simply reference the issue number
+without a keyword (Related to #123). -->
+
+## How to Validate
+
+<!-- List exact steps for reviewers to validate the change. Include commands,
+expected results, and edge cases. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- A maintainer will only start reviewing once the automated code reviewers
+(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
+pass before expecting human review. -->
+
+## Summary
+
+<!-- Describe what this PR changes and why, for reviewers. Link any related
+issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
+pnpm/pnpm#123 for a partial fix). -->
+
+## Squash Commit Body
+
+<!-- This PR will be squash-merged, using the PR title as the commit subject.
+Provide the body of that commit below.
+
+This body is for developers reading the git history, so be as detailed as the
+change warrants: explain the rationale, design decisions, and trade-offs. The
+user-facing release note belongs in the changeset, not here. -->
+
+```text
+Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
+```
+
+## Checklist
+
+<!-- Mark items with [x] once done. Remove items that don't apply. -->
+
+- [ ] The change is implemented in both the TypeScript CLI and the Rust
+  `pacquet/` port, or the description notes what still needs porting.
+- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
+  package. Keep it short and written for pnpm users — it becomes a release note.
+- [ ] Added or updated tests.
+- [ ] Updated the documentation if needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ GitHub turns any `@name` into a mention of that user/org/team, which is wrong ei
 
 ## Changesets (TypeScript only)
 
-If your changes affect published packages, you MUST create a changeset file in the `.changeset` directory. The changeset file should describe the change and specify the packages that are affected with the pending version bump types: patch, minor, or major.
+If your changes affect published packages, you MUST create a changeset file in the `.changeset` directory. The changeset file should describe the change and specify the packages that are affected with the pending version bump types: patch, minor, or major. Write the description for pnpm users and keep it concise — it becomes a release note. Implementation rationale belongs in the commit message, not the changeset.
 
 **IMPORTANT: Always explicitly include `"pnpm"` in the changeset** with the appropriate version bump (patch, minor, or major). The pnpm CLI will only receive automatic patch bumps from its dependencies, so if your change warrants a minor or major version bump for the CLI, you must specify it explicitly. The changeset description will appear on the release notes page.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   ```
 
 - Create your patch, following [code style guidelines](#coding-style-guidelines), and **including appropriate test cases**.
-- Run `pnpm changeset` in the root of the repository and describe your changes. The resulting files should be committed as they will be used during release.
+- Run `pnpm changeset` in the root of the repository and describe your changes. The resulting files should be committed as they will be used during release. Write the description for pnpm users and keep it concise — it becomes a release note. Implementation rationale belongs in the commit message, not the changeset.
 - Run the full test suite and ensure that all tests pass.
 - Commit your changes using a descriptive commit message that follows our
   [commit message conventions](#commit-message-guidelines). Adherence to these conventions


### PR DESCRIPTION
This PR adds `pull_request_template.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation / Chores

- Added a fully populated pull request template with guided sections for writing change summaries, standardized squash commit body text, and a release-related checklist.
- Updated contribution guidance to require concise, pnpm-user-facing changeset descriptions for changes to published packages, moving implementation rationale to the commit message.
- Reinforced that generated changeset files should be committed as part of the PR workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->