### PR TITLE
feat: add minimumReleaseAgeIgnoreMissingTime setting

### DIFF
--- a/.changeset/minimum-release-age-ignore-missing-time.md
+++ b/.changeset/minimum-release-age-ignore-missing-time.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/resolving.npm-resolver": minor
+"@pnpm/store.connection-manager": patch
+"@pnpm/deps.inspection.outdated": patch
+"@pnpm/exec.commands": patch
+"@pnpm/testing.command-defaults": patch
+"pnpm": minor
+---
+
+Added a new setting `minimumReleaseAgeIgnoreMissingTime`, which is `true` by default. When enabled, pnpm skips the `minimumReleaseAge` maturity check if the registry metadata does not include the `time` field. Set to `false` to fail resolution instead.

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -259,6 +259,7 @@ export interface Config extends OptionsFromRootManifest {
   preserveAbsolutePaths?: boolean
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeIgnoreMissingTime?: boolean
   minimumReleaseAgeStrict?: boolean
   fetchWarnTimeoutMs?: number
   fetchMinSpeedKiBps?: number

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -36,6 +36,7 @@ export const pnpmConfigFileKeys = [
   'dlx-cache-max-age',
   'minimum-release-age',
   'minimum-release-age-exclude',
+  'minimum-release-age-ignore-missing-time',
   'minimum-release-age-strict',
   'network-concurrency',
   'noproxy',

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -173,6 +173,7 @@ export async function getConfig (opts: {
     'link-workspace-packages': false,
     'lockfile-include-tarball-url': false,
     'minimum-release-age': 24 * 60, // 1 day
+    'minimum-release-age-ignore-missing-time': true,
     'modules-cache-max-age': 7 * 24 * 60, // 7 days
     'dlx-cache-max-age': 24 * 60, // 1 day
     'node-linker': 'isolated',

--- a/config/reader/src/localConfig.ts
+++ b/config/reader/src/localConfig.ts
@@ -77,6 +77,7 @@ const AUTH_CFG_KEYS = [
 const SECURITY_POLICY_CFG_KEYS = [
   'minimumReleaseAge',
   'minimumReleaseAgeExclude',
+  'minimumReleaseAgeIgnoreMissingTime',
   'minimumReleaseAgeStrict',
   'trustPolicy',
   'trustPolicyExclude',

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -70,6 +70,7 @@ export const pnpmTypes = {
   'dlx-cache-max-age': Number,
   'minimum-release-age': Number,
   'minimum-release-age-exclude': [String, Array],
+  'minimum-release-age-ignore-missing-time': Boolean,
   'minimum-release-age-strict': Boolean,
   'modules-dir': String,
   'network-concurrency': Number,

--- a/deps/inspection/commands/src/fetchPackageInfo.ts
+++ b/deps/inspection/commands/src/fetchPackageInfo.ts
@@ -79,8 +79,8 @@ export async function fetchPackageInfo (
   const data = pickPackageFromMeta(
     pickVersionByVersionRange,
     { preferredVersionSelectors: undefined },
-    spec,
-    metadata
+    metadata,
+    spec
   )
   if (!data) {
     throw new PnpmError('PACKAGE_NOT_FOUND', `No matching version found for ${packageName}@${spec.fetchSpec}`)

--- a/deps/inspection/outdated/src/createManifestGetter.ts
+++ b/deps/inspection/outdated/src/createManifestGetter.ts
@@ -12,6 +12,7 @@ interface GetManifestOpts {
   configByUri: object
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeIgnoreMissingTime?: boolean
   minimumReleaseAgeStrict?: boolean
 }
 
@@ -31,6 +32,7 @@ export function createManifestGetter (
     configByUri: opts.configByUri,
     filterMetadata: false, // We need all the data from metadata for "outdated --long" to work.
     strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
+    ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
   })
 
   const publishedBy = opts.minimumReleaseAge

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -108,6 +108,7 @@ export async function handler (
     fullMetadata,
     filterMetadata: fullMetadata,
     strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
+    ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
     retry: {
       factor: opts.fetchRetryFactor,
       maxTimeout: opts.fetchRetryMaxtimeout,

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -360,7 +360,7 @@ async function resolveNpm (
       dryRun: opts.dryRun === true,
       preferredVersionSelectors: opts.preferredVersions?.[spec.name],
       registry,
-      updateToLatest: opts.update === 'latest',
+      includeLatestTag: opts.update === 'latest',
       optional: wantedDependency.optional,
     })
   } catch (err: any) { // eslint-disable-line
@@ -502,7 +502,7 @@ async function resolveJsr (
     dryRun: opts.dryRun === true,
     preferredVersionSelectors: opts.preferredVersions?.[spec.name],
     registry,
-    updateToLatest: opts.update === 'latest',
+    includeLatestTag: opts.update === 'latest',
   })
 
   if (pickedPackage == null) {

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -136,6 +136,7 @@ export interface ResolverFactoryOptions {
   saveWorkspaceProtocol?: boolean | 'rolling'
   preserveAbsolutePaths?: boolean
   strictPublishedByCheck?: boolean
+  ignoreMissingTimeField?: boolean
   fetchWarnTimeoutMs?: number
 }
 
@@ -224,6 +225,7 @@ export function createNpmResolver (
       preferOffline: opts.preferOffline,
       cacheDir: opts.cacheDir,
       strictPublishedByCheck: opts.strictPublishedByCheck,
+      ignoreMissingTimeField: opts.ignoreMissingTimeField,
     }),
     registries: opts.registries,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -80,10 +80,10 @@ interface PickerContext {
   ignoreMissingTimeField?: boolean
 }
 
-// Calls `pickOne` for the requested spec, or — when updateToLatest is set —
+// Runs `pickOne` for the requested spec, or — when updateToLatest is set —
 // for both the requested spec and the "latest" dist-tag, returning whichever
 // resolves to the higher version.
-function pickForAllSpecs (
+function runPicker (
   pickCtx: PickerContext,
   pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
 ): PackageInRegistry | null {
@@ -99,12 +99,12 @@ function pickForAllSpecs (
 // When minimumReleaseAge is active: try the highest mature version; if none
 // and strictPublishedByCheck is off, fall back to the lowest version in range
 // without applying the maturity filter.
-function pickWithMaturity (
+function pickRespectingMinReleaseAge (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  return pickForAllSpecs(pickCtx, (targetSpec) => {
+  return runPicker(pickCtx, (targetSpec) => {
     const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
     if (highest || pickCtx.strictPublishedByCheck) return highest
     return pickPackageFromMeta(pickLowestVersionByVersionRange, {
@@ -114,41 +114,41 @@ function pickWithMaturity (
 }
 
 // When minimumReleaseAge is not active: pick by pickLowestVersion preference.
-function pickWithoutMaturity (
+function pickIgnoringReleaseAge (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-  return pickForAllSpecs(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta))
+  return runPicker(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta))
 }
 
-function pickBest (
+function pickMatchingVersion (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   return filterOpts.publishedBy
-    ? pickWithMaturity(pickCtx, meta, filterOpts)
-    : pickWithoutMaturity(pickCtx, meta, filterOpts)
+    ? pickRespectingMinReleaseAge(pickCtx, meta, filterOpts)
+    : pickIgnoringReleaseAge(pickCtx, meta, filterOpts)
 }
 
 // When metadata lacks the per-version `time` field and ignoreMissingTimeField
 // is enabled, skip the minimumReleaseAge filter with a warning instead of
 // failing hard. Used only at terminal return sites; the cache/fallback paths
 // that deliberately rely on ERR_PNPM_MISSING_TIME to trigger an upgrade-to-full
-// fetch keep calling pickBest directly inside their try/catch.
-function pickOrSkipMissingTime (
+// fetch keep calling pickMatchingVersion directly inside their try/catch.
+function pickTolerantOfMissingTime (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   try {
-    return pickBest(pickCtx, meta, filterOpts)
+    return pickMatchingVersion(pickCtx, meta, filterOpts)
   } catch (err: unknown) {
     if (pickCtx.ignoreMissingTimeField && isMissingTimeError(err)) {
       warnMissingTimeFieldOnce(meta.name)
-      return pickBest(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
+      return pickMatchingVersion(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
     }
     throw err
   }
@@ -198,7 +198,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: pickOrSkipMissingTime(pickCtx, cachedMeta, filterOpts),
+      pickedPackage: pickTolerantOfMissingTime(pickCtx, cachedMeta, filterOpts),
     }
   }
 
@@ -213,14 +213,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts),
+          pickedPackage: pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts)
+        const pickedPackage = pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -236,7 +236,7 @@ export async function pickPackage (
       // otherwise it is probably out of date
       if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
+          const pickedPackage = pickMatchingVersion(pickCtx, metaCachedInStore, filterOpts)
           if (pickedPackage) {
             return {
               meta: metaCachedInStore,
@@ -256,7 +256,7 @@ export async function pickPackage (
         metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
         if (metaCachedInStore != null) {
           try {
-            const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
+            const pickedPackage = pickMatchingVersion(pickCtx, metaCachedInStore, filterOpts)
             if (pickedPackage) {
               return {
                 meta: metaCachedInStore,
@@ -300,7 +300,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts),
+            pickedPackage: pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -372,7 +372,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts),
+        pickedPackage: pickTolerantOfMissingTime(pickCtx, meta, filterOpts),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -382,7 +382,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts),
+        pickedPackage: pickTolerantOfMissingTime(pickCtx, meta, filterOpts),
       }
     }
   })

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -72,8 +72,7 @@ export interface PickPackageOptions extends PickPackageFromMetaOptions {
   optional?: boolean
 }
 
-interface PickerContext {
-  spec: RegistryPackageSpec
+interface PickerOptions extends PickPackageFromMetaOptions {
   pickLowestVersion?: boolean
   includeLatestTag?: boolean
   strictPublishedByCheck?: boolean
@@ -83,16 +82,13 @@ interface PickerContext {
 // When includeLatestTag is set, the "latest" dist-tag is added as a candidate
 // alongside the requested spec, and the higher-versioned pick wins.
 function runPicker (
-  pickCtx: PickerContext,
+  pickerOpts: PickerOptions,
+  spec: RegistryPackageSpec,
   pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
 ): PackageInRegistry | null {
-  const currentPkg = pickOne(pickCtx.spec)
-  if (!pickCtx.includeLatestTag) return currentPkg
-  const latestPkg = pickOne({
-    ...pickCtx.spec,
-    type: 'tag',
-    fetchSpec: 'latest',
-  })
+  const currentPkg = pickOne(spec)
+  if (!pickerOpts.includeLatestTag) return currentPkg
+  const latestPkg = pickOne({ ...spec, type: 'tag', fetchSpec: 'latest' })
   return pickMax(latestPkg, currentPkg)
 }
 
@@ -113,42 +109,40 @@ const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRang
 // and strictPublishedByCheck is off, fall back to the lowest version in range
 // without applying the maturity filter.
 function pickRespectingMinReleaseAge (
-  pickCtx: PickerContext,
-  meta: PackageMeta,
-  filterOpts: PickPackageFromMetaOptions
+  pickerOpts: PickerOptions,
+  spec: RegistryPackageSpec,
+  meta: PackageMeta
 ): PackageInRegistry | null {
-  return runPicker(pickCtx, (targetSpec) => {
-    const highest = pickHighest(filterOpts, meta, targetSpec)
-    if (highest || pickCtx.strictPublishedByCheck) return highest
+  return runPicker(pickerOpts, spec, (targetSpec) => {
+    const highest = pickHighest(pickerOpts, meta, targetSpec)
+    if (highest || pickerOpts.strictPublishedByCheck) return highest
     return pickLowest({
-      preferredVersionSelectors: filterOpts.preferredVersionSelectors,
+      preferredVersionSelectors: pickerOpts.preferredVersionSelectors,
     }, meta, targetSpec)
   })
 }
 
 // When minimumReleaseAge is not active: pick by pickLowestVersion preference.
 function pickIgnoringReleaseAge (
-  pickCtx: PickerContext,
-  meta: PackageMeta,
-  filterOpts: PickPackageFromMetaOptions
+  pickerOpts: PickerOptions,
+  spec: RegistryPackageSpec,
+  meta: PackageMeta
 ): PackageInRegistry | null {
-  const pickVersion = pickCtx.pickLowestVersion ? pickLowest : pickHighest
-  return runPicker(pickCtx, (targetSpec) => pickVersion(filterOpts, meta, targetSpec))
+  const pickVersion = pickerOpts.pickLowestVersion ? pickLowest : pickHighest
+  return runPicker(pickerOpts, spec, (targetSpec) => pickVersion(pickerOpts, meta, targetSpec))
 }
 
 // Used in shortcut/fall-through paths: if it fails (including with
 // ERR_PNPM_MISSING_TIME), the caller falls through to the next path — e.g.
 // the network fetch that can upgrade abbreviated metadata to full.
 function pickMatchingVersionFast (
-  pickCtx: PickerContext,
-  meta: PackageMeta,
-  filterOpts: PickPackageFromMetaOptions
+  pickerOpts: PickerOptions,
+  spec: RegistryPackageSpec,
+  meta: PackageMeta
 ): PackageInRegistry | null {
-  return (
-    filterOpts.publishedBy
-      ? pickRespectingMinReleaseAge
-      : pickIgnoringReleaseAge
-  )(pickCtx, meta, filterOpts)
+  return pickerOpts.publishedBy
+    ? pickRespectingMinReleaseAge(pickerOpts, spec, meta)
+    : pickIgnoringReleaseAge(pickerOpts, spec, meta)
 }
 
 // Used at terminal return sites where no further fallback path exists. When
@@ -156,16 +150,20 @@ function pickMatchingVersionFast (
 // enabled, skip the minimumReleaseAge filter with a warning instead of
 // failing hard.
 function pickMatchingVersionFinal (
-  pickCtx: PickerContext,
-  meta: PackageMeta,
-  filterOpts: PickPackageFromMetaOptions
+  pickerOpts: PickerOptions,
+  spec: RegistryPackageSpec,
+  meta: PackageMeta
 ): PackageInRegistry | null {
   try {
-    return pickMatchingVersionFast(pickCtx, meta, filterOpts)
+    return pickMatchingVersionFast(pickerOpts, spec, meta)
   } catch (err: unknown) {
-    if (pickCtx.ignoreMissingTimeField && isMissingTimeError(err)) {
+    if (pickerOpts.ignoreMissingTimeField && isMissingTimeError(err)) {
       warnMissingTimeFieldOnce(meta.name)
-      return pickMatchingVersionFast(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
+      return pickMatchingVersionFast({
+        ...pickerOpts,
+        publishedBy: undefined,
+        publishedByExclude: undefined,
+      }, spec, meta)
     }
     throw err
   }
@@ -188,17 +186,14 @@ export async function pickPackage (
 ): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> {
   opts = opts || {}
 
-  const pickCtx: PickerContext = {
-    spec,
+  const pickerOpts: PickerOptions = {
+    preferredVersionSelectors: opts.preferredVersionSelectors,
+    publishedBy: opts.publishedBy,
+    publishedByExclude: opts.publishedByExclude,
     pickLowestVersion: opts.pickLowestVersion,
     includeLatestTag: opts.includeLatestTag,
     strictPublishedByCheck: ctx.strictPublishedByCheck,
     ignoreMissingTimeField: ctx.ignoreMissingTimeField,
-  }
-  const filterOpts: PickPackageFromMetaOptions = {
-    preferredVersionSelectors: opts.preferredVersionSelectors,
-    publishedBy: opts.publishedBy,
-    publishedByExclude: opts.publishedByExclude,
   }
 
   validatePackageName(spec.name)
@@ -215,7 +210,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: pickMatchingVersionFinal(pickCtx, cachedMeta, filterOpts),
+      pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, cachedMeta),
     }
   }
 
@@ -230,14 +225,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts),
+          pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts)
+        const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -253,7 +248,7 @@ export async function pickPackage (
       // otherwise it is probably out of date
       if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = pickMatchingVersionFast(pickCtx, metaCachedInStore, filterOpts)
+          const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
           if (pickedPackage) {
             return {
               meta: metaCachedInStore,
@@ -273,7 +268,7 @@ export async function pickPackage (
         metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
         if (metaCachedInStore != null) {
           try {
-            const pickedPackage = pickMatchingVersionFast(pickCtx, metaCachedInStore, filterOpts)
+            const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
             if (pickedPackage) {
               return {
                 meta: metaCachedInStore,
@@ -317,7 +312,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts),
+            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -389,7 +384,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickCtx, meta, filterOpts),
+        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -399,7 +394,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickCtx, meta, filterOpts),
+        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
       }
     }
   })

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -106,19 +106,17 @@ export async function pickPackage (
     return pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta)
   }
 
-  // Pick a version from the metadata. When `applyMaturityCheck` is false the
-  // publishedBy filter is bypassed — used only by the missing-time fallback.
-  const pickFromMeta = (meta: PackageMeta, { applyMaturityCheck = true }: { applyMaturityCheck?: boolean } = {}): PackageInRegistry | null => {
-    const filterOpts: PickPackageFromMetaOptions = {
-      preferredVersionSelectors: opts.preferredVersionSelectors,
-      publishedBy: applyMaturityCheck ? opts.publishedBy : undefined,
-      publishedByExclude: applyMaturityCheck ? opts.publishedByExclude : undefined,
-    }
-    if (!opts.updateToLatest) {
-      return pickForSpec(spec, meta, filterOpts)
-    }
-    // updateToLatest: compare the "latest" dist-tag against the requested
-    // spec and return whichever resolves to the higher version.
+  const filterOpts: PickPackageFromMetaOptions = {
+    preferredVersionSelectors: opts.preferredVersionSelectors,
+    publishedBy: opts.publishedBy,
+    publishedByExclude: opts.publishedByExclude,
+  }
+
+  // Pick a version from the metadata using the given filter options. When
+  // updateToLatest is set, compares the "latest" dist-tag against the
+  // requested spec and returns whichever resolves to the higher version.
+  const pickBest = (meta: PackageMeta, filterOpts: PickPackageFromMetaOptions): PackageInRegistry | null => {
+    if (!opts.updateToLatest) return pickForSpec(spec, meta, filterOpts)
     const latestSpec: RegistryPackageSpec = { ...spec, type: 'tag', fetchSpec: 'latest' }
     const latest = pickForSpec(latestSpec, meta, filterOpts)
     const current = pickForSpec(spec, meta, filterOpts)
@@ -127,18 +125,20 @@ export async function pickPackage (
     return semver.lt(latest.version, current.version) ? current : latest
   }
 
-  // Wraps pickFromMeta so that, when we've already fetched full metadata
-  // (either directly or via an abbreviated→full upgrade) but it still lacks
-  // the per-version `time` field, we skip the minimumReleaseAge filter with a
-  // warning instead of failing hard. Before a full-metadata attempt has been
-  // made, we let ERR_PNPM_MISSING_TIME propagate so the upgrade path still runs.
+  const pickFromMeta = (meta: PackageMeta): PackageInRegistry | null => pickBest(meta, filterOpts)
+
+  // When we've already fetched full metadata (either directly or via an
+  // abbreviated→full upgrade) but it still lacks the per-version `time` field,
+  // skip the minimumReleaseAge filter with a warning instead of failing hard.
+  // Before a full-metadata attempt has been made, we let ERR_PNPM_MISSING_TIME
+  // propagate so the upgrade path still runs.
   const pickOrSkipMissingTime = (meta: PackageMeta, fullMetadataFetched: boolean): PackageInRegistry | null => {
     try {
-      return pickFromMeta(meta)
+      return pickBest(meta, filterOpts)
     } catch (err: unknown) {
       if (ctx.ignoreMissingTimeField && fullMetadataFetched && isMissingTimeError(err)) {
         warnMissingTimeFieldOnce(meta.name)
-        return pickFromMeta(meta, { applyMaturityCheck: false })
+        return pickBest(meta, { preferredVersionSelectors: opts.preferredVersionSelectors })
       }
       throw err
     }

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -80,6 +80,16 @@ interface PickerContext {
   ignoreMissingTimeField?: boolean
 }
 
+// Returns whichever pick has the higher version, treating null as "no match".
+function pickMax (
+  a: PackageInRegistry | null,
+  b: PackageInRegistry | null
+): PackageInRegistry | null {
+  if (!a) return b
+  if (!b) return a
+  return semver.lt(a.version, b.version) ? b : a
+}
+
 // Runs `pickOne` for the requested spec, or — when updateToLatest is set —
 // for both the requested spec and the "latest" dist-tag, returning whichever
 // resolves to the higher version.
@@ -89,11 +99,7 @@ function runPicker (
 ): PackageInRegistry | null {
   if (!pickCtx.updateToLatest) return pickOne(pickCtx.spec)
   const latestStableSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
-  const latestStable = pickOne(latestStableSpec)
-  const current = pickOne(pickCtx.spec)
-  if (!latestStable) return current
-  if (!current) return latestStable
-  return semver.lt(latestStable.version, current.version) ? current : latestStable
+  return pickMax(pickOne(latestStableSpec), pickOne(pickCtx.spec))
 }
 
 // When minimumReleaseAge is active: try the highest mature version; if none

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -68,26 +68,25 @@ export interface PickPackageOptions extends PickPackageFromMetaOptions {
   pickLowestVersion?: boolean
   registry: string
   dryRun: boolean
-  updateToLatest?: boolean
+  includeLatestTag?: boolean
   optional?: boolean
 }
 
 interface PickerContext {
   spec: RegistryPackageSpec
   pickLowestVersion?: boolean
-  updateToLatest?: boolean
+  includeLatestTag?: boolean
   strictPublishedByCheck?: boolean
   ignoreMissingTimeField?: boolean
 }
 
-// Runs `pickOne` for the requested spec, or — when updateToLatest is set —
-// for both the requested spec and the "latest" dist-tag, returning whichever
-// resolves to the higher version.
+// When includeLatestTag is set, the "latest" dist-tag is added as a candidate
+// alongside the requested spec, and the higher-versioned pick wins.
 function runPicker (
   pickCtx: PickerContext,
   pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
 ): PackageInRegistry | null {
-  if (!pickCtx.updateToLatest) return pickOne(pickCtx.spec)
+  if (!pickCtx.includeLatestTag) return pickOne(pickCtx.spec)
   const latestStableSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
   return pickMax(pickOne(latestStableSpec), pickOne(pickCtx.spec))
 }
@@ -110,12 +109,14 @@ function pickRespectingMinReleaseAge (
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
+  const pickHighest = pickPackageFromMeta.bind(null, pickVersionByVersionRange, filterOpts, meta)
+  const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRange, {
+    preferredVersionSelectors: filterOpts.preferredVersionSelectors,
+  }, meta)
   return runPicker(pickCtx, (targetSpec) => {
-    const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
+    const highest = pickHighest(targetSpec)
     if (highest || pickCtx.strictPublishedByCheck) return highest
-    return pickPackageFromMeta(pickLowestVersionByVersionRange, {
-      preferredVersionSelectors: filterOpts.preferredVersionSelectors,
-    }, targetSpec, meta)
+    return pickLowest(targetSpec)
   })
 }
 
@@ -126,7 +127,7 @@ function pickIgnoringReleaseAge (
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-  return runPicker(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta))
+  return runPicker(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, meta, targetSpec))
 }
 
 function pickMatchingVersion (
@@ -180,7 +181,7 @@ export async function pickPackage (
   const pickCtx: PickerContext = {
     spec,
     pickLowestVersion: opts.pickLowestVersion,
-    updateToLatest: opts.updateToLatest,
+    includeLatestTag: opts.includeLatestTag,
     strictPublishedByCheck: ctx.strictPublishedByCheck,
     ignoreMissingTimeField: ctx.ignoreMissingTimeField,
   }
@@ -236,7 +237,7 @@ export async function pickPackage (
       }
     }
 
-    if (!opts.updateToLatest && spec.type === 'version') {
+    if (!opts.includeLatestTag && spec.type === 'version') {
       metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
       // use the cached meta only if it has the required package version
       // otherwise it is probably out of date

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -132,21 +132,20 @@ function pickBest (
     : pickWithoutMaturity(pickCtx, meta, filterOpts)
 }
 
-// When we've already fetched full metadata (either directly or via an
-// abbreviated→full upgrade) but it still lacks the per-version `time` field,
-// skip the minimumReleaseAge filter with a warning instead of failing hard.
-// Before a full-metadata attempt has been made, we let ERR_PNPM_MISSING_TIME
-// propagate so the upgrade path still runs.
+// When metadata lacks the per-version `time` field and ignoreMissingTimeField
+// is enabled, skip the minimumReleaseAge filter with a warning instead of
+// failing hard. Used only at terminal return sites; the cache/fallback paths
+// that deliberately rely on ERR_PNPM_MISSING_TIME to trigger an upgrade-to-full
+// fetch keep calling pickBest directly inside their try/catch.
 function pickOrSkipMissingTime (
   pickCtx: PickerContext,
   meta: PackageMeta,
-  filterOpts: PickPackageFromMetaOptions,
-  fullMetadataFetched: boolean
+  filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   try {
     return pickBest(pickCtx, meta, filterOpts)
   } catch (err: unknown) {
-    if (pickCtx.ignoreMissingTimeField && fullMetadataFetched && isMissingTimeError(err)) {
+    if (pickCtx.ignoreMissingTimeField && isMissingTimeError(err)) {
       warnMissingTimeFieldOnce(meta.name)
       return pickBest(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
     }
@@ -198,7 +197,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: pickBest(pickCtx, cachedMeta, filterOpts),
+      pickedPackage: pickOrSkipMissingTime(pickCtx, cachedMeta, filterOpts),
     }
   }
 
@@ -213,14 +212,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: pickBest(pickCtx, metaCachedInStore, filterOpts),
+          pickedPackage: pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
+        const pickedPackage = pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -300,7 +299,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: pickBest(pickCtx, metaCachedInStore, filterOpts),
+            pickedPackage: pickOrSkipMissingTime(pickCtx, metaCachedInStore, filterOpts),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -309,7 +308,6 @@ export async function pickPackage (
 
       let meta = fetchResult.meta
       let resultToSave: FetchMetadataResult = fetchResult
-      let fullMetadataFetched = fullMetadata
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -348,7 +346,6 @@ export async function pickPackage (
           if (!fullFetchResult.notModified) {
             resultToSave = fullFetchResult
             meta = fullFetchResult.meta
-            fullMetadataFetched = true
           }
         }
       }
@@ -374,7 +371,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts, fullMetadataFetched),
+        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -384,7 +381,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickBest(pickCtx, meta, filterOpts),
+        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts),
       }
     }
   })
@@ -455,10 +452,18 @@ function isMissingTimeError (err: unknown): boolean {
   )
 }
 
+// Cap the size so long-lived processes (daemons, store servers) can't leak
+// memory via this Set as they resolve ever more distinct packages.
+const MAX_WARNED_MISSING_TIME = 1024
 const warnedMissingTimeFor = new Set<string>()
 
 function warnMissingTimeFieldOnce (pkgName: string): void {
   if (warnedMissingTimeFor.has(pkgName)) return
+  if (warnedMissingTimeFor.size >= MAX_WARNED_MISSING_TIME) {
+    // Set preserves insertion order, so the first entry is the oldest.
+    const oldest = warnedMissingTimeFor.values().next().value
+    if (oldest != null) warnedMissingTimeFor.delete(oldest)
+  }
   warnedMissingTimeFor.add(pkgName)
   globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the minimumReleaseAge check for this package.`)
 }

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -96,6 +96,7 @@ export async function pickPackage (
     preferOffline?: boolean
     filterMetadata?: boolean
     strictPublishedByCheck?: boolean
+    ignoreMissingTimeField?: boolean
   },
   spec: RegistryPackageSpec,
   opts: PickPackageOptions
@@ -109,6 +110,7 @@ export async function pickPackage (
     preferredVersionSelectors: opts.preferredVersionSelectors,
     publishedBy: opts.publishedBy,
     publishedByExclude: opts.publishedByExclude,
+    ignoreMissingTimeField: ctx.ignoreMissingTimeField,
   })
 
   let _pickPackageFromMeta!: (meta: PackageMeta) => PackageInRegistry | null

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -5,7 +5,7 @@ import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pn
 import { createHexHash } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
 import gfs from '@pnpm/fs.graceful-fs'
-import { logger } from '@pnpm/logger'
+import { globalWarn, logger } from '@pnpm/logger'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import getRegistryName from 'encode-registry'
 import pLimit, { type LimitFunction } from 'p-limit'
@@ -110,23 +110,52 @@ export async function pickPackage (
     preferredVersionSelectors: opts.preferredVersionSelectors,
     publishedBy: opts.publishedBy,
     publishedByExclude: opts.publishedByExclude,
-    ignoreMissingTimeField: ctx.ignoreMissingTimeField,
+  })
+
+  const pickVersionFn = opts.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
+  const pickPackageFromMetaBySpecNoPublishedBy = pickPackageFromMeta.bind(null, pickVersionFn).bind(null, {
+    preferredVersionSelectors: opts.preferredVersionSelectors,
   })
 
   let _pickPackageFromMeta!: (meta: PackageMeta) => PackageInRegistry | null
+  let _pickPackageFromMetaNoPublishedBy!: (meta: PackageMeta) => PackageInRegistry | null
   if (opts.updateToLatest) {
-    _pickPackageFromMeta = (meta) => {
+    const makePicker = (pick: (spec: RegistryPackageSpec, meta: PackageMeta) => PackageInRegistry | null) => (meta: PackageMeta) => {
       const latestStableSpec: RegistryPackageSpec = { ...spec, type: 'tag', fetchSpec: 'latest' }
-      const latestStable = pickPackageFromMetaBySpec(latestStableSpec, meta)
-      const current = pickPackageFromMetaBySpec(spec, meta)
+      const latestStable = pick(latestStableSpec, meta)
+      const current = pick(spec, meta)
 
       if (!latestStable) return current
       if (!current) return latestStable
       if (semver.lt(latestStable.version, current.version)) return current
       return latestStable
     }
+    _pickPackageFromMeta = makePicker(pickPackageFromMetaBySpec)
+    _pickPackageFromMetaNoPublishedBy = makePicker(pickPackageFromMetaBySpecNoPublishedBy)
   } else {
     _pickPackageFromMeta = pickPackageFromMetaBySpec.bind(null, spec)
+    _pickPackageFromMetaNoPublishedBy = pickPackageFromMetaBySpecNoPublishedBy.bind(null, spec)
+  }
+
+  // Wraps the final pick call so that, when we've already fetched full metadata
+  // (either directly or via an abbreviated→full upgrade) but it still lacks the
+  // per-version `time` field, we skip the minimumReleaseAge filter with a warning
+  // instead of failing hard. Before a full-metadata attempt has been made, we
+  // let ERR_PNPM_MISSING_TIME propagate so the upgrade-to-full path still runs.
+  const pickWithMissingTimeFallback = (meta: PackageMeta, fullMetadataFetched: boolean): PackageInRegistry | null => {
+    try {
+      return _pickPackageFromMeta(meta)
+    } catch (err: unknown) {
+      if (
+        ctx.ignoreMissingTimeField &&
+        fullMetadataFetched &&
+        isMissingTimeError(err)
+      ) {
+        warnMissingTimeFieldOnce(meta.name)
+        return _pickPackageFromMetaNoPublishedBy(meta)
+      }
+      throw err
+    }
   }
 
   validatePackageName(spec.name)
@@ -254,6 +283,7 @@ export async function pickPackage (
 
       let meta = fetchResult.meta
       let resultToSave: FetchMetadataResult = fetchResult
+      let fullMetadataFetched = fullMetadata
 
       // When minimumReleaseAge is active and we fetched abbreviated metadata,
       // check if the package was recently modified and needs full metadata
@@ -292,6 +322,7 @@ export async function pickPackage (
           if (!fullFetchResult.notModified) {
             resultToSave = fullFetchResult
             meta = fullFetchResult.meta
+            fullMetadataFetched = true
           }
         }
       }
@@ -317,7 +348,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: _pickPackageFromMeta(meta),
+        pickedPackage: pickWithMissingTimeFallback(meta, fullMetadataFetched),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -396,6 +427,14 @@ function isMissingTimeError (err: unknown): boolean {
     'code' in err &&
     (err as { code: string }).code === 'ERR_PNPM_MISSING_TIME'
   )
+}
+
+const warnedMissingTimeFor = new Set<string>()
+
+function warnMissingTimeFieldOnce (pkgName: string): void {
+  if (warnedMissingTimeFor.has(pkgName)) return
+  warnedMissingTimeFor.add(pkgName)
+  globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the minimumReleaseAge check for this package.`)
 }
 
 async function getFileMtime (filePath: string): Promise<Date | null> {

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -80,16 +80,6 @@ interface PickerContext {
   ignoreMissingTimeField?: boolean
 }
 
-// Returns whichever pick has the higher version, treating null as "no match".
-function pickMax (
-  a: PackageInRegistry | null,
-  b: PackageInRegistry | null
-): PackageInRegistry | null {
-  if (!a) return b
-  if (!b) return a
-  return semver.lt(a.version, b.version) ? b : a
-}
-
 // Runs `pickOne` for the requested spec, or — when updateToLatest is set —
 // for both the requested spec and the "latest" dist-tag, returning whichever
 // resolves to the higher version.
@@ -100,6 +90,16 @@ function runPicker (
   if (!pickCtx.updateToLatest) return pickOne(pickCtx.spec)
   const latestStableSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
   return pickMax(pickOne(latestStableSpec), pickOne(pickCtx.spec))
+}
+
+// Returns whichever pick has the higher version, treating null as "no match".
+function pickMax (
+  a: PackageInRegistry | null,
+  b: PackageInRegistry | null
+): PackageInRegistry | null {
+  if (!a) return b
+  if (!b) return a
+  return semver.lt(a.version, b.version) ? b : a
 }
 
 // When minimumReleaseAge is active: try the highest mature version; if none

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -86,9 +86,14 @@ function runPicker (
   pickCtx: PickerContext,
   pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
 ): PackageInRegistry | null {
-  if (!pickCtx.includeLatestTag) return pickOne(pickCtx.spec)
-  const latestStableSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
-  return pickMax(pickOne(latestStableSpec), pickOne(pickCtx.spec))
+  const currentPkg = pickOne(pickCtx.spec)
+  if (!pickCtx.includeLatestTag) return currentPkg
+  const latestPkg = pickOne({
+    ...pickCtx.spec,
+    type: 'tag',
+    fetchSpec: 'latest',
+  })
+  return pickMax(latestPkg, currentPkg)
 }
 
 // Returns whichever pick has the higher version, treating null as "no match".
@@ -101,6 +106,9 @@ function pickMax (
   return semver.lt(a.version, b.version) ? b : a
 }
 
+const pickHighest = pickPackageFromMeta.bind(null, pickVersionByVersionRange)
+const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRange)
+
 // When minimumReleaseAge is active: try the highest mature version; if none
 // and strictPublishedByCheck is off, fall back to the lowest version in range
 // without applying the maturity filter.
@@ -109,14 +117,12 @@ function pickRespectingMinReleaseAge (
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  const pickHighest = pickPackageFromMeta.bind(null, pickVersionByVersionRange, filterOpts, meta)
-  const pickLowest = pickPackageFromMeta.bind(null, pickLowestVersionByVersionRange, {
-    preferredVersionSelectors: filterOpts.preferredVersionSelectors,
-  }, meta)
   return runPicker(pickCtx, (targetSpec) => {
-    const highest = pickHighest(targetSpec)
+    const highest = pickHighest(filterOpts, meta, targetSpec)
     if (highest || pickCtx.strictPublishedByCheck) return highest
-    return pickLowest(targetSpec)
+    return pickLowest({
+      preferredVersionSelectors: filterOpts.preferredVersionSelectors,
+    }, meta, targetSpec)
   })
 }
 
@@ -126,8 +132,8 @@ function pickIgnoringReleaseAge (
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-  return runPicker(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, meta, targetSpec))
+  const pickVersion = pickCtx.pickLowestVersion ? pickLowest : pickHighest
+  return runPicker(pickCtx, (targetSpec) => pickVersion(filterOpts, meta, targetSpec))
 }
 
 // Used in shortcut/fall-through paths: if it fails (including with
@@ -138,9 +144,11 @@ function pickMatchingVersionFast (
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  return filterOpts.publishedBy
-    ? pickRespectingMinReleaseAge(pickCtx, meta, filterOpts)
-    : pickIgnoringReleaseAge(pickCtx, meta, filterOpts)
+  return (
+    filterOpts.publishedBy
+      ? pickRespectingMinReleaseAge
+      : pickIgnoringReleaseAge
+  )(pickCtx, meta, filterOpts)
 }
 
 // Used at terminal return sites where no further fallback path exists. When

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -88,12 +88,12 @@ function runPicker (
   pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
 ): PackageInRegistry | null {
   if (!pickCtx.updateToLatest) return pickOne(pickCtx.spec)
-  const latestSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
-  const latest = pickOne(latestSpec)
+  const latestStableSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
+  const latestStable = pickOne(latestStableSpec)
   const current = pickOne(pickCtx.spec)
-  if (!latest) return current
-  if (!current) return latest
-  return semver.lt(latest.version, current.version) ? current : latest
+  if (!latestStable) return current
+  if (!current) return latestStable
+  return semver.lt(latestStable.version, current.version) ? current : latestStable
 }
 
 // When minimumReleaseAge is active: try the highest mature version; if none

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -97,7 +97,8 @@ function pickForAllSpecs (
 }
 
 // When minimumReleaseAge is active: try the highest mature version; if none
-// and strictPublishedByCheck is off, fall back to the lowest mature version.
+// and strictPublishedByCheck is off, fall back to the lowest version in range
+// without applying the maturity filter.
 function pickWithMaturity (
   pickCtx: PickerContext,
   meta: PackageMeta,

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -72,6 +72,75 @@ export interface PickPackageOptions extends PickPackageFromMetaOptions {
   optional?: boolean
 }
 
+interface PickerContext {
+  spec: RegistryPackageSpec
+  pickLowestVersion?: boolean
+  updateToLatest?: boolean
+  strictPublishedByCheck?: boolean
+  ignoreMissingTimeField?: boolean
+}
+
+// Pick a version from the metadata for the given `targetSpec`, honoring
+// publishedBy (minimumReleaseAge) when set:
+// - with publishedBy, try the highest mature version; if none and
+//   strictPublishedByCheck is off, fall back to the lowest mature version.
+// - without publishedBy, use pickLowestVersion to choose the direction.
+function pickForSpec (
+  pickCtx: PickerContext,
+  targetSpec: RegistryPackageSpec,
+  meta: PackageMeta,
+  filterOpts: PickPackageFromMetaOptions
+): PackageInRegistry | null {
+  if (filterOpts.publishedBy) {
+    const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
+    if (highest || pickCtx.strictPublishedByCheck) return highest
+    return pickPackageFromMeta(pickLowestVersionByVersionRange, {
+      preferredVersionSelectors: filterOpts.preferredVersionSelectors,
+    }, targetSpec, meta)
+  }
+  const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
+  return pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta)
+}
+
+// Pick a version from the metadata using the given filter options. When
+// updateToLatest is set, compares the "latest" dist-tag against the
+// requested spec and returns whichever resolves to the higher version.
+function pickBest (
+  pickCtx: PickerContext,
+  meta: PackageMeta,
+  filterOpts: PickPackageFromMetaOptions
+): PackageInRegistry | null {
+  if (!pickCtx.updateToLatest) return pickForSpec(pickCtx, pickCtx.spec, meta, filterOpts)
+  const latestSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
+  const latest = pickForSpec(pickCtx, latestSpec, meta, filterOpts)
+  const current = pickForSpec(pickCtx, pickCtx.spec, meta, filterOpts)
+  if (!latest) return current
+  if (!current) return latest
+  return semver.lt(latest.version, current.version) ? current : latest
+}
+
+// When we've already fetched full metadata (either directly or via an
+// abbreviated→full upgrade) but it still lacks the per-version `time` field,
+// skip the minimumReleaseAge filter with a warning instead of failing hard.
+// Before a full-metadata attempt has been made, we let ERR_PNPM_MISSING_TIME
+// propagate so the upgrade path still runs.
+function pickOrSkipMissingTime (
+  pickCtx: PickerContext,
+  meta: PackageMeta,
+  filterOpts: PickPackageFromMetaOptions,
+  fullMetadataFetched: boolean
+): PackageInRegistry | null {
+  try {
+    return pickBest(pickCtx, meta, filterOpts)
+  } catch (err: unknown) {
+    if (pickCtx.ignoreMissingTimeField && fullMetadataFetched && isMissingTimeError(err)) {
+      warnMissingTimeFieldOnce(meta.name)
+      return pickBest(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
+    }
+    throw err
+  }
+}
+
 export async function pickPackage (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -89,59 +158,17 @@ export async function pickPackage (
 ): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> {
   opts = opts || {}
 
-  // Select a specific version from the given meta for `targetSpec`, honoring
-  // publishedBy (minimumReleaseAge) when set:
-  // - with publishedBy, try the highest mature version; if none and
-  //   strictPublishedByCheck is off, fall back to the lowest mature version.
-  // - without publishedBy, use opts.pickLowestVersion to choose the direction.
-  const pickForSpec = (targetSpec: RegistryPackageSpec, meta: PackageMeta, filterOpts: PickPackageFromMetaOptions): PackageInRegistry | null => {
-    if (filterOpts.publishedBy) {
-      const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
-      if (highest || ctx.strictPublishedByCheck) return highest
-      return pickPackageFromMeta(pickLowestVersionByVersionRange, {
-        preferredVersionSelectors: filterOpts.preferredVersionSelectors,
-      }, targetSpec, meta)
-    }
-    const pickVersion = opts.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-    return pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta)
+  const pickCtx: PickerContext = {
+    spec,
+    pickLowestVersion: opts.pickLowestVersion,
+    updateToLatest: opts.updateToLatest,
+    strictPublishedByCheck: ctx.strictPublishedByCheck,
+    ignoreMissingTimeField: ctx.ignoreMissingTimeField,
   }
-
   const filterOpts: PickPackageFromMetaOptions = {
     preferredVersionSelectors: opts.preferredVersionSelectors,
     publishedBy: opts.publishedBy,
     publishedByExclude: opts.publishedByExclude,
-  }
-
-  // Pick a version from the metadata using the given filter options. When
-  // updateToLatest is set, compares the "latest" dist-tag against the
-  // requested spec and returns whichever resolves to the higher version.
-  const pickBest = (meta: PackageMeta, filterOpts: PickPackageFromMetaOptions): PackageInRegistry | null => {
-    if (!opts.updateToLatest) return pickForSpec(spec, meta, filterOpts)
-    const latestSpec: RegistryPackageSpec = { ...spec, type: 'tag', fetchSpec: 'latest' }
-    const latest = pickForSpec(latestSpec, meta, filterOpts)
-    const current = pickForSpec(spec, meta, filterOpts)
-    if (!latest) return current
-    if (!current) return latest
-    return semver.lt(latest.version, current.version) ? current : latest
-  }
-
-  const pickFromMeta = (meta: PackageMeta): PackageInRegistry | null => pickBest(meta, filterOpts)
-
-  // When we've already fetched full metadata (either directly or via an
-  // abbreviated→full upgrade) but it still lacks the per-version `time` field,
-  // skip the minimumReleaseAge filter with a warning instead of failing hard.
-  // Before a full-metadata attempt has been made, we let ERR_PNPM_MISSING_TIME
-  // propagate so the upgrade path still runs.
-  const pickOrSkipMissingTime = (meta: PackageMeta, fullMetadataFetched: boolean): PackageInRegistry | null => {
-    try {
-      return pickBest(meta, filterOpts)
-    } catch (err: unknown) {
-      if (ctx.ignoreMissingTimeField && fullMetadataFetched && isMissingTimeError(err)) {
-        warnMissingTimeFieldOnce(meta.name)
-        return pickBest(meta, { preferredVersionSelectors: opts.preferredVersionSelectors })
-      }
-      throw err
-    }
   }
 
   validatePackageName(spec.name)
@@ -158,7 +185,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: pickFromMeta(cachedMeta),
+      pickedPackage: pickBest(pickCtx, cachedMeta, filterOpts),
     }
   }
 
@@ -173,14 +200,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: pickFromMeta(metaCachedInStore),
+          pickedPackage: pickBest(pickCtx, metaCachedInStore, filterOpts),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = pickFromMeta(metaCachedInStore)
+        const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -196,7 +223,7 @@ export async function pickPackage (
       // otherwise it is probably out of date
       if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = pickFromMeta(metaCachedInStore)
+          const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
           if (pickedPackage) {
             return {
               meta: metaCachedInStore,
@@ -216,7 +243,7 @@ export async function pickPackage (
         metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
         if (metaCachedInStore != null) {
           try {
-            const pickedPackage = pickFromMeta(metaCachedInStore)
+            const pickedPackage = pickBest(pickCtx, metaCachedInStore, filterOpts)
             if (pickedPackage) {
               return {
                 meta: metaCachedInStore,
@@ -260,7 +287,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: pickFromMeta(metaCachedInStore),
+            pickedPackage: pickBest(pickCtx, metaCachedInStore, filterOpts),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -334,7 +361,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickOrSkipMissingTime(meta, fullMetadataFetched),
+        pickedPackage: pickOrSkipMissingTime(pickCtx, meta, filterOpts, fullMetadataFetched),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -344,7 +371,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickFromMeta(meta),
+        pickedPackage: pickBest(pickCtx, meta, filterOpts),
       }
     }
   })

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -130,7 +130,10 @@ function pickIgnoringReleaseAge (
   return runPicker(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, meta, targetSpec))
 }
 
-function pickMatchingVersion (
+// Used in shortcut/fall-through paths: if it fails (including with
+// ERR_PNPM_MISSING_TIME), the caller falls through to the next path — e.g.
+// the network fetch that can upgrade abbreviated metadata to full.
+function pickMatchingVersionFast (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
@@ -140,22 +143,21 @@ function pickMatchingVersion (
     : pickIgnoringReleaseAge(pickCtx, meta, filterOpts)
 }
 
-// When metadata lacks the per-version `time` field and ignoreMissingTimeField
-// is enabled, skip the minimumReleaseAge filter with a warning instead of
-// failing hard. Used only at terminal return sites; the cache/fallback paths
-// that deliberately rely on ERR_PNPM_MISSING_TIME to trigger an upgrade-to-full
-// fetch keep calling pickMatchingVersion directly inside their try/catch.
-function pickTolerantOfMissingTime (
+// Used at terminal return sites where no further fallback path exists. When
+// metadata lacks the per-version `time` field and ignoreMissingTimeField is
+// enabled, skip the minimumReleaseAge filter with a warning instead of
+// failing hard.
+function pickMatchingVersionFinal (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
   try {
-    return pickMatchingVersion(pickCtx, meta, filterOpts)
+    return pickMatchingVersionFast(pickCtx, meta, filterOpts)
   } catch (err: unknown) {
     if (pickCtx.ignoreMissingTimeField && isMissingTimeError(err)) {
       warnMissingTimeFieldOnce(meta.name)
-      return pickMatchingVersion(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
+      return pickMatchingVersionFast(pickCtx, meta, { preferredVersionSelectors: filterOpts.preferredVersionSelectors })
     }
     throw err
   }
@@ -205,7 +207,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: pickTolerantOfMissingTime(pickCtx, cachedMeta, filterOpts),
+      pickedPackage: pickMatchingVersionFinal(pickCtx, cachedMeta, filterOpts),
     }
   }
 
@@ -220,14 +222,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts),
+          pickedPackage: pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts)
+        const pickedPackage = pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -243,7 +245,7 @@ export async function pickPackage (
       // otherwise it is probably out of date
       if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = pickMatchingVersion(pickCtx, metaCachedInStore, filterOpts)
+          const pickedPackage = pickMatchingVersionFast(pickCtx, metaCachedInStore, filterOpts)
           if (pickedPackage) {
             return {
               meta: metaCachedInStore,
@@ -263,7 +265,7 @@ export async function pickPackage (
         metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
         if (metaCachedInStore != null) {
           try {
-            const pickedPackage = pickMatchingVersion(pickCtx, metaCachedInStore, filterOpts)
+            const pickedPackage = pickMatchingVersionFast(pickCtx, metaCachedInStore, filterOpts)
             if (pickedPackage) {
               return {
                 meta: metaCachedInStore,
@@ -307,7 +309,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: pickTolerantOfMissingTime(pickCtx, metaCachedInStore, filterOpts),
+            pickedPackage: pickMatchingVersionFinal(pickCtx, metaCachedInStore, filterOpts),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -379,7 +381,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickTolerantOfMissingTime(pickCtx, meta, filterOpts),
+        pickedPackage: pickMatchingVersionFinal(pickCtx, meta, filterOpts),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -389,7 +391,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickTolerantOfMissingTime(pickCtx, meta, filterOpts),
+        pickedPackage: pickMatchingVersionFinal(pickCtx, meta, filterOpts),
       }
     }
   })

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -72,20 +72,6 @@ export interface PickPackageOptions extends PickPackageFromMetaOptions {
   optional?: boolean
 }
 
-const pickPackageFromMetaUsingTimeStrict = pickPackageFromMeta.bind(null, pickVersionByVersionRange)
-
-function pickPackageFromMetaUsingTime (
-  opts: PickPackageFromMetaOptions,
-  spec: RegistryPackageSpec,
-  meta: PackageMeta
-): PackageInRegistry | null {
-  const pickedPackage = pickPackageFromMeta(pickVersionByVersionRange, opts, spec, meta)
-  if (pickedPackage) return pickedPackage
-  return pickPackageFromMeta(pickLowestVersionByVersionRange, {
-    preferredVersionSelectors: opts.preferredVersionSelectors,
-  }, spec, meta)
-}
-
 export async function pickPackage (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -102,57 +88,57 @@ export async function pickPackage (
   opts: PickPackageOptions
 ): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> {
   opts = opts || {}
-  const pickPackageFromMetaBySpec = (
-    opts.publishedBy
-      ? (ctx.strictPublishedByCheck ? pickPackageFromMetaUsingTimeStrict : pickPackageFromMetaUsingTime)
-      : (pickPackageFromMeta.bind(null, opts.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange))
-  ).bind(null, {
-    preferredVersionSelectors: opts.preferredVersionSelectors,
-    publishedBy: opts.publishedBy,
-    publishedByExclude: opts.publishedByExclude,
-  })
 
-  const pickVersionFn = opts.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-  const pickPackageFromMetaBySpecNoPublishedBy = pickPackageFromMeta.bind(null, pickVersionFn).bind(null, {
-    preferredVersionSelectors: opts.preferredVersionSelectors,
-  })
-
-  let _pickPackageFromMeta!: (meta: PackageMeta) => PackageInRegistry | null
-  let _pickPackageFromMetaNoPublishedBy!: (meta: PackageMeta) => PackageInRegistry | null
-  if (opts.updateToLatest) {
-    const makePicker = (pick: (spec: RegistryPackageSpec, meta: PackageMeta) => PackageInRegistry | null) => (meta: PackageMeta) => {
-      const latestStableSpec: RegistryPackageSpec = { ...spec, type: 'tag', fetchSpec: 'latest' }
-      const latestStable = pick(latestStableSpec, meta)
-      const current = pick(spec, meta)
-
-      if (!latestStable) return current
-      if (!current) return latestStable
-      if (semver.lt(latestStable.version, current.version)) return current
-      return latestStable
+  // Select a specific version from the given meta for `targetSpec`, honoring
+  // publishedBy (minimumReleaseAge) when set:
+  // - with publishedBy, try the highest mature version; if none and
+  //   strictPublishedByCheck is off, fall back to the lowest mature version.
+  // - without publishedBy, use opts.pickLowestVersion to choose the direction.
+  const pickForSpec = (targetSpec: RegistryPackageSpec, meta: PackageMeta, filterOpts: PickPackageFromMetaOptions): PackageInRegistry | null => {
+    if (filterOpts.publishedBy) {
+      const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
+      if (highest || ctx.strictPublishedByCheck) return highest
+      return pickPackageFromMeta(pickLowestVersionByVersionRange, {
+        preferredVersionSelectors: filterOpts.preferredVersionSelectors,
+      }, targetSpec, meta)
     }
-    _pickPackageFromMeta = makePicker(pickPackageFromMetaBySpec)
-    _pickPackageFromMetaNoPublishedBy = makePicker(pickPackageFromMetaBySpecNoPublishedBy)
-  } else {
-    _pickPackageFromMeta = pickPackageFromMetaBySpec.bind(null, spec)
-    _pickPackageFromMetaNoPublishedBy = pickPackageFromMetaBySpecNoPublishedBy.bind(null, spec)
+    const pickVersion = opts.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
+    return pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta)
   }
 
-  // Wraps the final pick call so that, when we've already fetched full metadata
-  // (either directly or via an abbreviated→full upgrade) but it still lacks the
-  // per-version `time` field, we skip the minimumReleaseAge filter with a warning
-  // instead of failing hard. Before a full-metadata attempt has been made, we
-  // let ERR_PNPM_MISSING_TIME propagate so the upgrade-to-full path still runs.
-  const pickWithMissingTimeFallback = (meta: PackageMeta, fullMetadataFetched: boolean): PackageInRegistry | null => {
+  // Pick a version from the metadata. When `applyMaturityCheck` is false the
+  // publishedBy filter is bypassed — used only by the missing-time fallback.
+  const pickFromMeta = (meta: PackageMeta, { applyMaturityCheck = true }: { applyMaturityCheck?: boolean } = {}): PackageInRegistry | null => {
+    const filterOpts: PickPackageFromMetaOptions = {
+      preferredVersionSelectors: opts.preferredVersionSelectors,
+      publishedBy: applyMaturityCheck ? opts.publishedBy : undefined,
+      publishedByExclude: applyMaturityCheck ? opts.publishedByExclude : undefined,
+    }
+    if (!opts.updateToLatest) {
+      return pickForSpec(spec, meta, filterOpts)
+    }
+    // updateToLatest: compare the "latest" dist-tag against the requested
+    // spec and return whichever resolves to the higher version.
+    const latestSpec: RegistryPackageSpec = { ...spec, type: 'tag', fetchSpec: 'latest' }
+    const latest = pickForSpec(latestSpec, meta, filterOpts)
+    const current = pickForSpec(spec, meta, filterOpts)
+    if (!latest) return current
+    if (!current) return latest
+    return semver.lt(latest.version, current.version) ? current : latest
+  }
+
+  // Wraps pickFromMeta so that, when we've already fetched full metadata
+  // (either directly or via an abbreviated→full upgrade) but it still lacks
+  // the per-version `time` field, we skip the minimumReleaseAge filter with a
+  // warning instead of failing hard. Before a full-metadata attempt has been
+  // made, we let ERR_PNPM_MISSING_TIME propagate so the upgrade path still runs.
+  const pickOrSkipMissingTime = (meta: PackageMeta, fullMetadataFetched: boolean): PackageInRegistry | null => {
     try {
-      return _pickPackageFromMeta(meta)
+      return pickFromMeta(meta)
     } catch (err: unknown) {
-      if (
-        ctx.ignoreMissingTimeField &&
-        fullMetadataFetched &&
-        isMissingTimeError(err)
-      ) {
+      if (ctx.ignoreMissingTimeField && fullMetadataFetched && isMissingTimeError(err)) {
         warnMissingTimeFieldOnce(meta.name)
-        return _pickPackageFromMetaNoPublishedBy(meta)
+        return pickFromMeta(meta, { applyMaturityCheck: false })
       }
       throw err
     }
@@ -172,7 +158,7 @@ export async function pickPackage (
   if (cachedMeta != null) {
     return {
       meta: cachedMeta,
-      pickedPackage: _pickPackageFromMeta(cachedMeta),
+      pickedPackage: pickFromMeta(cachedMeta),
     }
   }
 
@@ -187,14 +173,14 @@ export async function pickPackage (
       if (ctx.offline) {
         if (metaCachedInStore != null) return {
           meta: metaCachedInStore,
-          pickedPackage: _pickPackageFromMeta(metaCachedInStore),
+          pickedPackage: pickFromMeta(metaCachedInStore),
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
       if (metaCachedInStore != null) {
-        const pickedPackage = _pickPackageFromMeta(metaCachedInStore)
+        const pickedPackage = pickFromMeta(metaCachedInStore)
         if (pickedPackage) {
           return {
             meta: metaCachedInStore,
@@ -210,7 +196,7 @@ export async function pickPackage (
       // otherwise it is probably out of date
       if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = _pickPackageFromMeta(metaCachedInStore)
+          const pickedPackage = pickFromMeta(metaCachedInStore)
           if (pickedPackage) {
             return {
               meta: metaCachedInStore,
@@ -230,7 +216,7 @@ export async function pickPackage (
         metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
         if (metaCachedInStore != null) {
           try {
-            const pickedPackage = _pickPackageFromMeta(metaCachedInStore)
+            const pickedPackage = pickFromMeta(metaCachedInStore)
             if (pickedPackage) {
               return {
                 meta: metaCachedInStore,
@@ -274,7 +260,7 @@ export async function pickPackage (
           ctx.metaCache.set(cacheKey, metaCachedInStore)
           return {
             meta: metaCachedInStore,
-            pickedPackage: _pickPackageFromMeta(metaCachedInStore),
+            pickedPackage: pickFromMeta(metaCachedInStore),
           }
         }
         throw new PnpmError('CACHE_MISSING_AFTER_304',
@@ -348,7 +334,7 @@ export async function pickPackage (
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickWithMissingTimeFallback(meta, fullMetadataFetched),
+        pickedPackage: pickOrSkipMissingTime(meta, fullMetadataFetched),
       }
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
@@ -358,7 +344,7 @@ export async function pickPackage (
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: _pickPackageFromMeta(meta),
+        pickedPackage: pickFromMeta(meta),
       }
     }
   })

--- a/resolving/npm-resolver/src/pickPackage.ts
+++ b/resolving/npm-resolver/src/pickPackage.ts
@@ -80,43 +80,56 @@ interface PickerContext {
   ignoreMissingTimeField?: boolean
 }
 
-// Pick a version from the metadata for the given `targetSpec`, honoring
-// publishedBy (minimumReleaseAge) when set:
-// - with publishedBy, try the highest mature version; if none and
-//   strictPublishedByCheck is off, fall back to the lowest mature version.
-// - without publishedBy, use pickLowestVersion to choose the direction.
-function pickForSpec (
+// Calls `pickOne` for the requested spec, or — when updateToLatest is set —
+// for both the requested spec and the "latest" dist-tag, returning whichever
+// resolves to the higher version.
+function pickForAllSpecs (
   pickCtx: PickerContext,
-  targetSpec: RegistryPackageSpec,
+  pickOne: (targetSpec: RegistryPackageSpec) => PackageInRegistry | null
+): PackageInRegistry | null {
+  if (!pickCtx.updateToLatest) return pickOne(pickCtx.spec)
+  const latestSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
+  const latest = pickOne(latestSpec)
+  const current = pickOne(pickCtx.spec)
+  if (!latest) return current
+  if (!current) return latest
+  return semver.lt(latest.version, current.version) ? current : latest
+}
+
+// When minimumReleaseAge is active: try the highest mature version; if none
+// and strictPublishedByCheck is off, fall back to the lowest mature version.
+function pickWithMaturity (
+  pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  if (filterOpts.publishedBy) {
+  return pickForAllSpecs(pickCtx, (targetSpec) => {
     const highest = pickPackageFromMeta(pickVersionByVersionRange, filterOpts, targetSpec, meta)
     if (highest || pickCtx.strictPublishedByCheck) return highest
     return pickPackageFromMeta(pickLowestVersionByVersionRange, {
       preferredVersionSelectors: filterOpts.preferredVersionSelectors,
     }, targetSpec, meta)
-  }
-  const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
-  return pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta)
+  })
 }
 
-// Pick a version from the metadata using the given filter options. When
-// updateToLatest is set, compares the "latest" dist-tag against the
-// requested spec and returns whichever resolves to the higher version.
+// When minimumReleaseAge is not active: pick by pickLowestVersion preference.
+function pickWithoutMaturity (
+  pickCtx: PickerContext,
+  meta: PackageMeta,
+  filterOpts: PickPackageFromMetaOptions
+): PackageInRegistry | null {
+  const pickVersion = pickCtx.pickLowestVersion ? pickLowestVersionByVersionRange : pickVersionByVersionRange
+  return pickForAllSpecs(pickCtx, (targetSpec) => pickPackageFromMeta(pickVersion, filterOpts, targetSpec, meta))
+}
+
 function pickBest (
   pickCtx: PickerContext,
   meta: PackageMeta,
   filterOpts: PickPackageFromMetaOptions
 ): PackageInRegistry | null {
-  if (!pickCtx.updateToLatest) return pickForSpec(pickCtx, pickCtx.spec, meta, filterOpts)
-  const latestSpec: RegistryPackageSpec = { ...pickCtx.spec, type: 'tag', fetchSpec: 'latest' }
-  const latest = pickForSpec(pickCtx, latestSpec, meta, filterOpts)
-  const current = pickForSpec(pickCtx, pickCtx.spec, meta, filterOpts)
-  if (!latest) return current
-  if (!current) return latest
-  return semver.lt(latest.version, current.version) ? current : latest
+  return filterOpts.publishedBy
+    ? pickWithMaturity(pickCtx, meta, filterOpts)
+    : pickWithoutMaturity(pickCtx, meta, filterOpts)
 }
 
 // When we've already fetched full metadata (either directly or via an

--- a/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -31,8 +31,8 @@ export function pickPackageFromMeta (
     publishedBy,
     publishedByExclude,
   }: PickPackageFromMetaOptions,
-  spec: RegistryPackageSpec,
-  meta: PackageMeta
+  meta: PackageMeta,
+  spec: RegistryPackageSpec
 ): PackageInRegistry | null {
   if (publishedBy) {
     const excludeResult = publishedByExclude?.(meta.name) ?? false

--- a/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -1,6 +1,7 @@
 import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
+import { globalWarn } from '@pnpm/logger'
 import { filterPkgMetadataByPublishDate } from '@pnpm/resolving.registry.pkg-metadata-filter'
 import type { PackageInRegistry, PackageMeta, PackageMetaWithTime } from '@pnpm/resolving.registry.types'
 import type { VersionSelectors } from '@pnpm/resolving.resolver-base'
@@ -22,6 +23,7 @@ export interface PickPackageFromMetaOptions {
   preferredVersionSelectors: VersionSelectors | undefined
   publishedBy?: Date
   publishedByExclude?: PackageVersionPolicy
+  ignoreMissingTimeField?: boolean
 }
 
 export function pickPackageFromMeta (
@@ -30,6 +32,7 @@ export function pickPackageFromMeta (
     preferredVersionSelectors,
     publishedBy,
     publishedByExclude,
+    ignoreMissingTimeField,
   }: PickPackageFromMetaOptions,
   spec: RegistryPackageSpec,
   meta: PackageMeta
@@ -48,7 +51,11 @@ export function pickPackageFromMeta (
           // Abbreviated metadata without per-version timestamps, and the package
           // was recently modified (or has no/invalid modified field). We cannot determine
           // which individual versions are mature enough — need full metadata.
-          assertMetaHasTime(meta)
+          if (ignoreMissingTimeField) {
+            warnMissingTimeFieldOnce(meta.name)
+          } else {
+            assertMetaHasTime(meta)
+          }
         }
         // else: meta.modified < publishedBy — all versions are old enough, no filtering needed
       }
@@ -111,6 +118,14 @@ export function assertMetaHasTime (meta: PackageMeta): asserts meta is PackageMe
   if (meta.time == null) {
     throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
   }
+}
+
+const warnedMissingTimeFor = new Set<string>()
+
+function warnMissingTimeFieldOnce (pkgName: string): void {
+  if (warnedMissingTimeFor.has(pkgName)) return
+  warnedMissingTimeFor.add(pkgName)
+  globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the minimumReleaseAge check for this package.`)
 }
 
 function parseModifiedDate (modified: string | undefined): Date | null {

--- a/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -1,7 +1,6 @@
 import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
-import { globalWarn } from '@pnpm/logger'
 import { filterPkgMetadataByPublishDate } from '@pnpm/resolving.registry.pkg-metadata-filter'
 import type { PackageInRegistry, PackageMeta, PackageMetaWithTime } from '@pnpm/resolving.registry.types'
 import type { VersionSelectors } from '@pnpm/resolving.resolver-base'
@@ -23,7 +22,6 @@ export interface PickPackageFromMetaOptions {
   preferredVersionSelectors: VersionSelectors | undefined
   publishedBy?: Date
   publishedByExclude?: PackageVersionPolicy
-  ignoreMissingTimeField?: boolean
 }
 
 export function pickPackageFromMeta (
@@ -32,7 +30,6 @@ export function pickPackageFromMeta (
     preferredVersionSelectors,
     publishedBy,
     publishedByExclude,
-    ignoreMissingTimeField,
   }: PickPackageFromMetaOptions,
   spec: RegistryPackageSpec,
   meta: PackageMeta
@@ -51,11 +48,7 @@ export function pickPackageFromMeta (
           // Abbreviated metadata without per-version timestamps, and the package
           // was recently modified (or has no/invalid modified field). We cannot determine
           // which individual versions are mature enough — need full metadata.
-          if (ignoreMissingTimeField) {
-            warnMissingTimeFieldOnce(meta.name)
-          } else {
-            assertMetaHasTime(meta)
-          }
+          assertMetaHasTime(meta)
         }
         // else: meta.modified < publishedBy — all versions are old enough, no filtering needed
       }
@@ -118,14 +111,6 @@ export function assertMetaHasTime (meta: PackageMeta): asserts meta is PackageMe
   if (meta.time == null) {
     throw new PnpmError('MISSING_TIME', `The metadata of ${meta.name} is missing the "time" field`)
   }
-}
-
-const warnedMissingTimeFor = new Set<string>()
-
-function warnMissingTimeFieldOnce (pkgName: string): void {
-  if (warnedMissingTimeFor.has(pkgName)) return
-  warnedMissingTimeFor.add(pkgName)
-  globalWarn(`The metadata of ${pkgName} is missing the "time" field; skipping the minimumReleaseAge check for this package.`)
 }
 
 function parseModifiedDate (modified: string | undefined): Date | null {

--- a/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/resolving/npm-resolver/test/publishedBy.test.ts
@@ -212,6 +212,51 @@ test('re-fetch full metadata when abbreviated modified date is recent', async ()
   expect(resolveResult!.id).toBe('is-positive@1.0.0')
 })
 
+test('ignoreMissingTimeField=true skips maturity check when full metadata has no time field', async () => {
+  const { time: _time, ...metaWithoutTime } = isPositiveMeta
+
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, metaWithoutTime)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+    ignoreMissingTimeField: true,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-08-17T19:26:00.508Z'),
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+})
+
+test('ignoreMissingTimeField=false throws when full metadata has no time field', async () => {
+  const { time: _time, ...metaWithoutTime } = isPositiveMeta
+
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, metaWithoutTime)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+    ignoreMissingTimeField: false,
+  })
+  await expect(resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-08-17T19:26:00.508Z'),
+  })).rejects.toThrow(/missing the "time" field/)
+})
+
 test('use cached metadata based on file mtime when publishedBy is set', async () => {
   const cacheDir = temporaryDirectory()
   // Write abbreviated metadata to the abbreviated cache dir

--- a/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/resolving/npm-resolver/test/publishedBy.test.ts
@@ -288,6 +288,37 @@ test('ignoreMissingTimeField=false throws when full metadata has no time field',
   })).rejects.toThrow(/missing the "time" field/)
 })
 
+test('ignoreMissingTimeField=true skips maturity check from disk-cached metadata lacking time', async () => {
+  // Exercise the cached-metadata return path: write full metadata to disk
+  // with the `time` field stripped, and verify that resolution succeeds
+  // (no ERR_PNPM_MISSING_TIME) when the setting is on.
+  const { time: _time, ...metaWithoutTime } = isPositiveMeta
+
+  const cacheDir = temporaryDirectory()
+  const cacheDir2 = path.join(cacheDir, `${FULL_FILTERED_META_DIR}/registry.npmjs.org`)
+  fs.mkdirSync(cacheDir2, { recursive: true })
+  const cachePath = path.join(cacheDir2, 'is-positive.jsonl')
+  fs.writeFileSync(cachePath, `${JSON.stringify({})}\n${JSON.stringify(metaWithoutTime)}`, 'utf8')
+
+  // No mock agent intercepts — test would fail if a network request fired.
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+    ignoreMissingTimeField: true,
+    offline: true,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-08-17T19:26:00.508Z'),
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+})
+
 test('use cached metadata based on file mtime when publishedBy is set', async () => {
   const cacheDir = temporaryDirectory()
   // Write abbreviated metadata to the abbreviated cache dir

--- a/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/resolving/npm-resolver/test/publishedBy.test.ts
@@ -236,6 +236,37 @@ test('ignoreMissingTimeField=true skips maturity check when full metadata has no
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })
 
+test('ignoreMissingTimeField=true still upgrades abbreviated→full when time is missing', async () => {
+  // With ignoreMissingTimeField=true, pnpm should still re-fetch full metadata
+  // when abbreviated metadata lacks time — only falling back to skip+warn if
+  // even the full metadata has no time field. Here the full response DOES have
+  // time, so the maturity check must run (and pick the old 1.0.0, not latest).
+  const recentAbbreviated = {
+    ...isPositiveAbbreviatedMeta,
+    modified: '2015-06-10T00:00:00.000Z',
+  }
+
+  const agent = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, recentAbbreviated)
+  agent.intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    registries,
+    ignoreMissingTimeField: true,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^1.0.0' }, {
+    publishedBy: new Date('2015-06-05T00:00:00.000Z'),
+  })
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@1.0.0')
+})
+
 test('ignoreMissingTimeField=false throws when full metadata has no time field', async () => {
   const { time: _time, ...metaWithoutTime } = isPositiveMeta
 

--- a/store/connection-manager/src/createNewStoreController.ts
+++ b/store/connection-manager/src/createNewStoreController.ts
@@ -34,6 +34,7 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
 | 'localAddress'
 | 'maxSockets'
 | 'minimumReleaseAge'
+| 'minimumReleaseAgeIgnoreMissingTime'
 | 'minimumReleaseAgeStrict'
 | 'networkConcurrency'
 | 'noProxy'
@@ -111,6 +112,7 @@ export async function createNewStoreController (
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
     preserveAbsolutePaths: opts.preserveAbsolutePaths,
     strictPublishedByCheck: Boolean(opts.minimumReleaseAge) && opts.minimumReleaseAgeStrict === true,
+    ignoreMissingTimeField: opts.minimumReleaseAgeIgnoreMissingTime,
     storeIndex,
   })
   return {

--- a/testing/command-defaults/src/index.ts
+++ b/testing/command-defaults/src/index.ts
@@ -36,6 +36,7 @@ export const DEFAULT_OPTS = {
   lock: false,
   lockStaleDuration: 90,
   minimumReleaseAge: 0,
+  minimumReleaseAgeIgnoreMissingTime: true,
   networkConcurrency: 16,
   offline: false,
   pending: false,


### PR DESCRIPTION
## Summary

- Adds a new `minimumReleaseAgeIgnoreMissingTime` setting (default `true`) that skips the `minimumReleaseAge` maturity check when registry metadata lacks the `time` field, instead of throwing `ERR_PNPM_MISSING_TIME`.
- Some registries don't populate the `time` field in their metadata, which would otherwise break installs after `minimumReleaseAge` defaulted to 1 day in v11.
- Prints a `globalWarn` once per affected package when the check is skipped, so the omission is visible.
- Set the setting to `false` to restore the strict behavior and fail resolution on missing `time`.

## Test plan

- [x] New unit tests in `resolving/npm-resolver/test/publishedBy.test.ts` cover both `ignoreMissingTimeField: true` (resolves) and `false` (throws).
- [x] Existing `publishedBy`/`minimumReleaseAge` tests in `resolving/npm-resolver` and `installing/deps-installer` still pass.