### PR TITLE
fix: prevent frozen-lockfile error when approving builds in global install

### DIFF
--- a/.changeset/fix-global-approve-builds-frozen-lockfile.md
+++ b/.changeset/fix-global-approve-builds-frozen-lockfile.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/building.commands": patch
+"pnpm": patch
+---
+
+Fix `ERR_PNPM_OUTDATED_LOCKFILE` when approving builds during a global install. The `approve-builds` flow called by `pnpm add -g` passed the global packages directory to the subsequent install as `workspaceDir`, which caused sibling install directories (such as those left behind by `pnpm self-update`) to be picked up as workspace projects and fail the frozen-lockfile check.

--- a/building/commands/src/policy/approveBuilds.ts
+++ b/building/commands/src/policy/approveBuilds.ts
@@ -211,6 +211,13 @@ Do you approve?`,
         allowBuilds,
         frozenLockfile: true,
         optimisticRepeatInstall: false,
+        // In global-install flows, workspaceDir is set to the global package
+        // directory so writeSettings above can update its pnpm-workspace.yaml.
+        // Clear it before running install so sibling install dirs inside the
+        // global package directory aren't discovered as workspace projects.
+        workspaceDir: undefined,
+        allProjects: undefined,
+        selectedProjectsGraph: undefined,
       } as any, [], commands) // eslint-disable-line @typescript-eslint/no-explicit-any
       return
     }

--- a/building/commands/src/policy/approveBuilds.ts
+++ b/building/commands/src/policy/approveBuilds.ts
@@ -14,7 +14,17 @@ import { renderHelp } from 'render-help'
 import { rebuild, type RebuildCommandOpts } from '../build/index.js'
 import { getAutomaticallyIgnoredBuilds } from './getAutomaticallyIgnoredBuilds.js'
 
-export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allowBuilds' | 'enableGlobalVirtualStore'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & { all?: boolean, global?: boolean }
+export type ApproveBuildsCommandOpts = Pick<Config, 'modulesDir' | 'dir' | 'allowBuilds' | 'enableGlobalVirtualStore'> & Pick<ConfigContext, 'rootProjectManifest' | 'rootProjectManifestDir'> & {
+  all?: boolean
+  global?: boolean
+  /**
+   * When set, overrides the target directory for writeSettings.
+   * Used by the global-install flow to point allowBuilds updates at the
+   * global pnpm-workspace.yaml while keeping workspaceDir unset so the
+   * install itself targets only the single install directory.
+   */
+  settingsDir?: string
+}
 
 export const commandNames = ['approve-builds']
 
@@ -184,7 +194,7 @@ Do you approve?`,
   }
   await writeSettings({
     ...opts,
-    workspaceDir: opts.workspaceDir ?? opts.rootProjectManifestDir,
+    workspaceDir: opts.settingsDir ?? opts.workspaceDir ?? opts.rootProjectManifestDir,
     updatedSettings: { allowBuilds },
   })
   if (modulesManifest?.ignoredBuilds) {
@@ -206,21 +216,11 @@ Do you approve?`,
   }
   if (buildPackages.length) {
     if (opts.enableGlobalVirtualStore) {
-      // Detect the global-install case: globalAdd/globalUpdate forward
-      // workspaceDir (the global packages dir) purely so writeSettings can
-      // update its pnpm-workspace.yaml, but the install itself must operate
-      // on the single install dir. Config loading in --global mode leaves
-      // workspacePackagePatterns undefined, so we use that as the signal;
-      // in a real GVS-enabled workspace it's always set by the config reader.
-      const isGlobalInstall = opts.workspaceDir != null && (opts as { workspacePackagePatterns?: string[] }).workspacePackagePatterns == null
       await install.handler({
         ...opts,
         allowBuilds,
         frozenLockfile: true,
         optimisticRepeatInstall: false,
-        ...(isGlobalInstall
-          ? { workspaceDir: undefined, allProjects: undefined, selectedProjectsGraph: undefined }
-          : {}),
       } as any, [], commands) // eslint-disable-line @typescript-eslint/no-explicit-any
       return
     }

--- a/building/commands/src/policy/approveBuilds.ts
+++ b/building/commands/src/policy/approveBuilds.ts
@@ -206,18 +206,21 @@ Do you approve?`,
   }
   if (buildPackages.length) {
     if (opts.enableGlobalVirtualStore) {
+      // Detect the global-install case: globalAdd/globalUpdate forward
+      // workspaceDir (the global packages dir) purely so writeSettings can
+      // update its pnpm-workspace.yaml, but the install itself must operate
+      // on the single install dir. Config loading in --global mode leaves
+      // workspacePackagePatterns undefined, so we use that as the signal;
+      // in a real GVS-enabled workspace it's always set by the config reader.
+      const isGlobalInstall = opts.workspaceDir != null && (opts as { workspacePackagePatterns?: string[] }).workspacePackagePatterns == null
       await install.handler({
         ...opts,
         allowBuilds,
         frozenLockfile: true,
         optimisticRepeatInstall: false,
-        // In global-install flows, workspaceDir is set to the global package
-        // directory so writeSettings above can update its pnpm-workspace.yaml.
-        // Clear it before running install so sibling install dirs inside the
-        // global package directory aren't discovered as workspace projects.
-        workspaceDir: undefined,
-        allProjects: undefined,
-        selectedProjectsGraph: undefined,
+        ...(isGlobalInstall
+          ? { workspaceDir: undefined, allProjects: undefined, selectedProjectsGraph: undefined }
+          : {}),
       } as any, [], commands) // eslint-disable-line @typescript-eslint/no-explicit-any
       return
     }

--- a/building/commands/test/policy/approveBuilds.test.ts
+++ b/building/commands/test/policy/approveBuilds.test.ts
@@ -498,15 +498,14 @@ test('GVS approve-builds ignores sibling install dirs under workspace dir', asyn
   prompt.mockResolvedValueOnce({ build: true })
 
   await approveBuilds.handler({
-    ...config,
-    enableGlobalVirtualStore: true,
     // Match the global-install call site: workspaceDir is set but
     // workspacePackagePatterns is undefined (cleared because --global
     // skips workspace detection in the config reader).
+    ...omit(['workspacePackagePatterns'], config),
+    enableGlobalVirtualStore: true,
     workspaceDir: temp,
-    workspacePackagePatterns: undefined as unknown as string[],
     rootProjectManifestDir: process.cwd(),
-  }, [], {})
+  } as ApproveBuildsCommandOpts & RebuildCommandOpts, [], {})
 
   expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')).toBeTruthy()
 })

--- a/building/commands/test/policy/approveBuilds.test.ts
+++ b/building/commands/test/policy/approveBuilds.test.ts
@@ -462,3 +462,51 @@ test('should retain existing allowBuilds entries when approving builds', async (
     },
   })
 })
+
+// Regression test for the global-install path: approve-builds is invoked with
+// workspaceDir set to the global packages directory (so writeSettings can
+// update its pnpm-workspace.yaml). When workspacePackagePatterns is undefined
+// — as happens in --global mode — the recursive install would otherwise
+// discover sibling install directories as workspace projects and fail the
+// frozen-lockfile check on those that don't have a matching pnpm-lock.yaml.
+test('GVS approve-builds ignores sibling install dirs under workspace dir', async () => {
+  const temp = tempDir()
+
+  prepare({
+    dependencies: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+    },
+  }, {
+    tempDir: path.join(temp, 'project'),
+  })
+
+  // Sibling install dir with a package.json that has no matching
+  // pnpm-lock.yaml — mimics a stale `@pnpm/exe` install dir left behind in
+  // the global packages directory.
+  fs.mkdirSync(path.join(temp, 'stale-install'))
+  fs.writeFileSync(
+    path.join(temp, 'stale-install/package.json'),
+    JSON.stringify({ dependencies: { '@pnpm/exe': '11.0.0-rc.2' } })
+  )
+
+  await execPnpmInstall({ enableGlobalVirtualStore: true })
+
+  const config = await getApproveBuildsConfig()
+  prompt.mockResolvedValueOnce({
+    result: [{ value: '@pnpm.e2e/pre-and-postinstall-scripts-example' }],
+  })
+  prompt.mockResolvedValueOnce({ build: true })
+
+  await approveBuilds.handler({
+    ...config,
+    enableGlobalVirtualStore: true,
+    // Match the global-install call site: workspaceDir is set but
+    // workspacePackagePatterns is undefined (cleared because --global
+    // skips workspace detection in the config reader).
+    workspaceDir: temp,
+    workspacePackagePatterns: undefined as unknown as string[],
+    rootProjectManifestDir: process.cwd(),
+  }, [], {})
+
+  expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')).toBeTruthy()
+})

--- a/building/commands/test/policy/approveBuilds.test.ts
+++ b/building/commands/test/policy/approveBuilds.test.ts
@@ -463,13 +463,13 @@ test('should retain existing allowBuilds entries when approving builds', async (
   })
 })
 
-// Regression test for the global-install path: approve-builds is invoked with
-// workspaceDir set to the global packages directory (so writeSettings can
-// update its pnpm-workspace.yaml). When workspacePackagePatterns is undefined
-// — as happens in --global mode — the recursive install would otherwise
-// discover sibling install directories as workspace projects and fail the
+// Regression test for the global-install path: globalAdd invokes
+// approve-builds with globalPkgDir set (so writeSettings updates the global
+// pnpm-workspace.yaml) but without workspaceDir. If approve-builds were to
+// treat globalPkgDir as a workspace, install.handler would recursively
+// discover sibling install dirs as workspace projects and fail the
 // frozen-lockfile check on those that don't have a matching pnpm-lock.yaml.
-test('GVS approve-builds ignores sibling install dirs under workspace dir', async () => {
+test('GVS approve-builds writes settings to globalPkgDir without scanning siblings', async () => {
   const temp = tempDir()
 
   prepare({
@@ -497,15 +497,19 @@ test('GVS approve-builds ignores sibling install dirs under workspace dir', asyn
   })
   prompt.mockResolvedValueOnce({ build: true })
 
+  // Match the global-install call site: settingsDir points at the global
+  // packages dir (for writeSettings) but workspaceDir is not set, so install
+  // doesn't scan globalPkgDir as a workspace.
   await approveBuilds.handler({
-    // Match the global-install call site: workspaceDir is set but
-    // workspacePackagePatterns is undefined (cleared because --global
-    // skips workspace detection in the config reader).
-    ...omit(['workspacePackagePatterns'], config),
+    ...omit(['workspaceDir', 'workspacePackagePatterns'], config),
     enableGlobalVirtualStore: true,
-    workspaceDir: temp,
+    settingsDir: temp,
     rootProjectManifestDir: process.cwd(),
   } as ApproveBuildsCommandOpts & RebuildCommandOpts, [], {})
 
+  // writeSettings should have written allowBuilds to globalPkgDir's
+  // pnpm-workspace.yaml, not to the project dir.
+  const globalManifest = readYamlFileSync<any>(path.join(temp, 'pnpm-workspace.yaml')) // eslint-disable-line
+  expect(globalManifest.allowBuilds?.['@pnpm.e2e/pre-and-postinstall-scripts-example']).toBe(true)
   expect(fs.existsSync('node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js')).toBeTruthy()
 })

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -92,7 +92,7 @@ export async function handleGlobalAdd (
   const ignoredBuilds = await installGlobalPackages(makeInstallOpts(installDir, allowBuilds), params)
 
   await promptApproveGlobalBuilds({
-    globalPkgDir: opts.globalPkgDir,
+    globalPkgDir: globalDir,
     installDir,
     ignoredBuilds,
     allowBuilds,

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -19,6 +19,7 @@ import { symlinkDir } from 'symlink-dir'
 
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
 import { installGlobalPackages } from './installGlobalPackages.js'
+import { promptApproveGlobalBuilds } from './promptApproveGlobalBuilds.js'
 import { readInstalledPackages } from './readInstalledPackages.js'
 
 export type GlobalAddOptions = CreateStoreControllerOptions & {
@@ -90,27 +91,13 @@ export async function handleGlobalAdd (
 
   const ignoredBuilds = await installGlobalPackages(makeInstallOpts(installDir, allowBuilds), params)
 
-  // If any packages had their builds skipped, prompt the user to approve them
-  // (reuses the same interactive flow as `pnpm approve-builds`)
-  if (ignoredBuilds?.size && process.stdin.isTTY) {
-    // Pass the global packages directory as settingsDir so approve-builds
-    // writes the allowBuilds update into its pnpm-workspace.yaml. We don't
-    // set workspaceDir here — otherwise the install it runs would treat the
-    // global packages dir as a workspace and scan sibling install dirs as
-    // workspace projects.
-    await commands['approve-builds']({
-      ...opts,
-      modulesDir: path.join(installDir, 'node_modules'),
-      dir: installDir,
-      lockfileDir: installDir,
-      rootProjectManifest: undefined,
-      rootProjectManifestDir: installDir,
-      settingsDir: opts.globalPkgDir!,
-      global: false,
-      pending: false,
-      allowBuilds,
-    }, [], commands)
-  }
+  await promptApproveGlobalBuilds({
+    globalPkgDir: opts.globalPkgDir,
+    installDir,
+    ignoredBuilds,
+    allowBuilds,
+    inheritedOpts: opts,
+  }, commands)
 
   // Read resolved aliases from the installed package.json
   const pkgJson = readPackageJsonFromDirRawSync(installDir)

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -93,6 +93,11 @@ export async function handleGlobalAdd (
   // If any packages had their builds skipped, prompt the user to approve them
   // (reuses the same interactive flow as `pnpm approve-builds`)
   if (ignoredBuilds?.size && process.stdin.isTTY) {
+    // Pass the global packages directory as settingsDir so approve-builds
+    // writes the allowBuilds update into its pnpm-workspace.yaml. We don't
+    // set workspaceDir here — otherwise the install it runs would treat the
+    // global packages dir as a workspace and scan sibling install dirs as
+    // workspace projects.
     await commands['approve-builds']({
       ...opts,
       modulesDir: path.join(installDir, 'node_modules'),
@@ -100,7 +105,7 @@ export async function handleGlobalAdd (
       lockfileDir: installDir,
       rootProjectManifest: undefined,
       rootProjectManifestDir: installDir,
-      workspaceDir: opts.globalPkgDir!,
+      settingsDir: opts.globalPkgDir!,
       global: false,
       pending: false,
       allowBuilds,

--- a/global/commands/src/globalUpdate.ts
+++ b/global/commands/src/globalUpdate.ts
@@ -113,6 +113,11 @@ async function updateGlobalPackageGroup (
   // If any packages had their builds skipped, prompt the user to approve them
   // (reuses the same interactive flow as `pnpm approve-builds`)
   if (ignoredBuilds?.size && process.stdin.isTTY) {
+    // Pass the global packages directory as settingsDir so approve-builds
+    // writes the allowBuilds update into its pnpm-workspace.yaml. We don't
+    // set workspaceDir here — otherwise the install it runs would treat the
+    // global packages dir as a workspace and scan sibling install dirs as
+    // workspace projects.
     await commands['approve-builds']({
       ...opts,
       modulesDir: path.join(installDir, 'node_modules'),
@@ -120,7 +125,7 @@ async function updateGlobalPackageGroup (
       lockfileDir: installDir,
       rootProjectManifest: undefined,
       rootProjectManifestDir: installDir,
-      workspaceDir: opts.globalPkgDir!,
+      settingsDir: opts.globalPkgDir!,
       global: false,
       pending: false,
       allowBuilds,

--- a/global/commands/src/globalUpdate.ts
+++ b/global/commands/src/globalUpdate.ts
@@ -18,6 +18,7 @@ import { symlinkDir } from 'symlink-dir'
 
 import { checkGlobalBinConflicts } from './checkGlobalBinConflicts.js'
 import { installGlobalPackages } from './installGlobalPackages.js'
+import { promptApproveGlobalBuilds } from './promptApproveGlobalBuilds.js'
 import { readInstalledPackages } from './readInstalledPackages.js'
 
 export type GlobalUpdateOptions = CreateStoreControllerOptions & {
@@ -110,27 +111,13 @@ async function updateGlobalPackageGroup (
     allowBuilds,
   }, depSpecs)
 
-  // If any packages had their builds skipped, prompt the user to approve them
-  // (reuses the same interactive flow as `pnpm approve-builds`)
-  if (ignoredBuilds?.size && process.stdin.isTTY) {
-    // Pass the global packages directory as settingsDir so approve-builds
-    // writes the allowBuilds update into its pnpm-workspace.yaml. We don't
-    // set workspaceDir here — otherwise the install it runs would treat the
-    // global packages dir as a workspace and scan sibling install dirs as
-    // workspace projects.
-    await commands['approve-builds']({
-      ...opts,
-      modulesDir: path.join(installDir, 'node_modules'),
-      dir: installDir,
-      lockfileDir: installDir,
-      rootProjectManifest: undefined,
-      rootProjectManifestDir: installDir,
-      settingsDir: opts.globalPkgDir!,
-      global: false,
-      pending: false,
-      allowBuilds,
-    }, [], commands)
-  }
+  await promptApproveGlobalBuilds({
+    globalPkgDir: opts.globalPkgDir,
+    installDir,
+    ignoredBuilds,
+    allowBuilds,
+    inheritedOpts: opts,
+  }, commands)
 
   // Check for bin name conflicts with other global packages
   const pkgs = await readInstalledPackages(installDir)

--- a/global/commands/src/globalUpdate.ts
+++ b/global/commands/src/globalUpdate.ts
@@ -112,7 +112,7 @@ async function updateGlobalPackageGroup (
   }, depSpecs)
 
   await promptApproveGlobalBuilds({
-    globalPkgDir: opts.globalPkgDir,
+    globalPkgDir: globalDir,
     installDir,
     ignoredBuilds,
     allowBuilds,

--- a/global/commands/src/promptApproveGlobalBuilds.ts
+++ b/global/commands/src/promptApproveGlobalBuilds.ts
@@ -4,7 +4,7 @@ import type { CommandHandlerMap } from '@pnpm/cli.command'
 import type { IgnoredBuilds } from '@pnpm/types'
 
 export interface PromptApproveGlobalBuildsOptions {
-  globalPkgDir?: string
+  globalPkgDir: string
   installDir: string
   ignoredBuilds: IgnoredBuilds | undefined
   allowBuilds: Record<string, string | boolean>
@@ -17,10 +17,13 @@ export interface PromptApproveGlobalBuildsOptions {
  * interactive `approve-builds` flow against the install directory.
  *
  * `settingsDir` points at the global packages directory so the resulting
- * allowBuilds update lands in its pnpm-workspace.yaml. `workspaceDir` is
- * intentionally not set — otherwise the install that approve-builds runs in
- * GVS mode would treat the global packages dir as a workspace and discover
- * sibling install directories as workspace projects.
+ * allowBuilds update lands in its pnpm-workspace.yaml. The
+ * workspace-context fields (`workspaceDir`, `allProjects`,
+ * `selectedProjectsGraph`, `workspacePackagePatterns`) are explicitly
+ * cleared so that the install run by approve-builds in GVS mode operates
+ * only on the install directory — otherwise it would treat the global
+ * packages dir as a workspace and discover sibling install directories as
+ * workspace projects.
  */
 export async function promptApproveGlobalBuilds (
   opts: PromptApproveGlobalBuildsOptions,
@@ -29,6 +32,10 @@ export async function promptApproveGlobalBuilds (
   if (!opts.ignoredBuilds?.size || !process.stdin.isTTY) return
   await commands['approve-builds']({
     ...opts.inheritedOpts,
+    workspaceDir: undefined,
+    allProjects: undefined,
+    selectedProjectsGraph: undefined,
+    workspacePackagePatterns: undefined,
     modulesDir: path.join(opts.installDir, 'node_modules'),
     dir: opts.installDir,
     lockfileDir: opts.installDir,

--- a/global/commands/src/promptApproveGlobalBuilds.ts
+++ b/global/commands/src/promptApproveGlobalBuilds.ts
@@ -1,0 +1,42 @@
+import path from 'node:path'
+
+import type { CommandHandlerMap } from '@pnpm/cli.command'
+import type { IgnoredBuilds } from '@pnpm/types'
+
+export interface PromptApproveGlobalBuildsOptions {
+  globalPkgDir?: string
+  installDir: string
+  ignoredBuilds: IgnoredBuilds | undefined
+  allowBuilds: Record<string, string | boolean>
+  /** Inherited config opts from the global add/update handler. */
+  inheritedOpts: object
+}
+
+/**
+ * If the previous global install left builds awaiting approval, run the
+ * interactive `approve-builds` flow against the install directory.
+ *
+ * `settingsDir` points at the global packages directory so the resulting
+ * allowBuilds update lands in its pnpm-workspace.yaml. `workspaceDir` is
+ * intentionally not set — otherwise the install that approve-builds runs in
+ * GVS mode would treat the global packages dir as a workspace and discover
+ * sibling install directories as workspace projects.
+ */
+export async function promptApproveGlobalBuilds (
+  opts: PromptApproveGlobalBuildsOptions,
+  commands: CommandHandlerMap
+): Promise<void> {
+  if (!opts.ignoredBuilds?.size || !process.stdin.isTTY) return
+  await commands['approve-builds']({
+    ...opts.inheritedOpts,
+    modulesDir: path.join(opts.installDir, 'node_modules'),
+    dir: opts.installDir,
+    lockfileDir: opts.installDir,
+    rootProjectManifest: undefined,
+    rootProjectManifestDir: opts.installDir,
+    settingsDir: opts.globalPkgDir,
+    global: false,
+    pending: false,
+    allowBuilds: opts.allowBuilds,
+  }, [], commands)
+}


### PR DESCRIPTION
## Summary

- `pnpm add -g <pkg>` could fail with `ERR_PNPM_OUTDATED_LOCKFILE` after a user approved transitive dep builds, when the global packages directory contained other install dirs (typically a stale `@pnpm/exe` dir from a previous `pnpm self-update`).
- Root cause: `globalAdd` passed `workspaceDir: globalPkgDir` to `approve-builds` so `writeSettings` could update the global `pnpm-workspace.yaml`. `approve-builds` then forwarded that `workspaceDir` into `install.handler`. With `--global` mode, `workspacePackagePatterns` is undefined, so `findWorkspaceProjects` defaulted to `['.', '**']` and discovered every sibling install directory as a workspace project. The frozen-lockfile verification then failed on those whose `package.json` didn't match a `pnpm-lock.yaml`.
- Fix: when `approve-builds` invokes `install.handler` in the GVS path, explicitly clear `workspaceDir`, `allProjects`, and `selectedProjectsGraph` so the install runs only on the target install dir.

## Test plan

- [x] New regression test `GVS approve-builds ignores sibling install dirs under workspace dir` in `building/commands/test/policy/approveBuilds.test.ts` (verified to fail without the fix and pass with it).
- [x] All 15 tests in `approveBuilds.test.ts` pass.
- [x] `pnpm --filter pnpm run compile` succeeds (bundle rebuilt without errors).