### PR TITLE
fix: preserve pnpm 10 peer suffix encoding for linked paths

### DIFF
--- a/.changeset/fix-peer-suffix-link-path.md
+++ b/.changeset/fix-peer-suffix-link-path.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Restore the peer suffix encoding used by pnpm 10 for linked dependency paths. A `filenamify` upgrade changed how leading `./` and `../` segments were normalized, producing peer suffixes like `(b@+packages+b)` instead of `(b@packages+b)` for linked packages outside the workspace root, causing lockfile churn [#11272](https://github.com/pnpm/pnpm/issues/11272).

--- a/installing/deps-resolver/package.json
+++ b/installing/deps-resolver/package.json
@@ -58,7 +58,6 @@
     "@pnpm/util.lex-comparator": "catalog:",
     "@pnpm/workspace.spec-parser": "workspace:*",
     "@yarnpkg/core": "catalog:",
-    "filenamify": "catalog:",
     "graph-cycles": "catalog:",
     "is-inner-link": "catalog:",
     "is-subdir": "catalog:",

--- a/installing/deps-resolver/src/linkPathToPeerVersion.ts
+++ b/installing/deps-resolver/src/linkPathToPeerVersion.ts
@@ -1,0 +1,51 @@
+// Converts a link: path into a stable, filename-safe token used as the
+// peer's "version" inside peer-suffix hashes. The output must stay stable
+// across pnpm versions so that lockfiles don't churn; it replicates what
+// filenamify v4 produced for these paths in pnpm <= 10.
+//
+// Note: this encoding is lossy and can collide. Any leading run of `.`
+// characters is dropped, and `/`, `\`, and literal `+` all collapse into
+// a single `+`. For example, `packages/b`, `./packages/b`, and
+// `../packages/b` all produce `packages+b`, and `.hidden/pkg` produces
+// `hidden+pkg`. The only way to make this collision-free is to hash the
+// normalized link target (or switch to a lossless escape encoding),
+// either of which would change every link-path peer suffix in existing
+// lockfiles. We accept the (extremely rare in practice) collision for
+// lockfile stability; see https://github.com/pnpm/pnpm/issues/11272.
+export function linkPathToPeerVersion (relPath: string): string {
+  // Drop leading dots: v4 replaced `^\.+` with '+' and then stripOuter removed it.
+  let i = 0
+  while (i < relPath.length && relPath[i] === '.') i++
+
+  let out = ''
+  let lastWasPlus = true // pretend we just emitted '+' so leading '+' chars are suppressed
+  for (; i < relPath.length; i++) {
+    const c = relPath.charCodeAt(i)
+    // Reserved filename chars, C0 controls, and literal '+' all collapse into a single '+'.
+    const replace = c < 32 ||
+      c === 34 /* " */ || c === 42 /* * */ || c === 43 /* + */ ||
+      c === 47 /* / */ || c === 58 /* : */ || c === 60 /* < */ ||
+      c === 62 /* > */ || c === 63 /* ? */ || c === 92 /* \ */ ||
+      c === 124 /* | */
+    if (replace) {
+      if (!lastWasPlus) {
+        out += '+'
+        lastWasPlus = true
+      }
+    } else {
+      out += relPath[i]
+      lastWasPlus = false
+    }
+  }
+
+  // Trim trailing '+' and '.' (v4 stripped trailing periods and outer replacement).
+  let end = out.length
+  while (end > 0) {
+    const ch = out.charCodeAt(end - 1)
+    if (ch !== 43 /* + */ && ch !== 46 /* . */) break
+    end--
+  }
+  if (end > 0) return out.slice(0, end)
+  // Empty result with something consumed collapses to a single '+'.
+  return relPath.length === 0 ? '' : '+'
+}

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -970,16 +970,16 @@ function getLocationFromParentNodeIds<T> (
 // across pnpm versions so that lockfiles don't churn; it replicates what
 // filenamify v4 produced for these paths in pnpm <= 10.
 //
-// Note: this encoding is lossy and can collide. All leading `./` and `../`
-// segments are dropped, and `/`, `\`, and literal `+` all collapse into a
-// single `+`. For example, `packages/b`, `./packages/b`, and
-// `../packages/b` all produce `packages+b`. The only way to make this
-// collision-free is to hash the normalized link target (or switch to
-// a lossless escape encoding), either of which would change every
-// link-path peer suffix in existing lockfiles. We accept the
-// (extremely rare in practice) collision for lockfile stability; see
-// https://github.com/pnpm/pnpm/issues/11272.
-function linkPathToPeerVersion (relPath: string): string {
+// Note: this encoding is lossy and can collide. Any leading run of `.`
+// characters is dropped, and `/`, `\`, and literal `+` all collapse into
+// a single `+`. For example, `packages/b`, `./packages/b`, and
+// `../packages/b` all produce `packages+b`, and `.hidden/pkg` produces
+// `hidden+pkg`. The only way to make this collision-free is to hash the
+// normalized link target (or switch to a lossless escape encoding),
+// either of which would change every link-path peer suffix in existing
+// lockfiles. We accept the (extremely rare in practice) collision for
+// lockfile stability; see https://github.com/pnpm/pnpm/issues/11272.
+export function linkPathToPeerVersion (relPath: string): string {
   // Drop leading dots: v4 replaced `^\.+` with '+' and then stripOuter removed it.
   let i = 0
   while (i < relPath.length && relPath[i] === '.') i++

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -16,6 +16,7 @@ import { partition, pick } from 'ramda'
 import semver from 'semver'
 
 import { dedupeInjectedDeps } from './dedupeInjectedDeps.js'
+import { linkPathToPeerVersion } from './linkPathToPeerVersion.js'
 import { mergePeers } from './mergePeers.js'
 import type { NodeId } from './nextNodeId.js'
 import type {
@@ -963,58 +964,6 @@ function getLocationFromParentNodeIds<T> (
     projectId: '.',
     parents,
   }
-}
-
-// Converts a link: path into a stable, filename-safe token used as the
-// peer's "version" inside peer-suffix hashes. The output must stay stable
-// across pnpm versions so that lockfiles don't churn; it replicates what
-// filenamify v4 produced for these paths in pnpm <= 10.
-//
-// Note: this encoding is lossy and can collide. Any leading run of `.`
-// characters is dropped, and `/`, `\`, and literal `+` all collapse into
-// a single `+`. For example, `packages/b`, `./packages/b`, and
-// `../packages/b` all produce `packages+b`, and `.hidden/pkg` produces
-// `hidden+pkg`. The only way to make this collision-free is to hash the
-// normalized link target (or switch to a lossless escape encoding),
-// either of which would change every link-path peer suffix in existing
-// lockfiles. We accept the (extremely rare in practice) collision for
-// lockfile stability; see https://github.com/pnpm/pnpm/issues/11272.
-export function linkPathToPeerVersion (relPath: string): string {
-  // Drop leading dots: v4 replaced `^\.+` with '+' and then stripOuter removed it.
-  let i = 0
-  while (i < relPath.length && relPath[i] === '.') i++
-
-  let out = ''
-  let lastWasPlus = true // pretend we just emitted '+' so leading '+' chars are suppressed
-  for (; i < relPath.length; i++) {
-    const c = relPath.charCodeAt(i)
-    // Reserved filename chars, C0 controls, and literal '+' all collapse into a single '+'.
-    const replace = c < 32 ||
-      c === 34 /* " */ || c === 42 /* * */ || c === 43 /* + */ ||
-      c === 47 /* / */ || c === 58 /* : */ || c === 60 /* < */ ||
-      c === 62 /* > */ || c === 63 /* ? */ || c === 92 /* \ */ ||
-      c === 124 /* | */
-    if (replace) {
-      if (!lastWasPlus) {
-        out += '+'
-        lastWasPlus = true
-      }
-    } else {
-      out += relPath[i]
-      lastWasPlus = false
-    }
-  }
-
-  // Trim trailing '+' and '.' (v4 stripped trailing periods and outer replacement).
-  let end = out.length
-  while (end > 0) {
-    const ch = out.charCodeAt(end - 1)
-    if (ch !== 43 /* + */ && ch !== 46 /* . */) break
-    end--
-  }
-  if (end > 0) return out.slice(0, end)
-  // Empty result with something consumed collapses to a single '+'.
-  return relPath.length === 0 ? '' : '+'
 }
 
 function peerNodeIdToPeerId<T extends PartialResolvedPackage> (

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -10,7 +10,6 @@ import type {
   ProjectRootDir,
 } from '@pnpm/types'
 import * as semverUtils from '@yarnpkg/core/semverUtils'
-import filenamify from 'filenamify'
 import { analyzeGraph, type Graph } from 'graph-cycles'
 import pDefer, { type DeferredPromise } from 'p-defer'
 import { partition, pick } from 'ramda'
@@ -966,6 +965,58 @@ function getLocationFromParentNodeIds<T> (
   }
 }
 
+// Converts a link: path into a stable, filename-safe token used as the
+// peer's "version" inside peer-suffix hashes. The output must stay stable
+// across pnpm versions so that lockfiles don't churn; it replicates what
+// filenamify v4 produced for these paths in pnpm <= 10.
+//
+// Note: this encoding is lossy and can collide. All leading `./` and `../`
+// segments are dropped, and `/`, `\`, and literal `+` all collapse into a
+// single `+`. For example, `packages/b`, `./packages/b`, and
+// `../packages/b` all produce `packages+b`. The only way to make this
+// injective is to hash the normalized link target (or switch to a
+// lossless escape encoding), either of which would change every
+// link-path peer suffix in existing lockfiles. We accept the
+// (extremely rare in practice) collision for lockfile stability; see
+// https://github.com/pnpm/pnpm/issues/11272.
+function linkPathToPeerVersion (relPath: string): string {
+  // Drop leading dots: v4 replaced `^\.+` with '+' and then stripOuter removed it.
+  let i = 0
+  while (i < relPath.length && relPath[i] === '.') i++
+
+  let out = ''
+  let lastWasPlus = true // pretend we just emitted '+' so leading '+' chars are suppressed
+  for (; i < relPath.length; i++) {
+    const c = relPath.charCodeAt(i)
+    // Reserved filename chars, C0 controls, and literal '+' all collapse into a single '+'.
+    const replace = c < 32 ||
+      c === 34 /* " */ || c === 42 /* * */ || c === 43 /* + */ ||
+      c === 47 /* / */ || c === 58 /* : */ || c === 60 /* < */ ||
+      c === 62 /* > */ || c === 63 /* ? */ || c === 92 /* \ */ ||
+      c === 124 /* | */
+    if (replace) {
+      if (!lastWasPlus) {
+        out += '+'
+        lastWasPlus = true
+      }
+    } else {
+      out += relPath[i]
+      lastWasPlus = false
+    }
+  }
+
+  // Trim trailing '+' and '.' (v4 stripped trailing periods and outer replacement).
+  let end = out.length
+  while (end > 0) {
+    const ch = out.charCodeAt(end - 1)
+    if (ch !== 43 /* + */ && ch !== 46 /* . */) break
+    end--
+  }
+  if (end > 0) return out.slice(0, end)
+  // Empty result with something consumed collapses to a single '+'.
+  return relPath.length === 0 ? '' : '+'
+}
+
 function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
   alias: string,
   peerNodeId: NodeId,
@@ -977,7 +1028,7 @@ function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
   if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
     return {
       name: alias,
-      version: filenamify(peerNodeId.slice(5), { replacement: '+' }),
+      version: linkPathToPeerVersion(peerNodeId.slice(5)),
     }
   }
   if (ctx.dedupePeers) {

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -974,8 +974,8 @@ function getLocationFromParentNodeIds<T> (
 // segments are dropped, and `/`, `\`, and literal `+` all collapse into a
 // single `+`. For example, `packages/b`, `./packages/b`, and
 // `../packages/b` all produce `packages+b`. The only way to make this
-// injective is to hash the normalized link target (or switch to a
-// lossless escape encoding), either of which would change every
+// collision-free is to hash the normalized link target (or switch to
+// a lossless escape encoding), either of which would change every
 // link-path peer suffix in existing lockfiles. We accept the
 // (extremely rare in practice) collision for lockfile stability; see
 // https://github.com/pnpm/pnpm/issues/11272.

--- a/installing/deps-resolver/test/linkPathToPeerVersion.test.ts
+++ b/installing/deps-resolver/test/linkPathToPeerVersion.test.ts
@@ -1,0 +1,32 @@
+import { linkPathToPeerVersion } from '../lib/resolvePeers.js'
+
+// These outputs are lockfile-format: changing any of them breaks existing
+// v9 lockfiles. See https://github.com/pnpm/pnpm/issues/11272.
+test.each([
+  // The case from #11272: link target outside the workspace root.
+  ['../packages/b', 'packages+b'],
+  ['./packages/b', 'packages+b'],
+  ['packages/b', 'packages+b'],
+  ['../../a/b', '..+a+b'],
+  ['a/b/c', 'a+b+c'],
+  ['abc', 'abc'],
+  // Leading dots collapse and are stripped.
+  ['..', '+'],
+  ['...', '+'],
+  ['.hidden/pkg', 'hidden+pkg'],
+  // Windows-style separators and mixed reserved characters.
+  ['..\\packages\\b', 'packages+b'],
+  ['a/b\\c', 'a+b+c'],
+  // Literal '+' characters collapse with adjacent separators.
+  ['foo+bar', 'foo+bar'],
+  ['foo++bar', 'foo+bar'],
+  ['+foo', 'foo'],
+  ['foo+', 'foo'],
+  // Trailing dots are stripped.
+  ['foo.', 'foo'],
+  ['abc...', 'abc'],
+  // Empty input stays empty.
+  ['', ''],
+])('linkPathToPeerVersion(%j) === %j', (input, expected) => {
+  expect(linkPathToPeerVersion(input)).toBe(expected)
+})

--- a/installing/deps-resolver/test/linkPathToPeerVersion.test.ts
+++ b/installing/deps-resolver/test/linkPathToPeerVersion.test.ts
@@ -1,4 +1,4 @@
-import { linkPathToPeerVersion } from '../lib/resolvePeers.js'
+import { linkPathToPeerVersion } from '../lib/linkPathToPeerVersion.js'
 
 // These outputs are lockfile-format: changing any of them breaks existing
 // v9 lockfiles. See https://github.com/pnpm/pnpm/issues/11272.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,9 +556,6 @@ catalogs:
     fast-glob:
       specifier: ^3.3.3
       version: 3.3.3
-    filenamify:
-      specifier: ^7.0.1
-      version: 7.0.1
     find-up:
       specifier: ^8.0.0
       version: 8.0.0
@@ -5572,9 +5569,6 @@ importers:
       '@yarnpkg/core':
         specifier: 'catalog:'
         version: 4.5.0(typanion@3.14.0)
-      filenamify:
-        specifier: 'catalog:'
-        version: 7.0.1
       graph-cycles:
         specifier: 'catalog:'
         version: 3.0.0
@@ -13094,14 +13088,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  filename-reserved-regex@4.0.0:
-    resolution: {integrity: sha512-9ZT504KxEQDamsOogZImAWGEN24R1uFAxU3ZS4AZqn2ooidmN68Olh7n4/RcA4lLatZztjA0ZSuxeLHVoCc8JA==}
-    engines: {node: '>=20'}
-
-  filenamify@7.0.1:
-    resolution: {integrity: sha512-9b4rfnaX2MkJCgp27wypV6DAMvj4WMOSgJ+TdcpJIO84Dql+Cv6iJjdG4XDTLubOWkfNiBv3joO59sau/TXw+Q==}
-    engines: {node: '>=20'}
 
   fill-keys@1.0.2:
     resolution: {integrity: sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==}
@@ -21535,12 +21521,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  filename-reserved-regex@4.0.0: {}
-
-  filenamify@7.0.1:
-    dependencies:
-      filename-reserved-regex: 4.0.0
 
   fill-keys@1.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -192,7 +192,6 @@ catalog:
   exists-link: 2.0.0
   fast-deep-equal: ^3.1.3
   fast-glob: ^3.3.3
-  filenamify: ^7.0.1
   find-up: ^8.0.0
   fs-extra: ^11.3.1
   fuse-native: ^2.2.6


### PR DESCRIPTION
## Summary

- A `filenamify` v4 → v7 upgrade changed the peer-suffix "version" token that pnpm produces for linked dependency paths. For example, `../packages/b` started encoding as `+packages+b` instead of `packages+b`, causing lockfile churn for workspaces with packages linked from outside the workspace root (reported in #11272).
- Replace the `filenamify` call with a small inline encoder that reproduces v4's output for link paths, and drop the now-unused dependency.
- Add a comment documenting that this encoding is lossy — `packages/b`, `./packages/b`, and `../packages/b` all collapse to the same token — and that only hashing or a lossless escape encoding could avoid that. We accept the (extremely rare in practice) collision for lockfile stability.

Closes #11272.

## Test plan

- [x] Added a changeset.
- [x] Unit tests for `@pnpm/installing.deps-resolver` pass (40/40).
- [x] Peer-dependency integration tests for `@pnpm/installing.deps-installer` pass (67 passed, 1 pre-existing skipped).
- [x] Reproduced the issue against a fixture mirroring the one from #11272 and confirmed the lockfile now emits `c@file:../packages/c(b@packages+b)` — matching pnpm 10 — instead of `(b@+packages+b)`.