### PR TITLE
fix(config): improve auth config errors and print config warnings before failures

### DIFF
--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -92,7 +92,17 @@ export async function getConfig (opts: {
   env?: Record<string, string | undefined>
   onlyInheritDlxSettingsFromLocal?: boolean
   ignoreLocalSettings?: boolean
+  /**
+   * Optional warning sink owned by the caller.
+   *
+   * Callers may pass their own array when they need access to warnings even if
+   * config loading later throws, for example to print collected warnings in a
+   * finally block before rethrowing the original error.
+   */
+  warnings?: string[]
 }): Promise<{ config: Config, context: ConfigContext, warnings: string[] }> {
+  const warnings = opts.warnings = opts.warnings ?? []
+
   if (opts.onlyInheritDlxSettingsFromLocal) {
     const { onlyInheritDlxSettingsFromLocal: _, ...localOpts } = opts
     const globalCfgOpts: typeof localOpts = {
@@ -105,7 +115,6 @@ export async function getConfig (opts: {
     }
     const [final, localSrc] = await Promise.all([getConfig(globalCfgOpts), getConfig(localOpts)])
     inheritDlxConfig(final, localSrc)
-    final.warnings.push(...localSrc.warnings)
     return final
   }
 
@@ -231,7 +240,7 @@ export async function getConfig (opts: {
     moduleDirname: import.meta.dirname,
     env: opts.env,
   })
-  const warnings = npmrcResult.warnings
+  warnings.push(...npmrcResult.warnings)
 
   const configFromCliOpts = Object.fromEntries(Object.entries(cliOptions)
     .filter(([_, value]) => typeof value !== 'undefined')
@@ -777,4 +786,3 @@ function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config & ConfigCo
   }
   pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
 }
-

--- a/config/reader/src/parseCreds.ts
+++ b/config/reader/src/parseCreds.ts
@@ -59,7 +59,7 @@ function parseBasicAuth ({
   authPassword,
 }: Pick<RawCreds, 'authPairBase64' | 'authUsername' | 'authPassword'>): BasicAuth | undefined {
   if (authPairBase64) {
-    const pair = atob(authPairBase64)
+    const pair = parseBase64Credential(authPairBase64, '_auth')
     const colonIndex = pair.indexOf(':')
     if (colonIndex < 0) {
       throw new AuthMissingSeparatorError()
@@ -70,10 +70,18 @@ function parseBasicAuth ({
   }
 
   if (authUsername && authPassword) {
-    return { username: authUsername, password: atob(authPassword) }
+    return { username: authUsername, password: parseBase64Credential(authPassword, '_password') }
   }
 
   return undefined
+}
+
+function parseBase64Credential (value: string, field: '_auth' | '_password'): string {
+  try {
+    return atob(value)
+  } catch (err) {
+    throw new InvalidAuthConfigError(field, value, err)
+  }
 }
 
 export class AuthMissingSeparatorError extends PnpmError {
@@ -81,6 +89,16 @@ export class AuthMissingSeparatorError extends PnpmError {
     super('AUTH_MISSING_SEPARATOR', 'No separator found in the decoded form of _auth', {
       hint: '_auth is a base64 encoded form of <username>:<password> where the colon (:) serves as the separator',
     })
+  }
+}
+
+export class InvalidAuthConfigError extends PnpmError {
+  constructor (field: '_auth' | '_password', value: string, cause: unknown) {
+    const hint = value.includes('${')
+      ? `The ${field} value still contains an unresolved env placeholder. Make sure the referenced env var is set in the config source that defines this credential before running pnpm.`
+      : `The ${field} value must be valid base64 in the parsed auth config.`
+    super('INVALID_AUTH_CONFIG', `Failed to parse auth config: invalid ${field} value`, { hint })
+    this.cause = cause
   }
 }
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1204,6 +1204,22 @@ test('return a warning when the .npmrc has an env variable that does not exist',
   expect(warnings).toEqual(expect.arrayContaining(expected))
 })
 
+test('throw a descriptive auth config error when unresolved _auth placeholder reaches auth parsing', async () => {
+  fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_auth=${ENV_VAR_123}', 'utf8')
+
+  await expect(getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_INVALID_AUTH_CONFIG',
+    message: 'Failed to parse auth config: invalid _auth value',
+    hint: expect.stringContaining('unresolved env placeholder'),
+  })
+})
+
 test('return a warning if a package.json has workspaces field but there is no pnpm-workspaces.yaml file', async () => {
   const prefix = f.find('pkg-using-workspaces')
   const { warnings } = await getConfig({

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1204,6 +1204,21 @@ test('return a warning when the .npmrc has an env variable that does not exist',
   expect(warnings).toEqual(expect.arrayContaining(expected))
 })
 
+test('return the caller-provided warnings array', async () => {
+  const warnings: string[] = []
+
+  const result = await getConfig({
+    cliOptions: {},
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    warnings,
+  })
+
+  expect(result.warnings).toBe(warnings)
+})
+
 test('throw a descriptive auth config error when unresolved _auth placeholder reaches auth parsing', async () => {
   fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_auth=${ENV_VAR_123}', 'utf8')
 

--- a/config/reader/test/parseCreds.test.ts
+++ b/config/reader/test/parseCreds.test.ts
@@ -44,6 +44,21 @@ describe('parseCreds', () => {
     })).toThrow(new AuthMissingSeparatorError())
   })
 
+  test('authPairBase64 throws a descriptive error when value is not valid base64', () => {
+    try {
+      parseCreds({
+        authPairBase64: '${ENV_VAR_123}',
+      })
+      throw new Error('expected parseCreds to throw')
+    } catch (err: any) { // eslint-disable-line
+      expect(err).toMatchObject({
+        code: 'ERR_PNPM_INVALID_AUTH_CONFIG',
+        message: 'Failed to parse auth config: invalid _auth value',
+        hint: 'The _auth value still contains an unresolved env placeholder. Make sure the referenced env var is set in the config source that defines this credential before running pnpm.',
+      })
+    }
+  })
+
   test('authUsername and authPassword', () => {
     expect(parseCreds({
       authUsername: 'foo',
@@ -62,6 +77,22 @@ describe('parseCreds', () => {
     expect(parseCreds({
       authPassword: 'bar',
     })).toBeUndefined()
+  })
+
+  test('authPassword throws a descriptive error when value is not valid base64', () => {
+    try {
+      parseCreds({
+        authUsername: 'foo',
+        authPassword: '${ENV_VAR_123}',
+      })
+      throw new Error('expected parseCreds to throw')
+    } catch (err: any) { // eslint-disable-line
+      expect(err).toMatchObject({
+        code: 'ERR_PNPM_INVALID_AUTH_CONFIG',
+        message: 'Failed to parse auth config: invalid _password value',
+        hint: 'The _password value still contains an unresolved env placeholder. Make sure the referenced env var is set in the config source that defines this credential before running pnpm.',
+      })
+    }
   })
 
   test('tokenHelper', () => {

--- a/pnpm/src/getConfig.ts
+++ b/pnpm/src/getConfig.ts
@@ -19,25 +19,29 @@ export async function getConfig (
     onlyInheritDlxSettingsFromLocal?: boolean
   }
 ): Promise<{ config: Config, context: ConfigContext }> {
-  const { config, context, warnings } = await _getConfig({
-    cliOptions,
-    globalDirShouldAllowWrite: opts.globalDirShouldAllowWrite,
-    packageManager,
-    workspaceDir: opts.workspaceDir,
-    onlyInheritDlxSettingsFromLocal: opts.onlyInheritDlxSettingsFromLocal,
-  })
-  context.cliOptions = cliOptions
-  applyDerivedConfig(config)
+  const warnings: string[] = []
+  try {
+    const { config, context } = await _getConfig({
+      cliOptions,
+      globalDirShouldAllowWrite: opts.globalDirShouldAllowWrite,
+      packageManager,
+      workspaceDir: opts.workspaceDir,
+      onlyInheritDlxSettingsFromLocal: opts.onlyInheritDlxSettingsFromLocal,
+      warnings,
+    })
+    context.cliOptions = cliOptions
+    applyDerivedConfig(config)
 
-  if (opts.excludeReporter) {
-    delete config.reporter // This is a silly workaround because @pnpm/installing.deps-installer expects a function as opts.reporter
+    if (opts.excludeReporter) {
+      delete config.reporter // This is a silly workaround because @pnpm/installing.deps-installer expects a function as opts.reporter
+    }
+
+    return { config, context }
+  } finally {
+    if (warnings.length > 0) {
+      console.warn(warnings.map((warning) => formatWarn(warning)).join('\n'))
+    }
   }
-
-  if (warnings.length > 0) {
-    console.warn(warnings.map((warning) => formatWarn(warning)).join('\n'))
-  }
-
-  return { config, context }
 }
 
 export async function installConfigDepsAndLoadHooks (

--- a/pnpm/test/getConfig.test.ts
+++ b/pnpm/test/getConfig.test.ts
@@ -30,6 +30,24 @@ test('console a warning when the .npmrc has an env variable that does not exist'
   expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
 })
 
+test('console warnings before rethrowing a config error', async () => {
+  prepare()
+
+  fs.writeFileSync('.npmrc', '//registry.npmjs.org/:_auth=${ENV_VAR_123}', 'utf8')
+
+  await expect(getConfig({
+    json: false,
+  }, {
+    workspaceDir: '.',
+    excludeReporter: false,
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_INVALID_AUTH_CONFIG',
+    message: 'Failed to parse auth config: invalid _auth value',
+  })
+
+  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to replace env in config: ${ENV_VAR_123}'))
+})
+
 describe('calcPnpmfilePathsOfPluginDeps', () => {
   test('yields pnpmfile.mjs when it exists', () => {
     const tmpDir = fs.mkdtempSync(path.join(import.meta.dirname, '.tmp-'))


### PR DESCRIPTION
## Summary

fixes #11298, this MR improves the config/auth failure path for unresolved credential placeholders and makes sure already-collected config warnings are still printed when config loading throws. 
## What changed

1. Auth config parsing now reports a more descriptive config/auth-specific error when invalid `_auth` / `_password` values reach credential parsing, instead of surfacing a low-level decode failure.
2. Config warnings are now printed from the pnpm wrapper in a `finally` path, so warnings are emitted both on successful config loading and on config-loading failure.

## Why

#11298 is the motivation for this MR and contains the full problem statement and reproduction, so this description intentionally does not repeat that analysis here. The key point for this change is that the warning path and the fatal error path were previously disconnected: warnings could be collected during config loading, but they were only printed if `getConfig()` completed successfully.

The warning-handling change uses a caller-provided warnings array because `@pnpm/config.reader.getConfig()` already has multiple callers with different output behavior. The main `pnpm` CLI prints warnings, while another direct caller does not print them. Keeping warning collection in `config.reader` and warning presentation in the caller preserves that existing boundary, while still allowing the CLI to print collected warnings even when config loading throws.

## Important note

If the long-term decision is that this kind of invalid config should **not** stop the CLI, the warning-printing part of this MR is still relevant.

In that case, the follow-up should not rely on throwing around the `atob()` path and recovering elsewhere. Instead, auth parsing would need a different policy that treats unresolved / invalid credential input as a warning-only condition and yields no credentials rather than throwing.