### PR TITLE
fix: suppress packageManager/devEngines.packageManager conflict warning when values match exactly

### DIFF
--- a/.changeset/dev-engines-package-manager-compatible.md
+++ b/.changeset/dev-engines-package-manager-compatible.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Do not print the `Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored` warning when the two fields specify compatible versions (same package manager name and the `packageManager` version satisfies the `devEngines.packageManager` version range). This lets projects keep both fields during the migration from `packageManager` to `devEngines.packageManager` without a noisy warning [#11301](https://github.com/pnpm/pnpm/issues/11301).
+Do not print the `Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored` warning when the two fields specify the exact same package manager name and version string. This lets projects keep both fields during the migration from `packageManager` to `devEngines.packageManager` without a noisy warning [#11301](https://github.com/pnpm/pnpm/issues/11301).

--- a/.changeset/dev-engines-package-manager-compatible.md
+++ b/.changeset/dev-engines-package-manager-compatible.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Do not print the `Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored` warning when the two fields specify compatible versions (same package manager name and the `packageManager` version satisfies the `devEngines.packageManager` version range). This lets projects keep both fields during the migration from `packageManager` to `devEngines.packageManager` without a noisy warning [#11301](https://github.com/pnpm/pnpm/issues/11301).

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -668,7 +668,7 @@ function getWantedPackageManager (manifest: ProjectManifest): { pm?: WantedPacka
       warnings.push(`Cannot use devEngines.packageManager version "${pmFromDevEngines.version}": not a valid version or range`)
       pmFromDevEngines.version = undefined
     }
-    if (manifest.packageManager) {
+    if (manifest.packageManager && packageManagerFieldsConflict(manifest.packageManager, pmFromDevEngines)) {
       warnings.push('Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored')
     }
     return { pm: { ...pmFromDevEngines, fromDevEngines: true }, warnings }
@@ -701,6 +701,16 @@ function parsePackageManager (packageManager: string): { name: string, version: 
     name,
     version,
   }
+}
+
+function packageManagerFieldsConflict (packageManager: string, pmFromDevEngines: EngineDependency): boolean {
+  const legacyPm = parsePackageManager(packageManager)
+  if (legacyPm.name !== pmFromDevEngines.name) return true
+  // If either side lacks a version, there's nothing concrete to conflict on.
+  if (pmFromDevEngines.version == null || legacyPm.version == null) return false
+  const legacyVersion = semver.valid(legacyPm.version)
+  if (legacyVersion == null) return true
+  return !semver.satisfies(legacyVersion, pmFromDevEngines.version)
 }
 
 function parseDevEnginesPackageManager (devEngines?: DevEngines): EngineDependency | undefined {

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -668,8 +668,11 @@ function getWantedPackageManager (manifest: ProjectManifest): { pm?: WantedPacka
       warnings.push(`Cannot use devEngines.packageManager version "${pmFromDevEngines.version}": not a valid version or range`)
       pmFromDevEngines.version = undefined
     }
-    if (manifest.packageManager && packageManagerFieldsConflict(manifest.packageManager, pmFromDevEngines)) {
-      warnings.push('Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored')
+    if (manifest.packageManager) {
+      const legacyPm = parsePackageManager(manifest.packageManager)
+      if (legacyPm.name !== pmFromDevEngines.name || legacyPm.version !== pmFromDevEngines.version) {
+        warnings.push('Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored')
+      }
     }
     return { pm: { ...pmFromDevEngines, fromDevEngines: true }, warnings }
   }
@@ -701,19 +704,6 @@ function parsePackageManager (packageManager: string): { name: string, version: 
     name,
     version,
   }
-}
-
-function packageManagerFieldsConflict (packageManager: string, pmFromDevEngines: EngineDependency): boolean {
-  const legacyPm = parsePackageManager(packageManager)
-  if (legacyPm.name !== pmFromDevEngines.name) return true
-  // If either side lacks a version, there's nothing concrete to conflict on.
-  if (pmFromDevEngines.version == null || legacyPm.version == null) return false
-  const legacyVersion = semver.valid(legacyPm.version)
-  // The legacy `packageManager` field is only respected for canonical exact versions.
-  // A non-canonical value (e.g. "pnpm@v1.2.3") would be rejected on its own, so treat
-  // it as a conflict here so the warning still surfaces the underlying problem.
-  if (legacyVersion == null || legacyVersion !== legacyPm.version) return true
-  return !semver.satisfies(legacyVersion, pmFromDevEngines.version)
 }
 
 function parseDevEnginesPackageManager (devEngines?: DevEngines): EngineDependency | undefined {

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -709,7 +709,10 @@ function packageManagerFieldsConflict (packageManager: string, pmFromDevEngines:
   // If either side lacks a version, there's nothing concrete to conflict on.
   if (pmFromDevEngines.version == null || legacyPm.version == null) return false
   const legacyVersion = semver.valid(legacyPm.version)
-  if (legacyVersion == null) return true
+  // The legacy `packageManager` field is only respected for canonical exact versions.
+  // A non-canonical value (e.g. "pnpm@v1.2.3") would be rejected on its own, so treat
+  // it as a conflict here so the warning still surfaces the underlying problem.
+  if (legacyVersion == null || legacyVersion !== legacyPm.version) return true
   return !semver.satisfies(legacyVersion, pmFromDevEngines.version)
 }
 

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -247,6 +247,74 @@ test('devEngines.packageManager takes precedence over packageManager field', asy
   expect(stderr.toString()).toContain('"packageManager" will be ignored')
 })
 
+test('no warning when packageManager and devEngines.packageManager specify the same exact version', async () => {
+  prepare({
+    packageManager: 'pnpm@1.2.3',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '1.2.3',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).not.toContain('Cannot use both')
+})
+
+test('no warning when packageManager version satisfies the devEngines.packageManager range', async () => {
+  prepare({
+    packageManager: 'pnpm@1.2.3',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=1.0.0',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).not.toContain('Cannot use both')
+})
+
+test('warns when packageManager specifies a different package manager from devEngines.packageManager', async () => {
+  prepare({
+    packageManager: 'yarn@4.0.0',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=1.0.0',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
+})
+
+test('warns when packageManager version does not satisfy the devEngines.packageManager range', async () => {
+  prepare({
+    packageManager: 'pnpm@1.2.3',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=2.0.0',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
+})
+
 test('pmOnFail=ignore via env var bypasses the devEngines.packageManager check', async () => {
   prepare({
     devEngines: {

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -264,64 +264,30 @@ test('no warning when packageManager and devEngines.packageManager specify the s
   expect(stderr.toString()).not.toContain('Cannot use both')
 })
 
-test('no warning when packageManager version satisfies the devEngines.packageManager range', async () => {
-  prepare({
-    packageManager: 'pnpm@1.2.3',
-    devEngines: {
-      packageManager: {
-        name: 'pnpm',
-        version: '>=1.0.0',
-        onFail: 'ignore',
-      },
-    },
-  })
-
-  const { stderr } = execPnpmSync(['install'])
-
-  expect(stderr.toString()).not.toContain('Cannot use both')
-})
-
 test('warns when packageManager specifies a different package manager from devEngines.packageManager', async () => {
   prepare({
-    packageManager: 'yarn@4.0.0',
-    devEngines: {
-      packageManager: {
-        name: 'pnpm',
-        version: '>=1.0.0',
-        onFail: 'ignore',
-      },
-    },
-  })
-
-  const { stderr } = execPnpmSync(['install'])
-
-  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
-})
-
-test('warns when packageManager version does not satisfy the devEngines.packageManager range', async () => {
-  prepare({
-    packageManager: 'pnpm@1.2.3',
-    devEngines: {
-      packageManager: {
-        name: 'pnpm',
-        version: '>=2.0.0',
-        onFail: 'ignore',
-      },
-    },
-  })
-
-  const { stderr } = execPnpmSync(['install'])
-
-  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
-})
-
-test('warns when packageManager uses a non-canonical exact version even if it would match devEngines.packageManager after normalization', async () => {
-  prepare({
-    packageManager: 'pnpm@v1.2.3',
+    packageManager: 'yarn@1.2.3',
     devEngines: {
       packageManager: {
         name: 'pnpm',
         version: '1.2.3',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
+})
+
+test('warns when packageManager version does not match the devEngines.packageManager version string exactly', async () => {
+  prepare({
+    packageManager: 'pnpm@1.2.3',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '>=1.0.0',
         onFail: 'ignore',
       },
     },

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -315,6 +315,23 @@ test('warns when packageManager version does not satisfy the devEngines.packageM
   expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
 })
 
+test('warns when packageManager uses a non-canonical exact version even if it would match devEngines.packageManager after normalization', async () => {
+  prepare({
+    packageManager: 'pnpm@v1.2.3',
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '1.2.3',
+        onFail: 'ignore',
+      },
+    },
+  })
+
+  const { stderr } = execPnpmSync(['install'])
+
+  expect(stderr.toString()).toContain('Cannot use both "packageManager" and "devEngines.packageManager"')
+})
+
 test('pmOnFail=ignore via env var bypasses the devEngines.packageManager check', async () => {
   prepare({
     devEngines: {


### PR DESCRIPTION
## Summary
- Suppress the `Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored` warning only when both fields specify the exact same package manager name and the exact same version string. Any other divergence (different name, range vs. exact version, prefixed versions like `v1.2.3`, etc.) still warns.
- Lets projects keep both fields during migration (e.g. so v10 installs still auto-switch via `packageManager`, while v11 uses `devEngines.packageManager` and `npm install` still errors) without a noisy warning — as long as the two values are kept in sync.

Closes #11301

## Test plan
- [x] `pnpm --filter pnpm test packageManagerCheck.test.ts` — added cases for same-exact-version (no warning), name mismatch (warns), and range vs. exact version (warns). All tests pass.
- [x] `pnpm --filter @pnpm/config.reader run lint` clean.
- [x] Manual: running `pnpm install` in a project with matching `"packageManager": "pnpm@X"` and `"devEngines.packageManager": { name: "pnpm", version: "X" }` no longer prints the warning; any divergence still prints it.