### PR TITLE
fix: sort the keys of the overrides object

### DIFF
--- a/.changeset/sort-audit-fix-overrides.md
+++ b/.changeset/sort-audit-fix-overrides.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+Sort the keys of the overrides object returned by `pnpm audit --fix` so that the log output order matches the order written to `pnpm-workspace.yaml`.

--- a/deps/compliance/commands/package.json
+++ b/deps/compliance/commands/package.json
@@ -53,6 +53,7 @@
     "@pnpm/lockfile.utils": "workspace:*",
     "@pnpm/lockfile.walker": "workspace:*",
     "@pnpm/network.auth-header": "workspace:*",
+    "@pnpm/object.key-sorting": "workspace:*",
     "@pnpm/store.path": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.project-manifest-reader": "workspace:*",

--- a/deps/compliance/commands/src/audit/fix.ts
+++ b/deps/compliance/commands/src/audit/fix.ts
@@ -1,5 +1,6 @@
 import { writeSettings } from '@pnpm/config.writer'
 import { type AuditAdvisory, type AuditReport, normalizeGhsaId } from '@pnpm/deps.compliance.audit'
+import { sortDirectKeys } from '@pnpm/object.key-sorting'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
@@ -42,7 +43,7 @@ function createOverrides (advisories: AuditAdvisory[]): Record<string, string> {
     if (!advisory.patched_versions) continue
     entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, caretRangeForPatched(advisory.patched_versions)])
   }
-  return Object.fromEntries(entries)
+  return sortDirectKeys(Object.fromEntries(entries))
 }
 
 // Use the minimum patched version with a caret so pnpm stays within the

--- a/deps/compliance/commands/tsconfig.json
+++ b/deps/compliance/commands/tsconfig.json
@@ -65,6 +65,9 @@
       "path": "../../../network/auth-header"
     },
     {
+      "path": "../../../object/key-sorting"
+    },
+    {
       "path": "../../../pkg-manifest/reader"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2819,6 +2819,9 @@ importers:
       '@pnpm/network.auth-header':
         specifier: workspace:*
         version: link:../../../network/auth-header
+      '@pnpm/object.key-sorting':
+        specifier: workspace:*
+        version: link:../../../object/key-sorting
       '@pnpm/store.path':
         specifier: workspace:*
         version: link:../../../store/path


### PR DESCRIPTION
Sort the keys of the overrides object returned by `pnpm audit --fix` so that the log output order matches the order written to `pnpm-workspace.yaml`.