### PR TITLE
test: replace deleted sveltejs/action-deploy-docs fixture

### DIFF
--- a/fetching/git-fetcher/test/index.ts
+++ b/fetching/git-fetcher/test/index.ts
@@ -171,8 +171,8 @@ test('fetch a big repository', async () => {
   const fetch = createGitFetcher({ storeIndex: createStoreIndex(storeDir) }).git
   const { filesMap } = await fetch(createCafsStore(storeDir),
     {
-      commit: 'a65fbf5a90f53c9d72fed4daaca59da50f074355',
-      repo: 'https://github.com/sveltejs/action-deploy-docs.git',
+      commit: 'f766801580f10543c24ba8bfa59046a776848097',
+      repo: 'https://github.com/pnpm-e2e/drupal-js-build.git',
       type: 'git',
     }, {
       filesIndexFile: path.join(storeDir, 'index.json'),

--- a/fetching/pick-fetcher/test/customFetch.ts
+++ b/fetching/pick-fetcher/test/customFetch.ts
@@ -480,8 +480,8 @@ describe('custom fetcher implementation examples', () => {
 
       const customResolution = createMockResolution({
         type: 'custom:git',
-        repo: 'sveltejs/action-deploy-docs',
-        commit: 'a65fbf5a90f53c9d72fed4daaca59da50f074355',
+        repo: 'pnpm-e2e/drupal-js-build',
+        commit: 'f766801580f10543c24ba8bfa59046a776848097',
       })
 
       const fetcher = await pickFetcher(

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -458,7 +458,7 @@ test('fetch a big repository', async () => {
 
   process.chdir(temporaryDirectory())
 
-  const resolution = { tarball: 'https://codeload.github.com/sveltejs/action-deploy-docs/tar.gz/a65fbf5a90f53c9d72fed4daaca59da50f074355' }
+  const resolution = { tarball: 'https://codeload.github.com/pnpm-e2e/drupal-js-build/tar.gz/f766801580f10543c24ba8bfa59046a776848097' }
 
   const result = await fetch.gitHostedTarball(cafs, resolution, {
     filesIndexFile,


### PR DESCRIPTION
## Summary

- The `sveltejs/action-deploy-docs` repository was deleted from GitHub (API returns 404), causing CI failures in three fetcher tests that referenced it.
- Replaces the reference with `pnpm-e2e/drupal-js-build` — owned by the pnpm org (so it won't disappear) and ~485KB, which is large enough to keep covering the regression from [#4064](https://github.com/pnpm/pnpm/issues/4064).
- Updates three test files: `fetching/git-fetcher/test/index.ts`, `fetching/tarball-fetcher/test/fetch.ts`, `fetching/pick-fetcher/test/customFetch.ts`.

## Test plan

- [x] `fetching/git-fetcher` → `fetch a big repository` passes locally
- [x] `fetching/tarball-fetcher` → `fetch a big repository` passes locally
- [x] `fetching/pick-fetcher` → `custom fetcher can use gitHostedTarball fetcher for custom git URLs` passes locally