### PR TITLE
fix(directory-fetcher): respect absolute paths in resolution.directory

### DIFF
--- a/.changeset/fix-directory-fetcher-absolute-path.md
+++ b/.changeset/fix-directory-fetcher-absolute-path.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fetching.directory-fetcher": patch
+"pnpm": patch
+---
+
+Fix installing a directory dependency (`file:<dir>`) from an absolute path on a different drive on Windows. The directory fetcher was joining the stored directory onto `lockfileDir`, which on Windows concatenates an absolute cross-drive path literally (`path.join('D:\\...', 'C:\\Users\\...')` → `'D:\\...\\C:\\Users\\...'`). Use `path.resolve` so absolute paths are respected. This surfaced as an ENOENT during `pnpm setup` in CI when `PNPM_HOME` and the OS temp directory were on different drives.

--- a/fetching/directory-fetcher/src/index.ts
+++ b/fetching/directory-fetcher/src/index.ts
@@ -24,7 +24,10 @@ export function createDirectoryFetcher (
   const fetchFromDir = opts?.includeOnlyPackageFiles ? fetchPackageFilesFromDir : fetchAllFilesFromDir.bind(null, readFileStat)
 
   const directoryFetcher: DirectoryFetcher = (cafs, resolution, opts) => {
-    const dir = path.join(opts.lockfileDir, resolution.directory)
+    // Use path.resolve so absolute directories (e.g. cross-drive Windows paths
+    // stored by `file:` deps) are respected instead of being concatenated
+    // onto lockfileDir.
+    const dir = path.resolve(opts.lockfileDir, resolution.directory)
     return fetchFromDir(dir)
   }
 

--- a/fetching/directory-fetcher/test/index.ts
+++ b/fetching/directory-fetcher/test/index.ts
@@ -111,6 +111,26 @@ test('fetch does not fail on package with broken symlink', async () => {
   expect(debug).toHaveBeenCalledWith({ brokenSymlink: path.resolve('not-exists') })
 })
 
+test('fetch respects absolute directory regardless of lockfileDir', async () => {
+  const absDir = f.find('simple-pkg')
+  const fetcher = createDirectoryFetcher({ includeOnlyPackageFiles: true })
+
+  // lockfileDir is unrelated to the directory being fetched. When the
+  // stored directory is absolute (e.g. cross-drive `file:` deps on Windows)
+  // the fetcher must use the absolute path as-is rather than joining it
+  // onto lockfileDir.
+  // eslint-disable-next-line
+  const fetchResult = await fetcher.directory({} as any, {
+    directory: absDir,
+    type: 'directory',
+  }, {
+    lockfileDir: f.find('no-manifest'),
+  })
+
+  expect(fetchResult.local).toBe(true)
+  expect(fetchResult.filesMap.get('package.json')).toBe(path.join(absDir, 'package.json'))
+})
+
 describe('fetch resolves symlinked files to their real locations', () => {
   const indexJsPath = path.join(f.find('no-manifest'), 'index.js')
   const srcPath = f.find('simple-pkg')


### PR DESCRIPTION
## Summary

- On Windows, `path.join('D:\\foo', 'C:\\bar')` returns `'D:\\foo\\C:\\bar'` (literal concatenation), it does not respect absolute second arguments across drives. The directory fetcher was using `path.join(opts.lockfileDir, resolution.directory)`, which mangled any cross-drive absolute path stored in `resolution.directory`.
- Switch to `path.resolve`, which respects absolute right-hand paths.
- Add a test that fetches a directory whose absolute path is unrelated to `lockfileDir`.

## Motivation

Hit in get.pnpm.io CI (`install.ps1` → `pnpm setup` → `pnpm add -g file:<extracted-tarball-dir>`). `PNPM_HOME` was on `D:\a\_temp\pnpm-home` (GitHub runner temp), while the install script extracts the v11 tarball under `%TEMP%` which is on `C:\Users\runneradmin\AppData\Local\Temp`. The fetcher produced:

```
ENOENT  ENOENT: no such file or directory, scandir
'D:\a\_temp\pnpm-home\global\v11\1ff0-19dab4f12b5\C:\Users\runneradmin\AppData\Local\Temp\9c3c26ed-...'
```

This was failing `pnpm setup` itself on Windows whenever the OS temp directory and `PNPM_HOME` were on different drives.

## Test plan

- [x] `pnpm --filter @pnpm/fetching.directory-fetcher test`
- [ ] Verify get.pnpm.io's PowerShell CI (windows-latest, `next-11`) passes once this lands and a new v11 prerelease is published