### PR TITLE
test: fix grammar in config/reader test descriptions

### DIFF
--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -429,7 +429,7 @@ test('when using --global, linkWorkspacePackages, sharedWorkspaceLockfile and lo
     })
     expect(config.linkWorkspacePackages).toBeFalsy()
     expect(config.sharedWorkspaceLockfile).toBeFalsy()
-    // FIXME: it supposed to return null but is undefined
+    // FIXME: it is supposed to return null but is undefined
     expect(config.lockfileDir).toBeUndefined()
   }
 })
@@ -454,7 +454,7 @@ test('registries of scoped packages are read and normalized', async () => {
   })
 })
 
-test('registries in current directory\'s .npmrc have bigger priority then global config settings', async () => {
+test('registries in current directory\'s .npmrc have bigger priority than global config settings', async () => {
   prepare()
 
   fs.writeFileSync('.npmrc', 'registry=https://pnpm.io/', 'utf8')


### PR DESCRIPTION

**Repo:** pnpm/pnpm (⭐ 29000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Fixes two minor grammar issues in `config/reader/test/index.ts`: a test description used "bigger priority then" instead of "than", and a `FIXME` comment read "it supposed to return" instead of "it is supposed to return".

## Why
Test names show up in test runners and CI output, and comments are read by every contributor opening the file. Correcting the conjunction ("then" → "than") and the missing verb ("is") is a tiny readability win with zero behavioral risk.

## Testing
Pure string changes inside a test description and a comment — no runtime behavior changes. `git diff` reviewed; the test still runs and asserts the same things. No code paths altered.

## Risk
Low — comment + test-name text only.
