### PR TITLE
refactor: use `pnpm pack-app` for SEA artifacts; rename `--node-version` → `--runtime`

### DIFF
--- a/.changeset/pack-app-runtime-flag.md
+++ b/.changeset/pack-app-runtime-flag.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/releasing.commands": minor
+"pnpm": minor
+---
+
+`pnpm pack-app`: replaced the `--node-version` flag with `--runtime`, which takes a `<name>@<version>` spec (e.g. `--runtime node@22.0.0`). The corresponding `pnpm.app.nodeVersion` key in package.json was renamed to `pnpm.app.runtime` with the same syntax. Only `node` is supported today; the prefix leaves room for future runtimes (`bun`, `deno`).
+
+The previous `--node-version` flag silently inherited from pnpm's global `node-version` rc setting (which controls which Node runs user scripts), causing the wrong Node build to be embedded in SEAs for users who had that rc key set.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7616,9 +7616,6 @@ importers:
       execa:
         specifier: 'catalog:'
         version: safe-execa@0.3.0
-      tar:
-        specifier: 'catalog:'
-        version: 7.5.13
     optionalDependencies:
       '@pnpm/exe.darwin-arm64':
         specifier: workspace:*

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -57,7 +57,6 @@
       "entry": "../../pnpm.cjs",
       "outputDir": "..",
       "outputName": "pnpm",
-      "nodeVersion": "25.6.1",
       "targets": [
         "win32-x64",
         "linux-x64",

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -50,8 +50,25 @@
     "@jest/globals": "catalog:",
     "@pnpm/exe": "workspace:*",
     "@pnpm/jest-config": "workspace:*",
-    "execa": "catalog:",
-    "tar": "catalog:"
+    "execa": "catalog:"
+  },
+  "pnpm": {
+    "app": {
+      "entry": "../../pnpm.cjs",
+      "outputDir": "..",
+      "outputName": "pnpm",
+      "nodeVersion": "25.6.1",
+      "targets": [
+        "win32-x64",
+        "linux-x64",
+        "darwin-x64",
+        "darwin-arm64",
+        "linux-arm64",
+        "win32-arm64",
+        "linux-x64-musl",
+        "linux-arm64-musl"
+      ]
+    }
   },
   "jest": {
     "preset": "@pnpm/jest-config"

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -1,253 +1,62 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import * as execa from 'execa'
-import fs from 'fs'
-import path from 'path'
-import { pipeline } from 'stream/promises'
-import { createGunzip } from 'zlib'
-import * as tar from 'tar'
 
-const NODE_VERSION = '25.6.1'
-const artifactsDir = path.join(import.meta.dirname, '../..')
-const pnpmDir = path.join(artifactsDir, '..')
-const nodeBinCacheDir = path.join(artifactsDir, '.node-binaries')
+// scripts/ → exe/ → artifacts/ → pnpm/
+const exeDir = path.resolve(import.meta.dirname, '..')
+const pnpmRootDir = path.resolve(exeDir, '..', '..')
 
-interface TargetConfig {
-  platform: string
-  arch: string
-  /** URL to download the Node.js binary */
-  nodeUrl: string
-  /** Path to the node binary inside the downloaded archive */
-  nodeBinPath: string
-  /** Whether this target needs ldid signing (macOS cross-compiled from Linux) */
-  needsLdidSigning: boolean
-}
+// On Intel Mac we only build the three baseline targets to keep dev-local runs
+// fast. CI (Linux) and M1 Macs produce the full eight-target matrix. The
+// defaults (entry, outputDir, outputName, nodeVersion, targets) live in the
+// "pnpm.app" object of pnpm/artifacts/exe/package.json — CLI --target flags
+// replace that list when we want to narrow it.
+const isM1Mac = process.platform === 'darwin' && process.arch === 'arm64'
+const buildFullMatrix = process.platform === 'linux' || isM1Mac
 
-function getTargets (): Record<string, TargetConfig> {
-  const v = NODE_VERSION
-  return {
-    'linux-x64': {
-      platform: 'linux',
-      arch: 'x64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-linux-x64.tar.xz`,
-      nodeBinPath: `node-v${v}-linux-x64/bin/node`,
-      needsLdidSigning: false,
-    },
-    'linux-arm64': {
-      platform: 'linux',
-      arch: 'arm64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-linux-arm64.tar.xz`,
-      nodeBinPath: `node-v${v}-linux-arm64/bin/node`,
-      needsLdidSigning: false,
-    },
-    'linux-x64-musl': {
-      platform: 'linux',
-      arch: 'x64',
-      nodeUrl: `https://unofficial-builds.nodejs.org/download/release/v${v}/node-v${v}-linux-x64-musl.tar.xz`,
-      nodeBinPath: `node-v${v}-linux-x64-musl/bin/node`,
-      needsLdidSigning: false,
-    },
-    'linux-arm64-musl': {
-      platform: 'linux',
-      arch: 'arm64',
-      nodeUrl: `https://unofficial-builds.nodejs.org/download/release/v${v}/node-v${v}-linux-arm64-musl.tar.xz`,
-      nodeBinPath: `node-v${v}-linux-arm64-musl/bin/node`,
-      needsLdidSigning: false,
-    },
-    'darwin-x64': {
-      platform: 'darwin',
-      arch: 'x64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-darwin-x64.tar.gz`,
-      nodeBinPath: `node-v${v}-darwin-x64/bin/node`,
-      needsLdidSigning: process.platform === 'linux',
-    },
-    'darwin-arm64': {
-      platform: 'darwin',
-      arch: 'arm64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-darwin-arm64.tar.gz`,
-      nodeBinPath: `node-v${v}-darwin-arm64/bin/node`,
-      needsLdidSigning: process.platform === 'linux',
-    },
-    'win32-x64': {
-      platform: 'win32',
-      arch: 'x64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-win-x64.zip`,
-      nodeBinPath: `node-v${v}-win-x64/node.exe`,
-      needsLdidSigning: false,
-    },
-    'win32-arm64': {
-      platform: 'win32',
-      arch: 'arm64',
-      nodeUrl: `https://nodejs.org/dist/v${v}/node-v${v}-win-arm64.zip`,
-      nodeBinPath: `node-v${v}-win-arm64/node.exe`,
-      needsLdidSigning: false,
-    },
+const narrowTargets = ['win32-x64', 'linux-x64', 'darwin-x64']
+
+const packAppArgs = ['pack-app']
+if (!buildFullMatrix) {
+  for (const target of narrowTargets) {
+    packAppArgs.push('--target', target)
   }
 }
 
-async function downloadNodeBinary (target: string, config: TargetConfig): Promise<string> {
-  const cacheDir = path.join(nodeBinCacheDir, target)
-  const cachedBin = path.join(cacheDir, path.basename(config.nodeBinPath))
+// Use the just-built bundle so pack-app is invoked from the same tree we're
+// releasing. runPnpmCli inside pack-app forwards through process.execPath +
+// argv[1], so nested `pnpm add node@runtime:<v>` calls also go through this
+// bundle rather than whatever pnpm happens to be on PATH.
+const pnpmBundle = path.join(pnpmRootDir, 'dist', 'pnpm.mjs')
+execa.sync(process.execPath, [pnpmBundle, ...packAppArgs], {
+  cwd: exeDir,
+  stdio: 'inherit',
+})
 
-  if (fs.existsSync(cachedBin)) {
-    console.log(`Using cached Node.js binary for ${target}`)
-    return cachedBin
-  }
+// Platform packages only contain the binary; the JS bundle ships inside
+// @pnpm/exe. Copy it here so `pn publish` picks it up from this package's
+// "files" list. Source maps are stripped (they're archived separately).
+const distSrc = path.join(pnpmRootDir, 'dist')
+const distDest = path.join(exeDir, 'dist')
+fs.rmSync(distDest, { recursive: true, force: true })
+fs.cpSync(distSrc, distDest, { recursive: true })
 
-  console.log(`Downloading Node.js binary for ${target} from ${config.nodeUrl}`)
-  fs.mkdirSync(cacheDir, { recursive: true })
-
-  const url = config.nodeUrl
-  if (url.endsWith('.zip')) {
-    // Windows: download zip and extract node.exe
-    const zipPath = path.join(cacheDir, 'node.zip')
-    const response = await fetch(url)
-    if (!response.ok) throw new Error(`Failed to download ${url}: ${response.status}`)
-    const buffer = Buffer.from(await response.arrayBuffer())
-    fs.writeFileSync(zipPath, buffer)
-
-    // Extract node.exe from zip using unzip command
-    execa.sync('unzip', ['-o', '-j', zipPath, config.nodeBinPath, '-d', cacheDir], {
-      stdio: 'inherit',
-    })
-    fs.unlinkSync(zipPath)
-  } else {
-    // Unix: download tar.gz or tar.xz and extract node binary
-    const response = await fetch(url)
-    if (!response.ok) throw new Error(`Failed to download ${url}: ${response.status}`)
-
-    const archivePath = path.join(cacheDir, 'node.tar')
-    if (url.endsWith('.tar.xz')) {
-      // xz-compressed: use xz command to decompress, then extract
-      const xzPath = path.join(cacheDir, 'node.tar.xz')
-      const buffer = Buffer.from(await response.arrayBuffer())
-      fs.writeFileSync(xzPath, buffer)
-      execa.sync('xz', ['-d', xzPath], { stdio: 'inherit' })
-      await tar.extract({
-        file: archivePath,
-        cwd: cacheDir,
-        strip: config.nodeBinPath.split('/').length - 1,
-        filter: (entryPath) => entryPath === config.nodeBinPath,
-      })
-      try { fs.unlinkSync(archivePath) } catch {}
-    } else {
-      // gzip-compressed: pipe through gunzip
-      const buffer = Buffer.from(await response.arrayBuffer())
-      fs.writeFileSync(archivePath + '.gz', buffer)
-      const readStream = fs.createReadStream(archivePath + '.gz')
-      const writeStream = fs.createWriteStream(archivePath)
-      await pipeline(readStream, createGunzip(), writeStream)
-      try { fs.unlinkSync(archivePath + '.gz') } catch {}
-      await tar.extract({
-        file: archivePath,
-        cwd: cacheDir,
-        strip: config.nodeBinPath.split('/').length - 1,
-        filter: (entryPath) => entryPath === config.nodeBinPath,
-      })
-      try { fs.unlinkSync(archivePath) } catch {}
+const removeMapFiles = (dir: string): void => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      removeMapFiles(fullPath)
+    } else if (entry.name.endsWith('.map')) {
+      fs.unlinkSync(fullPath)
     }
   }
-
-  if (!fs.existsSync(cachedBin)) {
-    throw new Error(`Failed to extract Node.js binary for ${target}: ${cachedBin} not found`)
-  }
-
-  return cachedBin
 }
+removeMapFiles(distDest)
 
-function copyDistAssets (targetDir: string): void {
-  const distSrc = path.join(pnpmDir, 'dist')
-  const distDest = path.join(targetDir, 'dist')
+// @pnpm/exe declares @reflink/reflink as a dependency, so npm installs the
+// right platform package on the consumer. Drop the bundled copies from the
+// published dist/ to avoid shipping them twice.
+fs.rmSync(path.join(distDest, 'node_modules', '@reflink'), { recursive: true, force: true })
 
-  // Remove existing dist directory
-  fs.rmSync(distDest, { recursive: true, force: true })
-
-  // Copy the dist directory
-  fs.cpSync(distSrc, distDest, { recursive: true })
-
-  // Remove source maps from the copied dist (they're archived separately)
-  const removeMapFiles = (dir: string) => {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name)
-      if (entry.isDirectory()) {
-        removeMapFiles(fullPath)
-      } else if (entry.name.endsWith('.map')) {
-        fs.unlinkSync(fullPath)
-      }
-    }
-  }
-  removeMapFiles(distDest)
-}
-
-async function build (target: string, config: TargetConfig): Promise<void> {
-  const targetDir = path.join(artifactsDir, target)
-  let artifactFile = path.join(targetDir, 'pnpm')
-  if (target.startsWith('win32-')) {
-    artifactFile += '.exe'
-  }
-
-  // Clean up existing artifact
-  try { fs.unlinkSync(artifactFile) } catch {}
-  fs.mkdirSync(targetDir, { recursive: true })
-
-  // Download the Node.js binary for this platform
-  const nodeBin = await downloadNodeBinary(target, config)
-
-  // Generate SEA config for this target
-  const seaConfig = {
-    main: path.join(pnpmDir, 'pnpm.cjs'),
-    executable: nodeBin,
-    output: artifactFile,
-    disableExperimentalSEAWarning: true,
-    useCodeCache: false,
-    useSnapshot: false,
-  }
-  const seaConfigPath = path.join(targetDir, 'sea-config.json')
-  fs.writeFileSync(seaConfigPath, JSON.stringify(seaConfig, null, 2))
-
-  // Build the SEA
-  console.log(`Building SEA for ${target}...`)
-  execa.sync('node', ['--build-sea', seaConfigPath], {
-    stdio: 'inherit',
-  })
-
-  // Clean up config
-  fs.unlinkSync(seaConfigPath)
-
-  // Sign macOS binaries
-  if (config.needsLdidSigning) {
-    console.log(`Signing macOS binary for ${target} with ldid...`)
-    execa.sync('ldid', ['-S', artifactFile], { stdio: 'inherit' })
-  } else if (config.platform === 'darwin' && process.platform === 'darwin') {
-    console.log(`Signing macOS binary for ${target} with codesign...`)
-    execa.sync('codesign', ['--sign', '-', artifactFile], { stdio: 'inherit' })
-  }
-
-  // Verifying that the artifact was created.
-  fs.statSync(artifactFile)
-  console.log(`Successfully built ${target}`)
-}
-
-;(async () => {
-  const targets = getTargets()
-
-  await build('win32-x64', targets['win32-x64'])
-  await build('linux-x64', targets['linux-x64'])
-  await build('darwin-x64', targets['darwin-x64'])
-
-  const isM1Mac = process.platform === 'darwin' && process.arch === 'arm64'
-  if (process.platform === 'linux' || isM1Mac) {
-    await build('darwin-arm64', targets['darwin-arm64'])
-    await build('linux-arm64', targets['linux-arm64'])
-    await build('win32-arm64', targets['win32-arm64'])
-    await build('linux-x64-musl', targets['linux-x64-musl'])
-    await build('linux-arm64-musl', targets['linux-arm64-musl'])
-  }
-
-  // Copy dist/ to the exe directory for npm publishing.
-  // Platform packages only contain the binary; dist/ is shipped in @pnpm/exe.
-  const exeDir = path.join(artifactsDir, 'exe')
-  copyDistAssets(exeDir)
-  // Remove all bundled reflink packages — @pnpm/exe declares @reflink/reflink
-  // as a dependency, so npm installs the right platform package automatically.
-  fs.rmSync(path.join(exeDir, 'dist', 'node_modules', '@reflink'), { recursive: true, force: true })
-  console.log('Copied dist/ to exe directory for npm publishing')
-})()
+console.log('Copied dist/ to exe directory for npm publishing')

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -17,9 +17,9 @@ const buildFullMatrix = process.platform === 'linux' || isM1Mac
 
 const narrowTargets = ['win32-x64', 'linux-x64', 'darwin-x64']
 
-// Could equivalently live under `pnpm.app.runtime` in package.json; keeping
-// it here colocates the pinned runtime with the other host-conditional build
-// logic (target narrowing) rather than splitting it across two files.
+// Could equivalently live under `pnpm.app.runtime` in package.json; kept here
+// next to the host-conditional target narrowing so the whole build matrix is
+// visible in one place.
 const EMBEDDED_RUNTIME = 'node@25.6.1'
 
 const packAppArgs = ['pack-app', '--runtime', EMBEDDED_RUNTIME]

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -17,13 +17,12 @@ const buildFullMatrix = process.platform === 'linux' || isM1Mac
 
 const narrowTargets = ['win32-x64', 'linux-x64', 'darwin-x64']
 
-// nodeVersion is passed on the CLI rather than from pnpm.app because pnpm's
-// global `node-version` rc setting (which controls which Node runs user
-// scripts) leaks into Config['nodeVersion'] and overrides pnpm.app.nodeVersion.
-// The CLI value always wins, so we pin the embedded Node explicitly here.
-const EMBEDDED_NODE_VERSION = '25.6.1'
+// Could equivalently live under `pnpm.app.runtime` in package.json; keeping
+// it here colocates the pinned runtime with the other host-conditional build
+// logic (target narrowing) rather than splitting it across two files.
+const EMBEDDED_RUNTIME = 'node@25.6.1'
 
-const packAppArgs = ['pack-app', '--node-version', EMBEDDED_NODE_VERSION]
+const packAppArgs = ['pack-app', '--runtime', EMBEDDED_RUNTIME]
 if (!buildFullMatrix) {
   for (const target of narrowTargets) {
     packAppArgs.push('--target', target)

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -20,7 +20,7 @@ const narrowTargets = ['win32-x64', 'linux-x64', 'darwin-x64']
 // Could equivalently live under `pnpm.app.runtime` in package.json; kept here
 // next to the host-conditional target narrowing so the whole build matrix is
 // visible in one place.
-const EMBEDDED_RUNTIME = 'node@25.6.1'
+const EMBEDDED_RUNTIME = 'node@25.9.0'
 
 const packAppArgs = ['pack-app', '--runtime', EMBEDDED_RUNTIME]
 if (!buildFullMatrix) {

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -9,15 +9,21 @@ const pnpmRootDir = path.resolve(exeDir, '..', '..')
 
 // On Intel Mac we only build the three baseline targets to keep dev-local runs
 // fast. CI (Linux) and M1 Macs produce the full eight-target matrix. The
-// defaults (entry, outputDir, outputName, nodeVersion, targets) live in the
-// "pnpm.app" object of pnpm/artifacts/exe/package.json — CLI --target flags
-// replace that list when we want to narrow it.
+// defaults (entry, outputDir, outputName, targets) live in the "pnpm.app"
+// object of pnpm/artifacts/exe/package.json — CLI --target flags replace that
+// list when we want to narrow it.
 const isM1Mac = process.platform === 'darwin' && process.arch === 'arm64'
 const buildFullMatrix = process.platform === 'linux' || isM1Mac
 
 const narrowTargets = ['win32-x64', 'linux-x64', 'darwin-x64']
 
-const packAppArgs = ['pack-app']
+// nodeVersion is passed on the CLI rather than from pnpm.app because pnpm's
+// global `node-version` rc setting (which controls which Node runs user
+// scripts) leaks into Config['nodeVersion'] and overrides pnpm.app.nodeVersion.
+// The CLI value always wins, so we pin the embedded Node explicitly here.
+const EMBEDDED_NODE_VERSION = '25.6.1'
+
+const packAppArgs = ['pack-app', '--node-version', EMBEDDED_NODE_VERSION]
 if (!buildFullMatrix) {
   for (const target of narrowTargets) {
     packAppArgs.push('--target', target)

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -29,7 +29,7 @@ if (!buildFullMatrix) {
 // argv[1], so nested `pnpm add node@runtime:<v>` calls also go through this
 // bundle rather than whatever pnpm happens to be on PATH.
 const pnpmBundle = path.join(pnpmRootDir, 'dist', 'pnpm.mjs')
-execa.sync(process.execPath, [pnpmBundle, ...packAppArgs], {
+execa.sync(process.execPath, [pnpmBundle, 'with', 'current', ...packAppArgs], {
   cwd: exeDir,
   stdio: 'inherit',
 })

--- a/releasing/commands/src/pack-app/packApp.ts
+++ b/releasing/commands/src/pack-app/packApp.ts
@@ -44,7 +44,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return {
     entry: String,
     target: [String, Array],
-    'node-version': String,
+    runtime: String,
     'output-dir': String,
     'output-name': String,
   }
@@ -64,13 +64,13 @@ export function help (): string {
       'the injection. The running Node.js is used when it is new enough; otherwise, the ' +
       `latest Node.js v${MIN_BUILDER_VERSION.major}.${MIN_BUILDER_VERSION.minor}+ in the ` +
       `v${MIN_BUILDER_VERSION.major}.x line is downloaded automatically.\n\n` +
-      'Defaults for --entry, --target, --node-version, --output-dir, and --output-name can be ' +
+      'Defaults for --entry, --target, --runtime, --output-dir, and --output-name can be ' +
       'set in the package.json under "pnpm.app". CLI flags override the config; --target entirely ' +
       'replaces the configured list so you can narrow it at invocation time.',
     url: docsUrl('pack-app'),
     usages: [
       'pnpm pack-app --entry dist/index.cjs --target linux-x64 --target win32-x64',
-      'pnpm pack-app --entry dist/index.cjs --target linux-x64-musl --node-version 22',
+      'pnpm pack-app --entry dist/index.cjs --target linux-x64-musl --runtime node@22',
     ],
     descriptionLists: [
       {
@@ -88,9 +88,10 @@ export function help (): string {
           },
           {
             description:
-              'Node.js version to embed in the output executables (e.g. "22", "22.0.0", "lts"). ' +
+              'Runtime to embed in the output executables, as a "<name>@<version>" spec ' +
+              '(e.g. "node@22", "node@22.0.0", "node@lts"). Only "node" is supported today. ' +
               'Defaults to the running Node.js version.',
-            name: '--node-version',
+            name: '--runtime',
           },
           {
             description: 'Output directory for the built executables. Defaults to "dist-app".',
@@ -126,7 +127,7 @@ export type PackAppOptions = Pick<Config,
 >> & {
   entry?: string
   target?: string | string[]
-  nodeVersion?: string
+  runtime?: string
   outputDir?: string
   outputName?: string
 }
@@ -171,11 +172,16 @@ export async function handler (opts: PackAppOptions, params: string[]): Promise<
   }
   const targets = rawTargets.map(parseTarget)
 
+  // Parse the runtime up front — before any I/O or output-name derivation —
+  // so a malformed --runtime fails fast with a clear error instead of being
+  // masked by later problems (missing package.json name, etc.).
+  const runtimeSpec = opts.runtime ?? project.app?.runtime ?? `node@${process.version.slice(1)}`
+  const { version: requestedNodeSpec } = parseRuntime(runtimeSpec)
+
   const outputDir = path.resolve(opts.dir, opts.outputDir ?? project.app?.outputDir ?? 'dist-app')
   await mkdir(outputDir, { recursive: true })
 
   const outputName = validateOutputName(opts.outputName ?? project.app?.outputName ?? deriveOutputNameFromPackage(project, opts.dir))
-  const requestedNodeSpec = opts.nodeVersion ?? project.app?.nodeVersion ?? process.version.slice(1)
 
   const fetch = createFetchFromRegistry(opts)
   const buildRoot = path.join(opts.pnpmHomeDir, 'pack-app')
@@ -369,6 +375,29 @@ function parseTarget (raw: string): ParsedTarget {
   return { raw, platform, arch, libc: libc || undefined }
 }
 
+// Runtime spec is "<name>@<version>". Only "node" is supported today; the
+// prefix is kept so future runtimes (bun, deno) can share the same flag
+// without a breaking change. Reading the runtime name rather than a bare
+// version also avoids shadowing pnpm's global `node-version` rc setting,
+// whose value would otherwise leak into Config['nodeVersion'] and override
+// `pnpm.app.runtime`.
+const SUPPORTED_RUNTIMES = ['node'] as const
+const RUNTIME_PATTERN = /^(node)@(.+)$/
+
+interface ParsedRuntime {
+  name: typeof SUPPORTED_RUNTIMES[number]
+  version: string
+}
+
+function parseRuntime (spec: string): ParsedRuntime {
+  const match = RUNTIME_PATTERN.exec(spec)
+  if (!match) {
+    throw new PnpmError('PACK_APP_INVALID_RUNTIME',
+      `Invalid runtime "${spec}". Expected format: <name>@<version> (supported runtimes: ${SUPPORTED_RUNTIMES.join(', ')}; e.g. "node@22.0.0", "node@lts").`)
+  }
+  return { name: match[1] as ParsedRuntime['name'], version: match[2] }
+}
+
 // Characters that Win32 rejects in filenames, plus NUL. Path separators are
 // checked separately via `path.basename` so the message is crisp.
 const INVALID_FILENAME_CHARS = /[<>:"|?*\0]/
@@ -398,7 +427,7 @@ function validateOutputName (name: string): string {
 export interface ProjectAppConfig {
   entry?: string
   targets?: string[]
-  nodeVersion?: string
+  runtime?: string
   outputDir?: string
   outputName?: string
 }
@@ -436,7 +465,7 @@ async function readProjectAppConfig (dir: string): Promise<ReadProjectAppConfigR
 }
 
 function validateAppConfig (raw: Record<string, unknown>): ProjectAppConfig {
-  const known = new Set(['entry', 'targets', 'nodeVersion', 'outputDir', 'outputName'])
+  const known = new Set(['entry', 'targets', 'runtime', 'outputDir', 'outputName'])
   for (const key of Object.keys(raw)) {
     if (!known.has(key)) {
       throw new PnpmError('PACK_APP_INVALID_CONFIG',
@@ -456,11 +485,11 @@ function validateAppConfig (raw: Record<string, unknown>): ProjectAppConfig {
     }
     config.targets = raw.targets
   }
-  if (raw.nodeVersion != null) {
-    if (typeof raw.nodeVersion !== 'string') {
-      throw new PnpmError('PACK_APP_INVALID_CONFIG', '"pnpm.app.nodeVersion" must be a string.')
+  if (raw.runtime != null) {
+    if (typeof raw.runtime !== 'string') {
+      throw new PnpmError('PACK_APP_INVALID_CONFIG', '"pnpm.app.runtime" must be a string.')
     }
-    config.nodeVersion = raw.nodeVersion
+    config.runtime = raw.runtime
   }
   if (raw.outputDir != null) {
     if (typeof raw.outputDir !== 'string') {

--- a/releasing/commands/src/pack-app/packApp.ts
+++ b/releasing/commands/src/pack-app/packApp.ts
@@ -172,9 +172,9 @@ export async function handler (opts: PackAppOptions, params: string[]): Promise<
   }
   const targets = rawTargets.map(parseTarget)
 
-  // Parse the runtime up front — before any I/O or output-name derivation —
-  // so a malformed --runtime fails fast with a clear error instead of being
-  // masked by later problems (missing package.json name, etc.).
+  // Parse the runtime before output-name derivation and any network work so
+  // that a malformed --runtime fails fast with a clear error instead of being
+  // masked by later problems (missing package.json name, registry lookup, etc.).
   const runtimeSpec = opts.runtime ?? project.app?.runtime ?? `node@${process.version.slice(1)}`
   const { version: requestedNodeSpec } = parseRuntime(runtimeSpec)
 

--- a/releasing/commands/test/pack-app/index.test.ts
+++ b/releasing/commands/test/pack-app/index.test.ts
@@ -29,7 +29,7 @@ describe('pack-app command', () => {
     const types = cliOptionsTypes()
     expect(types.entry).toBe(String)
     expect(types.target).toEqual([String, Array])
-    expect(types['node-version']).toBe(String)
+    expect(types.runtime).toBe(String)
     expect(types['output-dir']).toBe(String)
     expect(types['output-name']).toBe(String)
   })
@@ -114,7 +114,7 @@ describe('pack-app command', () => {
     fs.writeFileSync(path.join(tempDir, 'entry.cjs'), 'module.exports = {}')
     await expect(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handler({ ...baseOpts(), target: 'linux-x64', nodeVersion: '0.0.0-nonexistent-xxx' } as any, [])
+      handler({ ...baseOpts(), target: 'linux-x64', runtime: 'node@0.0.0-nonexistent-xxx' } as any, [])
     ).rejects.toMatchObject({ code: expect.not.stringMatching(/INVALID_TARGET/) })
   })
 
@@ -134,7 +134,7 @@ describe('pack-app command', () => {
     ['entry as number', { entry: 42 }],
     ['targets as string', { targets: 'linux-x64' }],
     ['targets with non-string', { targets: ['linux-x64', 7] }],
-    ['nodeVersion as array', { nodeVersion: ['25'] }],
+    ['runtime as array', { runtime: ['node@25'] }],
   ])('rejects malformed pnpm.app: %s', async (_label, appConfig) => {
     fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({
       name: 'test-app',
@@ -173,6 +173,21 @@ describe('pack-app command', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       handler({ ...baseOpts(), entry: 'entry.cjs', target } as any, [])
     ).rejects.toMatchObject({ code: 'ERR_PNPM_PACK_APP_INVALID_TARGET' })
+  })
+
+  it.each([
+    ['no prefix', '22'],
+    ['no prefix with full version', '22.0.0'],
+    ['unknown runtime', 'bun@1.0.0'],
+    ['empty version', 'node@'],
+    ['just @', '@'],
+    ['uppercase runtime', 'NODE@22'],
+  ])('rejects invalid --runtime: %s (%s)', async (_label, runtime) => {
+    fs.writeFileSync(path.join(tempDir, 'entry.cjs'), 'module.exports = {}')
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handler({ ...baseOpts(), entry: 'entry.cjs', target: 'linux-x64', runtime } as any, [])
+    ).rejects.toMatchObject({ code: 'ERR_PNPM_PACK_APP_INVALID_RUNTIME' })
   })
 
   it.each([


### PR DESCRIPTION
## Summary

- **@pnpm/exe build tooling**: Replace the 253-line hand-rolled SEA builder in `pnpm/artifacts/exe/scripts/build-artifacts.ts` with a thin ~60-line driver that delegates to the new `pnpm pack-app` command (shipped in #11312). Per-platform defaults (entry, outputDir, outputName, targets) move to `pnpm.app` in `pnpm/artifacts/exe/package.json`.
- **pack-app CLI (breaking, unreleased)**: Rename `--node-version <v>` → `--runtime <name>@<v>`, and `pnpm.app.nodeVersion` → `pnpm.app.runtime`. Only `node@<v>` is accepted today; the `<name>@` prefix reserves room for `bun` / `deno` without a future breaking change.
- **Embedded Node**: Pin `node@25.9.0` in the build-artifacts driver.

## Why the rename

pack-app's old `--node-version` flag silently inherited from pnpm's global `node-version` rc setting (which controls which Node pnpm uses to run user scripts). That value leaked into `Config['nodeVersion']` and overrode `pnpm.app.nodeVersion`, causing the wrong Node build to be embedded in SEAs for users who had the rc key set — reproduced locally, where `linux-arm64-musl` failed entirely because Node 22.13.0 has no arm64-musl variant. `runtime` doesn't collide with any Config field, so CLI / `pnpm.app` / running-Node precedence now behaves as intended.

## Behavior parity with the old script

- Same output paths: `pnpm/artifacts/<target>/pnpm` (or `pnpm.exe` for `win32-*`).
- Same signing (pack-app uses `codesign` natively on macOS, `ldid` when cross-signing from Linux).
- Same host-based target narrowing: Linux/M1 Mac build the full 8-target matrix; Intel Mac builds only `win32-x64`, `linux-x64`, `darwin-x64`.
- Same `dist/` copy + `@reflink/*` prune into `pnpm/artifacts/exe/dist/` for npm publishing.
- Same bundle-first step (`pn --filter=pnpm prepublishOnly &&` prefix is unchanged in the `build-artifacts` npm script).

## Test plan

- [x] `pnpm --filter=@pnpm/releasing.commands test` — 250 pack-app tests pass (including 6 new `--runtime` validation cases).
- [x] `pnpm run lint:meta` clean.
- [x] `pnpm run spellcheck` clean.
- [x] End-to-end: `pn --filter=@pnpm/exe run build-artifacts` on M1 Mac produced all 8 targets with `node@25.6.1`. The 25.6.1 → 25.9.0 bump is a trivial string change; not re-run end-to-end, but CI should exercise it.
- [x] `--runtime bun@1.0.0` rejected with `ERR_PNPM_PACK_APP_INVALID_RUNTIME` and a clear message listing supported runtimes.
- [ ] CI (Linux) produces all 8 targets with Node.js 25.9.0 embedded.
- [ ] Next release workflow publishes `@pnpm/exe` with `dist/` included and no bundled `@reflink/*` subfolder.