### PR TITLE
feat: add registryOverrides setting for per-package registry selection

### DIFF
--- a/.changeset/registry-overrides.md
+++ b/.changeset/registry-overrides.md
@@ -1,0 +1,25 @@
+---
+"@pnpm/types": minor
+"@pnpm/config.pick-registry-for-package": minor
+"@pnpm/config.reader": minor
+"@pnpm/resolving.npm-resolver": minor
+"@pnpm/deps.inspection.outdated": minor
+"@pnpm/deps.inspection.commands": minor
+"@pnpm/installing.env-installer": minor
+"@pnpm/registry-access.commands": minor
+"@pnpm/releasing.commands": minor
+"@pnpm/store.connection-manager": minor
+"pnpm": minor
+---
+
+Added a new `registryOverrides` setting for mixing public and private packages within the same scope. A package whose exact name matches a key in `registryOverrides` is resolved from the given registry URL, taking precedence over the scope's entry in `registries`. `pnpm publish` on an overridden package also targets the override URL. Authentication is picked up from the existing per-URL `.npmrc` entries (e.g. `//npm.pkg.github.com/:_authToken=...`), so no separate auth mechanism is required.
+
+Example in `pnpm-workspace.yaml`:
+
+```yaml
+registryOverrides:
+  "@foo/private-lib": https://npm.pkg.github.com/
+  "@foo/internal-tools": https://npm.pkg.github.com/
+```
+
+With this, `@foo/public` still resolves from the default registry (or whatever `@foo:registry` is set to), while `@foo/private-lib` and `@foo/internal-tools` are fetched from GitHub Packages.

--- a/config/pick-registry-for-package/README.md
+++ b/config/pick-registry-for-package/README.md
@@ -8,6 +8,58 @@
 pnpm add @pnpm/pick-registry-for-package
 ```
 
+## API
+
+```ts
+import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+
+pickRegistryForPackage(
+  registries,         // { default: string, [scope: string]: string }
+  packageName,        // e.g. '@foo/bar' or 'lodash' — can be a local alias
+  bareSpecifier?,     // e.g. 'npm:@foo/bar@1.2.3' (for aliased deps)
+  registryOverrides?, // { [exactPackageName: string]: string }
+): string
+```
+
+Resolution order:
+
+1. If `registryOverrides` contains an exact match for the real package name,
+   that URL is returned. This is how the `registryOverrides` setting from
+   `pnpm-workspace.yaml` lets a single package in a scope (e.g. `@foo/private`)
+   be served from a different registry than the rest of the scope.
+2. Otherwise, if the (resolved) package name is scoped and that scope is a key
+   in `registries`, the scope's registry URL is returned.
+3. Otherwise, `registries.default` is returned.
+
+When `bareSpecifier` is an `npm:` aliased specifier (e.g. `npm:@foo/private@1`),
+the real package name is extracted from the specifier for both the override
+lookup and the scope lookup.
+
+## Interactions with other registry-selection mechanisms
+
+`pickRegistryForPackage` is not the only thing that can influence which
+registry pnpm talks to for a given package. The full precedence, from highest
+to lowest, is:
+
+1. **Custom resolvers in `.pnpmfile.cjs`** — run before pnpm's built-in
+   resolution and can bypass registries entirely (see `CustomResolver` in
+   `@pnpm/hooks.types`).
+2. **`publishConfig.registry` in `package.json`** — only consulted for publish
+   operations; wins over `registryOverrides` during `pnpm publish`.
+3. **`registryOverrides`** — introduced by this package; exact-name lookup.
+4. **`registries[@scope]`** — npm-style scoped registry from `.npmrc` or
+   `pnpm-workspace.yaml`.
+5. **`registries.default`** — the default registry.
+
+## Auth
+
+The override does not introduce a new auth mechanism. Auth headers are looked
+up by URL via `createGetAuthHeaderByURI` (`@pnpm/network.auth-header`), which
+uses the same `nerfDart`-normalized `.npmrc` entries (`//host/:_authToken=...`,
+`//host/:_auth=...`, `//host/:tokenHelper=...`, TLS certs, etc.). As long as
+the override URL has credentials configured in `.npmrc`, no additional
+configuration is required.
+
 ## License
 
 [MIT](LICENSE)

--- a/config/pick-registry-for-package/src/index.ts
+++ b/config/pick-registry-for-package/src/index.ts
@@ -1,19 +1,56 @@
 import type { Registries } from '@pnpm/types'
 
-export function pickRegistryForPackage (registries: Registries, packageName: string, bareSpecifier?: string): string {
-  const scope = getScope(packageName, bareSpecifier)
+/**
+ * Picks the registry URL that should be used to resolve the given package.
+ *
+ * Resolution order:
+ *   1. An exact match in `registryOverrides` (keyed by the real package name,
+ *      derived from `npm:` aliases when applicable) wins. This is how the
+ *      `registryOverrides` setting lets a single package in a scope be served
+ *      from a different registry than the rest of the scope.
+ *   2. Otherwise, if the package is scoped and the scope is a key in
+ *      `registries`, the scope's registry is returned.
+ *   3. Otherwise, `registries.default` is returned.
+ *
+ * Note: this function only decides the registry URL. It does not run before
+ * custom resolvers configured in `.pnpmfile.cjs` — those still take precedence
+ * in the overall resolution chain (see `@pnpm/resolving.default-resolver`).
+ * Authentication for the returned URL is looked up separately by
+ * `createGetAuthHeaderByURI` using the existing per-URL `.npmrc` entries.
+ */
+export function pickRegistryForPackage (
+  registries: Registries,
+  packageName: string,
+  bareSpecifier?: string,
+  registryOverrides?: Record<string, string>
+): string {
+  const realName = getRealPackageName(packageName, bareSpecifier)
+  if (registryOverrides?.[realName]) return registryOverrides[realName]
+  const scope = getScopeFromName(realName)
   return (scope && registries[scope]) ?? registries.default
 }
 
-function getScope (pkgName: string, bareSpecifier?: string): string | null {
+/**
+ * Returns the canonical package name for a dependency. For `npm:`-aliased
+ * specifiers (e.g. `npm:@foo/pkg@1.2.3`), this extracts the original name
+ * (`@foo/pkg`) so that the override lookup and scope lookup match the real
+ * package rather than the local alias.
+ */
+function getRealPackageName (pkgName: string, bareSpecifier?: string): string {
   if (bareSpecifier?.startsWith('npm:')) {
-    bareSpecifier = bareSpecifier.slice(4)
-    if (bareSpecifier[0] === '@') {
-      return bareSpecifier.substring(0, bareSpecifier.indexOf('/'))
-    }
+    const rest = bareSpecifier.slice(4)
+    if (rest === '') return pkgName
+    // Strip the version tail: "@foo/pkg@1.2.3" -> "@foo/pkg", "pkg@1.2.3" -> "pkg".
+    // In a scoped name, the name-version separator is the second '@'.
+    const versionAt = rest.indexOf('@', rest[0] === '@' ? 1 : 0)
+    if (versionAt === 0) return pkgName
+    return versionAt > 0 ? rest.slice(0, versionAt) : rest
   }
-  if (pkgName[0] === '@') {
-    return pkgName.substring(0, pkgName.indexOf('/'))
-  }
-  return null
+  return pkgName
+}
+
+function getScopeFromName (pkgName: string): string | null {
+  if (pkgName[0] !== '@') return null
+  const slashIdx = pkgName.indexOf('/')
+  return slashIdx > 0 ? pkgName.substring(0, slashIdx) : null
 }

--- a/config/pick-registry-for-package/test/index.spec.ts
+++ b/config/pick-registry-for-package/test/index.spec.ts
@@ -9,3 +9,71 @@ test('pick correct scope', () => {
   expect(pickRegistryForPackage(registries, '@random/lodash')).toBe('https://registry.npmjs.org/')
   expect(pickRegistryForPackage(registries, '@random/lodash', 'npm:@private/lodash@1')).toBe('https://private.registry.com/')
 })
+
+describe('registryOverrides', () => {
+  const registries = {
+    default: 'https://registry.npmjs.org/',
+    '@foo': 'https://registry.npmjs.org/',
+  }
+
+  test('per-package override beats scope registry', () => {
+    const overrides = { '@foo/private-lib': 'https://npm.pkg.github.com/' }
+    expect(pickRegistryForPackage(registries, '@foo/private-lib', undefined, overrides))
+      .toBe('https://npm.pkg.github.com/')
+  })
+
+  test('unmatched package in overridden scope still uses scope registry', () => {
+    const overrides = { '@foo/private-lib': 'https://npm.pkg.github.com/' }
+    expect(pickRegistryForPackage(registries, '@foo/public-lib', undefined, overrides))
+      .toBe('https://registry.npmjs.org/')
+  })
+
+  test('per-package override works for unscoped packages', () => {
+    const overrides = { 'my-private-lib': 'https://private.example.com/' }
+    expect(pickRegistryForPackage(registries, 'my-private-lib', undefined, overrides))
+      .toBe('https://private.example.com/')
+  })
+
+  test('override matches real package name via npm: aliasing', () => {
+    const overrides = { '@foo/private-lib': 'https://npm.pkg.github.com/' }
+    expect(pickRegistryForPackage(registries, 'local-alias', 'npm:@foo/private-lib@1.0.0', overrides))
+      .toBe('https://npm.pkg.github.com/')
+  })
+
+  test('falls through to scope/default when override map is empty or undefined', () => {
+    expect(pickRegistryForPackage(registries, '@foo/private-lib', undefined, {}))
+      .toBe('https://registry.npmjs.org/')
+    expect(pickRegistryForPackage(registries, '@foo/private-lib'))
+      .toBe('https://registry.npmjs.org/')
+  })
+
+  test('falls through when package name does not match override key', () => {
+    const overrides = { '@foo/other': 'https://other.example.com/' }
+    expect(pickRegistryForPackage(registries, '@foo/private-lib', undefined, overrides))
+      .toBe('https://registry.npmjs.org/')
+  })
+
+  test('malformed npm: specifier does not match the empty-string override key', () => {
+    // "npm:" with no package body must not accidentally look up overrides[''].
+    const overrides = { '': 'https://should-not-be-used.example.com/' }
+    expect(pickRegistryForPackage(registries, 'my-pkg', 'npm:', overrides))
+      .toBe('https://registry.npmjs.org/')
+  })
+
+  test('npm: specifier with a leading @ but no version does not collapse to empty', () => {
+    // "npm:@foo/pkg" (no @version) must resolve to the full name for override lookup.
+    const overrides = { '@foo/pkg': 'https://override.example.com/' }
+    expect(pickRegistryForPackage(registries, 'alias', 'npm:@foo/pkg', overrides))
+      .toBe('https://override.example.com/')
+  })
+
+  test('override on unscoped package does not mask scope registry lookups', () => {
+    const withScope = {
+      default: 'https://registry.npmjs.org/',
+      '@bar': 'https://bar.example.com/',
+    }
+    const overrides = { 'lodash': 'https://override.example.com/' }
+    expect(pickRegistryForPackage(withScope, '@bar/thing', undefined, overrides))
+      .toBe('https://bar.example.com/')
+  })
+})

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -23,6 +23,7 @@ export type OptionsFromRootManifest = {
   supportedArchitectures?: SupportedArchitectures
   allowBuilds?: Record<string, boolean | string>
   requiredScripts?: string[]
+  registryOverrides?: Record<string, string>
 } & Pick<PnpmSettings, 'configDependencies' | 'auditConfig' | 'agent' | 'updateConfig'>
 
 export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnpmSettings: PnpmSettings, manifest?: ProjectManifest): OptionsFromRootManifest {

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -445,6 +445,19 @@ export async function getConfig (opts: {
       pnpmConfig.registries[scope] = normalizeRegistryUrl(url)
     }
   }
+  if (pnpmConfig.registryOverrides) {
+    const normalized: Record<string, string> = {}
+    for (const [pkgName, url] of Object.entries(pnpmConfig.registryOverrides)) {
+      if (typeof url === 'string' && url !== '') {
+        normalized[pkgName] = normalizeRegistryUrl(url)
+      }
+    }
+    if (Object.keys(normalized).length === 0) {
+      delete pnpmConfig.registryOverrides
+    } else {
+      pnpmConfig.registryOverrides = normalized
+    }
+  }
 
   // omit some schema that the custom parser can't yet handle
   const envPnpmTypes = omit([

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -31,3 +31,14 @@ test('getOptionsFromPnpmSettings() converts allowBuilds', () => {
     },
   })
 })
+
+test('getOptionsFromPnpmSettings() passes registryOverrides through', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    registryOverrides: {
+      '@foo/private-lib': 'https://npm.pkg.github.com/',
+    },
+  })
+  expect(options.registryOverrides).toStrictEqual({
+    '@foo/private-lib': 'https://npm.pkg.github.com/',
+  })
+})

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -434,6 +434,57 @@ test('when using --global, linkWorkspacePackages, sharedWorkspaceLockfile and lo
   }
 })
 
+test('registryOverrides from pnpm-workspace.yaml are read and URL-normalized', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registryOverrides: {
+      '@foo/private-lib': 'https://npm.pkg.github.com',
+      '@foo/internal': 'https://npm.pkg.github.com:443',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {
+      global: false,
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  // normalize-registry-url adds a trailing slash and strips default ports.
+  expect(config.registryOverrides).toStrictEqual({
+    '@foo/private-lib': 'https://npm.pkg.github.com/',
+    '@foo/internal': 'https://npm.pkg.github.com/',
+  })
+})
+
+test('registryOverrides is dropped when all entries are empty or invalid', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registryOverrides: {
+      '@foo/x': '',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {
+      global: false,
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.registryOverrides).toBeUndefined()
+})
+
 test('registries of scoped packages are read and normalized', async () => {
   const { config } = await getConfig({
     cliOptions: {

--- a/core/types/src/package.ts
+++ b/core/types/src/package.ts
@@ -171,6 +171,14 @@ export interface AuditConfig {
 export interface PnpmSettings {
   npmrcAuthFile?: string
   registries?: Registries
+  /**
+   * Per-package registry overrides. Keys are exact package names (including scope)
+   * and values are registry URLs. An override takes precedence over the scope-based
+   * registry lookup in `registries`, allowing mixing of public and private packages
+   * within the same scope (e.g. some `@foo/*` packages from GitHub Packages,
+   * others from the default npm registry).
+   */
+  registryOverrides?: Record<string, string>
   configDependencies?: ConfigDependencies
   allowBuilds?: Record<string, boolean | string>
   overrides?: Record<string, string>

--- a/deps/inspection/commands/src/fetchPackageInfo.ts
+++ b/deps/inspection/commands/src/fetchPackageInfo.ts
@@ -50,7 +50,7 @@ export async function fetchPackageInfo (
     fetchSpec: subSpec?.fetchSpec ?? 'latest',
     type: specType,
   }
-  const registry = pickRegistryForPackage(opts.registries, packageName)
+  const registry = pickRegistryForPackage(opts.registries, packageName, undefined, opts.registryOverrides)
   const fetchFromRegistry = createFetchFromRegistry(opts)
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {}, opts.registries?.default)
   const fetchResult = await fetchMetadataFromFromRegistry(

--- a/deps/inspection/outdated/src/outdated.ts
+++ b/deps/inspection/outdated/src/outdated.ts
@@ -59,6 +59,7 @@ export async function outdated (
     minimumReleaseAgeExclude?: string[]
     prefix: string
     registries: Registries
+    registryOverrides?: Record<string, string>
     wantedLockfile: LockfileObject | null
   }
 ): Promise<OutdatedPackage[]> {
@@ -139,7 +140,7 @@ export async function outdated (
           // it means that the package is not from a npm-compatible registry.
           // In that case, we can't check whether the package is up-to-date
           if (
-            parseBareSpecifier(bareSpecifier, alias, 'latest', pickRegistryForPackage(opts.registries, name)) == null
+            parseBareSpecifier(bareSpecifier, alias, 'latest', pickRegistryForPackage(opts.registries, name, undefined, opts.registryOverrides)) == null
           ) {
             if (current !== wanted) {
               outdated.push({

--- a/deps/inspection/outdated/src/outdatedDepsOfProjects.ts
+++ b/deps/inspection/outdated/src/outdatedDepsOfProjects.ts
@@ -62,6 +62,7 @@ export async function outdatedDepsOfProjects (
       minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
       prefix: rootDir,
       registries: opts.registries,
+      registryOverrides: opts.registryOverrides,
       wantedLockfile,
     })
   }))

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -20,6 +20,7 @@ import type { NormalizedConfigDep } from './parseIntegrity.js'
 export interface InstallConfigDepsOpts {
   frozenLockfile?: boolean
   registries: Registries
+  registryOverrides?: Record<string, string>
   rootDir: string
   store: StoreController
   storeDir: string
@@ -95,14 +96,14 @@ async function normalizeForInstall (
 ): Promise<Record<string, NormalizedConfigDep>> {
   // If it's a EnvLockfile object (has lockfileVersion), use it directly
   if (isEnvLockfile(configDepsOrLockfile)) {
-    return normalizeFromLockfile(configDepsOrLockfile, opts.registries)
+    return normalizeFromLockfile(configDepsOrLockfile, opts.registries, opts.registryOverrides)
   }
 
   // It's ConfigDependencies from workspace manifest.
   // Try to read the env lockfile first.
   const envLockfile = await readEnvLockfile(opts.rootDir)
   if (envLockfile) {
-    return normalizeFromLockfile(envLockfile, opts.registries)
+    return normalizeFromLockfile(envLockfile, opts.registries, opts.registryOverrides)
   }
 
   // No env lockfile yet — migrate from old inline integrity format
@@ -127,7 +128,8 @@ function isEnvLockfile (obj: ConfigDependencies | EnvLockfile): obj is EnvLockfi
 
 function normalizeFromLockfile (
   lockfile: EnvLockfile,
-  registries: Registries
+  registries: Registries,
+  registryOverrides?: Record<string, string>
 ): Record<string, NormalizedConfigDep> {
   const deps: Record<string, NormalizedConfigDep> = {}
   const configDeps = lockfile.importers['.']?.configDependencies ?? {}
@@ -148,7 +150,7 @@ function normalizeFromLockfile (
         `pnpm-lock.yaml is corrupted or incomplete: missing integrity for "${pkgKey}"`
       )
     }
-    const registry = pickRegistryForPackage(registries, pkgName)
+    const registry = pickRegistryForPackage(registries, pkgName, undefined, registryOverrides)
     deps[pkgName] = {
       version,
       resolution: {

--- a/installing/env-installer/src/migrateConfigDeps.ts
+++ b/installing/env-installer/src/migrateConfigDeps.ts
@@ -11,6 +11,7 @@ import { parseIntegrity } from './parseIntegrity.js'
 
 interface MigrateOpts {
   registries: Registries
+  registryOverrides?: Record<string, string>
   rootDir: string
 }
 
@@ -30,7 +31,7 @@ export async function migrateConfigDepsToLockfile (
   const normalizedDeps: Record<string, NormalizedConfigDep> = {}
 
   for (const [pkgName, pkgSpec] of Object.entries(configDeps)) {
-    const registry = pickRegistryForPackage(opts.registries, pkgName)
+    const registry = pickRegistryForPackage(opts.registries, pkgName, undefined, opts.registryOverrides)
 
     if (typeof pkgSpec === 'object') {
       const { version, integrity } = parseIntegrity(pkgName, pkgSpec.integrity)

--- a/installing/env-installer/src/resolveAndInstallConfigDeps.ts
+++ b/installing/env-installer/src/resolveAndInstallConfigDeps.ts
@@ -44,7 +44,7 @@ export async function resolveAndInstallConfigDeps (
     if (typeof value === 'object') {
       // Old object format — migrate inline into lockfile
       if (!lockfileConfigDeps[name]) {
-        const registry = pickRegistryForPackage(opts.registries, name)
+        const registry = pickRegistryForPackage(opts.registries, name, undefined, opts.registryOverrides)
         const { version, integrity } = parseIntegrity(name, value.integrity)
         const tarball = value.tarball ?? getNpmTarballUrl(name, version, { registry })
         const pkgKey = `${name}@${version}`
@@ -61,7 +61,7 @@ export async function resolveAndInstallConfigDeps (
     if (value.includes('+')) {
       // Old string format with inline integrity — migrate into lockfile
       if (!lockfileConfigDeps[name]) {
-        const registry = pickRegistryForPackage(opts.registries, name)
+        const registry = pickRegistryForPackage(opts.registries, name, undefined, opts.registryOverrides)
         const { version, integrity } = parseIntegrity(name, value)
         const tarball = getNpmTarballUrl(name, version, { registry })
         const pkgKey = `${name}@${version}`
@@ -117,7 +117,7 @@ export async function resolveAndInstallConfigDeps (
       throw new PnpmError('BAD_CONFIG_DEP', `Cannot resolve ${name}@${specifier} as a configuration dependency because it has no integrity`)
     }
     const version = resolution.manifest.version
-    const registry = pickRegistryForPackage(opts.registries, name)
+    const registry = pickRegistryForPackage(opts.registries, name, undefined, opts.registryOverrides)
     const pkgKey = `${name}@${version}`
 
     lockfileConfigDeps[name] = {

--- a/installing/env-installer/src/resolveConfigDeps.ts
+++ b/installing/env-installer/src/resolveConfigDeps.ts
@@ -50,7 +50,7 @@ export async function resolveConfigDeps (configDeps: string[], opts: ResolveConf
     }
     const pkgName = wantedDep.alias
     const version = resolution.manifest.version
-    const registry = pickRegistryForPackage(opts.registries, pkgName)
+    const registry = pickRegistryForPackage(opts.registries, pkgName, undefined, opts.registryOverrides)
 
     // Write clean specifier to workspace manifest
     configDependencySpecifiers[pkgName] = wantedDep.bareSpecifier ?? version

--- a/registry-access/commands/src/deprecation/common.ts
+++ b/registry-access/commands/src/deprecation/common.ts
@@ -24,6 +24,7 @@ export interface DeprecateOptions extends CreateFetchFromRegistryOptions {
   }
   configByUri?: Record<string, RegistryConfig>
   registries?: Registries
+  registryOverrides?: Record<string, string>
 }
 
 interface UpdateDeprecationOptions {
@@ -36,7 +37,7 @@ export async function updateDeprecation (
   opts: DeprecateOptions,
   { deprecated, packageName, versionRange }: UpdateDeprecationOptions
 ): Promise<string> {
-  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
 
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {}, registryUrl)
 

--- a/registry-access/commands/src/distTag.ts
+++ b/registry-access/commands/src/distTag.ts
@@ -73,6 +73,7 @@ export interface DistTagOptions extends CreateFetchFromRegistryOptions {
   }
   configByUri?: Record<string, RegistryConfig>
   registries?: Registries
+  registryOverrides?: Record<string, string>
 }
 
 export async function handler (
@@ -103,7 +104,7 @@ async function distTagLs (
   }
 
   const packageName = params[0]
-  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
   const authHeader = getAuthHeaderForRegistry(opts.configByUri, registryUrl)
   const fetchFromRegistry = createFetchFromRegistry(opts)
 
@@ -136,7 +137,7 @@ async function distTagAdd (
 
   const tag = params[1] ?? 'latest'
 
-  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
   const authHeader = getAuthHeaderForRegistry(opts.configByUri, registryUrl)
   const fetchFromRegistry = createFetchFromRegistry(opts)
   const otp = opts.cliOptions?.otp
@@ -174,7 +175,7 @@ async function distTagRm (
     throw new PnpmError('DIST_TAG_RM_LATEST', 'Removing the "latest" dist-tag is not allowed')
   }
 
-  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
   const authHeader = getAuthHeaderForRegistry(opts.configByUri, registryUrl)
   const fetchFromRegistry = createFetchFromRegistry(opts)
   const otp = opts.cliOptions?.otp

--- a/registry-access/commands/src/star/common.ts
+++ b/registry-access/commands/src/star/common.ts
@@ -20,6 +20,7 @@ export function rcOptionsTypes (): Record<string, unknown> {
 export interface StarOptions extends CreateFetchFromRegistryOptions {
   configByUri?: Record<string, RegistryConfig>
   registries?: Registries
+  registryOverrides?: Record<string, string>
 }
 
 interface StarActionArgs {
@@ -36,7 +37,7 @@ interface PackumentWithStars {
 export async function performStarAction (opts: StarOptions, { packageName, star }: StarActionArgs): Promise<void> {
   const { escapedName } = parsePackageSpec(packageName)
   const registryUrl = normalizeRegistryUrl(
-    pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+    pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
   )
   const authHeader = getAuthHeaderForRegistry(opts.configByUri, registryUrl)
   const action = star ? 'star' : 'unstar'

--- a/registry-access/commands/src/unpublish.ts
+++ b/registry-access/commands/src/unpublish.ts
@@ -59,6 +59,7 @@ export interface UnpublishOptions extends CreateFetchFromRegistryOptions {
   }
   configByUri?: Record<string, RegistryConfig>
   registries?: Registries
+  registryOverrides?: Record<string, string>
 }
 
 interface PackumentResponse {
@@ -102,7 +103,7 @@ async function unpublishPackage (
   versionRange: string | undefined,
   opts: UnpublishOptions
 ): Promise<string> {
-  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName)
+  const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, packageName, undefined, opts.registryOverrides)
 
   const getAuthHeader = createGetAuthHeaderByURI(opts.configByUri ?? {}, registryUrl)
 

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 
+import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
 import { globalInfo, globalWarn } from '@pnpm/logger'
@@ -26,6 +27,7 @@ export type PublishPackedPkgOptions = Pick<Config,
 | 'fetchRetryMintimeout'
 | 'fetchTimeout'
 | 'registries'
+| 'registryOverrides'
 | 'tag'
 | 'userAgent'
 > & {
@@ -133,13 +135,9 @@ interface RegistryInfo {
  */
 function findRegistryInfo (
   { name }: ExportedManifest,
-  { configByUri, registries }: Pick<Config, 'configByUri' | 'registries'>
+  { configByUri, registries, registryOverrides }: Pick<Config, 'configByUri' | 'registries' | 'registryOverrides'>
 ): Partial<RegistryInfo> {
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  const scopedMatches = /@(?<scope>[^/]+)\/(?<slug>[^/]+)/.exec(name)
-
-  const registryName = scopedMatches?.groups ? `@${scopedMatches.groups.scope}` : 'default'
-  const nonNormalizedRegistry = registries[registryName] ?? registries.default
+  const nonNormalizedRegistry = pickRegistryForPackage(registries, name, undefined, registryOverrides)
 
   const supportedRegistryInfo = parseSupportedRegistryUrl(nonNormalizedRegistry)
   if (!supportedRegistryInfo) {

--- a/releasing/commands/src/publish/recursivePublish.ts
+++ b/releasing/commands/src/publish/recursivePublish.ts
@@ -48,6 +48,7 @@ Partial<Pick<Config,
 | 'noProxy'
 | 'npmPath'
 | 'offline'
+| 'registryOverrides'
 | 'strictSsl'
 | 'unsafePerm'
 | 'userAgent'
@@ -119,7 +120,7 @@ export async function recursivePublish (
       for (const pkgDir of chunk) {
         if (!publishedPkgDirs.has(pkgDir)) continue
         const pkg = opts.selectedProjectsGraph[pkgDir].package
-        const registry = pkg.manifest.publishConfig?.registry ?? pickRegistryForPackage(opts.registries, pkg.manifest.name!)
+        const registry = pkg.manifest.publishConfig?.registry ?? pickRegistryForPackage(opts.registries, pkg.manifest.name!, undefined, opts.registryOverrides)
         // eslint-disable-next-line no-await-in-loop
         const publishResult = await publish({
           ...opts,

--- a/resolving/npm-resolver/src/index.ts
+++ b/resolving/npm-resolver/src/index.ts
@@ -133,6 +133,7 @@ export interface ResolverFactoryOptions {
   retry?: RetryTimeoutOptions
   timeout?: number
   registries: Registries
+  registryOverrides?: Record<string, string>
   saveWorkspaceProtocol?: boolean | 'rolling'
   preserveAbsolutePaths?: boolean
   strictPublishedByCheck?: boolean
@@ -232,6 +233,7 @@ export function createNpmResolver (
       ignoreMissingTimeField: opts.ignoreMissingTimeField,
     }),
     registries: opts.registries,
+    registryOverrides: opts.registryOverrides,
     saveWorkspaceProtocol: opts.saveWorkspaceProtocol,
     peekManifestFromStore,
   }
@@ -251,6 +253,7 @@ export interface ResolveFromNpmContext {
   pickPackage: (spec: RegistryPackageSpec, opts: PickPackageOptions) => ReturnType<typeof pickPackage>
   getAuthHeaderValueByURI: (registry: string) => string | undefined
   registries: Registries
+  registryOverrides?: Record<string, string>
   saveWorkspaceProtocol?: boolean | 'rolling'
   peekManifestFromStore?: (opts: {
     id: PkgResolutionId
@@ -299,7 +302,7 @@ async function resolveNpm (
 ): Promise<NpmResolveResult | WorkspaceResolveResult | null> {
   const defaultTag = opts.defaultTag ?? 'latest'
   const registry = wantedDependency.alias
-    ? pickRegistryForPackage(ctx.registries, wantedDependency.alias, wantedDependency.bareSpecifier)
+    ? pickRegistryForPackage(ctx.registries, wantedDependency.alias, wantedDependency.bareSpecifier, ctx.registryOverrides)
     : ctx.registries.default
   if (wantedDependency.bareSpecifier?.startsWith('workspace:')) {
     if (wantedDependency.bareSpecifier.startsWith('workspace:.')) return null

--- a/store/connection-manager/src/createNewStoreController.ts
+++ b/store/connection-manager/src/createNewStoreController.ts
@@ -43,6 +43,7 @@ export type CreateNewStoreControllerOptions = CreateResolverOptions & Pick<Confi
 | 'preferOffline'
 | 'preserveAbsolutePaths'
 | 'registries'
+| 'registryOverrides'
 | 'registrySupportsTimeField'
 | 'resolutionMode'
 | 'saveWorkspaceProtocol'
@@ -92,6 +93,7 @@ export async function createNewStoreController (
     preferOffline: opts.preferOffline,
     configByUri: opts.configByUri,
     registries: opts.registries,
+    registryOverrides: opts.registryOverrides,
     retry: {
       factor: opts.fetchRetryFactor,
       maxTimeout: opts.fetchRetryMaxtimeout,


### PR DESCRIPTION
fixes #9093 #5581

This PR adds a new `registryOverrides` config setting that maps exact package names to registry URLs, taking precedence over the scope-level `registries` entry. This change makes it possible to mix public and private packages within the same scope (e.g. `@foo/public` from npm, `@foo/private-lib` from GitHub Packages) without having to rename scopes or add a custom resolver in `.pnpmfile.cjs`.

It plugs into the existing single-function registry lookup (`pickRegistryForPackage`), so all downstream resolution, fetching, and `pnpm publish` paths pick up the override with no additional wiring.

Auth is unchanged: credentials for override URLs resolve through the existing per-URL `.npmrc` lookup, so no new auth surface is introduced.

If `registryOverrides` is not set, behavior is identical to before.

  ## Example

  ```yaml
  # pnpm-workspace.yaml
  registryOverrides:
    "@foo/private-lib": https://npm.pkg.github.com/
    "@foo/internal-tools": https://npm.pkg.github.com/
```

## Alternatives considered

  - Registry fallback arrays (try private, fall back on 404). Extra round-trips per install, ambiguous  404-vs-auth failures, non-deterministic metadata provenance — hostile to pnpm's reproducibility guarantees.
  - Glob patterns (@foo/private-*). No precedent in .npmrc; exact-match covers the common "handful of private packages" case and can be extended later without breaking the shape.
  - Extending the registries map to string | string[] or nested objects. Registries is a flat lookup used in dozens of places and serialized into the lockfile; reshaping it has a large blast radius for a small gain.
  - Status quo: custom resolver in .pnpmfile.cjs. Works today but is imperative boilerplate for what is really declarative configuration.

Note: there is also https://github.com/pnpm/pnpm/pull/11324 to address the problem from a different angle, if that is preferable, but it solves the problem in a way that would make package.json incompatible with npm, which does not support github alias.