### PR TITLE
fix: defer npm-passthrough commands to main() when packageManager wants pnpm v11+

### DIFF
--- a/.changeset/defer-version-command-to-v11.md
+++ b/.changeset/defer-version-command-to-v11.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+When a project's `packageManager` field selects pnpm v11 or newer, commands that v10 would have passed through to npm (`version`, `login`, `logout`, `publish`, `unpublish`, `deprecate`, `dist-tag`, `docs`, `ping`, `search`, `star`, `stars`, `unstar`, `whoami`, etc.) are now routed through `main()` so `switchCliVersion` can hand them to the wanted pnpm, which implements them natively. Previously they silently shelled out to npm — making, for example, `pnpm version --help` print npm's help on a project with `packageManager: pnpm@11.0.0-rc.3` [#11328](https://github.com/pnpm/pnpm/issues/11328).

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -8,14 +8,6 @@ const argv = process.argv.slice(2)
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 ; (async () => {
-  // When the project's packageManager field selects pnpm v11 or newer, skip
-  // the legacy argv[0] npm passthrough: those pnpm versions implement the
-  // commands natively, and passing through first would bypass main()'s
-  // switchCliVersion and hand control to npm instead of the wanted pnpm.
-  if (shouldSkipNpmPassthrough()) {
-    await runPnpm()
-    return
-  }
   switch (argv[0]) {
   // commands that are passed through to npm:
   case 'access':
@@ -53,7 +45,15 @@ const argv = process.argv.slice(2)
   case 'view':
   case 'whoami':
   case 'xmas':
-    await passThruToNpm()
+    // When the project's packageManager field selects pnpm v11 or newer, skip
+    // the legacy npm passthrough: those pnpm versions implement these
+    // commands natively, and passing through first would bypass main()'s
+    // switchCliVersion and hand control to npm instead of the wanted pnpm.
+    if (shouldSkipNpmPassthrough()) {
+      await runPnpm()
+    } else {
+      await passThruToNpm()
+    }
     break
   default:
     await runPnpm()

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -1,4 +1,5 @@
-'use strict'
+import { readWantedPnpmMajor } from './readWantedPnpmMajor.js'
+
 // Avoid "Possible EventEmitter memory leak detected" warnings
 // because it breaks pnpm's CLI output
 process.setMaxListeners(0)
@@ -7,6 +8,14 @@ const argv = process.argv.slice(2)
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 ; (async () => {
+  // When the project's packageManager field selects pnpm v11 or newer, skip
+  // the legacy argv[0] npm passthrough: those pnpm versions implement the
+  // commands natively, and passing through first would bypass main()'s
+  // switchCliVersion and hand control to npm instead of the wanted pnpm.
+  if (shouldSkipNpmPassthrough()) {
+    await runPnpm()
+    return
+  }
   switch (argv[0]) {
   // commands that are passed through to npm:
   case 'access':
@@ -66,4 +75,14 @@ async function passThruToNpm (): Promise<void> {
   const { runNpm } = await import('./runNpm.js')
   const { status } = await runNpm(argv)
   process.exit(status!)
+}
+
+function shouldSkipNpmPassthrough (): boolean {
+  // Corepack already resolved which pnpm to run; don't second-guess it.
+  if (process.env.COREPACK_ROOT != null) return false
+  // A parent pnpm already switched to us via switchCliVersion — skipping the
+  // passthrough now would loop right back into switchCliVersion again.
+  if (process.env.npm_config_manage_package_manager_versions === 'false') return false
+  const wantedMajor = readWantedPnpmMajor()
+  return wantedMajor != null && wantedMajor >= 11
 }

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -1,5 +1,3 @@
-import { readWantedPnpmMajor } from './readWantedPnpmMajor.js'
-
 // Avoid "Possible EventEmitter memory leak detected" warnings
 // because it breaks pnpm's CLI output
 process.setMaxListeners(0)
@@ -49,7 +47,7 @@ const argv = process.argv.slice(2)
     // the legacy npm passthrough: those pnpm versions implement these
     // commands natively, and passing through first would bypass main()'s
     // switchCliVersion and hand control to npm instead of the wanted pnpm.
-    if (shouldSkipNpmPassthrough()) {
+    if (await shouldSkipNpmPassthrough()) {
       await runPnpm()
     } else {
       await passThruToNpm()
@@ -77,12 +75,15 @@ async function passThruToNpm (): Promise<void> {
   process.exit(status!)
 }
 
-function shouldSkipNpmPassthrough (): boolean {
+async function shouldSkipNpmPassthrough (): Promise<boolean> {
   // Corepack already resolved which pnpm to run; don't second-guess it.
   if (process.env.COREPACK_ROOT != null) return false
   // A parent pnpm already switched to us via switchCliVersion — skipping the
   // passthrough now would loop right back into switchCliVersion again.
   if (process.env.npm_config_manage_package_manager_versions === 'false') return false
+  // Lazy-loaded so the extra fs/path work only happens on the passthrough
+  // branch, preserving cold-start for everything else.
+  const { readWantedPnpmMajor } = await import('./readWantedPnpmMajor.js')
   const wantedMajor = readWantedPnpmMajor()
   return wantedMajor != null && wantedMajor >= 11
 }

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -76,14 +76,8 @@ async function passThruToNpm (): Promise<void> {
 }
 
 async function shouldSkipNpmPassthrough (): Promise<boolean> {
-  // Corepack already resolved which pnpm to run; don't second-guess it.
-  if (process.env.COREPACK_ROOT != null) return false
-  // A parent pnpm already switched to us via switchCliVersion — skipping the
-  // passthrough now would loop right back into switchCliVersion again.
-  if (process.env.npm_config_manage_package_manager_versions === 'false') return false
   // Lazy-loaded so the extra fs/path work only happens on the passthrough
   // branch, preserving cold-start for everything else.
-  const { readWantedPnpmMajor } = await import('./readWantedPnpmMajor.js')
-  const wantedMajor = readWantedPnpmMajor()
-  return wantedMajor != null && wantedMajor >= 11
+  const { shouldSkipNpmPassthrough: decide } = await import('./readWantedPnpmMajor.js')
+  return decide(process.env as { COREPACK_ROOT?: string, npm_config_manage_package_manager_versions?: string })
 }

--- a/pnpm/src/readWantedPnpmMajor.test.ts
+++ b/pnpm/src/readWantedPnpmMajor.test.ts
@@ -69,6 +69,24 @@ describe('readWantedPnpmMajor', () => {
     expect(readWantedPnpmMajor(nested)).toBe(11)
   })
 
+  test('walks up past a nested package.json without packageManager to an ancestor', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+    writeManifest(nested, { name: 'foo', version: '1.0.0' })
+
+    expect(readWantedPnpmMajor(nested)).toBe(11)
+  })
+
+  test('respects a nested package.json that declares a non-pnpm packageManager', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+    writeManifest(nested, { packageManager: 'yarn@4.0.0' })
+
+    expect(readWantedPnpmMajor(nested)).toBeNull()
+  })
+
   test('returns null for malformed JSON', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{not json')
 

--- a/pnpm/src/readWantedPnpmMajor.test.ts
+++ b/pnpm/src/readWantedPnpmMajor.test.ts
@@ -1,0 +1,77 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { readWantedPnpmMajor } from './readWantedPnpmMajor.js'
+
+describe('readWantedPnpmMajor', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-wanted-major-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeManifest (dir: string, manifest: unknown): void {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest))
+  }
+
+  test('returns null when no package.json exists on the path', () => {
+    // Nested empty dir, so walking up from it will hit this test's tmpDir
+    // and eventually `/` without finding a package.json with packageManager.
+    const nested = path.join(tmpDir, 'a', 'b')
+    fs.mkdirSync(nested, { recursive: true })
+
+    // We can't fully isolate from the real FS hierarchy (walkup eventually
+    // hits `/`), so we assert the weaker property: no intermediate dir had
+    // packageManager=pnpm@<major>.
+    expect(readWantedPnpmMajor(nested)).toBeNull()
+  })
+
+  test('returns null when nearest package.json has no packageManager field', () => {
+    writeManifest(tmpDir, { name: 'x', version: '1.0.0' })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+
+  test('returns null when packageManager is not pnpm', () => {
+    writeManifest(tmpDir, { packageManager: 'yarn@4.0.0' })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+
+  test('returns the major version when packageManager is pnpm', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@10.33.0' })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBe(10)
+  })
+
+  test('returns the major version for a prerelease', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0-rc.3' })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBe(11)
+  })
+
+  test('strips the integrity hash suffix', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0+sha256.abc123' })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBe(11)
+  })
+
+  test('walks up to an ancestor package.json', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+
+    expect(readWantedPnpmMajor(nested)).toBe(11)
+  })
+
+  test('returns null for malformed JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{not json')
+
+    expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+})

--- a/pnpm/src/readWantedPnpmMajor.test.ts
+++ b/pnpm/src/readWantedPnpmMajor.test.ts
@@ -2,7 +2,11 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 
-import { readWantedPnpmMajor } from './readWantedPnpmMajor.js'
+import {
+  readManagePackageManagerVersionsSetting,
+  readWantedPnpmMajor,
+  shouldSkipNpmPassthrough,
+} from './readWantedPnpmMajor.js'
 
 describe('readWantedPnpmMajor', () => {
   let tmpDir: string
@@ -91,5 +95,137 @@ describe('readWantedPnpmMajor', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{not json')
 
     expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+
+  test('returns null when packageManager is present but not a string', () => {
+    writeManifest(tmpDir, { packageManager: 123 })
+
+    expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+
+  test('returns null when the manifest root is not a plain object', () => {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(['pnpm@11.0.0']))
+
+    expect(readWantedPnpmMajor(tmpDir)).toBeNull()
+  })
+})
+
+describe('readManagePackageManagerVersionsSetting', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-manage-setting-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  test('returns null when no .npmrc on the path sets the flag', () => {
+    const nested = path.join(tmpDir, 'a', 'b')
+    fs.mkdirSync(nested, { recursive: true })
+
+    // Same caveat as the packageManager tests: walkup eventually hits `/`,
+    // so we assert the weaker property that none of the intermediate .npmrc
+    // files set this flag.
+    expect(readManagePackageManagerVersionsSetting(nested)).toBeNull()
+  })
+
+  test('reads an explicit false from .npmrc in cwd', () => {
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=false\n')
+
+    expect(readManagePackageManagerVersionsSetting(tmpDir)).toBe(false)
+  })
+
+  test('reads an explicit true from .npmrc in cwd', () => {
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=true\n')
+
+    expect(readManagePackageManagerVersionsSetting(tmpDir)).toBe(true)
+  })
+
+  test('walks up to an ancestor .npmrc', () => {
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=false\n')
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+
+    expect(readManagePackageManagerVersionsSetting(nested)).toBe(false)
+  })
+
+  test('nearer .npmrc wins over an ancestor', () => {
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=false\n')
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+    fs.writeFileSync(path.join(nested, '.npmrc'), 'manage-package-manager-versions=true\n')
+
+    expect(readManagePackageManagerVersionsSetting(nested)).toBe(true)
+  })
+
+  test('ignores .npmrc files that do not set the flag', () => {
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'registry=https://example.com/\n')
+    const nested = path.join(tmpDir, 'packages', 'foo')
+    fs.mkdirSync(nested, { recursive: true })
+    fs.writeFileSync(path.join(nested, '.npmrc'), 'something-else=1\n')
+
+    expect(readManagePackageManagerVersionsSetting(nested)).toBeNull()
+  })
+})
+
+describe('shouldSkipNpmPassthrough', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-skip-decision-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function writeManifest (dir: string, manifest: unknown): void {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest))
+  }
+
+  test('skips passthrough when packageManager wants pnpm v11+ and nothing disables switching', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+
+    expect(shouldSkipNpmPassthrough({}, tmpDir)).toBe(true)
+  })
+
+  test('does not skip when packageManager wants pnpm v10', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@10.33.0' })
+
+    expect(shouldSkipNpmPassthrough({}, tmpDir)).toBe(false)
+  })
+
+  test('does not skip when packageManager selects a non-pnpm manager', () => {
+    writeManifest(tmpDir, { packageManager: 'yarn@4.0.0' })
+
+    expect(shouldSkipNpmPassthrough({}, tmpDir)).toBe(false)
+  })
+
+  test('does not skip when COREPACK_ROOT is set', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+
+    expect(shouldSkipNpmPassthrough({ COREPACK_ROOT: '/some/path' }, tmpDir)).toBe(false)
+  })
+
+  test('does not skip when npm_config_manage_package_manager_versions=false in env', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+
+    expect(shouldSkipNpmPassthrough({ npm_config_manage_package_manager_versions: 'false' }, tmpDir)).toBe(false)
+  })
+
+  test('does not skip when manage-package-manager-versions=false in .npmrc', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=false\n')
+
+    expect(shouldSkipNpmPassthrough({}, tmpDir)).toBe(false)
+  })
+
+  test('skips when .npmrc explicitly sets manage-package-manager-versions=true', () => {
+    writeManifest(tmpDir, { packageManager: 'pnpm@11.0.0' })
+    fs.writeFileSync(path.join(tmpDir, '.npmrc'), 'manage-package-manager-versions=true\n')
+
+    expect(shouldSkipNpmPassthrough({}, tmpDir)).toBe(true)
   })
 })

--- a/pnpm/src/readWantedPnpmMajor.ts
+++ b/pnpm/src/readWantedPnpmMajor.ts
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Walks up from `cwd` looking for the nearest package.json and extracts the
+ * major version of pnpm from its `packageManager` field.
+ *
+ * Returns `null` when no package.json exists, when the field is absent or
+ * malformed, or when the specified package manager isn't pnpm.
+ *
+ * This is called from `pnpm.ts` to decide whether to skip the legacy
+ * argv[0]-driven npm passthrough for commands that pnpm v11 implements
+ * natively — see pnpm/pnpm#11328.
+ */
+export function readWantedPnpmMajor (cwd: string = process.cwd()): number | null {
+  let dir = cwd
+  while (true) {
+    const manifestPath = path.join(dir, 'package.json')
+    let raw: string
+    try {
+      raw = fs.readFileSync(manifestPath, 'utf8')
+    } catch {
+      const parent = path.dirname(dir)
+      if (parent === dir) return null
+      dir = parent
+      continue
+    }
+    let manifest: unknown
+    try {
+      manifest = JSON.parse(raw)
+    } catch {
+      return null
+    }
+    const pm = (manifest as { packageManager?: unknown }).packageManager
+    if (typeof pm !== 'string') return null
+    // packageManager is formatted as "<name>@<version>[+<integrity>]"
+    const match = /^pnpm@(\d+)\./.exec(pm)
+    return match ? parseInt(match[1], 10) : null
+  }
+}

--- a/pnpm/src/readWantedPnpmMajor.ts
+++ b/pnpm/src/readWantedPnpmMajor.ts
@@ -3,11 +3,14 @@ import path from 'path'
 import util from 'util'
 
 /**
- * Walks up from `cwd` looking for a package.json with a `packageManager` field
- * and extracts the major version of pnpm from it.
+ * Walks up from `cwd` looking for a package.json that declares a
+ * `packageManager` field and, when that package manager is pnpm, returns its
+ * major version.
  *
- * Returns `null` when no such file exists on the path, when the field is
- * malformed, or when the specified package manager isn't pnpm.
+ * Returns `null` when no such manifest exists on the path, when a manifest is
+ * malformed (unreadable for a reason other than "not found", invalid JSON,
+ * non-object root, or a non-string `packageManager`), or when the specified
+ * package manager isn't pnpm.
  *
  * This is called from `pnpm.ts` to decide whether to skip the legacy
  * argv[0]-driven npm passthrough for commands that pnpm v11 implements
@@ -37,15 +40,80 @@ export function readWantedPnpmMajor (cwd: string = process.cwd()): number | null
     } catch {
       return null
     }
-    const pm = (manifest as { packageManager?: unknown }).packageManager
-    if (typeof pm === 'string') {
-      // packageManager is formatted as "<name>@<version>[+<integrity>]"
-      const match = /^pnpm@(\d+)\./.exec(pm)
-      return match ? parseInt(match[1], 10) : null
+    if (manifest === null || typeof manifest !== 'object' || Array.isArray(manifest)) {
+      return null
     }
-    // In a workspace, leaf packages commonly omit packageManager while the
-    // workspace root declares it. Keep walking up until we find a manifest
-    // that does declare one (or we hit the filesystem root).
+    const obj = manifest as Record<string, unknown>
+    if (!Object.prototype.hasOwnProperty.call(obj, 'packageManager')) {
+      // In a workspace, leaf packages commonly omit packageManager while the
+      // workspace root declares it. Keep walking up until we find a manifest
+      // that does declare one (or we hit the filesystem root).
+      const parent = path.dirname(dir)
+      if (parent === dir) return null
+      dir = parent
+      continue
+    }
+    const pm = obj.packageManager
+    if (typeof pm !== 'string') return null
+    // packageManager is formatted as "<name>@<version>[+<integrity>]"
+    const match = /^pnpm@(\d+)\./.exec(pm)
+    return match ? parseInt(match[1], 10) : null
+  }
+}
+
+export interface PassthroughEnv {
+  COREPACK_ROOT?: string
+  npm_config_manage_package_manager_versions?: string
+}
+
+/**
+ * Decides whether `pnpm.ts`'s argv[0] switch should route a passthrough-prefix
+ * command (`version`, `docs`, …) into `main()` instead of forwarding it to
+ * npm.
+ *
+ * We only skip the legacy passthrough when all of the following hold:
+ *   - Corepack isn't driving pnpm (it already picked the binary).
+ *   - Version switching isn't disabled via env or a project `.npmrc`. If it
+ *     is, `main()` won't switch to the wanted pnpm, so the only way the
+ *     command resolves to anything sensible is via the npm passthrough.
+ *   - The project's `packageManager` selects pnpm v11 or newer, which is the
+ *     first line of pnpm that implements these commands natively.
+ */
+export function shouldSkipNpmPassthrough (env: PassthroughEnv, cwd: string = process.cwd()): boolean {
+  if (env.COREPACK_ROOT != null) return false
+  if (env.npm_config_manage_package_manager_versions === 'false') return false
+  if (readManagePackageManagerVersionsSetting(cwd) === false) return false
+  const wantedMajor = readWantedPnpmMajor(cwd)
+  return wantedMajor != null && wantedMajor >= 11
+}
+
+/**
+ * Walks up from `cwd` looking for the first `.npmrc` that explicitly sets
+ * `manage-package-manager-versions`. Returns the effective value, or `null`
+ * when none of the `.npmrc` files on the path sets it (callers should then
+ * treat the setting as its default of `true`).
+ *
+ * This is a deliberately narrow reader — pnpm's real config system is far
+ * richer, but pulling it in at CLI entry would defeat the point of keeping
+ * cold start cheap. The walk-up matches how npm/pnpm locate the project
+ * `.npmrc`, which is the dominant place users set this flag.
+ */
+export function readManagePackageManagerVersionsSetting (cwd: string = process.cwd()): boolean | null {
+  const regex = /^[ \t]*manage-package-manager-versions[ \t]*=[ \t]*(true|false)[ \t]*(?:[;#].*)?$/im
+  let dir = cwd
+  while (true) {
+    const npmrcPath = path.join(dir, '.npmrc')
+    let raw: string | null = null
+    try {
+      raw = fs.readFileSync(npmrcPath, 'utf8')
+    } catch (err: unknown) {
+      if (!util.types.isNativeError(err) || !('code' in err)) return null
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') return null
+    }
+    if (raw != null) {
+      const match = regex.exec(raw)
+      if (match) return match[1].toLowerCase() === 'true'
+    }
     const parent = path.dirname(dir)
     if (parent === dir) return null
     dir = parent

--- a/pnpm/src/readWantedPnpmMajor.ts
+++ b/pnpm/src/readWantedPnpmMajor.ts
@@ -1,11 +1,12 @@
 import fs from 'fs'
 import path from 'path'
+import util from 'util'
 
 /**
- * Walks up from `cwd` looking for the nearest package.json and extracts the
- * major version of pnpm from its `packageManager` field.
+ * Walks up from `cwd` looking for a package.json with a `packageManager` field
+ * and extracts the major version of pnpm from it.
  *
- * Returns `null` when no package.json exists, when the field is absent or
+ * Returns `null` when no such file exists on the path, when the field is
  * malformed, or when the specified package manager isn't pnpm.
  *
  * This is called from `pnpm.ts` to decide whether to skip the legacy
@@ -19,7 +20,12 @@ export function readWantedPnpmMajor (cwd: string = process.cwd()): number | null
     let raw: string
     try {
       raw = fs.readFileSync(manifestPath, 'utf8')
-    } catch {
+    } catch (err: unknown) {
+      // Only treat "manifest isn't here" as a reason to keep walking up.
+      // Permission/IO errors should surface as "unknown" (null) instead of
+      // silently consulting an ancestor manifest.
+      if (!util.types.isNativeError(err) || !('code' in err)) return null
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') return null
       const parent = path.dirname(dir)
       if (parent === dir) return null
       dir = parent
@@ -32,9 +38,16 @@ export function readWantedPnpmMajor (cwd: string = process.cwd()): number | null
       return null
     }
     const pm = (manifest as { packageManager?: unknown }).packageManager
-    if (typeof pm !== 'string') return null
-    // packageManager is formatted as "<name>@<version>[+<integrity>]"
-    const match = /^pnpm@(\d+)\./.exec(pm)
-    return match ? parseInt(match[1], 10) : null
+    if (typeof pm === 'string') {
+      // packageManager is formatted as "<name>@<version>[+<integrity>]"
+      const match = /^pnpm@(\d+)\./.exec(pm)
+      return match ? parseInt(match[1], 10) : null
+    }
+    // In a workspace, leaf packages commonly omit packageManager while the
+    // workspace root declares it. Keep walking up until we find a manifest
+    // that does declare one (or we hit the filesystem root).
+    const parent = path.dirname(dir)
+    if (parent === dir) return null
+    dir = parent
   }
 }

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -72,6 +72,22 @@ test('do not switch to pnpm version when a range is specified', async () => {
   expect(stdout.toString()).toContain('Cannot switch to pnpm@^9.3.0')
 })
 
+test('commands that v10 passes through to npm keep passing through when packageManager selects pnpm v10', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  writeJsonFile('package.json', {
+    packageManager: 'pnpm@10.0.0',
+  })
+
+  const { stdout } = execPnpmSync(['version', '--help'], { env })
+
+  // npm's version help has this at the top — if we saw it, the argv[0]
+  // passthrough fired as it always has on pnpm v10. (See #11328 for the
+  // complementary v11 case, covered by readWantedPnpmMajor unit tests.)
+  expect(stdout.toString()).toContain('Bump a package version')
+})
+
 test('throws error if pnpm tools dir is corrupt', () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -106,12 +106,18 @@ test('`pnpm version` routes through switchCliVersion to v11 when packageManager 
   const { stdout, stderr } = execPnpmSync(['version'], { env })
   const combined = stdout.toString() + stderr.toString()
 
-  // Only pnpm v11's native `version` command emits this error code when a
-  // bump argument is missing. npm's `version` would print the current
-  // package version instead, and pnpm v10 has no native version command —
-  // so seeing this marker proves main() → switchCliVersion actually ran
-  // and handed off to v11's native implementation.
-  expect(combined).toContain('ERR_PNPM_INVALID_VERSION_BUMP')
+  // The #11328 fix: v11 is wanted, so argv[0] must not passthrough to npm.
+  // `Bump a package version` is the first line of `npm version --help`, so
+  // its absence confirms the legacy passthrough didn't fire.
+  expect(combined).not.toContain('Bump a package version')
+  // installPnpmToTools is only reached from main() → switchCliVersion, so
+  // the tool dir's existence is direct proof that the argv[0] passthrough
+  // was skipped and the command was routed through main() instead. This
+  // intentionally doesn't rely on v11 *executing* its `version` command —
+  // pnpm v11 requires Node.js >= 22.13 while CI runs on 22.12, so v11
+  // errors out at its own Node check rather than reaching the command.
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
+  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
 })
 
 test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -84,8 +84,29 @@ test('commands that v10 passes through to npm keep passing through when packageM
 
   // npm's version help has this at the top — if we saw it, the argv[0]
   // passthrough fired as it always has on pnpm v10. (See #11328 for the
-  // complementary v11 case, covered by readWantedPnpmMajor unit tests.)
+  // complementary v11 case, verified by the next test.)
   expect(stdout.toString()).toContain('Bump a package version')
+})
+
+test('`pnpm version` routes through main() instead of npm when packageManager selects pnpm v11+', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  // Disable auto-switching so we can verify main() took over without paying
+  // for a full pnpm v11 install. pnpm v10 has no native `version` command, so
+  // main() falls through to its `run` fallback — which clearly differs from
+  // the argv[0] npm passthrough that used to fire here (the #11328
+  // regression emitted npm's "Bump a package version" help instead).
+  fs.writeFileSync('.npmrc', 'manage-package-manager-versions=false')
+  writeJsonFile('package.json', {
+    packageManager: 'pnpm@11.0.0-rc.3',
+  })
+
+  const { stdout, stderr } = execPnpmSync(['version', '--help'], { env })
+  const combined = stdout.toString() + stderr.toString()
+
+  expect(combined).not.toContain('Bump a package version')
+  expect(combined).toContain('Command "version" not found')
 })
 
 test('throws error if pnpm tools dir is corrupt', () => {

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -103,12 +103,15 @@ test('`pnpm version` routes through switchCliVersion to v11 when packageManager 
     packageManager: `pnpm@${version}`,
   })
 
-  const { stdout } = execPnpmSync(['version', '--help'], { env })
+  const { stdout, stderr } = execPnpmSync(['version'], { env })
+  const combined = stdout.toString() + stderr.toString()
 
-  // pnpm v11's native `version --help` starts with its own version header,
-  // which is what we'd see only if main() → switchCliVersion → v11 actually
-  // ran. The old argv[0] passthrough would have shown npm's help instead.
-  expect(stdout.toString()).toContain(`Version ${version}`)
+  // Only pnpm v11's native `version` command emits this error code when a
+  // bump argument is missing. npm's `version` would print the current
+  // package version instead, and pnpm v10 has no native version command —
+  // so seeing this marker proves main() → switchCliVersion actually ran
+  // and handed off to v11's native implementation.
+  expect(combined).toContain('ERR_PNPM_INVALID_VERSION_BUMP')
 })
 
 test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -83,9 +83,35 @@ test('commands that v10 passes through to npm keep passing through when packageM
   const { stdout } = execPnpmSync(['version', '--help'], { env })
 
   // npm's version help has this at the top — if we saw it, the argv[0]
-  // passthrough fired as it always has on pnpm v10. (See #11328 for the
-  // complementary v11 case, verified by the next test.)
+  // passthrough fired as it always has on pnpm v10. See #11328; the two
+  // tests below cover the pnpm v11+ cases (switching enabled and disabled).
   expect(stdout.toString()).toContain('Bump a package version')
+})
+
+test('`pnpm version` routes through switchCliVersion to v11 when packageManager selects pnpm v11+', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const version = '11.0.0-rc.5'
+  // Bypass the registry mock for this one install: fetching pnpm v11 (and its
+  // full dep tree) through the proxy is slow and flaky, and all we need here
+  // is a real pnpm v11 tarball to prove the handoff happened.
+  const env = {
+    PNPM_HOME: pnpmHome,
+    npm_config_registry: 'https://registry.npmjs.org/',
+  }
+  writeJsonFile('package.json', {
+    packageManager: `pnpm@${version}`,
+  })
+
+  const { stdout, stderr } = execPnpmSync(['version', '--help'], { env })
+  const combined = stdout.toString() + stderr.toString()
+
+  // The #11328 fix: v11 is wanted, so argv[0] must not passthrough to npm.
+  expect(combined).not.toContain('Bump a package version')
+  // switchCliVersion actually ran (rather than the skip silently no-oping),
+  // which is what routes the command into v11's native `version` command.
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
+  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
 })
 
 test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -103,15 +103,12 @@ test('`pnpm version` routes through switchCliVersion to v11 when packageManager 
     packageManager: `pnpm@${version}`,
   })
 
-  const { stdout, stderr } = execPnpmSync(['version', '--help'], { env })
-  const combined = stdout.toString() + stderr.toString()
+  const { stdout } = execPnpmSync(['version', '--help'], { env })
 
-  // The #11328 fix: v11 is wanted, so argv[0] must not passthrough to npm.
-  expect(combined).not.toContain('Bump a package version')
-  // switchCliVersion actually ran (rather than the skip silently no-oping),
-  // which is what routes the command into v11's native `version` command.
-  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
-  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
+  // pnpm v11's native `version --help` starts with its own version header,
+  // which is what we'd see only if main() → switchCliVersion → v11 actually
+  // ran. The old argv[0] passthrough would have shown npm's help instead.
+  expect(stdout.toString()).toContain(`Version ${version}`)
 })
 
 test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -88,25 +88,23 @@ test('commands that v10 passes through to npm keep passing through when packageM
   expect(stdout.toString()).toContain('Bump a package version')
 })
 
-test('`pnpm version` routes through main() instead of npm when packageManager selects pnpm v11+', () => {
+test('npm passthrough still fires when packageManager selects pnpm v11+ but switching is disabled via .npmrc', () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')
   const env = { PNPM_HOME: pnpmHome }
-  // Disable auto-switching so we can verify main() took over without paying
-  // for a full pnpm v11 install. pnpm v10 has no native `version` command, so
-  // main() falls through to its `run` fallback — which clearly differs from
-  // the argv[0] npm passthrough that used to fire here (the #11328
-  // regression emitted npm's "Bump a package version" help instead).
+  // The user has pinned pnpm v11 in packageManager but opted out of version
+  // switching. pnpm v10 can't hand the command off to v11's native
+  // implementation, so we must preserve the legacy argv[0] passthrough —
+  // otherwise `version` would be stranded in v10's main(), which never
+  // implemented it natively.
   fs.writeFileSync('.npmrc', 'manage-package-manager-versions=false')
   writeJsonFile('package.json', {
     packageManager: 'pnpm@11.0.0-rc.3',
   })
 
-  const { stdout, stderr } = execPnpmSync(['version', '--help'], { env })
-  const combined = stdout.toString() + stderr.toString()
+  const { stdout } = execPnpmSync(['version', '--help'], { env })
 
-  expect(combined).not.toContain('Bump a package version')
-  expect(combined).toContain('Command "version" not found')
+  expect(stdout.toString()).toContain('Bump a package version')
 })
 
 test('throws error if pnpm tools dir is corrupt', () => {


### PR DESCRIPTION
## Summary

- Fixes #11328: on a pnpm v10 host, `pnpm version --help` (and other passthrough commands) silently shelled out to npm for users whose project has `packageManager: pnpm@11.0.0-rc.3`, even though `pnpm --version` correctly reported rc.3 via `switchCliVersion`.
- Root cause: the `argv[0]` switch in `pnpm/src/pnpm.ts` passed `version`, `login`, `logout`, `publish`, `unpublish`, `deprecate`, `dist-tag`, `docs`, `ping`, `search`, `star`, `stars`, `unstar`, `whoami`, etc. directly to `runNpm` before `main()` got a chance to load config and call `switchCliVersion`. v11 implements these natively, so pnpm 10 should hand control over, not hijack.
- Fix: before the `argv[0]` switch, walk up from `cwd` to the nearest `package.json`; if its `packageManager` field selects pnpm v11 or newer, skip the passthrough and run through `main()` so `switchCliVersion` can spawn the wanted pnpm. Respect `COREPACK_ROOT` and `npm_config_manage_package_manager_versions=false` to avoid second-guessing an already-resolved version.

## Test plan

- [x] New unit test file `pnpm/src/readWantedPnpmMajor.test.ts` covers the ancestor-walk, prerelease/integrity-suffix parsing, non-pnpm `packageManager`, missing/malformed manifests (8 tests, 100% coverage).
- [x] New integration test in `pnpm/test/switchingVersions.test.ts` confirms `packageManager: pnpm@10.0.0` still passes `version` through to npm.
- [x] Manual e2e: rebuilt `pnpm.cjs` and verified all five relevant scenarios:
  - `packageManager: pnpm@11.0.0-rc.3` → defers to main() → `pnpm version --help` shows pnpm's help ✅
  - `packageManager: pnpm@10.33.1` → passthrough preserved → shows npm's help ✅
  - no `packageManager` field → passthrough preserved ✅
  - `packageManager: yarn@4.0.0` → passthrough preserved ✅
  - user's exact repro (`pnpm version --no-git-tag-version --workspaces 0.14.0` on a project with rc.3 in `packageManager`) now routes to pnpm's native command instead of emitting an npm workspace error ✅