### PR TITLE
fix(binary-fetcher): skip zip directory entries during Node.js runtime extraction

### DIFF
--- a/.changeset/fix-binary-fetcher-zip-dir-entries.md
+++ b/.changeset/fix-binary-fetcher-zip-dir-entries.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fix Windows Node.js runtime installs still extracting bundled `npm`, `npx`, and `corepack` when the archive contains explicit directory entries. `extractZipToTarget` now skips directory entries: AdmZip's `extractEntryTo(dir, …)` internally recurses over every descendant via `getEntryChildren(subfolders: true)`, which bypassed the `ignoreEntry` filter and re-materialized the files the filter was supposed to drop. File extraction creates parent directories implicitly, so skipping directory entries doesn't regress the install layout.
+Fix Windows Node.js runtime installs still extracting bundled `npm`, `npx`, and `corepack` when the archive contains explicit directory entries. `extractZipToTarget` now skips directory entries: AdmZip's `extractEntryTo` for a directory recurses over every descendant internally, which bypassed the `ignoreEntry` filter and re-materialized the files the filter was supposed to drop. File extraction creates parent directories implicitly, so skipping directory entries doesn't regress the install layout.

--- a/.changeset/fix-binary-fetcher-zip-dir-entries.md
+++ b/.changeset/fix-binary-fetcher-zip-dir-entries.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fetching.binary-fetcher": patch
+"pnpm": patch
+---
+
+Fix Windows Node.js runtime installs still extracting bundled `npm`, `npx`, and `corepack` when the archive contains explicit directory entries. `extractZipToTarget` now skips directory entries: AdmZip's `extractEntryTo(dir, …)` internally recurses over every descendant via `getEntryChildren(subfolders: true)`, which bypassed the `ignoreEntry` filter and re-materialized the files the filter was supposed to drop. File extraction creates parent directories implicitly, so skipping directory entries doesn't regress the install layout.

--- a/fetching/binary-fetcher/src/index.ts
+++ b/fetching/binary-fetcher/src/index.ts
@@ -204,8 +204,8 @@ async function extractZipToTarget (
 
   // Extract each entry with path validation to prevent path traversal attacks.
   // Directory entries are skipped: AdmZip's `extractEntryTo(dir, ...)` expands
-  // to every descendant via `getEntryChildren(dir, subfolders=true)`, which
-  // would bypass the `ignoreEntry` filter (e.g. the archive's top-level
+  // to every descendant via `getEntryChildren`, which would bypass the
+  // `ignoreEntry` filter (e.g. the archive's top-level
   // `node-vX.Y.Z-<platform>-<arch>/` entry would pull in npm/corepack files
   // even though the per-file relative paths match the ignore regex).
   // File extraction creates parent directories implicitly.

--- a/fetching/binary-fetcher/src/index.ts
+++ b/fetching/binary-fetcher/src/index.ts
@@ -202,8 +202,15 @@ async function extractZipToTarget (
   // entries in this loop.
   const testEntry = toStatelessTester(ignoreEntry)
 
-  // Extract each entry with path validation to prevent path traversal attacks
+  // Extract each entry with path validation to prevent path traversal attacks.
+  // Directory entries are skipped: AdmZip's `extractEntryTo(dir, ...)` expands
+  // to every descendant via `getEntryChildren(dir, subfolders=true)`, which
+  // would bypass the `ignoreEntry` filter (e.g. the archive's top-level
+  // `node-vX.Y.Z-<platform>-<arch>/` entry would pull in npm/corepack files
+  // even though the per-file relative paths match the ignore regex).
+  // File extraction creates parent directories implicitly.
   for (const entry of zip.getEntries()) {
+    if (entry.isDirectory) continue
     const entryPath = entry.entryName
     validatePathSecurity(nodeDir, entryPath)
     if (testEntry) {

--- a/fetching/binary-fetcher/test/index.ts
+++ b/fetching/binary-fetcher/test/index.ts
@@ -283,8 +283,8 @@ describe('extractZipToTarget security', () => {
     it('still honors ignoreEntry when the archive contains directory entries (regression for #11325)', async () => {
       // Real Node.js Windows zips include directory entries in addition to file
       // entries. AdmZip's extractEntryTo(dirEntry, …) expands to every descendant
-      // via getEntryChildren(subfolders=true), which previously bypassed the
-      // ignoreEntry filter. Covering that path explicitly here.
+      // via getEntryChildren, which previously bypassed the ignoreEntry filter.
+      // Covering that path explicitly here.
       const targetDir = temporaryDirectory()
       const zip = new AdmZip()
       zip.addFile('node-v20.0.0/', Buffer.alloc(0))

--- a/fetching/binary-fetcher/test/index.ts
+++ b/fetching/binary-fetcher/test/index.ts
@@ -280,6 +280,41 @@ describe('extractZipToTarget security', () => {
       expect(fs.existsSync(path.join(targetDir, 'bin/npm'))).toBe(false)
     })
 
+    it('still honors ignoreEntry when the archive contains directory entries (regression for #11325)', async () => {
+      // Real Node.js Windows zips include directory entries in addition to file
+      // entries. AdmZip's extractEntryTo(dirEntry, …) expands to every descendant
+      // via getEntryChildren(subfolders=true), which previously bypassed the
+      // ignoreEntry filter. Covering that path explicitly here.
+      const targetDir = temporaryDirectory()
+      const zip = new AdmZip()
+      zip.addFile('node-v20.0.0/', Buffer.alloc(0))
+      zip.addFile('node-v20.0.0/node.exe', Buffer.from('binary'))
+      zip.addFile('node-v20.0.0/node_modules/', Buffer.alloc(0))
+      zip.addFile('node-v20.0.0/node_modules/npm/', Buffer.alloc(0))
+      zip.addFile('node-v20.0.0/node_modules/npm/package.json', Buffer.from('{}'))
+      zip.addFile('node-v20.0.0/node_modules/corepack/', Buffer.alloc(0))
+      zip.addFile('node-v20.0.0/node_modules/corepack/package.json', Buffer.from('{}'))
+      const zipBuffer = zip.toBuffer()
+      const integrity = ssri.fromData(zipBuffer).toString()
+      const mockFetch = createMockFetch(zipBuffer)
+
+      await downloadAndUnpackZip(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockFetch as any,
+        {
+          url: 'https://example.com/node.zip',
+          integrity,
+          basename: 'node-v20.0.0',
+          ignoreEntry: /^node_modules\/(?:npm|corepack)(?:\/|$)/,
+        },
+        targetDir
+      )
+
+      expect(fs.existsSync(path.join(targetDir, 'node.exe'))).toBe(true)
+      expect(fs.existsSync(path.join(targetDir, 'node_modules/npm'))).toBe(false)
+      expect(fs.existsSync(path.join(targetDir, 'node_modules/corepack'))).toBe(false)
+    })
+
     it('strips /g /y flags from ignoreEntry so .test() is not stateful across entries', async () => {
       const targetDir = temporaryDirectory()
       const zip = new AdmZip()


### PR DESCRIPTION
## Summary

- Fix Windows `node@runtime:<ver>` installs still extracting bundled `npm`, `npx`, and `corepack` when the Node.js zip contains explicit directory entries (which the real `node-vX.Y.Z-win-<arch>.zip` archives do).
- Root cause: in `fetching/binary-fetcher/src/index.ts`, `extractZipToTarget` iterates `zip.getEntries()` (files **and** directories). For the top-level directory entry `node-vX.Y.Z-win-<arch>/`, the relative path after stripping the basename prefix is `''`, which the `ignoreEntry` regex never matches — so it's not skipped. AdmZip's `extractEntryTo(dirEntry, ...)` then expands to every descendant via `getEntryChildren`, writing every child file directly and bypassing the per-entry filter. Result: all the npm/corepack files get written anyway.
- Fix: skip directory entries in the loop. File extraction creates parent directories implicitly (AdmZip's `writeFileTo` handles `mkdir -p`), so this doesn't regress the install layout.
- Caught by `installing/deps-installer/test/install/nodeRuntime.ts` failing on Windows CI after #11325 landed. Added a regression test in `fetching/binary-fetcher/test/index.ts` that constructs a zip with explicit directory entries (the existing tests only used `zip.addFile` for files, which don't produce directory entries, so the bug went unnoticed).

## Test plan

- [x] `pnpm --filter @pnpm/fetching.binary-fetcher test` — all 12 tests pass; the new regression test (`still honors ignoreEntry when the archive contains directory entries`) fails on the unpatched `extractZipToTarget` and passes with the fix.
- [ ] `installing/deps-installer` nodeRuntime test on Windows CI — should be green once this lands.