### PR TITLE
fix: global bin shim invokes pnpm instead of Node when installed via @pnpm/exe

### DIFF
--- a/.changeset/fix-global-shim-pnpm-exe.md
+++ b/.changeset/fix-global-shim-pnpm-exe.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+Globally-installed bins no longer fail with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` when pnpm was installed via the standalone `@pnpm/exe` binary (e.g. `curl -fsSL https://get.pnpm.io/install.sh | sh -`) on a system without a separate Node.js installation. Previously, when `which('node')` failed during `pnpm add --global`, pnpm fell back to `process.execPath`, which in `@pnpm/exe` is the pnpm binary itself — and that path was baked into the generated bin shim, causing the shim to invoke pnpm instead of Node [#11291](https://github.com/pnpm/pnpm/issues/11291), [#4645](https://github.com/pnpm/pnpm/issues/4645).

--- a/pkg-manager/plugin-commands-installation/package.json
+++ b/pkg-manager/plugin-commands-installation/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/cli-meta": "workspace:*",
     "@pnpm/cli-utils": "workspace:*",
     "@pnpm/colorize-semver-diff": "catalog:",
     "@pnpm/command": "workspace:*",

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -268,7 +268,7 @@ when running add/update with the --workspace option')
   }
   if (opts.global && opts.pnpmHomeDir != null) {
     const nodeExecPath = await getNodeExecPath()
-    if (isSubdir(opts.pnpmHomeDir, nodeExecPath)) {
+    if (nodeExecPath != null && isSubdir(opts.pnpmHomeDir, nodeExecPath)) {
       installOpts['nodeExecPath'] = nodeExecPath
     }
   }

--- a/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
+++ b/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'fs'
+import { detectIfCurrentPkgIsExecutable } from '@pnpm/cli-meta'
 import which from 'which'
 
-export async function getNodeExecPath (): Promise<string> {
+export async function getNodeExecPath (): Promise<string | undefined> {
   try {
     // The system default Node.js executable is preferred
     // not the one used to run the pnpm CLI.
@@ -9,6 +10,12 @@ export async function getNodeExecPath (): Promise<string> {
     return fs.realpath(nodeExecPath)
   } catch (err: any) { // eslint-disable-line
     if (err['code'] !== 'ENOENT') throw err
+    // When pnpm runs as @pnpm/exe (a Single Executable Application that
+    // bundles Node.js into the pnpm binary), process.execPath points at the
+    // pnpm binary itself rather than a standalone Node binary. Using it as
+    // the nodeExecPath of a bin shim makes the shim invoke pnpm instead of
+    // Node, which breaks globally-installed CLIs. See #11291 and #4645.
+    if (detectIfCurrentPkgIsExecutable()) return undefined
     return process.env.NODE ?? process.execPath
   }
 }

--- a/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
+++ b/pkg-manager/plugin-commands-installation/src/nodeExecPath.ts
@@ -10,10 +10,10 @@ export async function getNodeExecPath (): Promise<string | undefined> {
     return fs.realpath(nodeExecPath)
   } catch (err: any) { // eslint-disable-line
     if (err['code'] !== 'ENOENT') throw err
-    // When pnpm runs as @pnpm/exe (a Single Executable Application that
-    // bundles Node.js into the pnpm binary), process.execPath points at the
-    // pnpm binary itself rather than a standalone Node binary. Using it as
-    // the nodeExecPath of a bin shim makes the shim invoke pnpm instead of
+    // When pnpm runs as @pnpm/exe (a packaged executable that bundles
+    // Node.js into the pnpm binary), process.execPath points at the pnpm
+    // binary itself rather than a standalone Node binary. Using it as the
+    // nodeExecPath of a bin shim makes the shim invoke pnpm instead of
     // Node, which breaks globally-installed CLIs. See #11291 and #4645.
     if (detectIfCurrentPkgIsExecutable()) return undefined
     return process.env.NODE ?? process.execPath

--- a/pkg-manager/plugin-commands-installation/test/global.ts
+++ b/pkg-manager/plugin-commands-installation/test/global.ts
@@ -43,6 +43,7 @@ const DEFAULT_OPTIONS = {
 
 test('globally installed package is linked with active version of Node.js', async () => {
   const nodeExecPath = await getNodeExecPath()
+  if (nodeExecPath == null) throw new Error('Node.js executable was not found')
   prepare()
   await add.handler({
     ...DEFAULT_OPTIONS,

--- a/pkg-manager/plugin-commands-installation/test/nodeExecPath.ts
+++ b/pkg-manager/plugin-commands-installation/test/nodeExecPath.ts
@@ -1,0 +1,37 @@
+import { detectIfCurrentPkgIsExecutable } from '@pnpm/cli-meta'
+import which from 'which'
+import { getNodeExecPath } from '../lib/nodeExecPath.js'
+
+jest.mock('which', () => jest.fn())
+jest.mock('@pnpm/cli-meta', () => ({
+  detectIfCurrentPkgIsExecutable: jest.fn(),
+}))
+
+const whichMock = jest.mocked(which)
+const detectMock = jest.mocked(detectIfCurrentPkgIsExecutable)
+
+afterEach(() => {
+  whichMock.mockReset()
+  detectMock.mockReset()
+})
+
+test('returns undefined when node is not on PATH and pnpm is running as @pnpm/exe', async () => {
+  const enoent: NodeJS.ErrnoException = Object.assign(new Error('not found: node'), { code: 'ENOENT' })
+  whichMock.mockRejectedValue(enoent)
+  detectMock.mockReturnValue(true)
+
+  await expect(getNodeExecPath()).resolves.toBeUndefined()
+})
+
+test('falls back to process.execPath when node is not on PATH and pnpm is running under a real Node.js', async () => {
+  const enoent: NodeJS.ErrnoException = Object.assign(new Error('not found: node'), { code: 'ENOENT' })
+  whichMock.mockRejectedValue(enoent)
+  detectMock.mockReturnValue(false)
+  const savedNode = process.env.NODE
+  delete process.env.NODE
+  try {
+    await expect(getNodeExecPath()).resolves.toBe(process.execPath)
+  } finally {
+    if (savedNode != null) process.env.NODE = savedNode
+  }
+})

--- a/pkg-manager/plugin-commands-installation/tsconfig.json
+++ b/pkg-manager/plugin-commands-installation/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../../catalogs/types"
     },
     {
+      "path": "../../cli/cli-meta"
+    },
+    {
       "path": "../../cli/cli-utils"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5754,6 +5754,9 @@ importers:
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types
+      '@pnpm/cli-meta':
+        specifier: workspace:*
+        version: link:../../cli/cli-meta
       '@pnpm/cli-utils':
         specifier: workspace:*
         version: link:../../cli/cli-utils


### PR DESCRIPTION
## Summary

When pnpm is installed as `@pnpm/exe` (the Single Executable Application bundled with Node.js, used by `curl -fsSL https://get.pnpm.io/install.sh | sh -`) on a machine with **no separate Node.js on PATH**, globally-installed CLIs fail with:

```
ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "<cwd>".
```

### Root cause

`pkg-manager/plugin-commands-installation/src/nodeExecPath.ts` tries `which('node')` first, then falls back to `process.execPath` on `ENOENT`. Inside `@pnpm/exe` (SEA), `process.execPath` **is** the pnpm binary, not a standalone Node binary. That path is inside `$PNPM_HOME`, so `isSubdir(pnpmHomeDir, nodeExecPath)` matched, and pnpm baked the pnpm binary into the `nodeExecPath` of every global bin shim.

With `nodeExecPath` set, `@zkochan/cmd-shim` emits a shim of the form:

```sh
"<nodeExecPath>" "<target>" "$@"
```

So running any globally-installed CLI invoked pnpm with the script path as its first positional argument. pnpm then attempted to load a script from the current working directory's `package.json`, which did not exist — hence the error.

### Fix

Detect the `@pnpm/exe` case via the existing `detectIfCurrentPkgIsExecutable` helper from `@pnpm/cli-meta` and return `undefined` from `getNodeExecPath` instead of the SEA path. The caller in `installDeps.ts` skips setting `installOpts.nodeExecPath` when it is `undefined`, so `cmd-shim` emits the plain `exec "$basedir/node"` form that falls back to `node` on PATH.

Closes #11291
Refs #4645

## Test plan

- [x] New unit tests in `test/nodeExecPath.ts` cover both branches: `undefined` under `@pnpm/exe`, and `process.execPath` fallback under real Node.js
- [x] Existing `test/global.ts` updated for the new `string | undefined` return type
- [x] `tsc --build` is clean
- [ ] Manual verification: on a fresh Linux machine with no system Node.js, install pnpm via the official installer, run `pnpm add -g qrcode-terminal`, and confirm the resulting bin shim emits `exec "$basedir/node" …` (the `if [ -x "$basedir/node" ] … else exec node …` form) rather than a hardcoded pnpm path