### PR TITLE
[wontfix] fix: copy publishConfig.registry to manifest

### DIFF
--- a/core/types/src/package.ts
+++ b/core/types/src/package.ts
@@ -114,6 +114,7 @@ export interface BaseManifest {
   cpu?: string[]
   os?: string[]
   libc?: string[]
+  registry?: string
   main?: string
   module?: string
   typings?: string

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -132,14 +132,13 @@ interface RegistryInfo {
  * Follows {@link https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#auth-related-configuration}.
  */
 function findRegistryInfo (
-  { name }: ExportedManifest,
+  { name, registry: manifestRegistry }: ExportedManifest & { registry?: string },
   { configByUri, registries }: Pick<Config, 'configByUri' | 'registries'>
 ): Partial<RegistryInfo> {
-  // eslint-disable-next-line regexp/no-unused-capturing-group
-  const scopedMatches = /@(?<scope>[^/]+)\/(?<slug>[^/]+)/.exec(name)
+  const scopedMatches = /@(?<scope>[^/]+)\/[^/]+/.exec(name)
 
   const registryName = scopedMatches?.groups ? `@${scopedMatches.groups.scope}` : 'default'
-  const nonNormalizedRegistry = registries[registryName] ?? registries.default
+  const nonNormalizedRegistry = manifestRegistry ?? registries[registryName] ?? registries.default
 
   const supportedRegistryInfo = parseSupportedRegistryUrl(nonNormalizedRegistry)
   if (!supportedRegistryInfo) {

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -132,7 +132,7 @@ interface RegistryInfo {
  * Follows {@link https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#auth-related-configuration}.
  */
 function findRegistryInfo (
-  { name, registry: manifestRegistry }: ExportedManifest & { registry?: string },
+  { name, registry: manifestRegistry }: ExportedManifest,
   { configByUri, registries }: Pick<Config, 'configByUri' | 'registries'>
 ): Partial<RegistryInfo> {
   const scopedMatches = /@(?<scope>[^/]+)\/[^/]+/.exec(name)

--- a/releasing/exportable-manifest/src/overridePublishConfig.ts
+++ b/releasing/exportable-manifest/src/overridePublishConfig.ts
@@ -25,6 +25,7 @@ const PUBLISH_CONFIG_WHITELIST = new Set([
   'libc',
   // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
   'typesVersions',
+  'registry',
 ])
 
 export function overridePublishConfig (publishManifest: ProjectManifest): void {

--- a/releasing/exportable-manifest/src/transform/index.ts
+++ b/releasing/exportable-manifest/src/transform/index.ts
@@ -1,4 +1,4 @@
-import type { PackageJSON as ExportedManifest } from '@npm/types'
+import type { PackageJSON } from '@npm/types'
 import type { ProjectManifest } from '@pnpm/types'
 import { pipe } from 'ramda'
 
@@ -6,7 +6,9 @@ import { transformBin } from './bin.js'
 import { transformPeerDependenciesMeta } from './peerDependenciesMeta.js'
 import { transformRequiredFields } from './requiredFields.js'
 
-export { type ExportedManifest }
+export type ExportedManifest = PackageJSON & { registry?: string }
+
+export type { PackageJSON }
 
 export type Transform = (manifest: ProjectManifest) => ExportedManifest
 export const transform: Transform = pipe(

--- a/releasing/exportable-manifest/src/transform/index.ts
+++ b/releasing/exportable-manifest/src/transform/index.ts
@@ -6,9 +6,9 @@ import { transformBin } from './bin.js'
 import { transformPeerDependenciesMeta } from './peerDependenciesMeta.js'
 import { transformRequiredFields } from './requiredFields.js'
 
-export type ExportedManifest = PackageJSON & { registry?: string }
-
-export type { PackageJSON }
+export interface ExportedManifest extends PackageJSON {
+  registry?: string
+}
 
 export type Transform = (manifest: ProjectManifest) => ExportedManifest
 export const transform: Transform = pipe(

--- a/releasing/exportable-manifest/test/overridePublishConfig.test.ts
+++ b/releasing/exportable-manifest/test/overridePublishConfig.test.ts
@@ -31,3 +31,17 @@ test('publish config to be overridden', async () => {
     expect(publishManifest[publishConfigKey as keyof PackageManifest]).toEqual(publishConfig[publishConfigKey])
   }
 })
+
+test('publishConfig.registry is copied to manifest', async () => {
+  const publishConfig: PublishConfig = {
+    registry: 'https://custom.registry.example.com/',
+  }
+  const publishManifest: PackageManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    publishConfig,
+  }
+  overridePublishConfig(publishManifest)
+  expect(publishManifest.publishConfig).toBeUndefined()
+  expect(publishManifest.registry).toBe('https://custom.registry.example.com/')
+})


### PR DESCRIPTION
Closes pnpm/pnpm#11098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests can include a registry field; publish flow now respects registry specified in a package manifest.

* **Bug Fixes**
  * Publishing logic better detects scope-based registry selection to ensure packages are published to the intended registry.

* **Tests**
  * Added test coverage validating publishConfig.registry is moved into the manifest and honored during publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->