### PR TITLE
fix: prevent fork-bomb during packageManager-driven version switching

### DIFF
--- a/.changeset/fix-switch-fork-bomb.md
+++ b/.changeset/fix-switch-fork-bomb.md
@@ -1,0 +1,13 @@
+---
+"@pnpm/exec.pnpm-cli-runner": minor
+"@pnpm/tools.plugin-commands-self-updater": patch
+"pnpm": patch
+---
+
+Fix an infinite fork-bomb that could happen when pnpm was installed with one version (e.g. `npm install -g pnpm@A`) and run inside a project whose `package.json` selected a different pnpm version via the `packageManager` field (e.g. `pnpm@B`), while a `pnpm-workspace.yaml` also existed at the project root.
+
+The child process spawned by `installPnpmToTools` (to install the wanted pnpm version) inherited the parent's environment but had its working directory set to a fresh stage dir. pnpm's workspace walk-up from that stage dir would find the ancestor `pnpm-workspace.yaml` at the project root, adopt the root `package.json`, re-trigger `switchCliVersion`, and call `installPnpmToTools` again — recursively. Because the target tool dir isn't symlinked in until the outer install completes, each recursive call saw `alreadyExisted === false` and started another nested install, fork-bombing the process tree at ~100% CPU.
+
+The child's environment is now forced to `manage-package-manager-versions=false` (v10) and `pm-on-fail=ignore` (v11+), which disables the package-manager-version handling in whichever pnpm runs as the child.
+
+Fixes [#11337](https://github.com/pnpm/pnpm/issues/11337).

--- a/exec/pnpm-cli-runner/src/index.ts
+++ b/exec/pnpm-cli-runner/src/index.ts
@@ -1,10 +1,14 @@
 import path from 'path'
 import { sync as execSync } from 'execa'
 
-export function runPnpmCli (command: string[], { cwd }: { cwd: string }): void {
+export function runPnpmCli (
+  command: string[],
+  { cwd, env }: { cwd: string, env?: NodeJS.ProcessEnv }
+): void {
   const execOpts = {
     cwd,
     stdio: 'inherit' as const,
+    ...(env ? { env } : {}),
   }
   const execFileName = path.basename(process.execPath).toLowerCase()
   if (execFileName === 'pnpm' || execFileName === 'pnpm.exe') {

--- a/pnpm/src/switchCliVersion.ts
+++ b/pnpm/src/switchCliVersion.ts
@@ -43,7 +43,12 @@ export async function switchCliVersion (config: Config): Promise<void> {
     env: {
       ...process.env,
       [pnpmEnv.name]: pnpmEnv.value,
+      // Disable the target pnpm's own package-manager-version management so
+      // it doesn't try to switch again. We set both names because v10 reads
+      // npm_config_* while v11+ reads pnpm_config_*, and this spawn may
+      // target either major.
       npm_config_manage_package_manager_versions: 'false',
+      pnpm_config_pm_on_fail: 'ignore',
     },
   })
 

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -89,7 +89,7 @@ test('commands that v10 passes through to npm keep passing through when packageM
   expect(stdout.toString()).toContain('Bump a package version')
 })
 
-test('`pnpm version` routes through switchCliVersion to v11 when packageManager selects pnpm v11+', () => {
+test('`pnpm version` routes through switchCliVersion to v11 when packageManager selects pnpm v11+, even with a pnpm-workspace.yaml at the project root', () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')
   const version = '11.0.0-rc.5'
@@ -100,6 +100,11 @@ test('`pnpm version` routes through switchCliVersion to v11 when packageManager 
     PNPM_HOME: pnpmHome,
     npm_config_registry: 'https://registry.npmjs.org/',
   }
+  // pnpm-workspace.yaml at the project root is what lets the install-child's
+  // workspace walk-up see this dir's package.json + packageManager field.
+  // Before the #11337 fix this would fork-bomb; the tool-dir assertion below
+  // doubles as a fork-bomb regression check in the v11-target path.
+  fs.writeFileSync('pnpm-workspace.yaml', '')
   writeJsonFile('package.json', {
     packageManager: `pnpm@${version}`,
   })
@@ -158,36 +163,6 @@ test('switching does not fork-bomb when a pnpm-workspace.yaml at the project roo
 
   expect(stdout.toString()).toContain('Version 9.3.0')
 }, 90_000)
-
-test('switching to v11 does not fork-bomb when a pnpm-workspace.yaml at the project root is visible to the install-child (#11337 regression)', () => {
-  prepare()
-  const pnpmHome = path.resolve('pnpm')
-  const version = '11.0.0-rc.5'
-  // Same reasoning as the sibling v11 test above: fetch pnpm v11 from the real
-  // npmjs registry because the registry mock is slow/flaky for v11's full dep
-  // tree and here we only need a real tarball to prove the handoff happened.
-  const env = {
-    PNPM_HOME: pnpmHome,
-    npm_config_registry: 'https://registry.npmjs.org/',
-  }
-  // Pair a v11+ packageManager with a root pnpm-workspace.yaml. This mirrors
-  // the primary #11337 reproducer (where the target major differs from the
-  // running major), and would fork-bomb on v10 without the env-var guard that
-  // keeps the install-child from re-entering switchCliVersion.
-  fs.writeFileSync('pnpm-workspace.yaml', '')
-  writeJsonFile('package.json', {
-    packageManager: `pnpm@${version}`,
-  })
-
-  execPnpmSync(['version'], { env, timeout: 120_000 })
-
-  // The tool dir's presence is direct proof that installPnpmToTools completed
-  // (reached only from main() → switchCliVersion), so the switch succeeded
-  // without looping. See the sibling v11 test above for why we don't assert on
-  // v11 executing its own `version` command.
-  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
-  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
-}, 180_000)
 
 test('no spurious re-entry when the packageManager version matches the current pnpm, even with a pnpm-workspace.yaml at the root', () => {
   prepare()

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -139,6 +139,25 @@ test('npm passthrough still fires when packageManager selects pnpm v11+ but swit
   expect(stdout.toString()).toContain('Bump a package version')
 })
 
+test('switching does not fork-bomb when a pnpm-workspace.yaml at the project root is visible to the install-child (#11337 regression)', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  // pnpm-workspace.yaml at the project root is what makes the install-child's
+  // workspace walk-up hit this dir's package.json, pulling in its
+  // packageManager field and re-triggering switchCliVersion inside the child.
+  // Without the env-var guard in installPnpmToTools, that would recurse
+  // indefinitely because the target tool dir is not symlinked in yet.
+  fs.writeFileSync('pnpm-workspace.yaml', '')
+  writeJsonFile('package.json', {
+    packageManager: 'pnpm@9.3.0',
+  })
+
+  const { stdout } = execPnpmSync(['help'], { env, timeout: 60_000 })
+
+  expect(stdout.toString()).toContain('Version 9.3.0')
+}, 90_000)
+
 test('throws error if pnpm tools dir is corrupt', () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')

--- a/pnpm/test/switchingVersions.test.ts
+++ b/pnpm/test/switchingVersions.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import { packageManager } from '@pnpm/cli-meta'
 import { prepare } from '@pnpm/prepare'
 import { getToolDirPath } from '@pnpm/tools.path'
 import { sync as writeJsonFile } from 'write-json-file'
@@ -157,6 +158,58 @@ test('switching does not fork-bomb when a pnpm-workspace.yaml at the project roo
 
   expect(stdout.toString()).toContain('Version 9.3.0')
 }, 90_000)
+
+test('switching to v11 does not fork-bomb when a pnpm-workspace.yaml at the project root is visible to the install-child (#11337 regression)', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const version = '11.0.0-rc.5'
+  // Same reasoning as the sibling v11 test above: fetch pnpm v11 from the real
+  // npmjs registry because the registry mock is slow/flaky for v11's full dep
+  // tree and here we only need a real tarball to prove the handoff happened.
+  const env = {
+    PNPM_HOME: pnpmHome,
+    npm_config_registry: 'https://registry.npmjs.org/',
+  }
+  // Pair a v11+ packageManager with a root pnpm-workspace.yaml. This mirrors
+  // the primary #11337 reproducer (where the target major differs from the
+  // running major), and would fork-bomb on v10 without the env-var guard that
+  // keeps the install-child from re-entering switchCliVersion.
+  fs.writeFileSync('pnpm-workspace.yaml', '')
+  writeJsonFile('package.json', {
+    packageManager: `pnpm@${version}`,
+  })
+
+  execPnpmSync(['version'], { env, timeout: 120_000 })
+
+  // The tool dir's presence is direct proof that installPnpmToTools completed
+  // (reached only from main() → switchCliVersion), so the switch succeeded
+  // without looping. See the sibling v11 test above for why we don't assert on
+  // v11 executing its own `version` command.
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version } })
+  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(true)
+}, 180_000)
+
+test('no spurious re-entry when the packageManager version matches the current pnpm, even with a pnpm-workspace.yaml at the root', () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  // Same-version scenario: switchCliVersion must short-circuit at the
+  // `pm.version === packageManager.version` check (switchCliVersion.ts). The
+  // ancestor pnpm-workspace.yaml must not cause any detour through
+  // installPnpmToTools. If it did, `pnpm -v` would either hang or print the
+  // wrong version.
+  fs.writeFileSync('pnpm-workspace.yaml', '')
+  writeJsonFile('package.json', {
+    packageManager: `pnpm@${packageManager.version}`,
+  })
+
+  const { stdout } = execPnpmSync(['-v'], { env, timeout: 30_000 })
+
+  expect(stdout.toString().trim()).toBe(packageManager.version)
+  // And the tool dir must not have been created — no install should have run.
+  const toolDir = getToolDirPath({ pnpmHomeDir: pnpmHome, tool: { name: 'pnpm', version: packageManager.version } })
+  expect(fs.existsSync(path.join(toolDir, 'bin/pnpm'))).toBe(false)
+}, 60_000)
 
 test('throws error if pnpm tools dir is corrupt', () => {
   prepare()

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -52,7 +52,22 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
       // which breaks the junctions on Windows.
       '--config.node-linker=hoisted',
       '--config.bin=bin',
-    ], { cwd: stage })
+    ], {
+      cwd: stage,
+      // Force the child to skip its own package-manager-version switching.
+      // Without these the child's workspace walk-up from `stage` can discover
+      // an ancestor pnpm-workspace.yaml + package.json whose packageManager
+      // field selects a different pnpm version, causing the child to call
+      // installPnpmToTools again. Because the target tool dir hasn't been
+      // symlinked in yet, `fs.existsSync(binDir)` still returns false, so the
+      // child starts another nested install — fork-bombing the process tree.
+      // See pnpm/pnpm#11337.
+      env: {
+        ...process.env,
+        npm_config_manage_package_manager_versions: 'false', // v10 setting name
+        pnpm_config_pm_on_fail: 'ignore', // v11+ setting name
+      },
+    })
     if (currentPkgName === '@pnpm/exe') {
       linkExePlatformBinary(stage)
     }

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -52,20 +52,25 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
       // which breaks the junctions on Windows.
       '--config.node-linker=hoisted',
       '--config.bin=bin',
+      // This is an isolated install into `stage` and must not inherit the
+      // caller's workspace context. Without this, the child's workspace
+      // walk-up from `stage` can discover an ancestor pnpm-workspace.yaml
+      // and treat the caller's project as the workspace root — breaking the
+      // add (it's outside the workspace's packages list) and, before the env
+      // guards below existed, picking up the caller's packageManager field
+      // and re-entering switchCliVersion for a fork bomb. See pnpm/pnpm#11337.
+      '--ignore-workspace',
     ], {
       cwd: stage,
-      // Force the child to skip its own package-manager-version switching.
-      // Without these the child's workspace walk-up from `stage` can discover
-      // an ancestor pnpm-workspace.yaml + package.json whose packageManager
-      // field selects a different pnpm version, causing the child to call
-      // installPnpmToTools again. Because the target tool dir hasn't been
-      // symlinked in yet, `fs.existsSync(binDir)` still returns false, so the
-      // child starts another nested install — fork-bombing the process tree.
-      // See pnpm/pnpm#11337.
+      // Defense in depth against re-entering switchCliVersion in the child,
+      // in case any future code path surfaces a wantedPackageManager without
+      // going through workspace discovery. Both env-var names are set so the
+      // guard works regardless of whether the child reads pnpm's v10
+      // (npm_config_*) or v11+ (pnpm_config_*) convention.
       env: {
         ...process.env,
-        npm_config_manage_package_manager_versions: 'false', // v10 setting name
-        pnpm_config_pm_on_fail: 'ignore', // v11+ setting name
+        npm_config_manage_package_manager_versions: 'false',
+        pnpm_config_pm_on_fail: 'ignore',
       },
     })
     if (currentPkgName === '@pnpm/exe') {


### PR DESCRIPTION
## Summary

Fixes the infinite fork-bomb reported in #11337. When pnpm was installed via one method (e.g. `npm install -g pnpm@A`) and run inside a project whose `package.json` selected a different pnpm version via the `packageManager` field (`pnpm@B`), with a `pnpm-workspace.yaml` at the project root, pnpm would recursively spawn install-children at ~100% CPU forever.

**Root cause:** `switchCliVersion` → `installPnpmToTools` → `runPnpmCli` spawns a child pnpm to `add pnpm@B` into a stage directory under the pnpm home dir. The child inherited the parent's env and had `cwd` set to that stage dir. pnpm's workspace-dir detection walks up from `cwd` looking for `pnpm-workspace.yaml`, and when the user's workspace sits at a path that happens to be an ancestor of the stage dir (e.g. `/` in Docker with WORKDIR at `/`), the walk-up finds it. The child then adopts the user's `package.json`, sees `packageManager: pnpm@B`, and re-enters `switchCliVersion`. Because the target tool dir has not been symlinked in yet (the outer install is still in flight), `fs.existsSync(binDir)` returns false and the child starts another nested `installPnpmToTools` — fork-bombing the process tree.

**Fix:** force the install-child's environment to disable its own package-manager-version handling, using both env-var names so either a v10 or v11+ child honors it:

- `npm_config_manage_package_manager_versions=false` — v10 setting name
- `pnpm_config_pm_on_fail=ignore` — v11+ setting name

Also set `pnpm_config_pm_on_fail=ignore` on the terminal spawn at the end of `switchCliVersion` (which previously only set the v10 name). This matters when v10 switches forward to v11, because v11 reads the `pnpm_config_*` prefix, not `npm_config_*`.

## Changes

- `exec/pnpm-cli-runner/src/index.ts`: `runPnpmCli` now accepts an optional `env` param and forwards it to `execa`.
- `tools/plugin-commands-self-updater/src/installPnpmToTools.ts`: passes the guarded env to `runPnpmCli`.
- `pnpm/src/switchCliVersion.ts`: adds `pnpm_config_pm_on_fail=ignore` alongside the existing `npm_config_manage_package_manager_versions=false` on the terminal spawn.
- `pnpm/test/switchingVersions.test.ts`: regression test that reproduces the fork-bomb when a `pnpm-workspace.yaml` sits at the project root.

## Test plan

- [x] Manual repro of the original bug: `pnpm@10.33.1` installed globally + `package.json` with `packageManager: pnpm@10.33.0` + empty `pnpm-workspace.yaml` in the same dir → before this patch, 30+ chained `add pnpm@10.33.0` child processes at 100% CPU; after this patch, the command completes in a few seconds (with the existing `VERSION_SWITCH_FAIL` message when the target bin isn't resolvable, as expected in a throwaway env).
- [ ] Confirm the new regression test `switching does not fork-bomb when a pnpm-workspace.yaml at the project root is visible to the install-child` passes in CI.
- [ ] Verify existing `switchingVersions.test.ts` cases still pass.

Refs [#11337](https://github.com/pnpm/pnpm/issues/11337).