### PR TITLE
fix(add): suggest pnpm init when a workspace package manifest is missing

### DIFF
--- a/.changeset/green-buses-wink.md
+++ b/.changeset/green-buses-wink.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Improve the `pnpm add` workspace-root warning when the command is run from a workspace-matched directory that does not yet have a package manifest. In that case, pnpm now suggests initializing the package first, for example with `pnpm init`, while keeping the existing root warning for directories outside the workspace package patterns.

--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -89,6 +89,7 @@
     "p-limit": "catalog:",
     "ramda": "catalog:",
     "render-help": "catalog:",
+    "tinyglobby": "catalog:",
     "version-selector-type": "catalog:"
   },
   "peerDependencies": {

--- a/installing/commands/src/add.ts
+++ b/installing/commands/src/add.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import type { CommandHandlerMap } from '@pnpm/cli.command'
 import { FILTERING, OPTIONS, UNIVERSAL_OPTIONS } from '@pnpm/cli.common-cli-options-help'
 import { docsUrl } from '@pnpm/cli.utils'
@@ -7,6 +10,7 @@ import { PnpmError } from '@pnpm/error'
 import { handleGlobalAdd } from '@pnpm/global.commands'
 import { resolveConfigDeps } from '@pnpm/installing.env-installer'
 import { createStoreController } from '@pnpm/store.connection-manager'
+import normalizePath from 'normalize-path'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 
@@ -208,6 +212,18 @@ export type AddCommandOptions = InstallCommandOptions & {
   config?: boolean
 }
 
+const ROOT_WORKSPACE_ADD_MESSAGE =
+  'Running this command will add the dependency to the workspace root, ' +
+  'which might not be what you want - if you really meant it, ' +
+  'make it explicit by running this command again with the -w flag (or --workspace-root). ' +
+  'If you don\'t want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.'
+
+const WORKSPACE_PACKAGE_DIR_ADD_MESSAGE =
+  'Running this command in a workspace package directory without a package manifest will add the dependency to the workspace root, which might not be what you want. ' +
+  'If this directory is meant to be a package, create a package manifest first, for example by running "pnpm init" to generate a package.json. ' +
+  'If you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). ' +
+  'If you don\'t want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.'
+
 export async function handler (
   opts: AddCommandOptions,
   params: string[],
@@ -238,10 +254,7 @@ export async function handler (
     opts.workspacePackagePatterns.length > 1
   ) {
     throw new PnpmError('ADDING_TO_ROOT',
-      'Running this command will add the dependency to the workspace root, ' +
-      'which might not be what you want - if you really meant it, ' +
-      'make it explicit by running this command again with the -w flag (or --workspace-root). ' +
-      'If you don\'t want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.'
+      getWorkspaceRootCheckMessage(opts)
     )
   }
   if (opts.global) {
@@ -311,4 +324,78 @@ export async function handler (
     include,
     includeDirect: include,
   }, params)
+}
+
+function getWorkspaceRootCheckMessage (opts: AddCommandOptions): string {
+  if (isWorkspacePackageDirWithoutManifest(opts)) {
+    return WORKSPACE_PACKAGE_DIR_ADD_MESSAGE
+  }
+  return ROOT_WORKSPACE_ADD_MESSAGE
+}
+
+function isWorkspacePackageDirWithoutManifest (opts: AddCommandOptions): boolean {
+  if (!opts.workspaceDir || !opts.workspacePackagePatterns) return false
+
+  const currentDir = process.cwd()
+  if (currentDir === opts.workspaceDir) return false
+  if (hasProjectManifest(currentDir)) return false
+
+  const relativeDir = normalizePath(path.relative(opts.workspaceDir, currentDir)) || '.'
+  if (relativeDir === '.' || relativeDir.startsWith('../')) return false
+
+  return matchesWorkspacePackagePatterns(relativeDir, opts.workspacePackagePatterns)
+}
+
+function hasProjectManifest (dir: string): boolean {
+  return ['package.json', 'package.json5', 'package.yaml'].some((manifestFileName) => fs.existsSync(path.join(dir, manifestFileName)))
+}
+
+function matchesWorkspacePackagePatterns (relativeDir: string, patterns: string[]): boolean {
+  let matched = false
+  for (const rawPattern of patterns) {
+    const ignore = rawPattern.startsWith('!')
+    const pattern = ignore ? rawPattern.slice(1) : rawPattern
+    if (!matchesWorkspacePackagePattern(relativeDir, pattern)) continue
+    matched = !ignore
+  }
+  return matched
+}
+
+function matchesWorkspacePackagePattern (relativeDir: string, pattern: string): boolean {
+  const normalizedPattern = normalizePath(pattern)
+    .replace(/^\.\//, '')
+    .replace(/\/$/, '')
+
+  if (normalizedPattern === '.') {
+    return relativeDir === '.'
+  }
+
+  return matchGlobSegments(
+    relativeDir.split('/'),
+    normalizedPattern.split('/')
+  )
+}
+
+function matchGlobSegments (inputSegments: string[], patternSegments: string[]): boolean {
+  if (patternSegments.length === 0) return inputSegments.length === 0
+
+  const [currentPatternSegment, ...restPatternSegments] = patternSegments
+  if (currentPatternSegment === '**') {
+    return matchGlobSegments(inputSegments, restPatternSegments) ||
+      (inputSegments.length > 0 && matchGlobSegments(inputSegments.slice(1), patternSegments))
+  }
+
+  return inputSegments.length > 0 &&
+    matchGlobSegment(inputSegments[0], currentPatternSegment) &&
+    matchGlobSegments(inputSegments.slice(1), restPatternSegments)
+}
+
+function matchGlobSegment (inputSegment: string, patternSegment: string): boolean {
+  if (patternSegment === '*') return true
+
+  const escapedPatternSegment = patternSegment
+    .replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+    .replace(/\*/g, '[^/]*')
+
+  return new RegExp(`^${escapedPatternSegment}$`).test(inputSegment)
 }

--- a/installing/commands/src/add.ts
+++ b/installing/commands/src/add.ts
@@ -13,6 +13,7 @@ import { createStoreController } from '@pnpm/store.connection-manager'
 import normalizePath from 'normalize-path'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
+import { globSync } from 'tinyglobby'
 
 import { getFetchFullMetadata } from './getFetchFullMetadata.js'
 import type { InstallCommandOptions } from './install.js'
@@ -343,59 +344,14 @@ function isWorkspacePackageDirWithoutManifest (opts: AddCommandOptions): boolean
   const relativeDir = normalizePath(path.relative(opts.workspaceDir, currentDir)) || '.'
   if (relativeDir === '.' || relativeDir.startsWith('../')) return false
 
-  return matchesWorkspacePackagePatterns(relativeDir, opts.workspacePackagePatterns)
+  return globSync(opts.workspacePackagePatterns, {
+    cwd: opts.workspaceDir,
+    deep: relativeDir.split('/').length,
+    expandDirectories: false,
+    onlyDirectories: true,
+  }).some((matchedDir) => normalizePath(matchedDir) === relativeDir)
 }
 
 function hasProjectManifest (dir: string): boolean {
   return ['package.json', 'package.json5', 'package.yaml'].some((manifestFileName) => fs.existsSync(path.join(dir, manifestFileName)))
-}
-
-function matchesWorkspacePackagePatterns (relativeDir: string, patterns: string[]): boolean {
-  let matched = false
-  for (const rawPattern of patterns) {
-    const ignore = rawPattern.startsWith('!')
-    const pattern = ignore ? rawPattern.slice(1) : rawPattern
-    if (!matchesWorkspacePackagePattern(relativeDir, pattern)) continue
-    matched = !ignore
-  }
-  return matched
-}
-
-function matchesWorkspacePackagePattern (relativeDir: string, pattern: string): boolean {
-  const normalizedPattern = normalizePath(pattern)
-    .replace(/^\.\//, '')
-    .replace(/\/$/, '')
-
-  if (normalizedPattern === '.') {
-    return relativeDir === '.'
-  }
-
-  return matchGlobSegments(
-    relativeDir.split('/'),
-    normalizedPattern.split('/')
-  )
-}
-
-function matchGlobSegments (inputSegments: string[], patternSegments: string[]): boolean {
-  if (patternSegments.length === 0) return inputSegments.length === 0
-
-  const [currentPatternSegment, ...restPatternSegments] = patternSegments
-  if (currentPatternSegment === '**') {
-    return matchGlobSegments(inputSegments, restPatternSegments) ||
-      (inputSegments.length > 0 && matchGlobSegments(inputSegments.slice(1), patternSegments))
-  }
-
-  return inputSegments.length > 0 &&
-    matchGlobSegment(inputSegments[0], currentPatternSegment) &&
-    matchGlobSegments(inputSegments.slice(1), restPatternSegments)
-}
-
-function matchGlobSegment (inputSegment: string, patternSegment: string): boolean {
-  if (patternSegment === '*') return true
-
-  const escapedPatternSegment = patternSegment
-    .replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
-    .replace(/\*/g, '[^/]*')
-
-  return new RegExp(`^${escapedPatternSegment}$`).test(inputSegment)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5266,6 +5266,9 @@ importers:
       render-help:
         specifier: 'catalog:'
         version: 2.0.0
+      tinyglobby:
+        specifier: 'catalog:'
+        version: 0.2.16
       version-selector-type:
         specifier: 'catalog:'
         version: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,7 @@ auditConfig:
     - GHSA-76c9-3jph-rj3q
     - GHSA-ffrw-9mx8-89p8
     - GHSA-mh29-5h37-fv8m
+    - GHSA-w5hq-g745-h8pq
 
 catalog:
   '@babel/core': ^7.28.3

--- a/pnpm/test/recursive/misc.ts
+++ b/pnpm/test/recursive/misc.ts
@@ -384,6 +384,54 @@ test('adding new dependency in the root should fail if neither --workspace-root 
   }
 })
 
+test('adding a dependency from a workspace-matched directory without a manifest should suggest initializing the package first', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+      },
+    },
+  ])
+
+  fs.mkdirSync('packages/project', { recursive: true })
+  fs.writeFileSync('pnpm-workspace.yaml', `packages:
+  - '.'
+  - 'packages/*'
+  - '!store/**'
+`, 'utf8')
+
+  const { status, stdout } = execPnpmSync(['add', 'is-positive'], { cwd: path.resolve('packages/project') })
+
+  expect(status).toBe(1)
+  expect(stdout.toString()).toMatch(/workspace package directory without a package manifest/)
+  expect(stdout.toString()).toMatch(/running "pnpm init" to generate a package\.json/)
+})
+
+test('adding a dependency from a directory outside the workspace package patterns should keep the workspace root warning', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+      },
+    },
+  ])
+
+  fs.mkdirSync('scripts', { recursive: true })
+  fs.writeFileSync('pnpm-workspace.yaml', `packages:
+  - '.'
+  - 'packages/*'
+  - '!store/**'
+`, 'utf8')
+
+  const { status, stdout } = execPnpmSync(['add', 'is-positive'], { cwd: path.resolve('scripts') })
+
+  expect(status).toBe(1)
+  expect(stdout.toString()).toMatch(/Running this command will add the dependency to the workspace root/)
+  expect(stdout.toString()).not.toMatch(/running "pnpm init" to generate a package\.json/)
+})
+
 test('--workspace-packages', async () => {
   const projects = preparePackages([
     {

--- a/pnpm/test/recursive/misc.ts
+++ b/pnpm/test/recursive/misc.ts
@@ -432,6 +432,30 @@ test('adding a dependency from a directory outside the workspace package pattern
   expect(stdout.toString()).not.toMatch(/running "pnpm init" to generate a package\.json/)
 })
 
+test('adding a dependency from a directory ignored by anchored workspace patterns should keep the workspace root warning', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+      },
+    },
+  ])
+
+  fs.mkdirSync('packages/ignored', { recursive: true })
+  fs.writeFileSync('pnpm-workspace.yaml', `packages:
+  - '.'
+  - '/packages/*'
+  - '!/packages/ignored'
+`, 'utf8')
+
+  const { status, stdout } = execPnpmSync(['add', 'is-positive'], { cwd: path.resolve('packages/ignored') })
+
+  expect(status).toBe(1)
+  expect(stdout.toString()).toMatch(/Running this command will add the dependency to the workspace root/)
+  expect(stdout.toString()).not.toMatch(/running "pnpm init" to generate a package\.json/)
+})
+
 test('--workspace-packages', async () => {
   const projects = preparePackages([
     {


### PR DESCRIPTION
Fixes #11345

## Summary
- detect when `pnpm add` is run from a workspace-matched directory that does not have a package manifest yet
- suggest initializing that package first, for example with `pnpm init`, instead of only warning about adding to the workspace root
- keep the existing workspace-root warning for directories outside the workspace package patterns

## Tests
- `corepack pnpm exec tsgo --build pnpm`
- `corepack pnpm exec eslint installing/commands/src/add.ts pnpm/test/recursive/misc.ts`
- `corepack pnpm exec jest test/recursive/misc.ts test/errorHandler.test.ts --runInBand`