### PR TITLE
feat(self-update): point users at the migration guide across major bumps

### DIFF
--- a/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -30,6 +30,15 @@ export function cliOptionsTypes (): Record<string, unknown> {
 
 export const commandNames = ['self-update']
 
+// Migration guidance printed once when `pnpm self-update` crosses a major
+// boundary. Add an entry here for each future major that ships breaking
+// changes users need to act on.
+const MAJOR_UPGRADE_HINTS: Record<number, string> = {
+  11:
+    'pnpm v11 removed or renamed several v10 settings. ' +
+    'See https://pnpm.io/11.x/migration for migration instructions.',
+}
+
 export const skipPackageManagerCheck = true
 
 export function help (): string {
@@ -73,6 +82,30 @@ export async function handler (
   })
   if (!resolution?.manifest) {
     throw new PnpmError('CANNOT_RESOLVE_PNPM', `Cannot find "${bareSpecifier}" version of pnpm`)
+  }
+
+  // Determine the "previous" pnpm version being upgraded FROM. If the
+  // project pins pnpm via `packageManager`/`devEngines.packageManager`,
+  // the pin is the source of truth — the running pnpm binary may already
+  // be at a newer major (e.g. a globally-installed v11 operating on a
+  // project still pinned to v10). Otherwise fall back to the running
+  // binary. Skip the hint entirely on a no-op (target === previous).
+  const targetVersion = resolution.manifest.version
+  let previousVersion: string | undefined
+  if (opts.wantedPackageManager?.name === packageManager.name) {
+    if (opts.wantedPackageManager.version !== targetVersion) {
+      previousVersion = opts.wantedPackageManager.version
+    }
+  } else if (packageManager.version !== targetVersion) {
+    previousVersion = packageManager.version
+  }
+  const previousMajor = previousVersion != null
+    ? semver.coerce(previousVersion)?.major
+    : undefined
+  const targetMajor = semver.major(targetVersion)
+  if (previousMajor != null && targetMajor > previousMajor) {
+    const hint = MAJOR_UPGRADE_HINTS[targetMajor]
+    if (hint) globalWarn(hint)
   }
 
   if (opts.wantedPackageManager?.name === packageManager.name) {


### PR DESCRIPTION
## Summary

Makes `pnpm self-update` print a one-line pointer to the per-major migration guide on pnpm.io when the update crosses a major version upward. For v11, the hint points at https://pnpm.io/11.x/migration (the guide + codemod walk users through the rest).

Why the "from" version is the project pin, not the running binary: with corepack (or any case where the global pnpm was already bumped), the running binary may already be v11 while the project is still pinned to v10. Using `opts.wantedPackageManager.version` when present means the hint still fires for that scenario. The no-op case (target === previous) is silent.

## Test plan

- [ ] From v10 global install, run `pnpm self-update 11` in a bare dir → hint prints once.
- [ ] From v10 global install, `pnpm self-update 11` in a v11-pinned project → no hint (already on target).
- [ ] From v11 global install, `pnpm self-update 11` in a v10-pinned project → hint prints (the pin is the "from").
- [ ] Downgrade path (`pnpm self-update 10` from v11) → no hint.

## Companion PR

pnpm/pnpm.io#777 adds the `/11.x/migration` page this hint points at.