### PR TITLE
fix(peers-checker): suppress missing peer warning when satisfied by workspace root (#1284)

### DIFF
--- a/.changeset/peers-checker-workspace-root.md
+++ b/.changeset/peers-checker-workspace-root.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.inspection.peers-checker": minor
+"@pnpm/deps.inspection.commands": patch
+"pnpm": patch
+---
+
+Fix incorrect missing peer dependency warnings in monorepos. When checking peer dependencies via the lockfile (used by `pnpm peers` and friends), peers that are provided by the workspace root importer are no longer reported as missing for sub-projects. This matches the install-time behavior governed by `resolvePeersFromWorkspaceRoot`. The new behavior is enabled by default and can be disabled by setting `resolvePeersFromWorkspaceRoot: false`. See pnpm/pnpm#1284.

--- a/deps/inspection/commands/src/peers.ts
+++ b/deps/inspection/commands/src/peers.ts
@@ -66,6 +66,7 @@ export type PeersCommandOptions = Pick<Config,
 | 'dir'
 | 'modulesDir'
 | 'peerDependencyRules'
+| 'resolvePeersFromWorkspaceRoot'
 > & Pick<ConfigContext, 'selectedProjectsGraph'>
 & Partial<Pick<ConfigContext, 'cliOptions'>> & {
   json?: boolean
@@ -100,6 +101,9 @@ async function checkCmd (
     checkWantedLockfileOnly: opts.lockfileOnly,
     modulesDir: opts.modulesDir,
     peerDependencyRules: opts.peerDependencyRules,
+    // Defaults to true (matches install-time behavior). When the user opts
+    // out via config, the lockfile-based check should reflect the same.
+    resolvePeersFromWorkspaceRoot: opts.resolvePeersFromWorkspaceRoot ?? true,
   })
 
   const noIssues = hasNoIssues(issues)

--- a/deps/inspection/peers-checker/src/checkPeerDependencies.ts
+++ b/deps/inspection/peers-checker/src/checkPeerDependencies.ts
@@ -8,6 +8,7 @@ import {
   getLockfileImporterId,
   type LockfileObject,
   type PackageSnapshots,
+  type ProjectSnapshot,
   readCurrentLockfile,
   readWantedLockfile,
 } from '@pnpm/lockfile.fs'
@@ -31,6 +32,14 @@ export async function checkPeerDependencies (
     checkWantedLockfileOnly?: boolean
     modulesDir?: string
     peerDependencyRules?: PeerDependencyRules
+    /**
+     * When true (default), peer dependencies provided by the workspace root
+     * importer are not reported as missing or unmet for non-root importers.
+     * This matches the behavior of `resolvePeersFromWorkspaceRoot` during
+     * install: in a monorepo, peers can legitimately be satisfied by a
+     * singleton installed at the workspace root.
+     */
+    resolvePeersFromWorkspaceRoot?: boolean
   }
 ): Promise<PeerDependencyIssuesByProjects> {
   const modulesDir = opts.modulesDir ?? 'node_modules'
@@ -40,22 +49,37 @@ export async function checkPeerDependencies (
       ?? await readWantedLockfile(opts.lockfileDir, { ignoreIncompatible: false })
   if (!lockfile) return {}
 
-  const issues = checkPeerDependenciesFromLockfile(projectPaths, lockfile, opts.lockfileDir)
+  const issues = checkPeerDependenciesFromLockfile(projectPaths, lockfile, opts.lockfileDir, {
+    resolvePeersFromWorkspaceRoot: opts.resolvePeersFromWorkspaceRoot ?? true,
+  })
   if (opts.peerDependencyRules) {
     return filterPeerDependencyIssues(issues, opts.peerDependencyRules)
   }
   return issues
 }
 
+interface RootPeerProvider {
+  /** Pre-resolved version provided by the workspace root for a given peer name. */
+  resolvedVersionByPeerName: Map<string, string>
+}
+
 function checkPeerDependenciesFromLockfile (
   projectPaths: string[],
   lockfile: LockfileObject,
-  lockfileDir: string
+  lockfileDir: string,
+  opts: { resolvePeersFromWorkspaceRoot: boolean }
 ): PeerDependencyIssuesByProjects {
   const packages = lockfile.packages ?? {}
   const importerIds = projectPaths.map((p) => getLockfileImporterId(lockfileDir, p))
   const walkerSteps = lockfileWalkerGroupImporterSteps(lockfile, importerIds as ProjectId[])
   const result: PeerDependencyIssuesByProjects = {}
+
+  // Build a lookup of peer-eligible packages provided by the workspace root.
+  // We only do this when there's an actual workspace (multiple importers) and
+  // a root importer exists at id ".".
+  const rootPeerProvider = opts.resolvePeersFromWorkspaceRoot
+    ? buildRootPeerProvider(lockfile, packages, importerIds)
+    : undefined
 
   for (const { importerId, step } of walkerSteps) {
     const projectIssues: PeerDependencyIssues = {
@@ -65,7 +89,12 @@ function checkPeerDependenciesFromLockfile (
       intersections: {},
     }
 
-    walkStep(step, packages, [], projectIssues)
+    // The workspace root provides peers; sub-projects can rely on those.
+    // For the root importer itself, we don't apply this filter because its
+    // peers must be satisfied within its own dependency tree.
+    const provider = importerId === '.' ? undefined : rootPeerProvider
+
+    walkStep(step, packages, [], projectIssues, provider)
 
     const merged = mergePeers(projectIssues.missing)
     projectIssues.conflicts = merged.conflicts
@@ -77,11 +106,39 @@ function checkPeerDependenciesFromLockfile (
   return result
 }
 
+function buildRootPeerProvider (
+  lockfile: LockfileObject,
+  packages: PackageSnapshots,
+  importerIds: string[]
+): RootPeerProvider | undefined {
+  // Only meaningful in a workspace where the root and at least one other
+  // importer are being checked together.
+  if (importerIds.length < 2 || !importerIds.includes('.')) return undefined
+  const rootImporter: ProjectSnapshot | undefined = lockfile.importers?.['.' as ProjectId]
+  if (!rootImporter) return undefined
+
+  const resolvedVersionByPeerName = new Map<string, string>()
+  const directRefs: Record<string, string> = {
+    ...(rootImporter.dependencies ?? {}),
+    ...(rootImporter.devDependencies ?? {}),
+    ...(rootImporter.optionalDependencies ?? {}),
+  }
+  for (const [alias, ref] of Object.entries(directRefs)) {
+    if (typeof ref !== 'string') continue
+    // Workspace links and link: refs cannot be inspected via packages map.
+    if (ref.startsWith('link:') || ref.startsWith('file:')) continue
+    const version = extractVersion(ref, alias, packages)
+    if (version) resolvedVersionByPeerName.set(alias, version)
+  }
+  return resolvedVersionByPeerName.size > 0 ? { resolvedVersionByPeerName } : undefined
+}
+
 function walkStep (
   step: LockfileWalkerStep,
   packages: PackageSnapshots,
   parents: ParentPackages,
-  issues: PeerDependencyIssues
+  issues: PeerDependencyIssues,
+  rootPeerProvider?: RootPeerProvider
 ): void {
   for (const { depPath, pkgSnapshot, next } of step.dependencies) {
     const parsed = parseDependencyPath(depPath)
@@ -95,14 +152,19 @@ function walkStep (
         const resolvedPeerRef = pkgSnapshot.dependencies?.[peerName] ?? pkgSnapshot.optionalDependencies?.[peerName]
 
         if (!resolvedPeerRef) {
-          if (!isOptional) {
-            if (!issues.missing[peerName]) issues.missing[peerName] = []
-            issues.missing[peerName].push({
-              parents: currentParents,
-              optional: isOptional,
-              wantedRange: peerRange,
-            })
-          }
+          if (isOptional) continue
+          // If the workspace root provides this peer at a satisfying version,
+          // suppress the warning entirely. This mirrors install-time behavior
+          // where peers hoisted at the workspace root are considered resolved
+          // for sub-projects.
+          const rootVersion = rootPeerProvider?.resolvedVersionByPeerName.get(peerName)
+          if (rootVersion && satisfies(rootVersion, peerRange)) continue
+          if (!issues.missing[peerName]) issues.missing[peerName] = []
+          issues.missing[peerName].push({
+            parents: currentParents,
+            optional: isOptional,
+            wantedRange: peerRange,
+          })
         } else {
           const peerVersion = extractVersion(resolvedPeerRef, peerName, packages)
           if (peerVersion && !satisfies(peerVersion, peerRange)) {
@@ -119,7 +181,7 @@ function walkStep (
       }
     }
 
-    walkStep(next(), packages, currentParents, issues)
+    walkStep(next(), packages, currentParents, issues, rootPeerProvider)
   }
 }
 

--- a/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/package.json
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "with-missing-peer-in-workspace",
+  "version": "1.0.0",
+  "dependencies": {
+    "ajv": "6.10.0"
+  }
+}

--- a/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pkg/package.json
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pkg",
+  "version": "1.0.0",
+  "dependencies": {
+    "ajv-keywords": "3.4.1"
+  }
+}

--- a/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pnpm-lock.yaml
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pnpm-lock.yaml
@@ -1,0 +1,35 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      ajv:
+        specifier: 6.10.0
+        version: 6.10.0
+
+  pkg:
+    dependencies:
+      ajv-keywords:
+        specifier: 3.4.1
+        version: 3.4.1
+
+packages:
+
+  ajv@6.10.0:
+    resolution: {integrity: sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==}
+
+  ajv-keywords@3.4.1:
+    resolution: {integrity: sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==}
+    peerDependencies:
+      ajv: ^6.9.1
+
+snapshots:
+
+  ajv@6.10.0: {}
+
+  ajv-keywords@3.4.1: {}

--- a/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pnpm-workspace.yaml
+++ b/deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'pkg'

--- a/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
+++ b/deps/inspection/peers-checker/test/checkPeerDependencies.test.ts
@@ -98,3 +98,39 @@ test('returns no issues when there are no peer dependency problems', async () =>
   expect(Object.keys(projectIssues.bad)).toHaveLength(0)
   expect(Object.keys(projectIssues.missing)).toHaveLength(0)
 })
+
+// Regression test for https://github.com/pnpm/pnpm/issues/1284
+// Sub-package depends on `ajv-keywords` which has a peer dep on `ajv`.
+// `ajv` is provided by the workspace root. The lockfile-based peer check
+// must not warn that `ajv` is missing for the sub-package.
+test('does not warn about peers satisfied by the workspace root importer', async () => {
+  const fixture = f.find('with-missing-peer-in-workspace')
+  const rootDir = fixture
+  const subDir = `${fixture}/pkg`
+  const issues = await checkPeerDependencies([rootDir, subDir], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+  })
+
+  expect(issues['.']).toBeDefined()
+  expect(Object.keys(issues['.'].missing)).toHaveLength(0)
+  expect(issues['pkg']).toBeDefined()
+  expect(Object.keys(issues['pkg'].missing)).toHaveLength(0)
+  expect(Object.keys(issues['pkg'].bad)).toHaveLength(0)
+})
+
+// When the workspace-root resolution is opted-out, the existing strict
+// per-importer behavior is preserved.
+test('still reports missing peer when resolvePeersFromWorkspaceRoot is disabled', async () => {
+  const fixture = f.find('with-missing-peer-in-workspace')
+  const rootDir = fixture
+  const subDir = `${fixture}/pkg`
+  const issues = await checkPeerDependencies([rootDir, subDir], {
+    lockfileDir: fixture,
+    checkWantedLockfileOnly: true,
+    resolvePeersFromWorkspaceRoot: false,
+  })
+
+  expect(issues['pkg']).toBeDefined()
+  expect(issues['pkg'].missing).toHaveProperty('ajv')
+})


### PR DESCRIPTION
## Summary
Closes #1284. The lockfile-based peers-checker (`pnpm peers`) walked each importer in isolation and warned about missing peer deps that were actually provided by the workspace root. Install-time already honored `resolvePeersFromWorkspaceRoot`; the checker did not.

## Fix
When `resolvePeersFromWorkspaceRoot` is enabled (default), build a `resolvedVersionByPeerName` map from the root importer's direct dependencies. During sub-importer walks, suppress any `missing` warning whose range is satisfied by a root-provided version. Behavior preserved for the root importer itself; opt-out via `resolvePeersFromWorkspaceRoot: false`.

## Files changed
- `deps/inspection/peers-checker/src/checkPeerDependencies.ts` — core fix + new option
- `deps/inspection/commands/src/peers.ts` — threads the option from config
- `deps/inspection/peers-checker/test/checkPeerDependencies.test.ts` — 2 regression tests
- `deps/inspection/peers-checker/test/__fixtures__/with-missing-peer-in-workspace/` — new fixture
- `.changeset/peers-checker-workspace-root.md`

## Test plan
- jest 8/8 passing for peers-checker
- eslint clean for both packages
- tsgo build clean
