### PR TITLE
fix: clean pnpm workspace state during ci

### DIFF
--- a/pnpm/.changeset/clean-ci-workspace-state.md
+++ b/pnpm/.changeset/clean-ci-workspace-state.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Remove pnpm's workspace state file when cleaning node_modules so `pnpm ci` performs a fresh install after the clean step.

--- a/pnpm/src/cmd/clean.ts
+++ b/pnpm/src/cmd/clean.ts
@@ -103,7 +103,7 @@ async function cleanProjectDir (opts: { modulesDir: string, removeLockfile?: boo
   }
 }
 
-const PNPM_HIDDEN_ENTRIES = new Set(['.bin', '.modules.yaml', '.pnpm'])
+const PNPM_HIDDEN_ENTRIES = new Set(['.bin', '.modules.yaml', '.pnpm', '.pnpm-workspace-state-v1.json'])
 
 async function hasContentsToRemove (modulesDir: string): Promise<boolean> {
   let items: string[]

--- a/pnpm/test/clean.ts
+++ b/pnpm/test/clean.ts
@@ -20,6 +20,7 @@ test('pnpm clean removes pnpm entries and packages but preserves non-pnpm hidden
   fs.mkdirSync('node_modules/.pnpm', { recursive: true })
   fs.mkdirSync('node_modules/.bin')
   fs.writeFileSync('node_modules/.modules.yaml', 'storeDir: /tmp/store')
+  fs.writeFileSync('node_modules/.pnpm-workspace-state-v1.json', '{}')
   fs.mkdirSync('node_modules/.cache')
   fs.writeFileSync('node_modules/.cache/some-file', 'cached')
   fs.mkdirSync('node_modules/lodash')
@@ -34,6 +35,7 @@ test('pnpm clean removes pnpm entries and packages but preserves non-pnpm hidden
   expect(fs.existsSync('node_modules/.pnpm')).toBe(false)
   expect(fs.existsSync('node_modules/.bin')).toBe(false)
   expect(fs.existsSync('node_modules/.modules.yaml')).toBe(false)
+  expect(fs.existsSync('node_modules/.pnpm-workspace-state-v1.json')).toBe(false)
 
   // Regular packages should be removed
   expect(fs.existsSync('node_modules/lodash')).toBe(false)


### PR DESCRIPTION
## Summary
- include `.pnpm-workspace-state-v1.json` in the pnpm-owned `node_modules` entries removed by `pnpm clean`
- cover that cleanup path in the existing clean command test
- add a patch changeset for the CLI fix

Fixes #11361.

## Verification
- `pnpm --filter pnpm run compile` ✅
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --filter pnpm exec jest test/clean.ts -t 'pnpm clean removes pnpm entries' --runInBand` ✅
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --filter pnpm exec jest test/ci.ts -t 'pnpm ci removes node_modules' --runInBand` ✅
