### PR TITLE
docs(env): update Node.js examples in help output

### DIFF
--- a/.changeset/update-env-help-examples.md
+++ b/.changeset/update-env-help-examples.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.runtime.commands": patch
+"pnpm": patch
+---
+
+Updated `pnpm env` help examples to use Node.js 24 and its LTS codename.

--- a/engine/runtime/commands/src/env/env.ts
+++ b/engine/runtime/commands/src/env/env.ts
@@ -52,17 +52,17 @@ export function help (): string {
     ],
     url: docsUrl('env'),
     usages: [
-      'pnpm env use --global 18',
+      'pnpm env use --global 24',
       'pnpm env use --global lts',
-      'pnpm env use --global argon',
+      'pnpm env use --global krypton',
       'pnpm env use --global latest',
-      'pnpm env use --global rc/18',
+      'pnpm env use --global rc/24',
       'pnpm env list',
-      'pnpm env list 18',
+      'pnpm env list 24',
       'pnpm env list lts',
-      'pnpm env list argon',
+      'pnpm env list krypton',
       'pnpm env list latest',
-      'pnpm env list rc/18',
+      'pnpm env list rc/24',
     ],
   })
 }


### PR DESCRIPTION
The previous examples used outdated Node.js 18 and the old `argon` LTS codename, so this updates them to the current Node.js 24 LTS line and its `krypton` codename.