### PR TITLE
fix(config): load onlyBuiltDependencies from global pnpm-workspace.yaml during --global install

### DIFF
--- a/.changeset/fix-global-workspace-dir.md
+++ b/.changeset/fix-global-workspace-dir.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/config": patch
+"pnpm": patch
+---
+
+**fix**: `--global` installs load `onlyBuiltDependencies` from `pnpm-workspace.yaml` in the global package directory.
+
+The `workspaceDir` field is deleted during `--global` installs to prevent reading from the current working directory, but there was no fallback to read the workspace manifest from `globalPkgDir`. As a result, `onlyBuiltDependencies` from a global `pnpm-workspace.yaml` was silently ignored, causing all build scripts to be skipped by default in pnpm v10.
+
+This fix adds an `else if (cliOptions['global'])` branch that reads the workspace manifest from `globalPkgDir`, ensuring global installs respect the build policy configured in the global `pnpm-workspace.yaml`.
+
+Fixes #9073, #9478.

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -387,6 +387,17 @@ export async function getConfig (opts: {
         }
         pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
       }
+    } else if (cliOptions['global']) {
+      const workspaceManifest = await readWorkspaceManifest(pnpmConfig.globalPkgDir)
+      if (workspaceManifest) {
+        const newSettings = Object.assign(getOptionsFromPnpmSettings(pnpmConfig.globalPkgDir, workspaceManifest, pnpmConfig.rootProjectManifest), configFromCliOpts)
+        for (const [key, value] of Object.entries(newSettings)) {
+          // @ts-expect-error
+          pnpmConfig[key] = value
+          pnpmConfig.rawConfig[kebabCase(key)] = value
+        }
+        pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
+      }
     }
   }
 

--- a/config/config/test/fixtures/has-global-workspace-yaml/pnpm-home/global/5/pnpm-workspace.yaml
+++ b/config/config/test/fixtures/has-global-workspace-yaml/pnpm-home/global/5/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+- esbuild

--- a/config/config/test/fixtures/has-global-workspace-yaml/pnpm-workspace.yaml
+++ b/config/config/test/fixtures/has-global-workspace-yaml/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+- esbuild

--- a/config/config/test/fixtures/has-global-workspace-yaml/pnpm-workspace.yaml
+++ b/config/config/test/fixtures/has-global-workspace-yaml/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-- esbuild

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -83,14 +83,16 @@ test('correct settings on global install', async () => {
 })
 
 test('onlyBuiltDependencies is loaded from pnpm-workspace.yaml in globalPkgDir during --global install', async () => {
-  const globalPkgDir = path.join(__dirname, 'fixtures', 'has-global-workspace-yaml')
+  const fixtureDir = path.join(__dirname, 'fixtures', 'has-global-workspace-yaml')
+  const pnpmHomeDir = path.join(fixtureDir, 'pnpm-home')
   const { config } = await getConfig({
     cliOptions: {
       global: true,
     },
     env: {
       ...env,
-      PNPM_HOME: path.join(globalPkgDir, 'pnpm-home'),
+      PNPM_HOME: pnpmHomeDir,
+      [PATH]: `${process.env.PATH}${path.delimiter}${pnpmHomeDir}`,
     },
     packageManager: {
       name: 'pnpm',

--- a/config/config/test/index.ts
+++ b/config/config/test/index.ts
@@ -82,6 +82,24 @@ test('correct settings on global install', async () => {
   expect(config.save).toBe(true)
 })
 
+test('onlyBuiltDependencies is loaded from pnpm-workspace.yaml in globalPkgDir during --global install', async () => {
+  const globalPkgDir = path.join(__dirname, 'fixtures', 'has-global-workspace-yaml')
+  const { config } = await getConfig({
+    cliOptions: {
+      global: true,
+    },
+    env: {
+      ...env,
+      PNPM_HOME: path.join(globalPkgDir, 'pnpm-home'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.onlyBuiltDependencies).toStrictEqual(['esbuild'])
+})
+
 test('throw error if --shared-workspace-lockfile is used with --global', async () => {
   await expect(getConfig({
     cliOptions: {


### PR DESCRIPTION
## Summary

When `--global` is used, `workspaceDir` is deleted to prevent reading from the current working directory. However, there was no fallback to read the workspace manifest from `globalPkgDir`, causing `onlyBuiltDependencies` from a global `pnpm-workspace.yaml` to be silently ignored.

This adds an `else if (cliOptions['global'])` branch that reads the workspace manifest from `globalPkgDir`, mirroring the normal workspace manifest reading logic but using `globalPkgDir` as the workspace root.

## Root Cause

See the analysis in [PR #11363](https://github.com/pnpm/pnpm/pull/11363) for the full context. This is the v10 backport of the same fix that was applied to v11's config reader.

## Test

A regression test verifies that `onlyBuiltDependencies` from a global `pnpm-workspace.yaml` is loaded when `--global` is used.

## Fixes

Fixes #9073, #9478.