### PR TITLE
fix(publish): report generated manifest in publish summary

### DIFF
--- a/.changeset/publish-summary-directory.md
+++ b/.changeset/publish-summary-directory.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fix recursive publish summaries to report the manifest from `publishConfig.directory` when packages publish from a generated directory [#11239](https://github.com/pnpm/pnpm/issues/11239).

--- a/releasing/commands/src/publish/publish.ts
+++ b/releasing/commands/src/publish/publish.ts
@@ -6,6 +6,7 @@ import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config
 import { PnpmError } from '@pnpm/error'
 import { runLifecycleHook, type RunLifecycleHookOptions } from '@pnpm/exec.lifecycle'
 import { getCurrentBranch, isGitRepo, isRemoteHistoryClean, isWorkingTreeClean } from '@pnpm/network.git-utils'
+import type { ExportedManifest } from '@pnpm/releasing.exportable-manifest'
 import type { ProjectManifest } from '@pnpm/types'
 import { rimraf } from '@zkochan/rimraf'
 import enquirer from 'enquirer'
@@ -134,6 +135,7 @@ export async function handler (
 export interface PublishResult {
   exitCode?: number
   manifest?: ProjectManifest
+  publishedManifest?: ExportedManifest
 }
 
 export async function publish (
@@ -234,6 +236,7 @@ Do you want to continue?`,
   // from the current working directory, ignoring the package.json file
   // that was generated and packed to the tarball.
   const packDestination = temporaryDirectory()
+  let publishedManifest: ExportedManifest | undefined
   try {
     const packResult = await pack.api({
       ...opts,
@@ -242,6 +245,7 @@ Do you want to continue?`,
       dryRun: false,
     })
     await publishPackedPkg(packResult, opts)
+    publishedManifest = packResult.publishedManifest
   } finally {
     await rimraf(packDestination)
   }
@@ -252,7 +256,7 @@ Do you want to continue?`,
       'postpublish',
     ], manifest)
   }
-  return { manifest }
+  return { manifest, publishedManifest }
 }
 
 export async function runScriptsIfPresent (

--- a/releasing/commands/src/publish/recursivePublish.ts
+++ b/releasing/commands/src/publish/recursivePublish.ts
@@ -137,8 +137,9 @@ export async function recursivePublish (
           gitChecks: false,
           recursive: false,
         }, [pkg.rootDir])
-        if (publishResult?.manifest != null) {
-          publishedPackages.push(pick(['name', 'version'], publishResult.manifest))
+        const publishedManifest = publishResult?.publishedManifest ?? publishResult?.manifest
+        if (publishedManifest != null) {
+          publishedPackages.push(pick(['name', 'version'], publishedManifest))
         } else if (publishResult?.exitCode) {
           return { exitCode: publishResult.exitCode }
         }

--- a/releasing/commands/test/publish/recursivePublish.ts
+++ b/releasing/commands/test/publish/recursivePublish.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
 import { streamParser } from '@pnpm/logger'
@@ -278,6 +279,47 @@ test('recursive publish writes publish summary', async () => {
       publishedPackages: [],
     })
   }
+})
+
+test('recursive publish summary uses manifest from publishConfig.directory', async () => {
+  const pkgName = `@pnpmtest/test-recursive-publish-config-directory-${Date.now()}`
+  const packages = preparePackages([
+    {
+      name: pkgName,
+      version: '1.0.0',
+
+      publishConfig: {
+        directory: 'dist',
+      },
+    },
+  ])
+  const selectedProjects = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  const project = packages[pkgName]
+  fs.mkdirSync(path.join(project.dir(), 'dist'))
+  fs.writeFileSync(path.join(project.dir(), 'dist/package.json'), JSON.stringify({
+    name: pkgName,
+    version: '2.0.0',
+  }))
+
+  await publish.handler({
+    ...DEFAULT_OPTS,
+    ...selectedProjects,
+    configByUri: CONFIG_BY_URI,
+    dir: process.cwd(),
+    dryRun: true,
+    force: true,
+    recursive: true,
+    reportSummary: true,
+  }, [])
+
+  expect(loadJsonFileSync('pnpm-publish-summary.json')).toStrictEqual({
+    publishedPackages: [
+      {
+        name: pkgName,
+        version: '2.0.0',
+      },
+    ],
+  })
 })
 
 test('errors on fake registry', async () => {


### PR DESCRIPTION
Fixes #11239.

When recursive publish calls `publish()` for a package with `publishConfig.directory`, the packed package can use a different manifest from the workspace package manifest. `pnpm-publish-summary.json` was using the workspace manifest returned from `publish()`, so it could report the root version instead of the version that was actually packed from the generated directory.

This keeps returning the workspace manifest for existing callers, also exposes the packed manifest, and uses that manifest for recursive publish summaries.

Validation:
- `pnpm --filter @pnpm/releasing.commands run compile`
- `pnpm --filter @pnpm/releasing.commands exec jest test/publish/recursivePublish.ts`
- `pnpm --filter pnpm run compile`
- `pnpm run spellcheck`
- `git diff --check`