### PR TITLE
feat: add preferredManifestFormat setting for pnpm-workspace.yaml

### DIFF
--- a/.changeset/preferred-manifest-format.md
+++ b/.changeset/preferred-manifest-format.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/types": minor
+"@pnpm/workspace.project-manifest-reader": minor
+"@pnpm/workspace.projects-reader": minor
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+Added a new `preferredManifestFormat` setting in `pnpm-workspace.yaml` that selects which manifest format pnpm should read and write when multiple manifest files coexist in the same directory (e.g. `package.json` and `package.json5`). Allowed values are `json` (default), `json5`, and `yaml`. Falls back to the default chain (`json` > `json5` > `yaml`) when the preferred format is missing. The setting only applies to manifests within the workspace, not to dependencies. Also fixes a workspace-discovery bug where a directory containing multiple manifest files would produce duplicate project entries [#3027](https://github.com/pnpm/pnpm/issues/3027) [#5541](https://github.com/pnpm/pnpm/issues/5541).

--- a/cli/commands/src/completion/complete.ts
+++ b/cli/commands/src/completion/complete.ts
@@ -37,6 +37,7 @@ export async function complete (
       const workspaceManifest = await readWorkspaceManifest(workspaceDir)
       const allProjects = await findWorkspaceProjects(workspaceDir, {
         patterns: workspaceManifest?.packages,
+        preferredManifestFormat: workspaceManifest?.preferredManifestFormat,
         supportedArchitectures: {
           os: ['current'],
           cpu: ['current'],

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -23,7 +23,7 @@ export type OptionsFromRootManifest = {
   supportedArchitectures?: SupportedArchitectures
   allowBuilds?: Record<string, boolean | string>
   requiredScripts?: string[]
-} & Pick<PnpmSettings, 'configDependencies' | 'auditConfig' | 'updateConfig'>
+} & Pick<PnpmSettings, 'configDependencies' | 'auditConfig' | 'updateConfig' | 'preferredManifestFormat'>
 
 export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnpmSettings: PnpmSettings, manifest?: ProjectManifest): OptionsFromRootManifest {
   const settings: OptionsFromRootManifest = replaceEnvInSettings(pnpmSettings)

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -400,7 +400,24 @@ export async function getConfig (opts: {
 
   if (!opts.ignoreLocalSettings) {
     pnpmConfig.rootProjectManifestDir = pnpmConfig.lockfileDir ?? pnpmConfig.workspaceDir ?? pnpmConfig.dir
-    pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir) ?? undefined
+
+    // Read pnpm-workspace.yaml first so settings like `preferredManifestFormat`
+    // can influence how the root project manifest is read below.
+    let workspaceManifest: WorkspaceManifest | undefined
+    let workspaceManifestDir: string | undefined
+    if (pnpmConfig.workspaceDir != null) {
+      workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
+      workspaceManifestDir = pnpmConfig.workspaceDir
+      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages ?? ['.']
+    } else if (cliOptions['global']) {
+      // For global installs, read settings from pnpm-workspace.yaml in the global package directory
+      workspaceManifest = await readWorkspaceManifest(pnpmConfig.globalPkgDir)
+      workspaceManifestDir = pnpmConfig.globalPkgDir
+    }
+
+    pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir, {
+      preferredManifestFormat: workspaceManifest?.preferredManifestFormat,
+    }) ?? undefined
     if (pnpmConfig.rootProjectManifest != null) {
       if (pnpmConfig.rootProjectManifest.workspaces?.length && !pnpmConfig.workspaceDir) {
         warnings.push('The "workspaces" field in package.json is not supported by pnpm. Create a "pnpm-workspace.yaml" file instead.')
@@ -415,29 +432,13 @@ export async function getConfig (opts: {
       }
     }
 
-    if (pnpmConfig.workspaceDir != null) {
-      const workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
-
-      pnpmConfig.workspacePackagePatterns = cliOptions['workspace-packages'] as string[] ?? workspaceManifest?.packages ?? ['.']
-      if (workspaceManifest) {
-        addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
-          configFromCliOpts,
-          projectManifest: pnpmConfig.rootProjectManifest,
-          workspaceDir: pnpmConfig.workspaceDir,
-          workspaceManifest,
-        })
-      }
-    } else if (cliOptions['global']) {
-      // For global installs, read settings from pnpm-workspace.yaml in the global package directory
-      const workspaceManifest = await readWorkspaceManifest(pnpmConfig.globalPkgDir)
-      if (workspaceManifest) {
-        addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
-          configFromCliOpts,
-          projectManifest: pnpmConfig.rootProjectManifest,
-          workspaceDir: pnpmConfig.globalPkgDir,
-          workspaceManifest,
-        })
-      }
+    if (workspaceManifest) {
+      addSettingsFromWorkspaceManifestToConfig(pnpmConfig, {
+        configFromCliOpts,
+        projectManifest: pnpmConfig.rootProjectManifest,
+        workspaceDir: workspaceManifestDir!,
+        workspaceManifest,
+      })
     }
   }
 

--- a/core/types/src/package.ts
+++ b/core/types/src/package.ts
@@ -167,6 +167,8 @@ export interface AuditConfig {
   ignoreGhsas?: string[]
 }
 
+export type ManifestFormat = 'json' | 'json5' | 'yaml'
+
 export interface PnpmSettings {
   configDependencies?: ConfigDependencies
   allowBuilds?: Record<string, boolean | string>
@@ -177,6 +179,14 @@ export interface PnpmSettings {
   allowedDeprecatedVersions?: AllowedDeprecatedVersions
   allowUnusedPatches?: boolean
   patchedDependencies?: Record<string, string>
+  /**
+   * When multiple manifest files coexist in a project directory (e.g. both
+   * package.json and package.json5), this setting selects which format pnpm
+   * should read and write. Falls back to the default chain
+   * (json > json5 > yaml) when the preferred format is missing. Applies only
+   * to manifests within the workspace, not to dependencies.
+   */
+  preferredManifestFormat?: ManifestFormat
   updateConfig?: {
     ignoreDependencies?: string[]
   }

--- a/deps/status/src/checkDepsStatus.ts
+++ b/deps/status/src/checkDepsStatus.ts
@@ -339,6 +339,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     if (workspaceManifest ?? workspaceDir) {
       const allProjects = await findWorkspaceProjects(rootProjectManifestDir, {
         patterns: workspaceManifest?.packages,
+        preferredManifestFormat: workspaceManifest?.preferredManifestFormat,
         sharedWorkspaceLockfile,
       })
       return checkDepsStatus({

--- a/workspace/project-manifest-reader/__fixtures__/package-json-and-json5/package.json
+++ b/workspace/project-manifest-reader/__fixtures__/package-json-and-json5/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "from-json",
+  "version": "1.0.0"
+}

--- a/workspace/project-manifest-reader/__fixtures__/package-json-and-json5/package.json5
+++ b/workspace/project-manifest-reader/__fixtures__/package-json-and-json5/package.json5
@@ -1,0 +1,4 @@
+{
+    name: 'from-json5',
+    version: '1.0.0',
+}

--- a/workspace/project-manifest-reader/src/index.ts
+++ b/workspace/project-manifest-reader/src/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { PnpmError } from '@pnpm/error'
 import { convertEnginesRuntimeToDependencies } from '@pnpm/pkg-manifest.utils'
 import { type CommentSpecifier, extractComments } from '@pnpm/text.comments-parser'
-import type { EngineDependency, ProjectManifest } from '@pnpm/types'
+import type { EngineDependency, ManifestFormat, ProjectManifest } from '@pnpm/types'
 import { writeProjectManifest } from '@pnpm/workspace.project-manifest-writer'
 import detectIndent from 'detect-indent'
 import equal from 'fast-deep-equal'
@@ -18,9 +18,28 @@ import {
 
 export type WriteProjectManifest = (manifest: ProjectManifest, force?: boolean) => Promise<void>
 
-export async function safeReadProjectManifestOnly (projectDir: string): Promise<ProjectManifest | null> {
+export interface ReadProjectManifestOptions {
+  preferredManifestFormat?: ManifestFormat
+}
+
+const DEFAULT_FORMAT_ORDER: readonly ManifestFormat[] = ['json', 'json5', 'yaml']
+
+function buildFormatOrder (preferred?: ManifestFormat): ManifestFormat[] {
+  if (!preferred || !DEFAULT_FORMAT_ORDER.includes(preferred)) {
+    return [...DEFAULT_FORMAT_ORDER]
+  }
+  return [preferred, ...DEFAULT_FORMAT_ORDER.filter(f => f !== preferred)]
+}
+
+const FORMAT_FILENAMES: Record<ManifestFormat, string> = {
+  json: 'package.json',
+  json5: 'package.json5',
+  yaml: 'package.yaml',
+}
+
+export async function safeReadProjectManifestOnly (projectDir: string, opts?: ReadProjectManifestOptions): Promise<ProjectManifest | null> {
   try {
-    return await readProjectManifestOnly(projectDir)
+    return await readProjectManifestOnly(projectDir, opts)
   } catch (err: any) { // eslint-disable-line
     if ((err as NodeJS.ErrnoException).code === 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND') {
       return null
@@ -29,12 +48,12 @@ export async function safeReadProjectManifestOnly (projectDir: string): Promise<
   }
 }
 
-export async function readProjectManifest (projectDir: string): Promise<{
+export async function readProjectManifest (projectDir: string, opts?: ReadProjectManifestOptions): Promise<{
   fileName: string
   manifest: ProjectManifest
   writeProjectManifest: WriteProjectManifest
 }> {
-  const result = await tryReadProjectManifest(projectDir)
+  const result = await tryReadProjectManifest(projectDir, opts)
   if (result.manifest !== null) {
     return result as {
       fileName: string
@@ -46,56 +65,64 @@ export async function readProjectManifest (projectDir: string): Promise<{
     `No package.json (or package.yaml, or package.json5) was found in "${projectDir}".`)
 }
 
-export async function readProjectManifestOnly (projectDir: string): Promise<ProjectManifest> {
-  const { manifest } = await readProjectManifest(projectDir)
+export async function readProjectManifestOnly (projectDir: string, opts?: ReadProjectManifestOptions): Promise<ProjectManifest> {
+  const { manifest } = await readProjectManifest(projectDir, opts)
   return manifest
 }
 
-export async function tryReadProjectManifest (projectDir: string): Promise<{
+async function tryReadFormat (projectDir: string, format: ManifestFormat): Promise<{
   fileName: string
-  manifest: ProjectManifest | null
+  manifest: ProjectManifest
   writeProjectManifest: WriteProjectManifest
-}> {
+} | null> {
+  const fileName = FORMAT_FILENAMES[format]
+  const manifestPath = path.join(projectDir, fileName)
   try {
-    const manifestPath = path.join(projectDir, 'package.json')
-    const { data, text } = await readJsonFile(manifestPath)
-    return {
-      fileName: 'package.json',
-      manifest: convertManifestAfterRead(data),
-      writeProjectManifest: createManifestWriter({
-        ...detectFileFormatting(text),
-        initialManifest: data,
-        manifestPath,
-      }),
+    if (format === 'json') {
+      const { data, text } = await readJsonFile(manifestPath)
+      return {
+        fileName,
+        manifest: convertManifestAfterRead(data),
+        writeProjectManifest: createManifestWriter({
+          ...detectFileFormatting(text),
+          initialManifest: data,
+          manifestPath,
+        }),
+      }
     }
-  } catch (err: any) { // eslint-disable-line
-    if (err.code !== 'ENOENT') throw err
-  }
-  try {
-    const manifestPath = path.join(projectDir, 'package.json5')
-    const { data, text } = await readJson5File(manifestPath)
-    return {
-      fileName: 'package.json5',
-      manifest: convertManifestAfterRead(data),
-      writeProjectManifest: createManifestWriter({
-        ...detectFileFormattingAndComments(text),
-        initialManifest: data,
-        manifestPath,
-      }),
+    if (format === 'json5') {
+      const { data, text } = await readJson5File(manifestPath)
+      return {
+        fileName,
+        manifest: convertManifestAfterRead(data),
+        writeProjectManifest: createManifestWriter({
+          ...detectFileFormattingAndComments(text),
+          initialManifest: data,
+          manifestPath,
+        }),
+      }
     }
-  } catch (err: any) { // eslint-disable-line
-    if (err.code !== 'ENOENT') throw err
-  }
-  try {
-    const manifestPath = path.join(projectDir, 'package.yaml')
     const manifest = await readPackageYaml(manifestPath)
     return {
-      fileName: 'package.yaml',
+      fileName,
       manifest: convertManifestAfterRead(manifest),
       writeProjectManifest: createManifestWriter({ initialManifest: manifest, manifestPath }),
     }
   } catch (err: any) { // eslint-disable-line
     if (err.code !== 'ENOENT') throw err
+    return null
+  }
+}
+
+export async function tryReadProjectManifest (projectDir: string, opts?: ReadProjectManifestOptions): Promise<{
+  fileName: string
+  manifest: ProjectManifest | null
+  writeProjectManifest: WriteProjectManifest
+}> {
+  const order = buildFormatOrder(opts?.preferredManifestFormat)
+  for (const format of order) {
+    const result = await tryReadFormat(projectDir, format)
+    if (result != null) return result
   }
   if (isWindows()) {
     // ENOTDIR isn't used on Windows, but pnpm expects it.
@@ -112,9 +139,10 @@ export async function tryReadProjectManifest (projectDir: string): Promise<{
       throw err
     }
   }
-  const filePath = path.join(projectDir, 'package.json')
+  const fallbackFileName = FORMAT_FILENAMES[order[0]]
+  const filePath = path.join(projectDir, fallbackFileName)
   return {
-    fileName: 'package.json',
+    fileName: fallbackFileName,
     manifest: null,
     writeProjectManifest: async (manifest: ProjectManifest) => writeProjectManifest(filePath, manifest),
   }

--- a/workspace/project-manifest-reader/test/index.ts
+++ b/workspace/project-manifest-reader/test/index.ts
@@ -33,6 +33,30 @@ test('readProjectManifest()', async () => {
   ).toBeNull()
 })
 
+test('tryReadProjectManifest() prefers package.json by default when both files exist', async () => {
+  const result = await tryReadProjectManifest(f.find('package-json-and-json5'))
+  expect(result.fileName).toBe('package.json')
+  expect(result.manifest).toStrictEqual({ name: 'from-json', version: '1.0.0' })
+})
+
+test('tryReadProjectManifest() honors preferredManifestFormat=json5 when both files exist', async () => {
+  const result = await tryReadProjectManifest(f.find('package-json-and-json5'), { preferredManifestFormat: 'json5' })
+  expect(result.fileName).toBe('package.json5')
+  expect(result.manifest).toStrictEqual({ name: 'from-json5', version: '1.0.0' })
+})
+
+test('tryReadProjectManifest() falls back to default chain when preferred format is missing', async () => {
+  const result = await tryReadProjectManifest(f.find('package-json'), { preferredManifestFormat: 'json5' })
+  expect(result.fileName).toBe('package.json')
+  expect(result.manifest).toStrictEqual({ name: 'foo', version: '1.0.0' })
+})
+
+test('tryReadProjectManifest() with preferredManifestFormat returns matching writer fileName when no manifest exists', async () => {
+  const result = await tryReadProjectManifest(import.meta.dirname, { preferredManifestFormat: 'json5' })
+  expect(result.fileName).toBe('package.json5')
+  expect(result.manifest).toBeNull()
+})
+
 test('readProjectManifest() converts devEngines runtime to devDependencies', async () => {
   const dir = f.prepare('package-json-with-dev-engines')
   const { manifest, writeProjectManifest } = await tryReadProjectManifest(dir)

--- a/workspace/projects-filter/src/filterProjectsFromDir.ts
+++ b/workspace/projects-filter/src/filterProjectsFromDir.ts
@@ -18,6 +18,7 @@ export async function filterProjectsBySelectorObjectsFromDir (
   const allProjects = await findWorkspaceProjects(workspaceDir, {
     patterns: workspaceManifest?.packages,
     engineStrict: opts?.engineStrict,
+    preferredManifestFormat: workspaceManifest?.preferredManifestFormat,
     supportedArchitectures: opts?.supportedArchitectures ?? {
       os: ['current'],
       cpu: ['current'],

--- a/workspace/projects-reader/src/findPackages.ts
+++ b/workspace/projects-reader/src/findPackages.ts
@@ -2,7 +2,8 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
 
-import type { Project, ProjectRootDir, ProjectRootDirRealPath } from '@pnpm/types'
+import { logger } from '@pnpm/logger'
+import type { ManifestFormat, Project, ProjectRootDir, ProjectRootDirRealPath } from '@pnpm/types'
 import { lexCompare } from '@pnpm/util.lex-comparator'
 import { readExactProjectManifest } from '@pnpm/workspace.project-manifest-reader'
 import pFilter from 'p-filter'
@@ -15,10 +16,19 @@ const DEFAULT_IGNORE = [
   '**/tests/**',
 ]
 
+const DEFAULT_FORMAT_ORDER: readonly ManifestFormat[] = ['json', 'json5', 'yaml']
+
+const FILENAME_TO_FORMAT: Record<string, ManifestFormat> = {
+  'package.json': 'json',
+  'package.json5': 'json5',
+  'package.yaml': 'yaml',
+}
+
 export interface FindPackagesOptions {
   ignore?: string[]
   includeRoot?: boolean
   patterns?: string[]
+  preferredManifestFormat?: ManifestFormat
 }
 
 export async function findPackages (root: string, opts?: FindPackagesOptions): Promise<Project[]> {
@@ -27,6 +37,7 @@ export async function findPackages (root: string, opts?: FindPackagesOptions): P
   globOpts.ignore = opts.ignore ?? DEFAULT_IGNORE
   const patterns = normalizePatterns(opts.patterns ?? ['.', '**'])
   delete globOpts.patterns
+  delete (globOpts as { preferredManifestFormat?: ManifestFormat }).preferredManifestFormat
   const paths: string[] = await glob(patterns, globOpts)
 
   if (opts.includeRoot) {
@@ -34,18 +45,17 @@ export async function findPackages (root: string, opts?: FindPackagesOptions): P
     paths.push(...(await glob(normalizePatterns(['.']), globOpts)))
   }
 
+  const selectedManifestPaths = pickManifestPerDirectory(
+    Array.from(new Set(paths.map(manifestPath => path.join(root, manifestPath)))),
+    opts.preferredManifestFormat
+  )
+  selectedManifestPaths.sort((path1, path2) =>
+    lexCompare(path.dirname(path1), path.dirname(path2))
+  )
+
   return pFilter(
-    // `Array.from()` doesn't create an intermediate instance,
-    // unlike `array.map()`
     Array.from(
-      // Remove duplicate paths using `Set`
-      new Set(
-        paths
-          .map(manifestPath => path.join(root, manifestPath))
-          .sort((path1, path2) =>
-            lexCompare(path.dirname(path1), path.dirname(path2))
-          )
-      ),
+      selectedManifestPaths,
       async manifestPath => {
         try {
           const rootDir = path.dirname(manifestPath) as ProjectRootDir
@@ -60,9 +70,51 @@ export async function findPackages (root: string, opts?: FindPackagesOptions): P
           }
           throw err
         }
-      }),
+      }
+    ),
     Boolean
   )
+}
+
+function pickManifestPerDirectory (manifestPaths: string[], preferredFormat?: ManifestFormat): string[] {
+  const order: ManifestFormat[] = preferredFormat && DEFAULT_FORMAT_ORDER.includes(preferredFormat)
+    ? [preferredFormat, ...DEFAULT_FORMAT_ORDER.filter(f => f !== preferredFormat)]
+    : [...DEFAULT_FORMAT_ORDER]
+  const byDir = new Map<string, Map<ManifestFormat, string>>()
+  for (const manifestPath of manifestPaths) {
+    const format = FILENAME_TO_FORMAT[path.basename(manifestPath)]
+    if (!format) continue
+    const dir = path.dirname(manifestPath)
+    let formatMap = byDir.get(dir)
+    if (!formatMap) {
+      formatMap = new Map()
+      byDir.set(dir, formatMap)
+    }
+    formatMap.set(format, manifestPath)
+  }
+  const selected: string[] = []
+  for (const [dir, formatMap] of byDir) {
+    let chosen: { format: ManifestFormat, manifestPath: string } | undefined
+    for (const format of order) {
+      const manifestPath = formatMap.get(format)
+      if (manifestPath != null) {
+        chosen = { format, manifestPath }
+        break
+      }
+    }
+    if (!chosen) continue
+    if (formatMap.size > 1 && preferredFormat != null && chosen.format !== preferredFormat) {
+      // Multiple manifest files coexist and the preferred format is not among
+      // them — the user's stub manifest may be shadowing the intended one.
+      const present = Array.from(formatMap.keys()).map(f => `package.${f}`).join(', ')
+      logger.warn({
+        message: `Preferred manifest format "${preferredFormat}" not found in "${dir}". Found ${present}; using "${path.basename(chosen.manifestPath)}".`,
+        prefix: dir,
+      })
+    }
+    selected.push(chosen.manifestPath)
+  }
+  return selected
 }
 
 function normalizePatterns (patterns: readonly string[]): string[] {

--- a/workspace/projects-reader/src/index.ts
+++ b/workspace/projects-reader/src/index.ts
@@ -1,6 +1,6 @@
 import { packageIsInstallable } from '@pnpm/cli.utils'
 import { logger } from '@pnpm/logger'
-import type { Project, ProjectManifest, SupportedArchitectures } from '@pnpm/types'
+import type { ManifestFormat, Project, ProjectManifest, SupportedArchitectures } from '@pnpm/types'
 import { lexCompare } from '@pnpm/util.lex-comparator'
 
 import { findPackages } from './findPackages.js'
@@ -23,6 +23,7 @@ export interface FindWorkspaceProjectsOpts {
   nodeVersion?: string
   sharedWorkspaceLockfile?: boolean
   supportedArchitectures?: SupportedArchitectures
+  preferredManifestFormat?: ManifestFormat
 }
 
 export async function findWorkspaceProjects (
@@ -48,7 +49,7 @@ export async function findWorkspaceProjects (
   return projects
 }
 
-export async function findWorkspaceProjectsNoCheck (workspaceRoot: string, opts?: { patterns?: string[] }): Promise<Project[]> {
+export async function findWorkspaceProjectsNoCheck (workspaceRoot: string, opts?: { patterns?: string[], preferredManifestFormat?: ManifestFormat }): Promise<Project[]> {
   const projects = await findPackages(workspaceRoot, {
     ignore: [
       '**/node_modules/**',
@@ -56,6 +57,7 @@ export async function findWorkspaceProjectsNoCheck (workspaceRoot: string, opts?
     ],
     includeRoot: true,
     patterns: opts?.patterns,
+    preferredManifestFormat: opts?.preferredManifestFormat,
   })
   projects.sort((project1: { rootDir: string }, project2: { rootDir: string }) => lexCompare(project1.rootDir, project2.rootDir))
   return projects

--- a/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-both/package.json
+++ b/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-both/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pkg-with-both",
+  "version": "1.0.0",
+  "_source": "json"
+}

--- a/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-both/package.json5
+++ b/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-both/package.json5
@@ -1,0 +1,5 @@
+{
+    name: 'pkg-with-both',
+    version: '1.0.0',
+    _source: 'json5',
+}

--- a/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-only-json/package.json
+++ b/workspace/projects-reader/test/findPackages-fixtures/conflicting-manifests/pkg-with-only-json/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pkg-with-only-json",
+  "version": "1.0.0",
+  "_source": "json"
+}

--- a/workspace/projects-reader/test/findPackages.ts
+++ b/workspace/projects-reader/test/findPackages.ts
@@ -86,3 +86,35 @@ test('json and yaml manifests are also found', async () => {
   expect(pkgs[2].rootDir).toBeDefined()
   expect(pkgs[2].manifest.name).toBe('foo')
 })
+
+test('dedupes coexisting manifest files in the same directory and prefers package.json by default', async () => {
+  const root = path.join(fixtures, 'conflicting-manifests')
+  const pkgs = await findPackages(root)
+
+  expect(pkgs).toHaveLength(2)
+  const both = pkgs.find(p => p.manifest.name === 'pkg-with-both')
+  expect(both).toBeDefined()
+  // @ts-expect-error
+  expect(both!.manifest._source).toBe('json')
+})
+
+test('honors preferredManifestFormat=json5 when both files coexist', async () => {
+  const root = path.join(fixtures, 'conflicting-manifests')
+  const pkgs = await findPackages(root, { preferredManifestFormat: 'json5' })
+
+  expect(pkgs).toHaveLength(2)
+  const both = pkgs.find(p => p.manifest.name === 'pkg-with-both')
+  expect(both).toBeDefined()
+  // @ts-expect-error
+  expect(both!.manifest._source).toBe('json5')
+})
+
+test('preferredManifestFormat falls back silently when only one format exists', async () => {
+  const root = path.join(fixtures, 'conflicting-manifests')
+  const pkgs = await findPackages(root, { preferredManifestFormat: 'json5' })
+
+  const onlyJson = pkgs.find(p => p.manifest.name === 'pkg-with-only-json')
+  expect(onlyJson).toBeDefined()
+  // @ts-expect-error
+  expect(onlyJson!.manifest._source).toBe('json')
+})


### PR DESCRIPTION
## Summary

Adds a new `preferredManifestFormat` setting in `pnpm-workspace.yaml` that selects which manifest format pnpm reads and writes when multiple manifest files coexist in the same directory.

```yaml
# pnpm-workspace.yaml
preferredManifestFormat: json5  # 'json' (default) | 'json5' | 'yaml'
```

Default behavior is unchanged. When the preferred format is missing in a given directory, pnpm falls back to the existing `json > json5 > yaml` chain. The setting only applies to manifests within the workspace, not to dependencies.

This addresses a long-standing pain point for users who want to use `package.json5` (with comments) as their primary manifest while keeping a stub `package.json` for tools that don't understand JSON5. Closes/refs #3027 and #5541.

While in here, this also fixes a separate workspace-discovery bug: `findPackages` would previously return duplicate `Project` entries for a single `rootDir` when multiple manifest files coexisted, because the glob `package.{json,yaml,json5}` matched all of them and there was no per-directory dedup.

## Implementation notes

- Added `ManifestFormat` type and `preferredManifestFormat` field on `PnpmSettings` in `@pnpm/types`.
- Threaded the option through `tryReadProjectManifest` / `readProjectManifest` / `safeReadProjectManifestOnly` in `@pnpm/workspace.project-manifest-reader`. The try-chain is reordered to put the preferred format first; the others fall through in their existing order.
- Reordered the bootstrap in `@pnpm/config.reader` to read `pnpm-workspace.yaml` **before** the root project manifest, so the preference applies to the root read too.
- Updated `findPackages` in `@pnpm/workspace.projects-reader` to group glob results by directory and pick one manifest per directory using the preferred-then-default chain. Emits a single `logger.warn` only when `preferredManifestFormat` is set, multiple manifest files coexist, and the preferred file is missing — i.e. the surprising case where the user's stub manifest is shadowing the intended one. Quiet by default for partial migrations (only `package.json` present).
- A few callers that already had `workspaceManifest` in scope (`filterProjectsBySelectorObjectsFromDir`, `complete.ts`, `checkDepsStatus`) now thread `preferredManifestFormat` through to `findWorkspaceProjects`. Most install/run paths spread `...opts` and pick it up automatically via `Config`.

## Test plan

- [x] All `@pnpm/workspace.project-manifest-reader` unit tests pass (42 tests, including 4 new ones)
- [x] All `@pnpm/workspace.projects-reader` unit tests pass (21 tests, including 3 new ones)
- [x] `tsgo --build` compiles cleanly across `core/types`, `config/reader`, `workspace/project-manifest-reader`, `workspace/projects-reader`, `workspace/projects-filter`
- [ ] e2e smoke test: `pnpm install` in a fixture with both `package.json` and `package.json5` and `preferredManifestFormat: json5`, verify the right manifest is written back
- [ ] Confirm full bundle build via `pnpm --filter pnpm run compile`

Marking as draft for the maintainers' input on the design before polishing the e2e coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)