### PR TITLE
fix: validate unknown options before implicit run

### DIFF
--- a/.changeset/curly-panthers-check.md
+++ b/.changeset/curly-panthers-check.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Report unknown top-level options before falling back to implicit `pnpm run` scripts.

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -75,7 +75,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     return
   }
 
-  if (unknownOptions.size > 0 && !fallbackCommandUsed && !(cmd && NOT_IMPLEMENTED_COMMAND_SET.has(cmd))) {
+  if (unknownOptions.size > 0 && !(cmd && NOT_IMPLEMENTED_COMMAND_SET.has(cmd))) {
     printError(formatUnknownOptionsError(unknownOptions), `For help, run: pnpm help${cmd ? ` ${cmd}` : ''}`)
     process.exitCode = 1
     return

--- a/pnpm/test/cli.ts
+++ b/pnpm/test/cli.ts
@@ -95,11 +95,11 @@ test('implicit run command fails when an unsupported top-level flag is used', ()
     },
   })
 
-  const { status, stdout, stderr } = execPnpmSync(['--fitler', 'web', 'dev'])
+  const { status, stdout, stderr } = execPnpmSync(['--fitler', 'web', 'dev']) // cspell:disable-line
 
   expect(status).toBe(1)
   expect(stdout.toString()).not.toContain('script should not run')
-  expect(stderr.toString()).toMatch(/Unknown option: 'fitler'/)
+  expect(stderr.toString()).toMatch(/Unknown option: 'fitler'/) // cspell:disable-line
   expect(stderr.toString()).toMatch(/Did you mean 'filter'/)
 })
 

--- a/pnpm/test/cli.ts
+++ b/pnpm/test/cli.ts
@@ -88,6 +88,21 @@ test('command fails when an unsupported flag is used', async () => {
   expect(stderr.toString()).toMatch(/Unknown option: 'save-dev'/)
 })
 
+test('implicit run command fails when an unsupported top-level flag is used', () => {
+  prepare({
+    scripts: {
+      web: 'node -e "console.log(\'script should not run\')"',
+    },
+  })
+
+  const { status, stdout, stderr } = execPnpmSync(['--fitler', 'web', 'dev'])
+
+  expect(status).toBe(1)
+  expect(stdout.toString()).not.toContain('script should not run')
+  expect(stderr.toString()).toMatch(/Unknown option: 'fitler'/)
+  expect(stderr.toString()).toMatch(/Did you mean 'filter'/)
+})
+
 test('command fails when a deprecated option is used', async () => {
   prepare()
 


### PR DESCRIPTION
## Summary

- validate unknown top-level options even when pnpm falls back to implicit `pnpm run`
- add a CLI regression test for `pnpm --fitler web dev` so the script is not executed and the unknown option is reported

Fixes #11347.

## Tests

- `pnpm --filter pnpm run compile`
- `pnpm --filter pnpm test -- test/cli.ts -t "implicit run command fails when an unsupported top-level flag is used"`
- `pnpm --dir pnpm exec cross-env NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" jest test/cli.ts -t "implicit run command fails when an unsupported top-level flag is used"`
