### PR TITLE
fix: negated `os` / `cpu` skipped under multi-platform `supportedArchitectures`

### DIFF
--- a/.changeset/check-platform-multi-negation.md
+++ b/.changeset/check-platform-multi-negation.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.package-is-installable": patch
+"pnpm": patch
+---
+
+Fix negated `os` / `cpu` entries (e.g. `["!win32"]`) being incorrectly rejected when `supportedArchitectures` expands to multiple platforms [#11375](https://github.com/pnpm/pnpm/pull/11375).

--- a/config/package-is-installable/src/checkPlatform.ts
+++ b/config/package-is-installable/src/checkPlatform.ts
@@ -82,7 +82,7 @@ function checkList (value: string | string[], list: string | string[]): boolean 
       }
     }
   }
-  return match || blc === list.length
+  return match || blc === list.length * values.length
 }
 
 function dedupeCurrent (current: string, supported: string[]): string[] {

--- a/config/package-is-installable/src/checkPlatform.ts
+++ b/config/package-is-installable/src/checkPlatform.ts
@@ -56,7 +56,6 @@ export type WantedPlatform = Partial<Platform>
 function checkList (value: string | string[], list: string | string[]): boolean {
   let tmp
   let match = false
-  let blc = 0
 
   if (typeof list === 'string') {
     list = [list]
@@ -76,13 +75,14 @@ function checkList (value: string | string[], list: string | string[]): boolean 
         if (tmp === value) {
           return false
         }
-        ++blc
       } else {
         match = match || tmp === value
       }
     }
   }
-  return match || blc === list.length * values.length
+  // No negation rejected any value. Accept if a positive entry matched, or if the list
+  // contains only negations (no positive constraints to satisfy).
+  return match || list.every(entry => entry[0] === '!')
 }
 
 function dedupeCurrent (current: string, supported: string[]): string[] {

--- a/config/package-is-installable/test/checkPlatform.ts
+++ b/config/package-is-installable/test/checkPlatform.ts
@@ -151,3 +151,29 @@ test('accept another libc', () => {
     libc: ['current', 'glibc'],
   })).toBeNull()
 })
+
+test('accept negated os with multi-valued supportedArchitectures', () => {
+  expect(checkPlatform(packageId, { cpu: 'any', os: ['!win32'], libc: 'any' }, {
+    os: ['linux', 'current'],
+    cpu: ['current'],
+    libc: ['current'],
+  })).toBeNull()
+})
+
+test('accept negated cpu with multi-valued supportedArchitectures', () => {
+  expect(checkPlatform(packageId, { cpu: ['!ia32'], os: 'any', libc: 'any' }, {
+    os: ['current'],
+    cpu: ['x64', 'current'],
+    libc: ['current'],
+  })).toBeNull()
+})
+
+test('reject negated os when any supported value matches the negation', () => {
+  const err = checkPlatform(packageId, { cpu: 'any', os: ['!win32'], libc: 'any' }, {
+    os: ['win32', 'current'],
+    cpu: ['current'],
+    libc: ['current'],
+  })
+  expect(err).toBeTruthy()
+  expect(err?.code).toBe('ERR_PNPM_UNSUPPORTED_PLATFORM')
+})


### PR DESCRIPTION
Hey there! We depend on a package called `fs-xattr` which in its [package.json](https://github.com/LinusU/fs-xattr/blob/master/package.json) specifies the `os` value like so:
```json
"os": [
  "!win32"
]
```

[This is valid per npm's docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json?utm_source=chatgpt.com#os). These negation cases however, break when `supportedArchitectures` resolves to multiple platforms (e.g. ["linux", "darwin"]).

This is easily reproducible. I am on a Mac with Apple Silicon:
1. `pnpm init`
2. Configure the following `supportedArchitectures` and `engineStrict` in `pnpm-workspace.yaml`:
    ```yaml
    engineStrict: true
    supportedArchitectures:
        os: [linux, current]
    ```
3. Run `pnpm add fs-xattr`
4. See the following error:
    ```
    Unsupported platform for fs-xattr@0.4.0: wanted {"cpu":["any"],"os":["!win32"],"libc":["any"]} (current: {"os":"darwin","cpu":"arm64","libc":"unknown"})
    ```


I put together a GitHub repo with this setup: https://github.com/Armster15/pnpm-fs-xattr-reproducible

This PR implements a fix for this issue:
1. The existing check used a counter that overcounts by a factor of the number of platforms being checked. Multiplying the right-hand side of the comparison by that factor lets the "all entries are negations" check stay correct without changing behavior for any single-platform call
2. Adds test coverage to prevent this issue from regressing