### PR TITLE
fix: reject invalid patchedDependencies values

### DIFF
--- a/.changeset/fix-patched-dependencies-value-validation.md
+++ b/.changeset/fix-patched-dependencies-value-validation.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Throw a pnpm error when `patchedDependencies` contains a non-string value.

--- a/.changeset/fix-patched-dependencies-value-validation.md
+++ b/.changeset/fix-patched-dependencies-value-validation.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Throw a pnpm error when `patchedDependencies` contains a non-string value.
+Throw a pnpm error when `patchedDependencies` has an invalid shape or contains a non-string value.

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -37,6 +37,9 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
   if (pnpmSettings.patchedDependencies) {
     settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
     for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {
+      if (typeof patchFile !== 'string') {
+        throw new PnpmError('INVALID_PATCHED_DEPENDENCY', `The value of patchedDependencies.${dep} should be a string, but got ${patchFile === null ? 'null' : typeof patchFile}`)
+      }
       if (manifestDir == null || path.isAbsolute(patchFile)) continue
       settings.patchedDependencies[dep] = path.join(manifestDir, patchFile)
     }

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -34,7 +34,8 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
       settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
     }
   }
-  if (pnpmSettings.patchedDependencies) {
+  if (pnpmSettings.patchedDependencies != null) {
+    assertValidPatchedDependencies(pnpmSettings.patchedDependencies)
     settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
     for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {
       if (typeof patchFile !== 'string') {
@@ -46,6 +47,12 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
   }
 
   return settings
+}
+
+function assertValidPatchedDependencies (patchedDependencies: unknown): asserts patchedDependencies is Record<string, string> {
+  if (typeof patchedDependencies !== 'object' || Array.isArray(patchedDependencies)) {
+    throw new PnpmError('INVALID_PATCHED_DEPENDENCY', `The patchedDependencies field should be an object, but got ${Array.isArray(patchedDependencies) ? 'array' : typeof patchedDependencies}`)
+  }
 }
 
 function replaceEnvInSettings (settings: PnpmSettings): PnpmSettings {

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -35,7 +35,7 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
       settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
     }
   }
-  if (pnpmSettings.patchedDependencies != null) {
+  if (pnpmSettings.patchedDependencies !== undefined) {
     assertValidPatchedDependencies(pnpmSettings.patchedDependencies)
     settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
     for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -35,10 +35,11 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
       settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
     }
   }
-  if (pnpmSettings.patchedDependencies !== undefined) {
-    assertValidPatchedDependencies(pnpmSettings.patchedDependencies)
-    settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
-    for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {
+  if (settings.patchedDependencies !== undefined) {
+    assertValidPatchedDependencies(settings.patchedDependencies)
+    const patchedDependencies = { ...settings.patchedDependencies }
+    settings.patchedDependencies = patchedDependencies
+    for (const [dep, patchFile] of Object.entries(patchedDependencies)) {
       if (manifestDir == null || path.isAbsolute(patchFile)) continue
       settings.patchedDependencies[dep] = path.join(manifestDir, patchFile)
     }

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -35,7 +35,8 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
       settings.overrides = mapValues(createVersionReferencesReplacer(manifest), settings.overrides)
     }
   }
-  if (pnpmSettings.patchedDependencies) {
+  if (pnpmSettings.patchedDependencies != null) {
+    assertValidPatchedDependencies(pnpmSettings.patchedDependencies)
     settings.patchedDependencies = { ...pnpmSettings.patchedDependencies }
     for (const [dep, patchFile] of Object.entries(pnpmSettings.patchedDependencies)) {
       if (manifestDir == null || path.isAbsolute(patchFile)) continue
@@ -53,6 +54,17 @@ function assertValidOverrides (overrides: unknown): asserts overrides is Record<
   for (const [selector, spec] of Object.entries(overrides)) {
     if (typeof spec !== 'string') {
       throw new PnpmError('INVALID_OVERRIDES', `The value of overrides.${selector} should be a string, but got ${renderReceivedType(spec)}`)
+    }
+  }
+}
+
+function assertValidPatchedDependencies (patchedDependencies: unknown): asserts patchedDependencies is Record<string, string> {
+  if (patchedDependencies == null || typeof patchedDependencies !== 'object' || Array.isArray(patchedDependencies)) {
+    throw new PnpmError('INVALID_PATCHED_DEPENDENCY', `The patchedDependencies field should be an object, but got ${renderReceivedType(patchedDependencies)}`)
+  }
+  for (const [dep, patchFile] of Object.entries(patchedDependencies)) {
+    if (typeof patchFile !== 'string') {
+      throw new PnpmError('INVALID_PATCHED_DEPENDENCY', `The value of patchedDependencies.${dep} should be a string, but got ${renderReceivedType(patchFile)}`)
     }
   }
 }

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -33,3 +33,14 @@ test('getOptionsFromPnpmSettings() converts allowBuilds', () => {
     },
   })
 })
+
+test('getOptionsFromPnpmSettings() rejects non-string patchedDependencies values', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: {
+      foo: null,
+    } as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The value of patchedDependencies.foo should be a string, but got null',
+  }))
+})

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -44,3 +44,21 @@ test('getOptionsFromPnpmSettings() rejects non-string patchedDependencies values
     message: 'The value of patchedDependencies.foo should be a string, but got null',
   }))
 })
+
+test('getOptionsFromPnpmSettings() rejects array patchedDependencies', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: [] as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The patchedDependencies field should be an object, but got array',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects string patchedDependencies', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: 'foo' as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The patchedDependencies field should be an object, but got string',
+  }))
+})

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -85,3 +85,14 @@ test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
     message: 'The overrides field should be an object, but got array',
   }))
 })
+
+test('getOptionsFromPnpmSettings() rejects non-string patchedDependencies values', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: {
+      foo: null,
+    } as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The value of patchedDependencies.foo should be a string, but got null',
+  }))
+})

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -96,3 +96,21 @@ test('getOptionsFromPnpmSettings() rejects non-string patchedDependencies values
     message: 'The value of patchedDependencies.foo should be a string, but got null',
   }))
 })
+
+test('getOptionsFromPnpmSettings() rejects array patchedDependencies', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: [] as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The patchedDependencies field should be an object, but got array',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects string patchedDependencies', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: 'foo' as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The patchedDependencies field should be an object, but got string',
+  }))
+})

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -106,6 +106,15 @@ test('getOptionsFromPnpmSettings() rejects array patchedDependencies', () => {
   }))
 })
 
+test('getOptionsFromPnpmSettings() rejects null patchedDependencies', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    patchedDependencies: null as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_PATCHED_DEPENDENCY',
+    message: 'The patchedDependencies field should be an object, but got null',
+  }))
+})
+
 test('getOptionsFromPnpmSettings() rejects string patchedDependencies', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     patchedDependencies: 'foo' as unknown as Record<string, string>,


### PR DESCRIPTION
## Summary

Reject non-string `patchedDependencies` values while reading root pnpm settings.

## Problem

`patchedDependencies` entries were assumed to always have string values. If a workspace config contained an invalid value like:

``yaml
patchedDependencies:
  foo: null``
  
pnpm attempted to pass null into path handling and threw a raw TypeError.
  
## Fix
Validate each `patchedDependencies` value before resolving patch paths and throw a pnpm error when the value is not a string.

## Test
pnpm --filter @pnpm/config.reader test getOptionsFromRootManifest.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for patchedDependencies: invalid structures or non-string values now produce a clear, descriptive error to prevent misconfiguration and silent failures.
* **Tests**
  * Unit tests expanded to cover the patchedDependencies validation and its error handling.
* **Chores**
  * Added a changeset marking a patch release for related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->