### PR TITLE
fix: reject invalid overrides values

### DIFF
--- a/.changeset/fix-overrides-value-validation.md
+++ b/.changeset/fix-overrides-value-validation.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Throw a pnpm error when `overrides` contains a non-string value.
+Throw a pnpm error when `overrides` has an invalid shape or contains a non-string value.

--- a/.changeset/fix-overrides-value-validation.md
+++ b/.changeset/fix-overrides-value-validation.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Throw a pnpm error when `overrides` contains a non-string value.

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -48,13 +48,19 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
 
 function assertValidOverrides (overrides: unknown): asserts overrides is Record<string, string> {
   if (overrides == null || typeof overrides !== 'object' || Array.isArray(overrides)) {
-    throw new PnpmError('INVALID_OVERRIDES', `The overrides field should be an object, but got ${overrides === null ? 'null' : Array.isArray(overrides) ? 'array' : typeof overrides}`)
+    throw new PnpmError('INVALID_OVERRIDES', `The overrides field should be an object, but got ${renderReceivedType(overrides)}`)
   }
   for (const [selector, spec] of Object.entries(overrides)) {
     if (typeof spec !== 'string') {
-      throw new PnpmError('INVALID_OVERRIDES', `The value of overrides.${selector} should be a string, but got ${spec === null ? 'null' : typeof spec}`)
+      throw new PnpmError('INVALID_OVERRIDES', `The value of overrides.${selector} should be a string, but got ${renderReceivedType(spec)}`)
     }
   }
+}
+
+function renderReceivedType (value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
 }
 
 function replaceEnvInSettings (settings: PnpmSettings): PnpmSettings {

--- a/config/reader/src/getOptionsFromRootManifest.ts
+++ b/config/reader/src/getOptionsFromRootManifest.ts
@@ -28,6 +28,7 @@ export type OptionsFromRootManifest = {
 export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnpmSettings: PnpmSettings, manifest?: ProjectManifest): OptionsFromRootManifest {
   const settings: OptionsFromRootManifest = replaceEnvInSettings(pnpmSettings)
   if (settings.overrides) {
+    assertValidOverrides(settings.overrides)
     if (Object.keys(settings.overrides).length === 0) {
       delete settings.overrides
     } else if (manifest) {
@@ -43,6 +44,17 @@ export function getOptionsFromPnpmSettings (manifestDir: string | undefined, pnp
   }
 
   return settings
+}
+
+function assertValidOverrides (overrides: unknown): asserts overrides is Record<string, string> {
+  if (overrides == null || typeof overrides !== 'object' || Array.isArray(overrides)) {
+    throw new PnpmError('INVALID_OVERRIDES', `The overrides field should be an object, but got ${overrides === null ? 'null' : Array.isArray(overrides) ? 'array' : typeof overrides}`)
+  }
+  for (const [selector, spec] of Object.entries(overrides)) {
+    if (typeof spec !== 'string') {
+      throw new PnpmError('INVALID_OVERRIDES', `The value of overrides.${selector} should be a string, but got ${spec === null ? 'null' : typeof spec}`)
+    }
+  }
 }
 
 function replaceEnvInSettings (settings: PnpmSettings): PnpmSettings {

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -45,6 +45,17 @@ test('getOptionsFromPnpmSettings() rejects non-string overrides values', () => {
   }))
 })
 
+test('getOptionsFromPnpmSettings() rejects array overrides values', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: {
+      foo: [],
+    } as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_OVERRIDES',
+    message: 'The value of overrides.foo should be a string, but got array',
+  }))
+})
+
 test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     overrides: [] as unknown as Record<string, string>,

--- a/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -33,3 +33,23 @@ test('getOptionsFromPnpmSettings() converts allowBuilds', () => {
     },
   })
 })
+
+test('getOptionsFromPnpmSettings() rejects non-string overrides values', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: {
+      foo: null,
+    } as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_OVERRIDES',
+    message: 'The value of overrides.foo should be a string, but got null',
+  }))
+})
+
+test('getOptionsFromPnpmSettings() rejects non-object overrides values', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    overrides: [] as unknown as Record<string, string>,
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_OVERRIDES',
+    message: 'The overrides field should be an object, but got array',
+  }))
+})


### PR DESCRIPTION
## Summary

Reject invalid overrides values while reading root pnpm settings.

## Problem

overrides entries were assumed to contain string specs. If a workspace config contained an invalid value like:

``yaml overrides:
  foo: null``
  
pnpm passed the value into version reference replacement and threw a raw TypeError.

## Fix

Validate overrides before processing them and throw a pnpm error when the field has an invalid shape or contains non-string values.

## Test

pnpm --filter @pnpm/config.reader test getOptionsFromRootManifest.test.ts