### PR TITLE
docs: clarify default catalog protocol behavior

### DIFF
--- a/catalogs/protocol-parser/README.md
+++ b/catalogs/protocol-parser/README.md
@@ -1,3 +1,3 @@
 # @pnpm/catalogs.protocol-parser
 
-> Parse catalog protocol specifiers and return the catalog name.
+> Parse catalog protocol specifiers and return the catalog name, using `default` for `catalog:`.

--- a/catalogs/protocol-parser/README.md
+++ b/catalogs/protocol-parser/README.md
@@ -1,3 +1,10 @@
 # @pnpm/catalogs.protocol-parser
 
-> Parse catalog protocol specifiers and return the catalog name, using `default` for `catalog:`.
+> Parse catalog protocol specifiers and return the catalog name.
+
+Catalog protocol specifiers start with `catalog:`. The parser reads the value after that prefix as the catalog name, and returns `default` when no name is provided.
+
+## Examples
+
+- `catalog:foo` -> `"foo"`
+- `catalog:` -> `"default"`


### PR DESCRIPTION
## Summary

Clarify how the default catalog is handled in the catalog protocol parser.

## Problem

The README states that it parses catalog protocol specifiers and returns the catalog name, but it does not mention how the `catalog:` case is handled.

## Fix

Document that `catalog:` resolves to the `default` catalog.

## Verification

- matches implementation in `parseCatalogProtocol`
- matches existing test behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README documentation for the catalog protocol parser, providing explanations and examples for users to understand how to work with catalog protocol specifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->