### PR TITLE
chore: ship .git-wt/pr-hook so wt <pr> auto-launches a Claude review

### DIFF
--- a/.git-wt/pr-hook
+++ b/.git-wt/pr-hook
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Invoked by @zkochan/git-wt's `wt` shell function after `wt <pr-number>`
+# creates a worktree and cds into it. Silently no-ops for contributors who
+# don't have claude installed.
+command -v claude >/dev/null 2>&1 || exit 0
+exec claude --dangerously-skip-permissions "Review and fix PR #$PR_NUMBER. Steps:
+1. Use gh to read the PR description, diff, and all review comments (both PR-level and inline).
+2. Understand the intent of the PR and what each change does.
+3. Resolve any conflicts with the base branch by running './shell/resolve-pr-conflicts.sh $PR_NUMBER'. This force-fetches the base branch (avoiding stale refs), rebases, and auto-resolves lockfile conflicts. If it prints MANUAL_RESOLUTION_NEEDED, read the listed conflicted files, resolve the conflict markers, run 'git add' on each resolved file, then run './shell/resolve-pr-conflicts.sh $PR_NUMBER --continue' to finish the rebase and push. Do NOT skip this step. Do NOT assume the branch is up to date.
+4. Address every review comment — fix the code as requested or as appropriate.
+5. Look for any other bugs, issues, or style problems in the changed code and fix those too.
+6. Run the relevant tests to verify your fixes work (check CLAUDE.md for how to run tests).
+7. Give me a summary of what you found and what you changed, including any conflicts you resolved.
+Do NOT push. Leave all non-merge changes unstaged for me to review."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,12 @@ Passing a number is interpreted as a PR number. The PR is fetched via
 `git fetch origin pull/<number>/head` into a local branch named `pr-<number>`, so it works
 for both same-repo branches and forks.
 
+If [Claude Code](https://www.anthropic.com/claude-code) is installed on your system, `wt
+<pr-number>` will additionally launch a Claude review of the PR via the tracked hook at
+`.git-wt/pr-hook`. The hook silently no-ops if `claude` isn't on your `PATH`, so contributors
+who don't use Claude aren't affected. Requires `@zkochan/git-wt` ≥ 0.0.3, which is the
+version that introduced the per-repo hook lookup.
+
 If you only need the worktree path (e.g. to open it in an editor) without switching directories,
 invoke `git-wt` directly — it's also exposed as a native git subcommand:
 


### PR DESCRIPTION
## Summary
- Adds a tracked, executable `.git-wt/pr-hook` containing the pnpm-specific Claude PR-review prompt that previously lived in the now-removed `shell/wt.fish` (replaced by `@zkochan/git-wt` in #11359). With `@zkochan/git-wt` ≥ 0.0.3, contributors who run `wt <pr-number>` from a pnpm worktree will automatically launch a Claude Code review of the PR.
- The hook silently no-ops when `claude` isn't on `PATH`, so contributors who don't use Claude Code aren't affected.
- Documents the behavior and the 0.0.3 requirement in `CONTRIBUTING.md`.

## Test plan
- [x] `git ls-files --stage .git-wt/pr-hook` reports mode `100755`.
- [x] With `@zkochan/git-wt` < 0.0.3 installed: `wt <pr-number>` works as before (no hook lookup).
- [x] With `@zkochan/git-wt` ≥ 0.0.3 installed and `claude` not on `PATH`: `wt <pr-number>` creates the worktree, `cd`s in, hook runs and exits 0 silently.
- [x] With `@zkochan/git-wt` ≥ 0.0.3 installed and `claude` on `PATH`: `wt <pr-number>` creates the worktree, `cd`s in, and launches the Claude review with the PR number substituted into the prompt.
- [x] CONTRIBUTING.md renders correctly on GitHub.