### PR TITLE
fix: sync env lockfile when devEngines.packageManager version is stale

### DIFF
--- a/.changeset/sync-env-lockfile-devengines.md
+++ b/.changeset/sync-env-lockfile-devengines.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Update the env lockfile's `packageManagerDependencies` entry when `devEngines.packageManager` declares a pnpm version that the lockfile no longer satisfies. Previously, the stale entry was kept even though the running pnpm matched the declared version, silently breaking the integrity record [#11387](https://github.com/pnpm/pnpm/issues/11387).

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -31,6 +31,7 @@ import type { ParsedCliArgsWithBuiltIn } from './parseCliArgs.js'
 import { parseCliArgs } from './parseCliArgs.js'
 import { initReporter, type ReporterType } from './reporter/index.js'
 import { switchCliVersion } from './switchCliVersion.js'
+import { syncEnvLockfile } from './syncEnvLockfile.js'
 
 export const REPORTER_INITIALIZED = Symbol('reporterInitialized')
 
@@ -111,6 +112,9 @@ export async function main (inputArgv: string[]): Promise<void> {
           globalWarn('Using --global skips the package manager check for this project')
         } else {
           checkPackageManager(pm)
+          if (pm.name === 'pnpm') {
+            await syncEnvLockfile(config, context)
+          }
         }
       }
     }

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -105,10 +105,10 @@ export async function main (inputArgv: string[]): Promise<void> {
     }) as { config: typeof config, context: ConfigContext })
     if (!isExecutedByCorepack() && cmd !== 'setup' && context.wantedPackageManager != null && !shouldSkipPmHandling(cmd, cliParams)) {
       const pm = context.wantedPackageManager
-      if (pm.onFail === 'download' && pm.name === 'pnpm') {
-        await switchCliVersion(config, context)
-      } else if (pm.onFail !== 'ignore') {
-        if (cliOptions.global) {
+      if (pm.onFail !== 'ignore') {
+        if (pm.name === 'pnpm' && pm.onFail === 'download') {
+          await switchCliVersion(config, context)
+        } else if (cliOptions.global) {
           globalWarn('Using --global skips the package manager check for this project')
         } else {
           checkPackageManager(pm)

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -112,9 +112,7 @@ export async function main (inputArgv: string[]): Promise<void> {
           globalWarn('Using --global skips the package manager check for this project')
         } else {
           checkPackageManager(pm)
-          if (pm.name === 'pnpm') {
-            await syncEnvLockfile(config, context)
-          }
+          await syncEnvLockfile(config, context)
         }
       }
     }

--- a/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm/src/syncEnvLockfile.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { packageManager } from '@pnpm/cli.meta'
+import type { Config, ConfigContext } from '@pnpm/config.reader'
+import type { EnvLockfile } from '@pnpm/lockfile.types'
+import { tempDir } from '@pnpm/prepare'
+
+const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: object) => Promise<EnvLockfile>>(async () => ({} as EnvLockfile))
+const createStoreController = jest.fn<(opts: object) => Promise<{ ctrl: { close: () => Promise<void> }, dir: string }>>(async () => ({
+  ctrl: { close: jest.fn<() => Promise<void>>(async () => {}) },
+  dir: '/store',
+}))
+
+jest.unstable_mockModule('@pnpm/installing.env-installer', () => ({
+  resolvePackageManagerIntegrities,
+}))
+
+jest.unstable_mockModule('@pnpm/store.connection-manager', () => ({
+  createStoreController,
+}))
+
+const { syncEnvLockfile } = await import('./syncEnvLockfile.js')
+
+beforeEach(() => {
+  resolvePackageManagerIntegrities.mockClear()
+  createStoreController.mockClear()
+})
+
+function makeContext (rootDir: string, overrides: Partial<ConfigContext> = {}): ConfigContext {
+  return {
+    rootProjectManifestDir: rootDir,
+    wantedPackageManager: undefined,
+    ...overrides,
+  } as ConfigContext
+}
+
+const baseConfig = { registries: { default: 'https://registry.npmjs.org/' } } as unknown as Config
+
+test('no-op when wantedPackageManager is undefined', async () => {
+  const dir = tempDir()
+  await syncEnvLockfile(baseConfig, makeContext(dir))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when wantedPackageManager is not pnpm', async () => {
+  const dir = tempDir()
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'yarn', version: '4.0.0', fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when shouldPersistLockfile is false (legacy packageManager < v12)', async () => {
+  const dir = tempDir()
+  writeStaleEnvLockfile(dir, '9.0.0')
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: '11.0.0' },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when running pnpm does not satisfy wanted range', async () => {
+  const dir = tempDir()
+  writeStaleEnvLockfile(dir, '9.0.0')
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: '0.0.1', fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when no env lockfile exists', async () => {
+  const dir = tempDir()
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when lockfile has no packageManagerDependencies for pnpm', async () => {
+  const dir = tempDir()
+  writeEnvLockfileWithoutPmDeps(dir)
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('no-op when lockfile already records a satisfying version', async () => {
+  const dir = tempDir()
+  writeStaleEnvLockfile(dir, packageManager.version)
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+})
+
+test('updates the lockfile when locked version no longer satisfies wanted version', async () => {
+  const dir = tempDir()
+  writeStaleEnvLockfile(dir, '9.0.0')
+  await syncEnvLockfile(baseConfig, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
+  }))
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledTimes(1)
+  expect(resolvePackageManagerIntegrities.mock.calls[0][0]).toBe(packageManager.version)
+  const opts = resolvePackageManagerIntegrities.mock.calls[0][1] as { rootDir: string, save: boolean }
+  expect(opts.rootDir).toBe(dir)
+  expect(opts.save).toBe(true)
+})
+
+function writeStaleEnvLockfile (dir: string, pnpmVersion: string): void {
+  // readEnvLockfile expects a multi-document YAML file beginning with `---\n`,
+  // where the env lockfile is the first document.
+  const envYaml = `lockfileVersion: '9.0'
+importers:
+  '.':
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: ${pnpmVersion}
+        version: ${pnpmVersion}
+packages: {}
+snapshots: {}
+`
+  fs.writeFileSync(path.join(dir, 'pnpm-lock.yaml'), `---\n${envYaml}\n---\n`)
+}
+
+function writeEnvLockfileWithoutPmDeps (dir: string): void {
+  const envYaml = `lockfileVersion: '9.0'
+importers:
+  '.':
+    configDependencies: {}
+packages: {}
+snapshots: {}
+`
+  fs.writeFileSync(path.join(dir, 'pnpm-lock.yaml'), `---\n${envYaml}\n---\n`)
+}

--- a/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm/src/syncEnvLockfile.test.ts
@@ -4,10 +4,24 @@ import path from 'node:path'
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { packageManager } from '@pnpm/cli.meta'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
+import { readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import type { EnvLockfile } from '@pnpm/lockfile.types'
 import { tempDir } from '@pnpm/prepare'
 
-const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: object) => Promise<EnvLockfile>>(async () => ({} as EnvLockfile))
+// Simulate what the real resolvePackageManagerIntegrities does that this test
+// cares about: record the resolved pnpm version under
+// packageManagerDependencies and persist the lockfile to disk.
+const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: { envLockfile?: EnvLockfile, rootDir: string, save?: boolean }) => Promise<EnvLockfile>>(
+  async (version, opts) => {
+    const lockfile = opts.envLockfile ?? ({ lockfileVersion: '9.0', importers: { '.': { configDependencies: {} } }, packages: {}, snapshots: {} } as EnvLockfile)
+    lockfile.importers['.'].packageManagerDependencies = {
+      pnpm: { specifier: version, version },
+      '@pnpm/exe': { specifier: version, version },
+    }
+    if (opts.save) await writeEnvLockfile(opts.rootDir, lockfile)
+    return lockfile
+  }
+)
 const createStoreController = jest.fn<(opts: object) => Promise<{ ctrl: { close: () => Promise<void> }, dir: string }>>(async () => ({
   ctrl: { close: jest.fn<() => Promise<void>>(async () => {}) },
   dir: '/store',
@@ -102,11 +116,12 @@ test('updates the lockfile when locked version no longer satisfies wanted versio
   await syncEnvLockfile(baseConfig, makeContext(dir, {
     wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true },
   }))
-  expect(resolvePackageManagerIntegrities).toHaveBeenCalledTimes(1)
-  expect(resolvePackageManagerIntegrities.mock.calls[0][0]).toBe(packageManager.version)
-  const opts = resolvePackageManagerIntegrities.mock.calls[0][1] as { rootDir: string, save: boolean }
-  expect(opts.rootDir).toBe(dir)
-  expect(opts.save).toBe(true)
+  const updated = await readEnvLockfile(dir)
+  expect(updated).not.toBeNull()
+  expect(updated!.importers['.'].packageManagerDependencies?.['pnpm']).toEqual({
+    specifier: packageManager.version,
+    version: packageManager.version,
+  })
 })
 
 function writeStaleEnvLockfile (dir: string, pnpmVersion: string): void {

--- a/pnpm/src/syncEnvLockfile.ts
+++ b/pnpm/src/syncEnvLockfile.ts
@@ -1,0 +1,48 @@
+import { packageManager } from '@pnpm/cli.meta'
+import type { Config, ConfigContext } from '@pnpm/config.reader'
+import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
+import { readEnvLockfile } from '@pnpm/lockfile.fs'
+import { createStoreController } from '@pnpm/store.connection-manager'
+import semver from 'semver'
+
+import { shouldPersistLockfile } from './shouldPersistLockfile.js'
+
+/**
+ * Refreshes the env lockfile's `packageManagerDependencies` entry when it
+ * records a pnpm version that no longer satisfies the wanted
+ * `devEngines.packageManager` range. The currently running pnpm version
+ * (already verified to satisfy the wanted range by checkPackageManager) is
+ * recorded as the new resolution.
+ *
+ * No-op when the project does not pin a pnpm version, when no env lockfile
+ * exists yet, or when the recorded version still satisfies the wanted range.
+ */
+export async function syncEnvLockfile (config: Config, context: ConfigContext): Promise<void> {
+  const pm = context.wantedPackageManager
+  if (pm == null || pm.name !== 'pnpm' || pm.version == null) return
+  if (!shouldPersistLockfile(pm)) return
+  // The currently running pnpm must satisfy the wanted range. Otherwise,
+  // recording it in the lockfile would cement an incompatible resolution —
+  // checkPackageManager has already surfaced the mismatch to the user.
+  if (!semver.satisfies(packageManager.version, pm.version, { includePrerelease: true })) return
+
+  const envLockfile = await readEnvLockfile(context.rootProjectManifestDir)
+  if (envLockfile == null) return
+  const lockedVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
+  if (lockedVersion == null) return
+  if (semver.satisfies(lockedVersion, pm.version, { includePrerelease: true })) return
+
+  const store = await createStoreController({ ...config, ...context })
+  try {
+    await resolvePackageManagerIntegrities(packageManager.version, {
+      envLockfile,
+      registries: config.registries,
+      rootDir: context.rootProjectManifestDir,
+      storeController: store.ctrl,
+      storeDir: store.dir,
+      save: true,
+    })
+  } finally {
+    await store.ctrl.close()
+  }
+}


### PR DESCRIPTION
## Summary

- When `devEngines.packageManager` declared a pnpm version that the lockfile no longer satisfied, pnpm previously left the stale `packageManagerDependencies` entry in place — silently breaking the integrity record while still using the new version.
- Add `syncEnvLockfile`, invoked after `checkPackageManager` for pnpm, which detects a stale lockfile entry and re-resolves it against the currently running pnpm version (already verified to satisfy the wanted range). No-ops when there is no env lockfile, no existing entry, the entry already satisfies, or the running pnpm doesn't satisfy.
- Closes #11387.

## Test plan

- [x] `pnpm exec tsgo --build` clean
- [x] `pnpm run lint` clean (only pre-existing warnings)
- [x] New unit tests in `pnpm/src/syncEnvLockfile.test.ts` (8 tests, 100% coverage of the new module) pass
- [x] `pnpm/test/switchingVersions.test.ts` (12 tests) pass
- [x] `pnpm/test/packageManagerCheck.test.ts` + `pnpm/test/configurationalDependencies.test.ts` (28 tests) pass