### PR TITLE
fix(@pnpm/exe): preserve relative symlinks when packaging dist/

### DIFF
--- a/.changeset/exe-build-verbatim-symlinks.md
+++ b/.changeset/exe-build-verbatim-symlinks.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/exe": patch
+---
+
+Preserve relative symlinks under `dist/node_modules/.bin/` when copying `dist/` for the standalone executable artifact, by passing `verbatimSymlinks: true` to `fs.cpSync`. This stops the release tarballs from baking absolute paths to the build host (e.g. `/home/runner/work/pnpm/pnpm/...`) into symlink targets, which previously made the tarballs unextractable by strict tar implementations that validate symlink targets (e.g. hermit) [#11398](https://github.com/pnpm/pnpm/issues/11398).

--- a/cspell.json
+++ b/cspell.json
@@ -340,6 +340,7 @@
     "undeprecate",
     "underperformance",
     "undollar",
+    "unextractable",
     "uninstallation",
     "unnest",
     "unreviewed",

--- a/pnpm/artifacts/exe/scripts/build-artifacts.ts
+++ b/pnpm/artifacts/exe/scripts/build-artifacts.ts
@@ -45,7 +45,7 @@ execa.sync(process.execPath, [pnpmBundle, 'with', 'current', ...packAppArgs], {
 const distSrc = path.join(pnpmRootDir, 'dist')
 const distDest = path.join(exeDir, 'dist')
 fs.rmSync(distDest, { recursive: true, force: true })
-fs.cpSync(distSrc, distDest, { recursive: true })
+fs.cpSync(distSrc, distDest, { recursive: true, verbatimSymlinks: true })
 
 const removeMapFiles = (dir: string): void => {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
Closes #11398.

## Problem

The v11 standalone executable release tarballs (`pnpm-{darwin,linux}-{x64,arm64}.tar.gz`) ship 4 broken absolute symlinks under `dist/node_modules/.bin/`:

```
dist/node_modules/.bin/node-gyp    -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js
dist/node_modules/.bin/node-which  -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/which/bin/which.js
dist/node_modules/.bin/nopt        -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/nopt/bin/nopt.js
dist/node_modules/.bin/semver      -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/semver/bin/semver.js
```

The `/home/runner/work/pnpm/pnpm/...` paths leak the GitHub Actions runner's filesystem layout into a public artifact, and the symlinks are dangling on every user's machine. Lenient extractors (`get.pnpm.io/install.sh`, npm, corepack, asdf, etc.) silently extract them as dangling — pnpm itself never traverses these paths at runtime, so the bug has been invisible. Strict extractors that validate symlink targets ([hermit](https://github.com/cashapp/hermit) is the one that surfaced this) refuse to extract the tarball entirely.

See #11398 for the full investigation and reproducer.

## Root cause

`pnpm/artifacts/exe/scripts/build-artifacts.ts` copies the repo's `dist/` into the `@pnpm/exe` package directory with:

```ts
fs.cpSync(distSrc, distDest, { recursive: true })
```

Node's `fs.cpSync` defaults to `verbatimSymlinks: false`, which resolves relative symlinks into absolute paths at the source filesystem location during the copy. So a relative link in the pnpm repo (`dist/node_modules/.bin/node-gyp -> ../node-gyp/bin/node-gyp.js`) gets rewritten to an absolute `/home/runner/work/pnpm/pnpm/pnpm/dist/...` link in the destination directory that subsequently gets archived. See [nodejs/node#41693](https://github.com/nodejs/node/issues/41693) for the underlying Node behavior.

## Fix

Add `verbatimSymlinks: true` to the `fs.cpSync` options. This preserves relative symlinks verbatim so the archived links stay valid at any extraction location.

```diff
-fs.cpSync(distSrc, distDest, { recursive: true })
+fs.cpSync(distSrc, distDest, { recursive: true, verbatimSymlinks: true })
```

## Testing

The build script runs in CI on every release, so the next release will demonstrate the fix. Locally I can't easily exercise the full release pipeline, but the change is a one-line option flag well-documented in the [Node.js docs](https://nodejs.org/api/fs.html#fscpsyncsrc-dest-options).

🤖 Generated with [Amp](https://ampcode.com)
