### PR TITLE
fix: run packageManager check and lockfile sync under corepack

### DIFF
--- a/.changeset/sync-env-lockfile-corepack.md
+++ b/.changeset/sync-env-lockfile-corepack.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed `packageManagerDependencies` going stale when pnpm is invoked through corepack. The lockfile sync (and the `devEngines.packageManager` version check) previously ran only when pnpm was invoked directly; under corepack the entire block was skipped, so a stale entry would persist even after the running pnpm version changed. The lockfile sync now runs regardless of how pnpm was invoked, while the pnpm-managed version switch (`onFail: 'download'`) remains skipped under corepack so it doesn't fight corepack's own version selection [#11397](https://github.com/pnpm/pnpm/issues/11397).

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -103,15 +103,24 @@ export async function main (inputArgv: string[]): Promise<void> {
       workspaceDir,
       onlyInheritDlxSettingsFromLocal: isDlxOrCreateCommand,
     }) as { config: typeof config, context: ConfigContext })
-    if (!isExecutedByCorepack() && cmd !== 'setup' && context.wantedPackageManager != null && !shouldSkipPmHandling(cmd, cliParams)) {
+    if (cmd !== 'setup' && context.wantedPackageManager != null && !shouldSkipPmHandling(cmd, cliParams)) {
       const pm = context.wantedPackageManager
       if (pm.onFail !== 'ignore') {
-        if (pm.name === 'pnpm' && pm.onFail === 'download') {
+        if (pm.name === 'pnpm' && pm.onFail === 'download' && !isExecutedByCorepack()) {
+          // Corepack owns version switching; pnpm only switches versions when
+          // the user is running pnpm directly.
           await switchCliVersion(config, context)
         } else if (cliOptions.global) {
           globalWarn('Using --global skips the package manager check for this project')
         } else {
-          checkPackageManager(pm)
+          // checkPackageManager and syncEnvLockfile run regardless of how pnpm
+          // was invoked. Different developers on the same project may use
+          // corepack or invoke pnpm directly, and the lockfile's
+          // `packageManagerDependencies` entry must stay consistent across both
+          // workflows. syncEnvLockfile self-gates via shouldPersistLockfile so
+          // it only writes to the lockfile when the project opted in (via
+          // `devEngines.packageManager`, or a v12+ `packageManager` pin).
+          checkPackageManager(pm, { underCorepack: isExecutedByCorepack() })
           await syncEnvLockfile(config, context)
         }
       }
@@ -388,7 +397,7 @@ function shouldSkipPmHandling (cmd: string | null, cliParams: string[]): boolean
   return false
 }
 
-function checkPackageManager (pm: EngineDependency): void {
+function checkPackageManager (pm: EngineDependency, opts: { underCorepack: boolean }): void {
   if (!pm.name) return
   const shouldError = pm.onFail === 'error' || pm.onFail === 'download'
   if (pm.name !== 'pnpm') {
@@ -402,11 +411,20 @@ function checkPackageManager (pm: EngineDependency): void {
       ? packageManager.version
       : undefined
     if (currentPnpmVersion && !semver.satisfies(currentPnpmVersion, pm.version, { includePrerelease: true })) {
-      const msg = `This project is configured to use ${pm.version} of pnpm. Your current pnpm is v${currentPnpmVersion}`
+      let msg = `This project is configured to use ${pm.version} of pnpm. Your current pnpm is v${currentPnpmVersion}`
+      // When pnpm runs under corepack, corepack — not pnpm — selects the
+      // running version, so users see this mismatch even with onFail='download'
+      // (which would normally auto-switch). Spell out that pnpm cannot switch
+      // here and point at the two ways out.
+      if (opts.underCorepack) {
+        msg += '\nCorepack invoked pnpm with this version, and pnpm does not switch versions when running under corepack.'
+      }
       if (shouldError) {
-        throw new PnpmError('BAD_PM_VERSION', msg, {
-          hint: 'If you want to bypass this version check, you can set the "pmOnFail" configuration to "warn" or "ignore" (e.g. via --pm-on-fail=ignore). If using "devEngines.packageManager", you can set its "onFail" to "warn" or "ignore"',
-        })
+        const baseHint = 'If you want to bypass this version check, you can set the "pmOnFail" configuration to "warn" or "ignore" (e.g. via --pm-on-fail=ignore). If using "devEngines.packageManager", you can set its "onFail" to "warn" or "ignore"'
+        const hint = opts.underCorepack
+          ? `Align the "packageManager" field in package.json with "devEngines.packageManager", or invoke pnpm directly (without corepack) so it can switch versions automatically.\n${baseHint}`
+          : baseHint
+        throw new PnpmError('BAD_PM_VERSION', msg, { hint })
       } else {
         globalWarn(msg)
       }

--- a/pnpm/test/configurationalDependencies.test.ts
+++ b/pnpm/test/configurationalDependencies.test.ts
@@ -149,6 +149,47 @@ test('package manager from the packageManager field is not saved into the lockfi
   expect(envLockfile!.importers['.'].packageManagerDependencies).toBeUndefined()
 })
 
+test('packageManagerDependencies is refreshed when pnpm is invoked via corepack (#11397)', async () => {
+  const pnpmVersion = JSON.parse(fs.readFileSync(path.join(path.dirname(pnpmBinLocation), '..', 'package.json'), 'utf8')).version as string
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: pnpmVersion,
+      },
+    },
+  })
+
+  // Seed the lockfile with a stale packageManagerDependencies entry that no
+  // longer satisfies devEngines.packageManager. Multi-document YAML: env
+  // lockfile is the first doc, the (empty) installer lockfile is the second.
+  fs.writeFileSync('pnpm-lock.yaml', `---
+lockfileVersion: '9.0'
+importers:
+  '.':
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 0.0.1
+        version: 0.0.1
+packages: {}
+snapshots: {}
+
+---
+`)
+
+  // COREPACK_ROOT used to skip the entire pm-handling block, leaving the stale
+  // 0.0.1 entry untouched. The sync must run regardless of how pnpm was
+  // invoked.
+  await execPnpm(['install'], {
+    env: { COREPACK_ROOT: '/fake/corepack' },
+  })
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile).not.toBeNull()
+  expect(envLockfile!.importers['.'].packageManagerDependencies?.['pnpm'].version).toBe(pnpmVersion)
+})
+
 test('installing a new configurational dependency', async () => {
   prepare()
 

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -333,6 +333,61 @@ test('pmOnFail via --pm-on-fail CLI flag bypasses the devEngines.packageManager 
   expect(execPnpmSync(['install', '--config.pm-on-fail=ignore']).status).toBe(0)
 })
 
+test('devEngines.packageManager check runs even when pnpm is invoked via corepack', async () => {
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '0.0.1',
+        onFail: 'warn',
+      },
+    },
+  })
+
+  // COREPACK_ROOT signals corepack-managed invocation. The package-manager
+  // handling block (check + lockfile sync) used to be guarded out entirely
+  // when this was set, leaving packageManagerDependencies stale (#11397).
+  // The check (and sync) must run regardless of how pnpm was invoked, since
+  // different developers on the same project may use either path.
+  const { status, stdout } = execPnpmSync(['install'], {
+    env: { COREPACK_ROOT: '/fake/corepack' },
+  })
+
+  expect(status).toBe(0)
+  expect(stdout.toString()).toContain('This project is configured to use 0.0.1 of pnpm')
+  // Make sure the warning explains that pnpm did not switch the version
+  // because corepack is in charge — otherwise the warning is confusing.
+  expect(stdout.toString()).toContain('Corepack invoked pnpm')
+})
+
+test('devEngines.packageManager onFail=download surfaces a regular error under corepack instead of switching versions', async () => {
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '0.0.1',
+        onFail: 'download',
+      },
+    },
+  })
+
+  // Corepack owns version selection, so pnpm should not attempt a version
+  // switch when COREPACK_ROOT is set. Mismatches fall through to the regular
+  // check, which treats onFail=download as shouldError=true. The error
+  // message must spell out that pnpm did not switch the version *because*
+  // corepack is in charge — otherwise the user sees a download-on-mismatch
+  // contract that silently failed to download.
+  const { status, stderr } = execPnpmSync(['install'], {
+    env: { COREPACK_ROOT: '/fake/corepack' },
+  })
+
+  expect(status).toBe(1)
+  expect(stderr.toString()).toContain('This project is configured to use 0.0.1 of pnpm')
+  expect(stderr.toString()).toContain('Corepack invoked pnpm')
+  expect(stderr.toString()).toContain('does not switch versions when running under corepack')
+  expect(stderr.toString()).toContain('invoke pnpm directly')
+})
+
 test('pmOnFail=ignore set in pnpm-workspace.yaml bypasses the devEngines.packageManager check', async () => {
   prepare({
     devEngines: {


### PR DESCRIPTION
## Summary

- Closes #11397.
- Moves the `!isExecutedByCorepack()` guard off the outer pm-handling block in `pnpm/src/main.ts` and onto the `switchCliVersion` branch only. `checkPackageManager` and `syncEnvLockfile` now run regardless of how pnpm was invoked, so the lockfile's `packageManagerDependencies` stays consistent for teams where some developers use corepack and others invoke pnpm directly. `switchCliVersion` is still skipped under corepack — corepack owns version selection there.
- Augments the version-mismatch message and hint when running under corepack to explain that pnpm cannot switch versions in that mode (otherwise `onFail: 'download'` looks like a silently-failed download contract). Hint points to the two ways out: align `packageManager` with `devEngines.packageManager`, or invoke pnpm directly.
- `shouldPersistLockfile` already self-gates inside `syncEnvLockfile`, so projects that only use the legacy `packageManager` field (without `devEngines.packageManager`) still won't have the lockfile rewritten.

## Test plan

- [x] `pnpm/src/syncEnvLockfile.test.ts` — existing 8 unit tests still pass.
- [x] `pnpm/test/packageManagerCheck.test.ts` — added 2 e2e tests for corepack-aware behavior; full suite (23 tests) passes.
  - `devEngines.packageManager check runs even when pnpm is invoked via corepack` — `onFail: 'warn'` + `COREPACK_ROOT` set → version warning still printed (was previously bypassed) and includes "Corepack invoked pnpm".
  - `devEngines.packageManager onFail=download surfaces a regular error under corepack instead of switching versions` — `onFail: 'download'` + `COREPACK_ROOT` set → BAD_PM_VERSION error instead of attempted switch, message and hint cite corepack.
- [x] `pnpm/test/configurationalDependencies.test.ts` — added an e2e test seeding a stale `packageManagerDependencies.pnpm: 0.0.1` and verifying it's rewritten to the running version when `pnpm install` runs with `COREPACK_ROOT` set.