### PR TITLE
fix: also preserve relative symlinks in copy-artifacts.ts (release tarballs)

### DIFF
--- a/.changeset/copy-artifacts-verbatim-symlinks.md
+++ b/.changeset/copy-artifacts-verbatim-symlinks.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/exe": patch
+---
+
+Also pass `verbatimSymlinks: true` to the `fs.cpSync` call in `__utils__/scripts/src/copy-artifacts.ts`, which is the script that actually produces the GitHub release tarballs (`pnpm-{darwin,linux}-{x64,arm64}.tar.gz`). The previous fix in #11399 only covered the `fs.cpSync` in `pnpm/artifacts/exe/scripts/build-artifacts.ts`, which packages the `dist/` shipped inside the npm-published `@pnpm/exe` package. Verified by inspecting the v11.0.2 release tarballs after #11399 landed: the broken `/home/runner/work/pnpm/pnpm/...` symlinks under `dist/node_modules/.bin/` were still present, confirming `copy-artifacts.ts` is the offender for the GitHub release path. Follow-up to #11398.

--- a/__utils__/scripts/src/copy-artifacts.ts
+++ b/__utils__/scripts/src/copy-artifacts.ts
@@ -48,7 +48,7 @@ async function createArtifactTarball (target: string, binaryName: string): Promi
     // createSourceMapsArchive(), which reads from the original pnpmDistDir.
     const distDest = path.join(artifactDir, 'dist')
     fs.rmSync(distDest, { recursive: true, force: true })
-    fs.cpSync(pnpmDistDir, distDest, { recursive: true })
+    fs.cpSync(pnpmDistDir, distDest, { recursive: true, verbatimSymlinks: true })
     stripReflinkPackages(distDest, getReflinkKeepPackages(target))
     for (const mapFile of await glob('**/*.map', { cwd: distDest })) {
       fs.rmSync(path.join(distDest, mapFile))


### PR DESCRIPTION
Follow-up to #11399 / #11398.

## TL;DR

#11399 fixed the wrong file. The same one-line `verbatimSymlinks: true` fix needs to be applied to `__utils__/scripts/src/copy-artifacts.ts` to actually clean up the GitHub release tarballs.

## Why #11399 wasn't enough

The pnpm release pipeline produces two distinct sets of artifacts that each have their own copy of `dist/`:

| Artifact | Built by | `fs.cpSync` location |
|---|---|---|
| **npm-published `@pnpm/exe` package** | `pn build` → `build-artifacts.ts` | `pnpm/artifacts/exe/scripts/build-artifacts.ts:48` ✅ fixed in #11399 |
| **GitHub release tarballs** (`pnpm-{darwin,linux}-{x64,arm64}.tar.gz`) | `pn copy-artifacts` (in `release.yml`) → `copy-artifacts.ts` | `__utils__/scripts/src/copy-artifacts.ts:51` ❌ still broken |

Both files do roughly the same thing — copy `pnpmDistDir` into a per-target `dist/` for archiving — but `copy-artifacts.ts` is what actually creates the `.tar.gz` and `.zip` archives uploaded to the GitHub release page.

## Verification

After #11399 merged and v11.0.2 was cut, I re-ran the original reproducer:

```sh
$ curl -sL https://github.com/pnpm/pnpm/releases/download/v11.0.2/pnpm-darwin-arm64.tar.gz | tar -tvz | grep '^l'
lrwxrwxrwx  0 runner 1001  0 Apr 30 11:24 dist/node_modules/.bin/node-gyp    -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js
lrwxrwxrwx  0 runner 1001  0 Apr 30 11:24 dist/node_modules/.bin/node-which  -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/which/bin/which.js
lrwxrwxrwx  0 runner 1001  0 Apr 30 11:24 dist/node_modules/.bin/nopt        -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/nopt/bin/nopt.js
lrwxrwxrwx  0 runner 1001  0 Apr 30 11:24 dist/node_modules/.bin/semver      -> /home/runner/work/pnpm/pnpm/pnpm/dist/node_modules/semver/bin/semver.js
```

Same broken absolute symlinks as v11.0.0 / v11.0.1. Source maps timestamp confirms these are from the v11.0.2 build run.

The source code at the v11.0.2 tag has the `build-artifacts.ts` fix applied correctly — but the release tarballs come from `copy-artifacts.ts`, which still has the unfixed call.

## Fix

```diff
-    fs.cpSync(pnpmDistDir, distDest, { recursive: true })
+    fs.cpSync(pnpmDistDir, distDest, { recursive: true, verbatimSymlinks: true })
```

Same rationale as #11399: Node's `fs.cpSync` defaults to `verbatimSymlinks: false`, which resolves relative symlinks into absolute paths at the source filesystem location. On the GitHub Actions runner this rewrites the `.bin` symlinks to `/home/runner/work/pnpm/...` targets that ship verbatim in the tarball.

## Apologies

Sorry for the incomplete fix — I should have grepped for all `fs.cpSync` callers in the release pipeline before opening #11399, not just the one I'd already pinpointed in my issue. Confirmed via `grep -r 'fs\.cpSync'` that these are now the only two callers and both have `verbatimSymlinks: true` after this PR.

🤖 Generated with [Amp](https://ampcode.com)
