### PR TITLE
test: make checkPlatform negation tests platform-independent

### DIFF
--- a/config/package-is-installable/test/checkPlatform.ts
+++ b/config/package-is-installable/test/checkPlatform.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { afterEach, expect, jest, test } from '@jest/globals'
 import type * as DetectLibc from 'detect-libc'
 
 const packageId = 'registry.npmjs.org/foo/1.0.0'
@@ -12,6 +12,22 @@ jest.mock('detect-libc', () => {
 })
 
 const { checkPlatform } = await import('../lib/checkPlatform.js')
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+const originalArch = Object.getOwnPropertyDescriptor(process, 'arch')!
+
+function setPlatform (platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { ...originalPlatform, value: platform })
+}
+
+function setArch (arch: NodeJS.Architecture): void {
+  Object.defineProperty(process, 'arch', { ...originalArch, value: arch })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform)
+  Object.defineProperty(process, 'arch', originalArch)
+})
 
 test('target cpu wrong', () => {
   const target = {
@@ -153,22 +169,25 @@ test('accept another libc', () => {
 })
 
 test('accept negated os with multi-valued supportedArchitectures', () => {
+  setPlatform('linux')
   expect(checkPlatform(packageId, { cpu: 'any', os: ['!win32'], libc: 'any' }, {
-    os: ['linux', 'darwin'],
+    os: ['linux', 'current'],
     cpu: ['current'],
     libc: ['current'],
   })).toBeNull()
 })
 
 test('accept negated cpu with multi-valued supportedArchitectures', () => {
+  setArch('x64')
   expect(checkPlatform(packageId, { cpu: ['!ia32'], os: 'any', libc: 'any' }, {
     os: ['current'],
-    cpu: ['x64', 'arm64'],
+    cpu: ['x64', 'current'],
     libc: ['current'],
   })).toBeNull()
 })
 
 test('reject negated os when any supported value matches the negation', () => {
+  setPlatform('darwin')
   const err = checkPlatform(packageId, { cpu: 'any', os: ['!win32'], libc: 'any' }, {
     os: ['win32', 'current'],
     cpu: ['current'],

--- a/config/package-is-installable/test/checkPlatform.ts
+++ b/config/package-is-installable/test/checkPlatform.ts
@@ -154,7 +154,7 @@ test('accept another libc', () => {
 
 test('accept negated os with multi-valued supportedArchitectures', () => {
   expect(checkPlatform(packageId, { cpu: 'any', os: ['!win32'], libc: 'any' }, {
-    os: ['linux', 'current'],
+    os: ['linux', 'darwin'],
     cpu: ['current'],
     libc: ['current'],
   })).toBeNull()
@@ -163,7 +163,7 @@ test('accept negated os with multi-valued supportedArchitectures', () => {
 test('accept negated cpu with multi-valued supportedArchitectures', () => {
   expect(checkPlatform(packageId, { cpu: ['!ia32'], os: 'any', libc: 'any' }, {
     os: ['current'],
-    cpu: ['x64', 'current'],
+    cpu: ['x64', 'arm64'],
     libc: ['current'],
   })).toBeNull()
 })


### PR DESCRIPTION
## Summary

- The two `supportedArchitectures` negation tests added in #11375 used `'current'` alongside a value the wanted platform's negation could match on some hosts (e.g. `os: ['linux', 'current']` on Windows expands to `['linux', 'win32']`, which is correctly rejected by `['!win32']`). The expected `null` only held on non-Windows runners.
- Replace `'current'` with fixed second values (`'darwin'`, `'arm64'`) so the multi-value code path that #11375 fixed is still exercised, but the test result no longer depends on `process.platform` / `process.arch`.
- Production logic in `checkPlatform` is correct and unchanged — `supportedArchitectures` requires *all* listed targets to be supported, and a package declaring `!win32` genuinely cannot satisfy a Windows host that's also asked to install for `linux`.

## Test plan

- [x] `pnpm --filter @pnpm/config.package-is-installable test` (20/20 pass on macOS/arm64)
- [x] CI green on Windows runners