### PR TITLE
feat(fs.graceful-fs): expose promisified chmod and unlink

### DIFF
--- a/.changeset/graceful-fs-chmod-unlink.md
+++ b/.changeset/graceful-fs-chmod-unlink.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/fs.graceful-fs": minor
+---
+
+Add `chmod` and `unlink` (promisified) to the exported fs interface so callers can perform mode changes and removals through the same EMFILE/ENFILE-queueing layer as the other operations.

--- a/.changeset/graceful-fs-chmod-unlink.md
+++ b/.changeset/graceful-fs-chmod-unlink.md
@@ -2,4 +2,4 @@
 "@pnpm/fs.graceful-fs": minor
 ---
 
-Add `chmod` and `unlink` (promisified) to the exported fs interface so callers can perform mode changes and removals through the same EMFILE/ENFILE-queueing layer as the other operations.
+Add `chmod` and `unlink` (promisified) to the exported fs interface so callers can perform mode changes and removals through the same EMFILE-queueing layer as the other operations.

--- a/fs/graceful-fs/src/index.ts
+++ b/fs/graceful-fs/src/index.ts
@@ -3,6 +3,7 @@ import util, { promisify } from 'node:util'
 import gfs from 'graceful-fs'
 
 export default { // eslint-disable-line
+  chmod: promisify(gfs.chmod),
   copyFile: promisify(gfs.copyFile),
   copyFileSync: withEagainRetry(gfs.copyFileSync),
   createReadStream: gfs.createReadStream,
@@ -16,6 +17,7 @@ export default { // eslint-disable-line
   readdirSync: gfs.readdirSync,
   stat: promisify(gfs.stat),
   statSync: gfs.statSync,
+  unlink: promisify(gfs.unlink),
   unlinkSync: gfs.unlinkSync,
   writeFile: promisify(gfs.writeFile),
   writeFileSync: withEagainRetry(gfs.writeFileSync),


### PR DESCRIPTION
## Summary

- Adds `chmod` and `unlink` (promisified) to `@pnpm/fs.graceful-fs`'s default export so callers can perform mode changes and removals through the same EMFILE-queueing layer as the other operations.
- Required by an upcoming `@zkochan/cmd-shim` release that switches its default `fs` implementation to `@pnpm/fs.graceful-fs` to fix [#11412](https://github.com/pnpm/pnpm/issues/11412) (`EMFILE: too many open files` on Windows during bin linking in large workspaces).

## Background

`@zkochan/cmd-shim@8.0.0` dropped graceful-fs in its ESM rewrite and switched to native `fs.promises`. `fs.promises` bypasses the userland patches that graceful-fs installs on the callback API, so under high concurrency the writes surface `EMFILE` instead of waiting for a free file descriptor. cmd-shim needs `chmod` and `unlink` to fully replace its `fs.promises` usage with `@pnpm/fs.graceful-fs`.

## Test plan

- [x] `pnpm --filter @pnpm/fs.graceful-fs run compile` succeeds
- [x] `chmod` and `unlink` appear in the generated `lib/index.d.ts` as `typeof gfs.chmod.__promisify__` / `typeof gfs.unlink.__promisify__`