### PR TITLE
ci(release): build artifacts on macos-latest to fix darwin-x64 signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,23 +10,11 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC
       contents: write  # for softprops/action-gh-release to create GitHub release
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install ldid
-        run: |
-          sudo apt-get update
-          sudo apt-get install git build-essential libplist-dev libssl-dev openssl qemu-user-binfmt pkg-config
-          cd /tmp
-          git clone https://gitlab.com/opensource-saurik/ldid.git
-          cd ldid
-          git checkout c2f8abf013b22c335f44241a6a552a7767e73419
-          git submodule update --init
-          gcc -I. -c -o lookup2.o lookup2.c
-          g++ -std=c++11 -o ldid lookup2.o ldid.cpp -I. -lcrypto $(pkg-config --cflags --libs libplist-2.0) -lxml2
-          sudo mv ldid /usr/local/bin
       - name: Install pnpm
         uses: pnpm/action-setup@6e7bdbda5fe05107efc88b23b7ed00aa05f84ca0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC
       contents: write  # for softprops/action-gh-release to create GitHub release
+    # Runs on macOS so darwin artifacts are signed with native `codesign`.
+    # Cross-signing on Linux with `ldid` produces ad-hoc signatures whose
+    # page hashes don't match the post-postject Mach-O layout for Node.js 25's
+    # chained fixups, leaving fixups unapplied and crashing the binary at
+    # startup (EXC_BAD_ACCESS in __cxx_global_var_init).
     runs-on: macos-latest
     environment: release
     steps:


### PR DESCRIPTION
## Summary

Fixes EXC_BAD_ACCESS at startup of the darwin-x64 release binary (reported against v11.0.2/v11.0.3 on Intel Macs).

The root cause is in the cross-signing step, not pnpm code. The release flow:

1. On Linux CI, `pnpm pack-app` downloads the official darwin-x64 Node.js 25.9.0 and uses postject to splice the SEA blob into a Mach-O segment.
2. The modified binary is then ad-hoc signed with `ldid -S` from the (saurik fork, pinned to `c2f8abf01…`).

Node.js 25 binaries use `LC_DYLD_CHAINED_FIXUPS`. When postject mutates the binary and the saurik fork of `ldid` recomputes the ad-hoc signature, the resulting `LC_CODE_SIGNATURE` page hashes don't match what the kernel sees on macOS 11+. dyld validates pages, skips fixup application on the offending pages, and a C++ global initializer reads a raw chained-fixup chain entry as a pointer — landing on `address=0x3`, which is exactly the low-bit "next-offset" pattern of an unprocessed chain entry.

A reporter's lldb trace makes this unambiguous:
```
EXC_BAD_ACCESS (code=1, address=0x3)
frame #0: pnpm`__cxx_global_var_init
frame #1: dyld`...findAndRunAllInitializers
frame #2: dyld`...forEachInitializer
```

## Fix

Move the entire release job onto `macos-latest`. `pack-app`'s `adHocSignMacBinary` (`releasing/commands/src/pack-app/packApp.ts:555-557`) already uses native `codesign --sign -` when running on darwin, which knows how to compute correct page hashes against post-postject Mach-O including chained-fixup data. No application code changes are required.

Side-effects:

- The entire `Install ldid` step (apt-get + GitLab clone + g++ build) is removed.
- `macos-latest` is Apple Silicon, so `buildFullMatrix` in `build-artifacts.ts:16` evaluates true — same 8-target matrix as today.
- Linux/Windows artifacts cross-build the same way (postject is byte-level and platform-neutral; those targets need no signing).
- `verify-binary.mjs`'s execution check shifts from `linux-x64` to `darwin-arm64`. Existence verification still runs for all targets.
- macOS runners are slower than Ubuntu, so the release job will take longer. Acceptable cost.

## Test plan

- [ ] Tag a `vX.Y.Z-rc.N` to exercise the workflow end-to-end on `macos-latest`.
- [ ] Download the resulting `pnpm-darwin-x64.tar.gz` and confirm `./pnpm --version` runs without segfaulting on an Intel Mac.
- [ ] `codesign -dv --verbose=4 ./pnpm` shows a valid ad-hoc signature with hashes matching the file.
- [ ] Confirm `pnpm-linux-x64.tar.gz`, `pnpm-linux-arm64.tar.gz`, `pnpm-linux-x64-musl.tar.gz`, `pnpm-linux-arm64-musl.tar.gz`, `pnpm-darwin-arm64.tar.gz`, `pnpm-win32-x64.zip`, `pnpm-win32-arm64.zip` are all produced.
- [ ] OIDC provenance attestations are still attached to the published npm packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to optimize build and signing processes for improved artifact distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->