### PR TITLE
Set default value for rawWantedDependency parameter

### DIFF
--- a/resolving/parse-wanted-dependency/src/index.ts
+++ b/resolving/parse-wanted-dependency/src/index.ts
@@ -12,7 +12,7 @@ export type ParseWantedDependencyResult = Partial<ParsedWantedDependency> &
   | ParsedWantedDependency
 )
 
-export function parseWantedDependency (rawWantedDependency: string): ParseWantedDependencyResult {
+export function parseWantedDependency (rawWantedDependency = ''): ParseWantedDependencyResult {
   const versionDelimiter = rawWantedDependency.indexOf('@', 1) // starting from 1 to skip the @ that marks scope
   if (versionDelimiter !== -1) {
     const alias = rawWantedDependency.slice(0, versionDelimiter)


### PR DESCRIPTION
Fix of 
pnpm: Cannot read properties of undefined (reading 'indexOf')
    at parseWantedDependency in \pnpm\dist\pnpm.cjs:110770:52)

when `pnpx` runned without arguments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dependency parsing to handle missing inputs more gracefully by providing a default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->