### PR TITLE
refactor: prematurely interrupting the link command without passing parameters

### DIFF
--- a/installing/commands/src/link.ts
+++ b/installing/commands/src/link.ts
@@ -106,6 +106,9 @@ export async function handler (
   opts: LinkOpts,
   params?: string[]
 ): Promise<void> {
+  if ((params == null) || (params.length === 0)) {
+    throw new PnpmError('LINK_BAD_PARAMS', 'You must provide a parameter. Usage: pnpm link <dir>')
+  }
   let workspacePackagesArr: Project[]
   let workspacePackages!: WorkspacePackages
   if (opts.workspaceDir) {
@@ -126,9 +129,6 @@ export async function handler (
 
   const writeProjectManifest = await createProjectManifestWriter(opts.rootProjectManifestDir)
 
-  if ((params == null) || (params.length === 0)) {
-    throw new PnpmError('LINK_BAD_PARAMS', 'You must provide a parameter. Usage: pnpm link <dir>')
-  }
 
   const [pkgPaths, pkgNames] = partition((inp) => isFilespec.test(inp), params)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved input validation timing to check parameters earlier, ensuring invalid inputs are caught before processing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->