### PR TITLE
fix: apply nodeDownloadMirrors from workspace config to Node downloads

### DIFF
--- a/config/reader/src/localConfig.test.ts
+++ b/config/reader/src/localConfig.test.ts
@@ -39,7 +39,7 @@ test('inheritAuthConfig copies only auth keys from source to target', () => {
   })
 })
 
-test('inheritDlxConfig copies auth and security policy keys from source to target', () => {
+test('inheritDlxConfig copies auth, security policy, and nodeDownloadMirrors from source to target', () => {
   const target: InheritableConfigPair = {
     config: {
       bin: 'foo',
@@ -59,6 +59,7 @@ test('inheritDlxConfig copies auth and security policy keys from source to targe
       storeDir: '/path/to/custom/store/dir',
       registry: 'https://example.com/local-registry/',
       shamefullyHoist: false,
+      nodeDownloadMirrors: { release: 'https://mirror.example/nodejs/' },
       minimumReleaseAge: 1440,
       minimumReleaseAgeExclude: ['trusted-pkg'],
       minimumReleaseAgeStrict: true,
@@ -72,13 +73,14 @@ test('inheritDlxConfig copies auth and security policy keys from source to targe
     },
   })
 
-  // Auth keys and security/trust policy keys are inherited;
+  // Auth, trust-policy, and Node mirror keys are inherited from the local workspace;
   // project-structural keys (bin, cacheDir, shamefullyHoist) keep their target values.
   expect(target.config).toMatchObject({
     bin: 'foo',
     cacheDir: '/path/to/cache/dir',
     shamefullyHoist: true,
     registry: 'https://example.com/local-registry/',
+    nodeDownloadMirrors: { release: 'https://mirror.example/nodejs/' },
     minimumReleaseAge: 1440,
     minimumReleaseAgeExclude: ['trusted-pkg'],
     minimumReleaseAgeStrict: true,

--- a/config/reader/src/localConfig.ts
+++ b/config/reader/src/localConfig.ts
@@ -52,11 +52,14 @@ const AUTH_CFG_KEYS = [
  *
  * `pnpm dlx` runs packages in isolation from the current project. It must not
  * read project-structural settings (hoisting, linking, workspace layout, etc.)
- * from local config. However, two categories of local settings DO apply:
+ * from local config. However, local settings that affect **where** artifacts are
+ * fetched from DO apply:
  *
  * 1. **Registry & auth:** needed to reach the same package sources
  *    (registries, tokens, certificates).
- * 2. **Security & trust policy:** these reflect the user's or organization's
+ * 2. **Node.js download mirrors:** same idea for Node.js runtime tarballs when
+ *    those URIs are declared in `pnpm-workspace.yaml`.
+ * 3. **Security & trust policy:** these reflect the user's or organization's
  *    security posture and must apply regardless of how a package is installed.
  *    A setting that answers "what am I allowed to download?" belongs here.
  *
@@ -69,6 +72,7 @@ const AUTH_CFG_KEYS = [
  * | Category                       | Inherited by dlx? | Examples                                         |
  * |--------------------------------|--------------------|--------------------------------------------------|
  * | Registry & auth                | Yes                | registry, _authToken, ca                         |
+ * | Node.js download mirrors       | Yes                | nodeDownloadMirrors (workspace/custom tarballs)   |
  * | Security & trust policy        | Yes                | minimumReleaseAge, trustPolicy                   |
  * | Installation structure         | No                 | shamefully-hoist, node-linker, hoist-pattern      |
  * | Workspace settings             | No                 | link-workspace-packages, shared-workspace-lockfile|
@@ -131,7 +135,11 @@ function pickAuthConfig (localCfg: Partial<Config>): Partial<Config> {
 function pickDlxConfig (localCfg: Partial<Config>): Partial<Config> {
   const result: Record<string, unknown> = {}
   for (const key in localCfg) {
-    if (isAuthCfgKey(key as keyof Config) || isSecurityPolicyCfgKey(key as keyof Config)) {
+    if (
+      isAuthCfgKey(key as keyof Config) ||
+      isSecurityPolicyCfgKey(key as keyof Config) ||
+      key === 'nodeDownloadMirrors'
+    ) {
       result[key] = localCfg[key as keyof Config]
     }
   }

--- a/config/reader/src/localConfig.ts
+++ b/config/reader/src/localConfig.ts
@@ -56,7 +56,9 @@ const AUTH_CFG_KEYS = [
  *
  * 1. **Registry & auth:** needed to reach the same package sources
  *    (registries, tokens, certificates).
- * 2. **Security & trust policy:** these reflect the user's or organization's
+ * 2. **Node.js download mirrors:** same idea for Node.js runtime tarballs when
+ *    those URIs are declared in `pnpm-workspace.yaml`.
+ * 3. **Security & trust policy:** these reflect the user's or organization's
  *    security posture and must apply regardless of how a package is installed.
  *    A setting that answers "what am I allowed to download?" belongs here.
  * 3. **Catalogs:** the `catalog:` protocol resolves package versions through
@@ -74,6 +76,7 @@ const AUTH_CFG_KEYS = [
  * | Category                       | Inherited by dlx? | Examples                                         |
  * |--------------------------------|--------------------|--------------------------------------------------|
  * | Registry & auth                | Yes                | registry, _authToken, ca                         |
+ * | Node.js download mirrors       | Yes                | nodeDownloadMirrors (workspace/custom tarballs)   |
  * | Security & trust policy        | Yes                | minimumReleaseAge, trustPolicy                   |
  * | Catalogs                       | Yes                | catalogs                                         |
  * | Fetch retry/timeout            | Yes                | fetchRetries, fetchTimeout                       |
@@ -158,7 +161,13 @@ function pickAuthConfig (localCfg: Partial<Config>): Partial<Config> {
 function pickDlxConfig (localCfg: Partial<Config>): Partial<Config> {
   const result: Record<string, unknown> = {}
   for (const key in localCfg) {
-    if (isAuthCfgKey(key as keyof Config) || isSecurityPolicyCfgKey(key as keyof Config) || isCatalogsCfgKey(key as keyof Config) || isFetchCfgKey(key as keyof Config)) {
+    if (
+      isAuthCfgKey(key as keyof Config) ||
+      isSecurityPolicyCfgKey(key as keyof Config) ||
+      isCatalogsCfgKey(key as keyof Config) ||
+      isFetchCfgKey(key as keyof Config) ||
+      key === 'nodeDownloadMirrors'
+    ) {
       result[key] = localCfg[key as keyof Config]
     }
   }

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -55,6 +55,25 @@ test('getConfig()', async () => {
   expect(config.nodeVersion).toBeUndefined()
 })
 
+test('onlyInheritDlxSettingsFromLocal inherits nodeDownloadMirrors from pnpm-workspace.yaml', async () => {
+  prepare({})
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['.'],
+    nodeDownloadMirrors: { release: 'https://mirror.example/nodejs/' },
+  })
+  const cwd = process.cwd()
+  const { config } = await getConfig({
+    cliOptions: { dir: cwd },
+    workspaceDir: cwd,
+    packageManager: {
+      name: 'pnpm',
+      version: '9.0.0',
+    },
+    onlyInheritDlxSettingsFromLocal: true,
+  })
+  expect(config.nodeDownloadMirrors).toStrictEqual({ release: 'https://mirror.example/nodejs/' })
+})
+
 test.each([
   { field: 'devEngines' as const, version: '22.20.0', onFail: 'download' as const, expected: '22.20.0' },
   { field: 'devEngines' as const, version: '22.20.0', onFail: 'error' as const, expected: '22.20.0' },


### PR DESCRIPTION
## Problem
`nodeDownloadMirrors` specified in `pnpm-workspace.yaml` is not applied when pnpm downloads Node.js via `pnpm dlx` or `pnpm create`, even though other workspace-level settings are respected.

## Change
Include `nodeDownloadMirrors` in `pickDlxConfig` so it is inherited alongside registry and security policy settings when building the effective config for dlx/create commands.

Fixes #11281.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node.js download mirrors are now correctly inherited when building DLX configurations (mirrors from workspace/local config are applied).

* **Documentation**
  * Inheritance rules updated to list Node.js download mirrors with an example.

* **Tests**
  * New tests added to verify mirror inheritance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->