### PR TITLE
fix(clean): ignore workspace lockfile setting

### DIFF
--- a/.changeset/clean-lockfile-cli-option.md
+++ b/.changeset/clean-lockfile-cli-option.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Do not remove `pnpm-lock.yaml` during `pnpm clean` when `lockfile: true` is configured in `pnpm-workspace.yaml`. The lockfile is only removed when the `--lockfile` option is passed to `pnpm clean`.

--- a/pnpm/src/cmd/clean.ts
+++ b/pnpm/src/cmd/clean.ts
@@ -13,7 +13,7 @@ export const commandNames = ['clean', 'purge']
 
 export const overridableByScript = true
 
-export const rcOptionsTypes = cliOptionsTypes
+export const rcOptionsTypes = (): Record<string, unknown> => ({})
 
 export function cliOptionsTypes (): Record<string, unknown> {
   return {
@@ -58,11 +58,14 @@ export async function handler (
     virtualStoreDir?: string
     workspaceDir?: string
     workspacePackagePatterns?: string[]
+    cliOptions?: {
+      lockfile?: boolean
+    }
   }
 ): Promise<void> {
   const modulesDir = opts.modulesDir ?? 'node_modules'
   const rootDir = opts.workspaceDir ?? opts.dir
-  const cleanOpts = { modulesDir, removeLockfile: opts.lockfile }
+  const cleanOpts = { modulesDir, removeLockfile: opts.cliOptions?.lockfile === true }
   const dirs = await getProjectDirs(opts)
   await Promise.all(dirs.map(cleanProjectDir.bind(null, cleanOpts)))
   if (opts.virtualStoreDir) {

--- a/pnpm/test/clean.ts
+++ b/pnpm/test/clean.ts
@@ -70,6 +70,20 @@ test('pnpm clean preserves lockfile by default', () => {
   expect(fs.existsSync('pnpm-lock.yaml')).toBe(true)
 })
 
+test('pnpm clean preserves lockfile when pnpm-workspace.yaml sets lockfile', () => {
+  tempDir()
+  fs.writeFileSync('package.json', '{}', 'utf8')
+  writeYamlFileSync('pnpm-workspace.yaml', { lockfile: true })
+  fs.writeFileSync('pnpm-lock.yaml', 'lockfileVersion: 9')
+  fs.mkdirSync('node_modules/.pnpm', { recursive: true })
+
+  const result = execPnpmSync(['clean'])
+  expect(result.status).toBe(0)
+
+  expect(fs.existsSync('node_modules/.pnpm')).toBe(false)
+  expect(fs.existsSync('pnpm-lock.yaml')).toBe(true)
+})
+
 test('pnpm clean --lockfile removes lockfile', () => {
   tempDir()
   fs.writeFileSync('package.json', '{}', 'utf8')


### PR DESCRIPTION
## Summary

- Treat `pnpm clean --lockfile` as a command-line-only opt-in for removing `pnpm-lock.yaml`.
- Preserve the lockfile when `lockfile: true` comes from `pnpm-workspace.yaml` and add regression coverage.

Fixes #11420

## Test plan

- `pnpm --filter pnpm run compile`
- `cd pnpm && NODE_OPTIONS="${NODE_OPTIONS:-} --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm exec jest test/clean.ts --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `pnpm clean` command to respect the `lockfile` configuration. When `lockfile: true` is set in `pnpm-workspace.yaml`, the `pnpm-lock.yaml` file will no longer be removed by `pnpm clean`. Use the explicit `--lockfile` option to remove the lockfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->