### PR TITLE
fix(ci): reinstall workspace package node_modules

### DIFF
--- a/pnpm/.changeset/ci-recursive-by-default.md
+++ b/pnpm/.changeset/ci-recursive-by-default.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed `pnpm ci` not reinstalling workspace package `node_modules` directories after the clean step [#11427](https://github.com/pnpm/pnpm/issues/11427).

--- a/pnpm/src/cmd/cleanInstall.ts
+++ b/pnpm/src/cmd/cleanInstall.ts
@@ -13,6 +13,8 @@ export const shorthands = install.shorthands
 
 export const commandNames = ['ci', 'clean-install', 'ic', 'install-clean']
 
+export const recursiveByDefault = true
+
 export function help (): string {
   return renderHelp({
     aliases: ['clean-install', 'ic', 'install-clean'],

--- a/pnpm/test/ci.ts
+++ b/pnpm/test/ci.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
-import { prepare, tempDir } from '@pnpm/prepare'
+import { prepare, preparePackages, tempDir } from '@pnpm/prepare'
+import { writeYamlFileSync } from 'write-yaml-file'
 
 import { execPnpmSync } from './utils/index.js'
 
@@ -45,6 +46,27 @@ test('pnpm ci removes node_modules and installs from lockfile', () => {
 
   // Verify dependencies are installed
   expect(fs.existsSync(path.join(process.cwd(), 'node_modules', 'is-positive'))).toBe(true)
+})
+
+test('pnpm ci reinstalls workspace package node_modules', () => {
+  preparePackages([
+    {
+      name: 'foo',
+      version: '0.0.0',
+      private: true,
+      dependencies: { 'is-positive': '1.0.0' },
+    },
+  ])
+
+  fs.writeFileSync('package.json', JSON.stringify({ name: 'root', version: '1.0.0', private: true }))
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['*'] })
+
+  expect(execPnpmSync(['install']).status).toBe(0)
+  expect(fs.existsSync(path.join('foo', 'node_modules', 'is-positive'))).toBe(true)
+
+  const result = execPnpmSync(['ci'])
+  expect(result.status).toBe(0)
+  expect(fs.existsSync(path.join('foo', 'node_modules', 'is-positive'))).toBe(true)
 })
 
 test('pnpm ci fails when package.json conflicts with lockfile', () => {


### PR DESCRIPTION
## Summary
- `pnpm ci` was missing `recursiveByDefault`, so when invoked in a workspace, `main.ts` skipped the workspace setup that builds `selectedProjectsGraph` / `allProjects`. The composed `install.handler` then ran only against the root project and never linked dependencies into workspace packages.
- Adds the flag and a regression test that asserts a workspace package's `node_modules` is repopulated after `pnpm ci`.

Closes #11427.

## Test plan
- [x] `pnpm --filter pnpm test test/ci.ts` (4 tests pass, including the new workspace one)
- [x] Manual repro from the issue: after the fix, `packages/foo/node_modules/<dep>` exists post-`pnpm ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- `pnpm ci` now properly reinstalls node_modules directories for workspace packages following the clean step, ensuring all dependencies are available in monorepo environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->