### PR TITLE
fix(self-update): do not downgrade when latest dist-tag is older

### DIFF
--- a/.changeset/self-update-no-downgrade.md
+++ b/.changeset/self-update-no-downgrade.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": minor
+---
+
+`pnpm self-update` (with no version argument) no longer downgrades pnpm when the registry's `latest` dist-tag points to an older release than the currently active version. Run `pnpm self-update latest` to force a downgrade [#11418](https://github.com/pnpm/pnpm/issues/11418).

--- a/engine/pm/commands/package.json
+++ b/engine/pm/commands/package.json
@@ -43,6 +43,7 @@
     "@pnpm/installing.client": "workspace:*",
     "@pnpm/installing.deps-restorer": "workspace:*",
     "@pnpm/installing.env-installer": "workspace:*",
+    "@pnpm/lockfile.fs": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/os.env.path-extender": "catalog:",
     "@pnpm/resolving.npm-resolver": "workspace:*",

--- a/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -75,6 +75,12 @@ export async function handler (
   globalInfo('Checking for updates...')
   const { resolve } = createResolver({ ...opts, configByUri: opts.configByUri })
   const pkgName = 'pnpm'
+  // `pnpm self-update` (no args) defaults to the `latest` dist-tag, but we
+  // refuse to downgrade in that case — `latest` on the registry can lag the
+  // installed version when a new major has shipped without being tagged.
+  // `pnpm self-update latest` (explicit) bypasses the guard so users can
+  // still force a downgrade when they want one.
+  const isImplicitLatest = params.length === 0
   const bareSpecifier = params[0] ?? 'latest'
   const resolution = await resolve({ alias: pkgName, bareSpecifier }, {
     lockfileDir: opts.lockfileDir ?? opts.dir,
@@ -111,6 +117,9 @@ export async function handler (
 
   if (opts.wantedPackageManager?.name === packageManager.name) {
     if (opts.wantedPackageManager?.version !== resolution.manifest.version) {
+      if (isImplicitLatest && resolvesToOlder(resolution.manifest.version, opts.wantedPackageManager?.version)) {
+        return `The current project is set to use pnpm v${opts.wantedPackageManager.version}, which is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+      }
       const { manifest, writeProjectManifest } = await readProjectManifest(opts.rootProjectManifestDir)
       if (manifest.devEngines?.packageManager) {
         let manifestChanged = false
@@ -163,6 +172,10 @@ export async function handler (
   }
   if (resolution.manifest.version === packageManager.version) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
+  }
+
+  if (isImplicitLatest && semver.lt(resolution.manifest.version, packageManager.version)) {
+    return `The currently active ${packageManager.name} v${packageManager.version} is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
   }
 
   globalInfo(`Updating pnpm from v${packageManager.version} to v${resolution.manifest.version}...`)
@@ -221,4 +234,16 @@ function versionSpecFromPinned (version: string, pinnedVersion: PinnedVersion): 
     case 'minor': return `~${version}`
     case 'patch': return version
   }
+}
+
+function resolvesToOlder (resolvedVersion: string, currentSpec: string | undefined): boolean {
+  if (currentSpec == null) return false
+  let minCurrent: semver.SemVer | null
+  try {
+    minCurrent = semver.minVersion(currentSpec)
+  } catch {
+    return false
+  }
+  if (minCurrent == null) return false
+  return semver.lt(resolvedVersion, minCurrent.version)
 }

--- a/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -7,6 +7,7 @@ import { type Config, type ConfigContext, parsePackageManager, types as allTypes
 import { PnpmError } from '@pnpm/error'
 import { createResolver } from '@pnpm/installing.client'
 import { resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
+import { readEnvLockfile } from '@pnpm/lockfile.fs'
 import { globalInfo, globalWarn } from '@pnpm/logger'
 import { whichVersionIsPinned } from '@pnpm/resolving.npm-resolver'
 import { createStoreController, type CreateStoreControllerOptions } from '@pnpm/store.connection-manager'
@@ -117,8 +118,14 @@ export async function handler (
 
   if (opts.wantedPackageManager?.name === packageManager.name) {
     if (opts.wantedPackageManager?.version !== resolution.manifest.version) {
-      if (isImplicitLatest && resolvesToOlder(resolution.manifest.version, opts.wantedPackageManager?.version)) {
-        return `The current project is set to use pnpm v${opts.wantedPackageManager.version}, which is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+      if (isImplicitLatest) {
+        // Prefer the lockfile-pinned version when available — for range
+        // specs like `>=8.0.0`, the spec's lower bound understates the
+        // version that was actually installed (see #11418 review).
+        const projectCurrentVersion = await readProjectPinnedPnpmVersion(opts.rootProjectManifestDir, opts.wantedPackageManager?.version)
+        if (projectCurrentVersion != null && semver.lt(resolution.manifest.version, projectCurrentVersion)) {
+          return `The current project is set to use pnpm v${projectCurrentVersion}, which is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+        }
       }
       const { manifest, writeProjectManifest } = await readProjectManifest(opts.rootProjectManifestDir)
       if (manifest.devEngines?.packageManager) {
@@ -236,14 +243,29 @@ function versionSpecFromPinned (version: string, pinnedVersion: PinnedVersion): 
   }
 }
 
-function resolvesToOlder (resolvedVersion: string, currentSpec: string | undefined): boolean {
-  if (currentSpec == null) return false
-  let minCurrent: semver.SemVer | null
+async function readProjectPinnedPnpmVersion (rootProjectManifestDir: string, spec: string | undefined): Promise<string | undefined> {
+  // The env lockfile is the most accurate source for the actually-installed
+  // pnpm version when the spec is a range. Fall back to the spec's minimum
+  // version when there's no lockfile entry (e.g. exact `packageManager` pins
+  // below v12 don't write to the lockfile). Take the max of the two so we
+  // pick whichever signal is more restrictive.
+  let lockfilePinned: string | undefined
   try {
-    minCurrent = semver.minVersion(currentSpec)
+    const envLockfile = await readEnvLockfile(rootProjectManifestDir)
+    lockfilePinned = envLockfile?.importers['.'].packageManagerDependencies?.pnpm?.version
   } catch {
-    return false
+    // ignore — fall through to spec min version
   }
-  if (minCurrent == null) return false
-  return semver.lt(resolvedVersion, minCurrent.version)
+  let specMin: string | undefined
+  if (spec != null) {
+    try {
+      specMin = semver.minVersion(spec)?.version
+    } catch {
+      // invalid range — ignore
+    }
+  }
+  if (lockfilePinned != null && specMin != null) {
+    return semver.gt(lockfilePinned, specMin) ? lockfilePinned : specMin
+  }
+  return lockfilePinned ?? specMin
 }

--- a/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -230,11 +230,12 @@ test('self-update refuses to downgrade when latest is older than current', async
 
 test('self-update latest forces the downgrade even when latest is older', async () => {
   const opts = prepare()
-  // Reuse the 9.1.0 fixture tarball — its package.json version drives the
-  // installed pnpm version regardless of what the registry metadata claims,
-  // so this test verifies that the install was attempted (not short-circuited
-  // by the no-downgrade guard) rather than the resulting pinned version.
-  mockRegistryForUpdate(opts.registries.default, '9.1.0', createMetadata('9.1.0', opts.registries.default))
+  // Mocked current pnpm is v9.0.0; mocking `latest` as v8.15.0 makes this an
+  // actual downgrade so the test exercises the explicit-`latest` bypass of
+  // the no-downgrade guard. The fixture tarball is still 9.1.0, but this test
+  // only checks that the install path was reached — not the resulting pinned
+  // version.
+  mockRegistryForUpdate(opts.registries.default, '8.15.0', createMetadata('8.15.0', opts.registries.default))
 
   const output = await selfUpdate.handler(opts, ['latest'])
 
@@ -277,6 +278,48 @@ test('self-update refuses to downgrade the project pin when latest is older', as
 
   expect(output).toBe('The current project is set to use pnpm v10.0.0, which is newer than the "latest" version on the registry (v9.5.0). No update performed. Run "pnpm self-update latest" to downgrade.')
   expect(JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).packageManager).toBe('pnpm@10.0.0')
+})
+
+test('self-update refuses to downgrade the project pin when the lockfile is pinned above the range', async () => {
+  // Range spec like ">=8.0.0" understates the installed version when the
+  // env lockfile has pinned a higher exact version. The guard must consult
+  // the lockfile, not just the spec's lower bound.
+  const opts = prepare({
+    devEngines: {
+      packageManager: { name: 'pnpm', version: '>=8.0.0' },
+    },
+  })
+  fs.writeFileSync(path.join(opts.dir, 'pnpm-lock.yaml'), [
+    '---',
+    "lockfileVersion: '9.0'",
+    '',
+    'importers:',
+    '',
+    '  .:',
+    '    configDependencies: {}',
+    '    packageManagerDependencies:',
+    '      pnpm:',
+    "        specifier: '>=8.0.0'",
+    '        version: 10.5.0',
+    '',
+    'packages: {}',
+    'snapshots: {}',
+    '---',
+    '',
+  ].join('\n'), 'utf8')
+  getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, createMetadata('9.5.0', opts.registries.default))
+
+  const output = await selfUpdate.handler({
+    ...opts,
+    wantedPackageManager: {
+      name: 'pnpm',
+      version: '>=8.0.0',
+    },
+  }, [])
+
+  expect(output).toBe('The current project is set to use pnpm v10.5.0, which is newer than the "latest" version on the registry (v9.5.0). No update performed. Run "pnpm self-update latest" to downgrade.')
 })
 
 test('should update packageManager field when a newer pnpm version is available', async () => {

--- a/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -214,6 +214,71 @@ test('self-update does nothing when pnpm is up to date', async () => {
   expect(output).toBe('The currently active pnpm v9.0.0 is already "latest" and doesn\'t need an update')
 })
 
+test('self-update refuses to downgrade when latest is older than current', async () => {
+  const opts = prepare()
+  getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, createMetadata('8.15.0', opts.registries.default))
+
+  const output = await selfUpdate.handler(opts, [])
+
+  expect(output).toBe('The currently active pnpm v9.0.0 is newer than the "latest" version on the registry (v8.15.0). No update performed. Run "pnpm self-update latest" to downgrade.')
+  // No global install dir should have been created.
+  const globalDir = path.join(opts.pnpmHomeDir, 'global', 'v11')
+  expect(fs.existsSync(globalDir)).toBe(false)
+})
+
+test('self-update latest forces the downgrade even when latest is older', async () => {
+  const opts = prepare()
+  // Reuse the 9.1.0 fixture tarball — its package.json version drives the
+  // installed pnpm version regardless of what the registry metadata claims,
+  // so this test verifies that the install was attempted (not short-circuited
+  // by the no-downgrade guard) rather than the resulting pinned version.
+  mockRegistryForUpdate(opts.registries.default, '9.1.0', createMetadata('9.1.0', opts.registries.default))
+
+  const output = await selfUpdate.handler(opts, ['latest'])
+
+  expect(output).not.toMatch(/No update performed/)
+  const globalDir = path.join(opts.pnpmHomeDir, 'global', 'v11')
+  expect(fs.existsSync(globalDir)).toBe(true)
+})
+
+test('self-update by exact older version skips the no-downgrade guard', async () => {
+  const opts = prepare()
+  // The fixture tarball's actual contents are still 9.1.0; only the registry
+  // metadata claims 8.15.0. That is fine here — this test only verifies that
+  // an explicit version argument bypasses the implicit-latest guard, not the
+  // resulting pinned version.
+  mockRegistryForUpdate(opts.registries.default, '8.15.0', createMetadata('8.15.0', opts.registries.default))
+
+  const output = await selfUpdate.handler(opts, ['8.15.0'])
+
+  expect(output).not.toMatch(/No update performed/)
+  const globalDir = path.join(opts.pnpmHomeDir, 'global', 'v11')
+  expect(fs.existsSync(globalDir)).toBe(true)
+})
+
+test('self-update refuses to downgrade the project pin when latest is older', async () => {
+  const opts = prepare({
+    packageManager: 'pnpm@10.0.0',
+  })
+  const pkgJsonPath = path.join(opts.dir, 'package.json')
+  getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, createMetadata('9.5.0', opts.registries.default))
+
+  const output = await selfUpdate.handler({
+    ...opts,
+    wantedPackageManager: {
+      name: 'pnpm',
+      version: '10.0.0',
+    },
+  }, [])
+
+  expect(output).toBe('The current project is set to use pnpm v10.0.0, which is newer than the "latest" version on the registry (v9.5.0). No update performed. Run "pnpm self-update latest" to downgrade.')
+  expect(JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).packageManager).toBe('pnpm@10.0.0')
+})
+
 test('should update packageManager field when a newer pnpm version is available', async () => {
   const opts = prepare()
   const pkgJsonPath = path.join(opts.dir, 'package.json')

--- a/engine/pm/commands/tsconfig.json
+++ b/engine/pm/commands/tsconfig.json
@@ -59,6 +59,9 @@
       "path": "../../../installing/env-installer"
     },
     {
+      "path": "../../../lockfile/fs"
+    },
+    {
       "path": "../../../lockfile/types"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3876,6 +3876,9 @@ importers:
       '@pnpm/installing.env-installer':
         specifier: workspace:*
         version: link:../../../installing/env-installer
+      '@pnpm/lockfile.fs':
+        specifier: workspace:*
+        version: link:../../../lockfile/fs
       '@pnpm/lockfile.types':
         specifier: workspace:*
         version: link:../../../lockfile/types


### PR DESCRIPTION
## Summary

- `pnpm self-update` (with no version arg) defaults to the `latest` dist-tag, but `latest` on the registry can lag the installed version when a new major has shipped without being tagged. In that case, the command silently downgraded users to the older release.
- The handler now refuses to downgrade when implicit `latest` resolves to a version older than the currently active pnpm — both for the global path (compared against the running binary) and the project-pin path (compared against `wantedPackageManager.version`, including ranges via `semver.minVersion`).
- An explicit `pnpm self-update latest` (or any explicit version/tag) still updates as before, so the downgrade can be forced when intentional.

Closes #11418.

## Test plan

- [x] `pnpm --filter @pnpm/engine.pm.commands run compile` passes
- [x] `NODE_OPTIONS="--experimental-vm-modules" npx jest selfUpdate` — 36/36 tests pass, including 4 new cases (implicit latest refuses downgrade globally, explicit `latest` forces it, explicit older version skips the guard, project pin refuses downgrade)
- [x] `pnpm --filter pnpm run compile` rebuilds the bundle cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm self-update` now prevents unintended downgrades when the registry’s `latest` resolves to an older release; use `pnpm self-update latest` to force a downgrade.

* **Documentation**
  * Updated self-update guidance to explain downgrade-prevention behavior.

* **Tests**
  * Added test coverage for downgrade prevention and for explicit-bypass behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->