### PR TITLE
fix(config): default minimumReleaseAgeStrict to true when user sets minimumReleaseAge

### DIFF
--- a/.changeset/strict-min-release-age-when-user-set.md
+++ b/.changeset/strict-min-release-age-when-user-set.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/config.reader": minor
-"pnpm": minor
+"@pnpm/config.reader": patch
+"pnpm": patch
 ---
 
 `minimumReleaseAgeStrict` now defaults to `true` whenever the user explicitly sets `minimumReleaseAge` (via `pnpm-workspace.yaml`, the global `config.yaml`, the CLI, or `pnpm_config_*` env vars). Previously, an explicitly configured `minimumReleaseAge` could silently fall back to installing an immature version when no mature version satisfied the requested range, making the setting look like it had no effect [#11433](https://github.com/pnpm/pnpm/issues/11433). Set `minimumReleaseAgeStrict: false` to opt back into the silent fallback behavior. The built-in default (1440) remains non-strict, preserving the existing behavior for users who haven't configured the setting.

--- a/.changeset/strict-min-release-age-when-user-set.md
+++ b/.changeset/strict-min-release-age-when-user-set.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": minor
+"pnpm": minor
+---
+
+`minimumReleaseAgeStrict` now defaults to `true` whenever the user explicitly sets `minimumReleaseAge` (via `pnpm-workspace.yaml`, the global `config.yaml`, the CLI, or `pnpm_config_*` env vars). Previously, an explicitly configured `minimumReleaseAge` could silently fall back to installing an immature version when no mature version satisfied the requested range, making the setting look like it had no effect [#11433](https://github.com/pnpm/pnpm/issues/11433). Set `minimumReleaseAgeStrict: false` to opt back into the silent fallback behavior. The built-in default (1440) remains non-strict, preserving the existing behavior for users who haven't configured the setting.

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -429,6 +429,19 @@ export async function getConfig (opts: {
     }
   }
 
+  // When the user explicitly sets `minimumReleaseAge`, treat it as strict by
+  // default. Without this, a user-set value would silently fall back to
+  // installing an immature version when no mature version satisfies the
+  // requested range — making the setting look like it had no effect.
+  // The built-in default for `minimumReleaseAge` is intentionally non-strict
+  // for backward compatibility.
+  if (
+    pnpmConfig.explicitlySetKeys.has('minimumReleaseAge') &&
+    pnpmConfig.minimumReleaseAgeStrict == null
+  ) {
+    pnpmConfig.minimumReleaseAgeStrict = true
+  }
+
   // Merge registries from pnpm-workspace.yaml onto the .npmrc-based registries.
   // The workspace manifest may have set pnpmConfig.registries via addSettingsFromWorkspaceManifestToConfig,
   // but we need to ensure 'default' is always set and all URLs are normalized.

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -429,19 +429,6 @@ export async function getConfig (opts: {
     }
   }
 
-  // When the user explicitly sets `minimumReleaseAge`, treat it as strict by
-  // default. Without this, a user-set value would silently fall back to
-  // installing an immature version when no mature version satisfies the
-  // requested range — making the setting look like it had no effect.
-  // The built-in default for `minimumReleaseAge` is intentionally non-strict
-  // for backward compatibility.
-  if (
-    pnpmConfig.explicitlySetKeys.has('minimumReleaseAge') &&
-    pnpmConfig.minimumReleaseAgeStrict == null
-  ) {
-    pnpmConfig.minimumReleaseAgeStrict = true
-  }
-
   // Merge registries from pnpm-workspace.yaml onto the .npmrc-based registries.
   // The workspace manifest may have set pnpmConfig.registries via addSettingsFromWorkspaceManifestToConfig,
   // but we need to ensure 'default' is always set and all URLs are normalized.
@@ -483,6 +470,20 @@ export async function getConfig (opts: {
       }
       pnpmConfig.registries.default = normalizeRegistryUrl(value)
     }
+  }
+
+  // When the user explicitly sets `minimumReleaseAge`, treat it as strict by
+  // default. Without this, a user-set value would silently fall back to
+  // installing an immature version when no mature version satisfies the
+  // requested range — making the setting look like it had no effect.
+  // The built-in default for `minimumReleaseAge` is intentionally non-strict
+  // for backward compatibility. This must run after env var parsing so
+  // pnpm_config_minimum_release_age also enables strict mode.
+  if (
+    pnpmConfig.explicitlySetKeys.has('minimumReleaseAge') &&
+    pnpmConfig.minimumReleaseAgeStrict == null
+  ) {
+    pnpmConfig.minimumReleaseAgeStrict = true
   }
 
   overrideSupportedArchitecturesWithCLI(pnpmConfig, cliOptions)

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -316,6 +316,72 @@ test('.npmrc does not load pnpm settings', async () => {
   expect(config.authConfig.packages).toBeUndefined()
 })
 
+describe('minimumReleaseAgeStrict default', () => {
+  test('defaults to true when minimumReleaseAge is set in pnpm-workspace.yaml', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      minimumReleaseAge: 60,
+    })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.minimumReleaseAge).toBe(60)
+    expect(config.minimumReleaseAgeStrict).toBe(true)
+  })
+
+  test('defaults to true when minimumReleaseAge is set on the CLI', async () => {
+    prepareEmpty()
+
+    const { config } = await getConfig({
+      cliOptions: {
+        'minimum-release-age': 60,
+      },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.minimumReleaseAge).toBe(60)
+    expect(config.minimumReleaseAgeStrict).toBe(true)
+  })
+
+  test('respects an explicit minimumReleaseAgeStrict=false from pnpm-workspace.yaml', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      minimumReleaseAge: 60,
+      minimumReleaseAgeStrict: false,
+    })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.minimumReleaseAgeStrict).toBe(false)
+  })
+
+  test('does not become strict when only the built-in default for minimumReleaseAge applies', async () => {
+    prepareEmpty()
+
+    writeYamlFileSync('pnpm-workspace.yaml', {})
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.minimumReleaseAge).toBe(1440)
+    expect(config.minimumReleaseAgeStrict).toBeUndefined()
+  })
+})
+
 test('camelCase settings from pnpm-workspace.yaml are read into typed Config properties', async () => {
   prepareEmpty()
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -379,6 +379,7 @@ describe('minimumReleaseAgeStrict default', () => {
       workspaceDir: process.cwd(),
     })
 
+    expect(config.minimumReleaseAge).toBe(60)
     expect(config.minimumReleaseAgeStrict).toBe(false)
   })
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -349,6 +349,22 @@ describe('minimumReleaseAgeStrict default', () => {
     expect(config.minimumReleaseAgeStrict).toBe(true)
   })
 
+  test('defaults to true when minimumReleaseAge is set via pnpm_config_* env var', async () => {
+    prepareEmpty()
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        pnpm_config_minimum_release_age: '60',
+      },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.minimumReleaseAge).toBe(60)
+    expect(config.minimumReleaseAgeStrict).toBe(true)
+  })
+
   test('respects an explicit minimumReleaseAgeStrict=false from pnpm-workspace.yaml', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
## Summary

- When the user explicitly sets `minimumReleaseAge` (via `pnpm-workspace.yaml`, the global `config.yaml`, the CLI, or `pnpm_config_*` env vars), `minimumReleaseAgeStrict` now defaults to `true` so the constraint is actually enforced.
- Previously, an explicitly configured `minimumReleaseAge` could silently fall back to installing an immature version when no mature version satisfied the requested range, making the setting look like it had no effect.
- The built-in default of `minimumReleaseAge` (1440) stays non-strict, preserving existing behavior for users who haven't configured it. An explicit `minimumReleaseAgeStrict: false` is still respected.

Fixes #11433.

## Test plan

- [x] Unit tests in `config/reader/test/index.ts` cover all four cases (workspace yaml, CLI, explicit `false` override, built-in default)
- [x] End-to-end manual test: `minimumReleaseAge` set in `pnpm-workspace.yaml` with no satisfying version → install errors instead of silently picking an immature version
- [x] End-to-end manual test: explicit `minimumReleaseAgeStrict: false` → silent fallback preserved
- [x] End-to-end manual test: no user config (default 1440) → silent fallback preserved (no behavior change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * When a user explicitly configures a minimum release age, strict validation now defaults to true; explicitly setting strictness to false restores prior fallback behavior. The built-in default release age remains non-strict for users who do not configure it.

* **Tests**
  * Added tests verifying default strictness behavior across config, CLI, and environment variable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->