### PR TITLE
ci(release): attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write  # Required for OIDC
       contents: write  # for softprops/action-gh-release to create GitHub release
+      attestations: write  # for actions/attest-build-provenance
     # Runs on macOS so darwin artifacts are signed with native `codesign`.
     # Cross-signing on Linux with `ldid` produces ad-hoc signatures whose
     # page hashes don't match the post-postject Mach-O layout for Node.js 25's
@@ -39,6 +40,10 @@ jobs:
           pn release
       - name: Copy Artifacts
         run: pn copy-artifacts
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'dist/*'
       - name: Generate release description
         run: pn make-release-description
       - name: Release


### PR DESCRIPTION
## Summary

Generate Sigstore-backed [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance) for the per-platform binary archives produced by `pn copy-artifacts`, using [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance). Users can then verify with `gh attestation verify` that the binaries attached to a GitHub Release were actually produced by this repo's release workflow rather than uploaded manually.

```
gh attestation verify pnpm-linux-x64.tar.gz \
    --repo pnpm/pnpm \
    --predicate-type https://slsa.dev/provenance/v1
```

## Why this is not redundant with the existing release attestation

GitHub already auto-generates a *release* attestation (predicate type `https://in-toto.io/attestation/release/v0.2`) for every release in this repo, e.g. for [`v11.0.4`](https://github.com/pnpm/pnpm/releases/tag/v11.0.4). That attestation only proves *which file digests were attached to a tag in this repo*. It does not prove *how those files were built* — anyone with release-write permission (a leaked PAT, a malicious workflow) can attach arbitrary binaries to a release, and GitHub will dutifully sign a release attestation for them.

The new build-provenance attestation uses predicate type `https://slsa.dev/provenance/v1` and binds each artifact's digest to:

- the exact workflow file (`.github/workflows/release.yml`) and commit SHA that built it,
- the GitHub-hosted runner identity,
- the workflow run ID.

The two attestations are complementary, not duplicates: release proves "where the file was hosted," build provenance proves "how the file was built."

The `pn release` step already publishes the npm tarballs with `--provenance`, so this closes the same gap on the GitHub Release side.

## Implementation notes

- `attestations: write` permission added to the `release` job alongside the existing `id-token: write` (already present for npm OIDC).
- The attest step runs after `Copy Artifacts` (so `dist/*` exists) and before `Release` (so the digests being signed match what gets uploaded).
- The action is pinned to its `v4.1.0` SHA to match the convention used by the other actions in this workflow.

## Test plan

- [ ] Cut a pre-release tag from a branch off this PR and verify `gh attestation verify <artifact> --repo pnpm/pnpm --predicate-type https://slsa.dev/provenance/v1` succeeds for each `pnpm-*` archive and `source-maps.tgz`.
- [ ] Confirm both predicate types (`slsa.dev/provenance/v1` and `in-toto.io/attestation/release/v0.2`) are visible in the release's [attestations API](https://docs.github.com/en/rest/attestations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process with build provenance attestation to improve build integrity verification and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->