### PR TITLE
[fixed] fix: ignore false positive vulnerability GHSA-r4q5-vmmm-2653

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,6 +68,7 @@ auditConfig:
     - GHSA-ffrw-9mx8-89p8
     - GHSA-mh29-5h37-fv8m
     - GHSA-w5hq-g745-h8pq
+    - GHSA-r4q5-vmmm-2653
 
 catalog:
   '@babel/core': ^7.28.3


### PR DESCRIPTION
Ignores GHSA-r4q5-vmmm-2653 as follow-redirects@1.16.0 is already patched (>=1.15.12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace audit configuration to ignore an additional security advisory in the dependency scanning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->