### PR TITLE
docs(release): correct rationale comment on macos-latest runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,12 @@ jobs:
       id-token: write  # Required for OIDC
       contents: write  # for softprops/action-gh-release to create GitHub release
       attestations: write  # for actions/attest-build-provenance
-    # Runs on macOS so darwin artifacts are signed with native `codesign`.
-    # Cross-signing on Linux with `ldid` produces ad-hoc signatures whose
-    # page hashes don't match the post-postject Mach-O layout for Node.js 25's
-    # chained fixups, leaving fixups unapplied and crashing the binary at
-    # startup (EXC_BAD_ACCESS in __cxx_global_var_init).
+    # Runs on macOS so the darwin artifacts can be ad-hoc signed with native
+    # `codesign` (no need to build/install `ldid` on the runner) and so
+    # `verify-binary.mjs` can smoke-test the darwin-arm64 SEA in place — a
+    # macos-latest runner is Apple Silicon and can execute the arm64 binary.
+    # Note: this does NOT fix the darwin-x64 crash (nodejs/node#62893) — that's
+    # an upstream Node.js SEA bug independent of signing; see pack-app docs.
     runs-on: macos-latest
     environment: release
     steps:


### PR DESCRIPTION
## Summary

The release workflow's comment block on the `macos-latest` runner choice (added in #11415) attributed darwin SEA crashes to `ldid` producing bad code-signature page hashes. That theory turned out to be wrong:

- The upstream minimal repro in [nodejs/node#62893](https://github.com/nodejs/node/issues/62893) is `node --build-sea` + `codesign --sign -` + run, with no pnpm and no `ldid` involved. It still crashes on Intel Mac.
- `codesign` produces correct page hashes by definition, so if signing were the bug, this repro would work. It doesn't.
- The actual bug is in LIEF's Mach-O surgery during `--build-sea` for x64 — chained-fixup chain entries get rewritten incorrectly when the SEA segment is inserted, and dyld dereferences the unprocessed chain values at startup.
- Re-signing with anything (codesign, ldid, ProcursusTeam ldid) just covers the structurally broken bytes.

The Node.js team has [opted not to fix this](https://github.com/nodejs/node/pull/60250) on the grounds that x64 macOS is being phased out (related: [nodejs/node#59553](https://github.com/nodejs/node/issues/59553)).

## What this changes

Comment-only update to `.github/workflows/release.yml`. No behaviour change. The job still runs on `macos-latest`, just for the actually-correct reasons:

1. Native `codesign` is on the runner — no need to build/install `ldid`.
2. `macos-latest` is Apple Silicon, so `verify-binary.mjs` can execute and smoke-test the `darwin-arm64` SEA in place.

The new comment also explicitly notes that this **does not** fix the `darwin-x64` crash — that's an upstream Node.js bug, separately documented in the `pack-app` docs (pnpm/pnpm.io@36d962f6).

## Related

- Issue: #11423
- Prior PR with the now-incorrect comment: #11415
- Upstream Node: nodejs/node#62893, nodejs/node#59553, nodejs/node#60250

## Test plan

- [x] `git diff origin/main` shows only the comment change; `attestations: write` and the `Attest build provenance` step from #11441 are preserved.
- [ ] No CI required — comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow documentation to clarify macOS code signing process and Apple Silicon build details, along with notes on known upstream issues affecting certain build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->