### PR TITLE
fix(publish): respect publishConfig.registry in non-recursive publish

### DIFF
--- a/.changeset/publish-respect-publishconfig-registry.md
+++ b/.changeset/publish-respect-publishconfig-registry.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm publish` to honor `publishConfig.registry` from `package.json` when publishing a single package. The native publish flow introduced in v11 was reading the registry from `.npmrc` only, ignoring the per-package override [#11419](https://github.com/pnpm/pnpm/issues/11419).

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -59,7 +59,10 @@ export async function publishPackedPkg (
 }
 
 async function createPublishOptions (manifest: ExportedManifest, options: PublishPackedPkgOptions): Promise<PublishOptions> {
-  const { registry, config } = findRegistryInfo(manifest, options)
+  const publishConfigRegistry = typeof manifest.publishConfig?.registry === 'string'
+    ? manifest.publishConfig.registry
+    : undefined
+  const { registry, config } = findRegistryInfo(manifest, options, publishConfigRegistry)
   const { creds, tls } = config ?? {}
 
   const {
@@ -130,16 +133,19 @@ interface RegistryInfo {
 /**
  * Find credentials and SSL info for a package's registry.
  * Follows {@link https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#auth-related-configuration}.
+ *
+ * The manifest's `publishConfig.registry`, when set, takes precedence over `registries`.
  */
 function findRegistryInfo (
   { name }: ExportedManifest,
-  { configByUri, registries }: Pick<Config, 'configByUri' | 'registries'>
+  { configByUri, registries }: Pick<Config, 'configByUri' | 'registries'>,
+  publishConfigRegistry?: string
 ): Partial<RegistryInfo> {
   // eslint-disable-next-line regexp/no-unused-capturing-group
   const scopedMatches = /@(?<scope>[^/]+)\/(?<slug>[^/]+)/.exec(name)
 
   const registryName = scopedMatches?.groups ? `@${scopedMatches.groups.scope}` : 'default'
-  const nonNormalizedRegistry = registries[registryName] ?? registries.default
+  const nonNormalizedRegistry = publishConfigRegistry ?? registries[registryName] ?? registries.default
 
   const supportedRegistryInfo = parseSupportedRegistryUrl(nonNormalizedRegistry)
   if (!supportedRegistryInfo) {

--- a/releasing/commands/test/publish/publish.ts
+++ b/releasing/commands/test/publish/publish.ts
@@ -304,6 +304,28 @@ test('publish: package with all possible fields in publishConfig', async () => {
   })
 })
 
+test('publish: package with publishConfig.registry overrides the default registry', async () => {
+  const pkgName = `test-publish-config-registry-${Date.now()}`
+  prepare({
+    name: pkgName,
+    version: '1.0.0',
+
+    publishConfig: {
+      registry: `http://localhost:${REGISTRY_MOCK_PORT}`,
+    },
+  })
+
+  await publish.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: ['publish'] },
+    configByUri: CONFIG_BY_URI,
+    dir: process.cwd(),
+    registries: { default: 'https://__fake_npm_registry__.com' },
+  }, [])
+
+  await checkPkgExists(pkgName, '1.0.0')
+})
+
 test('publish: package with publishConfig.directory', async () => {
   const packages = preparePackages([
     {


### PR DESCRIPTION
## Summary

- Fix [#11419](https://github.com/pnpm/pnpm/issues/11419): `pnpm publish` in v11 stopped honoring `publishConfig.registry` from `package.json` when publishing a single package.
- Root cause: when the native publish flow replaced the `npm publish` shell-out with `libnpmpublish` (#10591), `findRegistryInfo` in `releasing/commands/src/publish/publishPackedPkg.ts` only consulted the configured `registries` map. The npm CLI honored `publishConfig.registry` implicitly; the native code path does not.
- Fix: extract `manifest.publishConfig.registry` and pass it to `findRegistryInfo` as the highest-precedence registry URL, falling back to `registries[scope]` then `registries.default`. Credentials/TLS continue to be looked up via `configByUri` keyed by the resolved registry URL, so a token under `//my.nexus/repository/npm-hosted/:_authToken=…` is picked up correctly.

## Test plan

- [x] Added a regression test in `releasing/commands/test/publish/publish.ts` that sets `registries.default` to a fake host and `publishConfig.registry` to the mock — the publish only succeeds if the override wins.
- [x] Verified the test fails on `main` and passes with this change.
- [x] All existing `releasing/commands/test/publish/publish.ts` and `recursivePublish.ts` tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* `pnpm publish` now respects `publishConfig.registry` from package.json when publishing individual packages, instead of only using `.npmrc` configuration.

## Tests
* Added test case validating that `publishConfig.registry` correctly overrides default registry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->