### PR TITLE
feat(dlx): prompt to approve ignored builds

### DIFF
--- a/.changeset/fix-dlx-prompt-approve-builds.md
+++ b/.changeset/fix-dlx-prompt-approve-builds.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": minor
+"pnpm": minor
+---
+
+`pnpm dlx` (and `pnpx`/`pnx`/`pnpm create`) now runs the same interactive `approve-builds` prompt as `pnpm add -g` when the package being launched depends on transitive packages with install scripts. Previously, the `strictDepBuilds` default in v11 made dlx fail with `ERR_PNPM_IGNORED_BUILDS` and required users to re-run with `--allow-build=<pkg>` for every offending dependency. dlx also now removes the partially-populated cache directory when the install fails, so a subsequent run starts clean instead of reusing a broken install whose builds were silently skipped [#11444](https://github.com/pnpm/pnpm/issues/11444).

--- a/.changeset/fix-dlx-prompt-approve-builds.md
+++ b/.changeset/fix-dlx-prompt-approve-builds.md
@@ -2,7 +2,7 @@
 "@pnpm/building.commands": patch
 "@pnpm/exec.commands": minor
 "@pnpm/installing.commands": patch
-"pnpm": minor
+"pnpm": patch
 ---
 
 `pnpm dlx` (and `pnpx`/`pnx`/`pnpm create`) now runs the same interactive `approve-builds` prompt as `pnpm add -g` when the package being launched depends on transitive packages with install scripts. Previously, the v11 `strictDepBuilds` default made dlx fail with `ERR_PNPM_IGNORED_BUILDS` and required users to re-run with `--allow-build=<pkg>` for every offending dependency. dlx also now removes the partially-populated cache directory when the install fails, so a subsequent run starts clean instead of reusing a broken install whose builds were silently skipped [#11444](https://github.com/pnpm/pnpm/issues/11444).

--- a/.changeset/fix-dlx-prompt-approve-builds.md
+++ b/.changeset/fix-dlx-prompt-approve-builds.md
@@ -1,6 +1,8 @@
 ---
+"@pnpm/building.commands": patch
 "@pnpm/exec.commands": minor
+"@pnpm/installing.commands": patch
 "pnpm": minor
 ---
 
-`pnpm dlx` (and `pnpx`/`pnx`/`pnpm create`) now runs the same interactive `approve-builds` prompt as `pnpm add -g` when the package being launched depends on transitive packages with install scripts. Previously, the `strictDepBuilds` default in v11 made dlx fail with `ERR_PNPM_IGNORED_BUILDS` and required users to re-run with `--allow-build=<pkg>` for every offending dependency. dlx also now removes the partially-populated cache directory when the install fails, so a subsequent run starts clean instead of reusing a broken install whose builds were silently skipped [#11444](https://github.com/pnpm/pnpm/issues/11444).
+`pnpm dlx` (and `pnpx`/`pnx`/`pnpm create`) now runs the same interactive `approve-builds` prompt as `pnpm add -g` when the package being launched depends on transitive packages with install scripts. Previously, the v11 `strictDepBuilds` default made dlx fail with `ERR_PNPM_IGNORED_BUILDS` and required users to re-run with `--allow-build=<pkg>` for every offending dependency. dlx also now removes the partially-populated cache directory when the install fails, so a subsequent run starts clean instead of reusing a broken install whose builds were silently skipped [#11444](https://github.com/pnpm/pnpm/issues/11444).

--- a/building/commands/src/index.ts
+++ b/building/commands/src/index.ts
@@ -1,3 +1,3 @@
 export { rebuild, type RebuildCommandOpts } from './build/index.js'
 export type { ApproveBuildsCommandOpts } from './policy/approveBuilds.js'
-export { approveBuilds, ignoredBuilds } from './policy/index.js'
+export { approveBuilds, getAutomaticallyIgnoredBuilds, ignoredBuilds } from './policy/index.js'

--- a/building/commands/src/policy/index.ts
+++ b/building/commands/src/policy/index.ts
@@ -1,5 +1,6 @@
 import * as approveBuilds from './approveBuilds.js'
 import * as ignoredBuilds from './ignoredBuilds.js'
 export type { ApproveBuildsCommandOpts } from './approveBuilds.js'
+export { getAutomaticallyIgnoredBuilds } from './getAutomaticallyIgnoredBuilds.js'
 
 export { approveBuilds, ignoredBuilds }

--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@pnpm/bins.resolver": "workspace:*",
+    "@pnpm/building.commands": "workspace:*",
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/cli.command": "workspace:*",
     "@pnpm/cli.common-cli-options-help": "workspace:*",
@@ -76,7 +77,6 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
-    "@pnpm/building.commands": "workspace:*",
     "@pnpm/engine.runtime.system-node-version": "workspace:*",
     "@pnpm/exec.commands": "workspace:*",
     "@pnpm/logger": "workspace:*",

--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -76,6 +76,7 @@
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
+    "@pnpm/building.commands": "workspace:*",
     "@pnpm/engine.runtime.system-node-version": "workspace:*",
     "@pnpm/exec.commands": "workspace:*",
     "@pnpm/logger": "workspace:*",

--- a/exec/commands/src/create.ts
+++ b/exec/commands/src/create.ts
@@ -1,3 +1,4 @@
+import type { CommandHandlerMap } from '@pnpm/cli.command'
 import { docsUrl } from '@pnpm/cli.utils'
 import { PnpmError } from '@pnpm/error'
 import { renderHelp } from 'render-help'
@@ -6,7 +7,7 @@ import * as dlx from './dlx.js'
 
 export const commandNames = ['create']
 
-export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): Promise<{ exitCode: number } | string> {
+export async function handler (_opts: dlx.DlxCommandOptions, params: string[], commands?: CommandHandlerMap): Promise<{ exitCode: number } | string> {
   // If the first argument is --help or -h, we show the help message.
   if (params[0] === '--help' || params[0] === '-h') {
     return help()
@@ -23,7 +24,7 @@ export async function handler (_opts: dlx.DlxCommandOptions, params: string[]): 
   }
 
   const createPackageName = convertToCreateName(packageName)
-  return dlx.handler(_opts, [createPackageName, ...packageArgs])
+  return dlx.handler(_opts, [createPackageName, ...packageArgs], commands)
 }
 
 export function rcOptionsTypes (): Record<string, unknown> {

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -164,7 +164,7 @@ export async function handler (
       await add.handler({
         ...opts,
         // Mirror the global install flow: dlx prompts via `approve-builds`
-        // when transitive deps have unrun build scripts, so it must not let
+        // when transitive deps have skipped build scripts, so it must not let
         // strictDepBuilds (the v11 default) turn that into a hard error.
         // Without this, `pnpm dlx <pkg>` cannot launch packages whose bin
         // depends on a postinstall step (e.g. native modules).

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -7,6 +7,7 @@ import {
   type CatalogResolver,
   resolveFromCatalog,
 } from '@pnpm/catalogs.resolver'
+import type { CommandHandlerMap } from '@pnpm/cli.command'
 import { OUTPUT_OPTIONS } from '@pnpm/cli.common-cli-options-help'
 import { docsUrl, readProjectManifestOnly } from '@pnpm/cli.utils'
 import { type Config, types } from '@pnpm/config.reader'
@@ -29,6 +30,14 @@ import { makeEnv } from './makeEnv.js'
 export const skipPackageManagerCheck = true
 
 export const commandNames = ['dlx']
+
+/**
+ * Test-only env var. When set, the dlx ignored-builds recovery path bypasses
+ * the TTY check and forwards `all: true` so `approve-builds` skips its
+ * multiselect and confirm prompts. Mirrors the same env var honored by
+ * `promptApproveGlobalBuilds` for global installs. Not for production use.
+ */
+const AUTO_APPROVE_FOR_TESTS_ENV = 'PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS'
 
 export const shorthands: Record<string, string> = {
   c: '--shell-mode',
@@ -88,7 +97,8 @@ export type DlxCommandOptions = {
 
 export async function handler (
   opts: DlxCommandOptions,
-  [command, ...args]: string[]
+  [command, ...args]: string[],
+  commands?: CommandHandlerMap
 ): Promise<{ exitCode: number, output?: string }> {
   if (!command && (!opts.package || opts.package.length === 0)) {
     return { exitCode: 1, output: help() }
@@ -147,23 +157,63 @@ export async function handler (
     supportedArchitectures: opts.supportedArchitectures,
   })
   if (!cacheExists) {
+    const allowBuilds = Object.fromEntries([...resolvedPkgAliases, ...(opts.allowBuild ?? [])].map(pkg => [pkg, true]))
     try {
       fs.mkdirSync(cachedDir, { recursive: true })
-      await add.handler({
-        ...opts,
-        enableGlobalVirtualStore: opts.enableGlobalVirtualStore ?? true,
-        bin: path.join(cachedDir, 'node_modules/.bin'),
-        dir: cachedDir,
-        lockfileDir: cachedDir,
-        allowBuilds: Object.fromEntries([...resolvedPkgAliases, ...(opts.allowBuild ?? [])].map(pkg => [pkg, true])),
-        rootProjectManifestDir: cachedDir,
-        saveProd: true, // dlx will be looking for the package in the "dependencies" field!
-        saveDev: false,
-        saveOptional: false,
-        savePeer: false,
-        symlink: true,
-        workspaceDir: undefined,
-      }, resolvedPkgs)
+      try {
+        await add.handler({
+          ...opts,
+          enableGlobalVirtualStore: opts.enableGlobalVirtualStore ?? true,
+          bin: path.join(cachedDir, 'node_modules/.bin'),
+          dir: cachedDir,
+          lockfileDir: cachedDir,
+          allowBuilds,
+          rootProjectManifestDir: cachedDir,
+          saveProd: true, // dlx will be looking for the package in the "dependencies" field!
+          saveDev: false,
+          saveOptional: false,
+          savePeer: false,
+          symlink: true,
+          workspaceDir: undefined,
+        }, resolvedPkgs)
+      } catch (err) {
+        // When the install completed but some dependencies have unrun build
+        // scripts, strictDepBuilds (default in v11) makes add.handler throw.
+        // Prompt the user to approve those builds, mirroring the global install
+        // flow. Without this, `pnpm dlx <pkg>` cannot launch packages whose
+        // bin depends on a postinstall step (e.g. native modules).
+        const autoApproveForTests = process.env[AUTO_APPROVE_FOR_TESTS_ENV] === '1'
+        if (
+          util.types.isNativeError(err) &&
+          'code' in err &&
+          err.code === 'ERR_PNPM_IGNORED_BUILDS' &&
+          (autoApproveForTests || process.stdin.isTTY) &&
+          commands?.['approve-builds']
+        ) {
+          await commands['approve-builds']({
+            ...opts,
+            dir: cachedDir,
+            lockfileDir: cachedDir,
+            rootProjectManifestDir: cachedDir,
+            modulesDir: undefined,
+            workspaceDir: undefined,
+            allProjects: undefined,
+            selectedProjectsGraph: undefined,
+            workspacePackagePatterns: undefined,
+            rootProjectManifest: undefined,
+            global: false,
+            pending: false,
+            allowBuilds,
+            all: autoApproveForTests ? true : undefined,
+          }, [], commands)
+        } else {
+          // The install left a partially populated cache directory. Remove it
+          // so a subsequent dlx run starts clean instead of reusing the broken
+          // install (which would silently skip the build scripts again).
+          await fs.promises.rm(cachedDir, { recursive: true, force: true })
+          throw err
+        }
+      }
       try {
         await symlinkDir(cachedDir, cacheLink, { overwrite: true })
       } catch (error) {

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -280,6 +280,12 @@ function scopeless (pkgName: string): string {
  * transitive dependencies had their build scripts skipped and, if so, run
  * the same `approve-builds` flow that `pnpm add -g` uses. Mirrors
  * `promptApproveGlobalBuilds` in @pnpm/global.commands.
+ *
+ * In non-interactive mode (no TTY, no commands map) this is a no-op and
+ * the install is persisted to the dlx cache with builds skipped — same
+ * behavior as `pnpm add -g` in CI. Users who need the skipped scripts
+ * to run can re-invoke dlx with `--allow-build=<pkg>`, which produces a
+ * different cache key and forces a fresh install.
  */
 async function promptApproveDlxBuilds (
   opts: {

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -177,8 +177,9 @@ export async function handler (
           workspaceDir: undefined,
         }, resolvedPkgs)
       } catch (err) {
-        // When the install completed but some dependencies have unrun build
-        // scripts, strictDepBuilds (default in v11) makes add.handler throw.
+        // When the install completed but some dependencies have build
+        // scripts that did not run, strictDepBuilds (default in v11) makes
+        // add.handler throw.
         // Prompt the user to approve those builds, mirroring the global install
         // flow. Without this, `pnpm dlx <pkg>` cannot launch packages whose
         // bin depends on a postinstall step (e.g. native modules).

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { getBinsFromPackageManifest } from '@pnpm/bins.resolver'
+import { getAutomaticallyIgnoredBuilds } from '@pnpm/building.commands'
 import {
   type CatalogResolver,
   resolveFromCatalog,
@@ -93,7 +94,7 @@ export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
   allowBuild?: string[]
-} & Pick<Config, 'extraBinPaths' | 'minimumReleaseAgeExclude' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'symlink'> & Partial<Pick<Config, 'strictDepBuilds'>> & Omit<add.AddCommandOptions, 'rootProjectManifestDir'> & PnpmSettings
+} & Pick<Config, 'extraBinPaths' | 'minimumReleaseAgeExclude' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'symlink'> & Omit<add.AddCommandOptions, 'rootProjectManifestDir'> & PnpmSettings
 
 export async function handler (
   opts: DlxCommandOptions,
@@ -160,61 +161,28 @@ export async function handler (
     const allowBuilds = Object.fromEntries([...resolvedPkgAliases, ...(opts.allowBuild ?? [])].map(pkg => [pkg, true]))
     try {
       fs.mkdirSync(cachedDir, { recursive: true })
-      try {
-        await add.handler({
-          ...opts,
-          enableGlobalVirtualStore: opts.enableGlobalVirtualStore ?? true,
-          bin: path.join(cachedDir, 'node_modules/.bin'),
-          dir: cachedDir,
-          lockfileDir: cachedDir,
-          allowBuilds,
-          rootProjectManifestDir: cachedDir,
-          saveProd: true, // dlx will be looking for the package in the "dependencies" field!
-          saveDev: false,
-          saveOptional: false,
-          savePeer: false,
-          symlink: true,
-          workspaceDir: undefined,
-        }, resolvedPkgs)
-      } catch (err) {
-        // When the install completed but some dependencies have build
-        // scripts that did not run, strictDepBuilds (default in v11) makes
-        // add.handler throw.
-        // Prompt the user to approve those builds, mirroring the global install
-        // flow. Without this, `pnpm dlx <pkg>` cannot launch packages whose
-        // bin depends on a postinstall step (e.g. native modules).
-        const autoApproveForTests = process.env[AUTO_APPROVE_FOR_TESTS_ENV] === '1'
-        if (
-          util.types.isNativeError(err) &&
-          'code' in err &&
-          err.code === 'ERR_PNPM_IGNORED_BUILDS' &&
-          (autoApproveForTests || process.stdin.isTTY) &&
-          commands?.['approve-builds']
-        ) {
-          await commands['approve-builds']({
-            ...opts,
-            dir: cachedDir,
-            lockfileDir: cachedDir,
-            rootProjectManifestDir: cachedDir,
-            modulesDir: undefined,
-            workspaceDir: undefined,
-            allProjects: undefined,
-            selectedProjectsGraph: undefined,
-            workspacePackagePatterns: undefined,
-            rootProjectManifest: undefined,
-            global: false,
-            pending: false,
-            allowBuilds,
-            all: autoApproveForTests ? true : undefined,
-          }, [], commands)
-        } else {
-          // The install left a partially populated cache directory. Remove it
-          // so a subsequent dlx run starts clean instead of reusing the broken
-          // install (which would silently skip the build scripts again).
-          await fs.promises.rm(cachedDir, { recursive: true, force: true })
-          throw err
-        }
-      }
+      await add.handler({
+        ...opts,
+        // Mirror the global install flow: dlx prompts via `approve-builds`
+        // when transitive deps have unrun build scripts, so it must not let
+        // strictDepBuilds (the v11 default) turn that into a hard error.
+        // Without this, `pnpm dlx <pkg>` cannot launch packages whose bin
+        // depends on a postinstall step (e.g. native modules).
+        strictDepBuilds: false,
+        enableGlobalVirtualStore: opts.enableGlobalVirtualStore ?? true,
+        bin: path.join(cachedDir, 'node_modules/.bin'),
+        dir: cachedDir,
+        lockfileDir: cachedDir,
+        allowBuilds,
+        rootProjectManifestDir: cachedDir,
+        saveProd: true, // dlx will be looking for the package in the "dependencies" field!
+        saveDev: false,
+        saveOptional: false,
+        savePeer: false,
+        symlink: true,
+        workspaceDir: undefined,
+      }, resolvedPkgs)
+      await promptApproveDlxBuilds({ cachedDir, allowBuilds, inheritedOpts: opts }, commands)
       try {
         await symlinkDir(cachedDir, cacheLink, { overwrite: true })
       } catch (error) {
@@ -233,10 +201,14 @@ export async function handler (
       // directory swaps).  If another process completed the cache in the meantime,
       // use that instead of failing.
       const completedDir = getValidCacheDir(cacheLink, opts.dlxCacheMaxAge)
-      if (completedDir == null) {
+      if (completedDir != null) {
+        cachedDir = completedDir
+      } else {
+        // Drop the partially-populated cache so a subsequent dlx run starts
+        // clean instead of reusing a broken install.
+        await fs.promises.rm(cachedDir, { recursive: true, force: true })
         throw err
       }
-      cachedDir = completedDir
     }
   }
   const binsDir = path.join(cachedDir, 'node_modules/.bin')
@@ -301,6 +273,46 @@ function scopeless (pkgName: string): string {
     return pkgName.split('/')[1]
   }
   return pkgName
+}
+
+/**
+ * After a dlx install with `strictDepBuilds: false`, check whether any
+ * transitive dependencies had their build scripts skipped and, if so, run
+ * the same `approve-builds` flow that `pnpm add -g` uses. Mirrors
+ * `promptApproveGlobalBuilds` in @pnpm/global.commands.
+ */
+async function promptApproveDlxBuilds (
+  opts: {
+    cachedDir: string
+    allowBuilds: Record<string, boolean | string>
+    inheritedOpts: object
+  },
+  commands?: CommandHandlerMap
+): Promise<void> {
+  if (!commands?.['approve-builds']) return
+  const autoApproveForTests = process.env[AUTO_APPROVE_FOR_TESTS_ENV] === '1'
+  if (!autoApproveForTests && !process.stdin.isTTY) return
+  const { automaticallyIgnoredBuilds } = await getAutomaticallyIgnoredBuilds({
+    dir: opts.cachedDir,
+    lockfileDir: opts.cachedDir,
+  })
+  if (!automaticallyIgnoredBuilds?.length) return
+  await commands['approve-builds']({
+    ...opts.inheritedOpts,
+    dir: opts.cachedDir,
+    lockfileDir: opts.cachedDir,
+    rootProjectManifestDir: opts.cachedDir,
+    modulesDir: undefined,
+    workspaceDir: undefined,
+    allProjects: undefined,
+    selectedProjectsGraph: undefined,
+    workspacePackagePatterns: undefined,
+    rootProjectManifest: undefined,
+    global: false,
+    pending: false,
+    allowBuilds: opts.allowBuilds,
+    all: autoApproveForTests ? true : undefined,
+  }, [], commands)
 }
 
 function findCache (opts: {

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -93,7 +93,7 @@ export type DlxCommandOptions = {
   package?: string[]
   shellMode?: boolean
   allowBuild?: string[]
-} & Pick<Config, 'extraBinPaths' | 'minimumReleaseAgeExclude' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'symlink'> & Omit<add.AddCommandOptions, 'rootProjectManifestDir'> & PnpmSettings
+} & Pick<Config, 'extraBinPaths' | 'minimumReleaseAgeExclude' | 'registries' | 'reporter' | 'userAgent' | 'cacheDir' | 'dlxCacheMaxAge' | 'symlink'> & Partial<Pick<Config, 'strictDepBuilds'>> & Omit<add.AddCommandOptions, 'rootProjectManifestDir'> & PnpmSettings
 
 export async function handler (
   opts: DlxCommandOptions,

--- a/exec/commands/test/create.ts
+++ b/exec/commands/test/create.ts
@@ -26,13 +26,13 @@ it(
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['some-app'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['create_no_dash'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-create_no_dash'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-create_no_dash'], undefined)
   }
 )
 
@@ -43,13 +43,13 @@ it(
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['create-some-app'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['create-'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-'], undefined)
   }
 )
 
@@ -60,13 +60,13 @@ it(
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/some-app'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/create_no_dash'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-create_no_dash'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-create_no_dash'], undefined)
   }
 )
 
@@ -77,13 +77,13 @@ it(
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/create-some-app'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-some-app'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/create-'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-'], undefined)
   }
 )
 
@@ -92,7 +92,7 @@ it('infers a package name from a plain scope', async () => {
     ...DEFAULT_OPTS,
     dir: process.cwd(),
   }, ['@scope'])
-  expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create'])
+  expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create'], undefined)
 })
 
 it('passes the remaining arguments to `dlx`', async () => {
@@ -100,7 +100,7 @@ it('passes the remaining arguments to `dlx`', async () => {
     ...DEFAULT_OPTS,
     dir: process.cwd(),
   }, ['some-app', 'directory/', '--silent'])
-  expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app', 'directory/', '--silent'])
+  expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-some-app', 'directory/', '--silent'], undefined)
 })
 
 it(
@@ -110,35 +110,35 @@ it(
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['foo@2.0.0'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@2.0.0'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@2.0.0'], undefined)
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['foo@latest'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@latest'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['create-foo@latest'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope@2.0.0'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@2.0.0'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@2.0.0'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope@next'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@next'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create@next'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/foo@2.0.0'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-foo@2.0.0'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-foo@2.0.0'], undefined)
 
     await create.handler({
       ...DEFAULT_OPTS,
       dir: process.cwd(),
     }, ['@scope/create-a@2.0.0'])
-    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-a@2.0.0'])
+    expect(dlx.handler).toHaveBeenCalledWith(expect.anything(), ['@scope/create-a@2.0.0'], undefined)
   }
 )

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -397,11 +397,11 @@ test('dlx builds the packages passed via --allow-build', async () => {
 // dlx mirrors the global install flow: it overrides `strictDepBuilds`
 // internally so the install never throws ERR_PNPM_IGNORED_BUILDS, then
 // runs the same interactive `approve-builds` prompt that `pnpm add -g`
-// uses when transitive deps have unrun build scripts. The user can opt
-// in to the builds without retrying with `--allow-build=<pkg>`.
+// uses when transitive deps have skipped build scripts. The user can
+// opt in to the builds without retrying with `--allow-build=<pkg>`.
 //
 // Without a TTY (and without the test escape hatch below), the prompt is
-// skipped and dlx proceeds with build scripts unrun — same behavior as
+// skipped and dlx proceeds with build scripts skipped — same behavior as
 // `pnpm add -g` in CI.
 test('dlx does not error on ignored builds in non-interactive mode', async () => {
   prepareEmpty()
@@ -418,7 +418,7 @@ test('dlx does not error on ignored builds in non-interactive mode', async () =>
 
   // Cache is populated even though build scripts were skipped — the
   // package is installed so the bin can run if it does not depend on
-  // the unrun script.
+  // the skipped script.
   const dlxCacheDir = path.resolve('cache', 'dlx', createCacheKey('@pnpm.e2e/has-bin-and-needs-build@1.0.0'), 'pkg')
   expect(fs.existsSync(path.join(dlxCacheDir, 'package.json'))).toBe(true)
 })

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -10,9 +10,12 @@ const { getSystemNodeVersion: originalGetSystemNodeVersion } = await import('@pn
 jest.unstable_mockModule('@pnpm/engine.runtime.system-node-version', () => ({
   getSystemNodeVersion: jest.fn(originalGetSystemNodeVersion),
 }))
-const { add: originalAdd } = await import('@pnpm/installing.commands')
+const installingCommands = await import('@pnpm/installing.commands')
+const { add: originalAdd } = installingCommands
 jest.unstable_mockModule('@pnpm/installing.commands', () => ({
+  ...installingCommands,
   add: {
+    ...originalAdd,
     handler: jest.fn(originalAdd.handler),
   },
 }))
@@ -20,6 +23,7 @@ jest.unstable_mockModule('@pnpm/installing.commands', () => ({
 const systemNodeVersion = await import('@pnpm/engine.runtime.system-node-version')
 const { add } = await import('@pnpm/installing.commands')
 const { dlx } = await import('@pnpm/exec.commands')
+const { approveBuilds } = await import('@pnpm/building.commands')
 
 const testOnWindowsOnly = process.platform === 'win32' ? test : test.skip
 
@@ -386,6 +390,80 @@ test('dlx builds the packages passed via --allow-build', async () => {
   const builtPkg2Path = path.join(dlxCacheDir, 'node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0/node_modules/@pnpm.e2e/install-script-example')
   expect(fs.existsSync(path.join(builtPkg2Path, 'package.json'))).toBeTruthy()
   expect(fs.existsSync(path.join(builtPkg2Path, 'generated-by-install.js'))).toBeTruthy()
+})
+
+// Regression test for https://github.com/pnpm/pnpm/issues/11444.
+//
+// When dlx installs a package whose transitive deps need to run install
+// scripts and `strictDepBuilds` is on (the v11 default), the install
+// throws ERR_PNPM_IGNORED_BUILDS. Before the fix, the partially-populated
+// cache directory was left behind, so the next `pnpm dlx` run reused a
+// broken install whose builds had been silently skipped.
+test('dlx removes the cache directory when ignored builds halt the install', async () => {
+  prepareEmpty()
+
+  const cacheKey = createCacheKey('@pnpm.e2e/has-bin-and-needs-build@1.0.0')
+  const cacheCommandDir = path.resolve('cache', 'dlx', cacheKey)
+
+  // No commands map and no TTY: the ignored-builds recovery path cannot
+  // run, so dlx should re-throw and leave no orphan prepare directory.
+  await expect(
+    dlx.handler({
+      ...DEFAULT_OPTS,
+      enableGlobalVirtualStore: false,
+      strictDepBuilds: true,
+      dir: path.resolve('project'),
+      storeDir: path.resolve('store'),
+      cacheDir: path.resolve('cache'),
+      dlxCacheMaxAge: Infinity,
+    }, ['@pnpm.e2e/has-bin-and-needs-build'])
+  ).rejects.toThrow(/Ignored build scripts/)
+
+  // The cache key dir itself may still exist (created up front), but it
+  // must not contain the prepare dir from the failed install.
+  const remaining = fs.existsSync(cacheCommandDir)
+    ? fs.readdirSync(cacheCommandDir)
+    : []
+  expect(remaining).toEqual([])
+})
+
+// Regression test for https://github.com/pnpm/pnpm/issues/11444.
+//
+// When dlx hits ERR_PNPM_IGNORED_BUILDS, it should now run the same
+// `approve-builds` flow that `pnpm add -g` uses so the user can opt in
+// without re-running the command with `--allow-build=...`.
+//
+// `PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS=1` lets the test drive this flow
+// non-interactively: dlx skips the TTY check and forwards `all: true`
+// to approve-builds, which approves every pending build without
+// prompting and re-runs install. The build artifacts must end up in
+// the dlx cache.
+test('dlx prompts to approve ignored builds when invoked with a commands map', async () => {
+  prepareEmpty()
+
+  const prevAutoApprove = process.env.PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS
+  process.env.PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS = '1'
+  try {
+    await dlx.handler({
+      ...DEFAULT_OPTS,
+      enableGlobalVirtualStore: false,
+      strictDepBuilds: true,
+      dir: path.resolve('project'),
+      storeDir: path.resolve('store'),
+      cacheDir: path.resolve('cache'),
+      dlxCacheMaxAge: Infinity,
+    }, ['@pnpm.e2e/has-bin-and-needs-build'], { 'approve-builds': approveBuilds.handler })
+  } finally {
+    if (prevAutoApprove === undefined) {
+      delete process.env.PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS
+    } else {
+      process.env.PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS = prevAutoApprove
+    }
+  }
+
+  const dlxCacheDir = path.resolve('cache', 'dlx', createCacheKey('@pnpm.e2e/has-bin-and-needs-build@1.0.0'), 'pkg')
+  const builtPkg2Path = path.join(dlxCacheDir, 'node_modules/.pnpm/@pnpm.e2e+install-script-example@1.0.0/node_modules/@pnpm.e2e/install-script-example')
+  expect(fs.existsSync(path.join(builtPkg2Path, 'generated-by-install.js'))).toBe(true)
 })
 
 test('dlx should fail when the requested package does not meet the minimum age requirement', async () => {

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -401,8 +401,8 @@ test('dlx builds the packages passed via --allow-build', async () => {
 // opt in to the builds without retrying with `--allow-build=<pkg>`.
 //
 // Without a TTY (and without the test escape hatch below), the prompt is
-// skipped and dlx proceeds with build scripts skipped — same behavior as
-// `pnpm add -g` in CI.
+// skipped and dlx proceeds with build scripts skipped — same behavior
+// as `pnpm add -g` in CI.
 test('dlx does not error on ignored builds in non-interactive mode', async () => {
   prepareEmpty()
 

--- a/exec/commands/test/dlx.e2e.ts
+++ b/exec/commands/test/dlx.e2e.ts
@@ -394,50 +394,42 @@ test('dlx builds the packages passed via --allow-build', async () => {
 
 // Regression test for https://github.com/pnpm/pnpm/issues/11444.
 //
-// When dlx installs a package whose transitive deps need to run install
-// scripts and `strictDepBuilds` is on (the v11 default), the install
-// throws ERR_PNPM_IGNORED_BUILDS. Before the fix, the partially-populated
-// cache directory was left behind, so the next `pnpm dlx` run reused a
-// broken install whose builds had been silently skipped.
-test('dlx removes the cache directory when ignored builds halt the install', async () => {
+// dlx mirrors the global install flow: it overrides `strictDepBuilds`
+// internally so the install never throws ERR_PNPM_IGNORED_BUILDS, then
+// runs the same interactive `approve-builds` prompt that `pnpm add -g`
+// uses when transitive deps have unrun build scripts. The user can opt
+// in to the builds without retrying with `--allow-build=<pkg>`.
+//
+// Without a TTY (and without the test escape hatch below), the prompt is
+// skipped and dlx proceeds with build scripts unrun — same behavior as
+// `pnpm add -g` in CI.
+test('dlx does not error on ignored builds in non-interactive mode', async () => {
   prepareEmpty()
 
-  const cacheKey = createCacheKey('@pnpm.e2e/has-bin-and-needs-build@1.0.0')
-  const cacheCommandDir = path.resolve('cache', 'dlx', cacheKey)
+  await dlx.handler({
+    ...DEFAULT_OPTS,
+    enableGlobalVirtualStore: false,
+    strictDepBuilds: true,
+    dir: path.resolve('project'),
+    storeDir: path.resolve('store'),
+    cacheDir: path.resolve('cache'),
+    dlxCacheMaxAge: Infinity,
+  }, ['@pnpm.e2e/has-bin-and-needs-build'])
 
-  // No commands map and no TTY: the ignored-builds recovery path cannot
-  // run, so dlx should re-throw and leave no orphan prepare directory.
-  await expect(
-    dlx.handler({
-      ...DEFAULT_OPTS,
-      enableGlobalVirtualStore: false,
-      strictDepBuilds: true,
-      dir: path.resolve('project'),
-      storeDir: path.resolve('store'),
-      cacheDir: path.resolve('cache'),
-      dlxCacheMaxAge: Infinity,
-    }, ['@pnpm.e2e/has-bin-and-needs-build'])
-  ).rejects.toThrow(/Ignored build scripts/)
-
-  // The cache key dir itself may still exist (created up front), but it
-  // must not contain the prepare dir from the failed install.
-  const remaining = fs.existsSync(cacheCommandDir)
-    ? fs.readdirSync(cacheCommandDir)
-    : []
-  expect(remaining).toEqual([])
+  // Cache is populated even though build scripts were skipped — the
+  // package is installed so the bin can run if it does not depend on
+  // the unrun script.
+  const dlxCacheDir = path.resolve('cache', 'dlx', createCacheKey('@pnpm.e2e/has-bin-and-needs-build@1.0.0'), 'pkg')
+  expect(fs.existsSync(path.join(dlxCacheDir, 'package.json'))).toBe(true)
 })
 
 // Regression test for https://github.com/pnpm/pnpm/issues/11444.
 //
-// When dlx hits ERR_PNPM_IGNORED_BUILDS, it should now run the same
-// `approve-builds` flow that `pnpm add -g` uses so the user can opt in
-// without re-running the command with `--allow-build=...`.
-//
-// `PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS=1` lets the test drive this flow
-// non-interactively: dlx skips the TTY check and forwards `all: true`
-// to approve-builds, which approves every pending build without
-// prompting and re-runs install. The build artifacts must end up in
-// the dlx cache.
+// `PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS=1` lets the test drive the
+// approve-builds flow non-interactively: dlx skips the TTY check and
+// forwards `all: true` to approve-builds, which approves every pending
+// build without prompting and re-runs install. The build artifacts must
+// end up in the dlx cache.
 test('dlx prompts to approve ignored builds when invoked with a commands map', async () => {
   prepareEmpty()
 

--- a/exec/commands/tsconfig.json
+++ b/exec/commands/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../../bins/resolver"
     },
     {
+      "path": "../../building/commands"
+    },
+    {
       "path": "../../catalogs/resolver"
     },
     {

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -353,7 +353,7 @@ export type InstallCommandOptions = Pick<Config,
   includeOnlyPackageFiles?: boolean
   confirmModulesPurge?: boolean
   pnpmfile: string[]
-} & Partial<Pick<Config, 'ci' | 'modulesCacheMaxAge' | 'pnpmHomeDir' | 'preferWorkspacePackages' | 'useLockfile' | 'symlink'>>
+} & Partial<Pick<Config, 'ci' | 'modulesCacheMaxAge' | 'pnpmHomeDir' | 'preferWorkspacePackages' | 'strictDepBuilds' | 'useLockfile' | 'symlink'>>
 
 export async function handler (opts: InstallCommandOptions & { _calledFromLink?: boolean }, _params?: string[], commands?: CommandHandlerMap): Promise<void> {
   if (opts.global && !opts._calledFromLink) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4252,6 +4252,9 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.3.0
+      '@pnpm/building.commands':
+        specifier: workspace:*
+        version: link:../../building/commands
       '@pnpm/engine.runtime.system-node-version':
         specifier: workspace:*
         version: link:../../engine/runtime/system-node-version

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4140,6 +4140,9 @@ importers:
       '@pnpm/bins.resolver':
         specifier: workspace:*
         version: link:../../bins/resolver
+      '@pnpm/building.commands':
+        specifier: workspace:*
+        version: link:../../building/commands
       '@pnpm/catalogs.resolver':
         specifier: workspace:*
         version: link:../../catalogs/resolver
@@ -4252,9 +4255,6 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.3.0
-      '@pnpm/building.commands':
-        specifier: workspace:*
-        version: link:../../building/commands
       '@pnpm/engine.runtime.system-node-version':
         specifier: workspace:*
         version: link:../../engine/runtime/system-node-version


### PR DESCRIPTION
## Summary

`pnpm dlx` (and `pnpx`/`pnx`/`pnpm create`) now mirrors the `pnpm add -g` flow when the launched package's transitive deps have install scripts:

- dlx overrides `strictDepBuilds: false` for its install so the v11 default no longer turns ignored builds into an `ERR_PNPM_IGNORED_BUILDS` error. Without this, `pnpx @google/gemini-cli` (and similar — `node-pty`, `@github/keytar`) failed outright and forced users to retry with `--allow-build=<pkg>` for every offending dependency.
- After install, dlx detects skipped builds via `getAutomaticallyIgnoredBuilds` and runs the same interactive `approve-builds` prompt as `pnpm add -g`. In non-interactive mode the install is committed with builds skipped, matching `pnpm add -g` in CI; users who need those scripts can re-invoke with `--allow-build=<pkg>` to force a fresh cache key.
- If the install errors for unrelated reasons (network, etc.) the partially-populated prepare directory is removed so the next dlx run starts clean.

Closes #11444.

### Plumbing

- Exports `getAutomaticallyIgnoredBuilds` from `@pnpm/building.commands` so dlx can detect skipped builds without re-implementing modules-yaml reading.
- Adds `strictDepBuilds` (optional) to `InstallCommandOptions` — already accepted at runtime via the spread, this just makes it explicit at the type level so callers can override it.

## Test plan

- [x] Two new regression tests in `exec/commands/test/dlx.e2e.ts`:
  - non-interactive dlx no longer errors on ignored builds and the cache is populated
  - dlx runs `approve-builds` and the build artifacts end up in the dlx cache when invoked with a commands map and `PNPM_AUTO_APPROVE_BUILDS_FOR_TESTS=1`
- [x] Existing `@pnpm/exec.commands` dlx e2e tests continue to pass
- [x] `@pnpm/exec.commands` create tests updated to assert the new third (`commands`) argument forwarded from `create.handler` to `dlx.handler`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm dlx` (including `pnpx`, `pnx`, and `pnpm create`) now uses an interactive prompt to approve package builds when transitive dependencies contain install scripts, consistent with `pnpm add -g` behavior.

* **Bug Fixes**
  * `pnpm dlx` now cleans up partially populated cache directories when installation fails, preventing reuse of broken installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->