### PR TITLE
fix(self-update): swap to pnpm package on Intel Mac when upgrading to v11+

### DIFF
--- a/.changeset/v10-self-update-darwin-x64-to-pnpm-js.md
+++ b/.changeset/v10-self-update-darwin-x64-to-pnpm-js.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tools.plugin-commands-self-updater": patch
+"pnpm": patch
+---
+
+When self-updating from v10's `@pnpm/exe` to v11+ on Intel macOS (darwin-x64), `pnpm self-update` now transparently switches to the JS-only `pnpm` package on npm instead of installing `@pnpm/exe@v11+` (which doesn't ship a working binary for Intel Macs because of an upstream Node.js SEA bug — see [#11423](https://github.com/pnpm/pnpm/issues/11423) and [nodejs/node#62893](https://github.com/nodejs/node/issues/62893)). Without this, the self-update would silently leave the user with no working `pnpm` binary. The new install requires Node.js to be available on `PATH`; a warning is printed when the swap happens. All other host/version combinations are unchanged.

--- a/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
+++ b/tools/plugin-commands-self-updater/src/installPnpmToTools.ts
@@ -2,9 +2,11 @@ import fs from 'fs'
 import path from 'path'
 import { getCurrentPackageName } from '@pnpm/cli-meta'
 import { runPnpmCli } from '@pnpm/exec.pnpm-cli-runner'
+import { globalWarn } from '@pnpm/logger'
 import { getToolDirPath } from '@pnpm/tools.path'
 import { sync as rimraf } from '@zkochan/rimraf'
 import { fastPathTemp as pathTemp } from 'path-temp'
+import semver from 'semver'
 import symlinkDir from 'symlink-dir'
 import { type SelfUpdateCommandOptions } from './selfUpdate.js'
 
@@ -16,10 +18,30 @@ export interface InstallPnpmToToolsResult {
 
 export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateCommandOptions): Promise<InstallPnpmToToolsResult> {
   const currentPkgName = getCurrentPackageName()
+  // pnpm v11 dropped the darwin-x64 artifact from @pnpm/exe because Node.js
+  // SEA injection produces a binary that segfaults at startup on Intel Macs
+  // (pnpm/pnpm#11423, upstream nodejs/node#62893). Self-updating a v10
+  // @pnpm/exe install to v11+ on Intel Mac would leave the user with no
+  // working binary. Transparently swap to the JS-only `pnpm` package, which
+  // runs against the user's system Node.js — typically already present
+  // because v10 @pnpm/exe users tend to manage Node via `pnpm env use`.
+  const targetPkgName = (
+    currentPkgName === '@pnpm/exe' &&
+    process.platform === 'darwin' &&
+    process.arch === 'x64' &&
+    semver.major(pnpmVersion) >= 11
+  )
+    ? 'pnpm'
+    : currentPkgName
+  if (targetPkgName !== currentPkgName) {
+    globalWarn(
+      `Switching from @pnpm/exe to the "pnpm" npm package because @pnpm/exe v${pnpmVersion} no longer ships a binary for Intel macOS (darwin-x64). The new "pnpm" install requires Node.js to be available on PATH. See https://github.com/pnpm/pnpm/issues/11423.`
+    )
+  }
   const dir = getToolDirPath({
     pnpmHomeDir: opts.pnpmHomeDir,
     tool: {
-      name: currentPkgName,
+      name: targetPkgName,
       version: pnpmVersion,
     },
   })
@@ -44,7 +66,7 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
     // Instead, we link the platform-specific binary in-process after install.
     runPnpmCli([
       'add',
-      `${currentPkgName}@${pnpmVersion}`,
+      `${targetPkgName}@${pnpmVersion}`,
       '--loglevel=error',
       '--ignore-scripts',
       '--config.strict-dep-builds=false',
@@ -73,7 +95,7 @@ export async function installPnpmToTools (pnpmVersion: string, opts: SelfUpdateC
         pnpm_config_pm_on_fail: 'ignore',
       },
     })
-    if (currentPkgName === '@pnpm/exe') {
+    if (targetPkgName === '@pnpm/exe') {
       linkExePlatformBinary(stage)
     }
     // We need the operation of installing pnpm to be atomic.


### PR DESCRIPTION
## Summary

v10 backport companion to #11455 (which drops `darwin-x64` from `@pnpm/exe` in v11).

When a v10 user on Intel macOS runs `pnpm self-update` and resolves a v11+ target, today's behavior would be:

1. `installPnpmToTools` resolves `@pnpm/exe@11.x` from the registry.
2. The v11 manifest no longer lists `@pnpm/macos-x64` in `optionalDependencies` (per #11455), so no platform binary is installed.
3. `linkExePlatformBinary` early-returns silently because `node_modules/@pnpm/macos-x64/pnpm` doesn't exist.
4. `linkBins` runs but there's nothing useful to link — the user is left with no working `pnpm`.

This PR teaches v10's `installPnpmToTools` to detect that exact scenario (current pkg is `@pnpm/exe`, host is `darwin-x64`, target version is v11+) and transparently swap the install target from `@pnpm/exe` to the JS-only `pnpm` npm package. The `pnpm` package runs against the user's system Node.js, which on Intel Mac is the only path that still works.

## Changes

`tools/plugin-commands-self-updater/src/installPnpmToTools.ts`:

- Added `targetPkgName` derived from `currentPkgName` plus the host/version check. Threaded through `getToolDirPath` (so the install lives under the right tool dir), the `pnpm add` command, and the `linkExePlatformBinary` guard (skipped when not installing `@pnpm/exe`).
- `globalWarn` printed when the swap happens, calling out that the new install requires Node.js on `PATH` and pointing at #11423.
- Added `semver` and `@pnpm/logger` imports (both already in `dependencies` / `peerDependencies`).

Plus a changeset.

## What this is and isn't

- **Is**: a one-shot migration path for existing v10 `@pnpm/exe` Intel-Mac users so they're not left with a broken bin shim after `pnpm self-update`. Future self-updates from the v11 `pnpm` package go through v11's own self-updater (which doesn't need this branch — it'll naturally re-install `pnpm`).
- **Is not**: a fallback for users without Node.js on `PATH`. If they self-update and don't have Node available, the new bin shim will fail at the next invocation — but the alternative (silently leaving them with a broken `@pnpm/exe`) is strictly worse, and the warning at swap time tells them what's needed. v10 `@pnpm/exe` users typically already manage Node through `pnpm env use`, so this should be uncommon.

## Compat

- Linux / Windows / Apple Silicon Mac users: no change. The condition is `currentPkgName === '@pnpm/exe' && process.platform === 'darwin' && process.arch === 'x64' && semver.major(pnpmVersion) >= 11`.
- Intel Mac on `pnpm self-update 10.x` (any v10 patch): no swap, install proceeds as before.
- Intel Mac on `pnpm self-update` (no version → resolves `latest`, currently v11+): swap fires, warning printed, JS pnpm installed.
- Intel Mac on `pnpm self-update 11.0.5` (explicit v11): swap fires.

## Test plan

- [x] `pnpm test` for `@pnpm/tools.plugin-commands-self-updater` — all 7 existing tests pass (the swap branch isn't triggered because the existing tests mock `packageManager` as `pnpm@9.0.0`).
- [x] `pnpm run spellcheck` clean.
- [x] `pnpm run compile` clean.
- [ ] Manual verification on Intel Mac (no hardware available locally) — would appreciate a maintainer running `PNPM_VERSION=11.0.5 pnpm self-update` from a v10 `@pnpm/exe` install and confirming it produces a working `pnpm` shim.

## References

- Companion PR (v11): #11455
- Issue: #11423
- Upstream Node: nodejs/node#62893, nodejs/node#59553, nodejs/node#60250