### PR TITLE
fix(publish): retry on transient 409 Conflict from registry

### DIFF
--- a/.changeset/publish-retry-transient-conflict.md
+++ b/.changeset/publish-retry-transient-conflict.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+`pnpm publish` now automatically retries with exponential backoff when the npm registry responds with a transient `409 Conflict` ("Failed to save packument."). This error happens when a publish is attempted while a previous write for the same package is still being processed by the registry — for example, when running `pnpm publish` shortly after `pnpm publish --dry-run` [#11454](https://github.com/pnpm/pnpm/issues/11454).

--- a/.changeset/publish-retry-transient-conflict.md
+++ b/.changeset/publish-retry-transient-conflict.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm publish` now automatically retries with exponential backoff when the npm registry responds with a transient `409 Conflict` ("Failed to save packument."). This error happens when a publish is attempted while a previous write for the same package is still being processed by the registry — for example, when running `pnpm publish` shortly after `pnpm publish --dry-run` [#11454](https://github.com/pnpm/pnpm/issues/11454).
+`pnpm publish` now automatically retries with exponential backoff when the npm registry responds with a transient `409 Conflict` ("Failed to save packument."). The registry returns this when a publish lands while a previous write for the same package is still being processed [#11454](https://github.com/pnpm/pnpm/issues/11454).

--- a/releasing/commands/src/publish/otp.ts
+++ b/releasing/commands/src/publish/otp.ts
@@ -6,6 +6,7 @@ import {
 import type { ExportedManifest } from '@pnpm/releasing.exportable-manifest'
 import type { PublishOptions } from 'libnpmpublish'
 
+import { retryOnTransientConflict } from './retryOnTransientConflict.js'
 import { SHARED_CONTEXT } from './utils/shared-context.js'
 
 export interface OtpPublishResponse {
@@ -59,6 +60,13 @@ export async function publishWithOtpHandling ({
     timeout: publishOptions.timeout,
   }
 
+  const retryConfig = {
+    factor: publishOptions.fetchRetryFactor,
+    maxTimeout: publishOptions.fetchRetryMaxtimeout,
+    minTimeout: publishOptions.fetchRetryMintimeout,
+    retries: publishOptions.fetchRetries,
+  }
+
   return withOtpHandling({
     context,
     fetchOptions,
@@ -66,6 +74,10 @@ export async function publishWithOtpHandling ({
     // otp: undefined to the options. This is safe because libnpmpublish treats
     // undefined the same as absent (unlike HTTP headers, where undefined gets
     // coerced to the string "undefined").
-    operation: otp => publish(manifest, tarballData, { ...publishOptions, otp }),
+    operation: otp => retryOnTransientConflict({
+      context,
+      config: retryConfig,
+      operation: () => publish(manifest, tarballData, { ...publishOptions, otp }),
+    }),
   })
 }

--- a/releasing/commands/src/publish/retryOnTransientConflict.ts
+++ b/releasing/commands/src/publish/retryOnTransientConflict.ts
@@ -1,0 +1,64 @@
+export interface TransientConflictRetryContext {
+  setTimeout: (cb: () => void, ms: number) => void
+  globalInfo: (message: string) => void
+}
+
+export interface TransientConflictRetryConfig {
+  retries?: number
+  factor?: number
+  minTimeout?: number
+  maxTimeout?: number
+}
+
+export interface RetryOnTransientConflictParams<T> {
+  context: TransientConflictRetryContext
+  config?: TransientConflictRetryConfig
+  operation: () => Promise<T>
+}
+
+const DEFAULT_RETRIES = 2
+const DEFAULT_FACTOR = 10
+const DEFAULT_MIN_TIMEOUT = 10_000
+const DEFAULT_MAX_TIMEOUT = 60_000
+
+/**
+ * Retries the operation when the npm registry responds with a transient
+ * 409 Conflict ("Failed to save packument"). The npm registry returns this
+ * error when a publish lands while a previous write for the same package
+ * is still being processed; waiting briefly and retrying typically resolves it.
+ */
+export async function retryOnTransientConflict<T> ({
+  context,
+  config,
+  operation,
+}: RetryOnTransientConflictParams<T>): Promise<T> {
+  const retries = config?.retries ?? DEFAULT_RETRIES
+  const factor = config?.factor ?? DEFAULT_FACTOR
+  const minTimeout = config?.minTimeout ?? DEFAULT_MIN_TIMEOUT
+  const maxTimeout = config?.maxTimeout ?? DEFAULT_MAX_TIMEOUT
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await operation() // eslint-disable-line no-await-in-loop
+    } catch (error) {
+      if (!isTransientPublishConflict(error) || attempt >= retries) throw error
+      const delay = Math.min(maxTimeout, minTimeout * Math.pow(factor, attempt))
+      context.globalInfo(
+        `The npm registry returned a transient 409 Conflict (the previous publish has not finished processing). Retrying in ${Math.round(delay / 1000)}s (attempt ${attempt + 1} of ${retries})...`
+      )
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>(resolve => {
+        context.setTimeout(() => {
+          resolve()
+        }, delay)
+      })
+    }
+  }
+}
+
+function isTransientPublishConflict (error: unknown): boolean {
+  if (error == null || typeof error !== 'object') return false
+  if ('statusCode' in error && (error as { statusCode?: unknown }).statusCode === 409) return true
+  if ('code' in error && (error as { code?: unknown }).code === 'E409') return true
+  return false
+}

--- a/releasing/commands/test/publish/otp.test.ts
+++ b/releasing/commands/test/publish/otp.test.ts
@@ -72,6 +72,33 @@ describe('publishWithOtpHandling', () => {
       .rejects.toBe(error)
   })
 
+  it('retries the publish when the registry returns a transient 409 conflict', async () => {
+    let publishCallCount = 0
+    const globalInfo = jest.fn()
+    const context = createMockContext({
+      globalInfo,
+      publish: async () => {
+        publishCallCount++
+        if (publishCallCount === 1) {
+          throw Object.assign(new Error('Failed to save packument.'), {
+            statusCode: 409,
+            code: 'E409',
+          })
+        }
+        return createOkResponse()
+      },
+    })
+    const result = await publishWithOtpHandling({
+      context,
+      manifest,
+      publishOptions: { ...publishOptions, fetchRetries: 2, fetchRetryFactor: 1, fetchRetryMintimeout: 0, fetchRetryMaxtimeout: 0 } as typeof publishOptions,
+      tarballData,
+    })
+    expect(result.ok).toBe(true)
+    expect(publishCallCount).toBe(2)
+    expect(globalInfo).toHaveBeenCalledWith(expect.stringContaining('409 Conflict'))
+  })
+
   it('throws OtpNonInteractiveError when terminal is not interactive', async () => {
     const context = createMockContext({
       process: { stdin: { isTTY: false } },

--- a/releasing/commands/test/publish/retryOnTransientConflict.test.ts
+++ b/releasing/commands/test/publish/retryOnTransientConflict.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, jest, test } from '@jest/globals'
+
+import {
+  retryOnTransientConflict,
+  type TransientConflictRetryContext,
+} from '../../src/publish/retryOnTransientConflict.js'
+
+function createContext (overrides?: Partial<TransientConflictRetryContext>): TransientConflictRetryContext {
+  return {
+    setTimeout: (cb: () => void) => cb(),
+    globalInfo: () => {},
+    ...overrides,
+  }
+}
+
+describe('retryOnTransientConflict', () => {
+  test('returns the result when the operation succeeds on the first attempt', async () => {
+    const operation = jest.fn(async () => 'ok')
+    const result = await retryOnTransientConflict({
+      context: createContext(),
+      operation,
+    })
+    expect(result).toBe('ok')
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  test('retries the operation when a 409 statusCode error is thrown', async () => {
+    let callCount = 0
+    const operation = jest.fn(async () => {
+      callCount++
+      if (callCount < 3) {
+        throw Object.assign(new Error('Conflict'), { statusCode: 409 })
+      }
+      return 'success'
+    })
+    const result = await retryOnTransientConflict({
+      context: createContext(),
+      config: { retries: 5 },
+      operation,
+    })
+    expect(result).toBe('success')
+    expect(operation).toHaveBeenCalledTimes(3)
+  })
+
+  test('retries the operation when an E409 code error is thrown', async () => {
+    let callCount = 0
+    const operation = jest.fn(async () => {
+      callCount++
+      if (callCount === 1) {
+        throw Object.assign(new Error('Conflict'), { code: 'E409' })
+      }
+      return 'success'
+    })
+    const result = await retryOnTransientConflict({
+      context: createContext(),
+      operation,
+    })
+    expect(result).toBe('success')
+    expect(operation).toHaveBeenCalledTimes(2)
+  })
+
+  test('rethrows the 409 error after exhausting retries', async () => {
+    const error = Object.assign(new Error('Conflict'), { statusCode: 409 })
+    const operation = jest.fn(async () => {
+      throw error
+    })
+    await expect(retryOnTransientConflict({
+      context: createContext(),
+      config: { retries: 2 },
+      operation,
+    })).rejects.toBe(error)
+    expect(operation).toHaveBeenCalledTimes(3)
+  })
+
+  test('rethrows non-conflict errors immediately without retrying', async () => {
+    const error = Object.assign(new Error('Server error'), { statusCode: 500 })
+    const operation = jest.fn(async () => {
+      throw error
+    })
+    await expect(retryOnTransientConflict({
+      context: createContext(),
+      operation,
+    })).rejects.toBe(error)
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  test('rethrows plain errors without statusCode immediately', async () => {
+    const error = new Error('Network failure')
+    const operation = jest.fn(async () => {
+      throw error
+    })
+    await expect(retryOnTransientConflict({
+      context: createContext(),
+      operation,
+    })).rejects.toBe(error)
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+
+  test('uses exponential backoff between retries', async () => {
+    const delays: number[] = []
+    let callCount = 0
+    const operation = jest.fn(async () => {
+      callCount++
+      if (callCount < 4) {
+        throw Object.assign(new Error('Conflict'), { statusCode: 409 })
+      }
+      return 'ok'
+    })
+    await retryOnTransientConflict({
+      context: createContext({
+        setTimeout: (cb, ms) => {
+          delays.push(ms)
+          cb()
+        },
+      }),
+      config: { retries: 5, factor: 2, minTimeout: 1000, maxTimeout: 10_000 },
+      operation,
+    })
+    expect(delays).toStrictEqual([1000, 2000, 4000])
+  })
+
+  test('clamps backoff to maxTimeout', async () => {
+    const delays: number[] = []
+    let callCount = 0
+    const operation = jest.fn(async () => {
+      callCount++
+      if (callCount < 4) {
+        throw Object.assign(new Error('Conflict'), { statusCode: 409 })
+      }
+      return 'ok'
+    })
+    await retryOnTransientConflict({
+      context: createContext({
+        setTimeout: (cb, ms) => {
+          delays.push(ms)
+          cb()
+        },
+      }),
+      config: { retries: 5, factor: 10, minTimeout: 5000, maxTimeout: 8000 },
+      operation,
+    })
+    expect(delays).toStrictEqual([5000, 8000, 8000])
+  })
+
+  test('logs informational messages when retrying', async () => {
+    const globalInfo = jest.fn<TransientConflictRetryContext['globalInfo']>()
+    let callCount = 0
+    const operation = async () => {
+      callCount++
+      if (callCount < 2) {
+        throw Object.assign(new Error('Conflict'), { statusCode: 409 })
+      }
+      return 'ok'
+    }
+    await retryOnTransientConflict({
+      context: createContext({ globalInfo }),
+      config: { retries: 3, minTimeout: 1000, factor: 2 },
+      operation,
+    })
+    expect(globalInfo).toHaveBeenCalledTimes(1)
+    expect(globalInfo).toHaveBeenCalledWith(expect.stringContaining('409 Conflict'))
+  })
+
+  test('does not retry when retries is 0', async () => {
+    const error = Object.assign(new Error('Conflict'), { statusCode: 409 })
+    const operation = jest.fn(async () => {
+      throw error
+    })
+    await expect(retryOnTransientConflict({
+      context: createContext(),
+      config: { retries: 0 },
+      operation,
+    })).rejects.toBe(error)
+    expect(operation).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- `pnpm publish` now retries the registry PUT with exponential backoff when the npm registry responds with a 409 Conflict ("Failed to save packument."). The registry's own error message says this happens when "you try to publish a new package before the previous package has been fully processed" and is transient.
- Defaults reuse pnpm's existing `fetchRetry*` config (retries: 2, factor: 10, min/max timeout: 10s/60s), so users who tune those settings get the same behavior here.
- The retry layer sits inside the OTP wrapper so OTP and conflict retries compose cleanly: a 409 after a successful OTP challenge retries the publish without re-prompting.

Fixes #11454. Note: I could not pin down why the reporter sees the 409 specifically after `pnpm publish --dry-run` — pnpm's dry-run path skips the PUT and (outside CI) makes no registry calls at all, so the conflict is most likely incidental to other registry activity around the same package. Either way, retrying the transient 409 makes `pnpm publish` more robust against this class of registry flake.

## Test plan

- [x] \`pnpm --filter @pnpm/releasing.commands test test/publish/retryOnTransientConflict.test.ts\` (10 unit tests for the new helper)
- [x] \`pnpm --filter @pnpm/releasing.commands test test/publish/otp.test.ts\` (15 tests, including a new integration test covering the 409 retry path)
- [x] \`pnpm --filter @pnpm/releasing.commands test test/publish/publish.ts\` and \`recursivePublish.ts\` (existing publish suites still green)
- [x] \`pnpm run lint\` — no new errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `pnpm publish` now automatically retries with exponential backoff when encountering transient npm registry conflicts (409 errors). This improves reliability during publish operations, particularly when registry writes overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->