### PR TITLE
fix: avoid lockfile churn for unrelated transitive deps

### DIFF
--- a/.changeset/fix-transitive-resolution-churn.md
+++ b/.changeset/fix-transitive-resolution-churn.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fix unrelated lockfile churn for transitive dependencies. Previously, adding a new dependency that transitively pulled in a different version of a package already present in the lockfile could cause unrelated transitive references to that package to flip to the new version, even when the existing resolution still satisfied the wanted range. Re-resolution is now only forced for transitive dependencies whose alias was directly added/changed at the importer level [#11456](https://github.com/pnpm/pnpm/issues/11456).

--- a/installing/deps-installer/test/install/dedupe.ts
+++ b/installing/deps-installer/test/install/dedupe.ts
@@ -213,3 +213,30 @@ test('when resolving dependencies, prefer versions that are used by direct depen
   const lockfile = project.readLockfile()
   expect(lockfile.snapshots['@pnpm.e2e/has-foo-100.0.0-range-dep@1.0.0']).toHaveProperty(['dependencies', '@pnpm.e2e/foo'], '100.0.0')
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/11456
+test('preserve existing transitive resolution when an unrelated direct dep introduces a new version of the same package', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  // @pnpm.e2e/has-foo-as-dep-and-subdep -> @pnpm.e2e/requires-any-foo -> @pnpm.e2e/foo: "*"
+  // After the initial install, requires-any-foo's transitive foo is locked to 100.0.0.
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/has-foo-as-dep-and-subdep'],
+    testDefaults()
+  )
+
+  let lockfile = project.readLockfile()
+  expect(lockfile.snapshots['@pnpm.e2e/requires-any-foo@1.0.0'])
+    .toHaveProperty(['dependencies', '@pnpm.e2e/foo'], '100.0.0')
+
+  // Add an unrelated direct dep whose own subdep pins @pnpm.e2e/foo to 100.1.0.
+  // The new version satisfies requires-any-foo's "*" range, but the existing
+  // 100.0.0 resolution is still valid and should not be replaced.
+  await addDependenciesToPackage(manifest, ['@pnpm.e2e/has-foo-100.1.0-dep-1'], testDefaults())
+
+  lockfile = project.readLockfile()
+  expect(lockfile.snapshots['@pnpm.e2e/requires-any-foo@1.0.0'])
+    .toHaveProperty(['dependencies', '@pnpm.e2e/foo'], '100.0.0')
+})

--- a/installing/deps-installer/test/install/dedupe.ts
+++ b/installing/deps-installer/test/install/dedupe.ts
@@ -237,6 +237,11 @@ test('preserve existing transitive resolution when an unrelated direct dep intro
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/has-foo-100.1.0-dep-1'], testDefaults())
 
   lockfile = project.readLockfile()
+  // Sanity-check that the competing branch was actually introduced.
+  // Without this, the assertion below could pass even if the test fixture
+  // ever stops pulling in @pnpm.e2e/foo@100.1.0.
+  expect(lockfile.snapshots['@pnpm.e2e/has-foo-100.1.0-dep-1@1.0.0'])
+    .toHaveProperty(['dependencies', '@pnpm.e2e/foo'], '100.1.0')
   expect(lockfile.snapshots['@pnpm.e2e/requires-any-foo@1.0.0'])
     .toHaveProperty(['dependencies', '@pnpm.e2e/foo'], '100.0.0')
 })

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -701,7 +701,11 @@ export async function resolveDependencies (
     if (currentParentPkgAliases[pkgAddress.alias] !== true) {
       currentParentPkgAliases[pkgAddress.alias] = pkgAddress
     }
-    if (pkgAddress.updated) {
+    // Only mark direct dependencies as updated. Marking transitive dependencies
+    // here would force re-resolution of unrelated transitive references to the
+    // same package, churning the lockfile when the previous resolution was
+    // still valid (see issue #11456).
+    if (pkgAddress.updated && options.currentDepth === 0) {
       ctx.updatedSet.add(pkgAddress.alias)
     }
     const resolvedPackage = ctx.resolvedPkgsById[pkgAddress.pkgId]


### PR DESCRIPTION
## Summary

- Stop adding freshly-resolved **transitive** packages to `ctx.updatedSet` in `resolveDependencies` (recursive). The set is meant to drive transitive dedupe of **user-requested** updates (the original goal of #3877), but populating it from any depth caused unrelated transitive references to flip to the newly resolved version whenever a different importer dep happened to introduce a new version of the same package.
- The flag is now only set at importer level (`currentDepth === 0`), which preserves the explicit-upgrade dedupe behavior while leaving valid transitive resolutions untouched.

Closes #11456.

## Test plan

- [x] Added a regression test in `installing/deps-installer/test/install/dedupe.ts` covering the scenario where adding an unrelated direct dep should not flip an existing transitive resolution.
- [x] All 11 dedupe tests pass.
- [x] Reproduced the original issue against the pnpm monorepo before the fix; with the fix applied, `pnpm install` no longer flips `wide-align@1.1.5`'s `string-width` from `1.0.2` to `4.2.3` when an unrelated workspace package is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced lockfile churn by preventing unnecessary re-resolution of transitive dependencies when adding unrelated new dependencies. Existing locked transitive resolutions that still satisfy requested ranges are preserved, so adding new top-level packages no longer flips unrelated transitive versions and produces a cleaner, more stable lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->