### PR TITLE
fix(self-update): do not downgrade when latest dist-tag is older (v10)

### DIFF
--- a/.changeset/v10-self-update-no-downgrade.md
+++ b/.changeset/v10-self-update-no-downgrade.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/tools.plugin-commands-self-updater": patch
+"pnpm": patch
+---
+
+`pnpm self-update` (with no version argument) no longer downgrades pnpm when the registry's `latest` dist-tag points to an older release than the currently active version. Run `pnpm self-update latest` to force a downgrade [#11418](https://github.com/pnpm/pnpm/issues/11418).

--- a/tools/plugin-commands-self-updater/src/selfUpdate.ts
+++ b/tools/plugin-commands-self-updater/src/selfUpdate.ts
@@ -69,6 +69,12 @@ export async function handler (
   }
   const { resolve } = createResolver({ ...opts, authConfig: opts.rawConfig })
   const pkgName = 'pnpm'
+  // `pnpm self-update` (no args) defaults to the `latest` dist-tag, but we
+  // refuse to downgrade in that case — `latest` on the registry can lag the
+  // installed version when a new major has shipped without being tagged.
+  // `pnpm self-update latest` (explicit) bypasses the guard so users can
+  // still force a downgrade when they want one.
+  const isImplicitLatest = params.length === 0
   const bareSpecifier = params[0] ?? 'latest'
   const resolution = await resolve({ alias: pkgName, bareSpecifier }, {
     lockfileDir: opts.lockfileDir ?? opts.dir,
@@ -105,6 +111,10 @@ export async function handler (
 
   if (opts.wantedPackageManager?.name === packageManager.name && opts.managePackageManagerVersions) {
     if (opts.wantedPackageManager?.version !== resolution.manifest.version) {
+      const pinnedVersion = opts.wantedPackageManager.version
+      if (isImplicitLatest && pinnedVersion != null && semver.lt(resolution.manifest.version, pinnedVersion)) {
+        return `The current project is set to use pnpm v${pinnedVersion}, which is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
+      }
       const { manifest, writeProjectManifest } = await readProjectManifest(opts.rootProjectManifestDir)
       manifest.packageManager = `pnpm@${resolution.manifest.version}`
       await writeProjectManifest(manifest)
@@ -115,6 +125,9 @@ export async function handler (
   }
   if (resolution.manifest.version === packageManager.version) {
     return `The currently active ${packageManager.name} v${packageManager.version} is already "${bareSpecifier}" and doesn't need an update`
+  }
+  if (isImplicitLatest && semver.lt(resolution.manifest.version, packageManager.version)) {
+    return `The currently active ${packageManager.name} v${packageManager.version} is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
   }
 
   const { baseDir, alreadyExisted } = await installPnpmToTools(resolution.manifest.version, opts)

--- a/tools/plugin-commands-self-updater/test/selfUpdate.test.ts
+++ b/tools/plugin-commands-self-updater/test/selfUpdate.test.ts
@@ -146,6 +146,81 @@ test('self-update does nothing when pnpm is up to date', async () => {
   expect(output).toBe('The currently active pnpm v9.0.0 is already "latest" and doesn\'t need an update')
 })
 
+test('self-update refuses to downgrade when latest is older than current', async () => {
+  const opts = prepare()
+  nock(opts.registries.default)
+    .get('/pnpm')
+    .reply(200, createMetadata('8.15.0', opts.registries.default))
+
+  const output = await selfUpdate.handler(opts, [])
+
+  expect(output).toBe('The currently active pnpm v9.0.0 is newer than the "latest" version on the registry (v8.15.0). No update performed. Run "pnpm self-update latest" to downgrade.')
+  // No tools dir should have been created.
+  expect(fs.existsSync(path.join(opts.pnpmHomeDir, '.tools'))).toBe(false)
+})
+
+test('self-update latest forces the downgrade even when latest is older', async () => {
+  const opts = prepare()
+  nock(opts.registries.default)
+    .get('/pnpm')
+    .reply(200, createMetadata('8.15.0', opts.registries.default))
+
+  // Pre-stage an existing install at the target version so the handler links it
+  // instead of running a real `pnpm add`. We only care that the install/link
+  // path was reached, not the resulting binary.
+  const baseDir = path.join(opts.pnpmHomeDir, '.tools/pnpm/8.15.0')
+  fs.mkdirSync(path.join(baseDir, 'bin'), { recursive: true })
+  const targetPnpmDir = path.join(baseDir, 'node_modules/pnpm')
+  fs.mkdirSync(targetPnpmDir, { recursive: true })
+  fs.writeFileSync(path.join(targetPnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', bin: 'bin.js' }), 'utf8')
+  fs.writeFileSync(path.join(targetPnpmDir, 'bin.js'), '#!/usr/bin/env node\n', 'utf8')
+
+  const output = await selfUpdate.handler(opts, ['latest'])
+
+  expect(output).toBe(`The latest version, v8.15.0, is already present on the system. It was activated by linking it from ${baseDir}.`)
+})
+
+test('self-update by exact older version skips the no-downgrade guard', async () => {
+  const opts = prepare()
+  nock(opts.registries.default)
+    .get('/pnpm')
+    .reply(200, createMetadata('8.15.0', opts.registries.default))
+
+  const baseDir = path.join(opts.pnpmHomeDir, '.tools/pnpm/8.15.0')
+  fs.mkdirSync(path.join(baseDir, 'bin'), { recursive: true })
+  const targetPnpmDir = path.join(baseDir, 'node_modules/pnpm')
+  fs.mkdirSync(targetPnpmDir, { recursive: true })
+  fs.writeFileSync(path.join(targetPnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', bin: 'bin.js' }), 'utf8')
+  fs.writeFileSync(path.join(targetPnpmDir, 'bin.js'), '#!/usr/bin/env node\n', 'utf8')
+
+  const output = await selfUpdate.handler(opts, ['8.15.0'])
+
+  expect(output).toBe(`The 8.15.0 version, v8.15.0, is already present on the system. It was activated by linking it from ${baseDir}.`)
+})
+
+test('self-update refuses to downgrade the project pin when latest is older', async () => {
+  const opts = prepare()
+  const pkgJsonPath = path.join(opts.dir, 'package.json')
+  fs.writeFileSync(pkgJsonPath, JSON.stringify({
+    packageManager: 'pnpm@10.0.0',
+  }), 'utf8')
+  nock(opts.registries.default)
+    .get('/pnpm')
+    .reply(200, createMetadata('9.5.0', opts.registries.default))
+
+  const output = await selfUpdate.handler({
+    ...opts,
+    managePackageManagerVersions: true,
+    wantedPackageManager: {
+      name: 'pnpm',
+      version: '10.0.0',
+    },
+  }, [])
+
+  expect(output).toBe('The current project is set to use pnpm v10.0.0, which is newer than the "latest" version on the registry (v9.5.0). No update performed. Run "pnpm self-update latest" to downgrade.')
+  expect(JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).packageManager).toBe('pnpm@10.0.0')
+})
+
 test('should update packageManager field when a newer pnpm version is available', async () => {
   const opts = prepare()
   const pkgJsonPath = path.join(opts.dir, 'package.json')


### PR DESCRIPTION
Backport of #11435 to v10.

## Summary

- `pnpm self-update` (with no version arg) defaults to the `latest` dist-tag, but `latest` on the registry can lag the installed version when a new major has shipped without being tagged. In that case, the command silently downgraded users to the older release.
- The handler now refuses to downgrade when implicit `latest` resolves to a version older than the currently active pnpm — both for the global path (compared against the running binary) and the project-pin path (compared against `wantedPackageManager.version`).
- An explicit `pnpm self-update latest` (or any explicit version/tag) still updates as before, so the downgrade can be forced when intentional.
- v10's project pin always carries an exact `packageManager` version, so the v11 lockfile/range fallback isn't needed here.

Closes #11418.

## Test plan

- [x] `pnpm --filter @pnpm/tools.plugin-commands-self-updater run compile` passes
- [x] `NODE_OPTIONS="--experimental-vm-modules" npx jest selfUpdate` — 11/11 tests pass, including 4 new cases (implicit latest refuses downgrade globally, explicit `latest` forces it, explicit older version skips the guard, project pin refuses downgrade)