### PR TITLE
fix(lockfile.pruner): handle inline {specifier, version} dependency entries

### DIFF
--- a/.changeset/lockfile-pruner-inline-specifiers.md
+++ b/.changeset/lockfile-pruner-inline-specifiers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.pruner": patch
+"pnpm": patch
+---
+
+Fixed `pruneLockfile()` and `pruneSharedLockfile()` in `@pnpm/lockfile.pruner` throwing `TypeError: reference.startsWith is not a function` when an importer's dependency entries used the inline `{ specifier, version }` shape from lockfile v9 [#10126](https://github.com/pnpm/pnpm/issues/10126).

--- a/lockfile/pruner/src/index.ts
+++ b/lockfile/pruner/src/index.ts
@@ -13,6 +13,9 @@ export * from '@pnpm/lockfile.types'
 
 // cannot import DependenciesGraph from @pnpm/installing.deps-resolver due to circular dependency
 type DependenciesGraph = Record<DepPath, { optional?: boolean }>
+type InlineSpecifierAndResolution = { specifier?: string, version: string }
+type DependencyReference = string | InlineSpecifierAndResolution
+type ResolvedDependenciesWithInlineSpecifiers = Record<string, DependencyReference>
 
 export function pruneSharedLockfile (
   lockfile: LockfileObject,
@@ -65,26 +68,39 @@ export function pruneLockfile (
   const lockfileOptionalDependencies: ResolvedDependencies = {}
   const lockfileDevDependencies: ResolvedDependencies = {}
 
-  for (const depName in lockfileSpecs) {
+  const lockfileDepNames = new Set([
+    ...Object.keys(lockfileSpecs),
+    ...Object.keys(importer.dependencies ?? {}),
+    ...Object.keys(importer.optionalDependencies ?? {}),
+    ...Object.keys(importer.devDependencies ?? {}),
+  ])
+  for (const depName of lockfileDepNames) {
     if (!allDeps.has(depName)) continue
-    specifiers[depName] = lockfileSpecs[depName]
+    const specifier = lockfileSpecs[depName] ?? getDependencySpecifier(importer.dependencies?.[depName])
+      ?? getDependencySpecifier(importer.optionalDependencies?.[depName])
+      ?? getDependencySpecifier(importer.devDependencies?.[depName])
+    if (specifier != null) {
+      specifiers[depName] = specifier
+    }
     if (importer.dependencies?.[depName]) {
-      lockfileDependencies[depName] = importer.dependencies[depName]
+      lockfileDependencies[depName] = getDependencyReference(importer.dependencies[depName])
     } else if (importer.optionalDependencies?.[depName]) {
-      lockfileOptionalDependencies[depName] = importer.optionalDependencies[depName]
+      lockfileOptionalDependencies[depName] = getDependencyReference(importer.optionalDependencies[depName])
     } else if (importer.devDependencies?.[depName]) {
-      lockfileDevDependencies[depName] = importer.devDependencies[depName]
+      lockfileDevDependencies[depName] = getDependencyReference(importer.devDependencies[depName])
     }
   }
   if (importer.dependencies != null) {
-    for (const [alias, dep] of Object.entries(importer.dependencies)) {
+    for (const [alias, dep] of Object.entries(importer.dependencies) as Array<[string, DependencyReference]>) {
+      const reference = getDependencyReference(dep)
+      const specifier = lockfileSpecs[alias] ?? getDependencySpecifier(dep)
       if (
-        !lockfileDependencies[alias] && dep.startsWith('link:') &&
+        !lockfileDependencies[alias] && reference.startsWith('link:') &&
         // If the linked dependency was removed from package.json
         // then it is removed from pnpm-lock.yaml as well
-        !(lockfileSpecs[alias] && !allDeps.has(alias))
+        !(specifier && !allDeps.has(alias))
       ) {
-        lockfileDependencies[alias] = dep
+        lockfileDependencies[alias] = reference
       }
     }
   }
@@ -152,9 +168,17 @@ function copyPackageSnapshots (
 }
 
 function resolvedDepsToDepPaths (deps: ResolvedDependencies): DepPath[] {
-  return Object.entries(deps)
-    .map(([alias, ref]) => refToRelative(ref, alias))
+  return Object.entries(deps as ResolvedDependenciesWithInlineSpecifiers)
+    .map(([alias, ref]) => refToRelative(getDependencyReference(ref), alias))
     .filter((depPath) => depPath !== null) as DepPath[]
+}
+
+function getDependencyReference (dependency: DependencyReference): string {
+  return typeof dependency === 'string' ? dependency : dependency.version
+}
+
+function getDependencySpecifier (dependency: DependencyReference | undefined): string | undefined {
+  return typeof dependency === 'string' ? undefined : dependency?.specifier
 }
 
 function copyDependencySubGraph (

--- a/lockfile/pruner/src/index.ts
+++ b/lockfile/pruner/src/index.ts
@@ -5,6 +5,7 @@ import type {
   PackageSnapshots,
   ProjectSnapshot,
   ResolvedDependencies,
+  SpecifierAndResolution,
 } from '@pnpm/lockfile.types'
 import type { DepPath, PackageManifest, ProjectId } from '@pnpm/types'
 import { difference, isEmpty, unnest } from 'ramda'
@@ -13,8 +14,7 @@ export * from '@pnpm/lockfile.types'
 
 // cannot import DependenciesGraph from @pnpm/installing.deps-resolver due to circular dependency
 type DependenciesGraph = Record<DepPath, { optional?: boolean }>
-type InlineSpecifierAndResolution = { specifier?: string, version: string }
-type DependencyReference = string | InlineSpecifierAndResolution
+type DependencyReference = string | SpecifierAndResolution
 type ResolvedDependenciesWithInlineSpecifiers = Record<string, DependencyReference>
 
 export function pruneSharedLockfile (
@@ -167,8 +167,8 @@ function copyPackageSnapshots (
   return copiedSnapshots
 }
 
-function resolvedDepsToDepPaths (deps: ResolvedDependencies): DepPath[] {
-  return Object.entries(deps as ResolvedDependenciesWithInlineSpecifiers)
+function resolvedDepsToDepPaths (deps: ResolvedDependenciesWithInlineSpecifiers): DepPath[] {
+  return Object.entries(deps)
     .map(([alias, ref]) => refToRelative(getDependencyReference(ref), alias))
     .filter((depPath) => depPath !== null) as DepPath[]
 }

--- a/lockfile/pruner/test/index.ts
+++ b/lockfile/pruner/test/index.ts
@@ -938,3 +938,56 @@ test('pruneSharedLockfile: remove one redundant package', () => {
     },
   })
 })
+
+test('pruneSharedLockfile: handles inline {specifier, version} importer entries', () => {
+  expect(pruneSharedLockfile({
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        specifiers: {
+          foo: '^1.0.0',
+        },
+        dependencies: {
+          foo: {
+            specifier: '^1.0.0',
+            version: '1.0.0',
+          },
+        },
+      },
+    },
+    packages: {
+      ['foo@1.0.0' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+      ['unused@1.0.0' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+    },
+  } as unknown as Parameters<typeof pruneSharedLockfile>[0], DEFAULT_OPTS)).toStrictEqual({
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        specifiers: {
+          foo: '^1.0.0',
+        },
+        dependencies: {
+          foo: {
+            specifier: '^1.0.0',
+            version: '1.0.0',
+          },
+        },
+      },
+    },
+    packages: {
+      'foo@1.0.0': {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+    },
+  })
+})

--- a/lockfile/pruner/test/index.ts
+++ b/lockfile/pruner/test/index.ts
@@ -68,6 +68,101 @@ test('remove one redundant package', () => {
   })
 })
 
+test('prune lockfile with inline dependency specifiers', () => {
+  expect(pruneLockfile({
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: {
+          foo: {
+            specifier: '^1.0.0',
+            version: '1.0.0',
+          },
+        },
+        devDependencies: {
+          bar: {
+            specifier: '^2.0.0',
+            version: '2.0.0',
+          },
+        },
+        optionalDependencies: {
+          qar: {
+            specifier: '^3.0.0',
+            version: '3.0.0',
+          },
+        },
+      },
+    },
+    packages: {
+      ['bar@2.0.0' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+      ['foo@1.0.0' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+      ['qar@3.0.0' as DepPath]: {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+    },
+  } as unknown as Parameters<typeof pruneLockfile>[0], {
+    name: 'fixture',
+    version: '1.0.0',
+    dependencies: {
+      foo: '^1.0.0',
+    },
+    devDependencies: {
+      bar: '^2.0.0',
+    },
+    optionalDependencies: {
+      qar: '^3.0.0',
+    },
+  }, '.' as ProjectId, DEFAULT_OPTS)).toStrictEqual({
+    importers: {
+      '.': {
+        dependencies: {
+          foo: '1.0.0',
+        },
+        devDependencies: {
+          bar: '2.0.0',
+        },
+        optionalDependencies: {
+          qar: '3.0.0',
+        },
+        specifiers: {
+          bar: '^2.0.0',
+          foo: '^1.0.0',
+          qar: '^3.0.0',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+    packages: {
+      'bar@2.0.0': {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+      'foo@1.0.0': {
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+      'qar@3.0.0': {
+        optional: true,
+        resolution: {
+          integrity: 'sha512-placeholder',
+        },
+      },
+    },
+  })
+})
+
 test('remove redundant linked package', () => {
   expect(pruneLockfile({
     importers: {

--- a/lockfile/pruner/test/index.ts
+++ b/lockfile/pruner/test/index.ts
@@ -163,6 +163,41 @@ test('prune lockfile with inline dependency specifiers', () => {
   })
 })
 
+test('keep inline {specifier, version: "link:..."} importer entries', () => {
+  expect(pruneLockfile({
+    lockfileVersion: '9.0',
+    importers: {
+      ['.' as ProjectId]: {
+        dependencies: {
+          foo: {
+            specifier: 'workspace:*',
+            version: 'link:../foo',
+          },
+        },
+      },
+    },
+    packages: {},
+  } as unknown as Parameters<typeof pruneLockfile>[0], {
+    name: 'fixture',
+    version: '1.0.0',
+    dependencies: {
+      foo: 'workspace:*',
+    },
+  }, '.' as ProjectId, DEFAULT_OPTS)).toStrictEqual({
+    importers: {
+      '.': {
+        dependencies: {
+          foo: 'link:../foo',
+        },
+        specifiers: {
+          foo: 'workspace:*',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  })
+})
+
 test('remove redundant linked package', () => {
   expect(pruneLockfile({
     importers: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,7 @@ catalogs:
       version: 2.0.0
     '@pnpm/os.env.path-extender':
       specifier: ^3.0.0
-      version: 3.0.1
+      version: 3.0.0
     '@pnpm/patch-package':
       specifier: 0.0.1
       version: 0.0.1
@@ -546,7 +546,7 @@ catalogs:
       version: 5.0.0
     eslint:
       specifier: ^10.0.3
-      version: 10.4.0
+      version: 10.3.0
     eslint-plugin-import-x:
       specifier: ^4.16.2
       version: 4.16.2
@@ -842,7 +842,7 @@ catalogs:
       specifier: ^0.4.0
       version: 0.4.0
     socks:
-      specifier: ^2.8.1
+      specifier: ^2.8.8
       version: 2.8.9
     sort-keys:
       specifier: ^6.0.0
@@ -1057,10 +1057,10 @@ importers:
         version: 9.7.0
       eslint:
         specifier: 'catalog:'
-        version: 10.4.0(jiti@2.6.1)
+        version: 10.3.0(jiti@2.6.1)
       eslint-plugin-regexp:
         specifier: 'catalog:'
-        version: 3.1.0(eslint@10.4.0(jiti@2.6.1))
+        version: 3.1.0(eslint@10.3.0(jiti@2.6.1))
       husky:
         specifier: 'catalog:'
         version: 9.1.7
@@ -1237,41 +1237,41 @@ importers:
     dependencies:
       '@eslint/js':
         specifier: 'catalog:'
-        version: 10.0.1(eslint@10.4.0(jiti@2.6.1))
+        version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
       '@stylistic/eslint-plugin':
         specifier: 'catalog:'
-        version: 5.10.0(eslint@10.4.0(jiti@2.6.1))
+        version: 5.10.0(eslint@10.3.0(jiti@2.6.1))
       eslint:
         specifier: 'catalog:'
-        version: 10.4.0(jiti@2.6.1)
+        version: 10.3.0(jiti@2.6.1)
       eslint-plugin-import-x:
         specifier: 'catalog:'
-        version: 4.16.2(@typescript-eslint/utils@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))
+        version: 4.16.2(@typescript-eslint/utils@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-n:
         specifier: 'catalog:'
-        version: 17.24.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 17.24.0(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-promise:
         specifier: 'catalog:'
-        version: 7.3.0(eslint@10.4.0(jiti@2.6.1))
+        version: 7.3.0(eslint@10.3.0(jiti@2.6.1))
       eslint-plugin-simple-import-sort:
         specifier: 'catalog:'
-        version: 12.1.1(eslint@10.4.0(jiti@2.6.1))
+        version: 12.1.1(eslint@10.3.0(jiti@2.6.1))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
     devDependencies:
       '@pnpm/eslint-config':
         specifier: workspace:*
         version: 'link:'
       '@typescript-eslint/utils':
         specifier: 'catalog:'
-        version: 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-jest:
         specifier: 'catalog:'
-        version: 29.15.2(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(jest@30.4.2(@babel/types@7.29.0)(@types/node@22.19.19))(typescript@5.9.3)
+        version: 29.15.2(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(jest@30.4.2(@babel/types@7.29.0)(@types/node@22.19.19))(typescript@5.9.3)
 
   __utils__/get-release-text:
     dependencies:
@@ -3924,7 +3924,7 @@ importers:
         version: link:../../../lockfile/types
       '@pnpm/os.env.path-extender':
         specifier: 'catalog:'
-        version: 3.0.1
+        version: 3.0.0
       '@pnpm/resolving.npm-resolver':
         specifier: workspace:*
         version: link:../../../resolving/npm-resolver
@@ -10700,8 +10700,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -11371,16 +11371,16 @@ packages:
     resolution: {integrity: sha512-YTJCXyUGOrJuj4QqhSKqZa1vlVAm82h1/uw00ZmD/kL2OViggtyUwWyIe62kpwWVPwEYixfGjfvaFKVJy2mjzA==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/os.env.path-extender-posix@3.0.1':
-    resolution: {integrity: sha512-HhXeMJGE8rNVY61F2ZI8SWUpVuA+gRAa+qP6W6Gw5kW+CjjaIRf2zvQFiKO39vIyuOqDvBldT1I+8SE37O5USg==}
+  '@pnpm/os.env.path-extender-posix@3.0.0':
+    resolution: {integrity: sha512-541CmvX6CPc/YkLPEiqxXRj9dEd4Bd/LVeL4WZ4WZQaK/R/Rld2pxljoEHtx6bI91z2p+esG2OFOvnaHVyYr2A==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/os.env.path-extender-windows@3.0.1':
-    resolution: {integrity: sha512-waoddXma3zTrMthq0ukFcPJT+CVFmWZqrDcMV2pLS85mxisaTtBXyMGMeP30weIHHz18ouBskSDHCHfUCbNhfA==}
+  '@pnpm/os.env.path-extender-windows@3.0.0':
+    resolution: {integrity: sha512-P2z4D6TnCTfe0CL+p2lgtkOovbJbmb4t5xf1GJ/s3Lptf68HGhqbY5E3z1tg7vT9Hs4WN8kL6fbS+0378VOdYw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/os.env.path-extender@3.0.1':
-    resolution: {integrity: sha512-9Ha+RCotlfzWpwPlmpgd0oDHGMPZaeEBshWfXllhb0DZIP72AZQFR/ZcPKjD7YR4kOdoOmWoY9zdl8eQH7Bx/Q==}
+  '@pnpm/os.env.path-extender@3.0.0':
+    resolution: {integrity: sha512-gNA3d1w8m7JlyXfjurpqZ+SwWq91JVhrUcsNIGh64r/4Nxnq3o+yxUQyxyrBFlL8luW6OcL0cFfYdAkv19n78Q==}
     engines: {node: '>=22.13'}
 
   '@pnpm/package-bins@1000.0.17':
@@ -13570,8 +13570,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.4.0:
-    resolution: {integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==}
+  eslint@10.3.0:
+    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -18397,9 +18397,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0(jiti@2.6.1))':
     dependencies:
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -18412,7 +18412,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.5.5':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -18420,9 +18420,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.4.0(jiti@2.6.1))':
+  '@eslint/js@10.0.1(eslint@10.3.0(jiti@2.6.1))':
     optionalDependencies:
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -19567,21 +19567,21 @@ snapshots:
       '@pnpm/util.lex-comparator': 3.0.2
       sort-keys: 4.2.0
 
-  '@pnpm/os.env.path-extender-posix@3.0.1':
+  '@pnpm/os.env.path-extender-posix@3.0.0':
     dependencies:
       '@pnpm/error': 1000.1.0
 
-  '@pnpm/os.env.path-extender-windows@3.0.1':
+  '@pnpm/os.env.path-extender-windows@3.0.0':
     dependencies:
       '@pnpm/error': 1000.1.0
       safe-execa: 0.1.4
       string.prototype.matchall: 4.0.12
 
-  '@pnpm/os.env.path-extender@3.0.1':
+  '@pnpm/os.env.path-extender@3.0.0':
     dependencies:
       '@pnpm/error': 1000.1.0
-      '@pnpm/os.env.path-extender-posix': 3.0.1
-      '@pnpm/os.env.path-extender-windows': 3.0.1
+      '@pnpm/os.env.path-extender-posix': 3.0.0
+      '@pnpm/os.env.path-extender-windows': 3.0.0
 
   '@pnpm/package-bins@1000.0.17':
     dependencies:
@@ -20150,11 +20150,11 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.4.0(jiti@2.6.1))':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.3.0(jiti@2.6.1))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       '@typescript-eslint/types': 8.59.3
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -20419,15 +20419,15 @@ snapshots:
 
   '@types/yarnpkg__lockfile@1.1.9': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -20435,14 +20435,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -20465,13 +20465,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20494,13 +20494,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -22173,9 +22173,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@10.4.0(jiti@2.6.1)):
+  eslint-compat-utils@0.5.1(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       semver: 7.8.0
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
@@ -22185,20 +22185,20 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-plugin-es-x@7.8.0(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-es-x@7.8.0(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 10.4.0(jiti@2.6.1)
-      eslint-compat-utils: 0.5.1(eslint@10.4.0(jiti@2.6.1))
+      eslint: 10.3.0(jiti@2.6.1)
+      eslint-compat-utils: 0.5.1(eslint@10.3.0(jiti@2.6.1))
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.59.3
       comment-parser: 1.4.6
       debug: 4.4.3
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -22206,27 +22206,27 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(jest@30.4.2(@babel/types@7.29.0)(@types/node@22.19.19))(typescript@5.9.3):
+  eslint-plugin-jest@29.15.2(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(jest@30.4.2(@babel/types@7.29.0)(@types/node@22.19.19))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 10.4.0(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.3.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       jest: 30.4.2(@babel/types@7.29.0)(@types/node@22.19.19)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-n@17.24.0(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       enhanced-resolve: 5.21.3
-      eslint: 10.4.0(jiti@2.6.1)
-      eslint-plugin-es-x: 7.8.0(eslint@10.4.0(jiti@2.6.1))
+      eslint: 10.3.0(jiti@2.6.1)
+      eslint-plugin-es-x: 7.8.0(eslint@10.3.0(jiti@2.6.1))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -22236,25 +22236,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-promise@7.3.0(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-promise@7.3.0(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
-      eslint: 10.4.0(jiti@2.6.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
+      eslint: 10.3.0(jiti@2.6.1)
 
-  eslint-plugin-regexp@3.1.0(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-regexp@3.1.0(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       comment-parser: 1.4.6
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
       jsdoc-type-pratt-parser: 7.2.0
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-simple-import-sort@12.1.1(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-simple-import-sort@12.1.1(eslint@10.3.0(jiti@2.6.1)):
     dependencies:
-      eslint: 10.4.0(jiti@2.6.1)
+      eslint: 10.3.0(jiti@2.6.1)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -22269,12 +22269,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.0(jiti@2.6.1):
+  eslint@10.3.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.5.5
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.1
       '@humanfs/node': 0.16.8
@@ -26373,13 +26373,13 @@ snapshots:
     dependencies:
       ts-toolbelt: 9.6.0
 
-  typescript-eslint@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 10.4.0(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.59.3(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.3.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -285,7 +285,7 @@ catalog:
   semver-utils: ^1.1.4
   shlex: ^3.0.0
   shx: ^0.4.0
-  socks: ^2.8.1
+  socks: ^2.8.8
   sort-keys: ^6.0.0
   split-cmd: ^1.1.0
   split2: ^4.2.0


### PR DESCRIPTION
Closes #10126.

`@pnpm/lockfile.pruner`'s `pruneLockfile()` (and `pruneSharedLockfile()`) assumes every entry in `importer.dependencies` / `devDependencies` / `optionalDependencies` is a plain version string. With lockfile v9 those entries are stored as `{ specifier, version }` objects; if a caller forwards that shape directly to the public API the object reaches `refToRelative()` and throws:

```
TypeError: reference.startsWith is not a function
```

The reproduction in #10126 reads `pnpm-lock.yaml` and pipes it into `pruneLockfile()` — i.e. an external use of the API that doesn't go through `@pnpm/lockfile.fs`'s normalization.

Two small helpers normalize both shapes before any string operation:

- `getDependencyReference(dep)` returns `dep` if it's a string, otherwise `dep.version`.
- `getDependencySpecifier(dep)` returns `dep.specifier` for inline objects and falls back to the existing `lockfileSpecs` lookup for string entries.

They are applied to:

- direct importer `dependencies` / `devDependencies` / `optionalDependencies`
- the link-only fallback path
- transitive `resolvedDepsToDepPaths()` used by `copyDependencySubGraph`

Internal callers (`updateLockfile`, `make-dedicated-lockfile`, `env-installer`) already feed a normalized `LockfileObject`, so they're unaffected. The change only matters for callers that pass the inline file shape through the public API.

A regression test covers all three direct-dep fields plus the `optional: true` propagation. All existing string-only tests pass unchanged.

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/pnpm/pnpm/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Provide tests for your changes.
- [x] Use [descriptive commit messages](https://www.conventionalcommits.org).
- [x] Update the documentation if needed.
- [x] Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) describing the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a TypeError when pruning lockfiles with inline importer dependency objects; pruning now preserves importer specifiers, resolves dependency versions correctly, prunes packages to only referenced versions, and properly handles linked dependencies.

* **Tests**
  * Added tests covering inline {specifier, version} importer entries, linked dependency preservation, and shared-lockfile pruning.

* **Chores**
  * Updated workspace catalog version for a dependency (socks) from ^2.8.1 to ^2.8.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->