### PR TITLE
fix: accept uppercase PNPM_CONFIG_* env vars

### DIFF
--- a/.changeset/npmrc-auth-file-env-var-load-order.md
+++ b/.changeset/npmrc-auth-file-env-var-load-order.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fix `pnpm_config_npmrc_auth_file` and `pnpm_config_userconfig` env vars not actually loading the custom `.npmrc`. The env vars were parsed and assigned to the resolved config, but only after `loadNpmrcConfig` had already read the default `~/.npmrc` — so the custom file path was set but never read. The relevant env vars are now consulted before the user-level `.npmrc` is loaded [#11465](https://github.com/pnpm/pnpm/issues/11465).

--- a/.changeset/uppercase-pnpm-config-env-vars.md
+++ b/.changeset/uppercase-pnpm-config-env-vars.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Accept `PNPM_CONFIG_*` (uppercase) environment variables in addition to `pnpm_config_*`. Previously, only the lowercase form was honored, which made env vars renamed per the v11 migration guide (e.g. `PNPM_CONFIG_USERCONFIG`) silently have no effect on case-sensitive systems like macOS and Linux. The setting that determines which user-level `.npmrc` is loaded (`userconfig` / `npmrc-auth-file`) can now also be supplied via env var [#11465](https://github.com/pnpm/pnpm/issues/11465).

--- a/.changeset/uppercase-pnpm-config-env-vars.md
+++ b/.changeset/uppercase-pnpm-config-env-vars.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Accept `PNPM_CONFIG_*` (uppercase) environment variables in addition to `pnpm_config_*`. Previously, only the lowercase form was honored, which made env vars renamed per the v11 migration guide (e.g. `PNPM_CONFIG_USERCONFIG`) silently have no effect on case-sensitive systems like macOS and Linux. The setting that determines which user-level `.npmrc` is loaded (`userconfig` / `npmrc-auth-file`) can now also be supplied via env var [#11465](https://github.com/pnpm/pnpm/issues/11465).
+Accept `PNPM_CONFIG_*` (uppercase) environment variables in addition to `pnpm_config_*`. Previously, only the lowercase form was honored, so env vars renamed per the v11 migration guide (e.g. `PNPM_CONFIG_USERCONFIG`) silently had no effect on case-sensitive systems like macOS and Linux [#11465](https://github.com/pnpm/pnpm/issues/11465).

--- a/config/reader/src/env.ts
+++ b/config/reader/src/env.ts
@@ -5,6 +5,7 @@ import camelcase from 'camelcase'
 import kebabCase from 'lodash.kebabcase'
 
 const PREFIX = 'pnpm_config_'
+const PREFIX_UPPER = PREFIX.toUpperCase()
 
 export type ValueConstructor =
   | ArrayConstructor
@@ -173,19 +174,30 @@ function tryParseObjectOrArray (envVar: string): object | unknown[] | undefined 
 }
 
 /**
- * Return the suffix if {@link envKey} starts with {@link PREFIX} and is fully lower_snake_case.
+ * Return the lowercase suffix if {@link envKey} starts with {@link PREFIX} or
+ * {@link PREFIX_UPPER} and the suffix is fully snake_case (in matching case).
  * Otherwise, return `undefined`.
+ *
+ * Both lowercase (`pnpm_config_*`) and uppercase (`PNPM_CONFIG_*`) prefixes
+ * are accepted because shell convention favors uppercase env vars and the v11
+ * migration guide tells users to rename `NPM_CONFIG_*` to `PNPM_CONFIG_*`.
  */
 function getEnvKeySuffix (envKey: string): string | undefined {
-  if (!envKey.startsWith(PREFIX)) return undefined
-  const suffix = envKey.slice(PREFIX.length)
-  if (!isEnvKeySuffix(suffix)) return undefined
-  return suffix
+  if (envKey.startsWith(PREFIX)) {
+    const suffix = envKey.slice(PREFIX.length)
+    return isLowerSnakeCase(suffix) ? suffix : undefined
+  }
+  if (envKey.startsWith(PREFIX_UPPER)) {
+    const suffix = envKey.slice(PREFIX_UPPER.length)
+    return isUpperSnakeCase(suffix) ? suffix.toLowerCase() : undefined
+  }
+  return undefined
 }
 
-/**
- * A valid env key suffix is lower_snake_case without redundant underscore characters.
- */
-function isEnvKeySuffix (envKeySuffix: string): boolean {
-  return envKeySuffix.split('_').every(segment => /^[a-z0-9]+$/.test(segment))
+function isLowerSnakeCase (s: string): boolean {
+  return s.length > 0 && s.split('_').every(segment => /^[a-z0-9]+$/.test(segment))
+}
+
+function isUpperSnakeCase (s: string): boolean {
+  return s.length > 0 && s.split('_').every(segment => /^[A-Z0-9]+$/.test(segment))
 }

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -215,10 +215,16 @@ export async function getConfig (opts: {
 
   const configDir = getConfigDir(process)
 
-  // Read npmrcAuthFile early from global config.yaml (before loading .npmrc files)
+  // Read npmrcAuthFile early from global config.yaml (before loading .npmrc files).
+  // The general env var loop runs later (after .npmrc files are loaded), so we
+  // also have to peek at the relevant env vars here in order for
+  // PNPM_CONFIG_NPMRC_AUTH_FILE / PNPM_CONFIG_USERCONFIG (and their lowercase
+  // equivalents) to actually decide which user-level .npmrc gets read.
   const globalYamlConfigForNpmrcAuthFile = await readWorkspaceManifest(configDir, GLOBAL_CONFIG_YAML_FILENAME)
   const npmrcAuthFile = cliOptions['npmrc-auth-file'] as string | undefined
     ?? cliOptions.userconfig as string | undefined
+    ?? readEnvVar(env, 'npmrc_auth_file')
+    ?? readEnvVar(env, 'userconfig')
     ?? globalYamlConfigForNpmrcAuthFile?.npmrcAuthFile
 
   const npmrcResult = loadNpmrcConfig({
@@ -672,6 +678,15 @@ function getProcessEnv (env: string): string | undefined {
   return process.env[env] ??
     process.env[env.toUpperCase()] ??
     process.env[env.toLowerCase()]
+}
+
+// Look up a `pnpm_config_<key>` env var, accepting both lowercase and
+// uppercase forms. Used for env vars that need to be read before the
+// general parseEnvVars pass, such as those that affect which .npmrc file
+// is loaded.
+function readEnvVar (env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[`pnpm_config_${key}`] ?? env[`PNPM_CONFIG_${key.toUpperCase()}`]
+  return value !== '' ? value : undefined
 }
 
 function getWantedPackageManager (manifest: ProjectManifest): { pm?: WantedPackageManager, warnings: string[] } {

--- a/config/reader/test/env.test.ts
+++ b/config/reader/test/env.test.ts
@@ -209,16 +209,18 @@ test('parseEnvVars skips npm_config_*', () => {
   }))).toStrictEqual({})
 })
 
-test('parseEnvVars only reads lower snake case keys', () => {
+test('parseEnvVars reads fully lowercase or fully uppercase snake_case keys', () => {
   expect(pairsToObject(parseEnvVars(alwaysSchema(String), {
     PNPM_CONFIG_UPPER_SNAKE_CASE_KEY: 'whole key in upper snake case',
     pnpmConfigCamelCaseKey: 'whole key in snake case',
     'pnpm-config-kebab-case': 'whole key in kebab case',
-    pnpm_config_UPPER_SNAKE_CASE_SUFFIX: 'suffix in upper snake case',
+    pnpm_config_UPPER_SNAKE_CASE_SUFFIX: 'mixed case suffix',
+    PNPM_CONFIG_lower_snake_case_suffix: 'mixed case suffix',
     pnpm_config_camelCaseSuffix: 'suffix in camel case',
     'pnpm_config_kebab-case-suffix': 'suffix in kebab case',
     pnpm_config_lower_snake_case_key: 'whole key in lower snake case',
   }))).toStrictEqual({
+    upperSnakeCaseKey: 'whole key in upper snake case',
     lowerSnakeCaseKey: 'whole key in lower snake case',
   })
 })

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1177,6 +1177,27 @@ test('getConfig() reads userconfig from pnpm_config_npmrc_auth_file env var', as
   expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
 })
 
+// Locks in the precedence so future refactors don't accidentally flip it.
+test('getConfig() prefers pnpm_config_userconfig over PNPM_CONFIG_USERCONFIG when both are set', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', 'upper.npmrc'), 'registry = https://upper.example.test', 'utf-8')
+  fs.writeFileSync(path.resolve('user-home', 'lower.npmrc'), 'registry = https://lower.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_USERCONFIG: path.resolve('user-home', 'upper.npmrc'),
+      pnpm_config_userconfig: path.resolve('user-home', 'lower.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://lower.example.test' })
+})
+
 test('getConfig() sets sideEffectsCacheRead and sideEffectsCacheWrite when side-effects-cache is set', async () => {
   const { config } = await getConfig({
     cliOptions: {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1105,6 +1105,60 @@ test('getConfig() returns the userconfig even when overridden locally', async ()
   expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
 })
 
+test('getConfig() reads userconfig from PNPM_CONFIG_USERCONFIG env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_USERCONFIG: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
+test('getConfig() reads userconfig from pnpm_config_userconfig env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config_userconfig: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
+test('getConfig() reads userconfig from PNPM_CONFIG_NPMRC_AUTH_FILE env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_NPMRC_AUTH_FILE: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
 test('getConfig() sets sideEffectsCacheRead and sideEffectsCacheWrite when side-effects-cache is set', async () => {
   const { config } = await getConfig({
     cliOptions: {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1159,6 +1159,24 @@ test('getConfig() reads userconfig from PNPM_CONFIG_NPMRC_AUTH_FILE env var', as
   expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
 })
 
+test('getConfig() reads userconfig from pnpm_config_npmrc_auth_file env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config_npmrc_auth_file: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
 test('getConfig() sets sideEffectsCacheRead and sideEffectsCacheWrite when side-effects-cache is set', async () => {
   const { config } = await getConfig({
     cliOptions: {


### PR DESCRIPTION
## Summary

- `parseEnvVars` now accepts both lowercase `pnpm_config_*` and uppercase `PNPM_CONFIG_*` env-var prefixes (suffix must be fully snake_case in the matching case). On macOS/Linux env vars are case-sensitive, so the v11 migration guide's `NPM_CONFIG_USERCONFIG` → `PNPM_CONFIG_USERCONFIG` rename was silently a no-op.
- The env var is now also consulted *before* `loadNpmrcConfig` runs, so `PNPM_CONFIG_USERCONFIG` / `PNPM_CONFIG_NPMRC_AUTH_FILE` actually decide which user-level `.npmrc` gets loaded — previously the env loop ran too late to affect it.
- Docs updated to mention that the uppercase prefix is accepted.

Closes #11465.

## Test plan

- [x] `pnpm --filter @pnpm/config.reader test` — added cases cover `PNPM_CONFIG_USERCONFIG`, `pnpm_config_userconfig`, `PNPM_CONFIG_NPMRC_AUTH_FILE`, plus mixed-case rejection in `env.test.ts`.
- [x] End-to-end smoke: with a custom `.npmrc` containing `registry=...`, all four casings of the env var make `pnpm config get registry` return that registry, while no env var falls back to the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support uppercase env var prefixes (PNPM_CONFIG_), in addition to lowercase, so config env vars work on case-sensitive systems.
  * Allow selecting a user-level .npmrc via these environment variables.

* **Bug Fixes**
  * Env-specified .npmrc paths are now consulted earlier during config loading so custom files are applied correctly; lowercase form wins if both are set.

* **Tests**
  * Added tests for uppercase env vars and env-driven .npmrc loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->