### PR TITLE
feat(config.reader): export getNetworkConfigs and getDefaultCreds

### DIFF
--- a/.changeset/export-network-configs.md
+++ b/.changeset/export-network-configs.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/config.reader": minor
+---
+
+Export `getNetworkConfigs`, `getDefaultCreds`, and the `NetworkConfigs` type so consumers can derive a `configByUri` map from a flat npmrc-style auth dict without re-implementing the parsing logic.

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -52,6 +52,7 @@ import { types } from './types.js'
 export { types }
 
 export { getDefaultWorkspaceConcurrency, getWorkspaceConcurrency } from './concurrency.js'
+export { getDefaultCreds, getNetworkConfigs, type NetworkConfigs } from './getNetworkConfigs.js'
 export { getOptionsFromPnpmSettings, type OptionsFromRootManifest } from './getOptionsFromRootManifest.js'
 export type { Creds } from './parseCreds.js'
 export {


### PR DESCRIPTION
## Summary

- Re-export `getNetworkConfigs`, `getDefaultCreds`, and the `NetworkConfigs` type from `@pnpm/config.reader`.
- Both helpers already exist in `getNetworkConfigs.ts` and are used internally by `getConfig` to build `pnpmConfig.configByUri`. They're shipped to `lib/` but blocked from deep imports by the package's `exports` field.

## Motivation

Downstream consumers of `@pnpm/installing.client` and `@pnpm/store.connection-manager` need to provide a `configByUri: Record<string, RegistryConfig>` argument. The only way to derive that map from a flat npmrc-style auth dict (the shape returned by, e.g., bit's `getAuthConfig`) is to re-implement pnpm's parsing logic, which keeps drifting out of sync with the canonical implementation. Exporting the existing helpers lets consumers stay aligned with pnpm's behaviour for free.

## Test plan

- [x] `pnpm --filter @pnpm/config.reader run compile` — passes (lint warning is pre-existing).
- [ ] Bit imports the new exports and drops its local copy (separate PR; gated on a published `@pnpm/config.reader` release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the public API of `@pnpm/config.reader` with new exports: `getNetworkConfigs` and `getDefaultCreds` functions, plus the `NetworkConfigs` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->