### PR TITLE
docs: add PR/issue/comment instructions for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,10 +192,10 @@ try {
 ## Working with GitHub PRs, Issues, and Comments
 
 -   **Keep PR titles and descriptions current.** When pushing new changes to a PR, review the title and description and update them if they no longer accurately reflect what the PR does.
--   **Answer and close resolved review comments.** When a review comment is addressed, reply to the conversation with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
+-   **Reply to and resolve review conversations.** Once a review comment has been addressed, reply to the thread with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
 -   **Sign all agent-authored content.** When posting a comment, creating an issue, or opening a PR, append a footer to the message indicating that it was written by an agent. The footer must include the name of the agent and the name of the model used. Example:
 
-    ```
+    ```markdown
     ---
     Written by an agent (Claude Code, claude-opus-4-7).
     ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,17 @@ try {
 }
 ```
 
+## Working with GitHub PRs, Issues, and Comments
+
+-   **Keep PR titles and descriptions current.** When pushing new changes to a PR, review the title and description and update them if they no longer accurately reflect what the PR does.
+-   **Answer and close resolved review comments.** When a review comment is addressed, reply to the conversation with a description of the resolution including the commit hash that fixed it, then mark the conversation as resolved.
+-   **Sign all agent-authored content.** When posting a comment, creating an issue, or opening a PR, append a footer to the message indicating that it was written by an agent. The footer must include the name of the agent and the name of the model used. Example:
+
+    ```
+    ---
+    Written by an agent (Claude Code, claude-opus-4-7).
+    ```
+
 ## Resolving Conflicts in GitHub PRs
 
 Use `shell/resolve-pr-conflicts.sh` to resolve PR conflicts:


### PR DESCRIPTION
## Summary
- Add a "Working with GitHub PRs, Issues, and Comments" section to `AGENTS.md` covering three rules:
  - Keep PR title and description current when pushing new changes.
  - Reply to resolved review comments with the resolution + commit hash and close the conversation.
  - Sign all agent-authored comments, issues, and PRs with a footer that names the agent and model.

## Test plan
- [x] Docs-only change; no tests required.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Working with GitHub PRs, Issues, and Comments" guide covering keeping PR titles/descriptions current, replying to and resolving review conversations (with resolution details and commit references), and appending agent-authorship footers to agent-authored PRs/issues/comments (including agent name and model).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->