### PR TITLE
chore(release): track consumed changesets per branch to prevent re-application after cherry-pick

### DIFF
--- a/.changeset/.released/README.md
+++ b/.changeset/.released/README.md
@@ -1,0 +1,25 @@
+# Released changesets ledger
+
+This directory holds a per-branch record of which changesets have already been released. Each file is named after a release branch (with `/` replaced by `-`, e.g. `main.txt`, `release-10.0.txt`) and contains one consumed changeset id per line.
+
+## Why this exists
+
+Fixes are cherry-picked between `main` and `release/*` branches, so the same changeset file can end up on both. The release branch's release consumes its copy and deletes it, but the cherry-picked copy on `main` would otherwise survive the merge back and be applied a second time on the next `main` release.
+
+The ledger prevents that double-application. Each branch only writes to its own file, so cross-branch merges are conflict-free; the wrapper around `changeset version` reads the union of every file when deciding what to skip.
+
+## How it gets updated
+
+`pnpm bump` runs the wrapper at `__utils__/scripts/src/bump.ts`, which:
+
+1. Reads every `*.txt` in this directory and unions the ids.
+2. Hides any `.changeset/<id>.md` whose id is in that union (renames to `<id>.md.released`) so `changeset version` does not see it.
+3. Runs `changeset version`, which consumes the remaining `.md` files.
+4. Appends the newly-consumed ids to `<current-branch>.txt`.
+5. Deletes the hidden files (their consumption is already on record).
+
+If `changeset version` fails, hidden files are renamed back to their original `.md` names so the working tree is left clean. The current branch is detected from `git rev-parse --abbrev-ref HEAD`; set `RELEASE_BRANCH` to override.
+
+## Workflow requirement
+
+Release branches must be merged back into `main` between releases, so that `main` sees the release branch's ledger entries before its own next release runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,22 +123,6 @@ Added a new setting `blockExoticSubdeps` that prevents the resolution of exotic 
 - **minor**: New features, settings, or commands that should be documented (anything users should know about)
 - **major**: Breaking changes
 
-#### Cross-branch release tracking
-
-Because we cherry-pick fixes between `main` and `release/*` branches, the same changeset file can end up on both branches. After the release branch consumes its copy and is merged back into `main`, the cherry-picked copy on `main` would otherwise be applied a second time.
-
-To prevent that, `pnpm bump` is a wrapper around `changeset version` that maintains a per-branch ledger of consumed changeset IDs at `.changeset/.released/<branch>.txt` (one ID per line, branch name with `/` replaced by `-`). The wrapper:
-
-1. Reads the union of IDs across every `.changeset/.released/*.txt` file (so consumption records merged in from other branches are honoured).
-2. Hides any `.changeset/<id>.md` whose ID is already in that union by renaming it to `<id>.md.released`, so `changeset version` does not see it.
-3. Runs `changeset version`, which consumes and deletes the remaining `.md` files.
-4. Appends the IDs of those newly-deleted files to `.changeset/.released/<current-branch>.txt`.
-5. Deletes the hidden `.md.released` files (their consumption is already recorded elsewhere; keeping them around is just clutter).
-
-If `changeset version` fails, the hidden files are restored to their original `.md` names so the working tree is left clean. The current branch is detected from `git rev-parse --abbrev-ref HEAD` and can be overridden with the `RELEASE_BRANCH` environment variable.
-
-The one workflow requirement is that release branches are merged back into `main` between releases, so that `main` sees their `.released/release-X.Y.txt` before its own next release runs.
-
 ### Commit Messages
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,22 @@ Added a new setting `blockExoticSubdeps` that prevents the resolution of exotic 
 - **minor**: New features, settings, or commands that should be documented (anything users should know about)
 - **major**: Breaking changes
 
+#### Cross-branch release tracking
+
+Because we cherry-pick fixes between `main` and `release/*` branches, the same changeset file can end up on both branches. After the release branch consumes its copy and is merged back into `main`, the cherry-picked copy on `main` would otherwise be applied a second time.
+
+To prevent that, `pnpm bump` is a wrapper around `changeset version` that maintains a per-branch ledger of consumed changeset IDs at `.changeset/.released/<branch>.txt` (one ID per line, branch name with `/` replaced by `-`). The wrapper:
+
+1. Reads the union of IDs across every `.changeset/.released/*.txt` file (so consumption records merged in from other branches are honoured).
+2. Hides any `.changeset/<id>.md` whose ID is already in that union by renaming it to `<id>.md.released`, so `changeset version` does not see it.
+3. Runs `changeset version`, which consumes and deletes the remaining `.md` files.
+4. Appends the IDs of those newly-deleted files to `.changeset/.released/<current-branch>.txt`.
+5. Deletes the hidden `.md.released` files (their consumption is already recorded elsewhere; keeping them around is just clutter).
+
+If `changeset version` fails, the hidden files are restored to their original `.md` names so the working tree is left clean. The current branch is detected from `git rev-parse --abbrev-ref HEAD` and can be overridden with the `RELEASE_BRANCH` environment variable.
+
+The one workflow requirement is that release branches are merged back into `main` between releases, so that `main` sees their `.released/release-X.Y.txt` before its own next release runs.
+
 ### Commit Messages
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/__utils__/scripts/package.json
+++ b/__utils__/scripts/package.json
@@ -3,6 +3,10 @@
   "version": "1100.0.5",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "pn .test",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
+  },
   "dependencies": {
     "@pnpm/workspace.projects-reader": "workspace:*",
     "@pnpm/workspace.workspace-manifest-reader": "workspace:*",
@@ -14,10 +18,16 @@
     "tinyglobby": "catalog:"
   },
   "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@pnpm/jest-config": "workspace:*",
     "@pnpm/logger": "catalog:",
     "@pnpm/scripts": "workspace:*",
     "@types/normalize-path": "catalog:",
-    "@types/tar": "catalog:"
+    "@types/tar": "catalog:",
+    "cross-env": "catalog:"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
   },
   "keywords": [
     "pnpm",

--- a/__utils__/scripts/src/bump.ts
+++ b/__utils__/scripts/src/bump.ts
@@ -1,0 +1,133 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import glob from 'fast-glob'
+
+export interface HiddenFile {
+  id: string
+  from: string
+  to: string
+}
+
+export function branchToFilename (branch: string): string {
+  return `${branch.replace(/\//g, '-')}.txt`
+}
+
+export function readReleased (releasedDir: string): Set<string> {
+  const ids = new Set<string>()
+  if (!fs.existsSync(releasedDir)) return ids
+  for (const file of fs.readdirSync(releasedDir)) {
+    if (!file.endsWith('.txt')) continue
+    const content = fs.readFileSync(path.join(releasedDir, file), 'utf8')
+    for (const line of content.split('\n')) {
+      const id = line.trim()
+      if (id !== '' && !id.startsWith('#')) ids.add(id)
+    }
+  }
+  return ids
+}
+
+export function appendReleased (
+  releasedDir: string,
+  branch: string,
+  ids: readonly string[]
+): void {
+  if (ids.length === 0) return
+  fs.mkdirSync(releasedDir, { recursive: true })
+  const file = path.join(releasedDir, branchToFilename(branch))
+  const merged = new Set<string>()
+  if (fs.existsSync(file)) {
+    for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+      const id = line.trim()
+      if (id !== '' && !id.startsWith('#')) merged.add(id)
+    }
+  }
+  for (const id of ids) merged.add(id)
+  const sorted = [...merged].sort()
+  fs.writeFileSync(file, `${sorted.join('\n')}\n`)
+}
+
+export function listChangesetIds (changesetDir: string): string[] {
+  const files = glob.sync('*.md', { cwd: changesetDir, ignore: ['README.md'] })
+  return files.map(f => path.basename(f, '.md')).sort()
+}
+
+export function hideReleased (changesetDir: string, released: Set<string>): HiddenFile[] {
+  const hidden: HiddenFile[] = []
+  for (const id of released) {
+    const from = path.join(changesetDir, `${id}.md`)
+    if (!fs.existsSync(from)) continue
+    const to = path.join(changesetDir, `${id}.md.released`)
+    fs.renameSync(from, to)
+    hidden.push({ id, from, to })
+  }
+  return hidden
+}
+
+export function restoreHidden (hidden: readonly HiddenFile[]): void {
+  for (const h of hidden) {
+    if (fs.existsSync(h.to)) fs.renameSync(h.to, h.from)
+  }
+}
+
+export function deleteHidden (hidden: readonly HiddenFile[]): void {
+  for (const h of hidden) {
+    if (fs.existsSync(h.to)) fs.unlinkSync(h.to)
+  }
+}
+
+function detectCurrentBranch (cwd: string): string {
+  const override = process.env.RELEASE_BRANCH?.trim()
+  if (override !== undefined && override !== '') return override
+  const out = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf8' }).trim()
+  if (out === 'HEAD') {
+    throw new Error(
+      'Detached HEAD; set RELEASE_BRANCH to override the current branch name.'
+    )
+  }
+  return out
+}
+
+function main (): void {
+  const repoRoot = path.resolve(import.meta.dirname, '../../..')
+  const changesetDir = path.join(repoRoot, '.changeset')
+  const releasedDir = path.join(changesetDir, '.released')
+  const branch = detectCurrentBranch(repoRoot)
+
+  console.log(`Branch: ${branch}`)
+  const released = readReleased(releasedDir)
+  console.log(`Already-released changeset IDs: ${released.size}`)
+
+  const hidden = hideReleased(changesetDir, released)
+  if (hidden.length > 0) {
+    console.log(
+      `Hiding ${hidden.length} stale changeset(s) already released elsewhere: ${hidden.map(h => h.id).join(', ')}`
+    )
+  }
+
+  const before = listChangesetIds(changesetDir)
+  let success = false
+  try {
+    execSync('changeset version', { cwd: repoRoot, stdio: 'inherit' })
+    success = true
+  } finally {
+    if (!success) restoreHidden(hidden)
+  }
+
+  const after = new Set(listChangesetIds(changesetDir))
+  const newlyConsumed = before.filter(id => !after.has(id))
+  if (newlyConsumed.length > 0) {
+    console.log(`Recording newly-released: ${newlyConsumed.join(', ')}`)
+    appendReleased(releasedDir, branch, newlyConsumed)
+  }
+
+  // Stale (cherry-picked, already released elsewhere) changesets get dropped
+  // from the working tree — the released-list already prevents re-application.
+  deleteHidden(hidden)
+}
+
+const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`
+if (isDirectInvocation) {
+  main()
+}

--- a/__utils__/scripts/src/bump.ts
+++ b/__utils__/scripts/src/bump.ts
@@ -1,3 +1,10 @@
+// Wrapper around `changeset version` that prevents cherry-picked changesets
+// from being applied twice when a release branch is merged back into main.
+// Maintains a per-branch ledger at .changeset/.released/<branch>.txt of
+// consumed changeset ids; before running `changeset version` it hides any
+// changeset whose id is already in the union of those files. See
+// .changeset/.released/README.md for the full explanation.
+
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'

--- a/__utils__/scripts/src/bump.ts
+++ b/__utils__/scripts/src/bump.ts
@@ -8,6 +8,7 @@
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import url from 'node:url'
 
 import glob from 'fast-glob'
 
@@ -62,12 +63,17 @@ export function listChangesetIds (changesetDir: string): string[] {
 
 export function hideReleased (changesetDir: string, released: Set<string>): HiddenFile[] {
   const hidden: HiddenFile[] = []
-  for (const id of released) {
-    const from = path.join(changesetDir, `${id}.md`)
-    if (!fs.existsSync(from)) continue
-    const to = path.join(changesetDir, `${id}.md.released`)
-    fs.renameSync(from, to)
-    hidden.push({ id, from, to })
+  try {
+    for (const id of listChangesetIds(changesetDir)) {
+      if (!released.has(id)) continue
+      const from = path.join(changesetDir, `${id}.md`)
+      const to = path.join(changesetDir, `${id}.md.released`)
+      fs.renameSync(from, to)
+      hidden.push({ id, from, to })
+    }
+  } catch (err) {
+    restoreHidden(hidden)
+    throw err
   }
   return hidden
 }
@@ -122,19 +128,29 @@ function main (): void {
     if (!success) restoreHidden(hidden)
   }
 
-  const after = new Set(listChangesetIds(changesetDir))
-  const newlyConsumed = before.filter(id => !after.has(id))
-  if (newlyConsumed.length > 0) {
-    console.log(`Recording newly-released: ${newlyConsumed.join(', ')}`)
-    appendReleased(releasedDir, branch, newlyConsumed)
+  try {
+    const after = new Set(listChangesetIds(changesetDir))
+    const newlyConsumed = before.filter(id => !after.has(id))
+    if (newlyConsumed.length > 0) {
+      console.log(`Recording newly-released: ${newlyConsumed.join(', ')}`)
+      appendReleased(releasedDir, branch, newlyConsumed)
+    }
+  } finally {
+    // Stale (cherry-picked, already released elsewhere) changesets get dropped
+    // from the working tree — the released-list already prevents re-application.
+    deleteHidden(hidden)
   }
-
-  // Stale (cherry-picked, already released elsewhere) changesets get dropped
-  // from the working tree — the released-list already prevents re-application.
-  deleteHidden(hidden)
 }
 
-const isDirectInvocation = import.meta.url === `file://${process.argv[1]}`
-if (isDirectInvocation) {
+function isDirectInvocation (): boolean {
+  if (process.argv[1] === undefined) return false
+  try {
+    return import.meta.url === url.pathToFileURL(fs.realpathSync(process.argv[1])).href
+  } catch {
+    return false
+  }
+}
+
+if (isDirectInvocation()) {
   main()
 }

--- a/__utils__/scripts/test/bump.ts
+++ b/__utils__/scripts/test/bump.ts
@@ -124,6 +124,22 @@ describe('hideReleased / restoreHidden / deleteHidden', () => {
     expect(fs.existsSync(path.join(dir, 'foo.md'))).toBe(false)
     expect(fs.existsSync(path.join(dir, 'foo.md.released'))).toBe(false)
   })
+
+  test('rolls back already-renamed files when a later rename fails', () => {
+    fs.writeFileSync(path.join(dir, 'bar.md'), 'bar')
+    fs.writeFileSync(path.join(dir, 'foo.md'), 'foo')
+    // Pre-create a non-empty directory at the would-be rename target so the
+    // foo.md → foo.md.released rename throws (EISDIR / ENOTEMPTY).
+    fs.mkdirSync(path.join(dir, 'foo.md.released'))
+    fs.writeFileSync(path.join(dir, 'foo.md.released', 'sentinel'), 'x')
+
+    expect(() => hideReleased(dir, new Set(['bar', 'foo']))).toThrow()
+
+    // bar.md was renamed first; on the failure it must be restored.
+    expect(fs.existsSync(path.join(dir, 'bar.md'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'bar.md.released'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'foo.md'))).toBe(true)
+  })
 })
 
 describe('listChangesetIds', () => {

--- a/__utils__/scripts/test/bump.ts
+++ b/__utils__/scripts/test/bump.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
+
+import {
+  appendReleased,
+  branchToFilename,
+  deleteHidden,
+  hideReleased,
+  listChangesetIds,
+  readReleased,
+  restoreHidden,
+} from '../src/bump.js'
+
+describe('branchToFilename', () => {
+  test('plain branch name', () => {
+    expect(branchToFilename('main')).toBe('main.txt')
+  })
+
+  test('branch name with slash gets sanitized', () => {
+    expect(branchToFilename('release/10.0')).toBe('release-10.0.txt')
+  })
+
+  test('branch name with multiple slashes', () => {
+    expect(branchToFilename('feature/foo/bar')).toBe('feature-foo-bar.txt')
+  })
+})
+
+describe('readReleased', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-read-released-'))
+  })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('returns empty set when directory is missing', () => {
+    expect(readReleased(path.join(dir, 'missing'))).toEqual(new Set())
+  })
+
+  test('reads ids from .txt files and merges across files', () => {
+    fs.writeFileSync(path.join(dir, 'main.txt'), 'foo\nbar\n')
+    fs.writeFileSync(path.join(dir, 'release-10.0.txt'), 'baz\nfoo\n')
+    fs.writeFileSync(path.join(dir, 'README.md'), 'ignored\n')
+    expect(readReleased(dir)).toEqual(new Set(['foo', 'bar', 'baz']))
+  })
+
+  test('skips comments and empty lines', () => {
+    fs.writeFileSync(path.join(dir, 'main.txt'), '# header\n\nfoo\n   \nbar\n')
+    expect(readReleased(dir)).toEqual(new Set(['foo', 'bar']))
+  })
+})
+
+describe('appendReleased', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-append-'))
+  })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('writes ids to <branch>.txt sorted', () => {
+    appendReleased(dir, 'main', ['foo', 'bar', 'baz'])
+    expect(fs.readFileSync(path.join(dir, 'main.txt'), 'utf8')).toBe('bar\nbaz\nfoo\n')
+  })
+
+  test('dedupes against existing entries on disk', () => {
+    fs.writeFileSync(path.join(dir, 'main.txt'), 'foo\n')
+    appendReleased(dir, 'main', ['bar', 'foo'])
+    expect(fs.readFileSync(path.join(dir, 'main.txt'), 'utf8')).toBe('bar\nfoo\n')
+  })
+
+  test('uses sanitized filename for branches with /', () => {
+    appendReleased(dir, 'release/10.0', ['hotfix-1'])
+    expect(fs.existsSync(path.join(dir, 'release-10.0.txt'))).toBe(true)
+  })
+
+  test('no-op for empty list', () => {
+    appendReleased(dir, 'main', [])
+    expect(fs.existsSync(path.join(dir, 'main.txt'))).toBe(false)
+  })
+
+  test('creates the released directory if missing', () => {
+    const nested = path.join(dir, 'nested', '.released')
+    appendReleased(nested, 'main', ['foo'])
+    expect(fs.readFileSync(path.join(nested, 'main.txt'), 'utf8')).toBe('foo\n')
+  })
+})
+
+describe('hideReleased / restoreHidden / deleteHidden', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-hide-'))
+  })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('hides files matching released ids; leaves others alone', () => {
+    fs.writeFileSync(path.join(dir, 'foo.md'), 'foo')
+    fs.writeFileSync(path.join(dir, 'bar.md'), 'bar')
+    fs.writeFileSync(path.join(dir, 'baz.md'), 'baz')
+
+    const hidden = hideReleased(dir, new Set(['foo', 'baz', 'unknown']))
+
+    expect(hidden.map(h => h.id).sort()).toEqual(['baz', 'foo'])
+    expect(fs.existsSync(path.join(dir, 'foo.md'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'foo.md.released'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'bar.md'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'baz.md'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'baz.md.released'))).toBe(true)
+  })
+
+  test('restoreHidden brings them back to .md', () => {
+    fs.writeFileSync(path.join(dir, 'foo.md'), 'foo')
+    const hidden = hideReleased(dir, new Set(['foo']))
+    restoreHidden(hidden)
+    expect(fs.existsSync(path.join(dir, 'foo.md'))).toBe(true)
+    expect(fs.existsSync(path.join(dir, 'foo.md.released'))).toBe(false)
+  })
+
+  test('deleteHidden removes the .md.released files', () => {
+    fs.writeFileSync(path.join(dir, 'foo.md'), 'foo')
+    const hidden = hideReleased(dir, new Set(['foo']))
+    deleteHidden(hidden)
+    expect(fs.existsSync(path.join(dir, 'foo.md'))).toBe(false)
+    expect(fs.existsSync(path.join(dir, 'foo.md.released'))).toBe(false)
+  })
+})
+
+describe('listChangesetIds', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-list-'))
+  })
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+  test('lists *.md ids excluding README and non-md files', () => {
+    fs.writeFileSync(path.join(dir, 'foo.md'), '')
+    fs.writeFileSync(path.join(dir, 'bar.md'), '')
+    fs.writeFileSync(path.join(dir, 'README.md'), '')
+    fs.writeFileSync(path.join(dir, 'config.json'), '{}')
+    expect(listChangesetIds(dir)).toEqual(['bar', 'foo'])
+  })
+})

--- a/__utils__/scripts/test/tsconfig.json
+++ b/__utils__/scripts/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo-root",
   "private": true,
   "scripts": {
-    "bump": "changeset version && pn update-manifests",
+    "bump": "node __utils__/scripts/src/bump.ts && pn update-manifests",
     "changeset": "changeset",
     "prepare": "husky",
     "pretest": "pn compile-only && pn prepare-fixtures",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1390,6 +1390,12 @@ importers:
         specifier: 'catalog:'
         version: 0.2.16
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.3.0
+      '@pnpm/jest-config':
+        specifier: workspace:*
+        version: link:../jest-config
       '@pnpm/logger':
         specifier: 'catalog:'
         version: 1001.0.1
@@ -1402,6 +1408,9 @@ importers:
       '@types/tar':
         specifier: 'catalog:'
         version: 7.0.87
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
 
   __utils__/test-fixtures:
     dependencies:


### PR DESCRIPTION
## Summary

When a fix is cherry-picked between `main` and a `release/*` branch, the same changeset file ends up on both branches. The release branch's release consumes its copy and deletes it, but the cherry-picked copy on `main` survives the merge back and is re-applied on the next `main` release — producing a duplicate version bump and stale entry in the release notes.

This PR introduces a wrapper around `changeset version` (`__utils__/scripts/src/bump.ts`) that maintains a per-branch ledger at `.changeset/.released/<branch>.txt`. Each entry is a consumed changeset id; the file is written only by the branch it is named after, so the records merge across branches without conflicts.

### How it works

1. `pnpm bump` now invokes the wrapper instead of running `changeset version` directly.
2. The wrapper reads the union of ids across every `.changeset/.released/*.txt` file (so consumption records merged in from other branches are honoured).
3. It hides any `.changeset/<id>.md` whose id is in that union by renaming to `<id>.md.released`, so `changeset version` does not see it.
4. It runs `changeset version`, which consumes and deletes the remaining `.md` files.
5. The newly-deleted ids are appended to `.changeset/.released/<current-branch>.txt`.
6. The hidden `.md.released` files are removed (their consumption is already on record elsewhere).

If `changeset version` fails, the hidden files are restored to their original `.md` names so the working tree is left clean. The current branch is detected from `git rev-parse --abbrev-ref HEAD` and can be overridden with the `RELEASE_BRANCH` environment variable.

### Workflow requirement

Release branches must be merged back into `main` before `main`'s next release, so that `main` sees the release branch's `.released/release-X.Y.txt` before its own next release runs. (This already matches the current workflow.)

## Test plan

- [x] Unit tests cover all the helpers (`branchToFilename`, `readReleased`, `appendReleased`, `hideReleased`, `restoreHidden`, `deleteHidden`, `listChangesetIds`).
- [x] `pnpm --filter=@pnpm/scripts run test` — 15 tests pass.
- [x] `pnpm run lint:meta`, `pnpm run spellcheck`, and lint pass.
- [ ] Manual end-to-end verification on the next real release: confirm cherry-picked changesets on `main` are skipped after the release branch's release lands.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Jest test suite covering the new versioning helpers and file-handling behavior.

* **Chores**
  * Improved the versioning flow to avoid reapplying already-released changesets when merging release branches.
  * Updated the bump command to run the guarded versioning wrapper before manifest updates.

* **Documentation**
  * Added documentation describing the per-branch released changeset ledger and update/rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->