### PR TITLE
fix: keep workspace-root excluded when --recursive --filter uses only negative filters

### DIFF
--- a/.changeset/recursive-filter-root-exclusion.md
+++ b/.changeset/recursive-filter-root-exclusion.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fix a regression where `pnpm --recursive --filter '!<pkg>' run/exec/test/add` would include the workspace root in the matched projects. The workspace root is now correctly excluded by default when only negative `--filter` arguments are provided, matching the [documented behavior](https://pnpm.io/cli/recursive). To include the root, pass `--include-workspace-root` [#11341](https://github.com/pnpm/pnpm/issues/11341).

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -249,7 +249,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     if (config.workspaceRoot) {
       filters.push({ filter: `{${relativeWSDirPath()}}`, followProdDepsOnly: Boolean(config.filterProd.length) })
     } else if (
-      filters.length === 0 &&
+      !filters.some(({ filter }) => !filter.startsWith('!')) &&
       workspaceDir &&
       config.workspacePackagePatterns &&
       !isRootOnlyPatterns(config.workspacePackagePatterns) &&

--- a/pnpm/test/recursive/filter.ts
+++ b/pnpm/test/recursive/filter.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 
 import { expect, test } from '@jest/globals'
-import { prepare } from '@pnpm/prepare'
+import { prepare, preparePackages } from '@pnpm/prepare'
 
 import { execPnpmSync } from '../utils/index.js'
 
@@ -41,4 +41,114 @@ test('pnpm --filter . add <pkg> should work', async () => {
 
   const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'))
   expect(pkg.dependencies['is-positive']).toBeTruthy()
+})
+
+// Regression test for https://github.com/pnpm/pnpm/issues/11341
+test('pnpm --recursive --filter "!<pkg>" run should still exclude the workspace root', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        version: '0.0.0',
+        private: true,
+        scripts: {
+          which: "node -e \"console.log('root')\"",
+        },
+      },
+    },
+    {
+      location: 'a',
+      package: {
+        name: 'a',
+        version: '1.0.0',
+        scripts: {
+          which: "node -e \"console.log('a')\"",
+        },
+      },
+    },
+    {
+      location: 'b',
+      package: {
+        name: 'b',
+        version: '1.0.0',
+        scripts: {
+          which: "node -e \"console.log('b')\"",
+        },
+      },
+    },
+  ])
+
+  fs.writeFileSync('pnpm-workspace.yaml', 'packages:\n  - "*"\n')
+
+  const result = execPnpmSync([
+    '--stream',
+    '--config.verify-deps-before-run=false',
+    '--recursive',
+    '--filter',
+    '!a',
+    'run',
+    'which',
+  ])
+  expect(result.status).toBe(0)
+
+  const stdout = result.stdout.toString()
+  expect(stdout).toContain('b which$')
+  expect(stdout).not.toContain('root which$')
+  expect(stdout).not.toContain('a which$')
+})
+
+test('pnpm --recursive --filter "!<pkg>" --include-workspace-root run should include the workspace root', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        version: '0.0.0',
+        private: true,
+        scripts: {
+          which: "node -e \"console.log('root')\"",
+        },
+      },
+    },
+    {
+      location: 'a',
+      package: {
+        name: 'a',
+        version: '1.0.0',
+        scripts: {
+          which: "node -e \"console.log('a')\"",
+        },
+      },
+    },
+    {
+      location: 'b',
+      package: {
+        name: 'b',
+        version: '1.0.0',
+        scripts: {
+          which: "node -e \"console.log('b')\"",
+        },
+      },
+    },
+  ])
+
+  fs.writeFileSync('pnpm-workspace.yaml', 'packages:\n  - "*"\n')
+
+  const result = execPnpmSync([
+    '--stream',
+    '--config.verify-deps-before-run=false',
+    '--recursive',
+    '--include-workspace-root',
+    '--filter',
+    '!a',
+    'run',
+    'which',
+  ])
+  expect(result.status).toBe(0)
+
+  const stdout = result.stdout.toString()
+  expect(stdout).toContain('b which$')
+  expect(stdout).toContain('. which$')
+  expect(stdout).not.toContain('a which$')
 })

--- a/pnpm/test/recursive/filter.ts
+++ b/pnpm/test/recursive/filter.ts
@@ -94,7 +94,9 @@ test('pnpm --recursive --filter "!<pkg>" run should still exclude the workspace 
 
   const stdout = result.stdout.toString()
   expect(stdout).toContain('b which$')
-  expect(stdout).not.toContain('root which$')
+  // The `--stream` reporter prefixes lines with the project's relative directory,
+  // so the workspace root (cwd === wsDir) would appear as `. which$` if included.
+  expect(stdout).not.toContain('. which$')
   expect(stdout).not.toContain('a which$')
 })
 


### PR DESCRIPTION
## Summary

Fixes #11341. When `pnpm --recursive --filter '!<pkg>' run/exec/test/add` was used, the workspace root started appearing in the matched projects in 10.33.0+, contradicting the [documented default behavior](https://pnpm.io/cli/recursive) that root is excluded for these commands unless `--include-workspace-root` is set.

## Root cause

PR #10465 (which fixed #10462 — `--filter <root>` not finding the root in single-package workspaces) gated the implicit root-exclusion on `filters.length === 0`. That gate was too broad: any user filter — including a negative one like `--filter '!a'` — disabled the implicit exclusion.

## Fix

Suppress the implicit root exclusion only when the user provided at least one **positive** (non-`!`) filter that could have been intended to select the root. Negative-only filter sets keep the documented default, and `--include-workspace-root` continues to opt the root in explicitly.

| Filter | Before | After |
|---|---|---|
| (none) | root excluded ✓ | root excluded ✓ |
| `--filter '!a'` | root **included** ❌ | root excluded ✓ |
| `--filter a` | root excluded (a selected) ✓ | root excluded (a selected) ✓ |
| `--filter root-name` | root selected ✓ (#10462) | root selected ✓ (#10462) |
| `--include-workspace-root --filter '!a'` | root included ✓ | root included ✓ |

The `isRootOnlyPatterns` guard from #10927 still ensures single-package workspaces (`packages: ['.']` or empty `pnpm-workspace.yaml`) are unaffected.

## Test plan

- [x] Added 2 regression tests in `pnpm/test/recursive/filter.ts` covering `--filter '!a'` with and without `--include-workspace-root`.
- [x] Existing test for #10462 (`--filter <root>`) still passes.
- [x] Manual reproduction using the [shoebox639/pnpm-recursive-filter-root-bug](https://github.com/shoebox639/pnpm-recursive-filter-root-bug) repo confirms the fix.
- [x] `pnpm --filter pnpm run compile` and lint pass.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where the workspace root was incorrectly included when using --recursive with only negative filters; the root is now excluded by default. Use --include-workspace-root to include it.

* **Tests**
  * Added regression tests to verify recursive filtering now excludes or includes the workspace root as expected.

* **Documentation**
  * Added a patch changeset documenting the regression fix and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->