### PR TITLE
fix(config): align scoped registry resolution between config get and publish

### DIFF
--- a/.changeset/scoped-registry-config-get-publish.md
+++ b/.changeset/scoped-registry-config-get-publish.md
@@ -1,7 +1,6 @@
 ---
 "@pnpm/config.commands": patch
-"@pnpm/config.reader": patch
 "pnpm": patch
 ---
 
-`pnpm config get @<scope>:registry` now reports the same URL that `pnpm publish` and the resolvers actually use. Previously, `config get` only consulted `.npmrc`, while `publish`/install used the merged map that includes `pnpm-workspace.yaml`'s `registries` block — so the two could diverge silently and the user would publish to the wrong registry. pnpm now also emits a warning at config load time when the same scope (or the default registry) is defined in both `.npmrc` and `pnpm-workspace.yaml` with different values [#11492](https://github.com/pnpm/pnpm/issues/11492).
+`pnpm config get @<scope>:registry` now reports the same URL that `pnpm publish` and the resolvers actually use. Previously, `config get` only consulted `.npmrc`, while `publish`/install used the merged map that includes `pnpm-workspace.yaml`'s `registries` block — so the two could diverge silently and a publish could go to the wrong registry [#11492](https://github.com/pnpm/pnpm/issues/11492).

--- a/.changeset/scoped-registry-config-get-publish.md
+++ b/.changeset/scoped-registry-config-get-publish.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.commands": patch
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+`pnpm config get @<scope>:registry` now reports the same URL that `pnpm publish` and the resolvers actually use. Previously, `config get` only consulted `.npmrc`, while `publish`/install used the merged map that includes `pnpm-workspace.yaml`'s `registries` block — so the two could diverge silently and the user would publish to the wrong registry. pnpm now also emits a warning at config load time when the same scope (or the default registry) is defined in both `.npmrc` and `pnpm-workspace.yaml` with different values [#11492](https://github.com/pnpm/pnpm/issues/11492).

--- a/config/commands/src/configGet.ts
+++ b/config/commands/src/configGet.ts
@@ -21,6 +21,18 @@ interface Found<Value> {
 
 function lookupConfig (opts: ConfigCommandOptions, key: string, isScopedKey: boolean): Found<unknown> | undefined {
   if (isScopedKey) {
+    // Scoped registry keys (e.g. `@scope:registry`) can be set in two places:
+    // `.npmrc` (which lands in authConfig) or pnpm-workspace.yaml's
+    // `registries` block (which lands in the merged Config.registries map).
+    // Prefer the merged map so this command reports the same value that
+    // `pnpm publish` and the resolvers actually use.
+    if (key.endsWith(':registry')) {
+      const scope = key.slice(0, key.length - ':registry'.length)
+      const merged = opts._config.registries?.[scope]
+      if (merged !== undefined) {
+        return { value: merged }
+      }
+    }
     return { value: opts.authConfig[key] }
   }
   const kebabKey = isCamelCase(key) ? kebabCase(key) : key

--- a/config/commands/test/configGet.test.ts
+++ b/config/commands/test/configGet.test.ts
@@ -234,6 +234,27 @@ test('config get with scoped registry key (global: true)', async () => {
   expect(getOutputString(getResult)).toBe('https://custom-registry.example.com/')
 })
 
+test('config get with scoped registry returns the merged value from pnpm-workspace.yaml (#11492)', async () => {
+  // .npmrc set the scope to one URL, but pnpm-workspace.yaml's `registries`
+  // block overrides it. `pnpm config get` must report the URL that
+  // resolvers/publish actually use, not the raw .npmrc value.
+  const getResult = await config.handler(createConfigCommandOpts({
+    dir: process.cwd(),
+    cliOptions: {},
+    configDir: process.cwd(),
+    global: false,
+    authConfig: {
+      '@scope:registry': 'https://from-npmrc.example.com/',
+    },
+    registries: {
+      default: 'https://registry.npmjs.org/',
+      '@scope': 'https://from-workspace-yaml.example.com/',
+    },
+  }), ['get', '@scope:registry'])
+
+  expect(getOutputString(getResult)).toBe('https://from-workspace-yaml.example.com/')
+})
+
 test('config get with scoped registry key that does not exist', async () => {
   const getResult = await config.handler(createConfigCommandOpts({
     dir: process.cwd(),

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -446,25 +446,6 @@ export async function getConfig (opts: {
   // The workspace manifest may have set pnpmConfig.registries via addSettingsFromWorkspaceManifestToConfig,
   // but we need to ensure 'default' is always set and all URLs are normalized.
   const workspaceRegistries = pnpmConfig.registries as Record<string, string> | undefined
-  // The same registry can be defined in both .npmrc and pnpm-workspace.yaml.
-  // pnpm-workspace.yaml wins, but if the values disagree we warn so the user
-  // doesn't silently publish to (or install from) the wrong place — see #11492.
-  if (workspaceRegistries) {
-    for (const [scope, rawWsUrl] of Object.entries(workspaceRegistries)) {
-      if (typeof rawWsUrl !== 'string') continue
-      // For 'default', only flag when the .npmrc actually set `registry` —
-      // registriesFromNpmrc.default has a normalized fallback otherwise.
-      const npmrcUrl = scope === 'default'
-        ? (typeof pnpmConfig.authConfig.registry === 'string' ? registriesFromNpmrc.default : undefined)
-        : (registriesFromNpmrc as Record<string, string>)[scope]
-      if (npmrcUrl == null) continue
-      const wsUrl = normalizeRegistryUrl(rawWsUrl)
-      if (npmrcUrl === wsUrl) continue
-      const npmrcKey = scope === 'default' ? 'registry' : `${scope}:registry`
-      const wsKey = scope === 'default' ? 'registries.default' : `registries["${scope}"]`
-      warnings.push(`The ${scope === 'default' ? 'default' : scope} registry is set in both .npmrc (${npmrcKey}=${npmrcUrl}) and pnpm-workspace.yaml (${wsKey}=${wsUrl}). The pnpm-workspace.yaml value will be used; the .npmrc value is ignored.`)
-    }
-  }
   pnpmConfig.registries = {
     ...registriesFromNpmrc,
     ...workspaceRegistries,

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -446,6 +446,25 @@ export async function getConfig (opts: {
   // The workspace manifest may have set pnpmConfig.registries via addSettingsFromWorkspaceManifestToConfig,
   // but we need to ensure 'default' is always set and all URLs are normalized.
   const workspaceRegistries = pnpmConfig.registries as Record<string, string> | undefined
+  // The same registry can be defined in both .npmrc and pnpm-workspace.yaml.
+  // pnpm-workspace.yaml wins, but if the values disagree we warn so the user
+  // doesn't silently publish to (or install from) the wrong place — see #11492.
+  if (workspaceRegistries) {
+    for (const [scope, rawWsUrl] of Object.entries(workspaceRegistries)) {
+      if (typeof rawWsUrl !== 'string') continue
+      // For 'default', only flag when the .npmrc actually set `registry` —
+      // registriesFromNpmrc.default has a normalized fallback otherwise.
+      const npmrcUrl = scope === 'default'
+        ? (typeof pnpmConfig.authConfig.registry === 'string' ? registriesFromNpmrc.default : undefined)
+        : (registriesFromNpmrc as Record<string, string>)[scope]
+      if (npmrcUrl == null) continue
+      const wsUrl = normalizeRegistryUrl(rawWsUrl)
+      if (npmrcUrl === wsUrl) continue
+      const npmrcKey = scope === 'default' ? 'registry' : `${scope}:registry`
+      const wsKey = scope === 'default' ? 'registries.default' : `registries["${scope}"]`
+      warnings.push(`The ${scope === 'default' ? 'default' : scope} registry is set in both .npmrc (${npmrcKey}=${npmrcUrl}) and pnpm-workspace.yaml (${wsKey}=${wsUrl}). The pnpm-workspace.yaml value will be used; the .npmrc value is ignored.`)
+    }
+  }
   pnpmConfig.registries = {
     ...registriesFromNpmrc,
     ...workspaceRegistries,

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -561,6 +561,95 @@ test('registries in current directory\'s .npmrc have bigger priority then global
   })
 })
 
+describe('scoped registry conflicts between .npmrc and pnpm-workspace.yaml (#11492)', () => {
+  test('warns and uses pnpm-workspace.yaml value when both define the same scope', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('.npmrc', '@my-org:registry=https://from-npmrc.example.com/', 'utf8')
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      registries: {
+        '@my-org': 'https://from-workspace-yaml.example.com/',
+      },
+    })
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.registries['@my-org']).toBe('https://from-workspace-yaml.example.com/')
+    expect(warnings).toContainEqual(expect.stringContaining('@my-org'))
+    expect(warnings.find((w) => w.includes('@my-org'))).toMatch(/from-npmrc.example.com/)
+    expect(warnings.find((w) => w.includes('@my-org'))).toMatch(/from-workspace-yaml.example.com/)
+  })
+
+  test('warns and uses pnpm-workspace.yaml value when default registry differs', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('.npmrc', 'registry=https://from-npmrc.example.com/', 'utf8')
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      registries: {
+        default: 'https://from-workspace-yaml.example.com/',
+      },
+    })
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.registries.default).toBe('https://from-workspace-yaml.example.com/')
+    const defaultWarning = warnings.find((w) => w.includes('default registry'))
+    expect(defaultWarning).toBeDefined()
+    expect(defaultWarning).toMatch(/from-npmrc.example.com/)
+    expect(defaultWarning).toMatch(/from-workspace-yaml.example.com/)
+  })
+
+  test('does not warn when only one source defines the scope', async () => {
+    prepareEmpty()
+
+    fs.writeFileSync('.npmrc', '@my-org:registry=https://from-npmrc.example.com/', 'utf8')
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      registries: {
+        '@other': 'https://other.example.com/',
+      },
+    })
+
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.registries['@my-org']).toBe('https://from-npmrc.example.com/')
+    expect(config.registries['@other']).toBe('https://other.example.com/')
+    expect(warnings.find((w) => w.includes('registry is set in both'))).toBeUndefined()
+  })
+
+  test('does not warn when both sources agree (after normalization)', async () => {
+    prepareEmpty()
+
+    // .npmrc value lacks trailing slash; normalizeRegistryUrl adds one,
+    // so the two sources end up equivalent and there is no real conflict.
+    fs.writeFileSync('.npmrc', '@my-org:registry=https://same.example.com', 'utf8')
+    writeYamlFileSync('pnpm-workspace.yaml', {
+      registries: {
+        '@my-org': 'https://same.example.com/',
+      },
+    })
+
+    const { warnings } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(warnings.find((w) => w.includes('registry is set in both'))).toBeUndefined()
+  })
+})
+
 test('auth tokens from pnpm auth file override ~/.npmrc', async () => {
   prepareEmpty()
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -561,94 +561,23 @@ test('registries in current directory\'s .npmrc have bigger priority then global
   })
 })
 
-describe('scoped registry conflicts between .npmrc and pnpm-workspace.yaml (#11492)', () => {
-  test('warns and uses pnpm-workspace.yaml value when both define the same scope', async () => {
-    prepareEmpty()
+test('pnpm-workspace.yaml registries override the same scope from .npmrc (#11492)', async () => {
+  prepareEmpty()
 
-    fs.writeFileSync('.npmrc', '@my-org:registry=https://from-npmrc.example.com/', 'utf8')
-    writeYamlFileSync('pnpm-workspace.yaml', {
-      registries: {
-        '@my-org': 'https://from-workspace-yaml.example.com/',
-      },
-    })
-
-    const { config, warnings } = await getConfig({
-      cliOptions: {},
-      packageManager: { name: 'pnpm', version: '1.0.0' },
-      workspaceDir: process.cwd(),
-    })
-
-    expect(config.registries['@my-org']).toBe('https://from-workspace-yaml.example.com/')
-    const scopeWarning = warnings.find((w) => w.includes('@my-org'))
-    expect(scopeWarning).toBeDefined()
-    expect(scopeWarning).toContain('https://from-npmrc.example.com/')
-    expect(scopeWarning).toContain('https://from-workspace-yaml.example.com/')
+  fs.writeFileSync('.npmrc', '@my-org:registry=https://from-npmrc.example.com/', 'utf8')
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      '@my-org': 'https://from-workspace-yaml.example.com/',
+    },
   })
 
-  test('warns and uses pnpm-workspace.yaml value when default registry differs', async () => {
-    prepareEmpty()
-
-    fs.writeFileSync('.npmrc', 'registry=https://from-npmrc.example.com/', 'utf8')
-    writeYamlFileSync('pnpm-workspace.yaml', {
-      registries: {
-        default: 'https://from-workspace-yaml.example.com/',
-      },
-    })
-
-    const { config, warnings } = await getConfig({
-      cliOptions: {},
-      packageManager: { name: 'pnpm', version: '1.0.0' },
-      workspaceDir: process.cwd(),
-    })
-
-    expect(config.registries.default).toBe('https://from-workspace-yaml.example.com/')
-    const defaultWarning = warnings.find((w) => w.includes('default registry'))
-    expect(defaultWarning).toBeDefined()
-    expect(defaultWarning).toContain('https://from-npmrc.example.com/')
-    expect(defaultWarning).toContain('https://from-workspace-yaml.example.com/')
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
   })
 
-  test('does not warn when only one source defines the scope', async () => {
-    prepareEmpty()
-
-    fs.writeFileSync('.npmrc', '@my-org:registry=https://from-npmrc.example.com/', 'utf8')
-    writeYamlFileSync('pnpm-workspace.yaml', {
-      registries: {
-        '@other': 'https://other.example.com/',
-      },
-    })
-
-    const { config, warnings } = await getConfig({
-      cliOptions: {},
-      packageManager: { name: 'pnpm', version: '1.0.0' },
-      workspaceDir: process.cwd(),
-    })
-
-    expect(config.registries['@my-org']).toBe('https://from-npmrc.example.com/')
-    expect(config.registries['@other']).toBe('https://other.example.com/')
-    expect(warnings.find((w) => w.includes('registry is set in both'))).toBeUndefined()
-  })
-
-  test('does not warn when both sources agree (after normalization)', async () => {
-    prepareEmpty()
-
-    // .npmrc value lacks trailing slash; normalizeRegistryUrl adds one,
-    // so the two sources end up equivalent and there is no real conflict.
-    fs.writeFileSync('.npmrc', '@my-org:registry=https://same.example.com', 'utf8')
-    writeYamlFileSync('pnpm-workspace.yaml', {
-      registries: {
-        '@my-org': 'https://same.example.com/',
-      },
-    })
-
-    const { warnings } = await getConfig({
-      cliOptions: {},
-      packageManager: { name: 'pnpm', version: '1.0.0' },
-      workspaceDir: process.cwd(),
-    })
-
-    expect(warnings.find((w) => w.includes('registry is set in both'))).toBeUndefined()
-  })
+  expect(config.registries['@my-org']).toBe('https://from-workspace-yaml.example.com/')
 })
 
 test('auth tokens from pnpm auth file override ~/.npmrc', async () => {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -579,9 +579,10 @@ describe('scoped registry conflicts between .npmrc and pnpm-workspace.yaml (#114
     })
 
     expect(config.registries['@my-org']).toBe('https://from-workspace-yaml.example.com/')
-    expect(warnings).toContainEqual(expect.stringContaining('@my-org'))
-    expect(warnings.find((w) => w.includes('@my-org'))).toMatch(/from-npmrc.example.com/)
-    expect(warnings.find((w) => w.includes('@my-org'))).toMatch(/from-workspace-yaml.example.com/)
+    const scopeWarning = warnings.find((w) => w.includes('@my-org'))
+    expect(scopeWarning).toBeDefined()
+    expect(scopeWarning).toContain('https://from-npmrc.example.com/')
+    expect(scopeWarning).toContain('https://from-workspace-yaml.example.com/')
   })
 
   test('warns and uses pnpm-workspace.yaml value when default registry differs', async () => {
@@ -603,8 +604,8 @@ describe('scoped registry conflicts between .npmrc and pnpm-workspace.yaml (#114
     expect(config.registries.default).toBe('https://from-workspace-yaml.example.com/')
     const defaultWarning = warnings.find((w) => w.includes('default registry'))
     expect(defaultWarning).toBeDefined()
-    expect(defaultWarning).toMatch(/from-npmrc.example.com/)
-    expect(defaultWarning).toMatch(/from-workspace-yaml.example.com/)
+    expect(defaultWarning).toContain('https://from-npmrc.example.com/')
+    expect(defaultWarning).toContain('https://from-workspace-yaml.example.com/')
   })
 
   test('does not warn when only one source defines the scope', async () => {

--- a/pnpm/test/config/get.ts
+++ b/pnpm/test/config/get.ts
@@ -27,14 +27,16 @@ test('pnpm config get reads npm options but ignores other settings from .npmrc',
     'packages[]=qux',
   ].join('\n'))
 
+  // `config get @<scope>:registry` reports the merged (normalized) URL —
+  // the same one `pnpm publish` and the resolvers use — see #11492.
   {
     const { stdout } = execPnpmSync(['config', 'get', '@my-org:registry'], { expectSuccess: true })
-    expect(stdout.toString().trim()).toBe('https://my-org.registry.example.com')
+    expect(stdout.toString().trim()).toBe('https://my-org.registry.example.com/')
   }
 
   {
     const { stdout } = execPnpmSync(['config', 'get', '@jsr:registry'], { expectSuccess: true })
-    expect(stdout.toString().trim()).toBe('https://not-actually-jsr.example.com')
+    expect(stdout.toString().trim()).toBe('https://not-actually-jsr.example.com/')
   }
 
   {


### PR DESCRIPTION
## Summary

Fixes [#11492](https://github.com/pnpm/pnpm/issues/11492).

In pnpm v11 a scoped registry resolved to different URLs depending on which command read it:

- `pnpm config get @<scope>:registry` returned the value from `.npmrc`
- `pnpm publish` used the value from `pnpm-workspace.yaml`'s `registries` block

When the two sources disagreed, `pnpm publish` silently targeted the URL from `pnpm-workspace.yaml`, even though `pnpm config get` reported a different (and seemingly authoritative) URL — so users could publish to the wrong registry without any indication.

This PR makes `pnpm config get @<scope>:registry` read from the merged `Config.registries` map (the same map `publish` and the resolvers use) before falling back to `authConfig`. Both commands now report and use the same URL.

## Test plan

- [x] New `config.commands` test covering `config get @scope:registry` returning the merged value when `pnpm-workspace.yaml` overrides `.npmrc`.
- [x] New `config.reader` regression test confirming `pnpm-workspace.yaml`'s `registries` overrides the same scope from `.npmrc`.
- [x] Manual verification with the bundled CLI: `config get @my-org:registry` now returns the same URL `pnpm publish` PUTs to.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped registry resolution so pnpm-workspace.yaml values correctly override .npmrc for the same scope.

* **Improvements**
  * Improved `pnpm config get` to report registry URLs consistently with publish/resolvers and emit a warning when workspace and local registry values differ.

* **Tests**
  * Added tests covering scoped registry precedence and resolved URL formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->