### PR TITLE
ci(release): split publish into three steps to force trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,36 @@ jobs:
         timeout-minutes: 2
       - name: pnpm install
         run: pn install
-      - name: Publish Packages
+      # The publish phase is split into three sequential steps to control which packages
+      # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
+      # out of OIDC as soon as a static `_authToken` is configured, so the only way to
+      # force trusted publishing for a given package today is to run its publish in a
+      # step that doesn't have NPM_TOKEN set. See https://github.com/pnpm/pnpm/pull/11495
+      # for the longer-term fix that lets OIDC override a configured token.
+      - name: Publish @pnpm/exe (trusted publishing)
+        # No NPM_TOKEN: pnpm has no static token to short-circuit on, so it will perform
+        # the OIDC token exchange against npm's trusted-publishing config for `@pnpm/exe`.
+        # The exe artifacts must be built before the publish, so they're built here too.
+        run: |
+          pn --filter=@pnpm/exe run build-artifacts
+          pn --filter=@pnpm/exe publish --tag=next-11 --access=public --provenance
+      - name: Publish internal workspace packages (static token)
+        # The other workspace packages don't have trusted publishing configured on npm,
+        # so we still need a static token here. The token is removed from pnpm's config
+        # at the end of the step so it can't leak into the trusted-publishing step that
+        # follows (where its presence would silently downgrade `pnpm` to token publishing).
         env:
-          # setting the "npm_config_//registry.npmjs.org/:_authToken" env variable directly doesn't work.
-          # probably "pnpm release" doesn't pass auth tokens to child processes
+          # Setting the "npm_config_//registry.npmjs.org/:_authToken" env variable directly
+          # doesn't work — pnpm doesn't appear to pass auth tokens to child processes.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
-          pn release
+          pn publish --filter=!pnpm --filter=!@pnpm/exe --access=public --provenance
+          pn config delete "//registry.npmjs.org/:_authToken"
+      - name: Publish pnpm CLI (trusted publishing)
+        # No NPM_TOKEN — same rationale as the @pnpm/exe step above. This must come after
+        # the previous step has cleared its NPM_TOKEN from pnpm's config.
+        run: pn publish --filter=pnpm --tag=next-11 --access=public --provenance
       - name: Copy Artifacts
         run: pn copy-artifacts
       - name: Attest build provenance


### PR DESCRIPTION
## Summary

Splits the single `Publish Packages` step in `release.yml` into three sequential publish steps, isolating the packages we want to ship via npm's trusted publishing (`pnpm` and `@pnpm/exe`) into steps that don't have `NPM_TOKEN` set.

### Why

`pnpm publish` currently bails out of OIDC as soon as a static `_authToken` is configured (see #11495 for the longer-term fix). Our release workflow writes `NPM_TOKEN` into pnpm's config before `pn release`, so OIDC is never attempted — even for packages where npm's trusted-publishing config would issue a token. The result is visible in the registry metadata for recent releases: `pnpm@11.0.6` shows `_npmUser: pnpmuser` and no `attestations.provenance`, while the manually-published `pnpm@11.0.0-alpha.5` shows `_npmUser.trustedPublisher` and a SLSA provenance block.

#11495 will fix the precedence rule properly, but until then we need a way to ship `pnpm` and `@pnpm/exe` via trusted publishing on the next release. The workaround: don't put a static token in their environment at all.

## Changes

`.github/workflows/release.yml` — replace the `Publish Packages` step with three:

1. **`Publish @pnpm/exe (trusted publishing)`** — no `NPM_TOKEN`. Builds the exe artifacts and publishes `@pnpm/exe`. With no token configured, `pnpm publish` reaches its OIDC code path and exchanges the GitHub Actions ID token at npm's trusted-publishing endpoint.
2. **`Publish internal workspace packages (static token)`** — `NPM_TOKEN` is set, written into pnpm config, the publish runs, then `pn config delete` removes the token. The workspace's internal packages don't have trusted publishing configured on npm yet, so they still need the static token.
3. **`Publish pnpm CLI (trusted publishing)`** — no `NPM_TOKEN`. Same rationale as step 1. Must come after step 2 because step 2's `pn config delete` is what guarantees pnpm doesn't see a stale `_authToken` here.

`pn release` script in root `package.json` is left in place — unused after this change but harmless. Removing it is a separable cleanup.

## Caveats

- Trusted publishing must be configured on npm for both `pnpm` and `@pnpm/exe` (mapped to this repo + the `release` GitHub environment + this workflow file name). If either isn't set up, that step's OIDC exchange will return a 4xx and the publish will fail. Worth verifying before tagging the next release.
- The internal-package step's `pn config delete` runs after the publish; if the publish itself fails the delete won't run, but the step then fails and the workflow stops, so the stale token can't leak.

## Test plan

- [ ] Verify trusted publishing is configured on npm for `pnpm` and `@pnpm/exe`.
- [ ] On the first tagged release after merge, confirm the published metadata shows `_npmUser.trustedPublisher` and an `attestations.provenance` block for both `pnpm` and `@pnpm/exe`. The internal workspace packages should continue to show `_npmUser: pnpmuser` (no change there until they're onboarded to trusted publishing too).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to split publish operations into distinct steps with improved token management and clearer publishing strategy documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->