### PR TITLE
fix(exe): route pn/pnpx/pnx through .exe hardlinks on Windows (#11486)

### DIFF
--- a/.changeset/exe-windows-aliases.md
+++ b/.changeset/exe-windows-aliases.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+Fixed the `pn`, `pnpx`, and `pnx` aliases failing in Git Bash / MSYS2 on Windows when pnpm was installed via `@pnpm/exe` (or after `pnpm self-update`) [#11486](https://github.com/pnpm/pnpm/issues/11486). Running `pnpx` (or `pnx`) printed the cmd.exe banner and dropped the user into an interactive command prompt instead of running `pnpm dlx`. The `bin` field rewrite on Windows was pointing those aliases at `.cmd` files; cmd-shim's Bash shim for a `.cmd` target wraps it in `exec cmd /C ...`, and MSYS2 mangles `/C` into a Windows path before cmd.exe sees it. The aliases are now `.exe` hardlinks of the SEA binary, which detects which name it was launched as via `process.execPath` and prepends `dlx` for `pnpx` / `pnx`.

--- a/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -397,12 +397,24 @@ export function linkExePlatformBinary (installDir: string): void {
   forceLink(src, dest)
 
   if (platform === 'win32') {
+    // Aliases (pn / pnpx / pnx) need to be .exe hardlinks of the SEA binary,
+    // not the .cmd wrappers we ship in the tarball. cmd-shim's Bash shim for
+    // a .cmd target wraps it in `exec cmd /C ...`, and MSYS2 / Git Bash
+    // mangles `/C` into a Windows path — cmd.exe then falls into interactive
+    // mode and prints its banner instead of running the alias. .exe sources
+    // sidestep cmd-shim's wrapper. The SEA binary detects which name it was
+    // launched as via process.execPath and prepends `dlx` for pnpx / pnx.
+    // See https://github.com/pnpm/pnpm/issues/11486.
+    for (const alias of ['pn', 'pnpx', 'pnx']) {
+      forceLink(src, path.join(exePkgDir, `${alias}.exe`))
+    }
+
     const exePkgJsonPath = path.join(exePkgDir, 'package.json')
     const exePkg = JSON.parse(fs.readFileSync(exePkgJsonPath, 'utf8'))
     exePkg.bin.pnpm = 'pnpm.exe'
-    exePkg.bin.pn = 'pn.cmd'
-    exePkg.bin.pnpx = 'pnpx.cmd'
-    exePkg.bin.pnx = 'pnx.cmd'
+    exePkg.bin.pn = 'pn.exe'
+    exePkg.bin.pnpx = 'pnpx.exe'
+    exePkg.bin.pnx = 'pnx.exe'
     fs.writeFileSync(exePkgJsonPath, JSON.stringify(exePkg, null, 2))
   }
 }

--- a/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -908,6 +908,54 @@ describe('linkExePlatformBinary', () => {
     const result = fs.readFileSync(path.join(exeDir, executable), 'utf8')
     expect(result).toBe(fakeBinaryContent)
   })
+
+  // Regression coverage for https://github.com/pnpm/pnpm/issues/11486 — the
+  // `pn` / `pnpx` / `pnx` aliases were broken in MSYS2 / Git Bash on Windows.
+  // Root cause: linkExePlatformBinary pointed those bin entries at .cmd files,
+  // and @zkochan/cmd-shim's Bash shim for a .cmd source bounces through
+  // `exec cmd /C "...target.cmd" "$@"`. MSYS2's argument-conversion runtime
+  // mangles the lone `/C` switch into a Windows path before cmd.exe sees it,
+  // so cmd.exe finds no /C or /K and falls into interactive mode (printing its
+  // banner instead of running the alias). Routing the aliases through .exe
+  // hardlinks of the SEA binary takes cmd.exe out of the chain entirely.
+  const winOnlyTest = platform === 'win32' ? test : test.skip
+  winOnlyTest('rewrites bin to .exe entries and hardlinks pn/pnpx/pnx aliases to pnpm.exe (issue #11486)', () => {
+    const dir = tempDir(false)
+    const exeDir = path.join(dir, 'node_modules', '@pnpm', 'exe')
+    const platformDir = path.join(dir, 'node_modules', '@pnpm', platformPkgName)
+
+    fs.mkdirSync(exeDir, { recursive: true })
+    fs.mkdirSync(platformDir, { recursive: true })
+
+    fs.writeFileSync(path.join(exeDir, executable), 'This file intentionally left blank')
+    // Match the published bin field from pnpm/artifacts/exe/package.json
+    fs.writeFileSync(path.join(exeDir, 'package.json'), JSON.stringify({
+      bin: { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' },
+    }))
+
+    // The platform binary needs to be a real file so fs.linkSync can hardlink
+    // it. Content doesn't matter.
+    fs.writeFileSync(path.join(platformDir, executable), 'fake-pnpm-exe')
+
+    linkExePlatformBinary(dir)
+
+    const rewritten = JSON.parse(fs.readFileSync(path.join(exeDir, 'package.json'), 'utf8'))
+    expect(rewritten.bin).toEqual({
+      pnpm: 'pnpm.exe',
+      pn: 'pn.exe',
+      pnpx: 'pnpx.exe',
+      pnx: 'pnx.exe',
+    })
+
+    const pnpmIno = fs.statSync(path.join(exeDir, 'pnpm.exe')).ino
+    for (const name of ['pn', 'pnpx', 'pnx']) {
+      const aliasPath = path.join(exeDir, `${name}.exe`)
+      expect(fs.existsSync(aliasPath)).toBe(true)
+      // Hardlinked to pnpm.exe, so the SEA's argv[0] basename detection can
+      // tell `pnpx` apart from `pnpm` and inject `dlx` accordingly.
+      expect(fs.statSync(aliasPath).ino).toBe(pnpmIno)
+    }
+  })
 })
 
 describe('exePlatformPkgDirName', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7909,6 +7909,9 @@ importers:
       '@pnpm/jest-config':
         specifier: workspace:*
         version: link:../../../__utils__/jest-config
+      '@zkochan/cmd-shim':
+        specifier: 'catalog:'
+        version: 9.0.2
       execa:
         specifier: 'catalog:'
         version: safe-execa@0.3.0

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -30,7 +30,9 @@
   "scripts": {
     "preinstall": "node setup.js",
     "prepare": "node prepare.js",
-    "build-artifacts": "pn --filter=pnpm prepublishOnly && node ./scripts/build-artifacts.ts"
+    "build-artifacts": "pn --filter=pnpm prepublishOnly && node ./scripts/build-artifacts.ts",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest",
+    "test": "pn .test"
   },
   "dependencies": {
     "@reflink/reflink": "catalog:",

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -49,6 +49,7 @@
     "@jest/globals": "catalog:",
     "@pnpm/exe": "workspace:*",
     "@pnpm/jest-config": "workspace:*",
+    "@zkochan/cmd-shim": "catalog:",
     "execa": "catalog:"
   },
   "pnpm": {

--- a/pnpm/artifacts/exe/setup.js
+++ b/pnpm/artifacts/exe/setup.js
@@ -71,12 +71,26 @@ if (platform === 'win32') {
   // be the real binary so the shim can execute it.
   linkSync(bin, path.resolve(ownDir, 'pnpm'))
 
+  // Aliases (pn / pnpx / pnx) need to be .exe hardlinks of the SEA binary,
+  // not the .cmd / .ps1 wrappers we ship in the tarball. Reason: in MSYS2 /
+  // Git Bash, cmd-shim's Bash shim for a .cmd target does
+  //   exec cmd /C "...target.cmd" "$@"
+  // and MSYS2 mangles the lone `/C` switch into a Windows path before
+  // cmd.exe sees it — cmd.exe then finds no /C or /K and falls into
+  // interactive mode, printing its banner instead of the alias. .exe
+  // sources sidestep cmd-shim's wrapper. The SEA binary detects which name
+  // it was launched as via process.execPath and prepends `dlx` for
+  // pnpx / pnx. See https://github.com/pnpm/pnpm/issues/11486.
+  for (const alias of ['pn', 'pnpx', 'pnx']) {
+    linkSync(bin, path.resolve(ownDir, `${alias}.exe`))
+  }
+
   const pkgJsonPath = path.resolve(ownDir, 'package.json')
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'))
   pkg.bin.pnpm = 'pnpm.exe'
-  pkg.bin.pn = 'pn.cmd'
-  pkg.bin.pnpx = 'pnpx.cmd'
-  pkg.bin.pnx = 'pnx.cmd'
+  pkg.bin.pn = 'pn.exe'
+  pkg.bin.pnpx = 'pnpx.exe'
+  pkg.bin.pnx = 'pnx.exe'
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2))
 }
 

--- a/pnpm/artifacts/exe/test/setup.test.ts
+++ b/pnpm/artifacts/exe/test/setup.test.ts
@@ -170,12 +170,15 @@ function buildWinSetupSandbox (): string {
   // hardlinks it again into the sandbox @pnpm/exe dir; downstream tests can
   // invoke the resulting `pnpx.exe` (etc.) and assert the alias actually ran.
   fs.linkSync(process.execPath, path.join(platformDir, 'pnpm.exe'))
-  // platform-pkg-name.js calls into detect-libc on Linux; symlink the real
-  // package so the resolver finds it from the sandbox.
+  // platform-pkg-name.js calls into detect-libc; make the package resolvable
+  // from the sandbox. On Windows, use a junction — non-junction directory
+  // symlinks require Developer Mode or admin privileges, which Windows CI and
+  // most local Windows dev setups don't have. (See the failure-path tests
+  // higher in this file: they skip on Windows for the same reason.)
   fs.symlinkSync(
     path.join(exeDir, 'node_modules', 'detect-libc'),
     path.join(sandbox, 'node_modules', 'detect-libc'),
-    'dir'
+    isWindows ? 'junction' : 'dir'
   )
 
   execFileSync(process.execPath, [path.join(sandbox, 'prepare.js')], { cwd: sandbox })
@@ -210,7 +213,18 @@ winSetupTest('setup.js (Windows) rewrites bin to .exe entries and hardlinks pn/p
   }
 })
 
-winSetupTest('aliases run from Bash (Git Bash / MSYS2) without dropping into interactive cmd.exe (issue #11486)', async () => {
+// The Bash-shim end-to-end repro depends on Git Bash / MSYS2. CI runners
+// (windows-latest) ship Git Bash on PATH, but local Windows dev machines
+// often don't, so probe before running and skip the test cleanly otherwise
+// (rather than spawning bash and getting an opaque ENOENT).
+const bashAvailable = (() => {
+  if (!isWindows) return false
+  const probe = spawnSync('bash', ['--version'], { encoding: 'utf8', timeout: 5_000 })
+  return probe.status === 0
+})()
+const winBashTest = bashAvailable ? test : test.skip
+
+winBashTest('aliases run from Bash (Git Bash / MSYS2) without dropping into interactive cmd.exe (issue #11486)', async () => {
   const sandbox = buildWinSetupSandbox()
   const pkg = JSON.parse(fs.readFileSync(path.join(sandbox, 'package.json'), 'utf8'))
 
@@ -239,9 +253,16 @@ winSetupTest('aliases run from Bash (Git Bash / MSYS2) without dropping into int
     // `exec cmd /C ...`. MSYS2 mangles `/C` into a Windows path before
     // cmd.exe sees it; cmd.exe finds no /C or /K and falls into interactive
     // mode, printing its banner instead of running the alias.
-    expect({ alias, banner: /Microsoft Windows/.test(result.stdout + result.stderr) })
-      .toEqual({ alias, banner: false })
-    expect({ alias, stdout: result.stdout })
-      .toEqual({ alias, stdout: `${alias}_OK` })
+    expect({
+      alias,
+      status: result.status,
+      banner: /Microsoft Windows/.test(result.stdout + result.stderr),
+      stdout: result.stdout,
+    }).toEqual({
+      alias,
+      status: 0,
+      banner: false,
+      stdout: `${alias}_OK`,
+    })
   }
 })

--- a/pnpm/artifacts/exe/test/setup.test.ts
+++ b/pnpm/artifacts/exe/test/setup.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { describe, expect, test } from '@jest/globals'
+import { cmdShim } from '@zkochan/cmd-shim'
 import { familySync } from 'detect-libc'
 
 // @ts-expect-error — JS helper without type declarations
@@ -143,4 +144,104 @@ failurePathTest('setup.js exits 1 with the missing platform package name when ru
   // names the missing platform package. Both reference the package name, so
   // assert on that.
   expect(result.stderr).toContain(expectedPkgName === '@pnpm/macos-x64' ? '11423' : expectedPkgName)
+})
+
+// Build a sandboxed @pnpm/exe install with a real .exe playing the part of
+// pnpm.exe (we use the running node binary — setup.js only hardlinks it) and
+// run setup.js. Returns the sandbox directory.
+function buildWinSetupSandbox (): string {
+  const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-exe-fix11486-'))
+  fs.copyFileSync(path.join(exeDir, 'setup.js'), path.join(sandbox, 'setup.js'))
+  fs.copyFileSync(path.join(exeDir, 'prepare.js'), path.join(sandbox, 'prepare.js'))
+  fs.copyFileSync(path.join(exeDir, 'platform-pkg-name.js'), path.join(sandbox, 'platform-pkg-name.js'))
+  fs.writeFileSync(path.join(sandbox, 'package.json'), JSON.stringify({
+    name: '@pnpm/exe',
+    type: 'module',
+    bin: { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' },
+  }))
+
+  const platformPkgName = exePlatformPkgName(platform, process.arch, familySync())
+  const platformDir = path.join(sandbox, 'node_modules', platformPkgName)
+  fs.mkdirSync(platformDir, { recursive: true })
+  fs.writeFileSync(path.join(platformDir, 'package.json'), JSON.stringify({
+    name: platformPkgName, version: '0.0.0',
+  }))
+  // Hardlink the test's own node.exe as the platform binary. setup.js then
+  // hardlinks it again into the sandbox @pnpm/exe dir; downstream tests can
+  // invoke the resulting `pnpx.exe` (etc.) and assert the alias actually ran.
+  fs.linkSync(process.execPath, path.join(platformDir, 'pnpm.exe'))
+  // platform-pkg-name.js calls into detect-libc on Linux; symlink the real
+  // package so the resolver finds it from the sandbox.
+  fs.symlinkSync(
+    path.join(exeDir, 'node_modules', 'detect-libc'),
+    path.join(sandbox, 'node_modules', 'detect-libc'),
+    'dir'
+  )
+
+  execFileSync(process.execPath, [path.join(sandbox, 'prepare.js')], { cwd: sandbox })
+  execFileSync(process.execPath, [path.join(sandbox, 'setup.js')], { cwd: sandbox })
+
+  return sandbox
+}
+
+const winSetupTest = isWindows ? test : test.skip
+
+// Regression coverage for https://github.com/pnpm/pnpm/issues/11486.
+// See the matching describe block in
+// engine/pm/commands/test/self-updater/selfUpdate.test.ts for the full
+// rationale; this one covers the @pnpm/exe preinstall path that handles
+// fresh `npm install -g @pnpm/exe`.
+winSetupTest('setup.js (Windows) rewrites bin to .exe entries and hardlinks pn/pnpx/pnx aliases (issue #11486)', () => {
+  const sandbox = buildWinSetupSandbox()
+  const pkg = JSON.parse(fs.readFileSync(path.join(sandbox, 'package.json'), 'utf8'))
+
+  expect(pkg.bin).toEqual({
+    pnpm: 'pnpm.exe',
+    pn: 'pn.exe',
+    pnpx: 'pnpx.exe',
+    pnx: 'pnx.exe',
+  })
+
+  const pnpmIno = fs.statSync(path.join(sandbox, 'pnpm.exe')).ino
+  for (const name of ['pn', 'pnpx', 'pnx']) {
+    const aliasPath = path.join(sandbox, `${name}.exe`)
+    expect(fs.existsSync(aliasPath)).toBe(true)
+    expect(fs.statSync(aliasPath).ino).toBe(pnpmIno)
+  }
+})
+
+winSetupTest('aliases run from Bash (Git Bash / MSYS2) without dropping into interactive cmd.exe (issue #11486)', async () => {
+  const sandbox = buildWinSetupSandbox()
+  const pkg = JSON.parse(fs.readFileSync(path.join(sandbox, 'package.json'), 'utf8'))
+
+  // Mirror what `pnpm self-update` does in the global bin: feed each bin
+  // entry into @zkochan/cmd-shim and let it write the Bash / cmd / pwsh
+  // shims. Using cmd-shim here (the same lib pnpm's bin linker uses) is what
+  // lets this repro the real-world chain rather than just asserting the
+  // package.json shape.
+  const binDir = path.join(sandbox, 'global-bin')
+  await Promise.all(Object.entries(pkg.bin).map(([name, target]) =>
+    cmdShim(path.join(sandbox, target as string), path.join(binDir, name), { createPwshFile: true })
+  ))
+
+  for (const alias of ['pn', 'pnpx', 'pnx']) {
+    const shim = path.join(binDir, alias).replace(/\\/g, '/')
+    // The shim's target is hardlinked to node.exe in this test (it's the
+    // SEA pnpm.exe in production), so `-e "..."` lets us assert the alias
+    // really ran our snippet — a successful assertion implies the cmd.exe
+    // hop got bypassed.
+    const result = spawnSync('bash', ['-c', `'${shim}' -e "process.stdout.write('${alias}_OK')"`], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    })
+
+    // Pre-fix symptom: cmd-shim's Bash shim for a .cmd target does
+    // `exec cmd /C ...`. MSYS2 mangles `/C` into a Windows path before
+    // cmd.exe sees it; cmd.exe finds no /C or /K and falls into interactive
+    // mode, printing its banner instead of running the alias.
+    expect({ alias, banner: /Microsoft Windows/.test(result.stdout + result.stderr) })
+      .toEqual({ alias, banner: false })
+    expect({ alias, stdout: result.stdout })
+      .toEqual({ alias, stdout: `${alias}_OK` })
+  }
 })

--- a/pnpm/src/pnpm.ts
+++ b/pnpm/src/pnpm.ts
@@ -1,9 +1,11 @@
 'use strict'
+import path from 'node:path'
+
 // Avoid "Possible EventEmitter memory leak detected" warnings
 // because it breaks pnpm's CLI output
 process.setMaxListeners(0)
 
-const argv = process.argv.slice(2)
+const argv = buildArgv()
 
 ; (async () => {
   await runPnpm()
@@ -17,4 +19,20 @@ async function runPnpm (): Promise<void> {
   } catch (err: any) { // eslint-disable-line
     await errorHandler(err)
   }
+}
+
+// Resolve `pnpx` / `pnx` aliases of the SEA binary. On Windows the @pnpm/exe
+// install hardlinks pnpx.exe / pnx.exe to pnpm.exe; when invoked via either
+// of those names, `process.execPath` reflects the launch path, so we read its
+// basename and prepend `dlx` to argv. The non-SEA entry points (bin/pnpx.mjs,
+// shell scripts in pnpm setup) inject `dlx` themselves before reaching this
+// file, so this only triggers for the SEA path. See
+// https://github.com/pnpm/pnpm/issues/11486.
+function buildArgv (): string[] {
+  const userArgv = process.argv.slice(2)
+  const execName = path.basename(process.execPath, path.extname(process.execPath)).toLowerCase()
+  if (execName === 'pnpx' || execName === 'pnx') {
+    return ['dlx', ...userArgv]
+  }
+  return userArgv
 }


### PR DESCRIPTION
## Summary

- Fixes [#11486](https://github.com/pnpm/pnpm/issues/11486): `pn` / `pnpx` / `pnx` printed the cmd.exe banner and dropped into an interactive command prompt instead of running pnpm when invoked from Git Bash on Windows after a `pnpm self-update` (or fresh `npm install -g @pnpm/exe`).
- Roots out the cmd.exe hop entirely by hardlinking `pn.exe` / `pnpx.exe` / `pnx.exe` to the SEA `pnpm.exe` and pointing `bin` at those `.exe` files. The SEA detects which name it was launched as via `process.execPath` and prepends `dlx` for `pnpx` / `pnx`.

## Why this was broken

@pnpm/exe's install (both `setup.js` preinstall and `linkExePlatformBinary` in `pnpm self-update`) rewrote `bin` to point those aliases at `.cmd` wrappers. `@zkochan/cmd-shim` reads each bin source and infers an interpreter; for `.cmd` it emits a Bash shim of the form:

```sh
exec cmd /C \"\$basedir/.../pnpx.cmd\" \"\$@\"
```

In MSYS2 / Git Bash on Windows, the runtime mangles the lone \`/C\` switch into a Windows path before cmd.exe sees it. cmd.exe then finds no \`/C\` or \`/K\` switch and falls into interactive mode — the user sees its banner. \`pnpm\` itself worked because its bin source was already \`pnpm.exe\`, so cmd-shim emits a direct \`exec\` with no \`cmd.exe\` in the chain.

## Test plan

- [x] New Windows-only tests in \`pnpm/artifacts/exe/test/setup.test.ts\` and \`engine/pm/commands/test/self-updater/selfUpdate.test.ts\` repro the chain end-to-end via cmd-shim and Bash, and assert no cmd.exe banner appears (skipped on non-Windows). Committed before the fix so the diff makes the bug observable.
- [x] Existing tests pass on macOS (\`pnpm --filter @pnpm/exe test\`, linkExePlatformBinary describe).
- [x] Lint clean.
- [ ] Windows CI on this PR exercises the new tests.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command aliases (pn, pnpx, pnx) on Windows now behave correctly in Git Bash/MSYS2, avoiding interactive cmd prompts.
  * pnpx and pnx invocation issues on Windows (dlx execution) have been resolved.

* **Tests**
  * Added Windows-specific regression tests validating alias creation and packaging behavior.

* **Chores**
  * Packaging and build/setup adjusted so Windows command aliases are delivered as native .exe aliases; added related test/build scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->