### PR TITLE
fix: skip Content-Length check when response is content-encoded

### DIFF
--- a/.changeset/tarball-content-encoding.md
+++ b/.changeset/tarball-content-encoding.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fixed `ERR_PNPM_BAD_TARBALL_SIZE` when a registry serves tarballs with an end-to-end `Content-Encoding` (e.g. `gzip`). Per the HTTP spec, `Content-Length` in this case refers to the encoded payload, not the decoded bytes that the fetch layer yields, so the strict size check no longer applies when the response is content-encoded [#11506](https://github.com/pnpm/pnpm/issues/11506).
+Fixed `ERR_PNPM_BAD_TARBALL_SIZE` when a registry serves tarballs with an end-to-end `Content-Encoding` (e.g. `gzip`). Tarballs are already compressed, so the fetcher now requests them with `Accept-Encoding: identity` (matching pnpm v10's effective behavior) and, as defense in depth against misbehaving servers, no longer enforces the strict `Content-Length` check when the response declares a `Content-Encoding` — `Content-Length` in that case refers to the encoded payload, not the decoded bytes the fetch implementation yields [#11506](https://github.com/pnpm/pnpm/issues/11506).

--- a/.changeset/tarball-content-encoding.md
+++ b/.changeset/tarball-content-encoding.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fetching.tarball-fetcher": patch
+"pnpm": patch
+---
+
+Fixed `ERR_PNPM_BAD_TARBALL_SIZE` when a registry serves tarballs with an end-to-end `Content-Encoding` (e.g. `gzip`). Per the HTTP spec, `Content-Length` in this case refers to the encoded payload, not the decoded bytes that the fetch layer yields, so the strict size check no longer applies when the response is content-encoded [#11506](https://github.com/pnpm/pnpm/issues/11506).

--- a/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -120,6 +120,10 @@ export function createDownloader (
       try {
         const res = await fetchFromRegistry(url, {
           authHeaderValue,
+          // Tarballs are already compressed; ask the server not to apply an additional
+          // Content-Encoding so Content-Length matches the body we receive and we don't
+          // waste CPU on round-trip re-compression. See https://github.com/pnpm/pnpm/issues/11506
+          headers: { 'accept-encoding': 'identity' },
           // The fetch library can retry requests on bad HTTP responses.
           // However, it is not enough to retry on bad HTTP responses only.
           // Requests should also be retried when the tarball's integrity check fails.

--- a/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -133,7 +133,12 @@ export function createDownloader (
           throw new FetchError({ url, authHeaderValue }, res)
         }
 
-        const contentLength = res.headers.has('content-length') && res.headers.get('content-length')
+        // When Content-Encoding is present, Content-Length refers to the encoded form
+        // of the data, not the decoded bytes that the fetch implementation yields.
+        // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding
+        const contentEncoding = res.headers.get('content-encoding')
+        const isEncoded = contentEncoding != null && contentEncoding !== '' && contentEncoding.toLowerCase() !== 'identity'
+        const contentLength = !isEncoded && res.headers.has('content-length') && res.headers.get('content-length')
         const parsedLength = typeof contentLength === 'string' ? parseInt(contentLength, 10) : NaN
         const size = Number.isFinite(parsedLength) && parsedLength >= 0 ? parsedLength : null
         if (opts.onStart != null) {

--- a/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -140,8 +140,7 @@ export function createDownloader (
         // When Content-Encoding is present, Content-Length refers to the encoded form
         // of the data, not the decoded bytes that the fetch implementation yields.
         // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding
-        const contentEncoding = res.headers.get('content-encoding')
-        const isEncoded = contentEncoding != null && contentEncoding !== '' && contentEncoding.toLowerCase() !== 'identity'
+        const isEncoded = isContentEncoded(res.headers.get('content-encoding'))
         const contentLength = !isEncoded && res.headers.has('content-length') && res.headers.get('content-length')
         const parsedLength = typeof contentLength === 'string' ? parseInt(contentLength, 10) : NaN
         const size = Number.isFinite(parsedLength) && parsedLength >= 0 ? parsedLength : null
@@ -221,4 +220,15 @@ export function createDownloader (
       })
     }
   }
+}
+
+// Per RFC 9110 §8.4, Content-Encoding is a comma-separated list of codings.
+// The response is encoded unless every coding is `identity` (case-insensitive,
+// surrounding whitespace ignored).
+function isContentEncoded (header: string | null): boolean {
+  if (header == null) return false
+  return header
+    .split(',')
+    .map(coding => coding.trim().toLowerCase())
+    .some(coding => coding !== '' && coding !== 'identity')
 }

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -143,17 +143,25 @@ test('request tarballs with Accept-Encoding: identity', async () => {
   expect(observedAcceptEncoding).toBe('identity')
 })
 
-test("don't fail on content-length mismatch when Content-Encoding is set", async () => {
+test.each([
+  ['gzip'],
+  ['GZIP'],
+  ['identity, gzip'],
+  ['gzip, identity'],
+  [' gzip '],
+])("don't fail on content-length mismatch when Content-Encoding is %j", async (contentEncoding) => {
   // Defense in depth: a misbehaving server may stamp Content-Encoding on the response
   // even when the client sent Accept-Encoding: identity. In that case undici decodes
   // the body and Content-Length (encoded form) no longer matches the bytes we read.
+  // Per RFC 9110 §8.4, Content-Encoding is a comma-separated, case-insensitive list,
+  // so the parser must handle whitespace, casing, and mixed codings.
   const tarballContent = fs.readFileSync(tarballPath)
   const mockPool = mockAgent.get(registry)
 
   mockPool.intercept({ path: '/foo.tgz', method: 'GET' }).reply(200, tarballContent, {
     headers: {
       'Content-Length': (tarballSize + 100).toString(),
-      'Content-Encoding': 'gzip',
+      'Content-Encoding': contentEncoding,
     },
   })
 
@@ -168,6 +176,38 @@ test("don't fail on content-length mismatch when Content-Encoding is set", async
   })
 
   expect(result.filesMap).toBeTruthy()
+})
+
+test('still enforce content-length when Content-Encoding is identity', async () => {
+  // identity (alone, with whitespace, or with mixed casing) means "no transformation";
+  // Content-Length still reflects the bytes on the wire and the strict check applies.
+  const tarballContent = fs.readFileSync(tarballPath)
+  const mockPool = mockAgent.get(registry)
+
+  mockPool.intercept({ path: '/foo.tgz', method: 'GET' }).reply(200, tarballContent, {
+    headers: {
+      'Content-Length': (1024 * 1024).toString(),
+      'Content-Encoding': ' Identity ',
+    },
+  })
+  mockPool.intercept({ path: '/foo.tgz', method: 'GET' }).reply(200, tarballContent, {
+    headers: {
+      'Content-Length': (1024 * 1024).toString(),
+      'Content-Encoding': ' Identity ',
+    },
+  })
+
+  process.chdir(temporaryDirectory())
+
+  const resolution = { tarball: `${registry}/foo.tgz` }
+
+  await expect(
+    fetch.remoteTarball(cafs, resolution, {
+      filesIndexFile,
+      lockfileDir: process.cwd(),
+      pkg,
+    })
+  ).rejects.toThrow(BadTarballError)
 })
 
 test('retry when tarball size does not match content-length', async () => {

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -116,10 +116,37 @@ test('fail when tarball size does not match content-length', async () => {
   )
 })
 
-test("don't fail on content-length mismatch when Content-Encoding is set", async () => {
-  // When a server applies an end-to-end encoding (e.g. gzip), Content-Length refers to the
-  // encoded form, but undici fetch yields decoded bytes — so the size check would be wrong.
+test('request tarballs with Accept-Encoding: identity', async () => {
+  // Tarballs are already gzipped. Asking the server for an additional Content-Encoding
+  // wastes CPU and (when servers misbehave per RFC 7230 §3.3.2) breaks the size check
+  // because Content-Length refers to the encoded payload but undici yields decoded bytes.
   // See: https://github.com/pnpm/pnpm/issues/11506
+  const tarballContent = fs.readFileSync(tarballPath)
+  const mockPool = mockAgent.get(registry)
+
+  let observedAcceptEncoding: string | string[] | undefined
+  mockPool.intercept({ path: '/foo.tgz', method: 'GET' }).reply(({ headers }) => {
+    observedAcceptEncoding = (headers as Record<string, string | string[]>)['accept-encoding']
+    return { statusCode: 200, data: tarballContent }
+  })
+
+  process.chdir(temporaryDirectory())
+
+  const resolution = { tarball: `${registry}/foo.tgz` }
+
+  await fetch.remoteTarball(cafs, resolution, {
+    filesIndexFile,
+    lockfileDir: process.cwd(),
+    pkg,
+  })
+
+  expect(observedAcceptEncoding).toBe('identity')
+})
+
+test("don't fail on content-length mismatch when Content-Encoding is set", async () => {
+  // Defense in depth: a misbehaving server may stamp Content-Encoding on the response
+  // even when the client sent Accept-Encoding: identity. In that case undici decodes
+  // the body and Content-Length (encoded form) no longer matches the bytes we read.
   const tarballContent = fs.readFileSync(tarballPath)
   const mockPool = mockAgent.get(registry)
 

--- a/fetching/tarball-fetcher/test/fetch.ts
+++ b/fetching/tarball-fetcher/test/fetch.ts
@@ -116,6 +116,33 @@ test('fail when tarball size does not match content-length', async () => {
   )
 })
 
+test("don't fail on content-length mismatch when Content-Encoding is set", async () => {
+  // When a server applies an end-to-end encoding (e.g. gzip), Content-Length refers to the
+  // encoded form, but undici fetch yields decoded bytes — so the size check would be wrong.
+  // See: https://github.com/pnpm/pnpm/issues/11506
+  const tarballContent = fs.readFileSync(tarballPath)
+  const mockPool = mockAgent.get(registry)
+
+  mockPool.intercept({ path: '/foo.tgz', method: 'GET' }).reply(200, tarballContent, {
+    headers: {
+      'Content-Length': (tarballSize + 100).toString(),
+      'Content-Encoding': 'gzip',
+    },
+  })
+
+  process.chdir(temporaryDirectory())
+
+  const resolution = { tarball: `${registry}/foo.tgz` }
+
+  const result = await fetch.remoteTarball(cafs, resolution, {
+    filesIndexFile,
+    lockfileDir: process.cwd(),
+    pkg,
+  })
+
+  expect(result.filesMap).toBeTruthy()
+})
+
 test('retry when tarball size does not match content-length', async () => {
   const tarballContent = fs.readFileSync(tarballPath)
   const mockPool = mockAgent.get(registry)


### PR DESCRIPTION
## Summary

Fixes [#11506](https://github.com/pnpm/pnpm/issues/11506) — `ERR_PNPM_BAD_TARBALL_SIZE` when a registry serves tarballs with `Content-Encoding: gzip`.

### Why v10 worked but v11 doesn't

I verified this against the actual v10 source. v10 worked because of one line in `network/fetch/src/fetchFromRegistry.ts` on the `v10` branch:

```js
compress: opts?.compress ?? false,
```

`node-fetch` honored that flag by suppressing `Accept-Encoding` and not auto-decompressing the body. v11's switch to undici (#10537) silently dropped this — undici's WHATWG `fetch` always sends `Accept-Encoding: gzip, deflate, br` and transparently decodes the response body. Importantly, it leaves `Content-Length` pointed at the **encoded** payload (confirmed empirically — and matches the spec). When the strict size check landed in #11151, this began rejecting any tarball served with end-to-end content encoding.

Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Encoding): *"When the Content-Encoding header is present, other metadata (e.g., Content-Length) refer to the encoded form of the data, not the original resource."*

### Fix

Two layers:

1. **Send `Accept-Encoding: identity` for tarball requests.** Tarballs are already gzipped — asking for an additional encoding wastes CPU and triggers the bug. This restores v10's effective behavior.
2. **Skip the strict `Content-Length` check when the response declares a non-identity `Content-Encoding`.** Defense in depth against misbehaving servers that stamp `Content-Encoding` regardless of `Accept-Encoding` (the OP's case looked like Artifactory). Integrity verification via SHA still catches genuinely corrupt payloads.

## Test plan

- [x] New unit test asserts `Accept-Encoding: identity` is sent on the tarball request
- [x] New unit test asserts a server response with mismatched `Content-Length` and `Content-Encoding: gzip` is accepted
- [x] Existing `fetch.ts` suite still passes (24/24)
- [x] Lint clean

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ERR_PNPM_BAD_TARBALL_SIZE by requesting tarballs with Accept-Encoding: identity and by relaxing strict Content-Length validation for responses that are content-encoded.
* **Tests**
  * Added regression tests for the tarball request header and for handling responses with various Content-Encoding forms and size behaviors.
* **Documentation**
  * Bumped patch versions and added a changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->