### PR TITLE
fix(deploy): copy `.packageManager` from the workspace to the deployed `package.json`

### DIFF
--- a/.changeset/deploy-copy-package-manager.md
+++ b/.changeset/deploy-copy-package-manager.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+`pnpm deploy` should copy the `packageManager` from the workspace `package.json` to the deployed `package.json`.

--- a/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/releasing/commands/src/deploy/createDeployFiles.ts
@@ -29,6 +29,7 @@ export interface CreateDeployFilesOptions {
   lockfile: LockfileObject
   lockfileDir: string
   patchedDependencies?: PnpmSettings['patchedDependencies']
+  rootProjectManifest?: Pick<ProjectManifest, 'packageManager'>
   selectedProjectManifest: ProjectManifest
   projectId: ProjectId
   rootProjectManifestDir: string
@@ -52,6 +53,7 @@ export function createDeployFiles ({
   lockfile,
   lockfileDir,
   patchedDependencies,
+  rootProjectManifest,
   selectedProjectManifest,
   projectId,
   rootProjectManifestDir,
@@ -145,6 +147,7 @@ export function createDeployFiles ({
       dependencies: targetSnapshot.dependencies,
       devDependencies: targetSnapshot.devDependencies,
       optionalDependencies: targetSnapshot.optionalDependencies,
+      packageManager: rootProjectManifest?.packageManager ?? selectedProjectManifest.packageManager,
     },
   }
 

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -240,6 +240,7 @@ async function deployFromSharedLockfile (
     lockfile,
     lockfileDir,
     patchedDependencies: opts.patchedDependencies,
+    rootProjectManifest: opts.rootProjectManifest,
     selectedProjectManifest: selectedProject.manifest,
     projectId,
     rootProjectManifestDir,


### PR DESCRIPTION
(Hopefully a) fix for https://github.com/pnpm/pnpm/issues/9079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The `pnpm deploy` command now correctly copies the `packageManager` field from the workspace root configuration to the deployed package.json, ensuring consistent package manager settings across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->