### PR TITLE
fix(global): rescue co-installed packages when one of them is re-added

### DIFF
--- a/.changeset/fix-global-add-carry-over.md
+++ b/.changeset/fix-global-add-carry-over.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/global.commands": patch
+"pnpm": patch
+---
+
+fix(global): preserve other members of an isolated install group when re-adding one of them.
+
+When a global install group contains multiple packages, running `pnpm -g add <pkg>` on any single member used to remove the entire group and replace it with a fresh install of only the requested package, silently dropping the rest. The group's other members are now carried over at their current versions, so only the requested package is updated.

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -10,6 +10,7 @@ import {
   createGlobalCacheKey,
   createInstallDir,
   findGlobalPackage,
+  getGlobalPackageDetails,
   getHashLink,
   getInstalledBinNames,
 } from '@pnpm/global.packages'
@@ -93,7 +94,7 @@ async function installGroup (
   // Install into a new directory first, then read the resolved aliases
   // from the resulting package.json. This is more reliable than parsing
   // aliases from CLI params (which may be tarballs, git URLs, etc.).
-  const installDir = createInstallDir(globalDir)
+  let installDir = createInstallDir(globalDir)
 
   const include = {
     dependencies: true,
@@ -102,13 +103,13 @@ async function installGroup (
   }
   const fetchFullMetadata = opts.supportedArchitectures?.libc != null && true
 
-  const installOpts = {
+  const makeInstallOpts = (dir: string) => ({
     ...opts,
     global: false,
-    bin: path.join(installDir, 'node_modules/.bin'),
-    dir: installDir,
-    lockfileDir: installDir,
-    rootProjectManifestDir: installDir,
+    bin: path.join(dir, 'node_modules/.bin'),
+    dir,
+    lockfileDir: dir,
+    rootProjectManifestDir: dir,
     rootProjectManifest: undefined,
     saveProd: true,
     saveDev: false,
@@ -122,9 +123,24 @@ async function installGroup (
     includeDirect: include,
     allowBuilds,
     omitSummaryLog: true,
-  }
+  })
 
-  const ignoredBuilds = await installGlobalPackages(installOpts, params)
+  let ignoredBuilds = await installGlobalPackages(makeInstallOpts(installDir), params)
+  let aliases = Object.keys(readPackageJsonFromDirRawSync(installDir).dependencies ?? {})
+
+  // If a re-added alias belongs to an existing isolated group with other
+  // members, redo the install with those members carried over at their current
+  // versions. The group's composition is preserved with only the requested
+  // package(s) updated, instead of the rest being silently dropped when the
+  // old install dir is replaced.
+  const carryOver = await collectCarryOver(globalDir, aliases)
+  if (carryOver.length > 0) {
+    await fs.promises.rm(installDir, { recursive: true, force: true })
+    installDir = createInstallDir(globalDir)
+    const mergedParams = [...params, ...carryOver.map(({ alias, version }) => `${alias}@${version}`)]
+    ignoredBuilds = await installGlobalPackages(makeInstallOpts(installDir), mergedParams)
+    aliases = Object.keys(readPackageJsonFromDirRawSync(installDir).dependencies ?? {})
+  }
 
   await promptApproveGlobalBuilds({
     globalPkgDir: globalDir,
@@ -133,10 +149,6 @@ async function installGroup (
     allowBuilds,
     inheritedOpts: opts,
   }, commands)
-
-  // Read resolved aliases from the installed package.json
-  const pkgJson = readPackageJsonFromDirRawSync(installDir)
-  const aliases = Object.keys(pkgJson.dependencies ?? {})
 
   // Check for bin name conflicts with other global packages
   // (must happen before removeExistingGlobalInstalls so we don't lose existing packages on failure)
@@ -218,6 +230,25 @@ function resolveLocalParam (param: string, baseDir: string): string {
     return path.resolve(baseDir, param)
   }
   return param
+}
+
+async function collectCarryOver (
+  globalDir: string,
+  reAddedAliases: string[]
+): Promise<Array<{ alias: string, version: string }>> {
+  const reAddedSet = new Set(reAddedAliases)
+  const seenGroups = new Set<string>()
+  const carryOver: Array<{ alias: string, version: string }> = []
+  for (const alias of reAddedAliases) {
+    const existing = findGlobalPackage(globalDir, alias)
+    if (!existing || seenGroups.has(existing.hash)) continue
+    seenGroups.add(existing.hash)
+    const details = await getGlobalPackageDetails(existing) // eslint-disable-line no-await-in-loop
+    for (const { alias: a, version } of details) {
+      if (!reAddedSet.has(a)) carryOver.push({ alias: a, version })
+    }
+  }
+  return carryOver
 }
 
 async function removeExistingGlobalInstalls (

--- a/pnpm/test/install/global.ts
+++ b/pnpm/test/install/global.ts
@@ -670,6 +670,22 @@ test('global add bundles comma-separated packages into a single group', async ()
   expect(peerC!.installDir).not.toBe(positive!.installDir)
 })
 
+test('global add preserves the rest of a comma-grouped install when one member is re-added', async () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  const env = { [PATH_NAME]: path.join(pnpmHome, 'bin'), PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  await execPnpm(['add', '-g', 'is-positive@1.0.0,is-negative@1.0.0,@pnpm.e2e/peer-c@1'], { env })
+  await execPnpm(['add', '-g', 'is-positive@1.0.0'], { env })
+
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'is-positive')).toBeTruthy()
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'is-negative')).toBeTruthy()
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), '@pnpm.e2e/peer-c')).toBeTruthy()
+})
+
 test('global add does not treat commas inside a local path selector as a group separator', () => {
   prepare()
   const global = path.resolve('..', 'global')


### PR DESCRIPTION
Closes https://github.com/pnpm/pnpm/issues/11520

Assisted with an agent (Claude Code, claude-sonnet-4-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Global add now preserves other packages in a group when re-adding a member of an existing isolated global installation, maintaining their existing installed versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11541)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->