### PR TITLE
fix(config): honor NPM_CONFIG_USERCONFIG as a low-priority fallback

### DIFF
--- a/.changeset/honor-npm-config-userconfig.md
+++ b/.changeset/honor-npm-config-userconfig.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Honor `NPM_CONFIG_USERCONFIG` (and its lowercase `npm_config_userconfig` form) as a low-priority fallback when locating the user-level `.npmrc`. This restores compatibility with environments that point npm at a custom auth file via that env var — most notably `actions/setup-node`, which writes registry credentials to `${runner.temp}/.npmrc` and exports `NPM_CONFIG_USERCONFIG` to reference it. Without this, GitHub Actions workflows using `actions/setup-node` to authenticate to private registries broke after upgrading to pnpm v11. PNPM-prefixed env vars and `npmrcAuthFile` from the global `config.yaml` continue to take precedence [#11539](https://github.com/pnpm/pnpm/issues/11539).

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -221,12 +221,18 @@ export async function getConfig (opts: {
   // also have to peek at the relevant env vars here in order for
   // PNPM_CONFIG_NPMRC_AUTH_FILE / PNPM_CONFIG_USERCONFIG (and their lowercase
   // equivalents) to actually decide which user-level .npmrc gets read.
+  // npm_config_userconfig is honored as a low-priority compatibility fallback
+  // so that environments that point npm at a custom .npmrc (e.g. actions/setup-node
+  // writing to ${runner.temp}/.npmrc) keep working without requiring users to
+  // rename the env var to its PNPM_CONFIG_* equivalent.
   const globalYamlConfigForNpmrcAuthFile = await readWorkspaceManifest(configDir, GLOBAL_CONFIG_YAML_FILENAME)
   const npmrcAuthFile = cliOptions['npmrc-auth-file'] as string | undefined
     ?? cliOptions.userconfig as string | undefined
     ?? readEnvVar(env, 'npmrc_auth_file')
     ?? readEnvVar(env, 'userconfig')
     ?? globalYamlConfigForNpmrcAuthFile?.npmrcAuthFile
+    ?? env.npm_config_userconfig
+    ?? env.NPM_CONFIG_USERCONFIG
 
   const npmrcResult = loadNpmrcConfig({
     cliOptions,

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -231,8 +231,7 @@ export async function getConfig (opts: {
     ?? readEnvVar(env, 'npmrc_auth_file')
     ?? readEnvVar(env, 'userconfig')
     ?? globalYamlConfigForNpmrcAuthFile?.npmrcAuthFile
-    ?? env.npm_config_userconfig
-    ?? env.NPM_CONFIG_USERCONFIG
+    ?? readNpmEnvVar(env, 'userconfig')
 
   const npmrcResult = loadNpmrcConfig({
     cliOptions,
@@ -699,6 +698,14 @@ function getProcessEnv (env: string): string | undefined {
 // is loaded.
 function readEnvVar (env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[`pnpm_config_${key}`] ?? env[`PNPM_CONFIG_${key.toUpperCase()}`]
+  return value !== '' ? value : undefined
+}
+
+// Same shape as readEnvVar but for the `npm_config_<key>` family. Used as a
+// low-priority compatibility shim so that npm-style env vars (e.g.
+// NPM_CONFIG_USERCONFIG written by actions/setup-node) keep working.
+function readNpmEnvVar (env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[`npm_config_${key}`] ?? env[`NPM_CONFIG_${key.toUpperCase()}`]
   return value !== '' ? value : undefined
 }
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1275,6 +1275,33 @@ test('getConfig() prefers PNPM_CONFIG_USERCONFIG over NPM_CONFIG_USERCONFIG when
   expect(config.userConfig).toEqual({ registry: 'https://pnpm.example.test' })
 })
 
+// An empty NPM_CONFIG_USERCONFIG (e.g. `export NPM_CONFIG_USERCONFIG=`) must be
+// treated as unset. Otherwise it short-circuits the fallback chain and resolves
+// to the cwd, returning an empty/invalid auth config instead of ~/.npmrc.
+test('getConfig() ignores an empty NPM_CONFIG_USERCONFIG and falls back to ~/.npmrc', async () => {
+  prepareEmpty()
+  const homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(path.resolve('user-home'))
+  try {
+    fs.mkdirSync('user-home')
+    fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://home.example.test', 'utf-8')
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        NPM_CONFIG_USERCONFIG: '',
+        npm_config_userconfig: '',
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+    expect(config.userConfig).toEqual({ registry: 'https://home.example.test' })
+  } finally {
+    homedirSpy.mockRestore()
+  }
+})
+
 test('getConfig() sets sideEffectsCacheRead and sideEffectsCacheWrite when side-effects-cache is set', async () => {
   const { config } = await getConfig({
     cliOptions: {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -1217,6 +1217,64 @@ test('getConfig() prefers pnpm_config_userconfig over PNPM_CONFIG_USERCONFIG whe
   expect(config.userConfig).toEqual({ registry: 'https://lower.example.test' })
 })
 
+// actions/setup-node writes auth to ${runner.temp}/.npmrc and sets NPM_CONFIG_USERCONFIG;
+// pnpm honors it as a low-priority compatibility fallback for that flow.
+test('getConfig() reads userconfig from NPM_CONFIG_USERCONFIG env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      NPM_CONFIG_USERCONFIG: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
+test('getConfig() reads userconfig from npm_config_userconfig env var', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', '.npmrc'), 'registry = https://registry.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      npm_config_userconfig: path.resolve('user-home', '.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://registry.example.test' })
+})
+
+test('getConfig() prefers PNPM_CONFIG_USERCONFIG over NPM_CONFIG_USERCONFIG when both are set', async () => {
+  prepareEmpty()
+  fs.mkdirSync('user-home')
+  fs.writeFileSync(path.resolve('user-home', 'pnpm.npmrc'), 'registry = https://pnpm.example.test', 'utf-8')
+  fs.writeFileSync(path.resolve('user-home', 'npm.npmrc'), 'registry = https://npm.example.test', 'utf-8')
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      PNPM_CONFIG_USERCONFIG: path.resolve('user-home', 'pnpm.npmrc'),
+      NPM_CONFIG_USERCONFIG: path.resolve('user-home', 'npm.npmrc'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.userConfig).toEqual({ registry: 'https://pnpm.example.test' })
+})
+
 test('getConfig() sets sideEffectsCacheRead and sideEffectsCacheWrite when side-effects-cache is set', async () => {
   const { config } = await getConfig({
     cliOptions: {
@@ -1868,6 +1926,37 @@ describe('global config.yaml', () => {
     })
 
     expect(config.httpsProxy).toBe('http://cli-proxy.example.com:7070')
+  })
+
+  // npmrcAuthFile in global config.yaml is a deliberate pnpm-native setting and should
+  // not be silently overridden by an ambient NPM_CONFIG_USERCONFIG (e.g. from a CI runner).
+  test('npmrcAuthFile from global config.yaml takes precedence over NPM_CONFIG_USERCONFIG', async () => {
+    prepareEmpty()
+    fs.mkdirSync('user-home')
+    fs.writeFileSync(path.resolve('user-home', 'yaml.npmrc'), 'registry = https://yaml.example.test', 'utf-8')
+    fs.writeFileSync(path.resolve('user-home', 'npm.npmrc'), 'registry = https://npm.example.test', 'utf-8')
+
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', {
+      npmrcAuthFile: path.resolve('user-home', 'yaml.npmrc'),
+    })
+
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        NPM_CONFIG_USERCONFIG: path.resolve('user-home', 'npm.npmrc'),
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.userConfig).toEqual({ registry: 'https://yaml.example.test' })
   })
 })
 


### PR DESCRIPTION
## Summary

- Honor `NPM_CONFIG_USERCONFIG` (and lowercase `npm_config_userconfig`) as the lowest-priority fallback when locating the user-level `.npmrc`.
- Restores compatibility with `actions/setup-node`, which writes registry credentials to `${runner.temp}/.npmrc` and exports `NPM_CONFIG_USERCONFIG` to point at it. This silently broke in pnpm v11 because the env var loader only honors `PNPM_CONFIG_*` / `pnpm_config_*` prefixes, leaving GitHub Actions workflows that authenticate to private registries unable to install.
- `PNPM_CONFIG_USERCONFIG`, `PNPM_CONFIG_NPMRC_AUTH_FILE`, and `npmrcAuthFile` in the global `config.yaml` continue to take precedence — the npm-prefixed env var only kicks in when nothing pnpm-native is set.

Priority order (highest → lowest):
1. `--npmrc-auth-file` / `--userconfig` CLI flags
2. `PNPM_CONFIG_NPMRC_AUTH_FILE` / `pnpm_config_npmrc_auth_file`
3. `PNPM_CONFIG_USERCONFIG` / `pnpm_config_userconfig`
4. `npmrcAuthFile` in global `~/.config/pnpm/config.yaml` (pnpm-native)
5. `npm_config_userconfig` / `NPM_CONFIG_USERCONFIG` (new npm-compat fallback)
6. `~/.npmrc` (default)

Closes #11539.

## Test plan

- [x] New unit test: `NPM_CONFIG_USERCONFIG` is read from env
- [x] New unit test: `npm_config_userconfig` (lowercase) is read from env
- [x] New unit test: `PNPM_CONFIG_USERCONFIG` wins over `NPM_CONFIG_USERCONFIG` when both set
- [x] New unit test: `npmrcAuthFile` from global `config.yaml` wins over `NPM_CONFIG_USERCONFIG`
- [ ] Manual verification with the reporter's reproduction repo (https://github.com/aulonm/pnpm-11-repro-bug) once the PR builds a preview artifact

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * pnpm now respects NPM_CONFIG_USERCONFIG and npm_config_userconfig when locating the user-level .npmrc, improving authentication in CI/CD environments that set these vars. Existing pnpm-prefixed env vars and the global config setting for auth file remain higher priority, and empty values are treated as unset so defaults (e.g., ~/.npmrc) are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->