### PR TITLE
fix: run Node.js version check before loading bundle (#11546)

### DIFF
--- a/.changeset/pnpm-bin-version-check-hoisting.md
+++ b/.changeset/pnpm-bin-version-check-hoisting.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed the pnpm CLI crashing with a confusing `SyntaxError: Invalid regular expression flags` instead of printing a clear "requires Node.js v22.13" error when launched on an unsupported Node.js version. The Node.js version check in `bin/pnpm.mjs` was effectively dead code because the static `import` of the bundled `dist/pnpm.mjs` was hoisted by the ES module loader and parsed before the check could run [#11546](https://github.com/pnpm/pnpm/issues/11546).

--- a/pnpm/bin/pnpm.mjs
+++ b/pnpm/bin/pnpm.mjs
@@ -27,7 +27,10 @@ try {
 
 global['pnpm__startedAt'] = Date.now()
 
-import {} from '../dist/pnpm.mjs'
+// Use dynamic import so the Node.js version check above runs first; a static
+// import would be hoisted and parse the bundle before the check, crashing on
+// older Node.js versions that don't recognize newer syntax in bundled deps.
+await import('../dist/pnpm.mjs')
 
 // if you want to debug at your local env, you can use this
 // require('../lib/pnpm')


### PR DESCRIPTION
## Summary

Fixes [#11546](https://github.com/pnpm/pnpm/issues/11546).

The Node.js version check in `pnpm/bin/pnpm.mjs` was effectively dead code. It used a static `import` to load the bundled `dist/pnpm.mjs`, and ESM hoists static imports — so the bundle was parsed *before* the `if (major < 22 ...)` block could run. On Node.js versions older than the bundle's syntax target (e.g. Node 18 hitting a regex with the `/v` flag in a transitive dependency), users got a confusing `SyntaxError: Invalid regular expression flags` instead of the intended `ERROR: This version of pnpm requires at least Node.js v22.13` message.

Switching to `await import('../dist/pnpm.mjs')` makes the load order match the source order, so the version check runs first and exits with a friendly error.

The other entry points are unaffected:
- `pnpm/bin/pnpm.cjs` (Corepack shim) already uses dynamic `import('./pnpm.mjs')` and goes through the fixed file.
- `pnpm/pnpm.cjs` (`@pnpm/exe` SEA entry) ships its own embedded Node.js, so the version check isn't needed there.

## Test plan

- [x] Reproduced the hoisting behavior with a minimal ESM repro: a static `import` of a file containing `/a/v` parses before any code in the importing module runs, even when an early `process.exit(1)` should have prevented it.
- [x] Verified the fix: with the dynamic `await import()`, the version-check `console.error` + `process.exit(1)` runs first and the bundle is never parsed.
- [ ] Manual smoke test: `pnpm --version` on a supported Node.js (24+) still works.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash during pnpm CLI startup on unsupported Node.js versions that displayed a confusing syntax error instead of a clear compatibility message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->