### PR TITLE
fix: honor --prefix when resolving workspace dir

### DIFF
--- a/.changeset/prefix-workspace-resolution.md
+++ b/.changeset/prefix-workspace-resolution.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/cli.parse-cli-args": patch
+"pnpm": patch
+---
+
+Fixed `pnpm --prefix=<dir> install` overwriting the existing `pnpm-workspace.yaml` in `<dir>` with `set this to true or false` placeholders. The renamed `--prefix` option (which maps to `dir`) was not honored when locating the workspace root, so the workspace manifest's `allowBuilds` settings were not loaded into config and got clobbered when ignored builds were auto-populated [#11535](https://github.com/pnpm/pnpm/issues/11535).

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -65,7 +65,7 @@ export async function parseCliArgs (
     if (noptExploratoryResults['help']) {
       return {
         ...getParsedArgsForHelp(),
-        workspaceDir: await getWorkspaceDir(noptExploratoryResults),
+        workspaceDir: await getWorkspaceDir(noptExploratoryResults, opts.renamedOptions),
       }
     }
     if (noptExploratoryResults['version'] || noptExploratoryResults['v']) {
@@ -79,7 +79,7 @@ export async function parseCliArgs (
         params: noptExploratoryResults.argv.remain,
         unknownOptions: new Map(),
         fallbackCommandUsed: false,
-        workspaceDir: await getWorkspaceDir(noptExploratoryResults),
+        workspaceDir: await getWorkspaceDir(noptExploratoryResults, opts.renamedOptions),
       }
     }
   }
@@ -186,6 +186,18 @@ export async function parseCliArgs (
     const { argv: _, ...configOptions } = nopt({}, {}, configDotArgs, 0)
     Object.assign(options, configOptions)
   }
+  // Apply renamedOptions before workspace detection so `--prefix=foo`
+  // (renamed to `dir`) participates in finding the workspace root.
+  // Otherwise getWorkspaceDir falls back to process.cwd() and the
+  // workspace manifest at the prefix dir is missed (#11535).
+  if (opts.renamedOptions != null) {
+    for (const [cliOption, optionValue] of Object.entries(options)) {
+      if (opts.renamedOptions[cliOption]) {
+        options[opts.renamedOptions[cliOption]] = optionValue
+        delete options[cliOption]
+      }
+    }
+  }
   const workspaceDir = await getWorkspaceDir(options)
 
   // For the run command, it's not clear whether --help should be passed to the
@@ -194,15 +206,6 @@ export async function parseCliArgs (
     return {
       ...getParsedArgsForHelp(),
       workspaceDir,
-    }
-  }
-
-  if (opts.renamedOptions != null) {
-    for (const [cliOption, optionValue] of Object.entries(options)) {
-      if (opts.renamedOptions[cliOption]) {
-        options[opts.renamedOptions[cliOption]] = optionValue
-        delete options[cliOption]
-      }
     }
   }
 
@@ -287,8 +290,22 @@ function getClosestOptionMatches (knownOptions: string[], option: string): strin
   })
 }
 
-async function getWorkspaceDir (parsedOpts: Record<string, unknown>): Promise<string | undefined> {
+async function getWorkspaceDir (
+  parsedOpts: Record<string, unknown>,
+  renamedOptions?: Record<string, string>
+): Promise<string | undefined> {
   if (parsedOpts['global'] || parsedOpts['ignore-workspace']) return undefined
-  const dir = parsedOpts['dir'] ?? process.cwd()
-  return findWorkspaceDir(dir as string)
+  // Look up dir, also honoring renamed options like `prefix → dir` so that
+  // `--prefix` works even on code paths that read parsedOpts before the
+  // rename loop has run (e.g. the --help/--version short-circuits).
+  let dir = parsedOpts['dir']
+  if (dir == null && renamedOptions != null) {
+    for (const [from, to] of Object.entries(renamedOptions)) {
+      if (to === 'dir' && parsedOpts[from] != null) {
+        dir = parsedOpts[from]
+        break
+      }
+    }
+  }
+  return findWorkspaceDir((dir ?? process.cwd()) as string)
 }

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -190,10 +190,15 @@ export async function parseCliArgs (
   // (renamed to `dir`) participates in finding the workspace root.
   // Otherwise getWorkspaceDir falls back to process.cwd() and the
   // workspace manifest at the prefix dir is missed (#11535).
+  // The canonical option wins if both are supplied (e.g. `--prefix=foo
+  // --dir=bar` keeps `dir=bar`); the alias is always dropped.
   if (opts.renamedOptions != null) {
     for (const [cliOption, optionValue] of Object.entries(options)) {
-      if (opts.renamedOptions[cliOption]) {
-        options[opts.renamedOptions[cliOption]] = optionValue
+      const target = opts.renamedOptions[cliOption]
+      if (target) {
+        if (!(target in options)) {
+          options[target] = optionValue
+        }
         delete options[cliOption]
       }
     }

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -405,17 +405,54 @@ test('--workspace-root fails if used outside of a workspace', async () => {
 // a directory outside the project (e.g. `pnpm --prefix=child install` from
 // the parent dir) misses the workspace manifest in the prefix dir, and
 // settings declared there (e.g. allowBuilds) are silently overwritten.
-test('workspaceDir resolves from --prefix when prefix is renamed to dir', async () => {
+function setupParentWithChildWorkspace (): { parent: string, child: string } {
   const parent = temporaryDirectory()
   const child = path.join(parent, 'child')
   fs.mkdirSync(child)
   fs.writeFileSync(path.join(child, 'pnpm-workspace.yaml'), '')
   process.chdir(parent)
+  return { parent, child }
+}
+
+test('workspaceDir resolves from --prefix when prefix is renamed to dir', async () => {
+  const { child } = setupParentWithChildWorkspace()
   const { workspaceDir } = await parseCliArgs({
     ...DEFAULT_OPTS,
     universalOptionsTypes: { prefix: String },
   }, ['install', '--prefix=child'])
   expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+test('workspaceDir resolves from --prefix on the --help short-circuit', async () => {
+  const { child } = setupParentWithChildWorkspace()
+  const { cmd, workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, help: Boolean },
+  }, ['install', '--prefix=child', '--help'])
+  expect(cmd).toBe('help')
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+test('workspaceDir resolves from --prefix on the --version short-circuit', async () => {
+  const { child } = setupParentWithChildWorkspace()
+  const { cmd, workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, version: Boolean },
+  }, ['--prefix=child', '--version'])
+  expect(cmd).toBeNull()
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+// When both the alias and the canonical option are supplied, the canonical
+// value must win and the alias must be dropped — otherwise --prefix could
+// silently overwrite an explicit --dir.
+test('canonical option wins when both --prefix and --dir are passed', async () => {
+  const { options } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, dir: String },
+  }, ['install', '--prefix=fromPrefix', '--dir=fromDir'])
+  expect(options.dir).toBe('fromDir')
+  expect(options).not.toHaveProperty(['prefix'])
 })
 
 test('everything after an escape arg is a parameter', async () => {

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs'
 import os from 'node:os'
+import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { parseCliArgs } from '@pnpm/cli.parse-cli-args'
@@ -396,6 +398,24 @@ test('--workspace-root fails if used outside of a workspace', async () => {
   }
   expect(err).toBeTruthy()
   expect(err.code).toBe('ERR_PNPM_NOT_IN_WORKSPACE')
+})
+
+// Regression for #11535. The renamed option (`--prefix` → `dir`) must be
+// considered when locating the workspace root; otherwise running pnpm from
+// a directory outside the project (e.g. `pnpm --prefix=child install` from
+// the parent dir) misses the workspace manifest in the prefix dir, and
+// settings declared there (e.g. allowBuilds) are silently overwritten.
+test('workspaceDir resolves from --prefix when prefix is renamed to dir', async () => {
+  const parent = temporaryDirectory()
+  const child = path.join(parent, 'child')
+  fs.mkdirSync(child)
+  fs.writeFileSync(path.join(child, 'pnpm-workspace.yaml'), '')
+  process.chdir(parent)
+  const { workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String },
+  }, ['install', '--prefix=child'])
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
 })
 
 test('everything after an escape arg is a parameter', async () => {


### PR DESCRIPTION
## Summary

Fixes #11535. Running `pnpm --prefix=<dir> install` from a parent directory was overwriting `<dir>/pnpm-workspace.yaml`, replacing user-set `allowBuilds` values (e.g. `true`) with `set this to true or false` placeholders.

The CLI's `--prefix → dir` rename was applied **after** `getWorkspaceDir(options)` had already run, so workspace detection fell back to `process.cwd()` and missed the manifest at the prefix dir. With no workspace manifest loaded, `config.allowBuilds` ended up as `{}`, and the ignored-builds auto-population step (`handleIgnoredBuilds`) wrote placeholders over the user's existing settings.

The fix moves the rename loop ahead of `getWorkspaceDir` on the main parse path, and threads `renamedOptions` into `getWorkspaceDir` so the `--help`/`--version` short-circuit paths also resolve `--prefix` correctly.

## Test plan

- [x] Added regression test in `cli/parse-cli-args/test/index.ts` — verified it fails on `main` and passes with the fix
- [x] All 46 existing tests in `@pnpm/cli.parse-cli-args` pass
- [x] Lint passes

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm --prefix=<dir> install` overwriting a workspace manifest with placeholder values; `--prefix` now correctly affects workspace root detection to prevent unintended file changes.

* **Tests**
  * Added regression tests covering workspace detection with `--prefix` (and interactions with `--dir`), including short-circuit paths like `--help`/`--version`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->