### PR TITLE
fix: honor --prefix when resolving workspace dir (release/10)

### DIFF
--- a/.changeset/prefix-workspace-resolution.md
+++ b/.changeset/prefix-workspace-resolution.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/parse-cli-args": patch
+"pnpm": patch
+---
+
+Fixed `--prefix=<dir>` not being honored when locating the workspace root. The `--prefix → dir` rename was applied after workspace detection, so workspace settings declared in `<dir>/pnpm-workspace.yaml` were not loaded when pnpm was invoked from outside `<dir>` [#11535](https://github.com/pnpm/pnpm/issues/11535).

--- a/cli/parse-cli-args/src/index.ts
+++ b/cli/parse-cli-args/src/index.ts
@@ -65,7 +65,7 @@ export async function parseCliArgs (
     if (noptExploratoryResults['help']) {
       return {
         ...getParsedArgsForHelp(),
-        workspaceDir: await getWorkspaceDir(noptExploratoryResults),
+        workspaceDir: await getWorkspaceDir(noptExploratoryResults, opts.renamedOptions),
       }
     }
     if (noptExploratoryResults['version'] || noptExploratoryResults['v']) {
@@ -78,7 +78,7 @@ export async function parseCliArgs (
         params: noptExploratoryResults.argv.remain,
         unknownOptions: new Map(),
         fallbackCommandUsed: false,
-        workspaceDir: await getWorkspaceDir(noptExploratoryResults),
+        workspaceDir: await getWorkspaceDir(noptExploratoryResults, opts.renamedOptions),
       }
     }
   }
@@ -142,6 +142,23 @@ export async function parseCliArgs (
     0,
     { escapeArgs: getEscapeArgsWithSpecialCases() }
   )
+  // Apply renamedOptions before workspace detection so `--prefix=foo`
+  // (renamed to `dir`) participates in finding the workspace root.
+  // Otherwise getWorkspaceDir falls back to process.cwd() and the
+  // workspace manifest at the prefix dir is missed (#11535).
+  // The canonical option wins if both are supplied (e.g. `--prefix=foo
+  // --dir=bar` keeps `dir=bar`); the alias is always dropped.
+  if (opts.renamedOptions != null) {
+    for (const [cliOption, optionValue] of Object.entries(options)) {
+      const target = opts.renamedOptions[cliOption]
+      if (target) {
+        if (!(target in options)) {
+          options[target] = optionValue
+        }
+        delete options[cliOption]
+      }
+    }
+  }
   const workspaceDir = await getWorkspaceDir(options)
 
   // For the run command, it's not clear whether --help should be passed to the
@@ -150,15 +167,6 @@ export async function parseCliArgs (
     return {
       ...getParsedArgsForHelp(),
       workspaceDir,
-    }
-  }
-
-  if (opts.renamedOptions != null) {
-    for (const [cliOption, optionValue] of Object.entries(options)) {
-      if (opts.renamedOptions[cliOption]) {
-        options[opts.renamedOptions[cliOption]] = optionValue
-        delete options[cliOption]
-      }
     }
   }
 
@@ -243,8 +251,22 @@ function getClosestOptionMatches (knownOptions: string[], option: string): strin
   })
 }
 
-async function getWorkspaceDir (parsedOpts: Record<string, unknown>): Promise<string | undefined> {
+async function getWorkspaceDir (
+  parsedOpts: Record<string, unknown>,
+  renamedOptions?: Record<string, string>
+): Promise<string | undefined> {
   if (parsedOpts['global'] || parsedOpts['ignore-workspace']) return undefined
-  const dir = parsedOpts['dir'] ?? process.cwd()
-  return findWorkspaceDir(dir as string)
+  // Look up dir, also honoring renamed options like `prefix → dir` so that
+  // `--prefix` works even on code paths that read parsedOpts before the
+  // rename loop has run (e.g. the --help/--version short-circuits).
+  let dir = parsedOpts['dir']
+  if (dir == null && renamedOptions != null) {
+    for (const [from, to] of Object.entries(renamedOptions)) {
+      if (to === 'dir' && parsedOpts[from] != null) {
+        dir = parsedOpts[from]
+        break
+      }
+    }
+  }
+  return findWorkspaceDir((dir ?? process.cwd()) as string)
 }

--- a/cli/parse-cli-args/test/index.ts
+++ b/cli/parse-cli-args/test/index.ts
@@ -1,4 +1,6 @@
+import fs from 'fs'
 import os from 'os'
+import path from 'path'
 import { type PnpmError } from '@pnpm/error'
 import { parseCliArgs } from '@pnpm/parse-cli-args'
 import tempy from 'tempy'
@@ -299,6 +301,60 @@ test('--workspace-root fails if used outside of a workspace', async () => {
   }
   expect(err).toBeTruthy()
   expect(err.code).toBe('ERR_PNPM_NOT_IN_WORKSPACE')
+})
+
+// Regression for #11535. The renamed option (`--prefix` → `dir`) must be
+// considered when locating the workspace root; otherwise running pnpm from
+// a directory outside the project misses the workspace manifest in the
+// prefix dir and settings declared there are not loaded.
+function setupParentWithChildWorkspace (): { parent: string, child: string } {
+  const parent = tempy.directory()
+  const child = path.join(parent, 'child')
+  fs.mkdirSync(child)
+  fs.writeFileSync(path.join(child, 'pnpm-workspace.yaml'), '')
+  process.chdir(parent)
+  return { parent, child }
+}
+
+test('workspaceDir resolves from --prefix when prefix is renamed to dir', async () => {
+  const { child } = setupParentWithChildWorkspace()
+  const { workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String },
+  }, ['install', '--prefix=child'])
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+test('workspaceDir resolves from --prefix on the --help short-circuit', async () => {
+  const { child } = setupParentWithChildWorkspace()
+  const { cmd, workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, help: Boolean },
+  }, ['install', '--prefix=child', '--help'])
+  expect(cmd).toBe('help')
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+test('workspaceDir resolves from --prefix on the --version short-circuit', async () => {
+  const { child } = setupParentWithChildWorkspace()
+  const { cmd, workspaceDir } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, version: Boolean },
+  }, ['--prefix=child', '--version'])
+  expect(cmd).toBeNull()
+  expect(workspaceDir && fs.realpathSync.native(workspaceDir)).toBe(fs.realpathSync.native(child))
+})
+
+// When both the alias and the canonical option are supplied, the canonical
+// value must win and the alias must be dropped — otherwise --prefix could
+// silently overwrite an explicit --dir.
+test('canonical option wins when both --prefix and --dir are passed', async () => {
+  const { options } = await parseCliArgs({
+    ...DEFAULT_OPTS,
+    universalOptionsTypes: { prefix: String, dir: String },
+  }, ['install', '--prefix=fromPrefix', '--dir=fromDir'])
+  expect(options.dir).toBe('fromDir')
+  expect(options).not.toHaveProperty(['prefix'])
 })
 
 test('everything after an escape arg is a parameter', async () => {


### PR DESCRIPTION
Backport of #11549 to `release/10`.

## Summary

Fixes #11535 on the v10 line. The CLI's `--prefix → dir` rename was applied **after** `getWorkspaceDir(options)` had already run, so workspace detection fell back to `process.cwd()` instead of the prefix dir. Running pnpm from outside the project (e.g. `pnpm --prefix=child install` from the parent dir) silently skipped the workspace manifest at `child/pnpm-workspace.yaml`, so any settings declared there (e.g. `allowBuilds`, `overrides`) were not loaded into config.

The destructive overwrite reported in #11535 only manifests on v11 (where `pnpm install` auto-populates `allowBuilds` placeholders into the workspace manifest), but the underlying CLI ordering bug is identical on v10 and still causes silently-incorrect settings resolution for any write-back path. Fixing it here keeps behavior consistent.

The fix moves the rename loop ahead of `getWorkspaceDir`, makes the canonical option win when both `--prefix` and `--dir` are passed (so the alias never silently overwrites an explicit value), and threads `renamedOptions` into `getWorkspaceDir` so the `--help`/`--version` short-circuit paths also resolve `--prefix` correctly.

## Test plan

- [x] Added 4 regression tests in `cli/parse-cli-args/test/index.ts`
- [x] All 43 tests in `@pnpm/parse-cli-args` pass
- [x] Lint passes

---
Written by an agent (Claude Code, claude-opus-4-7).