### PR TITLE
fix(git-resolver): avoid encoded slash in GitLab tarball URL

### DIFF
--- a/.changeset/gitlab-tarball-archive-url.md
+++ b/.changeset/gitlab-tarball-archive-url.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"pnpm": patch
+---
+
+Fixed installation of GitLab-hosted dependencies. pnpm now downloads the tarball from `https://gitlab.com/<user>/<project>/-/archive/<sha>/<project>-<sha>.tar.gz` instead of the GitLab API endpoint that contained an encoded slash (`%2F`) between user and project. The encoded slash both triggered `406 Not Acceptable` responses from GitLab and produced virtual store directory names that Node refused to import (`ERR_INVALID_MODULE_SPECIFIER`) [#11533](https://github.com/pnpm/pnpm/issues/11533).

--- a/cspell.json
+++ b/cspell.json
@@ -330,6 +330,7 @@
     "szia",
     "tabtab",
     "taffydb",
+    "tarballtemplate",
     "teambit",
     "tempy",
     "testcase",

--- a/fetching/pick-fetcher/test/pickFetcher.ts
+++ b/fetching/pick-fetcher/test/pickFetcher.ts
@@ -32,7 +32,7 @@ test('should pick remoteTarball fetcher', async () => {
 test.each([
   'https://codeload.github.com/zkochan/is-negative/tar.gz/6dcce91c268805d456b8a575b67d7febc7ae2933',
   'https://bitbucket.org/pnpmjs/git-resolver/get/87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
-  'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz',
+  'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
 ])('should pick gitHostedTarball fetcher', async (tarball) => {
   const gitHostedTarball = jest.fn() as FetchFunction
   const fetcher = await pickFetcher(createMockFetchers({ gitHostedTarball }), { tarball })

--- a/fetching/pick-fetcher/test/pickFetcher.ts
+++ b/fetching/pick-fetcher/test/pickFetcher.ts
@@ -32,6 +32,7 @@ test('should pick remoteTarball fetcher', async () => {
 test.each([
   'https://codeload.github.com/zkochan/is-negative/tar.gz/6dcce91c268805d456b8a575b67d7febc7ae2933',
   'https://bitbucket.org/pnpmjs/git-resolver/get/87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
+  'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz',
   'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
 ])('should pick gitHostedTarball fetcher', async (tarball) => {
   const gitHostedTarball = jest.fn() as FetchFunction

--- a/resolving/git-resolver/src/parseBareSpecifier.ts
+++ b/resolving/git-resolver/src/parseBareSpecifier.ts
@@ -122,12 +122,21 @@ async function fromHostedGit (hosted: any, dispatcherOptions: DispatcherOptions)
     fetchSpec: fetchSpec!,
     hosted: {
       ...hosted,
+      tarballtemplate: hosted.type === 'gitlab' ? gitlabTarballTemplate : hosted.tarballtemplate,
       _fill: hosted._fill,
       tarball: hosted.tarball,
     },
     normalizedBareSpecifier: hosted.shortcut(),
     ...parseGitParams(hosted.committish),
   }
+}
+
+// hosted-git-info's default GitLab tarball URL contains an encoded slash
+// (`%2F`) which survives into the virtual store directory name and makes
+// Node refuse to import the package (ERR_INVALID_MODULE_SPECIFIER).
+function gitlabTarballTemplate ({ domain, user, project, committish }: { domain: string, user: string, project: string, committish: string | null }): string {
+  const ref = committish ? encodeURIComponent(committish) : 'HEAD'
+  return `https://${domain}/${user}/${project}/-/archive/${ref}/${project}-${ref}.tar.gz`
 }
 
 async function isRepoPublic (httpsUrl: string, dispatcherOptions: DispatcherOptions): Promise<boolean> {

--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -395,10 +395,10 @@ test('resolveFromGit() gitlab tarball uses /-/archive/ URL without encoded slash
 test.skip('resolveFromGit() gitlab with commit', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver#988c61e11dc8d9ca0b5580cb15291951812549dc' })
   expect(resolveResult).toStrictEqual({
-    id: 'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
+    id: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=988c61e11dc8d9ca0b5580cb15291951812549dc',
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#988c61e11dc8d9ca0b5580cb15291951812549dc',
     resolution: {
-      tarball: 'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
+      tarball: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=988c61e11dc8d9ca0b5580cb15291951812549dc',
       gitHosted: true,
     },
     resolvedVia: 'git-repository',
@@ -411,10 +411,10 @@ test.skip('resolveFromGit() gitlab with no commit', async () => {
   const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
-    id: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
+    id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver',
     resolution: {
-      tarball: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
+      tarball: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
     },
     resolvedVia: 'git-repository',
   })
@@ -426,10 +426,10 @@ test.skip('resolveFromGit() gitlab with branch', async () => {
   const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
-    id: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
+    id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#master',
     resolution: {
-      tarball: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
+      tarball: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
     },
     resolvedVia: 'git-repository',
   })
@@ -439,10 +439,10 @@ test.skip('resolveFromGit() gitlab with branch', async () => {
 test.skip('resolveFromGit() gitlab with tag', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver#0.3.4' })
   expect(resolveResult).toStrictEqual({
-    id: 'https://gitlab.com/pnpm/git-resolver/-/archive/87cf6a67064d2ce56e8cd20624769a5512b83ff9/git-resolver-87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
+    id: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=87cf6a67064d2ce56e8cd20624769a5512b83ff9',
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#0.3.4',
     resolution: {
-      tarball: 'https://gitlab.com/pnpm/git-resolver/-/archive/87cf6a67064d2ce56e8cd20624769a5512b83ff9/git-resolver-87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
+      tarball: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=87cf6a67064d2ce56e8cd20624769a5512b83ff9',
       gitHosted: true,
     },
     resolvedVia: 'git-repository',

--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -379,12 +379,12 @@ test('resolveFromGit() gitlab tarball uses /-/archive/ URL without encoded slash
     return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
   jest.mocked(git).mockImplementation(async () => ({ stdout: `${headCommit}\tHEAD` }))
-  const resolveResult = await resolveFromGit({ bareSpecifier: 'https://gitlab.com/pasosdejesus/m' })
+  const resolveResult = await resolveFromGit({ bareSpecifier: 'https://gitlab.com/pnpmjs/git-resolver' })
   expect(resolveResult).toStrictEqual({
-    id: `https://gitlab.com/pasosdejesus/m/-/archive/${headCommit}/m-${headCommit}.tar.gz`,
-    normalizedBareSpecifier: 'gitlab:pasosdejesus/m',
+    id: `https://gitlab.com/pnpmjs/git-resolver/-/archive/${headCommit}/git-resolver-${headCommit}.tar.gz`,
+    normalizedBareSpecifier: 'gitlab:pnpmjs/git-resolver',
     resolution: {
-      tarball: `https://gitlab.com/pasosdejesus/m/-/archive/${headCommit}/m-${headCommit}.tar.gz`,
+      tarball: `https://gitlab.com/pnpmjs/git-resolver/-/archive/${headCommit}/git-resolver-${headCommit}.tar.gz`,
       gitHosted: true,
     },
     resolvedVia: 'git-repository',

--- a/resolving/git-resolver/test/index.ts
+++ b/resolving/git-resolver/test/index.ts
@@ -370,14 +370,35 @@ test('resolveFromGit() gitlab with colon in the URL', async () => {
   })
 })
 
+// Regression test for #11533: the tarball URL must not contain `%2F`,
+// otherwise GitLab returns 406 and Node refuses to import the package
+// (the encoded slash ends up in the virtual store directory name).
+test('resolveFromGit() gitlab tarball uses /-/archive/ URL without encoded slash', async () => {
+  const headCommit = '988c61e11dc8d9ca0b5580cb15291951812549dc'
+  jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
+    return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
+  })
+  jest.mocked(git).mockImplementation(async () => ({ stdout: `${headCommit}\tHEAD` }))
+  const resolveResult = await resolveFromGit({ bareSpecifier: 'https://gitlab.com/pasosdejesus/m' })
+  expect(resolveResult).toStrictEqual({
+    id: `https://gitlab.com/pasosdejesus/m/-/archive/${headCommit}/m-${headCommit}.tar.gz`,
+    normalizedBareSpecifier: 'gitlab:pasosdejesus/m',
+    resolution: {
+      tarball: `https://gitlab.com/pasosdejesus/m/-/archive/${headCommit}/m-${headCommit}.tar.gz`,
+      gitHosted: true,
+    },
+    resolvedVia: 'git-repository',
+  })
+})
+
 // This test stopped working. Probably an environmental issue.
 test.skip('resolveFromGit() gitlab with commit', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver#988c61e11dc8d9ca0b5580cb15291951812549dc' })
   expect(resolveResult).toStrictEqual({
-    id: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=988c61e11dc8d9ca0b5580cb15291951812549dc',
+    id: 'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#988c61e11dc8d9ca0b5580cb15291951812549dc',
     resolution: {
-      tarball: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=988c61e11dc8d9ca0b5580cb15291951812549dc',
+      tarball: 'https://gitlab.com/pnpm/git-resolver/-/archive/988c61e11dc8d9ca0b5580cb15291951812549dc/git-resolver-988c61e11dc8d9ca0b5580cb15291951812549dc.tar.gz',
       gitHosted: true,
     },
     resolvedVia: 'git-repository',
@@ -390,10 +411,10 @@ test.skip('resolveFromGit() gitlab with no commit', async () => {
   const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
-    id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
+    id: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver',
     resolution: {
-      tarball: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
+      tarball: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
     },
     resolvedVia: 'git-repository',
   })
@@ -405,10 +426,10 @@ test.skip('resolveFromGit() gitlab with branch', async () => {
   const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
-    id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
+    id: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#master',
     resolution: {
-      tarball: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
+      tarball: `https://gitlab.com/pnpm/git-resolver/-/archive/${hash}/git-resolver-${hash}.tar.gz`,
     },
     resolvedVia: 'git-repository',
   })
@@ -418,10 +439,10 @@ test.skip('resolveFromGit() gitlab with branch', async () => {
 test.skip('resolveFromGit() gitlab with tag', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver#0.3.4' })
   expect(resolveResult).toStrictEqual({
-    id: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=87cf6a67064d2ce56e8cd20624769a5512b83ff9',
+    id: 'https://gitlab.com/pnpm/git-resolver/-/archive/87cf6a67064d2ce56e8cd20624769a5512b83ff9/git-resolver-87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
     normalizedBareSpecifier: 'gitlab:pnpm/git-resolver#0.3.4',
     resolution: {
-      tarball: 'https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=87cf6a67064d2ce56e8cd20624769a5512b83ff9',
+      tarball: 'https://gitlab.com/pnpm/git-resolver/-/archive/87cf6a67064d2ce56e8cd20624769a5512b83ff9/git-resolver-87cf6a67064d2ce56e8cd20624769a5512b83ff9.tar.gz',
       gitHosted: true,
     },
     resolvedVia: 'git-repository',


### PR DESCRIPTION
## Summary

Fixes #11533. Installation of dependencies referenced as `https://gitlab.com/<user>/<project>` (or `gitlab:<user>/<project>`) was failing in two ways:

- **v11**: `ERR_PNPM_FETCH_406` from GitLab when fetching the tarball.
- **v10**: install completed, but importing the package threw `ERR_INVALID_MODULE_SPECIFIER` because the virtual store directory contained an encoded slash.

Both stem from the same root cause. `@pnpm/hosted-git-info` builds GitLab tarball URLs as `https://gitlab.com/api/v4/projects/<user>%2F<project>/repository/archive.tar.gz?sha=<commit>`. The `%2F` survives into the virtual-store directory name (`depPathToFilename` only escapes raw `/`, not `%`), and Node refuses any module path with an encoded slash. The same API URL is also intermittently rejected by GitLab with 406.

This change overrides the `tarballtemplate` for `hosted.type === 'gitlab'` to the standard `https://gitlab.com/<user>/<project>/-/archive/<sha>/<project>-<sha>.tar.gz` URL, which works for public and private repos and contains no encoded slashes. The URL still matches the existing `isGitHostedPkgUrl` check (`https://gitlab.com/` + `tar.gz`), so fetcher selection is unaffected.

## Test plan

- [x] Added a mocked regression test in `resolving/git-resolver/test/index.ts` that resolves a `gitlab:` specifier and asserts the new URL shape.
- [x] Updated existing skipped GitLab tarball assertions and the `pick-fetcher` URL fixture.
- [x] Full `git-resolver` and `pick-fetcher` test suites pass locally.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved GitLab-hosted dependency installation that could return 406 errors and produce incorrect module naming leading to Node import failures.

* **Tests**
  * Added a regression test to ensure GitLab tarball URLs are generated correctly.

* **Chores**
  * Updated project metadata and spellcheck allowlist to accommodate the tarball URL template term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->