### PR TITLE
fix(tarball-fetcher): don't count local tarballs as downloaded

### DIFF
--- a/.changeset/local-tarball-not-downloaded.md
+++ b/.changeset/local-tarball-not-downloaded.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fetching.tarball-fetcher": patch
+"pnpm": patch
+---
+
+Local tarball dependencies (`file:` protocol) are no longer counted as "downloaded" in the progress banner.

--- a/fetching/tarball-fetcher/src/localTarballFetcher.ts
+++ b/fetching/tarball-fetcher/src/localTarballFetcher.ts
@@ -15,10 +15,10 @@ interface Resolution {
 }
 
 export function createLocalTarballFetcher (storeIndex: StoreIndex): FetchFunction {
-  const fetch = (cafs: Cafs, resolution: Resolution, opts: FetchOptions) => {
+  const fetch = async (cafs: Cafs, resolution: Resolution, opts: FetchOptions) => {
     const tarball = resolvePath(opts.lockfileDir, resolution.tarball.slice(5))
     const buffer = gfs.readFileSync(tarball)
-    return addFilesFromTarball({
+    const result = await addFilesFromTarball({
       storeDir: cafs.storeDir,
       storeIndex,
       buffer,
@@ -30,6 +30,7 @@ export function createLocalTarballFetcher (storeIndex: StoreIndex): FetchFunctio
       appendManifest: opts.appendManifest,
       ignoreFilePattern: opts.ignoreFilePattern,
     })
+    return { ...result, local: true }
   }
 
   return fetch as FetchFunction

--- a/installing/package-requester/test/index.ts
+++ b/installing/package-requester/test/index.ts
@@ -233,7 +233,7 @@ test('refetch local tarball if its integrity has changed', async () => {
     const { files, bundledManifest } = await response.fetching()
 
     expect(response.body.updated).toBeFalsy()
-    expect(files.resolvedFrom).toBe('remote')
+    expect(files.resolvedFrom).toBe('local-dir')
     expect(bundledManifest).toBeTruthy()
   }
 
@@ -263,7 +263,7 @@ test('refetch local tarball if its integrity has changed', async () => {
     const { files, bundledManifest } = await response.fetching!()
 
     expect(response.body.updated).toBeTruthy()
-    expect(files.resolvedFrom).toBe('remote')
+    expect(files.resolvedFrom).toBe('local-dir')
     expect(bundledManifest).toBeTruthy()
   }
 
@@ -330,7 +330,7 @@ test('refetch local tarball if its integrity has changed. The requester does not
     const { files, bundledManifest } = await response.fetching()
 
     expect(response.body.updated).toBeTruthy()
-    expect(files.resolvedFrom).toBe('remote')
+    expect(files.resolvedFrom).toBe('local-dir')
     expect(bundledManifest).toBeTruthy()
   }
 
@@ -353,7 +353,7 @@ test('refetch local tarball if its integrity has changed. The requester does not
     const { files, bundledManifest } = await response.fetching()
 
     expect(response.body.updated).toBeTruthy()
-    expect(files.resolvedFrom).toBe('remote')
+    expect(files.resolvedFrom).toBe('local-dir')
     expect(bundledManifest).toBeTruthy()
   }
 


### PR DESCRIPTION
Local tarball dependencies (`file:./path/to/pkg.tgz`) were counted as "downloaded" in the progress banner. The local tarball fetcher didn't set `local: true` in its return value, so `packageRequester` mapped it to `resolvedFrom: 'remote'`, which the reporter counts as "downloaded."

The directory fetcher already returns `local: true` — this change does the same for the local tarball fetcher, so both local dependency types are handled consistently. The existing `resolvedFrom` logic in `packageRequester` already checks `fetchedPackage.local` and maps it to `'local-dir'`, so no consumer changes were needed.

Note: with `disableRelinkLocalDirDeps` enabled (off by default, used by the Bit CLI), local tarballs will now also skip relinking when the target directory is already populated — matching the existing behavior for local directory deps.

Fixes #1103.

Validation:

```
pnpm --filter @pnpm/fetching.tarball-fetcher test
pnpm --filter @pnpm/installing.package-requester test
```

---
Written by an agent (Claude Code, claude-opus-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local tarball dependencies specified via the `file:` protocol are no longer included in the progress banner's "downloaded" count for more accurate progress reporting.

* **Tests**
  * Updated test assertions to reflect local tarball behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->