### PR TITLE
chore: add devEngines.runtime

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
       with:
         standalone: true
     - name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       with:
         standalone: true
     - name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
       with:
         standalone: true
     - name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
       with:
         standalone: true
     - name: Audit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
       with:
         standalone: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
       with:
         standalone: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       with:
         standalone: true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
       with:
         standalone: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       with:
         standalone: true
     - name: pnpm install
@@ -39,12 +39,12 @@ jobs:
         retention-days: 1
 
   test-smoke:
-    name: windows-latest / Node.js 22.13.0
+    name: ubuntu-latest / Node.js 24
     needs: compile-and-lint
     uses: ./.github/workflows/test.yml
     with:
-      node: '22.13.0'
-      platform: windows-latest
+      node: '24.0.0'
+      platform: ubuntu-latest
 
   test:
     name: ${{ matrix.platform }} / Node.js ${{ matrix.node }}
@@ -55,11 +55,10 @@ jobs:
         node: ['22.13.0', '24.0.0', '26.0.0']
         platform: [ubuntu-latest, windows-latest]
         exclude:
-          - node: '22.13.0'
-            platform: windows-latest
-          # On branches, skip the remaining Windows configs (the smoke
-          # already covers Windows). Exception: main and release branches
-          # (release/x, release/x.x) run the full matrix.
+          - node: '24.0.0'
+            platform: ubuntu-latest
+          # On branches, only run Windows with the lowest supported Node.js.
+          # Exception: main and release branches (release/x, release/x.x) run the full matrix.
           - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '24.0.0' }}
             platform: windows-latest
           - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '26.0.0' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
       with:
         standalone: true
     - name: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
       uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
       with:
         standalone: true
-    - name: Setup Node
-      run: pn runtime -g set node 24.6.0
-      timeout-minutes: 2
     - name: pnpm install
       run: pn install
       timeout-minutes: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
       with:
         standalone: true
     - name: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
       with:
         standalone: true
     - name: pnpm install
@@ -39,12 +39,12 @@ jobs:
         retention-days: 1
 
   test-smoke:
-    name: ubuntu-latest / Node.js 24
+    name: windows-latest / Node.js 22.13.0
     needs: compile-and-lint
     uses: ./.github/workflows/test.yml
     with:
-      node: '24.0.0'
-      platform: ubuntu-latest
+      node: '22.13.0'
+      platform: windows-latest
 
   test:
     name: ${{ matrix.platform }} / Node.js ${{ matrix.node }}
@@ -55,10 +55,11 @@ jobs:
         node: ['22.13.0', '24.0.0', '26.0.0']
         platform: [ubuntu-latest, windows-latest]
         exclude:
-          - node: '24.0.0'
-            platform: ubuntu-latest
-          # On branches, only run Windows with the lowest supported Node.js.
-          # Exception: main and release branches (release/x, release/x.x) run the full matrix.
+          - node: '22.13.0'
+            platform: windows-latest
+          # On branches, skip the remaining Windows configs (the smoke
+          # already covers Windows). Exception: main and release branches
+          # (release/x, release/x.x) run the full matrix.
           - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '24.0.0' }}
             platform: windows-latest
           - node: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'none' || '26.0.0' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+        uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
         with:
           standalone: true
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
           standalone: true
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+        uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
         with:
           standalone: true
       - name: Setup Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm
-        uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+        uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
         with:
           standalone: true
       - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Verify npm
       run: npm --version
     - name: pnpm install
-      run: pn install
+      run: pn install --runtime-on-fail=ignore
       timeout-minutes: 3
     - name: Download compiled artifacts
       uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
       with:
         standalone: true
     - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,15 @@ jobs:
     - name: pnpm install
       run: pn install --no-runtime
       timeout-minutes: 3
+    - name: Verify Node version
+      shell: bash
+      run: |
+        actual=$(pn node -v)
+        expected="v${{ inputs.node }}"
+        if [ "$actual" != "$expected" ]; then
+          echo "Expected Node version $expected but got $actual"
+          exit 1
+        fi
     - name: Download compiled artifacts
       uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       with:
         standalone: true
     - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
       with:
         standalone: true
     - name: Setup Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Verify npm
       run: npm --version
     - name: pnpm install
-      run: pn install --runtime-on-fail=ignore
+      run: pn install --no-runtime
       timeout-minutes: 3
     - name: Download compiled artifacts
       uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
       with:
         standalone: true
     - name: Setup Node

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -20,7 +20,7 @@ jobs:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       with:
         standalone: true
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -20,7 +20,7 @@ jobs:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@e578e19d19d31b011b841ba2aca34731a5f706a5
+      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
       with:
         standalone: true
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -20,7 +20,7 @@ jobs:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@551b42e879e37e74d986effdd2a1647d2b02d464
+      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
       with:
         standalone: true
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -20,7 +20,7 @@ jobs:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
     - name: Install pnpm
-      uses: pnpm/action-setup@4f29a020220876da9288d2e46daba34980c57487
+      uses: pnpm/action-setup@b2823a890048d209e1ec048942a39d5fd54a8f77
       with:
         standalone: true
 

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "typescript": "catalog:",
     "verdaccio": "catalog:"
   },
-  "packageManager": "pnpm@11.1.0",
+  "packageManager": "pnpm@11.1.1",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.1.0",
+      "version": "11.1.1",
       "onFail": "download"
     },
     "runtime": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
       "name": "pnpm",
       "version": "11.0.7",
       "onFail": "download"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "22.13.0",
+      "onFail": "download"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,16 +57,16 @@
     "typescript": "catalog:",
     "verdaccio": "catalog:"
   },
-  "packageManager": "pnpm@11.0.7",
+  "packageManager": "pnpm@11.1.0",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.0.7",
+      "version": "11.1.0",
       "onFail": "download"
     },
     "runtime": {
       "name": "node",
-      "version": "22.13.0",
+      "version": "24.6.0",
       "onFail": "download"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.1
+        version: 11.1.1
       pnpm:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 11.1.1
+        version: 11.1.1
 
 packages:
 
-  '@pnpm/exe@11.1.0':
-    resolution: {integrity: sha512-JnyoFKP06JxEAINmtjVRFTfsG6qQspgc8BN+Nlqnibsrj4iB2SXwBsmLFcQLAMJDcxDW6euHw4Zc1mxnsqoPSA==}
+  '@pnpm/exe@11.1.1':
+    resolution: {integrity: sha512-5mQnDW1NCBRRWA+cnGhQO+tIrfSfWm3/IyGxU88LnT+tzNW5UrwwKfjsnnYJToyAjIfdfEJtJKUxCvP+mhA+nQ==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.1.0':
-    resolution: {integrity: sha512-Mh8b1+KqxEj4koOx240Cv5SoCV3jFF9TCbiWwTrRp8POMwIQur2+wBPicRCr6Fn9rdE95MoFEUchbwJ6m2t/3g==}
+  '@pnpm/linux-arm64@11.1.1':
+    resolution: {integrity: sha512-u9hs51XV0/gU5LLfNLoQsozGKIxNjxsh/0xPr+8Hny0M38psa4lBtwFvarL2bLToPIrtueQYi65LdlzRxITRyg==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.1.0':
-    resolution: {integrity: sha512-W6nPEakEQCHj6635uTkrmd3NbXEYeRoqzqoMCc4v48LiF110Zak8SJXjwMr88Sv/7gXPLPR92OSKfHjNGVVWfg==}
+  '@pnpm/linux-x64@11.1.1':
+    resolution: {integrity: sha512-yQO9i57oyJmIG22BjV7sqLUT2syKQohiku8yNZRgp7M6wsVkikpVLLVSpBifQnrI/P/roueKnWSUEESH1aPaoA==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.1.0':
-    resolution: {integrity: sha512-jWBVXPjVhlalse0HZ4jgA/rSD5ws3OLn2cUCwAsks1RHdYyp924IWsCpxfYLwDxs+UV/saGaOYIGMgGUvDqslQ==}
+  '@pnpm/linuxstatic-arm64@11.1.1':
+    resolution: {integrity: sha512-FUZB8L9Z8L5m88G0RTx5AsHFr5yUQPW+28zQdTNUWxiLwj11FW/fOLodYdcNYHdNJFepsZyqt3aRnpiqIdZb2g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.1.0':
-    resolution: {integrity: sha512-lTZLzikADbg9iv8/W8MCREz051vqVzoVat4u03KbKSM7HnQshSUH15bxWFOgmRF9tQgajo2OjFZty6YpokjbBA==}
+  '@pnpm/linuxstatic-x64@11.1.1':
+    resolution: {integrity: sha512-I/z56hfa1zM5F/Unup/1NrgsA+dcptsKQ2TjJLFz3wHKDx0RLrfF7DB0Rkpnr5IoAZ33v0GFZjlGhkOtc9VFGw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.1.0':
-    resolution: {integrity: sha512-s0lz3AwtIE9y+e+EhUBt6cxS6GGupDYa3IDeOTzabtGowDJo3TdiuzCaSzenYaodwu/193lmw8GMkEnWDCOxAQ==}
+  '@pnpm/macos-arm64@11.1.1':
+    resolution: {integrity: sha512-YQu6fC27F4jTIpXhF+4PdzOV7uSnVVG9KUxj5W+AFj0XFlUvBw+I1NsoPCY6uV1nccxWpIAZOTZtSj8+hWPb8w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.1.0':
-    resolution: {integrity: sha512-MaazMGmq9a9VCqgQtE6/XEPbdn8HrsmS0sbZ1lBQAuapDoTGrGGzcdCk8VJCvcjDTZ7TFnpb47EiQLgya/d1Uw==}
+  '@pnpm/win-arm64@11.1.1':
+    resolution: {integrity: sha512-2HvZut3IcKPxzIfOjBJ4677PaLIh57mWccL86O+q71QhO5emnQvht0CE19IoEyUIOEe1WjlN+Su/dD5k6CuGyg==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.1.0':
-    resolution: {integrity: sha512-I5DhrlRDgjXRax91Odaz3Ab6zD5IcJmpnveMSPZkDI4bON1GJ2Z5CrU5OJJ7OWoyMg1KEpdieEB3m+ZcLOL/pw==}
+  '@pnpm/win-x64@11.1.1':
+    resolution: {integrity: sha512-QXBIBErgPhGLovOVzTRIpHsejFKebyqlcF3fea/TfH87gkhN5yWH0WuTPRBoOWvpk6aNhjDW4RPUMx8RaPqxjw==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.1.0:
-    resolution: {integrity: sha512-DEToQuVoaywGGoGt2osiWL2IGOlwSyzyxj1WuTGnsukQCS4IUCcAO5bKORGrVqB/bfWrrtK+mSUDTN1oalNbFA==}
+  pnpm@11.1.1:
+    resolution: {integrity: sha512-0f319zxhe2T6GlaoHDyN/g6WbjOmAQqiVrUXrne+Idk+Ba/8DeGoOw5PKdVp9otEaujwaM1yR8C7PfD7TXvfmg==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.1.0':
+  '@pnpm/exe@11.1.1':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.1.0
-      '@pnpm/linux-x64': 11.1.0
-      '@pnpm/linuxstatic-arm64': 11.1.0
-      '@pnpm/linuxstatic-x64': 11.1.0
-      '@pnpm/macos-arm64': 11.1.0
-      '@pnpm/win-arm64': 11.1.0
-      '@pnpm/win-x64': 11.1.0
+      '@pnpm/linux-arm64': 11.1.1
+      '@pnpm/linux-x64': 11.1.1
+      '@pnpm/linuxstatic-arm64': 11.1.1
+      '@pnpm/linuxstatic-x64': 11.1.1
+      '@pnpm/macos-arm64': 11.1.1
+      '@pnpm/win-arm64': 11.1.1
+      '@pnpm/win-x64': 11.1.1
 
-  '@pnpm/linux-arm64@11.1.0':
+  '@pnpm/linux-arm64@11.1.1':
     optional: true
 
-  '@pnpm/linux-x64@11.1.0':
+  '@pnpm/linux-x64@11.1.1':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.1.0':
+  '@pnpm/linuxstatic-arm64@11.1.1':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.1.0':
+  '@pnpm/linuxstatic-x64@11.1.1':
     optional: true
 
-  '@pnpm/macos-arm64@11.1.0':
+  '@pnpm/macos-arm64@11.1.1':
     optional: true
 
-  '@pnpm/win-arm64@11.1.0':
+  '@pnpm/win-arm64@11.1.1':
     optional: true
 
-  '@pnpm/win-x64@11.1.0':
+  '@pnpm/win-x64@11.1.1':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.1.0: {}
+  pnpm@11.1.1: {}
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1073,6 +1073,9 @@ importers:
       lcov-result-merger:
         specifier: 'catalog:'
         version: 5.0.1
+      node:
+        specifier: runtime:22.13.0
+        version: runtime:22.13.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -15353,6 +15356,137 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
+  node@runtime:22.13.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-JNF8f2ubGP4iXvS3DwMPhryeJotHhH5bTXj4KjdydLw=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-vB43TnOT4vSyDlu8FX0C6bH7LGNLL5khNrOPuMogI7c=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-z6r17d5YWhVUf4WPWztiopLPWSmiNwe28eNsKaMkh74=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-4MwIjLT7LpRdPVxBbGAeEQGhX3Pg8CTJUpuWTZ9tzls=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-bRtkAna6/BpAmIY5C65tIOB/GNrmkEuGASekAkCWIeA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-kLlut2+vQJvawBiy98kTQ5gyAfUYOCrH9Ti3dYMlukc=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-vvKnB3o6aqZrsCktH7rqkpRxqryxk3dByNtQ1jcrjaQ=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-mjPokJOg2UbFR4Hcs8yrTM91OKcTUoZSjKQcoFXps48=
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-jKLJCuA3PWnhMwEpMwbDHqmvyieAuDJbbKBZMZR55WA=
+            prefix: node-v22.13.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-sP6wnr9BMoYo5zg/egkvtzQs4eBchnqQz48TeSBahCk=
+            prefix: node-v22.13.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin:
+              node: node.exe
+            integrity: sha256-hGeOyeCh1SoEAYf8UMGTLMF72hRvsnskrp02jCISx5U=
+            prefix: node-v22.13.0-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-Rr0ykM7LRLwa6SeUFCkPeZEhaZNRB1P4NvYfFSv5+tc=
+            type: binary
+            url: https://unofficial-builds.nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-x64-musl.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+              libc: musl
+    version: 22.13.0
+    hasBin: true
+
   nopt@1.0.10:
     resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
     hasBin: true
@@ -24437,6 +24571,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.38: {}
+
+  node@runtime:22.13.0: {}
 
   nopt@1.0.10:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,52 +7,52 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 11.0.7
-        version: 11.0.7
+        specifier: 11.1.0
+        version: 11.1.0
       pnpm:
-        specifier: 11.0.7
-        version: 11.0.7
+        specifier: 11.1.0
+        version: 11.1.0
 
 packages:
 
-  '@pnpm/exe@11.0.7':
-    resolution: {integrity: sha512-zD5EMUePXPGAg4yKj1xEVQXIAOeIGuQh0YXo86t3n5fRmqDVwnGMAqZDBMdSXwXS/uvLpmserl6j9jqoeGlQUQ==}
+  '@pnpm/exe@11.1.0':
+    resolution: {integrity: sha512-JnyoFKP06JxEAINmtjVRFTfsG6qQspgc8BN+Nlqnibsrj4iB2SXwBsmLFcQLAMJDcxDW6euHw4Zc1mxnsqoPSA==}
     hasBin: true
 
-  '@pnpm/linux-arm64@11.0.7':
-    resolution: {integrity: sha512-Opx5npdHf8m3MS16yodVWcFjoaQ0N9FO9OQpdT3Ks7FxRNtp4T4VBRqlqlXfUA35CroTh22cXLZn3ByIT0MSDw==}
+  '@pnpm/linux-arm64@11.1.0':
+    resolution: {integrity: sha512-Mh8b1+KqxEj4koOx240Cv5SoCV3jFF9TCbiWwTrRp8POMwIQur2+wBPicRCr6Fn9rdE95MoFEUchbwJ6m2t/3g==}
     cpu: [arm64]
     os: [linux]
 
-  '@pnpm/linux-x64@11.0.7':
-    resolution: {integrity: sha512-+D8XIEC2fp9dKKR2emGjzPcsJB9Xw/rXqzVayyphBbaPu6J+JytET4kYHIsM1EeJ7o6UkmAXjPLmgc6Bxu11EQ==}
+  '@pnpm/linux-x64@11.1.0':
+    resolution: {integrity: sha512-W6nPEakEQCHj6635uTkrmd3NbXEYeRoqzqoMCc4v48LiF110Zak8SJXjwMr88Sv/7gXPLPR92OSKfHjNGVVWfg==}
     cpu: [x64]
     os: [linux]
 
-  '@pnpm/linuxstatic-arm64@11.0.7':
-    resolution: {integrity: sha512-EePML7trF6ygvIZpvmCX4ykYsiw3J5k6aiG4uIAi7gJ8N1ZFHrZiqJVXlQPek6XVaeLNu4gaAORi1P3b4M68HA==}
+  '@pnpm/linuxstatic-arm64@11.1.0':
+    resolution: {integrity: sha512-jWBVXPjVhlalse0HZ4jgA/rSD5ws3OLn2cUCwAsks1RHdYyp924IWsCpxfYLwDxs+UV/saGaOYIGMgGUvDqslQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/linuxstatic-x64@11.0.7':
-    resolution: {integrity: sha512-XwrdZAdn5ArA3yWnvMIabKCFGoZrahvY/q9FjRXKPyN1hiAuzdITBZW+w1ywq8lgLBJT+2acgpafuiQKol/0lA==}
+  '@pnpm/linuxstatic-x64@11.1.0':
+    resolution: {integrity: sha512-lTZLzikADbg9iv8/W8MCREz051vqVzoVat4u03KbKSM7HnQshSUH15bxWFOgmRF9tQgajo2OjFZty6YpokjbBA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/macos-arm64@11.0.7':
-    resolution: {integrity: sha512-dBnXwHY3flGveXgc+aAqr0jTddNJZIktAV8HmEalLty5bQQKi9bxNeCoMGImRjocgqc6on5wg1bNr9IdqwbhpQ==}
+  '@pnpm/macos-arm64@11.1.0':
+    resolution: {integrity: sha512-s0lz3AwtIE9y+e+EhUBt6cxS6GGupDYa3IDeOTzabtGowDJo3TdiuzCaSzenYaodwu/193lmw8GMkEnWDCOxAQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/win-arm64@11.0.7':
-    resolution: {integrity: sha512-Mg7hgalpv+55g0rqJgFKx5b4YuCF8i8AE9w8bHmAsx8Ezwe3fmIg8tubAIiH78ccUZN8vZ5Gp2x/h2fE+jH0+A==}
+  '@pnpm/win-arm64@11.1.0':
+    resolution: {integrity: sha512-MaazMGmq9a9VCqgQtE6/XEPbdn8HrsmS0sbZ1lBQAuapDoTGrGGzcdCk8VJCvcjDTZ7TFnpb47EiQLgya/d1Uw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/win-x64@11.0.7':
-    resolution: {integrity: sha512-nKEgq5TsQSmfZdwbQlAaH1gft1VxjWE46y0sixQJrsXhHL+t8VP+kLmMF76T5kW4kMynSv3SSyEx7stK4n8ecA==}
+  '@pnpm/win-x64@11.1.0':
+    resolution: {integrity: sha512-I5DhrlRDgjXRax91Odaz3Ab6zD5IcJmpnveMSPZkDI4bON1GJ2Z5CrU5OJJ7OWoyMg1KEpdieEB3m+ZcLOL/pw==}
     cpu: [x64]
     os: [win32]
 
@@ -116,45 +116,45 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  pnpm@11.0.7:
-    resolution: {integrity: sha512-ckp7XSMZzdcAnWXhWiwpqunTkCtQWFyhY9OKdzfrhbxOchloef9Zdopx6B/jKqcei3DwiLLiS55KKFDYfkYHtQ==}
+  pnpm@11.1.0:
+    resolution: {integrity: sha512-DEToQuVoaywGGoGt2osiWL2IGOlwSyzyxj1WuTGnsukQCS4IUCcAO5bKORGrVqB/bfWrrtK+mSUDTN1oalNbFA==}
     engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.0.7':
+  '@pnpm/exe@11.1.0':
     dependencies:
       '@reflink/reflink': 0.1.19
       detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.7
-      '@pnpm/linux-x64': 11.0.7
-      '@pnpm/linuxstatic-arm64': 11.0.7
-      '@pnpm/linuxstatic-x64': 11.0.7
-      '@pnpm/macos-arm64': 11.0.7
-      '@pnpm/win-arm64': 11.0.7
-      '@pnpm/win-x64': 11.0.7
+      '@pnpm/linux-arm64': 11.1.0
+      '@pnpm/linux-x64': 11.1.0
+      '@pnpm/linuxstatic-arm64': 11.1.0
+      '@pnpm/linuxstatic-x64': 11.1.0
+      '@pnpm/macos-arm64': 11.1.0
+      '@pnpm/win-arm64': 11.1.0
+      '@pnpm/win-x64': 11.1.0
 
-  '@pnpm/linux-arm64@11.0.7':
+  '@pnpm/linux-arm64@11.1.0':
     optional: true
 
-  '@pnpm/linux-x64@11.0.7':
+  '@pnpm/linux-x64@11.1.0':
     optional: true
 
-  '@pnpm/linuxstatic-arm64@11.0.7':
+  '@pnpm/linuxstatic-arm64@11.1.0':
     optional: true
 
-  '@pnpm/linuxstatic-x64@11.0.7':
+  '@pnpm/linuxstatic-x64@11.1.0':
     optional: true
 
-  '@pnpm/macos-arm64@11.0.7':
+  '@pnpm/macos-arm64@11.1.0':
     optional: true
 
-  '@pnpm/win-arm64@11.0.7':
+  '@pnpm/win-arm64@11.1.0':
     optional: true
 
-  '@pnpm/win-x64@11.0.7':
+  '@pnpm/win-x64@11.1.0':
     optional: true
 
   '@reflink/reflink-darwin-arm64@0.1.19':
@@ -194,7 +194,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  pnpm@11.0.7: {}
+  pnpm@11.1.0: {}
 
 ---
 lockfileVersion: '9.0'
@@ -1074,8 +1074,8 @@ importers:
         specifier: 'catalog:'
         version: 5.0.1
       node:
-        specifier: runtime:22.13.0
-        version: runtime:22.13.0
+        specifier: runtime:24.6.0
+        version: runtime:24.6.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -15356,7 +15356,7 @@ packages:
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
-  node@runtime:22.13.0:
+  node@runtime:24.6.0:
     resolution:
       type: variations
       variants:
@@ -15364,9 +15364,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-JNF8f2ubGP4iXvS3DwMPhryeJotHhH5bTXj4KjdydLw=
+            integrity: sha256-eXm+UQ/2iWLhaJHuKckQgOMh16Vbn7xrOY2MIKWTK98=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -15374,9 +15374,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-vB43TnOT4vSyDlu8FX0C6bH7LGNLL5khNrOPuMogI7c=
+            integrity: sha256-do8UlSQD4wJf7Y4oh1AN+mPutVYoqbID5LjrsPsJx+s=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -15384,9 +15384,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-z6r17d5YWhVUf4WPWztiopLPWSmiNwe28eNsKaMkh74=
+            integrity: sha256-aV/DNFSCGyFtaMsZjWRqmtdpx318Mj5zg4EjPkZm3/4=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -15394,9 +15394,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-4MwIjLT7LpRdPVxBbGAeEQGhX3Pg8CTJUpuWTZ9tzls=
+            integrity: sha256-iVbhHb71sZfWLri1uXoTHrQvuyU0f+DNybYqHBqjbfU=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -15404,19 +15404,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-bRtkAna6/BpAmIY5C65tIOB/GNrmkEuGASekAkCWIeA=
+            integrity: sha256-+vyIuqmsufv4KgiY64BlmRhTTA7W0ZpJDYZ1YwTGbmc=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-armv7l.tar.gz
-          targets:
-            - cpu: armv7l
-              os: linux
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-kLlut2+vQJvawBiy98kTQ5gyAfUYOCrH9Ti3dYMlukc=
-            type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -15424,9 +15414,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-vvKnB3o6aqZrsCktH7rqkpRxqryxk3dByNtQ1jcrjaQ=
+            integrity: sha256-HNd1hrSLbbG1JIZpYZxix4WuyiR6S/qulf6YILd6VAU=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -15434,9 +15424,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-mjPokJOg2UbFR4Hcs8yrTM91OKcTUoZSjKQcoFXps48=
+            integrity: sha256-NS3bxItYbBHwGOybiGIlEXkJ6pPgW0oEptsy8+Y9AoE=
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -15444,10 +15434,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-jKLJCuA3PWnhMwEpMwbDHqmvyieAuDJbbKBZMZR55WA=
-            prefix: node-v22.13.0-win-arm64
+            integrity: sha256-W9hfrLz6Mu84tzppDChFGlw9/3tFRX9e9CHE0LDe6sc=
+            prefix: node-v24.6.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -15455,36 +15445,25 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-sP6wnr9BMoYo5zg/egkvtzQs4eBchnqQz48TeSBahCk=
-            prefix: node-v22.13.0-win-x64
+            integrity: sha256-Om0y/liDaY5sWcpaZVS0HBsqldtPerfE7dJy9DkXgNo=
+            prefix: node-v24.6.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-x64.zip
+            url: https://nodejs.org/download/release/v24.6.0/node-v24.6.0-win-x64.zip
           targets:
             - cpu: x64
-              os: win32
-        - resolution:
-            archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-hGeOyeCh1SoEAYf8UMGTLMF72hRvsnskrp02jCISx5U=
-            prefix: node-v22.13.0-win-x86
-            type: binary
-            url: https://nodejs.org/download/release/v22.13.0/node-v22.13.0-win-x86.zip
-          targets:
-            - cpu: x86
               os: win32
         - resolution:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-Rr0ykM7LRLwa6SeUFCkPeZEhaZNRB1P4NvYfFSv5+tc=
+            integrity: sha256-6kuCABREMq8vAOeBGZiAzJrElmmMPxoYYwPPVgGh9FM=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v22.13.0/node-v22.13.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v24.6.0/node-v24.6.0-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 22.13.0
+    version: 24.6.0
     hasBin: true
 
   nopt@1.0.10:
@@ -24572,7 +24551,7 @@ snapshots:
 
   node-releases@2.0.38: {}
 
-  node@runtime:22.13.0: {}
+  node@runtime:24.6.0: {}
 
   nopt@1.0.10:
     dependencies:


### PR DESCRIPTION
Adds `devEngines.runtime` to pin the Node.js version (24.6.0, `onFail: download`) the project uses for development, so contributors don't have to manage Node versions manually.

CI changes that come with it:

- Bumps pnpm to **11.1.1** and `pnpm/action-setup` to a bootstrap that ships `@zkochan/cmd-shim` 9.0.3. The cmd-shim update is required because the previous shim's `exec cmd /C` got mangled by Git Bash's MSYS path conversion (`/C` → Windows path), which broke any `pn …` invocation from `shell: bash` on Windows.
- Switches the install step to `pn install --no-runtime` so the per-test-matrix Node version chosen by `pn runtime -g set node …` isn't overridden by the project-pinned 24.6.0.
- Adds a `Verify Node version` step that asserts `pn node -v` matches the matrix's Node.

---
Written by an agent (Claude Code, claude-opus-4-7).