### PR TITLE
fix(deploy): update error message for pnpm v11

### DIFF
--- a/.changeset/hip-animals-go.md
+++ b/.changeset/hip-animals-go.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/releasing.commands": patch
+---
+
+Update the DEPLOY_NONINJECTED_WORKSPACE error message to reflect pnpm v11 standards, using camelCase for configuration keys and referencing pnpm-workspace.yaml.

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -212,7 +212,7 @@ async function deployFromSharedLockfile (
 ): Promise<string | undefined> {
   if (!opts.injectWorkspacePackages) {
     throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v11, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
-      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in your configuration.',
+      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in pnpm-workspace.yaml.',
     })
   }
   const {

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -211,7 +211,7 @@ async function deployFromSharedLockfile (
   deployDir: string
 ): Promise<string | undefined> {
   if (!opts.injectWorkspacePackages) {
-    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v11, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
+    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v10, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
       hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in pnpm-workspace.yaml.',
     })
   }

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -211,7 +211,7 @@ async function deployFromSharedLockfile (
   deployDir: string
 ): Promise<string | undefined> {
   if (!opts.injectWorkspacePackages) {
-    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v10, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
+    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v11, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
       hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in pnpm-workspace.yaml.',
     })
   }

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -211,8 +211,8 @@ async function deployFromSharedLockfile (
   deployDir: string
 ): Promise<string | undefined> {
   if (!opts.injectWorkspacePackages) {
-    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v10, we only deploy from workspaces that have "inject-workspace-packages=true" set', {
-      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "force-legacy-deploy" to true',
+    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v11, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
+      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in your configuration.',
     })
   }
   const {


### PR DESCRIPTION
## Description
The current error message for `pnpm deploy` uses `kebab-case` (e.g., `inject-workspace-packages`) and references settings that were common in `.npmrc` during v9/v10. 

Since pnpm v11 has moved towards `pnpm-workspace.yaml` and `camelCase` configuration, this PR updates the message to be more accurate.

## Changes
- Updated the error message to use `injectWorkspacePackages` instead of `inject-workspace-packages`.
- Explicitly mentioned that this should be set in `pnpm-workspace.yaml`.
- Updated the hint to use `forceLegacyDeploy` (camelCase).
- Updated the message to reference pnpm v11.

## Related Issues
Fixes a point of confusion for users migrating to v11 where the suggested configuration key didn't match the new standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Published a patch to the releasing.commands package via an updated changeset.
  * Clarified the deploy error message for non-injected workspace deployments: uses pnpm v11-style (camelCased) configuration keys and now references the workspace config file, while preserving the existing legacy-deploy guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->