### PR TITLE
fix: change message for case that downgrading pnpm

### DIFF
--- a/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -186,7 +186,7 @@ export async function handler (
     return `The currently active ${packageManager.name} v${packageManager.version} is newer than the "latest" version on the registry (v${resolution.manifest.version}). No update performed. Run "pnpm self-update latest" to downgrade.`
   }
 
-  globalInfo(`Updating pnpm from v${packageManager.version} to v${resolution.manifest.version}...`)
+  globalInfo(`Switching pnpm from v${packageManager.version} to v${resolution.manifest.version}...`)
   const store = await createStoreController(opts)
 
   // Resolve integrities and write env lockfile to pnpm-lock.yaml


### PR DESCRIPTION
In GitHub Actions with `pnpm/action-setup`, pnpm may be downgraded according to repository config. ([example](https://github.com/g-plane/old-school-linguist-colors/actions/runs/25595097785/job/75139570699)) The message "updating" isn't correct in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The progress message displayed when switching the active pnpm version via `pnpm self-update` now correctly shows "Switching ..." instead of "Updating ...".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11560)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->