### PR TITLE
fix(deploy): update PNPM_ERR_DEPLOY_NONINJECTED_WORKSPACE error message for pnpm v11

### DIFF
--- a/.changeset/lovely-jobs-dress.md
+++ b/.changeset/lovely-jobs-dress.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/releasing.commands": patch
+---
+
+Update the DEPLOY_NONINJECTED_WORKSPACE error message to reflect pnpm v11 standards, using camelCase for configuration keys and referencing pnpm-workspace.yaml.

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -211,8 +211,8 @@ async function deployFromSharedLockfile (
   deployDir: string
 ): Promise<string | undefined> {
   if (!opts.injectWorkspacePackages) {
-    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v10, we only deploy from workspaces that have "inject-workspace-packages=true" set', {
-      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "force-legacy-deploy" to true',
+    throw new PnpmError('DEPLOY_NONINJECTED_WORKSPACE', 'By default, starting from pnpm v11, we only deploy from workspaces that have "injectWorkspacePackages: true" set in pnpm-workspace.yaml', {
+      hint: 'If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag or set "forceLegacyDeploy: true" in pnpm-workspace.yaml.',
     })
   }
   const {


### PR DESCRIPTION
## Description

The `PNPM_ERR_DEPLOY_NONINJECTED_WORKSPACE` error message still references legacy `kebab-case` config names commonly used in `.npmrc` with pnpm v9/v10.

Since pnpm v11 has moved towards `pnpm-workspace.yaml` and `camelCase` configuration, this PR updates the message to be more accurate.

## Changes
- Updated the error message to use `injectWorkspacePackages` instead of `inject-workspace-packages`.
- Explicitly mentioned that this should be set in `pnpm-workspace.yaml`.
- Updated the hint to use `forceLegacyDeploy` (camelCase).
- Updated the message to reference pnpm v11.

## Related Issues
Fixes a point of confusion for users migrating to v11 where the suggested configuration key didn't match the new standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment error messages to align with pnpm v11 conventions, ensuring accurate configuration syntax references and improved guidance for workspace package handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11582)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->