### PR TITLE
fix: allow `pnpm runtime set` in workspace root

### DIFF
--- a/.changeset/runtime-set-workspace-root.md
+++ b/.changeset/runtime-set-workspace-root.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.runtime.commands": patch
+"pnpm": patch
+---
+
+`pnpm runtime set <name> <version>` no longer fails in the root of a multi-package workspace with the `ADDING_TO_ROOT` error. Installing a runtime is workspace-wide configuration, so the command now implicitly targets the workspace root.

--- a/.changeset/runtime-set-workspace-root.md
+++ b/.changeset/runtime-set-workspace-root.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm runtime set <name> <version>` no longer fails in the root of a multi-package workspace with the `ADDING_TO_ROOT` error. Installing a runtime is workspace-wide configuration, so the command now implicitly targets the workspace root.
+`pnpm runtime set <name> <version>` no longer fails in the root of a multi-package workspace with the `ADDING_TO_ROOT` error. Installing the workspace root is a valid target for a runtime, so the command now bypasses that safety check.

--- a/engine/runtime/commands/src/runtime/runtime.ts
+++ b/engine/runtime/commands/src/runtime/runtime.ts
@@ -95,7 +95,7 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
     args.push('--global')
     if (opts.bin) args.push('--global-bin-dir', opts.bin)
   } else {
-    args.push('--workspace-root')
+    args.push('--ignore-workspace-root-check')
   }
   if (opts.storeDir) args.push('--store-dir', opts.storeDir)
   if (opts.cacheDir) args.push('--cache-dir', opts.cacheDir)

--- a/engine/runtime/commands/src/runtime/runtime.ts
+++ b/engine/runtime/commands/src/runtime/runtime.ts
@@ -94,6 +94,8 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
   if (opts.global) {
     args.push('--global')
     if (opts.bin) args.push('--global-bin-dir', opts.bin)
+  } else {
+    args.push('--workspace-root')
   }
   if (opts.storeDir) args.push('--store-dir', opts.storeDir)
   if (opts.cacheDir) args.push('--cache-dir', opts.cacheDir)

--- a/engine/runtime/commands/test/runtime.test.ts
+++ b/engine/runtime/commands/test/runtime.test.ts
@@ -37,7 +37,7 @@ test('runtime set uses project dir when not global', async () => {
   }, ['set', 'node', '22'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'node@runtime:22', '--workspace-root'],
+    ['add', 'node@runtime:22', '--ignore-workspace-root-check'],
     { cwd: '/tmp/project' }
   )
 })

--- a/engine/runtime/commands/test/runtime.test.ts
+++ b/engine/runtime/commands/test/runtime.test.ts
@@ -37,7 +37,7 @@ test('runtime set uses project dir when not global', async () => {
   }, ['set', 'node', '22'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'node@runtime:22'],
+    ['add', 'node@runtime:22', '--workspace-root'],
     { cwd: '/tmp/project' }
   )
 })


### PR DESCRIPTION
## Summary

`pnpm runtime set <name> <version>` was failing in the root of a multi-package workspace with the `ADDING_TO_ROOT` error:

> Running this command will add the dependency to the workspace root, which might not be what you want — if you really meant it, make it explicit by running this command again with the `-w` flag (or `--workspace-root`).

This is wrong for `runtime set`: installing a runtime is workspace-wide configuration, so the workspace root is exactly where it should land. The command now passes `--workspace-root` to the underlying `pnpm add` call when not running globally, bypassing the safety check.

## Test plan

- [x] Updated unit test for the non-global path in `engine/runtime/commands/test/runtime.test.ts`
- [x] All 7 tests in `runtime.test.ts` pass
- [ ] Manual check: `pnpm runtime set node lts` in a multi-package workspace root succeeds instead of throwing `ADDING_TO_ROOT`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm runtime set <name> <version>` no longer fails when run at the root of a multi-package workspace; the workspace root is now treated as a valid target.
  * Global vs non-global behavior preserved: global installs remain global; non-global installs now correctly operate within workspace projects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11584)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->