### PR TITLE
fix: install each global package in its own isolated directory by default

### DIFF
--- a/.changeset/fix-11587-global-isolated-per-arg.md
+++ b/.changeset/fix-11587-global-isolated-per-arg.md
@@ -1,6 +1,6 @@
 ---
-"@pnpm/global.commands": minor
-"pnpm": minor
+"@pnpm/global.commands": patch
+"pnpm": patch
 ---
 
 `pnpm add -g` now installs each space-separated package into its own isolated directory by default. To bundle multiple packages into the same isolated install (so that they share dependencies and are removed together), pass them as a comma-separated list. For example:

--- a/.changeset/fix-11587-global-isolated-per-arg.md
+++ b/.changeset/fix-11587-global-isolated-per-arg.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/global.commands": minor
+"pnpm": minor
+---
+
+`pnpm add -g` now installs each space-separated package into its own isolated directory by default. To bundle multiple packages into the same isolated install (so that they share dependencies and are removed together), pass them as a comma-separated list. For example:
+
+- `pnpm add -g foo bar` installs `foo` and `bar` as two independent globals — removing one does not affect the other.
+- `pnpm add -g foo,bar qar` bundles `foo` and `bar` into a single isolated install while `qar` lives in its own [#11587](https://github.com/pnpm/pnpm/issues/11587).

--- a/.changeset/fix-11587-global-isolated-per-arg.md
+++ b/.changeset/fix-11587-global-isolated-per-arg.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/global.commands": patch
+"@pnpm/installing.deps-installer": patch
 "pnpm": patch
 ---
 

--- a/.changeset/fix-11587-global-isolated-per-arg.md
+++ b/.changeset/fix-11587-global-isolated-per-arg.md
@@ -6,4 +6,6 @@
 `pnpm add -g` now installs each space-separated package into its own isolated directory by default. To bundle multiple packages into the same isolated install (so that they share dependencies and are removed together), pass them as a comma-separated list. For example:
 
 - `pnpm add -g foo bar` installs `foo` and `bar` as two independent globals — removing one does not affect the other.
-- `pnpm add -g foo,bar qar` bundles `foo` and `bar` into a single isolated install while `qar` lives in its own [#11587](https://github.com/pnpm/pnpm/issues/11587).
+- `pnpm add -g foo,bar qar` bundles `foo` and `bar` into a single isolated install while `qar` is installed on its own.
+
+Related: [#11587](https://github.com/pnpm/pnpm/issues/11587).

--- a/global/commands/package.json
+++ b/global/commands/package.json
@@ -39,6 +39,7 @@
     "@pnpm/cli.utils": "workspace:*",
     "@pnpm/config.matcher": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/core-loggers": "workspace:*",
     "@pnpm/deps.inspection.list": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/global.packages": "workspace:*",

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -39,18 +39,9 @@ export async function handleGlobalAdd (
   params: string[],
   commands: CommandHandlerMap
 ): Promise<void> {
-  // Resolve relative path selectors to absolute paths before the working
-  // directory is changed to the global install dir, otherwise "." or
-  // "./foo" would resolve against the temp install directory.
-  params = params.map((param) => resolveLocalParam(param, opts.dir))
   const globalDir = opts.globalPkgDir!
   const globalBinDir = opts.bin!
   cleanOrphanedInstallDirs(globalDir)
-
-  // Install into a new directory first, then read the resolved aliases
-  // from the resulting package.json. This is more reliable than parsing
-  // aliases from CLI params (which may be tarballs, git URLs, etc.).
-  const installDir = createInstallDir(globalDir)
 
   // Convert allowBuild array to allowBuilds Record (same conversion as add.handler)
   let allowBuilds = opts.allowBuilds ?? {}
@@ -61,6 +52,41 @@ export async function handleGlobalAdd (
     }
   }
 
+  // Each space-separated CLI param becomes its own isolated install group.
+  // A param containing commas is split into multiple selectors that share a
+  // single group, so `pnpm add -g foo,bar qar` installs foo+bar together
+  // and qar separately. Comma splitting only applies when the param itself
+  // contains a comma — protocols like `file:` or `link:` resolve via
+  // resolveLocalParam afterwards.
+  const groups = params
+    .map((param) => splitCommaSeparated(param).map((token) => resolveLocalParam(token, opts.dir)))
+    .filter((group) => group.length > 0)
+
+  for (const group of groups) {
+    // eslint-disable-next-line no-await-in-loop
+    await installGroup({ opts, globalDir, globalBinDir, allowBuilds, params: group }, commands)
+  }
+}
+
+interface InstallGroupContext {
+  opts: GlobalAddOptions
+  globalDir: string
+  globalBinDir: string
+  allowBuilds: Record<string, string | boolean>
+  params: string[]
+}
+
+async function installGroup (
+  ctx: InstallGroupContext,
+  commands: CommandHandlerMap
+): Promise<void> {
+  const { opts, globalDir, globalBinDir, allowBuilds, params } = ctx
+
+  // Install into a new directory first, then read the resolved aliases
+  // from the resulting package.json. This is more reliable than parsing
+  // aliases from CLI params (which may be tarballs, git URLs, etc.).
+  const installDir = createInstallDir(globalDir)
+
   const include = {
     dependencies: true,
     devDependencies: false,
@@ -68,13 +94,13 @@ export async function handleGlobalAdd (
   }
   const fetchFullMetadata = opts.supportedArchitectures?.libc != null && true
 
-  const makeInstallOpts = (dir: string, builds: Record<string, string | boolean>) => ({
+  const installOpts = {
     ...opts,
     global: false,
-    bin: path.join(dir, 'node_modules/.bin'),
-    dir,
-    lockfileDir: dir,
-    rootProjectManifestDir: dir,
+    bin: path.join(installDir, 'node_modules/.bin'),
+    dir: installDir,
+    lockfileDir: installDir,
+    rootProjectManifestDir: installDir,
     rootProjectManifest: undefined,
     saveProd: true,
     saveDev: false,
@@ -86,10 +112,10 @@ export async function handleGlobalAdd (
     fetchFullMetadata,
     include,
     includeDirect: include,
-    allowBuilds: builds,
-  })
+    allowBuilds,
+  }
 
-  const ignoredBuilds = await installGlobalPackages(makeInstallOpts(installDir, allowBuilds), params)
+  const ignoredBuilds = await installGlobalPackages(installOpts, params)
 
   await promptApproveGlobalBuilds({
     globalPkgDir: globalDir,
@@ -132,6 +158,11 @@ export async function handleGlobalAdd (
 
   // Link bins from installed packages into global bin dir
   await linkBinsOfPackages(pkgs, globalBinDir, { excludeBins: binsToSkip })
+}
+
+function splitCommaSeparated (param: string): string[] {
+  if (!param.includes(',')) return [param]
+  return param.split(',').map((token) => token.trim()).filter(Boolean)
 }
 
 function resolveLocalParam (param: string, baseDir: string): string {

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { linkBinsOfPackages } from '@pnpm/bins.linker'
 import { removeBin } from '@pnpm/bins.remover'
 import type { CommandHandlerMap } from '@pnpm/cli.command'
+import { summaryLogger } from '@pnpm/core-loggers'
 import {
   cleanOrphanedInstallDirs,
   createGlobalCacheKey,
@@ -65,6 +66,14 @@ export async function handleGlobalAdd (
     // eslint-disable-next-line no-await-in-loop
     await installGroup({ opts, globalDir, globalBinDir, allowBuilds, params: group }, commands)
   }
+
+  // The per-group `mutateModulesInSingleProject` calls run with
+  // `omitSummaryLog: true` so the default-reporter's summary block only
+  // appears once at the end, with every installed package listed under a
+  // single "global:" heading. Without this, the reporter would print
+  // group 1's summary and then ignore later groups, because its summary
+  // pipeline takes only the first `summary` log event.
+  summaryLogger.debug({ prefix: globalDir })
 }
 
 interface InstallGroupContext {
@@ -112,6 +121,7 @@ async function installGroup (
     include,
     includeDirect: include,
     allowBuilds,
+    omitSummaryLog: true,
   }
 
   const ignoredBuilds = await installGlobalPackages(installOpts, params)

--- a/global/commands/src/globalAdd.ts
+++ b/global/commands/src/globalAdd.ts
@@ -55,11 +55,10 @@ export async function handleGlobalAdd (
   // Each space-separated CLI param becomes its own isolated install group.
   // A param containing commas is split into multiple selectors that share a
   // single group, so `pnpm add -g foo,bar qar` installs foo+bar together
-  // and qar separately. Comma splitting only applies when the param itself
-  // contains a comma — protocols like `file:` or `link:` resolve via
-  // resolveLocalParam afterwards.
+  // and qar separately. Local paths and URLs that legitimately contain
+  // commas are detected and kept whole.
   const groups = params
-    .map((param) => splitCommaSeparated(param).map((token) => resolveLocalParam(token, opts.dir)))
+    .map((param) => splitCommaSeparated(param, opts.dir).map((token) => resolveLocalParam(token, opts.dir)))
     .filter((group) => group.length > 0)
 
   for (const group of groups) {
@@ -160,9 +159,39 @@ async function installGroup (
   await linkBinsOfPackages(pkgs, globalBinDir, { excludeBins: binsToSkip })
 }
 
-function splitCommaSeparated (param: string): string[] {
+function splitCommaSeparated (param: string, baseDir: string): string[] {
   if (!param.includes(',')) return [param]
+  // URLs may contain commas and are never a group of selectors.
+  if (param.includes('://')) return [param]
+  // For path-like specs (relative/absolute paths, file:, link:), the
+  // commas could either be part of a single path that legitimately
+  // contains commas, or be separators between multiple distinct paths.
+  // Resolve the ambiguity by checking whether the whole param actually
+  // refers to an existing local path on disk.
+  if (refersToExistingLocalPath(param, baseDir)) return [param]
   return param.split(',').map((token) => token.trim()).filter(Boolean)
+}
+
+function refersToExistingLocalPath (param: string, baseDir: string): boolean {
+  let pathPart: string
+  if (param.startsWith('file:')) {
+    pathPart = param.slice('file:'.length)
+  } else if (param.startsWith('link:')) {
+    pathPart = param.slice('link:'.length)
+  } else if (param[0] === '.' || param[0] === '/' || param[0] === '~') {
+    pathPart = param
+  } else if (/^[a-z]:[/\\]/i.test(param)) {
+    pathPart = param
+  } else {
+    return false
+  }
+  const resolved = path.isAbsolute(pathPart) ? pathPart : path.resolve(baseDir, pathPart)
+  try {
+    fs.statSync(resolved)
+    return true
+  } catch {
+    return false
+  }
 }
 
 function resolveLocalParam (param: string, baseDir: string): string {

--- a/global/commands/src/installGlobalPackages.ts
+++ b/global/commands/src/installGlobalPackages.ts
@@ -13,6 +13,7 @@ export interface InstallGlobalPackagesOptions extends CreateStoreControllerOptio
   include: IncludedDependencies
   includeDirect?: IncludedDependencies
   fetchFullMetadata?: boolean
+  omitSummaryLog?: boolean
   rootProjectManifest?: unknown
   rootProjectManifestDir?: string
   saveDev?: boolean

--- a/global/commands/tsconfig.json
+++ b/global/commands/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../../config/reader"
     },
     {
+      "path": "../../core/core-loggers"
+    },
+    {
       "path": "../../core/error"
     },
     {

--- a/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -180,6 +180,13 @@ export interface StrictInstallOptions {
   trustPolicyIgnoreAfter?: number
   packageVulnerabilityAudit?: PackageVulnerabilityAudit
   blockExoticSubdeps?: boolean
+  /**
+   * If true, `mutateModules` does not emit the per-install `summary` log
+   * event. Used by `pnpm add -g` when it runs multiple isolated installs
+   * inside a single command and wants to emit a single consolidated
+   * summary at the very end instead of one summary per install.
+   */
+  omitSummaryLog: boolean
   /** URL of a pnpm agent server. See the pnpm-agent README. */
   agent?: string
 }
@@ -284,6 +291,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     virtualStoreDirMaxLength: 120,
     peersSuffixMaxLength: 1000,
     blockExoticSubdeps: false,
+    omitSummaryLog: false,
   } as StrictInstallOptions
 }
 

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1676,7 +1676,9 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     rules: opts.peerDependencyRules,
   })
 
-  summaryLogger.debug({ prefix: opts.lockfileDir })
+  if (!opts.omitSummaryLog) {
+    summaryLogger.debug({ prefix: opts.lockfileDir })
+  }
 
   // Similar to the sequencing for when the original wanted lockfile is
   // copied, the new lockfile passed here should be as close as possible to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4941,6 +4941,9 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
+      '@pnpm/core-loggers':
+        specifier: workspace:*
+        version: link:../../core/core-loggers
       '@pnpm/deps.inspection.list':
         specifier: workspace:*
         version: link:../../deps/inspection/list

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -183,9 +183,15 @@ export async function main (inputArgv: string[]): Promise<void> {
 
   const printLogs = !config['parseable'] && !config['json']
   if (printLogs) {
+    // `pnpm add -g` may install several isolated groups in one run, one
+    // per CLI param. When that happens, force the reporter to show the
+    // per-prefix progress/stats output so every group's stats line up
+    // with the right install dir instead of being silently dropped.
+    const multiGroupGlobalAdd = cmd === 'add' && cliOptions.global === true && cliParams.length > 1
     initReporter(reporterType, {
       cmd,
       config: { ...config, ...context },
+      hideProgressPrefix: multiGroupGlobalAdd ? false : undefined,
     })
     global[REPORTER_INITIALIZED] = reporterType
   }

--- a/pnpm/src/reporter/index.ts
+++ b/pnpm/src/reporter/index.ts
@@ -12,6 +12,7 @@ export function initReporter (
   opts: {
     cmd: string | null
     config: Config & ConfigContext
+    hideProgressPrefix?: boolean
   }
 ): void {
   switch (reporterType) {
@@ -29,6 +30,7 @@ export function initReporter (
           throttleProgress: 200,
           hideAddedPkgsProgress: opts.config.lockfileOnly,
           hideLifecyclePrefix: opts.config.reporterHidePrefix,
+          hideProgressPrefix: opts.hideProgressPrefix,
         },
         streamParser: streamParser as StreamParser<Log>,
       })
@@ -46,6 +48,7 @@ export function initReporter (
           logLevel: opts.config.loglevel as LogLevel,
           throttleProgress: 1000,
           hideLifecyclePrefix: opts.config.reporterHidePrefix,
+          hideProgressPrefix: opts.hideProgressPrefix,
         },
         streamParser: streamParser as StreamParser<Log>,
       })

--- a/pnpm/test/install/global.ts
+++ b/pnpm/test/install/global.ts
@@ -25,6 +25,10 @@ function globalPkgDir (pnpmHome: string): string {
  * and returns the path to the package's node_modules entry.
  */
 function findGlobalPkg (globalDir: string, pkgName: string): string | null {
+  return findGlobalPkgInstall(globalDir, pkgName)?.pkgPath ?? null
+}
+
+function findGlobalPkgInstall (globalDir: string, pkgName: string): { installDir: string, pkgPath: string } | null {
   let entries: fs.Dirent[]
   try {
     entries = fs.readdirSync(globalDir, { withFileTypes: true })
@@ -46,7 +50,7 @@ function findGlobalPkg (globalDir: string, pkgName: string): string | null {
       continue
     }
     if (pkgJson.dependencies?.[pkgName]) {
-      return path.join(installDir, 'node_modules', pkgName)
+      return { installDir, pkgPath: path.join(installDir, 'node_modules', pkgName) }
     }
   }
   return null
@@ -605,8 +609,8 @@ test('global remove deletes install group and bin shims', async () => {
   }))
   fs.writeFileSync(path.join(pkgB, 'index.js'), '#!/usr/bin/env node\nconsole.log("b")\n')
 
-  // Install as a group
-  await execPnpm(['add', '-g', pkgA, pkgB], { env })
+  // Install as a single bundled group via comma syntax
+  await execPnpm(['add', '-g', `${pkgA},${pkgB}`], { env })
   expect(fs.existsSync(path.join(pnpmHome, 'bin', 'tool-a-bin'))).toBeTruthy()
   expect(fs.existsSync(path.join(pnpmHome, 'bin', 'tool-b-bin'))).toBeTruthy()
 
@@ -616,4 +620,52 @@ test('global remove deletes install group and bin shims', async () => {
   expect(fs.existsSync(path.join(pnpmHome, 'bin', 'tool-b-bin'))).toBeFalsy()
   expect(findGlobalPkg(globalPkgDir(pnpmHome), 'tool-a')).toBeNull()
   expect(findGlobalPkg(globalPkgDir(pnpmHome), 'tool-b')).toBeNull()
+})
+
+test('global add installs each space-separated package into its own isolated group', async () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  const env = { [PATH_NAME]: path.join(pnpmHome, 'bin'), PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  await execPnpm(['add', '-g', 'is-positive@1.0.0', 'is-negative@1.0.0'], { env })
+
+  const positive = findGlobalPkgInstall(globalPkgDir(pnpmHome), 'is-positive')
+  const negative = findGlobalPkgInstall(globalPkgDir(pnpmHome), 'is-negative')
+  expect(positive).toBeTruthy()
+  expect(negative).toBeTruthy()
+
+  // Each package lives in its own install dir (they are not bundled together).
+  expect(positive!.installDir).not.toBe(negative!.installDir)
+
+  // Removing one only removes that one — the other remains.
+  await execPnpm(['remove', '-g', 'is-positive'], { env })
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'is-positive')).toBeNull()
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'is-negative')).toBeTruthy()
+})
+
+test('global add bundles comma-separated packages into a single group', async () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  const env = { [PATH_NAME]: path.join(pnpmHome, 'bin'), PNPM_HOME: pnpmHome, XDG_DATA_HOME: global }
+
+  // `is-positive,is-negative` is one group; `@pnpm.e2e/peer-c@1` is its own group.
+  await execPnpm(['add', '-g', 'is-positive@1.0.0,is-negative@1.0.0', '@pnpm.e2e/peer-c@1'], { env })
+
+  const positive = findGlobalPkgInstall(globalPkgDir(pnpmHome), 'is-positive')
+  const negative = findGlobalPkgInstall(globalPkgDir(pnpmHome), 'is-negative')
+  const peerC = findGlobalPkgInstall(globalPkgDir(pnpmHome), '@pnpm.e2e/peer-c')
+  expect(positive).toBeTruthy()
+  expect(negative).toBeTruthy()
+  expect(peerC).toBeTruthy()
+
+  // is-positive and is-negative share an install dir (same group).
+  expect(positive!.installDir).toBe(negative!.installDir)
+  // peer-c is in a different install dir.
+  expect(peerC!.installDir).not.toBe(positive!.installDir)
 })

--- a/pnpm/test/install/global.ts
+++ b/pnpm/test/install/global.ts
@@ -669,3 +669,36 @@ test('global add bundles comma-separated packages into a single group', async ()
   // peer-c is in a different install dir.
   expect(peerC!.installDir).not.toBe(positive!.installDir)
 })
+
+test('global add does not treat commas inside a local path selector as a group separator', () => {
+  prepare()
+  const global = path.resolve('..', 'global')
+  const pnpmHome = path.join(global, 'pnpm')
+  fs.mkdirSync(pnpmHome, { recursive: true })
+
+  // Create a local package whose directory name contains a comma.
+  const pkgDir = path.resolve('..', 'tool,with,comma')
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+    name: 'tool-comma',
+    version: '1.0.0',
+    bin: { 'tool-comma-bin': './index.js' },
+  }))
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), '#!/usr/bin/env node\nconsole.log("ok")\n')
+
+  const env = {
+    [PATH_NAME]: path.join(pnpmHome, 'bin'),
+    PNPM_HOME: pnpmHome,
+    XDG_DATA_HOME: global,
+    pnpm_config_store_dir: path.resolve('..', 'store'),
+  }
+
+  // The path contains commas but must be treated as one selector, not split.
+  execPnpmSync(['add', '-g', pkgDir], { env, expectSuccess: true })
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'tool-comma')).toBeTruthy()
+  expect(fs.existsSync(path.join(pnpmHome, 'bin', 'tool-comma-bin'))).toBeTruthy()
+
+  // Same path via file: protocol should also be preserved.
+  execPnpmSync(['add', '-g', `file:${pkgDir}`], { env, expectSuccess: true })
+  expect(findGlobalPkg(globalPkgDir(pnpmHome), 'tool-comma')).toBeTruthy()
+})


### PR DESCRIPTION
## Summary

Fixes [#11587](https://github.com/pnpm/pnpm/issues/11587).

In v11, `pnpm add -g foo bar` bundled `foo` and `bar` into a single isolated install group, so `pnpm remove -g foo` also removed `bar`. This change reverts the default to per-package isolation while preserving a way to opt into grouped installs:

- `pnpm add -g foo bar` — `foo` and `bar` are installed as two independent globals; removing one does not affect the other.
- `pnpm add -g foo,bar qar` — `foo` and `bar` share a single isolated install dir (and are removed together); `qar` is its own.

## Test plan

- [x] New e2e test: each space-separated package lands in its own install dir, and removing one leaves the other intact.
- [x] New e2e test: comma-separated packages share an install dir while a third space-separated arg gets its own.
- [x] Updated the existing `global remove deletes install group and bin shims` test to use the comma syntax (since that is the new way to express bundling).
- [x] Full `pnpm/test/install/global.ts` suite passes (20 passed, 2 pre-existing skips).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global installs now default to isolating each space-separated package into its own global install.
  * Bundle multiple packages into a single global install by using comma-separated package selectors.

* **Tests**
  * Added tests verifying comma-separated bundling, space-separated isolation, and commas inside local path selectors.

* **Logging / Reporting**
  * Per-install summary logs suppressed during grouped installs; a single summary is emitted at the end.
  * Progress output shows per-prefix progress when installing multiple isolated global groups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11588)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->