### PR TITLE
chore(ci): migrate workflows to pnpm/setup

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
     - name: Audit
       run: pn audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@v0
+      uses: pnpm/setup@auto-no-runtime
     - name: Audit
       run: pn audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,8 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
+      uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
+      with:
+        install: false
     - name: Audit
       run: pn audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@auto-no-runtime
+      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
     - name: Audit
       run: pn audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,8 +14,6 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-      with:
-        standalone: true
+      uses: pnpm/setup@init-action
     - name: Audit
       run: pn audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@init-action
+      uses: pnpm/setup@v0
     - name: Audit
       run: pn audit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,9 +47,12 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
       with:
         runtime: node@26.0.0
+
+    - name: Install dependencies
+      run: pn install
 
     - name: Install hyperfine
       run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@v0
+      uses: pnpm/setup@auto-no-runtime
       with:
         runtime: node@26.0.0
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@init-action
+      uses: pnpm/setup@v0
       with:
         runtime: node@26.0.0
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@auto-no-runtime
+      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
       with:
         runtime: node@26.0.0
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,23 +46,15 @@ jobs:
         git checkout "origin/pr-${PR_NUMBER}"
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    - name: Install pnpm and Node
+      uses: pnpm/setup@init-action
       with:
-        standalone: true
-
-    - name: Setup Node
-      run: pnpm runtime -g set node 26.0.0
-      timeout-minutes: 2
+        runtime: node@26.0.0
 
     - name: Install hyperfine
       run: |
         wget -q https://github.com/sharkdp/hyperfine/releases/download/v1.18.0/hyperfine_1.18.0_amd64.deb
         sudo dpkg -i hyperfine_1.18.0_amd64.deb
-
-    - name: Install dependencies
-      run: pnpm install
-      timeout-minutes: 5
 
     - name: Compile
       run: pnpm run compile

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,12 +47,9 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
+      uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
       with:
         runtime: node@26.0.0
-
-    - name: Install dependencies
-      run: pn install
 
     - name: Install hyperfine
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,10 @@ jobs:
     steps:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    - name: Install pnpm and Node
+      uses: pnpm/setup@init-action
       with:
-        standalone: true
-    - name: pnpm install
-      run: pn install
-      timeout-minutes: 3
+        runtime: node@24.6.0
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
     steps:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Install pnpm and Node
+    - name: Install pnpm
       uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
-      with:
-        runtime: node@24.6.0
     - name: Install dependencies
       run: pn install
     - name: Compile TypeScript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
       with:
         runtime: node@24.6.0
+    - name: Install dependencies
+      run: pn install
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@init-action
+      uses: pnpm/setup@v0
       with:
         runtime: node@24.6.0
     - name: Compile TypeScript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@auto-no-runtime
+      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
       with:
         runtime: node@24.6.0
     - name: Compile TypeScript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm
-      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
-    - name: Install dependencies
-      run: pn install
+      uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@v0
+      uses: pnpm/setup@auto-no-runtime
       with:
         runtime: node@24.6.0
     - name: Compile TypeScript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm and Node
-        uses: pnpm/setup@auto-no-runtime
+        uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
         with:
           runtime: node@26.0.0
       # The publish phase is split into three sequential steps to control which packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm and Node
-        uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+        uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
         with:
           runtime: node@26.0.0
+      - name: Install dependencies
+        run: pn install
       # The publish phase is split into three sequential steps to control which packages
       # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
       # out of OIDC as soon as a static `_authToken` is configured, so the only way to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm and Node
-        uses: pnpm/setup@init-action
+        uses: pnpm/setup@v0
         with:
           runtime: node@26.0.0
       # The publish phase is split into three sequential steps to control which packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm and Node
-        uses: pnpm/setup@v0
+        uses: pnpm/setup@auto-no-runtime
         with:
           runtime: node@26.0.0
       # The publish phase is split into three sequential steps to control which packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      - name: Install pnpm and Node
+        uses: pnpm/setup@init-action
         with:
-          standalone: true
-      - name: Setup Node
-        run: pn runtime -g set node 26.0.0
-        timeout-minutes: 2
-      - name: pnpm install
-        run: pn install
+          runtime: node@26.0.0
       # The publish phase is split into three sequential steps to control which packages
       # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
       # out of OIDC as soon as a static `_authToken` is configured, so the only way to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install pnpm and Node
-        uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
+        uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
         with:
           runtime: node@26.0.0
-      - name: Install dependencies
-        run: pn install
       # The publish phase is split into three sequential steps to control which packages
       # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
       # out of OIDC as soon as a static `_authToken` is configured, so the only way to

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@auto-no-runtime
+      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
       with:
         runtime: node@${{ inputs.node }}
     # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@init-action
+      uses: pnpm/setup@v0
       with:
         runtime: node@${{ inputs.node }}
     # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,9 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
+      uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
       with:
         runtime: node@${{ inputs.node }}
-    # `--no-runtime` keeps the node version installed by pnpm/setup; without
-    # it, devEngines.runtime in package.json would swap node to its declared
-    # version and the matrix `inputs.node` selection would be silently lost.
-    - name: Install dependencies
-      run: pn install --no-runtime
     - name: Verify Node version
       shell: bash
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,28 +30,15 @@ jobs:
         git config --global user.email "x@y.z"
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    - name: Install pnpm and Node
+      uses: pnpm/setup@init-action
       with:
-        standalone: true
-    - name: Setup Node
-      run: pn runtime -g set node ${{ inputs.node }}
-      timeout-minutes: 2
-    # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests)
+        runtime: node@${{ inputs.node }}
+    # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).
+    # `pnpm runtime set node` does not extract npm; the runner image's
+    # pre-installed Node toolchain provides it on PATH.
     - name: Verify npm
       run: npm --version
-    - name: pnpm install
-      run: pn install --no-runtime
-      timeout-minutes: 3
-    - name: Verify Node version
-      shell: bash
-      run: |
-        actual=$(pn node -v)
-        expected="v${{ inputs.node }}"
-        if [ "$actual" != "$expected" ]; then
-          echo "Expected Node version $expected but got $actual"
-          exit 1
-        fi
     - name: Download compiled artifacts
       uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,11 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
       with:
         runtime: node@${{ inputs.node }}
+    - name: Install dependencies
+      run: pn install
     # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).
     # `pnpm runtime set node` does not extract npm; the runner image's
     # pre-installed Node toolchain provides it on PATH.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install pnpm and Node
-      uses: pnpm/setup@v0
+      uses: pnpm/setup@auto-no-runtime
       with:
         runtime: node@${{ inputs.node }}
     # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,20 @@ jobs:
       uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
       with:
         runtime: node@${{ inputs.node }}
+    # `--no-runtime` keeps the node version installed by pnpm/setup; without
+    # it, devEngines.runtime in package.json would swap node to its declared
+    # version and the matrix `inputs.node` selection would be silently lost.
     - name: Install dependencies
-      run: pn install
+      run: pn install --no-runtime
+    - name: Verify Node version
+      shell: bash
+      run: |
+        actual=$(pn node -v)
+        expected="v${{ inputs.node }}"
+        if [ "$actual" != "$expected" ]; then
+          echo "Expected Node version $expected but got $actual"
+          exit 1
+        fi
     # npm is needed for preparing git-hosted dependencies (e.g. in dlx tests).
     # `pnpm runtime set node` does not extract npm; the runner image's
     # pre-installed Node toolchain provides it on PATH.

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -19,10 +19,8 @@ jobs:
       with:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
-    - name: Install pnpm and Node
+    - name: Install pnpm
       uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
-      with:
-        runtime: node@24.6.0
 
     - name: Update lockfile
       run: |

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -19,8 +19,12 @@ jobs:
       with:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
+    # The job deletes the lockfile and regenerates it with `--lockfile-only`,
+    # so skip the action's auto-install — it would just be wasted work.
     - name: Install pnpm
-      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
+      uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
+      with:
+        install: false
 
     - name: Update lockfile
       run: |

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -24,7 +24,7 @@ jobs:
     # `--lockfile-only`, so the up-front install is wasted work — accepted for
     # now since this is a daily job.
     - name: Install pnpm and Node
-      uses: pnpm/setup@v0
+      uses: pnpm/setup@auto-no-runtime
       with:
         runtime: node@24.6.0
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -24,7 +24,7 @@ jobs:
     # `--lockfile-only`, so the up-front install is wasted work — accepted for
     # now since this is a daily job.
     - name: Install pnpm and Node
-      uses: pnpm/setup@auto-no-runtime
+      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
       with:
         runtime: node@24.6.0
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -19,12 +19,8 @@ jobs:
       with:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
-    # NOTE: pnpm/setup auto-runs `pnpm install` when package.json is present.
-    # This job then deletes the lockfile and regenerates it with
-    # `--lockfile-only`, so the up-front install is wasted work — accepted for
-    # now since this is a daily job.
     - name: Install pnpm and Node
-      uses: pnpm/setup@c4ced000cdec5aba00543598109cc3f2437e4e4e
+      uses: pnpm/setup@fb0036364f5a7e8d2e55f157adf7ad14617a222d
       with:
         runtime: node@24.6.0
 

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -19,14 +19,14 @@ jobs:
       with:
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+    # NOTE: pnpm/setup auto-runs `pnpm install` when package.json is present.
+    # This job then deletes the lockfile and regenerates it with
+    # `--lockfile-only`, so the up-front install is wasted work — accepted for
+    # now since this is a daily job.
+    - name: Install pnpm and Node
+      uses: pnpm/setup@init-action
       with:
-        standalone: true
-
-    - name: Setup Node
-      run: pnpm runtime -g set node 24.6.0
-      timeout-minutes: 2
+        runtime: node@24.6.0
 
     - name: Update lockfile
       run: |

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -24,7 +24,7 @@ jobs:
     # `--lockfile-only`, so the up-front install is wasted work — accepted for
     # now since this is a daily job.
     - name: Install pnpm and Node
-      uses: pnpm/setup@init-action
+      uses: pnpm/setup@v0
       with:
         runtime: node@24.6.0
 


### PR DESCRIPTION
## Summary

Migrates CI workflows from `pnpm/action-setup` + manual `pn runtime set node …` + `pn install` to the new combined `pnpm/setup` action (see https://github.com/pnpm/setup/pull/1).

`pnpm/setup` installs pnpm and the JS runtime in one step. It also runs `pnpm install` automatically when a `package.json` is present, so per-workflow install steps are dropped. When the `runtime` input is set, the action passes `--no-runtime` to `pnpm install` so the matrix-selected Node version isn't shadowed by a different `devEngines.runtime` pin.

## What changed

| Workflow | Migration |
|---|---|
| `test.yml` | `pnpm/setup` with `runtime: node@${{ inputs.node }}`. Verify-Node step asserts the matrix version stayed active. Verify-npm step retained as canary (npm comes from the runner image, not the pnpm-installed runtime). |
| `ci.yml` | `pnpm/setup` (no `runtime` input — `devEngines.runtime` in package.json handles the Node pin). |
| `release.yml` | `pnpm/setup` with `runtime: node@26.0.0`. |
| `benchmark.yml` | `pnpm/setup` with `runtime: node@26.0.0`. |
| `audit.yml` | `pnpm/setup` with `install: false` — audit only needs pnpm itself, not `node_modules`. |
| `update-lockfile.yml` | `pnpm/setup` with `install: false` — the job deletes `pnpm-lock.yaml` and regenerates it via `--lockfile-only`, so the action's auto-install would be wasted. |
| `update-latest.yml` | Untouched — it only uses npm, no pnpm setup needed. |

## Caveats / things to watch

- **npm availability.** `pnpm runtime set node` does not extract npm. The runner image's pre-installed Node toolchain provides `npm` on PATH; if a future runner image change removes that, dlx-style git-hosted dependency tests in `test.yml` will fail. The `Verify npm` step in `test.yml` is the canary.

## Related upstream change

- [pnpm/setup#3](https://github.com/pnpm/setup/pull/3) — added the `install` input so callers like `audit.yml` and `update-lockfile.yml` can opt out of the action's auto-install.

## Test plan

- [ ] CI workflow (`ci.yml`) passes — compile + lint with `pnpm/setup`
- [ ] `test.yml` matrix passes across node versions and platforms
- [ ] `audit.yml` passes
- [ ] Manual trigger of `benchmark.yml` (workflow_dispatch) — optional, only if the perf path needs verifying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to standardize pnpm installation tooling across audit, benchmark, continuous integration, release, test, and lockfile update jobs. These infrastructure refinements ensure consistent build environment setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11589)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
PR description updated by an agent (Claude Code, claude-opus-4-7).
