### PR TITLE
fix(deps.status): skip engine check when scanning workspace projects

### DIFF
--- a/.changeset/check-deps-status-skip-engine-check.md
+++ b/.changeset/check-deps-status-skip-engine-check.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.status": patch
+"pnpm": patch
+---
+
+Skip the engine check when scanning workspace projects in `checkDepsStatus`. The dependency status check (run by `verifyDepsBeforeRun`) was calling `findWorkspaceProjects` without a `nodeVersion`, causing the engine check to fall back to the system Node from `PATH` and emit spurious "Unsupported engine" warnings before scripts ran. Engine validation still happens during install.

--- a/.changeset/check-deps-status-skip-engine-check.md
+++ b/.changeset/check-deps-status-skip-engine-check.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Skip the engine check when scanning workspace projects in `checkDepsStatus`. The dependency status check (run by `verifyDepsBeforeRun`) was calling `findWorkspaceProjects` without a `nodeVersion`, causing the engine check to fall back to the system Node from `PATH` and emit spurious "Unsupported engine" warnings before scripts ran. Engine validation still happens during install.
+Skip installability validation when scanning workspace projects in `checkDepsStatus` (run by `verifyDepsBeforeRun`). Previously the status check called `findWorkspaceProjects`, which validates each project's `engines` and `os`/`cpu`/`libc` and warns about useless fields in non-root manifests — work that the install pipeline already performs. With no `nodeVersion` threaded through, the engine check also fell back to the system Node from `PATH` and emitted spurious "Unsupported engine" warnings before scripts ran. Status-only callers now use `findWorkspaceProjectsNoCheck`; install paths continue to validate.

--- a/deps/status/src/checkDepsStatus.ts
+++ b/deps/status/src/checkDepsStatus.ts
@@ -32,7 +32,7 @@ import type {
   ProjectId,
   ProjectManifest,
 } from '@pnpm/types'
-import { findWorkspaceProjects } from '@pnpm/workspace.projects-reader'
+import { findWorkspaceProjectsNoCheck } from '@pnpm/workspace.projects-reader'
 import { loadWorkspaceState, updateWorkspaceState, type WorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
 import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import { equals, filter, isEmpty, once } from 'ramda'
@@ -353,9 +353,8 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     const workspaceRoot = workspaceDir ?? rootProjectManifestDir
     const workspaceManifest = await readWorkspaceManifest(workspaceRoot)
     if (workspaceManifest ?? workspaceDir) {
-      const allProjects = await findWorkspaceProjects(rootProjectManifestDir, {
+      const allProjects = await findWorkspaceProjectsNoCheck(rootProjectManifestDir, {
         patterns: workspaceManifest?.packages,
-        sharedWorkspaceLockfile,
       })
       return checkDepsStatus({
         ...opts,

--- a/pnpm/test/verifyDepsBeforeRun/engineCheck.ts
+++ b/pnpm/test/verifyDepsBeforeRun/engineCheck.ts
@@ -35,9 +35,9 @@ test('verify-deps-before-run does not emit unsupported engine warnings for works
 
   await execPnpm(['install'])
 
-  const { stdout } = execPnpmSync(['--config.verify-deps-before-run=install', 'start'], {
+  const { stdout, stderr } = execPnpmSync(['--config.verify-deps-before-run=install', 'start'], {
     expectSuccess: true,
   })
   expect(stdout.toString()).toContain('hello from root')
-  expect(stdout.toString()).not.toContain('Unsupported engine')
+  expect(stdout.toString() + stderr.toString()).not.toContain('Unsupported engine')
 })

--- a/pnpm/test/verifyDepsBeforeRun/engineCheck.ts
+++ b/pnpm/test/verifyDepsBeforeRun/engineCheck.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@jest/globals'
+import { preparePackages } from '@pnpm/prepare'
+import type { ProjectManifest } from '@pnpm/types'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpm, execPnpmSync } from '../utils/index.js'
+
+test('verify-deps-before-run does not emit unsupported engine warnings for workspace projects', async () => {
+  const manifests: Record<string, ProjectManifest> = {
+    root: {
+      name: 'root',
+      private: true,
+      scripts: {
+        start: 'echo hello from root',
+      },
+    },
+    'has-strict-engine': {
+      name: 'has-strict-engine',
+      private: true,
+      engines: {
+        node: '>=99.0.0',
+      },
+      scripts: {
+        start: 'echo hello from has-strict-engine',
+      },
+    },
+  }
+
+  preparePackages([
+    { location: '.', package: manifests.root },
+    manifests['has-strict-engine'],
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  await execPnpm(['install'])
+
+  const { stdout } = execPnpmSync(['--config.verify-deps-before-run=install', 'start'], {
+    expectSuccess: true,
+  })
+  expect(stdout.toString()).toContain('hello from root')
+  expect(stdout.toString()).not.toContain('Unsupported engine')
+})


### PR DESCRIPTION
## Summary

- `checkDepsStatus` (run by `verifyDepsBeforeRun`) called `findWorkspaceProjects` without a `nodeVersion`, so the engine check fell back to the system Node from `PATH` and emitted spurious `[WARN] Unsupported engine` lines before scripts ran.
- Switched to `findWorkspaceProjectsNoCheck` — a status check shouldn't validate engines. Install paths still call `findWorkspaceProjects` with `nodeVersion` and continue to validate engines.

This was visible in CI when `devEngines.runtime.node` was set: the runner's pre-installed Node v20.20.2 (not the desired 24.6.0) was reported as `current` in the warning, because that's what `getSystemNodeVersion()` returned via PATH lookup.

## Test plan

- [x] `pnpm --filter @pnpm/deps.status test` passes
- [ ] CI green
- [ ] Confirm warnings no longer appear in `Compile & Lint` job on a branch that sets `devEngines.runtime`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed spurious "Unsupported engine" warnings during workspace dependency status checks; engine/os/cpu/libc validation still runs for install paths.
* **Tests**
  * Added an integration test verifying workspace start proceeds without emitting those false engine warnings.
* **Documentation**
  * Documented the behavior change: status-only checks now skip per-project installability validation when scanning workspaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11592)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->