### PR TITLE
feat: built-in `pnpm node` command that finds the right runtime

### DIFF
--- a/.changeset/pnpm-node-builtin-command.md
+++ b/.changeset/pnpm-node-builtin-command.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.runtime.commands": minor
+"pnpm": minor
+---
+
+Added a built-in `pnpm node` command that runs Node.js using the runtime managed by pnpm, regardless of whether `node` is on PATH. The binary is resolved from the project's `node_modules/node` (when `devEngines.runtime` is installed) or from pnpm's global runtime install (`pnpm runtime set node <version> -g`), and falls back to PATH only as a last resort. Previously `pnpm node` fell back through `run` → `exec`, which depended on `node` being resolvable from PATH and could fail on Windows when the runtime shim wasn't picked up by the calling shell. A project script named `node` continues to take precedence over the built-in.

--- a/engine/runtime/commands/package.json
+++ b/engine/runtime/commands/package.json
@@ -38,6 +38,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.pnpm-cli-runner": "workspace:*",
     "@pnpm/network.fetch": "workspace:*",
+    "cross-spawn": "catalog:",
     "render-help": "catalog:"
   },
   "peerDependencies": {
@@ -47,6 +48,8 @@
     "@jest/globals": "catalog:",
     "@pnpm/engine.runtime.commands": "workspace:*",
     "@pnpm/logger": "workspace:*",
+    "@pnpm/prepare-temp-dir": "workspace:*",
+    "@types/cross-spawn": "catalog:",
     "cross-env": "catalog:"
   },
   "engines": {

--- a/engine/runtime/commands/src/index.ts
+++ b/engine/runtime/commands/src/index.ts
@@ -1,2 +1,3 @@
 export { env } from './env/index.js'
+export { node } from './node/index.js'
 export { runtime } from './runtime/index.js'

--- a/engine/runtime/commands/src/node/index.ts
+++ b/engine/runtime/commands/src/node/index.ts
@@ -1,0 +1,3 @@
+import * as node from './node.js'
+
+export { node }

--- a/engine/runtime/commands/src/node/node.ts
+++ b/engine/runtime/commands/src/node/node.ts
@@ -1,0 +1,96 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
+import { docsUrl } from '@pnpm/cli.utils'
+import type { Config } from '@pnpm/config.reader'
+import crossSpawn from 'cross-spawn'
+import { renderHelp } from 'render-help'
+
+const IS_WINDOWS = process.platform === 'win32'
+const NODE_PKG_BIN_REL = IS_WINDOWS ? 'node.exe' : path.join('bin', 'node')
+
+export type NodeCommandOptions = Pick<Config,
+| 'dir'
+| 'pnpmHomeDir'
+> & Partial<Pick<Config,
+| 'globalBinDir'
+| 'modulesDir'
+| 'workspaceDir'
+>>
+
+export const commandNames = ['node']
+
+// A project script named "node" takes precedence — `pnpm node` then behaves
+// like `pnpm run node` (preserving prior fallback behavior for users who
+// already have such a script).
+export const overridableByScript = true
+
+export const skipPackageManagerCheck = true
+
+export function rcOptionsTypes (): Record<string, unknown> {
+  return {}
+}
+
+export function cliOptionsTypes (): Record<string, unknown> {
+  return {}
+}
+
+export function help (): string {
+  return renderHelp({
+    description: 'Runs Node.js using the version managed by pnpm, ignoring any "node" \
+binary that may be on PATH. The runtime is resolved from the project (when \
+"devEngines.runtime" is installed) or from pnpm\'s global runtime install \
+(`pnpm runtime set node <version> -g`). Falls back to "node" on PATH only as a \
+last resort.',
+    descriptionLists: [],
+    url: docsUrl('node'),
+    usages: [
+      'pnpm node -v',
+      'pnpm node script.js',
+      'pnpm node -e "console.log(1)"',
+    ],
+  })
+}
+
+export async function handler (
+  opts: NodeCommandOptions,
+  params: string[]
+): Promise<{ exitCode: number }> {
+  const nodePath = findNodeBinary(opts)
+  const { status, signal, error } = crossSpawn.sync(nodePath ?? 'node', params, {
+    stdio: 'inherit',
+  })
+  if (error) throw error
+  if (signal) {
+    // Forward the terminating signal to the parent so callers don't see a
+    // successful exit when the child was killed.
+    process.kill(process.pid, signal)
+    return { exitCode: 1 }
+  }
+  return { exitCode: status ?? 0 }
+}
+
+function findNodeBinary (opts: NodeCommandOptions): string | undefined {
+  // 1. Project-level runtime: look in the project's own node_modules, then
+  //    the workspace root's (pnpm hoists the runtime up to the workspace
+  //    when devEngines.runtime is set on the workspace root).
+  const modulesDir = opts.modulesDir ?? 'node_modules'
+  const candidates = [path.join(opts.dir, modulesDir)]
+  if (opts.workspaceDir && opts.workspaceDir !== opts.dir) {
+    candidates.push(path.join(opts.workspaceDir, modulesDir))
+  }
+  for (const nodeModulesDir of candidates) {
+    const projectBin = path.join(nodeModulesDir, 'node', NODE_PKG_BIN_REL)
+    if (existsSync(projectBin)) return projectBin
+  }
+
+  // 2. Global pnpm runtime: `pnpm runtime set node X -g` hardlinks/copies
+  //    `node.exe` (Windows) or symlinks `node` (POSIX) into the global bin
+  //    directory. That binary works regardless of whether the dir is on PATH.
+  const globalBin = opts.globalBinDir ?? path.join(opts.pnpmHomeDir, 'bin')
+  const globalNode = path.join(globalBin, IS_WINDOWS ? 'node.exe' : 'node')
+  if (existsSync(globalNode)) return globalNode
+
+  // 3. Fall back to PATH (cross-spawn will resolve "node").
+  return undefined
+}

--- a/engine/runtime/commands/test/node/node.test.ts
+++ b/engine/runtime/commands/test/node/node.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { tempDir } from '@pnpm/prepare-temp-dir'
+
+const mockSync = jest.fn(() => ({ status: 0, signal: null }))
+jest.unstable_mockModule('cross-spawn', () => ({
+  default: { sync: mockSync },
+}))
+
+const { node } = await import('@pnpm/engine.runtime.commands')
+
+const IS_WINDOWS = process.platform === 'win32'
+const NODE_BIN_NAME = IS_WINDOWS ? 'node.exe' : 'node'
+const PROJECT_NODE_BIN_REL = IS_WINDOWS ? 'node.exe' : 'bin/node'
+
+beforeEach(() => {
+  mockSync.mockClear()
+})
+
+test('spawns node with passed args and returns its exit code', async () => {
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+
+  const result = await node.handler({ dir, pnpmHomeDir }, ['-v'])
+
+  expect(mockSync).toHaveBeenCalledTimes(1)
+  expect(mockSync.mock.calls[0][1]).toEqual(['-v'])
+  expect(result).toEqual({ exitCode: 0 })
+})
+
+test('uses node binary from project node_modules when available', async () => {
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+  const nodePkgDir = path.join(dir, 'node_modules', 'node')
+  const nodeBin = path.join(nodePkgDir, PROJECT_NODE_BIN_REL)
+  fs.mkdirSync(path.dirname(nodeBin), { recursive: true })
+  fs.writeFileSync(path.join(nodePkgDir, 'package.json'), JSON.stringify({ name: 'node', version: '0.0.0' }))
+  fs.writeFileSync(nodeBin, '')
+
+  await node.handler({ dir, pnpmHomeDir }, [])
+
+  expect(mockSync.mock.calls[0][0]).toBe(nodeBin)
+})
+
+test('uses node binary hoisted to workspace root when project has none', async () => {
+  const workspaceDir = tempDir()
+  const dir = path.join(workspaceDir, 'pkg')
+  fs.mkdirSync(dir, { recursive: true })
+  const pnpmHomeDir = tempDir()
+  const nodePkgDir = path.join(workspaceDir, 'node_modules', 'node')
+  const nodeBin = path.join(nodePkgDir, PROJECT_NODE_BIN_REL)
+  fs.mkdirSync(path.dirname(nodeBin), { recursive: true })
+  fs.writeFileSync(path.join(nodePkgDir, 'package.json'), JSON.stringify({ name: 'node', version: '0.0.0' }))
+  fs.writeFileSync(nodeBin, '')
+
+  await node.handler({ dir, workspaceDir, pnpmHomeDir }, [])
+
+  expect(mockSync.mock.calls[0][0]).toBe(nodeBin)
+})
+
+test('falls back to global pnpm bin dir when no project node', async () => {
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+  const globalBin = path.join(pnpmHomeDir, 'bin')
+  const globalNode = path.join(globalBin, NODE_BIN_NAME)
+  fs.mkdirSync(globalBin, { recursive: true })
+  fs.writeFileSync(globalNode, '')
+
+  await node.handler({ dir, pnpmHomeDir }, [])
+
+  expect(mockSync.mock.calls[0][0]).toBe(globalNode)
+})
+
+test('honors globalBinDir when set', async () => {
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+  const globalBinDir = tempDir()
+  const globalNode = path.join(globalBinDir, NODE_BIN_NAME)
+  fs.writeFileSync(globalNode, '')
+
+  await node.handler({ dir, pnpmHomeDir, globalBinDir }, [])
+
+  expect(mockSync.mock.calls[0][0]).toBe(globalNode)
+})
+
+test('falls back to PATH lookup when no node binary is resolvable', async () => {
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+
+  await node.handler({ dir, pnpmHomeDir }, ['-v'])
+
+  expect(mockSync.mock.calls[0][0]).toBe('node')
+})
+
+test('propagates child exit code', async () => {
+  mockSync.mockReturnValueOnce({ status: 42, signal: null })
+  const dir = tempDir()
+  const pnpmHomeDir = tempDir()
+
+  const result = await node.handler({ dir, pnpmHomeDir }, [])
+
+  expect(result).toEqual({ exitCode: 42 })
+})

--- a/engine/runtime/commands/test/node/node.test.ts
+++ b/engine/runtime/commands/test/node/node.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { tempDir } from '@pnpm/prepare-temp-dir'
 
-const mockSync = jest.fn(() => ({ status: 0, signal: null }))
+const mockSync = jest.fn<(cmd: string, args: string[]) => { status: number, signal: NodeJS.Signals | null }>(() => ({ status: 0, signal: null }))
 jest.unstable_mockModule('cross-spawn', () => ({
   default: { sync: mockSync },
 }))

--- a/engine/runtime/commands/tsconfig.json
+++ b/engine/runtime/commands/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../../__utils__/prepare-temp-dir"
+    },
+    {
       "path": "../../../cli/utils"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4053,6 +4053,9 @@ importers:
       '@pnpm/network.fetch':
         specifier: workspace:*
         version: link:../../../network/fetch
+      cross-spawn:
+        specifier: 'catalog:'
+        version: 7.0.6
       render-help:
         specifier: 'catalog:'
         version: 2.0.0
@@ -4066,6 +4069,12 @@ importers:
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../../core/logger
+      '@pnpm/prepare-temp-dir':
+        specifier: workspace:*
+        version: link:../../../__utils__/prepare-temp-dir
+      '@types/cross-spawn':
+        specifier: 'catalog:'
+        version: 6.0.6
       cross-env:
         specifier: 'catalog:'
         version: 10.1.0

--- a/pnpm/src/cmd/index.ts
+++ b/pnpm/src/cmd/index.ts
@@ -8,7 +8,7 @@ import { types as allTypes } from '@pnpm/config.reader'
 import { audit, licenses, sbom } from '@pnpm/deps.compliance.commands'
 import { bugs, docs, list, ll, outdated, peers, view, why } from '@pnpm/deps.inspection.commands'
 import { selfUpdate, setup, withCmd } from '@pnpm/engine.pm.commands'
-import { env, runtime } from '@pnpm/engine.runtime.commands'
+import { env, node, runtime } from '@pnpm/engine.runtime.commands'
 import {
   create,
   dlx,
@@ -142,6 +142,7 @@ const commands: CommandDefinition[] = [
   docs,
   env,
   exec,
+  node,
   runtime,
   fetch,
   generateCompletion,

--- a/pnpm/src/parseCliArgs.ts
+++ b/pnpm/src/parseCliArgs.ts
@@ -23,7 +23,7 @@ export async function parseCliArgs (inputArgv: string[]): Promise<ParsedCliArgsW
   }
   const libOpts = {
     fallbackCommand: 'run',
-    escapeArgs: ['create', 'exec', 'test'],
+    escapeArgs: ['create', 'exec', 'node', 'test'],
     getCommandLongName: getCommandFullName,
     getTypesByCommandName: getCliOptionsTypes,
     renamedOptions: RENAMED_OPTIONS,

--- a/pnpm/test/node.ts
+++ b/pnpm/test/node.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+
+import { expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+import { execPnpm, execPnpmSync } from './utils/index.js'
+
+test('pnpm node -v prints the Node version', () => {
+  prepare()
+
+  const result = execPnpmSync(['node', '-v'])
+
+  expect(result.status).toBe(0)
+  // -v output is `v<major>.<minor>.<patch>` — assert the shape, not the exact
+  // version (whichever node binary cross-spawn falls back to may differ).
+  expect(String(result.stdout).trim()).toMatch(/^v\d+\.\d+\.\d+/)
+})
+
+test('pnpm node -e runs the passed expression', () => {
+  prepare()
+
+  const result = execPnpmSync(['node', '-e', 'console.log("PNPM_NODE_E")'])
+
+  expect(result.status).toBe(0)
+  expect(String(result.stdout)).toContain('PNPM_NODE_E')
+})
+
+test('pnpm node defers to a same-named script in package.json', () => {
+  prepare({
+    scripts: {
+      node: 'echo SCRIPT_RAN',
+    },
+  })
+
+  const result = execPnpmSync(['node'])
+
+  expect(result.status).toBe(0)
+  expect(String(result.stdout)).toContain('SCRIPT_RAN')
+})
+
+test('pnpm node uses the runtime installed in node_modules over PATH', async () => {
+  prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '22.20.0',
+        onFail: 'download',
+      },
+    },
+  })
+  // Make the global-bin-dir lookup miss so the project-level resolution
+  // is what serves this call (not the host's globally installed runtime).
+  fs.writeFileSync('.npmrc', 'global-bin-dir=does-not-exist\n', 'utf8')
+
+  await execPnpm(['install'])
+
+  const result = execPnpmSync(['node', '-v'])
+
+  expect(result.status).toBe(0)
+  expect(String(result.stdout).trim()).toBe('v22.20.0')
+})


### PR DESCRIPTION
## Summary

`pnpm node` previously fell through `run` → `exec`, which spawned `node` via `PATH`. On Windows this could surface a `cmd.exe` interactive banner when the runtime shim wasn't picked up by the calling shell — e.g. Git Bash after `pnpm runtime set node X -g`, reported in https://github.com/pnpm/pnpm/actions/runs/25692640268/job/75437945578.

The new built-in resolves the Node binary explicitly, in order:

1. Project's `node_modules/node/{node.exe|bin/node}` (installed via `devEngines.runtime`).
2. Workspace root's `node_modules/node/...` (hoisted runtime).
3. `globalBinDir` / `$PNPM_HOME/bin/node[.exe]` (the global runtime set by `pnpm runtime set node X -g`).
4. PATH fallback.

`node` is added to `escapeArgs` so `pnpm node -v` no longer short-circuits to pnpm's own `--version`. A package.json script named `node` continues to take precedence over the built-in (`overridableByScript: true`).

## Test plan

- [x] Unit tests for the resolver (project / workspace / global-bin / PATH precedence, exit code propagation)
- [x] e2e: `pnpm node -v`, `pnpm node -e`, script override, `devEngines.runtime` install used in preference to PATH
- [x] `pnpm --version` still returns pnpm's version (escapeArgs scope is correct)
- [x] Existing `cli/parse-cli-args` tests still pass
- [ ] CI on Windows confirms the original failure mode no longer reproduces

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `pnpm node` command to execute Node.js using the version managed by pnpm. The command resolves the Node binary from the project's installed runtime, then pnpm's global runtime, with fallback to system PATH. Project scripts named `node` continue to override the built-in command.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11594)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->