### PR TITLE
fix: update @zkochan/cmd-shim to 9.0.3

### DIFF
--- a/.changeset/update-cmd-shim-9-0-3.md
+++ b/.changeset/update-cmd-shim-9-0-3.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/bins.linker": patch
+"pnpm": patch
+---
+
+Updated `@zkochan/cmd-shim` to 9.0.3. The sh shim it writes for `.cmd` / `.bat` targets now escapes the `/C` switch as `//C`, so it survives the path translation Git Bash applies when launching `cmd.exe`. Without this, a bare `/C` was rewritten to `C:\` before reaching cmd.exe — the switch was dropped, cmd started interactively, and the calling script saw the cmd banner instead of the wrapped command's output. Affects any cmd-shim-wrapped batch script invoked from Git Bash / MSYS / Cygwin on Windows. See [pnpm/cmd-shim#55](https://github.com/pnpm/cmd-shim/pull/55).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,8 +434,8 @@ catalogs:
       specifier: ^4.0.8
       version: 4.1.5
     '@zkochan/cmd-shim':
-      specifier: ^9.0.2
-      version: 9.0.2
+      specifier: ^9.0.3
+      version: 9.0.3
     '@zkochan/retry':
       specifier: ^0.2.0
       version: 0.2.0
@@ -1591,7 +1591,7 @@ importers:
         version: link:../../workspace/project-manifest-reader
       '@zkochan/cmd-shim':
         specifier: 'catalog:'
-        version: 9.0.2
+        version: 9.0.3
       '@zkochan/rimraf':
         specifier: 'catalog:'
         version: 4.0.0
@@ -7914,7 +7914,7 @@ importers:
         version: link:../../../__utils__/jest-config
       '@zkochan/cmd-shim':
         specifier: 'catalog:'
-        version: 9.0.2
+        version: 9.0.3
       execa:
         specifier: 'catalog:'
         version: safe-execa@0.3.0
@@ -12282,8 +12282,8 @@ packages:
     resolution: {integrity: sha512-E5mgrRS8Kk80n19Xxmrx5qO9UG03FyZd8Me5gxYi++VPZsOv8+OsclA+0Fth4KTDCrQ/FkJryNFKJ6/642lo4g==}
     engines: {node: '>=18.12'}
 
-  '@zkochan/cmd-shim@9.0.2':
-    resolution: {integrity: sha512-l4x1ZcuZKS7nVVLrCzl4t0Q54mADMO6NtZFVMwoaOY/Emf62CbxMWh192nfiiwOhHmBcCR3iHrbEzwQXqCob1Q==}
+  '@zkochan/cmd-shim@9.0.3':
+    resolution: {integrity: sha512-u2kKE7N/UapZ0RyAQTNcnSQ9SYbvtcgwzfXl3WHcoJvja69T15Dou//ZU6Bsk3p0M6fFWD5ip+uwkJy61TvaMA==}
     engines: {node: '>=22.13'}
 
   '@zkochan/diable@1.0.2':
@@ -20725,7 +20725,7 @@ snapshots:
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       is-windows: 1.0.2
 
-  '@zkochan/cmd-shim@9.0.2':
+  '@zkochan/cmd-shim@9.0.3':
     dependencies:
       cmd-extension: 1.0.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -146,7 +146,7 @@ catalog:
   '@yarnpkg/nm': 4.0.7
   '@yarnpkg/parsers': 3.0.3
   '@yarnpkg/pnp': ^4.0.8
-  '@zkochan/cmd-shim': ^9.0.2
+  '@zkochan/cmd-shim': ^9.0.3
   '@zkochan/retry': ^0.2.0
   '@zkochan/rimraf': ^4.0.0
   '@zkochan/table': ^2.0.1
@@ -344,7 +344,7 @@ minimumReleaseAgeExclude:
   - '@pnpm/*'
   - '@rushstack/worker-pool@0.7.7'
   - '@zkochan/*'
-  - '@zkochan/cmd-shim@9.0.2'
+  - '@zkochan/cmd-shim@9.0.3'
   - better-path-resolve
   - body-parser@2.2.1
   - can-link


### PR DESCRIPTION
## Summary

Picks up the MSYS path-translation fix from [pnpm/cmd-shim#55](https://github.com/pnpm/cmd-shim/pull/55).

The sh shim that cmd-shim writes for `.cmd` / `.bat` targets ran the script via:

```sh
exec cmd /C "<path>" "$@"
```

When invoked from Git Bash / MSYS / Cygwin on Windows, the path-conversion layer that runs as bash launches a native Win32 process rewrites arguments matching POSIX-path heuristics — a bare `/C` is treated as a path and rewritten to `C:\`. cmd.exe then never sees the `/C` flag, starts interactively, and reads the remainder of the calling script as input until EOF. The fix escapes it as `//C` (the MSYS escape that passes through to cmd.exe as `/C`).

Surfaced as the `pnpm node` failure on PR #11553's Windows CI ([example](https://github.com/pnpm/pnpm/actions/runs/25692640268/job/75437945578)).

## Test plan

- [x] `pnpm install` updates lockfile cleanly
- [x] `pn run lint:meta` passes
- [x] `@pnpm/bins.linker` (the only consumer of `@zkochan/cmd-shim`) compiles and tests pass
- [x] CI green on Windows

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed batch script execution on Git Bash environments that was preventing proper command output delivery.

## Chores
* Updated command-line shim dependency to version 9.0.3.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11595)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->