### PR TITLE
fix(network): strip sec-fetch-* headers to fix Azure DevOps Artifacts 400 errors

### DIFF
--- a/.changeset/fix-ado-sec-fetch-headers.md
+++ b/.changeset/fix-ado-sec-fetch-headers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/network.fetch": patch
+"pnpm": patch
+---
+
+Strip `sec-fetch-*` headers from outgoing HTTP requests. These headers are automatically added by undici's `fetch()` implementation per the Fetch spec but cause Azure DevOps Artifacts to return HTTP 400 for uncached upstream packages, as ADO interprets them as browser requests [#11572](https://github.com/pnpm/pnpm/issues/11572).

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -47,8 +47,14 @@ function stripSecFetchHeaders (dispatch: Dispatcher['dispatch']): Dispatcher['di
         }
         opts = { ...opts, headers: filtered }
       } else if (typeof opts.headers === 'object') {
+        // undici also accepts an iterable of [key, value] pairs (e.g. a Map or
+        // web Headers). Use that iterator when present; otherwise fall back to
+        // Object.entries for plain IncomingHttpHeaders objects.
+        const entries = Symbol.iterator in opts.headers
+          ? (opts.headers as Iterable<[string, string | string[] | undefined]>)
+          : Object.entries(opts.headers as Record<string, string | string[] | undefined>)
         const headers: Record<string, string | string[] | undefined> = {}
-        for (const [key, value] of Object.entries(opts.headers as Record<string, string | string[] | undefined>)) {
+        for (const [key, value] of entries) {
           if (!key.toLowerCase().startsWith('sec-fetch-')) {
             headers[key] = value
           }

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -13,6 +13,37 @@ const DEFAULT_MAX_SOCKETS = 50
 const KEEP_ALIVE_TIMEOUT = 30_000 // 30 seconds
 const KEEP_ALIVE_MAX_TIMEOUT = 600_000 // 10 minutes
 
+// undici's fetch() automatically adds sec-fetch-* headers (e.g. sec-fetch-mode: cors)
+// per the Fetch spec. Some registries like Azure DevOps Artifacts interpret these as
+// browser requests and reject them with HTTP 400. Since pnpm is a CLI tool, these
+// headers serve no purpose and must be stripped.
+// See https://github.com/pnpm/pnpm/issues/11572
+function stripSecFetchHeaders (dispatch: Dispatcher['dispatch']): Dispatcher['dispatch'] {
+  return (opts, handler) => {
+    if (opts.headers) {
+      if (Array.isArray(opts.headers)) {
+        // Flat array format: [key1, val1, key2, val2, ...]
+        const filtered: string[] = []
+        for (let i = 0; i < opts.headers.length; i += 2) {
+          if (!opts.headers[i].toLowerCase().startsWith('sec-fetch-')) {
+            filtered.push(opts.headers[i], opts.headers[i + 1])
+          }
+        }
+        opts = { ...opts, headers: filtered }
+      } else if (typeof opts.headers === 'object') {
+        const headers: Record<string, string> = {}
+        for (const [key, value] of Object.entries(opts.headers as Record<string, string>)) {
+          if (!key.toLowerCase().startsWith('sec-fetch-')) {
+            headers[key] = value
+          }
+        }
+        opts = { ...opts, headers }
+      }
+    }
+    return dispatch(opts, handler)
+  }
+}
+
 // Set an optimized global dispatcher so that requests without custom options
 // (no proxy, no custom certs) still benefit from better keep-alive and Happy Eyeballs.
 //
@@ -27,7 +58,7 @@ setGlobalDispatcher(new Agent({
   connect: {
     autoSelectFamily: true,
   },
-}))
+}).compose(stripSecFetchHeaders))
 
 const DISPATCHER_CACHE = new LRUCache<string, Dispatcher>({
   max: 50,
@@ -165,6 +196,7 @@ function getProxyDispatcher (parsedUri: URL, opts: DispatcherOptions): Dispatche
     dispatcher = createHttpProxyDispatcher(proxyUrl, isHttps, opts, { ca, cert, key: certKey })
   }
 
+  dispatcher = dispatcher.compose(stripSecFetchHeaders)
   DISPATCHER_CACHE.set(key, dispatcher)
   return dispatcher
 }
@@ -301,8 +333,9 @@ function getNonProxyDispatcher (parsedUri: URL, opts: DispatcherOptions): Dispat
       },
   })
 
-  DISPATCHER_CACHE.set(key, agent)
-  return agent
+  const dispatcher = agent.compose(stripSecFetchHeaders)
+  DISPATCHER_CACHE.set(key, dispatcher)
+  return dispatcher
 }
 
 function checkNoProxy (parsedUri: URL, opts: { noProxy?: boolean | string }): boolean {

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -13,6 +13,22 @@ const DEFAULT_MAX_SOCKETS = 50
 const KEEP_ALIVE_TIMEOUT = 30_000 // 30 seconds
 const KEEP_ALIVE_MAX_TIMEOUT = 600_000 // 10 minutes
 
+// Set an optimized global dispatcher so that requests without custom options
+// (no proxy, no custom certs) still benefit from better keep-alive and Happy Eyeballs.
+//
+// Note: we intentionally do NOT enable HTTP/2 (allowH2) or HTTP/1.1 pipelining here.
+// With HTTP/2, undici multiplexes many streams over 1-2 TCP connections sharing a single
+// congestion window. In benchmarks this was slower than opening ~50 independent HTTP/1.1
+// connections that each get their own congestion window and can saturate bandwidth in parallel.
+setGlobalDispatcher(new Agent({
+  connections: DEFAULT_MAX_SOCKETS,
+  keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
+  keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
+  connect: {
+    autoSelectFamily: true,
+  },
+}).compose(stripSecFetchHeaders))
+
 // undici's fetch() automatically adds sec-fetch-* headers (e.g. sec-fetch-mode: cors)
 // per the Fetch spec. Some registries like Azure DevOps Artifacts interpret these as
 // browser requests and reject them with HTTP 400. Since pnpm is a CLI tool, these
@@ -31,8 +47,8 @@ function stripSecFetchHeaders (dispatch: Dispatcher['dispatch']): Dispatcher['di
         }
         opts = { ...opts, headers: filtered }
       } else if (typeof opts.headers === 'object') {
-        const headers: Record<string, string> = {}
-        for (const [key, value] of Object.entries(opts.headers as Record<string, string>)) {
+        const headers: Record<string, string | string[] | undefined> = {}
+        for (const [key, value] of Object.entries(opts.headers as Record<string, string | string[] | undefined>)) {
           if (!key.toLowerCase().startsWith('sec-fetch-')) {
             headers[key] = value
           }
@@ -43,22 +59,6 @@ function stripSecFetchHeaders (dispatch: Dispatcher['dispatch']): Dispatcher['di
     return dispatch(opts, handler)
   }
 }
-
-// Set an optimized global dispatcher so that requests without custom options
-// (no proxy, no custom certs) still benefit from better keep-alive and Happy Eyeballs.
-//
-// Note: we intentionally do NOT enable HTTP/2 (allowH2) or HTTP/1.1 pipelining here.
-// With HTTP/2, undici multiplexes many streams over 1-2 TCP connections sharing a single
-// congestion window. In benchmarks this was slower than opening ~50 independent HTTP/1.1
-// connections that each get their own congestion window and can saturate bandwidth in parallel.
-setGlobalDispatcher(new Agent({
-  connections: DEFAULT_MAX_SOCKETS,
-  keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
-  keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
-  connect: {
-    autoSelectFamily: true,
-  },
-}).compose(stripSecFetchHeaders))
 
 const DISPATCHER_CACHE = new LRUCache<string, Dispatcher>({
   max: 50,

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -313,8 +313,8 @@ test('createDispatchedFetch returns a fetch bound to the given dispatcher option
 
 test('sec-fetch-* headers are stripped from requests', async () => {
   const receivedHeaders = await new Promise<http.IncomingHttpHeaders>((resolve, reject) => {
-    const server = http.createServer((_req, res) => {
-      resolve(_req.headers)
+    const server = http.createServer((req, res) => {
+      resolve(req.headers)
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
     })

--- a/network/fetch/test/fetchFromRegistry.test.ts
+++ b/network/fetch/test/fetchFromRegistry.test.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import fs from 'node:fs'
+import http from 'node:http'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
@@ -308,4 +309,26 @@ test('createDispatchedFetch returns a fetch bound to the given dispatcher option
   } finally {
     await teardownMockAgent()
   }
+})
+
+test('sec-fetch-* headers are stripped from requests', async () => {
+  const receivedHeaders = await new Promise<http.IncomingHttpHeaders>((resolve, reject) => {
+    const server = http.createServer((_req, res) => {
+      resolve(_req.headers)
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end('{"ok":true}')
+    })
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number }
+      const fetchFromRegistry = createFetchFromRegistry({})
+      fetchFromRegistry(`http://127.0.0.1:${port}/test`).then(
+        (res) => res.text().then(() => server.close()),
+        (err) => {
+          server.close(); reject(err)
+        }
+      )
+    })
+  })
+  const secFetchHeaders = Object.keys(receivedHeaders).filter(h => h.startsWith('sec-fetch-'))
+  expect(secFetchHeaders).toEqual([])
 })


### PR DESCRIPTION
## Summary

Strip `sec-fetch-*` headers from all outgoing HTTP requests made by pnpm.

Fixes #11572

## Problem

pnpm 11 switched to undici's `fetch()`, which automatically adds `sec-fetch-mode: cors` and other `sec-fetch-*` headers per the WHATWG Fetch spec. Azure DevOps Artifacts interprets these headers as browser requests and returns HTTP 400 (`PotentiallyDangerousRequestException: "For security reasons, an upstream package cannot be downloaded from a browser"`) for uncached upstream packages. pnpm 10 used `node-fetch` which did not send these headers and worked fine.

As confirmed by @dmitrc in #11572, removing `sec-fetch-mode` from the request makes ADO return 200 instead of 400.

## Solution

Added a `stripSecFetchHeaders` interceptor in `@pnpm/network.fetch` that removes all `sec-fetch-*` headers from dispatch options before they reach the wire. The interceptor is applied via undici's `.compose()` API to:

- The global dispatcher
- Proxy dispatchers (HTTP and SOCKS)
- Non-proxy dispatchers

Since pnpm is a CLI tool, `sec-fetch-*` headers serve no purpose — they are browser-specific metadata. No npm registry (public or private) relies on them. This is a pragmatic workaround for undici being spec-compliant in a non-browser context; there is currently no upstream undici option to disable these headers.

## Test

Added a test that creates a real HTTP server, makes a request via `createFetchFromRegistry`, and asserts that no `sec-fetch-*` headers are present in the received request.

## Checklist

- [x] Changes in a new branch off `main`
- [x] Includes test case
- [x] Changeset created (`@pnpm/network.fetch`: patch, `pnpm`: patch)
- [x] Tests pass (`pnpm --filter @pnpm/network.fetch test`)
- [x] Lint passes
- [x] Conventional commit message

---
Written by an agent (GitHub Copilot, Claude Opus 4.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stripped browser-specific sec-fetch-* headers from outgoing package fetch requests, preventing HTTP 400 responses from certain upstream registries.

* **Tests**
  * Added a test that verifies sec-fetch-* headers are not sent with HTTP requests.

* **Chores**
  * Applied patch-level package updates and release metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11602)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->