### PR TITLE
ci: address zizmor findings across workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
       with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Checkout PR head
       if: inputs.pr_number != ''
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ inputs.pr_number }}
       run: |
-        PR_NUMBER="${{ inputs.pr_number }}"
         echo "Fetching PR #$PR_NUMBER head..."
         git fetch origin "refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr-${PR_NUMBER}"
         git checkout "origin/pr-${PR_NUMBER}"
@@ -75,8 +76,15 @@ jobs:
       if: steps.bench.outputs.bench_dir != ''
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BENCH_DIR: ${{ steps.bench.outputs.bench_dir }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        REF_NAME: ${{ github.ref_name }}
+        RUN_ID: ${{ github.run_id }}
+        SERVER_URL: ${{ github.server_url }}
+        REPO: ${{ github.repository }}
+        RUNS: ${{ inputs.runs }}
+        ACTOR: ${{ github.actor }}
       run: |
-        BENCH_DIR="${{ steps.bench.outputs.bench_dir }}"
         RESULTS_FILE="$BENCH_DIR/results.md"
 
         if [ ! -f "$RESULTS_FILE" ]; then
@@ -88,14 +96,14 @@ jobs:
         cat "$RESULTS_FILE"
         echo "-------------------------"
 
-        if [ -n "${{ inputs.pr_number }}" ]; then
-          PR_NUMBER="${{ inputs.pr_number }}"
+        if [ -n "$INPUT_PR_NUMBER" ]; then
+          PR_NUMBER="$INPUT_PR_NUMBER"
         else
-          PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          PR_NUMBER=$(gh pr list --head "$REF_NAME" --json number --jq '.[0].number' 2>/dev/null || echo "")
         fi
 
         if [ -z "$PR_NUMBER" ]; then
-          echo "::notice::No open PR found for branch ${{ github.ref_name }}. Results printed above."
+          echo "::notice::No open PR found for branch $REF_NAME. Results printed above."
           exit 0
         fi
 
@@ -104,15 +112,15 @@ jobs:
           echo "$MARKER"
           cat "$RESULTS_FILE"
           echo ""
-          echo "_Run [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) · ${{ inputs.runs }} runs per scenario · triggered by @${{ github.actor }}_"
+          echo "_Run [${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) · ${RUNS} runs per scenario · triggered by @${ACTOR}_"
         } > /tmp/comment-body.md
 
-        COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+        COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
           --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | .[0].id // empty" 2>/dev/null || echo "")
 
         if [ -n "$COMMENT_ID" ]; then
           echo "Updating existing benchmark comment $COMMENT_ID on PR #$PR_NUMBER"
-          gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
             -X PATCH \
             -F "body=@/tmp/comment-body.md"
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Install pnpm
       uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
     - name: Compile TypeScript

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Resolve release metadata
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install pnpm and Node
         uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
         with:
@@ -65,7 +67,9 @@ jobs:
       - name: Generate release description
         run: pn make-release-description
       - name: Release
-        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        # `gh release create` could replace this, but the release pipeline is
+        # sensitive and softprops/action-gh-release is widely battle-tested.
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
           files: dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,15 +30,19 @@ jobs:
         git config --global user.email "x@y.z"
     - name: Checkout Commit
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Install pnpm and Node
       uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
       with:
         runtime: node@${{ inputs.node }}
     - name: Verify Node version
       shell: bash
+      env:
+        NODE_VERSION: ${{ inputs.node }}
       run: |
         actual=$(pn node -v)
-        expected="v${{ inputs.node }}"
+        expected="v${NODE_VERSION}"
         if [ "$actual" != "$expected" ]; then
           echo "Expected Node version $expected but got $actual"
           exit 1
@@ -57,8 +61,10 @@ jobs:
     - name: Determine test scope
       id: test-scope
       shell: bash
+      env:
+        REF_NAME: ${{ github.ref_name }}
       run: |
-        if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "chore/update-lockfile" || "${{ github.ref_name }}" == release/* ]]; then
+        if [[ "$REF_NAME" == "main" || "$REF_NAME" == "chore/update-lockfile" || "$REF_NAME" == release/* ]]; then
           echo "script=ci:test-all" >> "$GITHUB_OUTPUT"
           echo "scope=all" >> "$GITHUB_OUTPUT"
         else
@@ -73,6 +79,7 @@ jobs:
         fi
     - name: Run tests (${{ steps.test-scope.outputs.scope }})
       timeout-minutes: 70
-      run: pn run ${{ steps.test-scope.outputs.script }}
       env:
         PNPM_WORKERS: 3
+        TEST_SCRIPT: ${{ steps.test-scope.outputs.script }}
+      run: pn run "$TEST_SCRIPT"

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -23,11 +23,13 @@ jobs:
     - name: Update tag
       env:
         "npm_config_//registry.npmjs.org/:_authToken": ${{ secrets.NPM_TOKEN }}
+        VERSION: ${{ github.event.inputs.version }}
+        TAG: ${{ github.event.inputs.tag }}
       run: |
-        npm dist-tag add pnpm@${{ github.event.inputs.version }} latest-11
-        npm dist-tag add pnpm@${{ github.event.inputs.version }} ${{ github.event.inputs.tag }}
-        npm dist-tag add @pnpm/exe@${{ github.event.inputs.version }} latest-11
-        npm dist-tag add @pnpm/exe@${{ github.event.inputs.version }} ${{ github.event.inputs.tag }}
+        npm dist-tag add "pnpm@${VERSION}" latest-11
+        npm dist-tag add "pnpm@${VERSION}" "${TAG}"
+        npm dist-tag add "@pnpm/exe@${VERSION}" latest-11
+        npm dist-tag add "@pnpm/exe@${VERSION}" "${TAG}"
 
   publish-to-winget:
     runs-on: ubuntu-latest
@@ -46,7 +48,7 @@ jobs:
     environment: release
     needs: tag-in-registry
     steps:
-      - uses: bluwy/release-for-reddit-action@b4ee0e0d64da893e0428912aac5cda675082bd85 # v2.0.0
+      - uses: bluwy/release-for-reddit-action@b4ee0e0d64da893e0428912aac5cda675082bd85 # v2
         with:
           username: ${{ secrets.REDDIT_USERNAME }}
           password: ${{ secrets.REDDIT_PASSWORD }}

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Commit
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
       with:
+        # The token must persist in .git/config so the "Create or update PR"
+        # step below can `git push` to the chore/update-lockfile branch.
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
 
     # The job deletes the lockfile and regenerates it with `--lockfile-only`,


### PR DESCRIPTION
## Summary

Resolves all 30 zizmor alerts reported on `main` after #11607 wired up the scanner.

| Rule | Count | Action |
|---|---|---|
| `template-injection` (error) | 19 | Move `${{ … }}` to `env:` and reference shell vars |
| `artipacked` (note) | 8 | Add `persist-credentials: false` to `actions/checkout` (1 inline-ignored) |
| `dependabot-cooldown` (warning) | 1 | Add 7-day cooldown in `dependabot.yml` |
| `ref-version-mismatch` (warning) | 1 | Fix comment: the SHA points at `v2`, not `v2.0.0` |
| `superfluous-actions` (note) | 1 | Inline-ignored with justification — see below |

## Notable decisions

- **`update-lockfile.yml`** keeps the persisted checkout token because the later `git push -f origin chore/update-lockfile` step depends on it. The line has `# zizmor: ignore[artipacked]` plus a comment explaining why.
- **`release.yml`** keeps `softprops/action-gh-release`. zizmor's suggestion (use `gh release create`) is valid in principle, but the release pipeline is sensitive and the action is battle-tested. Inline-ignored with justification.
- **`test.yml:76`** (running `pn run ${{ steps.test-scope.outputs.script }}`) was technically a false positive — the upstream step hardcodes the output to one of two literals — but moved to `env:` anyway for consistency and to keep the rule on by default.

## Verification

Ran zizmor locally against the modified workflows (with online audits enabled):

```
$ GH_TOKEN=… zizmor --persona regular .github
…
No findings to report. Good job! (2 ignored, 32 suppressed)
```

The 2 \"ignored\" are the inline-justified `release.yml` and `update-lockfile.yml` cases above. After merge, the zizmor workflow itself will re-run on `main` and the Code scanning dashboard should drop to 0 open alerts.

## Test plan

- [ ] zizmor check on this PR passes with no new alerts.
- [ ] Existing CI / test / docker / release / lockfile / etc. workflows still pass on this branch.
- [ ] After merge, https://github.com/pnpm/pnpm/security/code-scanning?query=tool:zizmor shows 0 open alerts.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security by disabling credential persistence across multiple workflows (audit, CI, CodeQL, Docker, release, and test pipelines).
  * Refactored workflows to use environment variables for improved configuration management and maintainability.
  * Updated Dependabot configuration to set a 7-day cooldown window for GitHub Actions updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->