### PR TITLE
ci: integrate garnet-org/action for supply-chain monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     with:
       node: '24.0.0'
       platform: ubuntu-latest
+      garnet: true
+    secrets:
+      GARNET_API_TOKEN: ${{ secrets.GARNET_API_TOKEN }}
 
   test:
     name: ${{ matrix.platform }} / Node.js ${{ matrix.node }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: garnet-org/action@9e819143e63d6dda04bca2e90ac85e3cf0e5289d # v2
+        with:
+          api_token: ${{ secrets.GARNET_API_TOKEN }}
       - name: Install pnpm and Node
         uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,13 @@ on:
       platform:
         required: true
         type: string
+      garnet:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GARNET_API_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -32,6 +39,10 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+    - if: ${{ inputs.garnet }}
+      uses: garnet-org/action@9e819143e63d6dda04bca2e90ac85e3cf0e5289d # v2
+      with:
+        api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
       uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
       with:

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -18,6 +18,9 @@ jobs:
     environment: release
     runs-on: ubuntu-latest
     steps:
+    - uses: garnet-org/action@9e819143e63d6dda04bca2e90ac85e3cf0e5289d # v2
+      with:
+        api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Setup Node
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
     - name: Update tag


### PR DESCRIPTION
## Summary

Wires the [Garnet](https://github.com/garnet-org/action) network-monitoring action into the workflows that touch publish/tag credentials or run a representative install/test:

- **`ci.yml`** — runs on the `test-smoke` job only. The full cross-platform/Node-version test matrix is intentionally excluded so the per-job overhead doesn't multiply across the matrix; the smoke job already exercises a representative install/test path.
- **`test.yml`** — gains an optional `garnet` boolean input (defaults to `false`) and an optional `GARNET_API_TOKEN` secret in the `workflow_call:` interface, so callers opt in explicitly. Secrets are passed explicitly from `ci.yml` rather than via `secrets: inherit`.
- **`release.yml`** — runs on the `release` job, which performs the npm publishes (both trusted-publishing OIDC steps and the static-token step).
- **`update-latest.yml`** — runs on the `tag-in-registry` job, which mutates npm dist-tags. The post-* notification jobs (winget/reddit/mastodon) are not instrumented.

The action is pinned by SHA with a `# v2` comment, matching the repo's existing pinning convention.

## Test plan

- [ ] After merge, confirm a CI run on `main` shows the garnet step running on `test-smoke` and skipped on the rest of the test matrix
- [ ] On the next release, confirm the garnet step runs in `release.yml` without blocking publish
- [ ] On the next dist-tag update, confirm the garnet step runs in the `tag-in-registry` job

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated Garnet service into CI/CD workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11626)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->