### PR TITLE
docs: split AGENTS.md into shared + pacquet-specific

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,13 @@
 
 This document provides context and instructions for AI agents working on the pnpm codebase.
 
+The repository contains two stacks:
+
+- The **TypeScript pnpm CLI** — everything outside `pacquet/`.
+- The **Rust pacquet port** — `pacquet/`. See [`pacquet/AGENTS.md`](./pacquet/AGENTS.md) for pacquet-specific rules; it adds to (and never contradicts) the conventions below.
+
+Sections below marked "(TypeScript only)" do not apply to pacquet. Everything else applies to both stacks.
+
 ## Repository Structure
 
 The pnpm codebase is a monorepo managed by pnpm itself. The root contains functional directories organized by domain:
@@ -40,7 +47,11 @@ The pnpm codebase is a monorepo managed by pnpm itself. The root contains functi
 -   `crypto/`: Cryptographic utilities.
 -   `text/`: Text processing utilities.
 
-## Setup & Build
+### Rust Port
+
+-   `pacquet/`: The pnpm CLI ported to Rust. Self-contained sub-project with its own crates, tests, and tooling — see [`pacquet/AGENTS.md`](./pacquet/AGENTS.md).
+
+## Setup & Build (TypeScript only)
 
 To set up the environment and build the project:
 
@@ -63,7 +74,7 @@ pnpm --filter pnpm run compile
 
 This runs `tsgo --build`, linting, and `pnpm run bundle` (which bundles all packages into `pnpm/dist/pnpm.mjs`). Without this step, e2e tests will use a stale bundle and your changes won't be tested.
 
-## Testing
+## Testing (TypeScript only)
 
 Never run all tests in the repository as it takes a lot of time.
 
@@ -89,9 +100,7 @@ Or a specific test case in a specific file:
 pnpm --filter <package_name> test <file_path> -t <test_name_pattern>
 ```
 
-**Never ignore test failures.** Do not dismiss a failing test as a "pre-existing" failure that is unrelated to your changes. Every test failure must be investigated and fixed. If a test was already broken before your changes, fix it as part of your work — do not silently skip it or treat it as acceptable.
-
-## Linting
+## Linting (TypeScript only)
 
 To run all linting checks:
 
@@ -99,9 +108,33 @@ To run all linting checks:
 pnpm run lint
 ```
 
-## Contribution Workflow
+## Never ignore test failures
 
-### Changesets
+Do not dismiss a failing test as a "pre-existing" failure that is unrelated to your changes. Every test failure must be investigated and fixed. If a test was already broken before your changes, fix it as part of your work — do not silently skip it or treat it as acceptable.
+
+## Code Reuse and Avoiding Duplication
+
+**Before writing new code, always analyze the existing codebase for similar functionality.** This is a large monorepo with many shared utilities — duplication is a real risk.
+
+-   **Search before you write.** Before implementing any non-trivial logic, search the codebase for existing functions, utilities, or patterns that do the same or similar thing. Check `packages/`, `fs/`, `crypto/`, `text/`, and other shared directories first.
+-   **Extract shared code.** If you find that the logic you need already exists in another package but is not exported or reusable, refactor it into a shared package rather than duplicating it. If you are adding new code that is similar to code that already exists elsewhere in the repo, move the common parts into a shared package that both locations can use.
+-   **Prefer open source packages over custom implementations.** Do not reimplement functionality that is already available as a well-maintained open source package. Use established libraries for common tasks (e.g., path manipulation, string utilities, data structures, schema validation). Only write custom code when no suitable package exists or when the existing packages are too heavy or unmaintained.
+-   **Keep the dependency on the right level.** When adding a new open source dependency, add it to the most specific package that needs it, not to the root or to a shared package unless multiple packages depend on it.
+
+## Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+-   `feat`: a new feature
+-   `fix`: a bug fix
+-   `docs`: documentation only changes
+-   `style`: formatting, missing semi-colons, etc.
+-   `refactor`: code change that neither fixes a bug nor adds a feature
+-   `perf`: a code change that improves performance
+-   `test`: adding missing tests
+-   `chore`: changes to build process or auxiliary tools
+
+## Changesets (TypeScript only)
 
 If your changes affect published packages, you MUST create a changeset file in the `.changeset` directory. The changeset file should describe the change and specify the packages that are affected with the pending version bump types: patch, minor, or major.
 
@@ -123,28 +156,7 @@ Added a new setting `blockExoticSubdeps` that prevents the resolution of exotic 
 - **minor**: New features, settings, or commands that should be documented (anything users should know about)
 - **major**: Breaking changes
 
-### Commit Messages
-
-Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
-    -   `feat`: a new feature
-    -   `fix`: a bug fix
-    -   `docs`: documentation only changes
-    -   `style`: formatting, missing semi-colons, etc.
-    -   `refactor`: code change that neither fixes a bug nor adds a feature
-    -   `perf`: a code change that improves performance
-    -   `test`: adding missing tests
-    -   `chore`: changes to build process or auxiliary tools
-
-## Code Reuse and Avoiding Duplication
-
-**Before writing new code, always analyze the existing codebase for similar functionality.** This is a large monorepo with many shared utilities — duplication is a real risk.
-
--   **Search before you write.** Before implementing any non-trivial logic, search the codebase for existing functions, utilities, or patterns that do the same or similar thing. Check `packages/`, `fs/`, `crypto/`, `text/`, and other shared directories first.
--   **Extract shared code.** If you find that the logic you need already exists in another package but is not exported or reusable, refactor it into a shared package rather than duplicating it. If you are adding new code that is similar to code that already exists elsewhere in the repo, move the common parts into a shared package that both locations can use.
--   **Prefer open source packages over custom implementations.** Do not reimplement functionality that is already available as a well-maintained open source package. Use established libraries for common tasks (e.g., path manipulation, string utilities, data structures, schema validation). Only write custom code when no suitable package exists or when the existing packages are too heavy or unmaintained.
--   **Keep the dependency on the right level.** When adding a new open source dependency, add it to the most specific package that needs it, not to the root or to a shared package unless multiple packages depend on it.
-
-## Code Style
+## Code Style (TypeScript only)
 
 This repository uses [Standard Style](https://github.com/standard/standard) with a few modifications:
 -   **Trailing commas** are used.
@@ -164,7 +176,7 @@ pnpm run lint
 
 ## Common Gotchas
 
-### Error Type Checking in Jest
+### Error Type Checking in Jest (TypeScript only)
 
 When checking if a caught error is an `Error` object, **do not use `instanceof Error`**. Jest runs tests in a VM context where `instanceof` checks can fail across realms.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ When you change one side, do the equivalent change on the other in the same PR i
 
 "User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
 
+**Scope caveat:** pacquet currently only implements `install`. Resolution and every other command (`update`, `add`, `remove`, `publish`, `exec`, `run`, `dlx`, `audit`, etc.) live only in the TypeScript code, so changes there don't need a pacquet-side port yet — they're outside pacquet's current surface area. The parity rule will widen as pacquet ports more commands; check what pacquet exposes before deciding whether your change is in scope.
+
 The pacquet-side obligation — pnpm is the source of truth, pacquet ports from it, never the other way around — is spelled out at [`pacquet/AGENTS.md`](./pacquet/AGENTS.md#the-cardinal-rule).
 
 ## Repository Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ When you change one side, do the equivalent change on the other in the same PR i
 
 "User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
 
-The pacquet-side obligation — pacquet must follow pnpm's `main`, never the other way around — is spelled out in detail at [`pacquet/AGENTS.md`](./pacquet/AGENTS.md#the-cardinal-rule).
+The pacquet-side obligation — pnpm is the source of truth, pacquet ports from it, never the other way around — is spelled out at [`pacquet/AGENTS.md`](./pacquet/AGENTS.md#the-cardinal-rule).
 
 ## Repository Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,16 @@ The repository contains two stacks:
 
 Sections below marked "(TypeScript only)" do not apply to pacquet. Everything else applies to both stacks.
 
+## Keep pnpm and pacquet in sync
+
+The two stacks are parallel implementations of the same CLI — pacquet is a Rust port of pnpm whose behavior, flags, defaults, error codes, file formats, and lockfile shape are meant to match pnpm exactly. **Any user-visible change has to land in both.**
+
+When you change one side, do the equivalent change on the other in the same PR if you can. If you can't (different expertise, scope too large, or pacquet hasn't ported the surrounding feature yet), open a tracking issue describing what needs porting and linking the originating PR — never leave one side silently ahead of the other.
+
+"User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
+
+The pacquet-side obligation — pacquet must follow pnpm's `main`, never the other way around — is spelled out in detail at [`pacquet/AGENTS.md`](./pacquet/AGENTS.md#the-cardinal-rule).
+
 ## Repository Structure
 
 The pnpm codebase is a monorepo managed by pnpm itself. The root contains functional directories organized by domain:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Sections below marked "(TypeScript only)" do not apply to pacquet. Everything el
 
 The two stacks are parallel implementations of the same CLI — pacquet is a Rust port of pnpm whose behavior, flags, defaults, error codes, file formats, and lockfile shape are meant to match pnpm exactly. **Any user-visible change has to land in both.**
 
-When you change one side, do the equivalent change on the other in the same PR if you can. If you can't (different expertise, scope too large, or pacquet hasn't ported the surrounding feature yet), open a tracking issue describing what needs porting and linking the originating PR — never leave one side silently ahead of the other.
+When you change one side, do the equivalent change on the other in the same PR if you can. If you can't (different expertise, scope too large, or pacquet hasn't ported the surrounding feature yet), open the PR with just your side — call out in the description what still needs porting, and someone else will push the matching commits to the same PR before it lands.
 
 "User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
 

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -298,6 +298,9 @@ Pacquet-specific notes:
 - Check whether the workspace already depends on something suitable (see
   `[workspace.dependencies]` in the root `Cargo.toml`) before adding a new
   dependency.
+- **Keep dependencies at the right level.** Add a new dependency to the
+  specific crate that needs it, not to the workspace root or to a shared
+  crate unless multiple crates actually depend on it.
 
 ## Errors and diagnostics
 

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -13,37 +13,27 @@ are meant to match pnpm exactly.
 
 ## The cardinal rule
 
-**Any change in this repo must match how the same feature is implemented in
-`pnpm/pnpm` on the latest `main` branch.** The inverse obligation —
-user-visible changes to the TypeScript pnpm CLI must also land in pacquet —
-lives in [`../AGENTS.md`](../AGENTS.md#keep-pnpm-and-pacquet-in-sync).
+**Any change in pacquet must match how the same feature is implemented in
+the TypeScript pnpm CLI (the workspaces outside `pacquet/`).** The inverse
+obligation — user-visible changes to the TypeScript pnpm CLI must also land
+in pacquet — lives in [`../AGENTS.md`](../AGENTS.md#keep-pnpm-and-pacquet-in-sync).
 
 Before writing code for a feature, bug fix, or behavior change:
 
-1. Find the equivalent code in `pnpm/pnpm` on `main`
-   (https://github.com/pnpm/pnpm). The TypeScript source lives under `pnpm/`
-   (workspaces such as `pnpm/lockfile/`, `pnpm/store/`, `pnpm/cli/`, etc.).
-   **Always confirm you are looking at the latest, most up-to-date version
-   of `main` before reading.** Local clones drift, and an outdated checkout
-   leads to porting decisions based on stale upstream behavior. If you have
-   a local clone, run `git fetch origin && git log -1 origin/main` and
-   compare the SHA against
-   `git ls-remote https://github.com/pnpm/pnpm.git refs/heads/main`
-   (or fetch the latest before reading). If you are reading on GitHub,
-   open the file from
-   `https://github.com/pnpm/pnpm/blob/main/...` (which always resolves to
-   the tip of `main`) rather than from a permalinked SHA you happened to
-   have on hand. The permalink rule below applies when *citing* upstream
-   code; while *researching* it, you want the freshest `main`.
-2. Read the upstream implementation — logic, edge cases, config resolution,
+1. Find the equivalent code in the TypeScript pnpm workspaces. They live
+   at the repo root — `pnpm/` (CLI entry), `pkg-manager/`, `resolving/`,
+   `lockfile/`, `store/`, `fetching/`, `config/`, `hooks/`, and so on.
+   See the repo-structure section in
+   [`../AGENTS.md`](../AGENTS.md#repository-structure) for the full list.
+2. Read the pnpm implementation — logic, edge cases, config resolution,
    error messages, file/lockfile formats, and existing tests.
 3. Port the behavior faithfully. Prefer structural similarity (same function
    decomposition, same names where reasonable) so future cross-referencing
    stays cheap.
 4. Do not invent behavior that pnpm does not have. Do not "fix" pnpm quirks
-   unless the same fix has landed upstream.
-5. If pnpm's `main` and this repo disagree, pnpm's `main` is the source of
-   truth — reconcile toward upstream, not away from it.
+   unless the same fix has landed in pnpm.
+5. If pnpm and pacquet disagree, pnpm is the source of truth — reconcile
+   toward pnpm, not away from it.
 6. **Log emissions are part of "match pnpm".** When porting a function
    that fires `pnpm:<channel>` events through `globalLogger` /
    `logger.debug(...)` / `streamParser.write(...)`, mirror the call
@@ -53,23 +43,24 @@ Before writing code for a feature, bug fix, or behavior change:
    in the style guide for the convention (channel mapping, threading
    `R: Reporter`, emit-site placement, recording-fake tests).
 
-If the upstream behavior is unclear or looks wrong, stop and ask the user
+If the pnpm behavior is unclear or looks wrong, stop and ask the user
 rather than guessing.
 
-When citing upstream code anywhere — code comments, doc comments, Markdown
-docs, PR descriptions, or commit messages — link to a specific commit SHA, not
+When citing code anywhere — code comments, doc comments, Markdown docs,
+PR descriptions, or commit messages — link to a specific commit SHA, not
 a branch name. Branch links such as `github.com/<owner>/<repo>/blob/main/...`
 or `.../tree/master/...` are *impermanent*: their target drifts as the branch
 moves and may eventually 404 if the file is renamed or deleted. Permanent
 links pin the commit (`github.com/<owner>/<repo>/blob/<sha>/...`) so the
-reference stays meaningful long after upstream changes. Use the **first 10
+reference stays meaningful long after the code changes. Use the **first 10
 hex characters** of the SHA — full 40-character SHAs make URLs unwieldy on
 narrow displays and in commit logs, and 10 characters is more than enough to
 disambiguate a commit in any real-world repository. Resolve the SHA with
-`git ls-remote https://github.com/<owner>/<repo>.git refs/heads/<branch>`
-(then take the first 10 characters) or by clicking "Copy permalink" (`y`) on
-GitHub and trimming the SHA segment. This rule applies to every GitHub
-repository, not only `pnpm/pnpm`.
+`git log -1 --format=%h` for an in-repo file, or `git ls-remote
+https://github.com/<owner>/<repo>.git refs/heads/<branch>` for an external
+repo (then take the first 10 characters), or by clicking "Copy permalink"
+(`y`) on GitHub and trimming the SHA segment. The rule applies to every
+GitHub repository, including this one.
 
 ## Porting branded string types
 

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -14,7 +14,9 @@ are meant to match pnpm exactly.
 ## The cardinal rule
 
 **Any change in this repo must match how the same feature is implemented in
-`pnpm/pnpm` on the latest `main` branch.**
+`pnpm/pnpm` on the latest `main` branch.** The inverse obligation —
+user-visible changes to the TypeScript pnpm CLI must also land in pacquet —
+lives in [`../AGENTS.md`](../AGENTS.md#keep-pnpm-and-pacquet-in-sync).
 
 Before writing code for a feature, bug fix, or behavior change:
 

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -1,6 +1,8 @@
-# AGENTS.md
+# AGENTS.md (pacquet)
 
-Guidance for AI coding agents working in this repository.
+Guidance for AI coding agents working in `pacquet/`.
+
+**Read [`../AGENTS.md`](../AGENTS.md) first.** It covers the conventions that apply across the whole monorepo — GitHub PR workflow, signing agent-authored content, conventional commit messages, code-reuse philosophy, "never ignore test failures," and the PR-conflict resolution script. This file specializes those rules for pacquet's Rust code and adds pacquet-only ones.
 
 ## What this project is
 
@@ -132,7 +134,7 @@ Rules when porting code that uses a branded string type:
 1. Follow the contributing guide in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and **ALWAYS** double-check before committing. It covers commit message format, writing style, setup, and the automated checks to run before committing.
 2. Follow the code style guide in [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md), and **ALWAYS** double-check before committing. It covers code-level conventions not enforced by tooling: imports, modules, naming, ownership and borrowing, parameter type selection, trait bounds, pattern matching, `pipe-trait`, error handling, test layout, logging during tests, and cloning of `Arc` and `Rc`.
 
-## Repo layout
+## Repo layout (inside `pacquet/`)
 
 - `crates/` — library and binary crates that make up pacquet.
   - `cli`, `package-manager`, `package-manifest`, `lockfile`, `store-dir`,
@@ -147,7 +149,10 @@ Rules when porting code that uses a branded string type:
   and borrowing, trait bounds, pattern matching, `pipe-trait`, error
   handling, test layout, and `Arc`/`Rc` cloning. Read it before submitting
   code.
-- `justfile` — canonical commands (see below).
+
+The Rust workspace (`Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`,
+`justfile`, `.cargo/`, `.taplo.toml`, etc.) lives at the **repo root**, not
+inside `pacquet/`. Run `cargo` and `just` from the repo root.
 
 ## Commands
 
@@ -209,11 +214,6 @@ cargo nextest run -p pacquet-lockfile --test <file_stem>
 ```
 
 Run `just ready` (full suite) before handing the PR off.
-
-**Never ignore a test failure.** Do not dismiss a failing test as "pre-existing"
-or "unrelated to my change." Investigate every failure. If a test was already
-broken on `main`, fix it as part of your work rather than silently skipping it
-or treating the red as acceptable.
 
 ## Style
 
@@ -284,27 +284,18 @@ commit message, or the PR description so a reviewer can confirm the rewrite
 was warranted. If the rewrite is purely stylistic, raise it with the user as
 its own change rather than including it in an unrelated edit.
 
-## Code reuse and avoiding duplication
+## Code reuse (pacquet specifics)
 
-This is a small workspace, but it is still a workspace — duplication is still
-a risk, especially between crates that touch the filesystem, the store, or
-package manifests.
+The general "search before you write / extract shared code / prefer mature
+crates / keep deps at the right level" rules from
+[`../AGENTS.md`](../AGENTS.md#code-reuse-and-avoiding-duplication) apply.
+Pacquet-specific notes:
 
-- **Search before you write.** Before implementing any non-trivial helper,
-  grep the workspace for existing functions or utilities that do the same
-  or a similar thing. Shared helpers tend to live in `crates/fs`,
-  `crates/testing-utils`, and `crates/diagnostics`.
-- **Extract shared code.** If logic you need already exists in another crate
-  but isn't exported, refactor it into a shared crate (or move it to one of
-  the utility crates above) rather than copy-pasting.
-- **Prefer well-maintained crates over custom implementations.** Don't
-  reimplement what a mature crate already provides. Check whether the
-  workspace already depends on something suitable (see
+- Shared helpers tend to live in `crates/fs`, `crates/testing-utils`, and
+  `crates/diagnostics` — check there first.
+- Check whether the workspace already depends on something suitable (see
   `[workspace.dependencies]` in the root `Cargo.toml`) before adding a new
   dependency.
-- **Keep dependencies at the right level.** Add a new dependency to the
-  specific crate that needs it, not to the workspace root or to a shared
-  crate unless multiple crates actually depend on it.
 
 ## Errors and diagnostics
 
@@ -325,18 +316,13 @@ are part of the public contract, not implementation detail. See
 
 ### Commit messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/). Use a
-scope that names the crate or area being touched, matching the existing
-history (`git log --oneline` for examples). Common types:
+Conventional Commits applies (see
+[`../AGENTS.md`](../AGENTS.md#commit-messages) for the full type list). Use
+a scope that names the crate or area being touched, matching the existing
+history (`git log --oneline` for examples). Pacquet adds one type beyond the
+standard list:
 
-- `feat`: a new feature
-- `fix`: a bug fix
-- `perf`: a performance improvement
-- `refactor`: code change that neither fixes a bug nor adds a feature
-- `test`: adding or adjusting tests
-- `docs`: documentation only
-- `chore`: build tooling, CI, or auxiliary changes
-- `bench`: benchmark-only changes
+- `bench`: benchmark-only changes.
 
 Examples (from this repo's history):
 
@@ -345,25 +331,6 @@ fix(network): set explicit timeouts on default reqwest client
 feat(lockfile): support npm-alias dependencies in snapshots
 perf(store-dir): share one read-only StoreIndex across cache lookups
 ```
-
-## Working with GitHub PRs, issues, and comments
-
-- **Keep PR titles and descriptions current.** When pushing new changes to a
-  PR, review the title and description and update them if they no longer
-  accurately reflect what the PR does.
-- **Reply to and resolve review conversations.** Once a review comment has
-  been addressed, reply to the thread with a description of the resolution
-  including the commit hash that fixed it, then mark the conversation as
-  resolved.
-- **Sign all agent-authored content.** When posting a comment, creating an
-  issue, or opening a PR, append a footer to the message indicating that it
-  was written by an agent. The footer must include the name of the agent and
-  the name of the model used. Example:
-
-  ```markdown
-  ---
-  Written by an agent (Claude Code, claude-opus-4-7).
-  ```
 
 ## Things not to do
 


### PR DESCRIPTION
## Summary

Splits the duplicated content between root `AGENTS.md` and `pacquet/AGENTS.md` into a single source of truth for each rule, and adds a bidirectional parity rule between the two stacks.

**Before**: both files maintained their own copies of the GitHub PR workflow, the agent-footer rule, "never ignore test failures," the Conventional Commits type list, and the code-reuse philosophy. The two had already started to drift in phrasing — a few months of independent edits and they would have drifted in substance too. Neither file said anything about keeping pnpm and pacquet in sync; pacquet's "cardinal rule" only worked in one direction (pacquet must match pnpm), with nothing on the pnpm side saying TS changes also need a pacquet port.

**After**:
- Root `AGENTS.md` owns the shared conventions and marks TS-only sections explicitly (`Setup & Build`, `Testing`, `Linting`, `Changesets`, `Code Style` (Standard Style), `Error Type Checking in Jest`).
- Root `AGENTS.md` has a new "Keep pnpm and pacquet in sync" section spelling out that user-visible changes (CLI flags, lockfile/manifest format, error codes, log emissions, defaults, env-var handling, store layout, hook semantics) must land in both stacks in the same PR or spawn a tracking issue. Refactors/perf/TS-only test cleanups don't need mirroring.
- `pacquet/AGENTS.md` opens with "Read `../AGENTS.md` first" and keeps only pacquet-specific rules: the cardinal "match pnpm" rule, branded-string porting, `just` recipes, `insta` snapshots, `miette` diagnostics, the `bench:` commit type, the method-chain preservation rule, and the things-not-to-do that are Rust-flavored.
- Pacquet's "cardinal rule" cross-links to the new sync section so a pacquet-side reader sees the obligation goes both ways.
- Root adds a one-line entry for `pacquet/` in the repo-structure list so first-time readers find the cross-link.

## What moved to root (shared)

- "Never ignore test failures"
- Code Reuse and Avoiding Duplication
- Commit Messages (Conventional Commits + standard type list)
- Working with GitHub PRs, Issues, and Comments (PR descriptions current, reply+resolve review threads, agent-footer)
- Resolving Conflicts in GitHub PRs (`shell/resolve-pr-conflicts.sh`)

## What is new

- "Keep pnpm and pacquet in sync" section in root, defining what counts as user-visible and what the workflow is when a TS change implies a pacquet change (and vice versa).

## What stayed (or specialized) in `pacquet/AGENTS.md`

- "What this project is" + the cardinal rule (now cross-linked to root's sync section)
- Porting branded string types (the 8 rules)
- "Follow the project guides" (CONTRIBUTING.md, CODE_STYLE_GUIDE.md)
- Repo layout under `pacquet/` (+ a note that the Cargo workspace lives at the repo root)
- Commands (`just` recipes)
- Tests (insta, test-porting plan, narrow-running)
- Style (Rust-specific) + "Preserve existing method chains"
- Code reuse — pacquet-specific notes (shared helpers in `crates/fs`, `crates/testing-utils`, `crates/diagnostics`)
- Errors and diagnostics (miette)
- Commit and PR hygiene (`just ready`, pre-push hook) + the `bench:` commit type
- Things not to do (Rust-flavored)

## Note on symlinks

`CLAUDE.md`, `pacquet/CLAUDE.md`, and `pacquet/GEMINI.md` are symlinks to their respective `AGENTS.md` files. They follow automatically — no source changes needed.

## Verification

- Each shared rule now appears exactly once.
- The bidirectional sync rule is reachable from either entry point (pnpm-side root, pacquet-side via cross-link in the cardinal rule).

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contributor guidance with explicit separation between TypeScript and Rust workflows and added a Rust-specific guide that references shared conventions
  * Scoped setup, testing, linting, code style, and changesets guidance to TypeScript-only where applicable
  * Strengthened porting/checklist and citation rules for Rust work, including permalink-to-SHA guidance
  * Expanded contribution/process guidance (conventional commit examples, added `bench` commit type, avoid ignoring test failures, prefer native-error checks)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11640)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->