### PR TITLE
ci(pacquet): fix all zizmor code-scanning findings

### DIFF
--- a/.github/actions/binstall/action.yml
+++ b/.github/actions/binstall/action.yml
@@ -12,8 +12,14 @@ runs:
 
   steps:
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@cargo-binstall
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-binstall
 
       - name: Running cargo-binstall with provided arguments
         shell: bash
-        run: cargo binstall --no-confirm ${{ inputs.packages }}
+        env:
+          PACKAGES: ${{ inputs.packages }}
+        # `$PACKAGES` is intentionally unquoted so each space-separated
+        # entry becomes its own positional argument to `cargo binstall`.
+        run: cargo binstall --no-confirm $PACKAGES

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -83,7 +83,7 @@ runs:
         git restore .
 
     - name: Cache on ${{ github.ref_name }}
-      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       if: ${{ inputs.restore-cache == 'true' }}
       with:
         shared-key: ${{ inputs.shared-key }}

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -34,12 +34,18 @@ runs:
   steps:
     - name: Print Inputs
       shell: bash
+      env:
+        CLIPPY: ${{ inputs.clippy }}
+        FMT: ${{ inputs.fmt }}
+        DOCS: ${{ inputs.docs }}
+        RESTORE_CACHE: ${{ inputs.restore-cache }}
+        SAVE_CACHE: ${{ inputs.save-cache }}
       run: |
-        echo 'clippy: ${{ inputs.clippy }}'
-        echo 'fmt: ${{ inputs.fmt }}'
-        echo 'docs: ${{ inputs.docs }}'
-        echo 'restore-cache: ${{ inputs.restore-cache }}'
-        echo 'save-cache: ${{ inputs.save-cache }}'
+        echo "clippy: $CLIPPY"
+        echo "fmt: $FMT"
+        echo "docs: $DOCS"
+        echo "restore-cache: $RESTORE_CACHE"
+        echo "save-cache: $SAVE_CACHE"
 
     - name: Remove `profile` line on MacOS
       shell: bash
@@ -77,7 +83,7 @@ runs:
         git restore .
 
     - name: Cache on ${{ github.ref_name }}
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
       if: ${{ inputs.restore-cache == 'true' }}
       with:
         shared-key: ${{ inputs.shared-key }}

--- a/.github/workflows/pacquet-cargo-unused.yml
+++ b/.github/workflows/pacquet-cargo-unused.yml
@@ -19,13 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
 
       - name: Install cargo-unused-features
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
         with:
           tool: cargo-unused-features
 
@@ -36,9 +38,11 @@ jobs:
     name: Check Unused Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -47,7 +51,9 @@ jobs:
 
       - name: Install cargo-udeps
         if: steps.filter.outputs.src == 'true'
-        uses: taiki-e/install-action@cargo-udeps
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-udeps
 
       - if: steps.filter.outputs.src == 'true'
         run: cargo udeps

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -57,7 +57,9 @@ jobs:
           - os: macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -71,7 +73,7 @@ jobs:
           install: false
 
       - name: Cache pnpm
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ci-pnpm-v11-${{ matrix.os }}
           path: |
@@ -84,13 +86,17 @@ jobs:
         run: cargo clippy --locked -- -D warnings
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: just
 
       - name: Install dependencies
         run: just install
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-nextest
 
       - name: Test
         shell: bash
@@ -110,7 +116,9 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -126,9 +134,11 @@ jobs:
     name: Spell Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: crate-ci/typos@v1.46.1
+      - uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef # v1.46.1
         with:
           files: pacquet
 
@@ -136,9 +146,11 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -148,7 +160,9 @@ jobs:
 
       - name: Install cargo-deny
         if: steps.filter.outputs.src == 'true'
-        uses: taiki-e/install-action@cargo-deny
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-deny
 
       - if: steps.filter.outputs.src == 'true'
         run: cargo deny check
@@ -157,7 +171,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: ./.github/actions/rustup
@@ -178,7 +194,9 @@ jobs:
     name: Dylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Two caches with disjoint scopes:
       #
@@ -204,7 +222,7 @@ jobs:
       # dylint-library cache can never be restored from a mismatched
       # `dylint.toml`.
       - name: Cache workspace artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 2
         continue-on-error: true
         with:
@@ -219,7 +237,7 @@ jobs:
             ${{ github.job }}-workspace-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-
 
       - name: Cache dylint lint library
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         timeout-minutes: 2
         continue-on-error: true
         with:

--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -27,18 +27,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true # Pull submodules for `cargo coverage`
+          persist-credentials: false
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cargo-nextest
 
       - name: Install llvm-tools-preview for llvm-cov
         run: rustup component add llvm-tools-preview
@@ -49,7 +54,7 @@ jobs:
           install: false
 
       - name: Cache pnpm
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: codecov-pnpm-v11-${{ runner.os }}
           path: |
@@ -59,7 +64,9 @@ jobs:
         continue-on-error: true
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: just
 
       - name: Install dependencies
         run: just install
@@ -78,7 +85,7 @@ jobs:
           just registry-mock end
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: codecov
           path: lcov.info
@@ -90,15 +97,17 @@ jobs:
     needs: coverage
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download coverage file
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: codecov
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -9,6 +9,14 @@ name: Pacquet Integrated-Benchmark Comment
 # for the security rationale.
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # `workflow_run` is intentional and required: this workflow runs in the
+  # base-repo privilege context so it can comment on fork PRs (the build
+  # workflow itself runs with a read-only token on fork PRs). The job-level
+  # `if` only proceeds on `success`, the PR number is resolved from the
+  # trusted `workflow_run` event payload (not from the fork-controlled
+  # artifact), and the artifact body is treated as untrusted markdown.
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
   workflow_run:
     workflows: ["Pacquet Integrated-Benchmark"]
     types: [completed]
@@ -95,7 +103,7 @@ jobs:
       - name: Download benchmark report
         # `run-id` + `github-token` lets v8 pull artifacts from a different
         # workflow run, which is exactly the workflow_run pattern.
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: integrated-benchmark-report-ubuntu-latest
           path: benchmark-artifact
@@ -109,7 +117,7 @@ jobs:
         # to keep this matcher in sync, otherwise duplicate comments
         # accrue across runs. Today the matrix only runs on Linux, so
         # there is one fixed string to track.
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ steps.meta.outputs.pr }}
@@ -117,7 +125,7 @@ jobs:
           body-includes: 'Integrated-Benchmark Report (Linux)'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ steps.meta.outputs.pr }}
           edit-mode: replace

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -40,9 +40,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Make main branch visible
         shell: bash
@@ -67,7 +68,7 @@ jobs:
           git branch
 
       - name: Cache verdaccio
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: integrated-benchmark-verdaccio-${{ hashFiles('pacquet/tasks/integrated-benchmark/src/fixtures/pnpm-lock.yaml') }}
           restore-keys: |
@@ -78,7 +79,7 @@ jobs:
         continue-on-error: true
 
       - name: Cache Rust builds
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: integrated-benchmark-builds-${{ matrix.os }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}
           restore-keys: |
@@ -105,7 +106,7 @@ jobs:
           install: false
 
       - name: Cache pnpm
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: integrated-benchmark-pnpm-v11-${{ hashFiles('pacquet/tasks/registry-mock/pnpm-lock.yaml') }}
           restore-keys: |
@@ -121,7 +122,9 @@ jobs:
           packages: hyperfine@1.18.0
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: just
 
       - name: Install dependencies
         run: just install
@@ -221,7 +224,7 @@ jobs:
           cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
 
       - name: Upload benchmark report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: integrated-benchmark-report-${{ matrix.os }}
           path: benchmark-artifact/

--- a/.github/workflows/pacquet-micro-benchmark.yml
+++ b/.github/workflows/pacquet-micro-benchmark.yml
@@ -20,8 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   benchmark:
@@ -32,9 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Main Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main # Checkout main first because the cache is warm
+          persist-credentials: false
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -52,10 +52,11 @@ jobs:
         run: cargo run --bin=micro-benchmark --release -- --save-baseline main
 
       - name: Checkout PR Branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           clean: false
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Compile
         run: cargo build --release --bin=micro-benchmark
@@ -68,7 +69,7 @@ jobs:
         run: cargo run --bin=micro-benchmark --release -- --save-baseline pr
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: benchmark-results-${{ matrix.os }}
           path: ./target/criterion
@@ -78,15 +79,19 @@ jobs:
     name: Compare Benchmarks
     needs:
       - benchmark
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Install critcmp
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
         with:
           tool: critcmp
 
       - name: Linux | Download PR benchmark results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: benchmark-results-ubuntu-latest
           path: ./target/criterion
@@ -107,7 +112,7 @@ jobs:
       - name: Find Comment
         # Check if the event is not triggered by a fork
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -117,7 +122,7 @@ jobs:
       - name: Create or update comment
         # Check if the event is not triggered by a fork
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace

--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -13,18 +13,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check version
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ env.version }}
       version_changed: ${{ steps.version.outputs.changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check version changes
-        uses: EndBug/version-check@v3
+        uses: EndBug/version-check@095362f3cd50f690c8fa0e6afeea81834bd8d320 # v3.0.0
         id: version
         with:
           static-checking: localIsNew
@@ -33,9 +40,12 @@ jobs:
 
       - name: Set version name
         if: steps.version.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          VERSION_TYPE: ${{ steps.version.outputs.version_type }}
         run: |
-          echo "Version change found! New version: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.version_type }})"
-          echo "version=${{ steps.version.outputs.version }}" >> $GITHUB_ENV
+          echo "Version change found! New version: $VERSION ($VERSION_TYPE)"
+          echo "version=$VERSION" >> "$GITHUB_ENV"
 
   build:
     needs: check
@@ -78,13 +88,17 @@ jobs:
     name: Package ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install cross
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2.78.0
+        with:
+          tool: cross
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: release-${{ matrix.target }}
 
@@ -112,13 +126,13 @@ jobs:
           tar czf $BIN_NAME.tar.gz $BIN_NAME
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             pacquet-${{ matrix.code-target }}*
 
       - name: Upload Binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           if-no-files-found: error
           name: binaries-${{ matrix.code-target }}
@@ -137,7 +151,9 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install pnpm and Node
         uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
@@ -146,13 +162,13 @@ jobs:
           install: false
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           pattern: binaries-*
           merge-multiple: true
 
       - name: Unzip
-        uses: montudor/action-zip@v1
+        uses: montudor/action-zip@a8e75c9faefcd80fac3baf53ef40b9b119d5b702 # v1.0.0
         with:
           args: unzip -qq *.zip -d .
 
@@ -177,7 +193,10 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        # `gh release create` could replace this, but the release pipeline is
+        # sensitive and softprops/action-gh-release is widely battle-tested
+        # (matches release.yml).
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           name: pacquet v${{ needs.build.outputs.version }}
           tag_name: v${{ needs.build.outputs.version }}

--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -98,7 +98,7 @@ jobs:
           tool: cross
 
       - name: Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: release-${{ matrix.target }}
 
@@ -168,7 +168,7 @@ jobs:
           merge-multiple: true
 
       - name: Unzip
-        uses: montudor/action-zip@a8e75c9faefcd80fac3baf53ef40b9b119d5b702 # v1.0.0
+        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
         with:
           args: unzip -qq *.zip -d .
 


### PR DESCRIPTION
## Summary

Resolves the **90 zizmor code-scanning alerts** against the recently-imported `pacquet-*` workflows and shared composite actions. After this PR, `zizmor .github` reports no findings.

The fixes break down into the rules zizmor flagged:

| Rule | Severity | Action |
| --- | --- | --- |
| `unpinned-uses` | error | Every third-party action pinned to SHA + `# vX.Y.Z` comment. SHAs match the existing pins in `ci.yml`/`test.yml`/`release.yml` where the action was already used; new pins (`Swatinem/rust-cache`, `peter-evans/*`, `dorny/paths-filter`, `crate-ci/typos`, `EndBug/version-check`, `codecov/codecov-action`, `softprops/action-gh-release@v3`, `montudor/action-zip`, `taiki-e/install-action`) resolved fresh from the GitHub API. The eight `taiki-e/install-action@<branch>` references collapsed onto a single SHA (`v2.78.0`) with explicit `tool:` inputs. |
| `artipacked` | note | Added `persist-credentials: false` to every `actions/checkout` step. |
| `template-injection` | error | `inputs.*` and `steps.*.outputs.*` shell expansions in `.github/actions/{binstall,rustup}/action.yml` and `pacquet-release-to-npm.yml` moved into `env:` blocks and consumed via `$VAR`. |
| `excessive-permissions` | error/warning | `pacquet-release-to-npm.yml` got a top-level `permissions: contents: read`; `pacquet-micro-benchmark.yml`'s workflow-level `issues:write` / `pull-requests:write` moved down to the `benchmark-compare` job that actually needs them. |
| `dangerous-triggers` | error | `workflow_run` in `pacquet-integrated-benchmark-comment.yml` kept (it's the documented secure pattern for commenting back on fork PRs) and suppressed with a `# zizmor: ignore[dangerous-triggers]` comment that explains the rationale. |
| `superfluous-actions` | note | `softprops/action-gh-release` kept and suppressed inline, mirroring the existing exception in `release.yml`. |

Workflow-only changes — no published packages affected, so no changeset is included.

## Test plan

- [x] `zizmor .github` (online + offline) — clean, no findings
- [x] All edited YAML parses with `python3 -c 'yaml.safe_load(...)'`
- [ ] CI runs clean on this PR (the `.github/actions/{rustup,binstall}/**` paths are already in `pacquet-ci.yml`'s trigger filter, so the suite will exercise the touched composite actions)
- [ ] zizmor workflow run on this PR confirms the alert count goes from 90 → 0

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD stability and security by pinning GitHub Actions and tool installers to specific commit SHAs, tightening job permissions, and refining workflow steps and inline documentation for clearer, more reproducible runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11641)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->