### PR TITLE
ci: enable manual releases for pacquet and pnpm

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -1,63 +1,30 @@
 name: Release Pacquet
 
-# When main is pushed and pacquet/npm/pacquet/package.json has been changed,
-# trigger the jobs after the ci workflow has been passed.
+# Manual-trigger only. Type the version to publish — the workflow patches
+# pacquet/npm/pacquet/package.json with it before generating per-platform
+# packages and publishing. No git tag is created and no GitHub release
+# asset is uploaded; npm is the authoritative artifact store.
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - pacquet/npm/pacquet/package.json # Please only commit this file, so we don't need to wait for test CI to pass.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.2.3 or 0.2.3-rc.1)'
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  check:
-    name: Check version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      version: ${{ env.version }}
-      version_changed: ${{ steps.version.outputs.changed }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Check version changes
-        uses: EndBug/version-check@095362f3cd50f690c8fa0e6afeea81834bd8d320 # v3.0.0
-        id: version
-        with:
-          static-checking: localIsNew
-          file-url: https://unpkg.com/pacquet@latest/package.json
-          file-name: pacquet/npm/pacquet/package.json
-
-      - name: Set version name
-        if: steps.version.outputs.changed == 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          VERSION_TYPE: ${{ steps.version.outputs.version_type }}
-        run: |
-          echo "Version change found! New version: $VERSION ($VERSION_TYPE)"
-          echo "version=$VERSION" >> "$GITHUB_ENV"
-
   build:
-    needs: check
-    if: needs.check.outputs.version_changed == 'true'
     permissions:
       contents: read
       id-token: write # needed for actions/attest-build-provenance
       attestations: write
-    env:
-      version: ${{ needs.check.outputs.version }}
-    outputs:
-      version: ${{ env.version }}
     strategy:
       matrix:
         include:
@@ -146,14 +113,34 @@ jobs:
     permissions:
       # Required for npm provenance attestations via OIDC.
       id-token: write
-      # Required for softprops/action-gh-release to create the release below.
-      contents: write
     needs:
       - build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version: '$VERSION' (expected semver like 0.2.3 or 0.2.3-rc.1)"
+            exit 1
+          fi
+
+      - name: Inject version into pacquet/npm/pacquet/package.json
+        # The committed package.json has no `version` field; the version comes
+        # from the workflow_dispatch input. Patching it here means
+        # generate-packages.mjs (which copies the version into each
+        # per-platform manifest) and `pnpm publish` (which reads from
+        # package.json) both see the right value.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          jq --arg v "$VERSION" '.version = $v' pacquet/npm/pacquet/package.json > pacquet/npm/pacquet/package.json.tmp
+          mv pacquet/npm/pacquet/package.json.tmp pacquet/npm/pacquet/package.json
+          cat pacquet/npm/pacquet/package.json
 
       - name: Install pnpm and Node
         uses: pnpm/setup@b1cac37306e39c21283b9dd6cb0ac288fb35ba6b
@@ -191,16 +178,3 @@ jobs:
           for package in pacquet/npm/pacquet*; do
             pnpm publish "$package/" --tag latest --access public --provenance --no-git-checks
           done
-
-      - name: Create GitHub Release
-        # `gh release create` could replace this, but the release pipeline is
-        # sensitive and softprops/action-gh-release is widely battle-tested
-        # (matches release.yml).
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0 # zizmor: ignore[superfluous-actions]
-        with:
-          name: pacquet v${{ needs.build.outputs.version }}
-          tag_name: v${{ needs.build.outputs.version }}
-          draft: true
-          files: pacquet-*
-          fail_on_unmatched_files: true
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,26 @@ jobs:
         # No NPM_TOKEN — same rationale as the @pnpm/exe step above. This must come after
         # the previous step has cleared its NPM_TOKEN from pnpm's config.
         run: pn publish --filter=pnpm --tag=next-11 --access=public --provenance
+      # The remaining steps build the GitHub Release (asset upload, body,
+      # attestation of the dist/* exe files). Skip them on workflow_dispatch:
+      # there's no version tag to attach the release to, so
+      # softprops/action-gh-release would default `tag_name` to `github.ref_name`
+      # (which is `main` for a manual dispatch from main) and produce a junk
+      # release. The npm publishes above are unaffected — they're the
+      # authoritative artifact path on manual runs.
       - name: Copy Artifacts
+        if: startsWith(github.ref, 'refs/tags/')
         run: pn copy-artifacts
       - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: 'dist/*'
       - name: Generate release description
+        if: startsWith(github.ref, 'refs/tags/')
         run: pn make-release-description
       - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
         # `gh release create` could replace this, but the release pipeline is
         # sensitive and softprops/action-gh-release is widely battle-tested.
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0 # zizmor: ignore[superfluous-actions]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
         # No NPM_TOKEN: pnpm has no static token to short-circuit on, so it will perform
         # the OIDC token exchange against npm's trusted-publishing config for `@pnpm/exe`.
         # The exe artifacts must be built before the publish, so they're built here too.
+        #
+        # On workflow_dispatch (tagless manual run), skip this step: building the exe
+        # artifacts takes ~minutes, and the CLI + exe are normally released together
+        # via a `v*.*.*` tag. Manual dispatch is for lib-only republishes.
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           pn --filter=@pnpm/exe run build-artifacts
           pn --filter=@pnpm/exe publish --tag=next-11 --access=public --provenance
@@ -66,6 +71,9 @@ jobs:
       - name: Publish pnpm CLI (trusted publishing)
         # No NPM_TOKEN — same rationale as the @pnpm/exe step above. This must come after
         # the previous step has cleared its NPM_TOKEN from pnpm's config.
+        #
+        # On workflow_dispatch (tagless manual run), skip — see the @pnpm/exe step.
+        if: startsWith(github.ref, 'refs/tags/')
         run: pn publish --filter=pnpm --tag=next-11 --access=public --provenance
       # The remaining steps build the GitHub Release (asset upload, body,
       # attestation of the dist/* exe files). Skip them on workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  # Manual trigger for publishing whatever versions are currently in each
+  # package.json on the selected ref (typically `main`). Useful after a
+  # version-bump commit that hasn't been tagged yet. Versions already on
+  # npm are rejected by the registry, so re-running on an already-released
+  # tree is a no-op rather than a corruption.
+  workflow_dispatch:
 
 jobs:
   release:

--- a/pacquet/npm/pacquet/package.json
+++ b/pacquet/npm/pacquet/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pacquet",
-  "version": "0.2.2-6",
   "description": "The official pnpm rewrite in Rust (preview, not production-ready)",
   "keywords": [
     "pnpm"


### PR DESCRIPTION
## Summary

Two related workflow changes:

### `pacquet-release-to-npm.yml`: switch to `workflow_dispatch`

The trigger was "push to main touching `pacquet/npm/pacquet/package.json`" — the version came from a committed bump and the workflow auto-fired on every such commit. Switch to `workflow_dispatch` only, with a `version` input (validated as semver). The workflow patches `pacquet/npm/pacquet/package.json` before `generate-packages.mjs` runs, so the version is single-sourced from the manual trigger rather than needing a separate commit to bump the manifest first.

The committed manifest now omits the `version` field entirely — it only exists at release time inside the runner.

Dropped along the way:

- The `check` job (EndBug/version-check against unpkg) — no longer needed when the operator types the version.
- The `Create GitHub Release` step — no draft release, no `v*.*.*` git tag. The pacquet `v0.x.x` tag scheme collided with pnpm's `v11.x.x`; npm is the authoritative artifact store and provenance attestations stay attached via `--provenance` on `pnpm publish`.
- `contents: write` on the publish job (no longer needs to create a tag).

### `release.yml`: add `workflow_dispatch` as a lib-only republish path

Add a `workflow_dispatch:` trigger alongside the existing tag-push trigger. Tag-push behaves exactly as before. Manual dispatch becomes a fast **lib-only republish** path — useful after a version bump to one or more lib packages that doesn't warrant a full CLI release.

On `workflow_dispatch` from any ref, the following are skipped (guarded with `if: startsWith(github.ref, 'refs/tags/')`):

- `Publish @pnpm/exe` step — also contains the multi-minute `build-artifacts` call.
- `Publish pnpm CLI` step.
- `Copy Artifacts`, `Attest build provenance` (the `dist/*` attestation), `Generate release description`, `Release` (`softprops/action-gh-release`) — these are the GitHub-Release-side ceremony. Without an explicit `tag_name`, `softprops/action-gh-release@v2.5.0` defaults to `github.ref_name`, which on a manual dispatch from main would create a junk release tagged literally `main`.

What still runs on `workflow_dispatch`:

- `actions/checkout`, garnet scan, `pnpm/setup`
- `Publish internal workspace packages (static token)` — i.e. `pn publish --filter=!pnpm --filter=!@pnpm/exe --access=public --provenance`

Compilation is handled by each lib package's own `prepublishOnly: tsgo --build` hook (which `pnpm publish` runs automatically), same as the existing tag-push flow.

The npm registry rejects any version already on it, so re-running on an already-released tree is a no-op — that's the safety net for accidental clicks.

## How to use

**pacquet release**: Actions → Release Pacquet → Run workflow → fill in `version` (e.g. `0.2.3` or `0.2.3-rc.1`) → Run. No tag, no GitHub release.

**pnpm full release**: still triggered by a `v*.*.*` tag push. Publishes @pnpm/exe + libs + CLI, attests, copies artifacts, creates a draft GitHub release.

**pnpm lib-only republish**: Actions → Release → Run workflow → choose `main` → Run. Publishes just the internal workspace packages from whatever versions are currently in each `package.json`. Skips CLI, @pnpm/exe, build-artifacts, GitHub release.

## Test plan

- [ ] Pacquet release: dry-run by triggering on a branch with `version: 0.0.0-test` (or similar) and inspecting the build matrix + publish-step preview before letting the OIDC step run. The semver validator should also reject obviously bad input (e.g. `not-a-version`).
- [ ] pnpm lib-only republish: trigger `Release` workflow on main, confirm @pnpm/exe / pnpm CLI / GitHub-Release steps all show as skipped in the Actions UI, and only the internal-packages publish runs.
- [ ] pnpm tag-push release: next `v11.x.y` tag push should run exactly as before — the new `if:` guards evaluate true on tag refs.

---
Written by an agent (Claude Code, claude-opus-4-7).
