### PR TITLE
fix: handle unresolved environment variables in .npmrc for auth tokens

### DIFF
--- a/config/reader/src/loadNpmrcFiles.ts
+++ b/config/reader/src/loadNpmrcFiles.ts
@@ -139,11 +139,15 @@ function readAndFilterNpmrc (
 
   const result: Record<string, unknown> = {}
   for (const [rawKey, rawValue] of Object.entries(raw)) {
-    // Apply ${VAR} substitution to both keys and values
+    // Apply ${VAR} substitution to both keys and values.
+    // If substitution fails (env var unset), skip the entry so that
+    // lower-priority config sources can provide the value.
     const key = substituteEnv(rawKey, env, warnings)
+    if (key == null) continue
     const value = typeof rawValue === 'string'
       ? substituteEnv(rawValue, env, warnings)
       : rawValue
+    if (value == null) continue
 
     // Only keep auth/registry related keys
     if (isNpmrcReadableKey(key)) {
@@ -153,12 +157,12 @@ function readAndFilterNpmrc (
   return result
 }
 
-function substituteEnv (value: string, env: Record<string, string | undefined>, warnings: string[]): string {
+function substituteEnv (value: string, env: Record<string, string | undefined>, warnings: string[]): string | undefined {
   try {
     return envReplace(value, env)
   } catch (err) {
     warnings.push(err instanceof Error ? err.message : String(err))
-    return value
+    return undefined
   }
 }
 

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -676,6 +676,7 @@ test('unresolved env var in workspace .npmrc falls back to auth.ini token', asyn
   )
 
   const originalXdg = process.env.XDG_CONFIG_HOME
+  const originalUnsetToken = process.env.UNSET_TOKEN_VAR_11614
   process.env.XDG_CONFIG_HOME = configHome
   // Ensure the env var is NOT set
   delete process.env.UNSET_TOKEN_VAR_11614
@@ -701,6 +702,11 @@ test('unresolved env var in workspace .npmrc falls back to auth.ini token', asyn
       ])
     )
   } finally {
+    if (originalUnsetToken != null) {
+      process.env.UNSET_TOKEN_VAR_11614 = originalUnsetToken
+    } else {
+      delete process.env.UNSET_TOKEN_VAR_11614
+    }
     if (originalXdg != null) {
       process.env.XDG_CONFIG_HOME = originalXdg
     } else {
@@ -724,6 +730,7 @@ test('resolved env var in workspace .npmrc overrides auth.ini token', async () =
   )
 
   const originalXdg = process.env.XDG_CONFIG_HOME
+  const originalResolvedToken = process.env.RESOLVED_TOKEN_VAR_11614
   process.env.XDG_CONFIG_HOME = configHome
   process.env.RESOLVED_TOKEN_VAR_11614 = 'workspace-env-token'
   try {
@@ -749,7 +756,11 @@ test('resolved env var in workspace .npmrc overrides auth.ini token', async () =
       ])
     )
   } finally {
-    delete process.env.RESOLVED_TOKEN_VAR_11614
+    if (originalResolvedToken != null) {
+      process.env.RESOLVED_TOKEN_VAR_11614 = originalResolvedToken
+    } else {
+      delete process.env.RESOLVED_TOKEN_VAR_11614
+    }
     if (originalXdg != null) {
       process.env.XDG_CONFIG_HOME = originalXdg
     } else {
@@ -773,6 +784,7 @@ test('empty env var in workspace .npmrc is kept (not treated as unset)', async (
   )
 
   const originalXdg = process.env.XDG_CONFIG_HOME
+  const originalEmptyToken = process.env.EMPTY_TOKEN_VAR_11614
   process.env.XDG_CONFIG_HOME = configHome
   process.env.EMPTY_TOKEN_VAR_11614 = ''
   try {
@@ -798,7 +810,11 @@ test('empty env var in workspace .npmrc is kept (not treated as unset)', async (
       ])
     )
   } finally {
-    delete process.env.EMPTY_TOKEN_VAR_11614
+    if (originalEmptyToken != null) {
+      process.env.EMPTY_TOKEN_VAR_11614 = originalEmptyToken
+    } else {
+      delete process.env.EMPTY_TOKEN_VAR_11614
+    }
     if (originalXdg != null) {
       process.env.XDG_CONFIG_HOME = originalXdg
     } else {
@@ -824,6 +840,7 @@ test('unresolved env var in workspace .npmrc _auth does not crash and falls back
   )
 
   const originalXdg = process.env.XDG_CONFIG_HOME
+  const originalUnsetAuth = process.env.UNSET_AUTH_VAR_11298
   process.env.XDG_CONFIG_HOME = configHome
   delete process.env.UNSET_AUTH_VAR_11298
   try {
@@ -846,6 +863,11 @@ test('unresolved env var in workspace .npmrc _auth does not crash and falls back
       ])
     )
   } finally {
+    if (originalUnsetAuth != null) {
+      process.env.UNSET_AUTH_VAR_11298 = originalUnsetAuth
+    } else {
+      delete process.env.UNSET_AUTH_VAR_11298
+    }
     if (originalXdg != null) {
       process.env.XDG_CONFIG_HOME = originalXdg
     } else {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -807,6 +807,53 @@ test('empty env var in workspace .npmrc is kept (not treated as unset)', async (
   }
 })
 
+test('unresolved env var in workspace .npmrc _auth does not crash and falls back to auth.ini', async () => {
+  prepareEmpty()
+
+  // Workspace .npmrc references an env var that is NOT set, used in _auth.
+  // Without the fallback fix, the literal '${UNSET_AUTH_VAR_11298}' would
+  // reach parseBasicAuth and crash atob() with "Invalid character".
+  fs.writeFileSync('.npmrc', '//registry.example.com/:_auth=${UNSET_AUTH_VAR_11298}', 'utf8')
+
+  // auth.ini has a valid base64-encoded `username:password` pair.
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  fs.writeFileSync(
+    path.join(configHome, 'pnpm', 'auth.ini'),
+    '//registry.example.com/:_auth=dXNlcjpwYXNz'
+  )
+
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  delete process.env.UNSET_AUTH_VAR_11298
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        XDG_CONFIG_HOME: configHome,
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    expect(config.authConfig['//registry.example.com/:_auth']).toBe('dXNlcjpwYXNz')
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Failed to replace env in config: ${UNSET_AUTH_VAR_11298}'),
+      ])
+    )
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})
+
 test('throw error if --save-prod is used with --save-peer', async () => {
   await expect(getConfig({
     cliOptions: {

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -661,6 +661,152 @@ test('workspace .npmrc overrides pnpm auth file', async () => {
   }
 })
 
+test('unresolved env var in workspace .npmrc falls back to auth.ini token', async () => {
+  prepareEmpty()
+
+  // Workspace .npmrc references an env var that is NOT set
+  fs.writeFileSync('.npmrc', '//registry.example.com/:_authToken=${UNSET_TOKEN_VAR_11614}', 'utf8')
+
+  // auth.ini has a valid fallback token (from pnpm login)
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  fs.writeFileSync(
+    path.join(configHome, 'pnpm', 'auth.ini'),
+    '//registry.example.com/:_authToken=fallback-token'
+  )
+
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  // Ensure the env var is NOT set
+  delete process.env.UNSET_TOKEN_VAR_11614
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        XDG_CONFIG_HOME: configHome,
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    // Should fall back to auth.ini token
+    expect(config.authConfig['//registry.example.com/:_authToken']).toBe('fallback-token')
+    // Should still emit the warning
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Failed to replace env in config: ${UNSET_TOKEN_VAR_11614}'),
+      ])
+    )
+  } finally {
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})
+
+test('resolved env var in workspace .npmrc overrides auth.ini token', async () => {
+  prepareEmpty()
+
+  // Workspace .npmrc references an env var that IS set
+  fs.writeFileSync('.npmrc', '//registry.example.com/:_authToken=${RESOLVED_TOKEN_VAR_11614}', 'utf8')
+
+  // auth.ini has a different token
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  fs.writeFileSync(
+    path.join(configHome, 'pnpm', 'auth.ini'),
+    '//registry.example.com/:_authToken=auth-ini-token'
+  )
+
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  process.env.RESOLVED_TOKEN_VAR_11614 = 'workspace-env-token'
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        XDG_CONFIG_HOME: configHome,
+        RESOLVED_TOKEN_VAR_11614: 'workspace-env-token',
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    // Workspace .npmrc (with resolved env var) should override auth.ini
+    expect(config.authConfig['//registry.example.com/:_authToken']).toBe('workspace-env-token')
+    // No env var warning expected
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('RESOLVED_TOKEN_VAR_11614'),
+      ])
+    )
+  } finally {
+    delete process.env.RESOLVED_TOKEN_VAR_11614
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})
+
+test('empty env var in workspace .npmrc is kept (not treated as unset)', async () => {
+  prepareEmpty()
+
+  // Workspace .npmrc references an env var that IS set but to an empty string
+  fs.writeFileSync('.npmrc', '//registry.example.com/:_authToken=${EMPTY_TOKEN_VAR_11614}', 'utf8')
+
+  // auth.ini has a fallback token
+  const configHome = path.resolve('xdg-config')
+  fs.mkdirSync(path.join(configHome, 'pnpm'), { recursive: true })
+  fs.writeFileSync(
+    path.join(configHome, 'pnpm', 'auth.ini'),
+    '//registry.example.com/:_authToken=auth-ini-token'
+  )
+
+  const originalXdg = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = configHome
+  process.env.EMPTY_TOKEN_VAR_11614 = ''
+  try {
+    const { config, warnings } = await getConfig({
+      cliOptions: {},
+      env: {
+        ...env,
+        XDG_CONFIG_HOME: configHome,
+        EMPTY_TOKEN_VAR_11614: '',
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    // Empty string is an explicit value — should NOT fall back to auth.ini
+    expect(config.authConfig['//registry.example.com/:_authToken']).toBe('')
+    // No env var warning expected
+    expect(warnings).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('EMPTY_TOKEN_VAR_11614'),
+      ])
+    )
+  } finally {
+    delete process.env.EMPTY_TOKEN_VAR_11614
+    if (originalXdg != null) {
+      process.env.XDG_CONFIG_HOME = originalXdg
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+  }
+})
+
 test('throw error if --save-prod is used with --save-peer', async () => {
   await expect(getConfig({
     cliOptions: {

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -27,8 +27,8 @@ use crate::{Config, api::EnvVar, env_replace::env_replace};
 ///
 /// Values pass through `${VAR}` substitution before being stored,
 /// matching pnpm's `loadNpmrcFiles.ts` flow. Substitution failures are
-/// recorded as warnings and the offending value is left verbatim, again
-/// matching pnpm.
+/// recorded as warnings and the entry is skipped so that lower-priority
+/// config sources can provide the value, again matching pnpm.
 ///
 /// Other `.npmrc` knobs (scoped `@scope:registry`, per-registry TLS
 /// like `//host:cafile=`, etc.) remain unparsed for now. See the
@@ -131,8 +131,8 @@ impl NpmrcAuth {
     /// Parse an `.npmrc` file's contents and pick out the auth/network keys.
     /// Unknown keys are silently dropped. `${VAR}` placeholders inside
     /// values are resolved via the [`EnvVar`] capability; placeholders
-    /// that cannot be resolved leave the value verbatim and emit a
-    /// warning.
+    /// that cannot be resolved emit a warning and the entry is skipped so
+    /// lower-priority config sources can provide the value.
     ///
     /// The `.npmrc` format is a tiny ini dialect: one `key=value` per line,
     /// plus comments starting with `;` or `#`. We hand-parse rather than
@@ -157,14 +157,14 @@ impl NpmrcAuth {
                 Ok(value) => value,
                 Err(error) => {
                     auth.warnings.push(error.to_string());
-                    raw_key.to_owned()
+                    continue;
                 }
             };
             let value = match env_replace::<Api>(raw_value) {
                 Ok(value) => value,
                 Err(error) => {
                     auth.warnings.push(error.to_string());
-                    raw_value.to_owned()
+                    continue;
                 }
             };
 

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -141,13 +141,10 @@ fn env_replace_substitutes_token() {
 }
 
 #[test]
-fn env_replace_failure_warns_and_keeps_raw_value() {
+fn env_replace_failure_warns_and_skips_entry() {
     let ini = "//reg.com/:_authToken=${MISSING}\n";
     let auth = NpmrcAuth::from_ini::<NoEnv>(ini);
-    assert_eq!(
-        auth.creds_by_uri.get("//reg.com/").map(|creds| creds.auth_token.as_deref()),
-        Some(Some("${MISSING}")),
-    );
+    assert_eq!(auth.creds_by_uri.get("//reg.com/"), None);
     assert_eq!(auth.warnings.len(), 1);
     assert!(auth.warnings[0].contains("${MISSING}"));
 }
@@ -193,16 +190,14 @@ fn ini_section_headers_are_dropped_silently() {
 }
 
 /// When a `${VAR}` placeholder appears in the *key* and cannot be
-/// resolved, the parser keeps the raw key verbatim and pushes a
-/// warning. Mirrors `substituteEnv` in pnpm's `loadNpmrcFiles.ts`.
+/// resolved, the parser skips the entry and pushes a warning. Mirrors
+/// `substituteEnv` in pnpm's `loadNpmrcFiles.ts`.
 #[test]
-fn env_replace_failure_on_key_warns_and_keeps_raw_key() {
-    // `${MISSING}_authToken` resolves to a literal key, so it lands
-    // in `default_creds` rather than being recognised as the typed
-    // `_authToken` field. The point of this test is to exercise the
-    // warning + raw-key branch at the top of `from_ini`.
+fn env_replace_failure_on_key_warns_and_skips_entry() {
     let ini = "${MISSING}_authToken=abc\n";
     let auth = NpmrcAuth::from_ini::<NoEnv>(ini);
+    assert_eq!(auth.default_creds, RawCreds::default());
+    assert!(auth.creds_by_uri.is_empty());
     assert!(auth.warnings.iter().any(|warning| warning.contains("${MISSING}")));
 }
 


### PR DESCRIPTION
Closes #11614
Closes #11298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `.npmrc` processing now substitutes environment variables in both keys and string values; unresolved substitutions are skipped and emit a warning so lower-priority sources can supply values.

* **Tests**
  * Added/updated tests for env-var interpolation: unset variable (falls back with warning), set variable (overrides without warning), and set-to-empty (empty value retained, no warning).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11653)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->