### PR TITLE
fix(lockfile): support CRLF line endings in env lockfiles

### DIFF
--- a/.changeset/floppy-parents-teach.md
+++ b/.changeset/floppy-parents-teach.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/lockfile.fs": patch
+---
+
+Fix lockfile parsing failures when `pnpm-lock.yaml` contains CRLF line endings and multiple YAML documents

--- a/.changeset/floppy-parents-teach.md
+++ b/.changeset/floppy-parents-teach.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/lockfile.fs": patch
+"pnpm": patch
 ---
 
-Fix lockfile parsing failures when `pnpm-lock.yaml` contains CRLF line endings and multiple YAML documents
+Fix lockfile parsing failures when `pnpm-lock.yaml` contains CRLF line endings and multiple YAML documents [#11612](https://github.com/pnpm/pnpm/issues/11612).

--- a/lockfile/fs/src/yamlDocuments.ts
+++ b/lockfile/fs/src/yamlDocuments.ts
@@ -6,7 +6,6 @@ import stripBom from 'strip-bom'
 export const YAML_DOCUMENT_SEPARATOR = '\n---\n'
 export const YAML_DOCUMENT_START = '---\n'
 
-
 /**
  * Reads the first YAML document from a multi-document YAML file using streaming.
  * The file must start with "---\n" to indicate it contains an env lockfile document.
@@ -24,11 +23,12 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
       if (buffer.length === 0) {
         // Strip BOM from the first chunk. Safe because the stream uses utf8 encoding,
         // so the 3-byte BOM is decoded into a single \uFEFF character in the first chunk.
-        // Normalize CRLF line endings (Windows) to LF before processing
-        buffer = stripBom(chunk.value as string).replace(/\r\n/g, '\n');
+        buffer = stripBom(chunk.value as string)
       } else {
-        buffer = (buffer + chunk.value).replace(/\r\n/g, '\n')
+        buffer += chunk.value
       }
+      // Normalize CRLF (Windows) to LF so document separator detection works.
+      buffer = buffer.replace(/\r\n/g, '\n')
       if (buffer.length >= YAML_DOCUMENT_START.length) break
     }
     if (!buffer.startsWith(YAML_DOCUMENT_START)) {
@@ -44,8 +44,7 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
       }
       const chunk = await chunks.next() // eslint-disable-line no-await-in-loop
       if (chunk.done) break
-
-      // Normalize CRLF line endings (Windows) to LF before processing
+      // Normalize CRLF (Windows) to LF so the separator search matches on Windows-checked-out files.
       buffer = (buffer + chunk.value).replace(/\r\n/g, '\n')
     }
   } catch (err: unknown) {
@@ -65,7 +64,7 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
  * Otherwise returns the entire content (no env document present).
  */
 export function extractMainDocument (content: string): string {
-  content = content.replace(/\r\n/g, '\n');
+  content = content.replace(/\r\n/g, '\n')
   if (!content.startsWith(YAML_DOCUMENT_START)) return content
   const sep = content.indexOf(YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START.length)
   if (sep === -1) return ''

--- a/lockfile/fs/src/yamlDocuments.ts
+++ b/lockfile/fs/src/yamlDocuments.ts
@@ -6,6 +6,7 @@ import stripBom from 'strip-bom'
 export const YAML_DOCUMENT_SEPARATOR = '\n---\n'
 export const YAML_DOCUMENT_START = '---\n'
 
+
 /**
  * Reads the first YAML document from a multi-document YAML file using streaming.
  * The file must start with "---\n" to indicate it contains an env lockfile document.
@@ -23,9 +24,10 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
       if (buffer.length === 0) {
         // Strip BOM from the first chunk. Safe because the stream uses utf8 encoding,
         // so the 3-byte BOM is decoded into a single \uFEFF character in the first chunk.
-        buffer = stripBom(chunk.value as string)
+        // Normalize CRLF line endings (Windows) to LF before processing
+        buffer = stripBom(chunk.value as string).replace(/\r\n/g, '\n');
       } else {
-        buffer += chunk.value
+        buffer = (buffer + chunk.value).replace(/\r\n/g, '\n')
       }
       if (buffer.length >= YAML_DOCUMENT_START.length) break
     }
@@ -42,7 +44,9 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
       }
       const chunk = await chunks.next() // eslint-disable-line no-await-in-loop
       if (chunk.done) break
-      buffer += chunk.value
+
+      // Normalize CRLF line endings (Windows) to LF before processing
+      buffer = (buffer + chunk.value).replace(/\r\n/g, '\n')
     }
   } catch (err: unknown) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
@@ -61,6 +65,7 @@ export async function streamReadFirstYamlDocument (filePath: string): Promise<st
  * Otherwise returns the entire content (no env document present).
  */
 export function extractMainDocument (content: string): string {
+  content = content.replace(/\r\n/g, '\n');
   if (!content.startsWith(YAML_DOCUMENT_START)) return content
   const sep = content.indexOf(YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START.length)
   if (sep === -1) return ''

--- a/lockfile/fs/test/yamlDocuments.test.ts
+++ b/lockfile/fs/test/yamlDocuments.test.ts
@@ -64,6 +64,25 @@ describe('streamReadFirstYamlDocument', () => {
     const result = await streamReadFirstYamlDocument(filePath)
     expect(result).toBe(envContent)
   })
+
+  test('handles CRLF line endings (Windows)', async () => {
+    const dir = temporaryDirectory()
+    const filePath = path.join(dir, 'test.yaml')
+    const envContent = 'lockfileVersion: env-1.0\nimporters:\n  .:\n    foo: bar'
+    const content = `---\n${envContent}\n---\nlockfileVersion: 9.0\n`.replace(/\n/g, '\r\n')
+    fs.writeFileSync(filePath, content)
+    const result = await streamReadFirstYamlDocument(filePath)
+    expect(result).toBe(envContent)
+  })
+
+  test('handles BOM with CRLF line endings', async () => {
+    const dir = temporaryDirectory()
+    const filePath = path.join(dir, 'test.yaml')
+    const content = '﻿---\r\nfoo: bar\r\n---\r\nlockfileVersion: 9.0\r\n'
+    fs.writeFileSync(filePath, content)
+    const result = await streamReadFirstYamlDocument(filePath)
+    expect(result).toBe('foo: bar')
+  })
 })
 
 describe('extractMainDocument', () => {
@@ -81,5 +100,16 @@ describe('extractMainDocument', () => {
     const mainContent = 'lockfileVersion: 9.0\npackages: {}\n'
     const combined = `---\nfoo: bar\n---\n${mainContent}`
     expect(extractMainDocument(combined)).toBe(mainContent)
+  })
+
+  test('handles CRLF line endings in combined file', () => {
+    const mainContent = 'lockfileVersion: 9.0\npackages: {}\n'
+    const combined = `---\nfoo: bar\n---\n${mainContent}`.replace(/\n/g, '\r\n')
+    expect(extractMainDocument(combined)).toBe(mainContent)
+  })
+
+  test('normalizes CRLF to LF for content without document separator', () => {
+    const content = 'lockfileVersion: 9.0\r\npackages: {}\r\n'
+    expect(extractMainDocument(content)).toBe('lockfileVersion: 9.0\npackages: {}\n')
   })
 })


### PR DESCRIPTION
## Summary

Normalize CRLF line endings before parsing YAML document separators
in streamed env lockfile reads.

Previously the parser only handled LF (`\n`) line endings, which
caused pnpm to report `ERR_PNPM_BROKEN_LOCKFILE` or outdated
lockfile errors when `configDependencies` lockfiles were checked
out with CRLF (`\r\n`) line endings on Windows.

Fixes #11612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lockfile parsing failures when lockfiles use Windows CRLF line endings and include multiple YAML documents by normalizing line endings during parsing so document boundaries are detected reliably.

* **Tests**
  * Added coverage for CRLF line endings and BOM+CRLF combinations to ensure correct document extraction.

* **Chores**
  * Added a changeset declaring a patch release for the affected packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11654)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->