### PR TITLE
ci: pin Run tests step to bash so $TEST_SCRIPT expands on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
         fi
     - name: Run tests (${{ steps.test-scope.outputs.scope }})
       timeout-minutes: 70
+      shell: bash
       env:
         PNPM_WORKERS: 3
         TEST_SCRIPT: ${{ steps.test-scope.outputs.script }}


### PR DESCRIPTION
## Summary

- The `Run tests` step in `.github/workflows/test.yml` had no explicit `shell:`, so on Windows it ran under PowerShell — where `\$TEST_SCRIPT` is not a variable (PowerShell exposes env vars as `\$env:TEST_SCRIPT`).
- That made the expansion empty, so `pn run ""` exited 0 and just printed the available scripts. **The Windows test legs have been silently no-op'ing since #11608** (May 12), when the script name was moved from a `\${{ ... }}` interpolation into the `TEST_SCRIPT` env var to satisfy zizmor's template-injection rule.
- This pins the step to `shell: bash`, matching the sibling `Verify Node version` and `Determine test scope` steps. `\$TEST_SCRIPT` now expands correctly on every platform.

## Test plan

- [ ] CI passes on this branch with Windows actually running tests (look for `Run pn run "ci:test-branch"` actually invoking jest/etc., not just `Lifecycle scripts:` followed by a script listing).
- [ ] The Linux jobs continue to pass.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Test workflow step now explicitly specifies bash shell, ensuring consistent behavior across different execution environments and improving configuration clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11659)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->