### PR TITLE
fix(test-ipc-server): allow tilde in shell-arg paths for Windows 8.3 short names

### DIFF
--- a/__utils__/test-ipc-server/src/TestIpcServer.ts
+++ b/__utils__/test-ipc-server/src/TestIpcServer.ts
@@ -129,7 +129,7 @@ export class TestIpcServer implements AsyncDisposable {
    * entry. Exits after sending the message.
    *
    * Throws if `message` contains characters outside the allowlist enforced by
-   * `quoteShellArg` (alphanumerics plus ``_ - . / \\ : @ space + = ,``). All
+   * `quoteShellArg` (alphanumerics plus ``_ - . / \\ : @ space + = , ~``). All
    * existing call sites pass short ASCII identifiers, so the constraint is
    * satisfied by construction.
    */
@@ -163,9 +163,12 @@ export const createTestIpcServer = TestIpcServer.listen
  * Wrap an argument for inclusion in a shell command. The argument must contain
  * only a restricted set of characters known to be safe in both POSIX and
  * Windows command interpreters when surrounded by double quotes (alphanumerics
- * plus `_ - . / \\ : @ space + = ,`). A trailing backslash is rejected because
- * under both shells `\\"` consumes the closing quote, which would break the
- * command line.
+ * plus `_ - . / \\ : @ space + = , ~`). The tilde is included because Windows
+ * 8.3 short-name temp paths (e.g. `C:\Users\RUNNER~1\AppData\Local\Temp`) flow
+ * through `os.tmpdir()` on GitHub's Windows runners; both shells treat `~` as a
+ * literal inside double quotes, so it is safe to allow. A trailing backslash is
+ * rejected because under both shells `\\"` consumes the closing quote, which
+ * would break the command line.
  *
  * Throws when the argument contains a character outside this allowlist. All
  * arguments produced internally (helper-script paths, the listen-path computed
@@ -176,7 +179,7 @@ function quoteShellArg (arg: string): string {
   // Anchored allowlist — CodeQL recognizes this as a sanitization barrier for
   // shell-injection sinks. The `endsWith('\\')` check rules out the one
   // remaining ambiguous case the allowlist allows.
-  if (arg.length === 0 || !/^[\w\-./\\:@ +=,]+$/.test(arg) || arg.endsWith('\\')) {
+  if (arg.length === 0 || !/^[\w\-./\\:@ +=,~]+$/.test(arg) || arg.endsWith('\\')) {
     throw new Error(`Unsupported character in shell argument: ${JSON.stringify(arg)}`)
   }
   return `"${arg}"`


### PR DESCRIPTION
## Summary

- On GitHub's Windows runners, `os.tmpdir()` returns the **8.3 short-name** form of the user profile dir — `C:\Users\RUNNER~1\AppData\Local\Temp` — because `runneradmin` is longer than 8 chars. The `~` character then trips the allowlist regex in `__utils__/test-ipc-server/src/TestIpcServer.ts`'s `quoteShellArg`, and every test that calls `sendLineScript` or `generateSendStdinScript` throws `Unsupported character in shell argument`.
- The fix is to add `~` to the allowlist:
  - `cmd.exe` performs no tilde expansion at all.
  - POSIX shells only expand `~` when it is **unquoted at the start of a word**; inside the double-quoted `"${arg}"` wrapper produced by `quoteShellArg` it is literal.
- The CodeQL shell-injection sanitization argument is unchanged — the regex is still anchored and still rejects every metacharacter.
- This bug existed since #11608 (introduced the allowlist) but was masked because the Windows test legs had been silently no-op'ing — see #11659. With that fix in, the failure surfaces on every Windows CI run that hits `building/commands`' `recursive.ts:rebuild multiple packages in correct order`.

## Test plan

- [ ] Merge or stack on top of #11659 so the Windows leg actually executes tests.
- [ ] CI passes on Windows for `building/commands`' `test/build/recursive.ts`.
- [ ] No regression on Linux/macOS legs.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to properly handle shell paths containing the `~` character, improving compatibility with Windows short-path notation and Unix home directory references in test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11661)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->