### PR TITLE
fix(pacquet/config): satisfy dylint perfectionist lints

### DIFF
--- a/pacquet/crates/config/src/env_replace.rs
+++ b/pacquet/crates/config/src/env_replace.rs
@@ -319,6 +319,6 @@ mod tests {
     fn collects_every_unresolved_placeholder_occurrence() {
         let (value, unresolved) = env_replace_lossy::<NoEnv>("${A}-${B}-${A}");
         assert_eq!(value, "--");
-        assert_eq!(unresolved, vec!["${A}".to_owned(), "${B}".to_owned(), "${A}".to_owned()],);
+        assert_eq!(unresolved, vec!["${A}".to_owned(), "${B}".to_owned(), "${A}".to_owned()]);
     }
 }

--- a/pacquet/crates/config/src/npmrc_auth/tests.rs
+++ b/pacquet/crates/config/src/npmrc_auth/tests.rs
@@ -143,7 +143,7 @@ fn env_replace_substitutes_token() {
 #[test]
 fn env_replace_failure_warns_and_drops_unresolved_to_empty() {
     // Mirrors pnpm's `substituteEnv` lossy fallback: unresolved `${VAR}` becomes
-    // "" so a downstream `Authorization: Bearer …` header is never sent with a
+    // "" so a downstream `Authorization: Bearer ...` header is never sent with a
     // literal placeholder. See https://github.com/pnpm/pnpm/issues/11513.
     let ini = "//reg.com/:_authToken=${MISSING}\n";
     let auth = NpmrcAuth::from_ini::<NoEnv>(ini);


### PR DESCRIPTION
## Summary

#11526 landed two changes that trip the perfectionist Dylint lints under CI's `RUSTFLAGS=-D warnings`:

1. **`perfectionist::macro-trailing-comma`** — `cargo fmt` collapsed a multi-line `assert_eq!(...)` into a single line in `pacquet/crates/config/src/env_replace.rs:322` but kept the trailing comma. Removed the trailing comma.
2. **`perfectionist::unicode_ellipsis_in_comments`** — a U+2026 `…` in a test comment in `pacquet/crates/config/src/npmrc_auth/tests.rs:146`. Replaced with ASCII `...`.

Verified locally with `cargo dylint --all -- --all-targets --workspace` under `RUSTFLAGS=-D warnings`; passes clean. `cargo fmt --check` + `cargo nextest run -p pacquet-config` also clean.

Restores green Dylint on main: https://github.com/pnpm/pnpm/actions/runs/25923143087/job/76197188840

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo dylint --all -- --all-targets --workspace` — clean
- [x] `cargo fmt --check -p pacquet-config` — clean
- [x] `cargo nextest run -p pacquet-config` — all 154 tests pass

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed formatting in test assertions to remove erroneous artifacts.
  * Updated test comments for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11672)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->