### PR TITLE
feat(pacquet): port directory fetcher for injected workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-directory-fetcher"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+ "pacquet-diagnostics",
+ "pacquet-git-fetcher",
+ "pacquet-package-manifest",
+ "pacquet-store-dir",
+ "pacquet-testing-utils",
+ "pretty_assertions",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "pacquet-executor"
 version = "0.0.1"
 dependencies = [
@@ -2224,6 +2241,7 @@ dependencies = [
  "node-semver",
  "pacquet-cmd-shim",
  "pacquet-config",
+ "pacquet-directory-fetcher",
  "pacquet-executor",
  "pacquet-fs",
  "pacquet-git-fetcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pacquet-modules-yaml           = { path = "pacquet/crates/modules-yaml" }
 pacquet-network                = { path = "pacquet/crates/network" }
 pacquet-config                 = { path = "pacquet/crates/config" }
 pacquet-executor               = { path = "pacquet/crates/executor" }
+pacquet-directory-fetcher      = { path = "pacquet/crates/directory-fetcher" }
 pacquet-git-fetcher            = { path = "pacquet/crates/git-fetcher" }
 pacquet-diagnostics            = { path = "pacquet/crates/diagnostics" }
 pacquet-graph-hasher           = { path = "pacquet/crates/graph-hasher" }

--- a/pacquet/crates/directory-fetcher/Cargo.toml
+++ b/pacquet/crates/directory-fetcher/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name                  = "pacquet-directory-fetcher"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-diagnostics      = { workspace = true }
+pacquet-git-fetcher      = { workspace = true }
+pacquet-package-manifest = { workspace = true }
+pacquet-store-dir        = { workspace = true }
+
+derive_more = { workspace = true }
+miette      = { workspace = true }
+serde_json  = { workspace = true }
+tracing     = { workspace = true }
+
+[dev-dependencies]
+pacquet-testing-utils = { workspace = true }
+
+pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }

--- a/pacquet/crates/directory-fetcher/src/error.rs
+++ b/pacquet/crates/directory-fetcher/src/error.rs
@@ -1,0 +1,32 @@
+use derive_more::{Display, Error};
+use pacquet_diagnostics::miette::{self, Diagnostic};
+
+/// Error type of [`crate::DirectoryFetcher`].
+///
+/// Mirrors the failure modes of upstream's
+/// [`fetching/directory-fetcher/src/index.ts`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts):
+/// directory-walk I/O, manifest parse / read, and the
+/// `includeOnlyPackageFiles` packlist pass (which pacquet delegates
+/// to `pacquet_git_fetcher::packlist`).
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum DirectoryFetcherError {
+    /// Failed to stat or read an entry under the source directory.
+    /// Broken symlinks are *not* surfaced here — they degrade to a
+    /// skipped entry inside the walker, matching upstream's
+    /// `brokenSymlink` debug log at
+    /// [`directory-fetcher/src/index.ts:115-131`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L115-L131).
+    #[display("I/O error while walking directory {dir:?}: {source}")]
+    #[diagnostic(code(pacquet_directory_fetcher::io))]
+    Io {
+        dir: String,
+        #[error(source)]
+        source: std::io::Error,
+    },
+
+    #[diagnostic(transparent)]
+    Packlist(#[error(source)] pacquet_git_fetcher::PacklistError),
+
+    #[diagnostic(transparent)]
+    ReadManifest(#[error(source)] pacquet_package_manifest::PackageManifestError),
+}

--- a/pacquet/crates/directory-fetcher/src/fetcher.rs
+++ b/pacquet/crates/directory-fetcher/src/fetcher.rs
@@ -1,0 +1,75 @@
+//! Public entry point of [`crate`]: turn a source directory into a
+//! relative-path → absolute-source-path map (`files_map`) plus the
+//! manifest and `requires_build` flag downstream needs to decide
+//! virtual-store layout and whether to run build scripts.
+//!
+//! Mirrors upstream's
+//! [`createDirectoryFetcher`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L20-L37)
+//! and [`fetchFromDir`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L50-L56).
+//! Pacquet collapses the factory plus the per-call closure into a
+//! single [`DirectoryFetcher`] struct because all the configuration
+//! knobs (`include_only_package_files`, `resolve_symlinks`) are
+//! per-fetch values in pacquet's install dispatch.
+
+use crate::{error::DirectoryFetcherError, walker};
+use pacquet_package_manifest::{pkg_requires_build, safe_read_package_json_from_dir};
+use std::{collections::HashMap, path::PathBuf};
+
+/// One directory-fetch request. The `directory` is the absolute
+/// resolved path the caller wants packaged — upstream's
+/// `path.resolve(opts.lockfileDir, resolution.directory)` happens at
+/// the call site so this struct doesn't need to know about lockfile
+/// layout. The two booleans match upstream's
+/// [`CreateDirectoryFetcherOptions`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L15-L18):
+///
+/// - `include_only_package_files = true` → packlist mode
+///   (`.npmignore` / `files` field / always-include filters).
+/// - `resolve_symlinks = true` → follow symlinks via `realpath` (used
+///   when `resolveSymlinksInInjectedDirs` is on).
+pub struct DirectoryFetcher {
+    pub directory: PathBuf,
+    pub include_only_package_files: bool,
+    pub resolve_symlinks: bool,
+}
+
+/// Result of [`DirectoryFetcher::run`]. Mirrors upstream's
+/// [`FetchResult`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L41-L48)
+/// minus `local: true` (implicit — pacquet routes locally-sourced
+/// snapshots through this fetcher only) and `packageImportMethod`
+/// (the install dispatcher encodes the import method by which slot it
+/// writes to, not by a field on the fetcher output).
+///
+/// `manifest` is `None` when the directory has no `package.json` —
+/// upstream supports this for the Bit-workspace shape documented at
+/// [`directory-fetcher/src/index.ts:63-66`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L63-L66).
+pub struct DirectoryFetchOutput {
+    pub files_map: HashMap<String, PathBuf>,
+    pub manifest: Option<serde_json::Value>,
+    pub requires_build: bool,
+}
+
+impl DirectoryFetcher {
+    pub fn run(&self) -> Result<DirectoryFetchOutput, DirectoryFetcherError> {
+        let files_map = if self.include_only_package_files {
+            walker::walk_package_files(&self.directory)?
+        } else {
+            walker::walk_all_files(&self.directory, self.resolve_symlinks)?
+        };
+        let manifest = safe_read_package_json_from_dir(&self.directory)
+            .map_err(DirectoryFetcherError::ReadManifest)?;
+        // Upstream's `pkgRequiresBuild(manifest, filesMap)` checks
+        // (a) scripts.preinstall / install / postinstall on the
+        // manifest, and (b) whether `binding.gyp` or `.hooks/*` is
+        // in the *filtered* filesMap. Pacquet's
+        // `pkg_requires_build(pkg_root)` does the same scripts check
+        // on the manifest read from disk, but inspects
+        // `binding.gyp` / `.hooks/` via the filesystem at `pkg_root`,
+        // not the post-filter files_map. The two diverge only when
+        // `include_only_package_files = true` AND the packlist
+        // excludes `binding.gyp` / `.hooks/` from the published
+        // tarball — uncommon, but a real parity gap. Documented;
+        // revisit when a real package surfaces it.
+        let requires_build = pkg_requires_build(&self.directory);
+        Ok(DirectoryFetchOutput { files_map, manifest, requires_build })
+    }
+}

--- a/pacquet/crates/directory-fetcher/src/lib.rs
+++ b/pacquet/crates/directory-fetcher/src/lib.rs
@@ -1,0 +1,14 @@
+//! Port of pnpm's
+//! [`fetching/directory-fetcher`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts)
+//! — the fetcher used for `LockfileResolution::Directory` snapshots,
+//! i.e. injected workspace packages (`file:./local-pkg` in the
+//! manifest, `dependenciesMeta[*].injected = true`).
+//!
+//! See [`DirectoryFetcher`] for the public entry point.
+
+mod error;
+mod fetcher;
+mod walker;
+
+pub use error::DirectoryFetcherError;
+pub use fetcher::{DirectoryFetchOutput, DirectoryFetcher};

--- a/pacquet/crates/directory-fetcher/src/walker.rs
+++ b/pacquet/crates/directory-fetcher/src/walker.rs
@@ -1,0 +1,192 @@
+//! Walk a local package directory and produce the relative-path →
+//! absolute-source-path map upstream's
+//! [`fetchAllFilesFromDir`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L58-L106)
+//! and [`fetchPackageFilesFromDir`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L150-L165)
+//! return as `filesMap`.
+//!
+//! Two modes:
+//!
+//! - [`walk_all_files`] mirrors `fetchAllFilesFromDir`: recursive
+//!   walk, exclude `node_modules`, drop broken symlinks, optionally
+//!   resolve symlinks via `realFileStat`.
+//! - [`walk_package_files`] mirrors `fetchPackageFilesFromDir`:
+//!   delegate to [`pacquet_git_fetcher::packlist`] for the npm-packlist
+//!   filtered set.
+
+use crate::error::DirectoryFetcherError;
+use pacquet_package_manifest::safe_read_package_json_from_dir;
+use std::{
+    collections::HashMap,
+    fs::{self, Metadata},
+    io,
+    path::{Path, PathBuf},
+};
+
+/// Output of [`walk_all_files`] / [`walk_package_files`]: the
+/// relative-path → absolute-source-path map a downstream CAS-write
+/// pass reads from. Forward-slash separators on every host (matches
+/// the rest of pacquet's CAS plumbing).
+pub(crate) type FilesMap = HashMap<String, PathBuf>;
+
+/// Recursive walk of `dir`, skipping `node_modules` at any depth and
+/// dropping entries whose `stat` (or `realpath` under `resolve_symlinks`)
+/// fails with `ENOENT`.
+///
+/// Mirrors upstream's
+/// [`_fetchAllFilesFromDir`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L78-L106).
+pub(crate) fn walk_all_files(
+    dir: &Path,
+    resolve_symlinks: bool,
+) -> Result<FilesMap, DirectoryFetcherError> {
+    let mut out = FilesMap::new();
+    walk_all_inner(dir, "", resolve_symlinks, &mut out)?;
+    Ok(out)
+}
+
+fn walk_all_inner(
+    dir: &Path,
+    rel_prefix: &str,
+    resolve_symlinks: bool,
+    out: &mut FilesMap,
+) -> Result<(), DirectoryFetcherError> {
+    let entries = fs::read_dir(dir)
+        .map_err(|source| DirectoryFetcherError::Io { dir: dir.display().to_string(), source })?;
+    for entry in entries {
+        let entry = entry.map_err(|source| DirectoryFetcherError::Io {
+            dir: dir.display().to_string(),
+            source,
+        })?;
+        let file_name = entry.file_name();
+        let file_name_str = match file_name.to_str() {
+            Some(s) => s,
+            // Non-UTF-8 names can't round-trip through pacquet's
+            // forward-slash relative-path map; skip them, matching
+            // upstream's implicit JS string semantics.
+            None => continue,
+        };
+        if file_name_str == "node_modules" {
+            continue;
+        }
+        let entry_path = entry.path();
+        let resolved = match resolve_entry(&entry_path, resolve_symlinks)? {
+            Some(r) => r,
+            None => continue,
+        };
+        let rel = if rel_prefix.is_empty() {
+            file_name_str.to_string()
+        } else {
+            format!("{rel_prefix}/{file_name_str}")
+        };
+        if resolved.metadata.is_dir() {
+            walk_all_inner(&resolved.path, &rel, resolve_symlinks, out)?;
+        } else {
+            out.insert(rel, resolved.path);
+        }
+    }
+    Ok(())
+}
+
+struct ResolvedEntry {
+    /// The path to use as the source for hardlinking / CAS-write.
+    /// Under `resolve_symlinks`, this is the realpath; otherwise it's
+    /// the lstat'd path the caller handed in.
+    path: PathBuf,
+    metadata: Metadata,
+}
+
+/// Stat a single entry. Returns `Ok(None)` when the entry is a broken
+/// symlink (`ENOENT` after `realpath`) or — under non-`resolve_symlinks`
+/// mode — when `fs::metadata` fails with `ENOENT`. Mirrors upstream's
+/// `fileStat` / `realFileStat` at
+/// [`directory-fetcher/src/index.ts:113-148`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L113-L148).
+fn resolve_entry(
+    path: &Path,
+    resolve_symlinks: bool,
+) -> Result<Option<ResolvedEntry>, DirectoryFetcherError> {
+    if resolve_symlinks {
+        let lstat = match fs::symlink_metadata(path) {
+            Ok(m) => m,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => {
+                return Err(DirectoryFetcherError::Io { dir: path.display().to_string(), source });
+            }
+        };
+        if !lstat.file_type().is_symlink() {
+            return Ok(Some(ResolvedEntry { path: path.to_path_buf(), metadata: lstat }));
+        }
+        let real = match fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    target: "pacquet::directory_fetcher",
+                    broken_symlink = %path.display(),
+                    "skipping broken symlink",
+                );
+                return Ok(None);
+            }
+            Err(source) => {
+                return Err(DirectoryFetcherError::Io { dir: path.display().to_string(), source });
+            }
+        };
+        let real_meta = match fs::metadata(&real) {
+            Ok(m) => m,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    target: "pacquet::directory_fetcher",
+                    broken_symlink = %path.display(),
+                    "skipping broken symlink",
+                );
+                return Ok(None);
+            }
+            Err(source) => {
+                return Err(DirectoryFetcherError::Io { dir: real.display().to_string(), source });
+            }
+        };
+        Ok(Some(ResolvedEntry { path: real, metadata: real_meta }))
+    } else {
+        // Upstream's `fileStat` uses `fs.stat` (not `lstat`), which
+        // follows symlinks for the *type* decision but reports the
+        // broken-symlink ENOENT as "skip". Match that: `fs::metadata`
+        // is Rust's `stat` analog.
+        match fs::metadata(path) {
+            Ok(m) => Ok(Some(ResolvedEntry { path: path.to_path_buf(), metadata: m })),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    target: "pacquet::directory_fetcher",
+                    broken_symlink = %path.display(),
+                    "skipping broken symlink",
+                );
+                Ok(None)
+            }
+            Err(source) => {
+                Err(DirectoryFetcherError::Io { dir: path.display().to_string(), source })
+            }
+        }
+    }
+}
+
+/// Read the manifest for packlist filtering, run
+/// [`pacquet_git_fetcher::packlist`], and absolutise each entry against
+/// `dir`. Mirrors upstream's `fetchPackageFilesFromDir` —
+/// [`directory-fetcher/src/index.ts:150-165`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L150-L165).
+pub(crate) fn walk_package_files(dir: &Path) -> Result<FilesMap, DirectoryFetcherError> {
+    // packlist requires *some* manifest; pnpm's `fetchPackageFilesFromDir`
+    // passes the JSON it just read. When the manifest is missing the
+    // packlist filter still works against an empty object (no `files`
+    // field, no `bundleDependencies`), which collapses to "include
+    // every walked file except always-excluded cruft".
+    let manifest = safe_read_package_json_from_dir(dir)
+        .map_err(DirectoryFetcherError::ReadManifest)?
+        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+    let files =
+        pacquet_git_fetcher::packlist(dir, &manifest).map_err(DirectoryFetcherError::Packlist)?;
+    let mut out = FilesMap::with_capacity(files.len());
+    for rel in files {
+        let abs = dir.join(&rel);
+        out.insert(rel, abs);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/directory-fetcher/src/walker.rs
+++ b/pacquet/crates/directory-fetcher/src/walker.rs
@@ -16,7 +16,7 @@
 use crate::error::DirectoryFetcherError;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::{self, Metadata},
     io,
     path::{Path, PathBuf},
@@ -39,7 +39,8 @@ pub(crate) fn walk_all_files(
     resolve_symlinks: bool,
 ) -> Result<FilesMap, DirectoryFetcherError> {
     let mut out = FilesMap::new();
-    walk_all_inner(dir, "", resolve_symlinks, &mut out)?;
+    let mut visited = HashSet::new();
+    walk_all_inner(dir, "", resolve_symlinks, &mut visited, &mut out)?;
     Ok(out)
 }
 
@@ -47,8 +48,31 @@ fn walk_all_inner(
     dir: &Path,
     rel_prefix: &str,
     resolve_symlinks: bool,
+    visited: &mut HashSet<PathBuf>,
     out: &mut FilesMap,
 ) -> Result<(), DirectoryFetcherError> {
+    // Symlink-cycle guard. Pnpm's directory-fetcher recurses without
+    // a visited-set so a `foo -> .` (or any ancestor-pointing
+    // symlink) sinks the whole walk into infinite recursion until the
+    // path exceeds OS limits and `read_dir` finally errors with
+    // ENAMETOOLONG. Stack overflow is also reachable on platforms
+    // where the path-too-long error has a higher ceiling than the
+    // default Rust stack. Skip-on-revisit instead, matching the
+    // pattern `pacquet_git_fetcher::packlist` already uses for
+    // `bundleDependencies` cycles. The check is keyed off
+    // `fs::canonicalize` so an unresolved symlink and its target
+    // share one entry; canonicalisation failure (permission denied,
+    // for example) falls back to the raw path so the guard still
+    // catches identity loops.
+    let canonical = fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+    if !visited.insert(canonical) {
+        tracing::warn!(
+            target: "pacquet::directory_fetcher",
+            dir = %dir.display(),
+            "symlink cycle: directory already visited at this canonical path; skipping",
+        );
+        return Ok(());
+    }
     let entries = fs::read_dir(dir)
         .map_err(|source| DirectoryFetcherError::Io { dir: dir.display().to_string(), source })?;
     for entry in entries {
@@ -78,7 +102,7 @@ fn walk_all_inner(
             format!("{rel_prefix}/{file_name_str}")
         };
         if resolved.metadata.is_dir() {
-            walk_all_inner(&resolved.path, &rel, resolve_symlinks, out)?;
+            walk_all_inner(&resolved.path, &rel, resolve_symlinks, visited, out)?;
         } else {
             out.insert(rel, resolved.path);
         }

--- a/pacquet/crates/directory-fetcher/src/walker/tests.rs
+++ b/pacquet/crates/directory-fetcher/src/walker/tests.rs
@@ -1,0 +1,205 @@
+use super::super::walker::{walk_all_files, walk_package_files};
+use pretty_assertions::assert_eq;
+use std::{collections::BTreeMap, fs, path::Path};
+use tempfile::tempdir;
+
+fn touch(root: &Path, rel: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, "").unwrap();
+}
+
+/// Collapse `walk_*` output to a `BTreeMap<rel_path, absolute_path
+/// rendered as forward slashes relative to root>` so assertions stay
+/// readable and order-independent. The value lets us distinguish
+/// "symlink left as-is" vs "symlink resolved" without baking the
+/// tmpdir's path into the assertion.
+fn collect_rels(
+    root: &Path,
+    files: std::collections::HashMap<String, std::path::PathBuf>,
+) -> BTreeMap<String, String> {
+    files
+        .into_iter()
+        .map(|(rel, abs)| {
+            // Use `dunce::canonicalize` semantics indirectly: strip
+            // the tmp root prefix off the absolute path and report
+            // the remainder. That keeps assertions deterministic.
+            let stripped = abs
+                .strip_prefix(root)
+                .map(|p| p.display().to_string().replace('\\', "/"))
+                .unwrap_or_else(|_| abs.display().to_string());
+            (rel, stripped)
+        })
+        .collect()
+}
+
+#[test]
+fn walk_all_files_recurses_and_returns_relative_paths() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "lib/inner.js");
+    touch(root, "lib/nested/deep.js");
+
+    let out = walk_all_files(root, false).unwrap();
+    let rels: BTreeMap<_, _> = collect_rels(root, out);
+
+    assert_eq!(
+        rels.keys().cloned().collect::<Vec<_>>(),
+        vec![
+            "index.js".to_string(),
+            "lib/inner.js".into(),
+            "lib/nested/deep.js".into(),
+            "package.json".into(),
+        ],
+    );
+}
+
+#[test]
+fn walk_all_files_skips_node_modules_at_root_and_nested() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "index.js");
+    touch(root, "node_modules/foo/index.js");
+    touch(root, "lib/node_modules/bar/index.js");
+
+    let out = walk_all_files(root, false).unwrap();
+    let rels: BTreeMap<_, _> = collect_rels(root, out);
+
+    // node_modules at any depth must drop out — pnpm's
+    // `fetchAllFilesFromDir` filters by basename in every recursion.
+    assert_eq!(rels.keys().cloned().collect::<Vec<_>>(), vec!["index.js".to_string()]);
+}
+
+#[test]
+fn walk_all_files_on_empty_directory_returns_empty_map() {
+    let dir = tempdir().unwrap();
+    let out = walk_all_files(dir.path(), false).unwrap();
+    assert!(out.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_all_files_skips_broken_symlink_without_resolve_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "real.txt");
+    symlink(root.join("missing.txt"), root.join("dangling")).unwrap();
+
+    let out = walk_all_files(root, false).unwrap();
+    let rels: BTreeMap<_, _> = collect_rels(root, out);
+
+    assert_eq!(rels.keys().cloned().collect::<Vec<_>>(), vec!["real.txt".to_string()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_all_files_skips_broken_symlink_with_resolve_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "real.txt");
+    symlink(root.join("missing.txt"), root.join("dangling")).unwrap();
+
+    let out = walk_all_files(root, true).unwrap();
+    let rels: BTreeMap<_, _> = collect_rels(root, out);
+
+    assert_eq!(rels.keys().cloned().collect::<Vec<_>>(), vec!["real.txt".to_string()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_all_files_resolves_symlinks_when_requested() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    // Build a target file outside the package dir, then a symlink
+    // *inside* the package dir pointing at it. Under `resolve_symlinks`
+    // upstream's `realFileStat` returns the realpath as the source
+    // entry — confirm we do the same.
+    let outside = tempdir().unwrap();
+    let target = outside.path().join("target.txt");
+    fs::write(&target, b"hello").unwrap();
+    symlink(&target, root.join("link.txt")).unwrap();
+
+    let out = walk_all_files(root, true).unwrap();
+    assert_eq!(out.len(), 1);
+    let src = out.get("link.txt").expect("link.txt entry");
+    // The source path must be the realpath, not the symlink path.
+    assert_eq!(
+        fs::canonicalize(src).unwrap(),
+        fs::canonicalize(&target).unwrap(),
+        "resolve_symlinks must return the realpath as the source",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn walk_all_files_keeps_symlink_path_without_resolve_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let outside = tempdir().unwrap();
+    let target = outside.path().join("target.txt");
+    fs::write(&target, b"hello").unwrap();
+    symlink(&target, root.join("link.txt")).unwrap();
+
+    let out = walk_all_files(root, false).unwrap();
+    let src = out.get("link.txt").expect("link.txt entry");
+    // Without resolve_symlinks the source path stays as the symlink
+    // location inside the package dir — upstream's `fileStat` uses
+    // `fs.stat`, which follows the link for type/size but returns the
+    // path the caller handed in.
+    assert_eq!(src, &root.join("link.txt"));
+}
+
+#[test]
+fn walk_package_files_applies_npm_packlist_filter() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{ "name": "x", "version": "0.0.0", "files": ["dist/**"] }"#,
+    )
+    .unwrap();
+    touch(root, "dist/index.js");
+    touch(root, "dist/sub/inner.js");
+    touch(root, "src/internal.ts");
+
+    let out = walk_package_files(root).unwrap();
+    let mut rels: Vec<_> = out.keys().cloned().collect();
+    rels.sort();
+
+    // `package.json` is always-included; the `files` field is
+    // honoured; `src/` falls out.
+    assert_eq!(
+        rels,
+        vec!["dist/index.js".to_string(), "dist/sub/inner.js".into(), "package.json".into(),],
+    );
+}
+
+#[test]
+fn walk_package_files_works_without_a_manifest() {
+    // pnpm's `fetchPackageFilesFromDir` reads the manifest with
+    // `safeReadProjectManifestOnly` and tolerates `null` for the
+    // Bit-workspace case where dirs have no package.json. The
+    // packlist then runs over an empty manifest (no `files`, no
+    // `bundleDependencies`) and returns "everything except cruft".
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "index.js");
+    touch(root, ".DS_Store");
+
+    let out = walk_package_files(root).unwrap();
+    let rels: Vec<_> = out.keys().cloned().collect();
+
+    assert_eq!(rels, vec!["index.js".to_string()]);
+}

--- a/pacquet/crates/directory-fetcher/src/walker/tests.rs
+++ b/pacquet/crates/directory-fetcher/src/walker/tests.rs
@@ -83,6 +83,34 @@ fn walk_all_files_on_empty_directory_returns_empty_map() {
 
 #[cfg(unix)]
 #[test]
+fn walk_all_files_terminates_on_symlink_cycle() {
+    use std::os::unix::fs::symlink;
+
+    // A `loop -> .` symlink would, without the cycle guard, sink the
+    // walker into infinite recursion until either ENAMETOOLONG fires
+    // or the Rust stack runs out. The visited-set guard keys off
+    // `fs::canonicalize`, so `root/loop` canonicalises to `root` and
+    // the second recursion bails before reading any further. The
+    // direct children of `root` (incl. `real.txt`) still land in the
+    // output; nothing under `loop/` does, because the recursive call
+    // returns immediately on the cycle.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "real.txt");
+    symlink(root, root.join("loop")).unwrap();
+
+    let out = walk_all_files(root, false).unwrap();
+    let rels: BTreeMap<_, _> = collect_rels(root, out);
+
+    assert!(rels.contains_key("real.txt"), "direct children must still be walked: {rels:?}");
+    assert!(
+        rels.keys().all(|k| !k.starts_with("loop/")),
+        "cycle guard must short-circuit before any `loop/` descendant is recorded: {rels:?}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
 fn walk_all_files_skips_broken_symlink_without_resolve_symlinks() {
     use std::os::unix::fs::symlink;
 

--- a/pacquet/crates/directory-fetcher/tests/fetcher.rs
+++ b/pacquet/crates/directory-fetcher/tests/fetcher.rs
@@ -1,0 +1,142 @@
+//! End-to-end integration tests for [`DirectoryFetcher::run`]. The
+//! per-walker invariants live alongside `walker.rs`; this file
+//! exercises the full request/response shape upstream callers depend
+//! on (`manifest`, `requires_build`, `files_map` keys).
+
+use pacquet_directory_fetcher::DirectoryFetcher;
+use pretty_assertions::assert_eq;
+use std::{fs, path::Path};
+use tempfile::tempdir;
+
+fn touch(root: &Path, rel: &str, body: &str) {
+    let path = root.join(rel);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+#[test]
+fn run_in_all_files_mode_returns_manifest_and_filesmap() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json", r#"{ "name": "x", "version": "0.0.0" }"#);
+    touch(root, "src/index.ts", "");
+    touch(root, "node_modules/foo/index.js", "");
+
+    let out = DirectoryFetcher {
+        directory: root.to_path_buf(),
+        include_only_package_files: false,
+        resolve_symlinks: false,
+    }
+    .run()
+    .unwrap();
+
+    // node_modules dropped; manifest read; no install scripts ↔
+    // requires_build = false.
+    let mut rels: Vec<_> = out.files_map.keys().cloned().collect();
+    rels.sort();
+    assert_eq!(rels, vec!["package.json".to_string(), "src/index.ts".into()]);
+
+    let manifest = out.manifest.expect("manifest read");
+    assert_eq!(manifest.get("name").and_then(|v| v.as_str()), Some("x"));
+    assert!(!out.requires_build);
+}
+
+#[test]
+fn run_flags_requires_build_when_install_script_present() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(
+        root,
+        "package.json",
+        r#"{
+            "name": "needs-build",
+            "version": "0.0.0",
+            "scripts": { "install": "node-gyp rebuild" }
+        }"#,
+    );
+
+    let out = DirectoryFetcher {
+        directory: root.to_path_buf(),
+        include_only_package_files: false,
+        resolve_symlinks: false,
+    }
+    .run()
+    .unwrap();
+
+    // `pkg_requires_build` sees the install script in the manifest
+    // and flips the bit. Matches upstream's
+    // `pkgRequiresBuild(manifest, filesIndex)` at
+    // <https://github.com/pnpm/pnpm/blob/85ceff2383/building/pkg-requires-build/src/index.ts>.
+    assert!(out.requires_build);
+}
+
+#[test]
+fn run_flags_requires_build_when_binding_gyp_present() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json", r#"{ "name": "native", "version": "0.0.0" }"#);
+    touch(root, "binding.gyp", "{ 'targets': [] }");
+
+    let out = DirectoryFetcher {
+        directory: root.to_path_buf(),
+        include_only_package_files: false,
+        resolve_symlinks: false,
+    }
+    .run()
+    .unwrap();
+
+    // No install script in the manifest, but `binding.gyp` at the
+    // package root is the canonical "this is a node-gyp native
+    // module" signal. Mirrors upstream's `filesIncludeInstallScripts`
+    // check.
+    assert!(out.requires_build);
+}
+
+#[test]
+fn run_returns_none_manifest_for_bit_workspace_directory_without_package_json() {
+    // pnpm's `safeReadProjectManifestOnly` returns null when no
+    // manifest variant exists; pacquet's `safe_read_package_json_from_dir`
+    // returns `Ok(None)` for the same `ENOENT` case. The fetcher
+    // must surface that as `manifest: None` rather than erroring —
+    // the Bit-workspace shape upstream documents at
+    // <https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L63-L66>.
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "index.js", "");
+
+    let out = DirectoryFetcher {
+        directory: root.to_path_buf(),
+        include_only_package_files: false,
+        resolve_symlinks: false,
+    }
+    .run()
+    .unwrap();
+
+    assert!(out.manifest.is_none());
+    assert!(!out.requires_build);
+    assert_eq!(out.files_map.len(), 1);
+}
+
+#[test]
+fn run_in_package_files_mode_honors_files_field() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json", r#"{ "name": "x", "version": "0.0.0", "files": ["dist/**"] }"#);
+    touch(root, "dist/index.js", "");
+    touch(root, "src/internal.ts", "");
+
+    let out = DirectoryFetcher {
+        directory: root.to_path_buf(),
+        include_only_package_files: true,
+        resolve_symlinks: false,
+    }
+    .run()
+    .unwrap();
+
+    let mut rels: Vec<_> = out.files_map.keys().cloned().collect();
+    rels.sort();
+
+    assert_eq!(rels, vec!["dist/index.js".to_string(), "package.json".into()]);
+}

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace  = true
 
 [dependencies]
 pacquet-cmd-shim               = { workspace = true }
+pacquet-directory-fetcher      = { workspace = true }
 pacquet-executor               = { workspace = true }
 pacquet-fs                     = { workspace = true }
 pacquet-git-fetcher            = { workspace = true }

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -368,12 +368,31 @@ impl<'a> CreateVirtualStore<'a> {
                 let Some(current_snapshot) = current_snapshots.get(*snapshot_key) else {
                     return true;
                 };
+                let wanted_metadata = packages.get(&snapshot_key.without_peer());
+                // Directory-typed snapshots carry mutable local
+                // source: the user can edit `file:./local-pkg` files
+                // between installs and pacquet must re-walk them on
+                // every install, otherwise the slot drifts. Mirrors
+                // upstream's `!isDirectoryDep` clause in `depIsPresent`
+                // at
+                // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L226-L228>
+                // — pnpm forces directory snapshots through the cold
+                // path for the same reason. Without this carve-out
+                // both `current` and `wanted` resolutions report
+                // `integrity() == None`, `integrity_equal` returns
+                // true, the slot directory check passes, and the
+                // directory-fetcher never runs on the second install.
+                if matches!(
+                    wanted_metadata.map(|m| &m.resolution),
+                    Some(LockfileResolution::Directory(_))
+                ) {
+                    return true;
+                }
                 if !snapshot_deps_equal(current_snapshot, snapshot) {
                     return true;
                 }
                 let current_metadata =
                     current_packages.and_then(|p| p.get(&snapshot_key.without_peer()));
-                let wanted_metadata = packages.get(&snapshot_key.without_peer());
                 if !integrity_equal(current_metadata, wanted_metadata) {
                     return true;
                 }
@@ -1028,6 +1047,11 @@ fn integrity_equal(current: Option<&PackageMetadata>, wanted: Option<&PackageMet
 /// - `GitFetch` — `git` CLI clone / checkout / preparePackage /
 ///   packlist / CAS import. Equivalent to upstream's git-fetcher
 ///   inside the same `fetchPackage` dispatch.
+/// - `DirectoryFetch` — local-directory walk / manifest read /
+///   packlist for injected workspace deps. Equivalent to upstream's
+///   directory-fetcher inside the same `fetchPackage` dispatch; pnpm
+///   swallows the throw for optional snapshots uniformly with the
+///   tarball / git paths.
 ///
 /// Excluded (propagate even for optional snapshots, matching
 /// upstream's post-`fetching()` `linkPkg` path that sits outside
@@ -1042,7 +1066,8 @@ fn is_fetch_side_failure(err: &InstallPackageBySnapshotError) -> bool {
     matches!(
         err,
         InstallPackageBySnapshotError::DownloadTarball(_)
-            | InstallPackageBySnapshotError::GitFetch(_),
+            | InstallPackageBySnapshotError::GitFetch(_)
+            | InstallPackageBySnapshotError::DirectoryFetch(_),
     )
 }
 

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -23,7 +23,7 @@ use pacquet_tarball::{PrefetchResult, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::atomic::AtomicU8,
 };
 
@@ -139,6 +139,12 @@ pub struct CreateVirtualStore<'a> {
     /// behavior of materializing only non-skipped snapshots in the
     /// graph passed to the build phase.
     pub skipped: &'a SkippedSnapshots,
+    /// Lockfile / workspace root — `lockfileDir` in upstream's
+    /// install options. Threaded into the per-snapshot
+    /// [`InstallPackageBySnapshot`] so the directory fetcher can
+    /// resolve `LockfileResolution::Directory` entries (e.g.
+    /// `directory: "../local-pkg"`) against the same base pnpm uses.
+    pub workspace_root: &'a Path,
     /// Selects between the isolated and hoisted install layouts.
     /// Under [`NodeLinker::Isolated`] the warm and cold batches
     /// populate per-snapshot virtual-store slot directories. Under
@@ -192,6 +198,7 @@ impl<'a> CreateVirtualStore<'a> {
             store_index_writer,
             allow_build_policy,
             skipped,
+            workspace_root,
             node_linker,
         } = self;
 
@@ -727,6 +734,7 @@ impl<'a> CreateVirtualStore<'a> {
                         snapshot,
                         allow_build_policy,
                         skipped,
+                        workspace_root,
                         node_linker,
                     }
                     .run::<R>()
@@ -896,12 +904,18 @@ fn snapshot_cache_key(
         LockfileResolution::Registry(r) => {
             Ok(Some(store_index_key(&r.integrity.to_string(), &pkg_id)))
         }
-        LockfileResolution::Directory(_) => Err(CreateVirtualStoreError::InstallPackageBySnapshot(
-            InstallPackageBySnapshotError::UnsupportedResolution {
-                package_key: snapshot_key.to_string(),
-                resolution_kind: "directory",
-            },
-        )),
+        LockfileResolution::Directory(_) => {
+            // Directory resolutions are injected workspace deps and
+            // bypass the CAFS entirely (the directory-fetcher returns
+            // source-path entries; no `write_cas_file` happens, no
+            // `PackageFilesIndex` row is written). There is therefore
+            // no warm-cache key to recover the install from — every
+            // install re-walks the source dir, matching upstream's
+            // behavior (the source may have changed since the last
+            // install). Returning `Ok(None)` routes the snapshot
+            // through the cold path which runs the fetcher.
+            Ok(None)
+        }
         LockfileResolution::Git(_) => {
             // `Git` resolutions land in CAS via
             // `pacquet_git_fetcher::GitFetcher`, which writes the

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -384,7 +384,7 @@ impl<'a> CreateVirtualStore<'a> {
                 // directory-fetcher never runs on the second install.
                 if matches!(
                     wanted_metadata.map(|m| &m.resolution),
-                    Some(LockfileResolution::Directory(_))
+                    Some(LockfileResolution::Directory(_)),
                 ) {
                     return true;
                 }

--- a/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_frozen_lockfile.rs
@@ -573,6 +573,7 @@ where
             store_index_writer: &store_index_writer,
             allow_build_policy: &allow_build_policy,
             skipped: &skipped,
+            workspace_root,
             node_linker,
         }
         .run::<R>()

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -5,6 +5,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::{Config, NodeLinker};
+use pacquet_directory_fetcher::DirectoryFetcherError;
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTarballFetcher};
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
@@ -26,7 +27,7 @@ use pipe_trait::Pipe;
 use std::{
     borrow::Cow,
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
 };
 
@@ -68,6 +69,14 @@ pub struct InstallPackageBySnapshot<'a> {
     /// [`crate::InstallFrozenLockfile::run`] and threaded through
     /// [`crate::CreateVirtualStore`].
     pub allow_build_policy: &'a AllowBuildPolicy,
+    /// Workspace / lockfile root used to resolve directory-typed
+    /// resolutions (`LockfileResolution::Directory`) against. Pnpm's
+    /// directory-fetcher computes the source dir as
+    /// `path.resolve(opts.lockfileDir, resolution.directory)`; pacquet
+    /// threads the same value through so the resolved source matches
+    /// upstream byte-for-byte even for relative resolutions like
+    /// `../local-pkg`.
+    pub workspace_root: &'a Path,
     /// Snapshots whose slots were not materialized on this host —
     /// threaded into [`CreateVirtualDirBySnapshot`] so the per-slot
     /// `create_symlink_layout` step can skip optional siblings whose
@@ -120,6 +129,15 @@ pub enum InstallPackageBySnapshotError {
     /// every fetcher path that exits through `pacquet-git-fetcher`.
     #[diagnostic(transparent)]
     GitFetch(#[error(source)] GitFetcherError),
+
+    /// Failure from the directory fetcher: walking the source
+    /// directory of an injected workspace dep, reading its manifest,
+    /// or running the npm-packlist filter for
+    /// `includeOnlyPackageFiles` mode. Mirrors the failure surface
+    /// of pnpm's `directory-fetcher` at
+    /// <https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts>.
+    #[diagnostic(transparent)]
+    DirectoryFetch(#[error(source)] DirectoryFetcherError),
 
     /// No variant in a [`LockfileResolution::Variations`] matches the
     /// host triple `(os, cpu, libc?)`. Surfaces with the host triple
@@ -208,6 +226,7 @@ impl<'a> InstallPackageBySnapshot<'a> {
             snapshot,
             allow_build_policy,
             skipped,
+            workspace_root,
             node_linker,
         } = self;
 
@@ -304,11 +323,37 @@ impl<'a> InstallPackageBySnapshot<'a> {
                     raw_cas_paths
                 }
             }
-            LockfileResolution::Directory(_) => {
-                return Err(InstallPackageBySnapshotError::UnsupportedResolution {
-                    package_key: package_key.to_string(),
-                    resolution_kind: "directory",
-                });
+            LockfileResolution::Directory(dir_resolution) => {
+                // Injected workspace dep (`file:./local-pkg` with
+                // `dependenciesMeta[*].injected = true`). Upstream's
+                // [`directory-fetcher`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts#L26-L32)
+                // resolves the source dir as
+                // `path.resolve(opts.lockfileDir, resolution.directory)`
+                // and returns `local: true` with a `filesMap` that
+                // points directly at the source files (no CAFS write).
+                // Pacquet does the same: the `files_map` keys are the
+                // forward-slash relative paths, the values are the
+                // source paths, and downstream `link_file` /
+                // `import_indexed_dir` hardlink-or-copy from those
+                // source paths into the slot / hoisted directory just
+                // like they would from a CAS-resident entry.
+                //
+                // `include_only_package_files = false` /
+                // `resolve_symlinks = false` match upstream's defaults
+                // in [`extendInstallOptions.ts:41`](https://github.com/pnpm/pnpm/blob/85ceff2383/installing/deps-installer/src/install/extendInstallOptions.ts#L41).
+                // Wiring those through pacquet's config surface is a
+                // follow-up; see the `resolveSymlinksInInjectedDirs`
+                // / `includeOnlyPackageFiles` plumbing tracked in the
+                // directory-fetcher PR description.
+                let directory = workspace_root.join(&dir_resolution.directory);
+                let output = pacquet_directory_fetcher::DirectoryFetcher {
+                    directory,
+                    include_only_package_files: false,
+                    resolve_symlinks: false,
+                }
+                .run()
+                .map_err(InstallPackageBySnapshotError::DirectoryFetch)?;
+                output.files_map
             }
             // Slice A of #437 wires the lockfile types; the install
             // dispatch for `Binary` / `Variations` lands in Slice D.


### PR DESCRIPTION
## Summary

- Ports pnpm's [`fetching/directory-fetcher`](https://github.com/pnpm/pnpm/blob/85ceff2383/fetching/directory-fetcher/src/index.ts) as a new `pacquet-directory-fetcher` crate (file walker, manifest read, `requires_build` detection, broken-symlink ENOENT skip, `resolveSymlinks` toggle).
- Wires `LockfileResolution::Directory` end-to-end through `InstallPackageBySnapshot::run` and `create_virtual_store.rs`, so injected workspace deps (`file:./local-pkg` + `dependenciesMeta[*].injected = true`) actually install instead of returning `UnsupportedResolution { resolution_kind: "directory" }`.
- No CAFS write for directory deps — matches upstream's `local: true, packageImportMethod: 'hardlink'` semantics: the fetcher returns source-path entries and `import_indexed_dir` / `link_file` hardlink-or-copy straight from the source.

## What's in scope

- `pacquet-directory-fetcher` crate:
  - `walk_all_files` ↔ upstream's `fetchAllFilesFromDir` (recursive, `node_modules` exclusion at any depth, `fs::metadata` vs `symlink_metadata + canonicalize` fork, broken-symlink ENOENT skip).
  - `walk_package_files` ↔ upstream's `fetchPackageFilesFromDir` (delegates to `pacquet_git_fetcher::packlist`, tolerates missing manifest for the Bit-workspace shape).
  - `DirectoryFetcher::run` returns `files_map` / `manifest` / `requires_build`.
- `install_package_by_snapshot.rs`: new `workspace_root: &Path` field threaded down from `InstallFrozenLockfile`; directory arm resolves `dir_resolution.directory` against it, calls the fetcher, and returns its `files_map` as `cas_paths`.
- `create_virtual_store.rs::snapshot_cache_key`: returns `Ok(None)` for directory resolutions (no warm-cache key — every install re-walks the source).
- 14 unit + integration tests covering the walker and the public entry point.

## What's deferred to follow-ups

- `resolveSymlinksInInjectedDirs` / `includeOnlyPackageFiles` config knobs — currently hard-coded to upstream's defaults (`false` / `false`) from [`extendInstallOptions.ts:41`](https://github.com/pnpm/pnpm/blob/85ceff2383/installing/deps-installer/src/install/extendInstallOptions.ts#L41).
- Injected-dep re-mirror pass — `hoisted_dep_graph.rs` already collects `injection_targets_by_dep_path` for every directory-typed snapshot location, but the post-install mirror that rebuilds those copies still needs implementing.
- `package.json5` / `package.yaml` manifest read — `safe_read_package_json_from_dir` only handles `package.json`. Same parity gap as every other manifest read in pacquet; not specific to this PR.

## Test plan

- [ ] `cargo nextest run -p pacquet-directory-fetcher` (14 tests) — passes locally.
- [ ] `cargo nextest run` (1277 tests) — passes locally.
- [ ] `cargo clippy --locked -- --deny warnings` — clean.
- [ ] `cargo check --locked` — clean.
- [ ] Manual smoke install with a workspace containing a `file:./local-pkg` injected dep (suggested validation; not covered by unit tests).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for local directory workspace dependencies: projects can reference and install packages from workspace directories.
  * Choice to fetch either package-listed files or all files for directory dependencies.
  * Automatic detection when a local dependency requires a build; more reliable handling of symlinks and excluded folders (e.g., node_modules).

* **Tests**
  * Added unit and integration tests for directory walking, packlist filtering, symlink behaviors, and fetcher outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->