### PR TITLE
fix: silence verify-deps auto-install output

### DIFF
--- a/.changeset/fix-verify-deps-silent-install.md
+++ b/.changeset/fix-verify-deps-silent-install.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/exec.commands": patch
+"@pnpm/exec.pnpm-cli-runner": patch
+"pnpm": patch
+---
+
+Honor `--silent` when `verifyDepsBeforeRun: install` auto-installs dependencies before `pnpm run` or `pnpm exec`, preventing install output from being written to stdout [#11636](https://github.com/pnpm/pnpm/issues/11636).

--- a/exec/commands/src/exec.ts
+++ b/exec/commands/src/exec.ts
@@ -156,6 +156,7 @@ export type ExecOpts = Required<Pick<ConfigContext, 'selectedProjectsGraph'>> & 
 | 'nodeOptions'
 | 'pnpmHomeDir'
 | 'recursive'
+| 'reporter'
 | 'reporterHidePrefix'
 | 'userAgent'
 | 'verifyDepsBeforeRun'

--- a/exec/commands/src/runDepsStatusCheck.ts
+++ b/exec/commands/src/runDepsStatusCheck.ts
@@ -1,4 +1,4 @@
-import type { VerifyDepsBeforeRun } from '@pnpm/config.reader'
+import type { Config, VerifyDepsBeforeRun } from '@pnpm/config.reader'
 import { checkDepsStatus, type CheckDepsStatusOptions, type WorkspaceStateSettings } from '@pnpm/deps.status'
 import { PnpmError } from '@pnpm/error'
 import { runPnpmCli } from '@pnpm/exec.pnpm-cli-runner'
@@ -7,6 +7,7 @@ import enquirer from 'enquirer'
 
 export interface RunDepsStatusCheckOptions extends CheckDepsStatusOptions {
   dir: string
+  reporter?: Config['reporter']
   verifyDepsBeforeRun?: VerifyDepsBeforeRun
 }
 
@@ -20,7 +21,7 @@ export async function runDepsStatusCheck (opts: RunDepsStatusCheckOptions): Prom
   if (upToDate) return
 
   const command = ['install', ...createInstallArgs(workspaceState?.settings)]
-  const install = runPnpmCli.bind(null, command, { cwd: opts.dir })
+  const install = runPnpmCli.bind(null, command, { cwd: opts.dir, silent: opts.reporter === 'silent' })
 
   switch (opts.verifyDepsBeforeRun) {
     case 'install':

--- a/exec/commands/src/runDepsStatusCheck.ts
+++ b/exec/commands/src/runDepsStatusCheck.ts
@@ -21,7 +21,7 @@ export async function runDepsStatusCheck (opts: RunDepsStatusCheckOptions): Prom
   if (upToDate) return
 
   const command = ['install', ...createInstallArgs(workspaceState?.settings)]
-  const install = runPnpmCli.bind(null, command, { cwd: opts.dir, silent: opts.reporter === 'silent' })
+  const install = runPnpmCli.bind(null, command, { cwd: opts.dir, reporter: opts.reporter })
 
   switch (opts.verifyDepsBeforeRun) {
     case 'install':

--- a/exec/pnpm-cli-runner/src/index.ts
+++ b/exec/pnpm-cli-runner/src/index.ts
@@ -2,17 +2,23 @@ import path from 'node:path'
 
 import { sync as execSync } from 'execa'
 
-export function runPnpmCli (command: string[], { cwd }: { cwd: string }): void {
+export interface RunPnpmCliOptions {
+  cwd: string
+  silent?: boolean
+}
+
+export function runPnpmCli (command: string[], { cwd, silent }: RunPnpmCliOptions): void {
   const execOpts = {
     cwd,
-    stdio: 'inherit' as const,
+    stdio: silent ? ['inherit', 'ignore', 'inherit'] as const : 'inherit' as const,
   }
+  const cliCommand = silent ? [...command, '--reporter=silent'] : command
   const execFileName = path.basename(process.execPath).toLowerCase()
   if (execFileName === 'pnpm' || execFileName === 'pnpm.exe') {
-    execSync(process.execPath, command, execOpts)
+    execSync(process.execPath, cliCommand, execOpts)
   } else if (path.basename(process.argv[1]) === 'pnpm.mjs') {
-    execSync(process.execPath, [process.argv[1], ...command], execOpts)
+    execSync(process.execPath, [process.argv[1], ...cliCommand], execOpts)
   } else {
-    execSync('pnpm', command, execOpts)
+    execSync('pnpm', cliCommand, execOpts)
   }
 }

--- a/exec/pnpm-cli-runner/src/index.ts
+++ b/exec/pnpm-cli-runner/src/index.ts
@@ -4,15 +4,15 @@ import { sync as execSync } from 'execa'
 
 export interface RunPnpmCliOptions {
   cwd: string
-  silent?: boolean
+  reporter?: string
 }
 
-export function runPnpmCli (command: string[], { cwd, silent }: RunPnpmCliOptions): void {
+export function runPnpmCli (command: string[], { cwd, reporter }: RunPnpmCliOptions): void {
   const execOpts = {
     cwd,
-    stdio: silent ? ['inherit', 'ignore', 'inherit'] as const : 'inherit' as const,
+    stdio: 'inherit' as const,
   }
-  const cliCommand = silent ? [...command, '--reporter=silent'] : command
+  const cliCommand = reporter ? [...command, `--reporter=${reporter}`] : command
   const execFileName = path.basename(process.execPath).toLowerCase()
   if (execFileName === 'pnpm' || execFileName === 'pnpm.exe') {
     execSync(process.execPath, cliCommand, execOpts)

--- a/pnpm/test/exec.ts
+++ b/pnpm/test/exec.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
+import { writeYamlFileSync } from 'write-yaml-file'
 
 import { execPnpm, execPnpmSync } from './utils/index.js'
 
@@ -29,4 +30,18 @@ test("exec should respect the caller's current working directory", async () => {
   )
 
   expect(fs.readFileSync(cmdFilePath, 'utf8')).toBe(subdirPath)
+})
+
+test('silent exec does not print verifyDepsBeforeRun install output', async () => {
+  prepare({})
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    verifyDepsBeforeRun: 'install',
+  })
+
+  const result = execPnpmSync(['--silent', 'exec', 'node', '-e', 'process.stdout.write("hi")'], {
+    expectSuccess: true,
+    omitEnvDefaults: ['pnpm_config_silent'],
+  })
+
+  expect(result.stdout.toString()).toBe('hi')
 })

--- a/pnpm/test/run.ts
+++ b/pnpm/test/run.ts
@@ -140,6 +140,24 @@ test('silent run only prints the output of the child process', async () => {
   expect(result.stdout.toString().trim()).toBe('hi')
 })
 
+test('silent run does not print verifyDepsBeforeRun install output', async () => {
+  prepare({
+    scripts: {
+      hi: 'echo hi',
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    verifyDepsBeforeRun: 'install',
+  })
+
+  const result = execPnpmSync(['run', '--silent', 'hi'], {
+    expectSuccess: true,
+    omitEnvDefaults: ['pnpm_config_silent'],
+  })
+
+  expect(result.stdout.toString().trim()).toBe('hi')
+})
+
 testOnPosix('pnpm run with preferSymlinkedExecutables true', async () => {
   prepare({
     scripts: {


### PR DESCRIPTION
## Summary

- Pass the caller's silent reporter state into the `verifyDepsBeforeRun: install` auto-install path.
- Run that internal install with a silent reporter and without inherited stdout when the parent command is silent.
- Add regressions for silent `pnpm run` and `pnpm exec` so auto-install output cannot contaminate stdout.

Fixes #11636

## Tests

- `pnpm --filter @pnpm/exec.pnpm-cli-runner run compile`
- `pnpm --filter @pnpm/exec.commands run compile`
- `pnpm --filter pnpm run compile`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" /root/.hermes/node/bin/node "$JEST_BIN" --no-coverage --runInBand test/createInstallArgs.test.ts` from `exec/commands`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" /root/.hermes/node/bin/node "$JEST_BIN" --no-coverage --runInBand test/verifyDepsBeforeRun.ts` from `exec/commands`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" /root/.hermes/node/bin/node "$JEST_BIN" --no-coverage --runInBand test/run.ts -t 'silent run does not print verifyDepsBeforeRun install output'` from `pnpm`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" /root/.hermes/node/bin/node "$JEST_BIN" --no-coverage --runInBand test/exec.ts -t 'silent exec does not print verifyDepsBeforeRun install output'` from `pnpm`
- `git diff --cached --check`
- `git diff --check`

## Notes

No pacquet change is included: this is in the TypeScript-only `run`/`exec` path, while pacquet currently only implements `install`.

---
Written by an agent (Hermes Agent, gpt-5.5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--silent` now correctly suppresses auto-install output when dependencies are installed before running `pnpm run` or `pnpm exec`, so only the invoked script’s output appears on stdout.

* **Tests**
  * Added tests verifying `--silent` behavior for both `run` and `exec` scenarios with auto-dependency installation.

* **Chores**
  * Added release metadata to trigger patch releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->