### PR TITLE
fix(config): apply pmOnFail default to devEngines.packageManager (singular)

### DIFF
--- a/.changeset/pmonfail-default-devengines-11676.md
+++ b/.changeset/pmonfail-default-devengines-11676.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fix `devEngines.packageManager` (singular form, without `onFail`) defaulting to `onFail: "error"` instead of the documented `pmOnFail: "download"`. As a result, a project that pinned a different pnpm version via `devEngines.packageManager` and ran `pnpm install` from a mismatched pnpm version failed with a hard error, even though the migration table from `managePackageManagerVersions: true` to `pmOnFail: download (default)` promises the install would auto-download the wanted version [#11676](https://github.com/pnpm/pnpm/issues/11676).
+
+The array form of `devEngines.packageManager` keeps its existing per-element defaults (`error` for the last entry, `ignore` for the rest), since those reflect explicit prioritisation by the user. Explicit `onFail` values continue to win.

--- a/.changeset/pmonfail-default-devengines-11676.md
+++ b/.changeset/pmonfail-default-devengines-11676.md
@@ -5,4 +5,4 @@
 
 Fix `devEngines.packageManager` (singular form, without `onFail`) defaulting to `onFail: "error"` instead of the documented `pmOnFail: "download"`. As a result, a project that pinned a different pnpm version via `devEngines.packageManager` and ran `pnpm install` from a mismatched pnpm version failed with a hard error, even though the migration table from `managePackageManagerVersions: true` to `pmOnFail: download (default)` promises the install would auto-download the wanted version [#11676](https://github.com/pnpm/pnpm/issues/11676).
 
-The array form of `devEngines.packageManager` keeps its existing per-element defaults (`error` for the last entry, `ignore` for the rest), since those reflect explicit prioritisation by the user. Explicit `onFail` values continue to win.
+The array form of `devEngines.packageManager` keeps its existing per-element defaults (`error` for the last entry, `ignore` for the rest), since those reflect explicit prioritization by the user. Explicit `onFail` values continue to win.

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -657,9 +657,11 @@ export async function getConfig (opts: {
 
   // The `pmOnFail` config setting overrides whatever onFail the
   // wantedPackageManager carried, so users (and internal callers) can force
-  // a specific behavior without editing the manifest. Otherwise, the legacy
-  // `packageManager` field defaults to `download` — `devEngines.packageManager`
-  // already has onFail set during parsing.
+  // a specific behavior without editing the manifest. Otherwise, both the
+  // legacy `packageManager` field and singular `devEngines.packageManager`
+  // fall through to `download` (the documented default for `pmOnFail`); the
+  // array form of `devEngines.packageManager` already has its own per-element
+  // defaults applied during parsing.
   if (pnpmConfig.wantedPackageManager) {
     if (pnpmConfig.pmOnFail) {
       pnpmConfig.wantedPackageManager.onFail = pnpmConfig.pmOnFail
@@ -764,7 +766,7 @@ export function parsePackageManager (packageManager: string): { name: string, ve
 function parseDevEnginesPackageManager (devEngines?: DevEngines): EngineDependency | undefined {
   if (!devEngines?.packageManager) return undefined
   let pmEngine: EngineDependency | undefined
-  let onFail: 'ignore' | 'warn' | 'error' | 'download'
+  let onFail: 'ignore' | 'warn' | 'error' | 'download' | undefined
   if (Array.isArray(devEngines.packageManager)) {
     const engines = devEngines.packageManager
     if (engines.length === 0) return undefined
@@ -781,7 +783,11 @@ function parseDevEnginesPackageManager (devEngines?: DevEngines): EngineDependen
     }
   } else {
     pmEngine = devEngines.packageManager
-    onFail = pmEngine.onFail ?? 'error'
+    // Singular form: leave onFail undefined when the user did not set it, so
+    // the central pmOnFail default ('download') applies. The array form keeps
+    // its own per-element defaults ('error' for the last entry, 'ignore' for
+    // the rest) because those reflect explicit prioritisation by the user.
+    onFail = pmEngine.onFail
   }
   if (!pmEngine?.name) return undefined
   return {

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -786,7 +786,7 @@ function parseDevEnginesPackageManager (devEngines?: DevEngines): EngineDependen
     // Singular form: leave onFail undefined when the user did not set it, so
     // the central pmOnFail default ('download') applies. The array form keeps
     // its own per-element defaults ('error' for the last entry, 'ignore' for
-    // the rest) because those reflect explicit prioritisation by the user.
+    // the rest) because those reflect explicit prioritization by the user.
     onFail = pmEngine.onFail
   }
   if (!pmEngine?.name) return undefined

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -166,6 +166,47 @@ test('runtimeOnFail=ignore overrides an existing onFail=download and removes nod
   expect(context.rootProjectManifest?.devDependencies?.node).toBeUndefined()
 })
 
+test('devEngines.packageManager without onFail resolves to the documented pmOnFail default "download" (#11676)', async () => {
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '11.0.0',
+      },
+    },
+  })
+
+  const { context } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '11.0.0' },
+  })
+
+  expect(context.wantedPackageManager).toMatchObject({
+    name: 'pnpm',
+    version: '11.0.0',
+    onFail: 'download',
+  })
+})
+
+test('devEngines.packageManager with explicit onFail is respected (regression guard for #11676)', async () => {
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '11.0.0',
+        onFail: 'error',
+      },
+    },
+  })
+
+  const { context } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '11.0.0' },
+  })
+
+  expect(context.wantedPackageManager?.onFail).toBe('error')
+})
+
 test('throw error if --link-workspace-packages is used with --global', async () => {
   await expect(getConfig({
     cliOptions: {

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -143,7 +143,7 @@ test('devEngines.packageManager with onFail=ignore should not check version', as
   expect(stderr.toString()).not.toContain('0.0.1')
 })
 
-test('devEngines.packageManager defaults to onFail=error', async () => {
+test('devEngines.packageManager defaults to onFail=download (#11676)', async () => {
   prepare({
     devEngines: {
       packageManager: {
@@ -153,10 +153,19 @@ test('devEngines.packageManager defaults to onFail=error', async () => {
     },
   })
 
-  const { status, stderr } = execPnpmSync(['install'])
+  // The documented `pmOnFail` default is `download`. Run under COREPACK_ROOT
+  // to short-circuit the actual version switch (corepack owns version
+  // selection there), so the test exercises the resolved default without a
+  // network round-trip. Pre-fix, devEngines.packageManager defaulted to
+  // `error` and the corepack-specific download-fallthrough hint did NOT
+  // appear. Asserting on that hint pins the new behavior.
+  const { status, stderr } = execPnpmSync(['install'], {
+    env: { COREPACK_ROOT: '/fake/corepack' },
+  })
 
   expect(status).toBe(1)
   expect(stderr.toString()).toContain('This project is configured to use 0.0.1 of pnpm')
+  expect(stderr.toString()).toContain('does not switch versions when running under corepack')
 })
 
 test('devEngines.packageManager with a different PM name should fail with onFail=error', async () => {


### PR DESCRIPTION
## Summary

Closes #11676.

The pnpm v11 release notes [migration table](https://github.com/pnpm/pnpm/blob/main/pnpm/CHANGELOG.md) documents the `pmOnFail` default as `download`:

| Removed setting                       | Replace with                   |
| ------------------------------------- | ------------------------------ |
| `managePackageManagerVersions: true`  | `pmOnFail: download` (default) |
| ...                                   | ...                            |

The legacy `packageManager` field already gets that default applied at the central onFail-resolution site in `getConfig` — but the **singular** form of `devEngines.packageManager` short-circuited it by setting `onFail = 'error'` inside `parseDevEnginesPackageManager`. So a project that pinned a different pnpm via `devEngines.packageManager` and ran `pnpm install` from a mismatched pnpm saw a hard version mismatch error instead of the auto-download the docs promise.

Reproduction (from the issue):

```bash
git clone --branch switch-from-yarn-v1-to-pnpm-v11 https://github.com/sql-formatter-org/sql-formatter.git
cd sql-formatter
pnpm install    # pre-fix: ERROR "This project is configured to use ... of pnpm"
```

After this PR, the same install resolves to `onFail: 'download'` and switches to the wanted version, matching `pnpm install --pm-on-fail=download`.

## The change

`parseDevEnginesPackageManager` (singular case) no longer applies a local `?? 'error'` default. The local `onFail` is left `undefined` when the user didn't set it, so the central `pmOnFail` default at `getConfig` line ~666 picks up `'download'`.

The **array** form of `devEngines.packageManager` keeps its existing per-element defaults (`'error'` for the last entry, `'ignore'` for the rest). Those reflect explicit prioritization by the user (alternatives list), not a system-wide fallback, so they should stay.

Explicit `onFail` values continue to win in all cases.

## Behavior change

This is technically a behavior change: previously `devEngines.packageManager: { name: 'pnpm', version: '<other>' }` (no `onFail`) errored out; now it switches versions. That matches the documented contract. The pre-existing test `devEngines.packageManager defaults to onFail=error` cemented the buggy behavior — it has been retargeted to assert the new default (`onFail=download`) using the corepack-fallthrough pattern from the adjacent `onFail=download surfaces a regular error under corepack` test, so the assertion stays fast and deterministic without a real download round-trip.

## Test plan

- [x] New unit tests in `config/reader/test/index.ts`:
  - `devEngines.packageManager without onFail resolves to the documented pmOnFail default "download" (#11676)`
  - `devEngines.packageManager with explicit onFail is respected (regression guard for #11676)`
- [x] Updated e2e test `devEngines.packageManager defaults to onFail=download (#11676)` in `pnpm/test/packageManagerCheck.test.ts` — asserts the corepack-fallthrough behavior that confirms the resolved default is `download`.
- [x] Verified end-to-end against the compiled bundle with a standalone script: `wantedPackageManager.onFail` resolves to `download` when not set, stays as `error` when explicitly set.

Local Jest still fails for me with `module is already linked` under `experimental-vm-modules` on Node 22/24 (env issue, reproduces on pristine `main`) — relying on CI for the real test run.

## pacquet parity note

Config-reader change. Pacquet currently install-only and does not consume `devEngines.packageManager` defaults yet. Flagging per `CLAUDE.md` so the parity shows up on the radar if/when pacquet grows this surface.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed package manager configuration to properly default to `download` behavior when `onFail` is not explicitly specified.

* **Documentation**
  * Updated documentation to clarify precedence rules for package manager failure handling.

* **Tests**
  * Added regression tests to verify correct default behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->