### PR TITLE
fix(fs,package-manager): match upstream symlink-dir semantics in pacquet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "derive_more",
  "junction",
  "miette 7.6.0",
+ "pathdiff",
  "tempfile",
 ]
 
@@ -2243,6 +2244,7 @@ dependencies = [
  "pacquet-testing-utils",
  "pacquet-workspace",
  "pacquet-workspace-state",
+ "pathdiff",
  "pipe-trait",
  "pretty_assertions",
  "rayon",

--- a/pacquet/crates/cli/tests/add.rs
+++ b/pacquet/crates/cli/tests/add.rs
@@ -76,21 +76,23 @@ pub fn should_symlink_correctly() {
     assert!(virtual_store_dir.exists());
 
     eprintln!("Make sure the symlinks are correct");
+    // pacquet writes the symlink target as a path relative to the
+    // link's parent (matching upstream `symlink-dir`), so
+    // canonicalize the symlink itself rather than comparing
+    // `read_link`'s relative output against an absolute path.
+    let symlink_path = virtual_store_dir
+        .join("@pnpm.e2e+hello-world-js-bin-parent@1.0.0")
+        .join("node_modules")
+        .join("@pnpm.e2e")
+        .join("hello-world-js-bin");
+    let target_path = virtual_store_dir
+        .join("@pnpm.e2e+hello-world-js-bin@1.0.0")
+        .join("node_modules")
+        .join("@pnpm.e2e")
+        .join("hello-world-js-bin");
     assert_eq!(
-        virtual_store_dir
-            .join("@pnpm.e2e+hello-world-js-bin-parent@1.0.0")
-            .join("node_modules")
-            .join("@pnpm.e2e")
-            .join("hello-world-js-bin")
-            .pipe(fs::read_link)
-            .expect("read link"),
-        virtual_store_dir
-            .join("@pnpm.e2e+hello-world-js-bin@1.0.0")
-            .join("node_modules")
-            .join("@pnpm.e2e")
-            .join("hello-world-js-bin")
-            .pipe(fs::canonicalize)
-            .expect("canonicalize link target"),
+        symlink_path.pipe(fs::canonicalize).expect("canonicalize symlink"),
+        target_path.pipe(fs::canonicalize).expect("canonicalize link target"),
     );
 
     drop((root, anchor)); // cleanup

--- a/pacquet/crates/fs/Cargo.toml
+++ b/pacquet/crates/fs/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [dependencies]
 derive_more = { workspace = true }
 miette      = { workspace = true }
+pathdiff    = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -160,7 +160,7 @@ fn force_symlink_inner(
                         format!(
                             "Error while trying to symlink {target:?} to {link:?}. \
                              The error happened while trying to create the parent directory \
-                             for the symlink target. Details: {mkdir_err}"
+                             for the symlink target. Details: {mkdir_err}",
                         ),
                     )
                 })?;
@@ -268,7 +268,7 @@ fn rename_overwrite(src: &Path, dst: &Path) -> io::Result<()> {
                 error.kind(),
                 io::ErrorKind::AlreadyExists
                     | io::ErrorKind::DirectoryNotEmpty
-                    | io::ErrorKind::PermissionDenied
+                    | io::ErrorKind::PermissionDenied,
             );
             if !occupied {
                 return Err(error);

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -1,27 +1,63 @@
 use std::{
-    io,
+    fs, io,
     path::{Path, PathBuf},
 };
 
-/// Create a symlink to a directory.
+/// Create a symlink to a directory, matching the on-disk shape that
+/// pnpm's [`symlink-dir`](https://github.com/pnpm/symlink-dir) npm
+/// package produces.
 ///
-/// The `link` path will be a symbolic link pointing to `original`.
+/// On Unix the symlink contents are stored as a path relative to the
+/// link's parent directory — `path.relative(dirname(link), target)` in
+/// upstream's `resolveSrcOnTrueSymlink`. Relative targets keep
+/// `node_modules` installs survivable across project-directory moves
+/// and match the byte-for-byte symlink contents pnpm writes, so
+/// snapshot tooling and lockfile-parity checks stay aligned.
+///
+/// On Windows the writer tries a true directory symlink first
+/// (`std::os::windows::fs::symlink_dir`) and falls back to a junction
+/// on `PermissionDenied` — mirroring upstream's `EPERM` arm
+/// ("symbolic links may require elevated privileges; junctions
+/// don't"). The first successful branch is cached process-wide so
+/// subsequent calls skip the EPERM probe.
 pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
     #[cfg(unix)]
-    return std::os::unix::fs::symlink(original, link);
+    {
+        let rel = relative_target_for(original, link);
+        std::os::unix::fs::symlink(&rel, link)
+    }
     #[cfg(windows)]
-    return junction::create(original, link); // junctions instead of symlinks because symlinks may require elevated privileges.
+    {
+        windows::create(original, link)
+    }
+}
+
+/// Compute the symlink contents for a true symlink: the path from the
+/// link's parent directory to `original`. Mirrors upstream's
+/// `resolveSrcOnTrueSymlink(src, dest) = path.relative(path.dirname(dest), src)`.
+///
+/// Callers in pacquet always pass absolute paths; if `pathdiff` cannot
+/// produce a relative form (one side is relative, or they live on
+/// different roots — only possible on Windows), fall back to the
+/// absolute `original` so the kernel still gets a valid path. This
+/// matches upstream's behavior when `path.relative` returns an
+/// absolute path because the two arguments share no common root.
+#[cfg(any(unix, test))]
+fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
+    let parent = link.parent().unwrap_or_else(|| Path::new(""));
+    pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
 }
 
 /// Remove a symlink (or junction on Windows) previously created with
 /// [`symlink_dir`].
 ///
 /// On Unix a directory symlink is a file-shaped entry and removed
-/// with `fs::remove_file`. On Windows [`symlink_dir`] creates a
-/// junction (a directory-shaped reparse point) so it needs
-/// `fs::remove_dir` to be unlinked — `remove_file` returns
-/// `ERROR_ACCESS_DENIED`. Wrapping both in one helper keeps the
-/// platform split contained.
+/// with `fs::remove_file`. On Windows [`symlink_dir`] may create
+/// either a true symlink (directory-shaped, since the target is a
+/// directory) or a junction (directory-shaped reparse point); both
+/// need `fs::remove_dir` to be unlinked — `remove_file` returns
+/// `ERROR_ACCESS_DENIED`. Wrapping the platform split here keeps
+/// callers free of `#[cfg]`.
 pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     return std::fs::remove_file(link);
@@ -37,10 +73,9 @@ pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
 /// reparse points and returns `ERROR_NOT_A_REPARSE_POINT`
 /// (`InvalidInput`) for `IO_REPARSE_TAG_MOUNT_POINT` junctions —
 /// see [`rust-lang/rust#28528`](https://github.com/rust-lang/rust/issues/28528),
-/// which has been open since 2015. Since [`symlink_dir`] creates
-/// junctions on Windows, every entry pacquet writes would
-/// otherwise be unreadable. Fall back to `junction::get_target`
-/// on `InvalidInput` to handle the junction case while keeping
+/// which has been open since 2015. Since [`symlink_dir`] may create
+/// junctions on Windows, fall back to `junction::get_target` on
+/// `InvalidInput` to handle the junction case while keeping
 /// `fs::read_link` as the fast path for true symlinks. (Plain
 /// backticks rather than an intra-doc link because the `junction`
 /// crate is only in scope on Windows targets — a link would
@@ -61,3 +96,239 @@ pub fn read_symlink_dir(link: &Path) -> io::Result<PathBuf> {
         }
     }
 }
+
+/// Outcome of a [`force_symlink_dir`] call.
+///
+/// `reused` is `true` when the symlink at `link` already pointed at
+/// the requested target, so no on-disk write was needed. `warning`
+/// carries the human-readable note pnpm's `symlinkDir` emits when it
+/// had to move an existing non-symlink occupant out of the way to
+/// install the symlink — surface it to the user if your call site
+/// has a reporter.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ForceSymlinkOutcome {
+    pub reused: bool,
+    pub warning: Option<String>,
+}
+
+/// Idempotent, overwrite-on-stale symlink creator that mirrors
+/// pnpm's [`symlinkDir`](https://github.com/pnpm/symlink-dir/blob/v10.0.1/src/index.ts#L22)
+/// with its default `{ overwrite: true }` semantics.
+///
+/// Behavior:
+///
+/// - **Parent missing** (`NotFound` on the underlying symlink call) →
+///   `create_dir_all` the parent and retry. Matches upstream's
+///   `fs.mkdir(dirname(path), { recursive: true })` arm.
+/// - **A symlink already exists at `link`**:
+///   - Pointing at `target` → return `{ reused: true }` (no-op).
+///   - Pointing elsewhere → `remove_symlink_dir` and retry.
+/// - **A regular file or non-empty directory occupies `link`** →
+///   rename it to `<parent>/.ignored_<basename>` and retry. If the
+///   rename fails because the source disappeared between the
+///   `AlreadyExists` and the rename, surface the initial
+///   `AlreadyExists` error rather than the rename's `NotFound`.
+///   The `warning` field carries upstream's "moved" message so a
+///   reporter can tell the user what happened.
+///
+/// Returns the same `(reused, warning)` shape upstream's TypeScript
+/// `forceSymlink` returns, so reporters can mirror the pnpm warning
+/// surface.
+pub fn force_symlink_dir(target: &Path, link: &Path) -> io::Result<ForceSymlinkOutcome> {
+    force_symlink_inner(target, link, false)
+}
+
+fn force_symlink_inner(
+    target: &Path,
+    link: &Path,
+    rename_tried: bool,
+) -> io::Result<ForceSymlinkOutcome> {
+    let initial_err = match symlink_dir(target, link) {
+        Ok(()) => return Ok(ForceSymlinkOutcome { reused: false, warning: None }),
+        Err(error) => error,
+    };
+
+    match initial_err.kind() {
+        io::ErrorKind::NotFound => {
+            // Parent directory missing — `create_dir_all` and retry.
+            // Wrap the mkdir failure so callers see *which* step
+            // tripped, the same way pnpm's `forceSymlink` does.
+            if let Some(parent) = link.parent() {
+                fs::create_dir_all(parent).map_err(|mkdir_err| {
+                    io::Error::new(
+                        mkdir_err.kind(),
+                        format!(
+                            "Error while trying to symlink {target:?} to {link:?}. \
+                             The error happened while trying to create the parent directory \
+                             for the symlink target. Details: {mkdir_err}"
+                        ),
+                    )
+                })?;
+            }
+            return force_symlink_inner(target, link, rename_tried);
+        }
+        io::ErrorKind::AlreadyExists | io::ErrorKind::IsADirectory => {}
+        _ => return Err(initial_err),
+    }
+
+    // Path exists. Is it already a symlink pointing where we want?
+    match read_symlink_dir(link) {
+        Ok(existing) => {
+            if existing_symlink_up_to_date(target, link, &existing) {
+                return Ok(ForceSymlinkOutcome { reused: true, warning: None });
+            }
+            // Stale link — unlink and retry. Ignore `NotFound` in
+            // case a parallel installer beat us to the unlink.
+            match remove_symlink_dir(link) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+            force_symlink_inner(target, link, rename_tried)
+        }
+        Err(_) => {
+            // `link` is occupied by a regular file or directory.
+            // Move it out of the way, then retry. On the second
+            // attempt (`rename_tried`) drop down to a plain unlink
+            // — pnpm carries the same fallback for an intermittent
+            // macOS bug, see
+            // <https://github.com/pnpm/pnpm/issues/5909#issuecomment-1400066890>.
+            let parent = link.parent().unwrap_or_else(|| Path::new(""));
+            let basename = link.file_name().unwrap_or_default().to_string_lossy().into_owned();
+            let warning = if rename_tried {
+                remove_occupant(link)?;
+                format!(
+                    "Symlink wanted name was occupied by directory or file. \
+                     Old entity removed: {parent:?}{sep}{basename}",
+                    sep = std::path::MAIN_SEPARATOR,
+                )
+            } else {
+                let ignore_name = format!(".ignored_{basename}");
+                let ignore_path = parent.join(&ignore_name);
+                if let Err(rename_err) = rename_overwrite(link, &ignore_path) {
+                    if rename_err.kind() == io::ErrorKind::NotFound {
+                        return Err(initial_err);
+                    }
+                    return Err(rename_err);
+                }
+                format!(
+                    "Symlink wanted name was occupied by directory or file. \
+                     Old entity moved: {parent:?}{sep}{basename} => {ignore_name}",
+                    sep = std::path::MAIN_SEPARATOR,
+                )
+            };
+            let mut outcome = force_symlink_inner(target, link, true)?;
+            outcome.warning = Some(warning);
+            Ok(outcome)
+        }
+    }
+}
+
+/// Lexical "does the existing link resolve to the wanted target?"
+/// check. Mirrors upstream's
+/// `path.relative(wantedTarget, existingTarget) === ''`: resolve the
+/// existing link's contents to an absolute path (using `link`'s
+/// parent dir when the contents are relative), then compare lexically
+/// against `wanted`. Single-level — does not follow chained symlinks.
+fn existing_symlink_up_to_date(wanted: &Path, link: &Path, existing_link_string: &Path) -> bool {
+    let existing_absolute = if existing_link_string.is_absolute() {
+        existing_link_string.to_path_buf()
+    } else {
+        link.parent().unwrap_or_else(|| Path::new("")).join(existing_link_string)
+    };
+    // `path.relative(a, b) === ''` returns true iff lexically equal,
+    // so a direct PathBuf equality check is the right Rust analogue
+    // once both sides are absolute.
+    existing_absolute == wanted
+}
+
+/// Remove a regular file or directory that's occupying a symlink
+/// slot. Tries `remove_dir_all` first; if the target isn't a
+/// directory, falls back to `remove_file`.
+fn remove_occupant(path: &Path) -> io::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(_) => fs::remove_file(path),
+    }
+}
+
+/// `fs::rename` that overwrites the destination when it exists.
+/// Mirrors the
+/// [`rename-overwrite`](https://github.com/zkochan/packages/tree/main/rename-overwrite)
+/// package upstream uses: if the rename fails because the destination
+/// is occupied (`AlreadyExists` for files, `DirectoryNotEmpty` for
+/// dirs, `PermissionDenied` on Windows when something holds a handle
+/// to the dest), remove the destination and retry once.
+fn rename_overwrite(src: &Path, dst: &Path) -> io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let occupied = matches!(
+                error.kind(),
+                io::ErrorKind::AlreadyExists
+                    | io::ErrorKind::DirectoryNotEmpty
+                    | io::ErrorKind::PermissionDenied
+            );
+            if !occupied {
+                return Err(error);
+            }
+            remove_occupant(dst)?;
+            fs::rename(src, dst)
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::{
+        io,
+        path::Path,
+        sync::atomic::{AtomicU8, Ordering},
+    };
+
+    /// Cached choice of writer. `UNDECIDED` until the first successful
+    /// call resolves the EPERM probe; afterward `USE_SYMLINK` or
+    /// `USE_JUNCTION`. Mirrors the way upstream's `symlink-dir`
+    /// rebinds `createSymlinkAsync` / `createSymlinkSync` to the
+    /// winning branch after the first call.
+    const UNDECIDED: u8 = 0;
+    const USE_SYMLINK: u8 = 1;
+    const USE_JUNCTION: u8 = 2;
+    static MODE: AtomicU8 = AtomicU8::new(UNDECIDED);
+
+    pub fn create(original: &Path, link: &Path) -> io::Result<()> {
+        match MODE.load(Ordering::Relaxed) {
+            USE_SYMLINK => std::os::windows::fs::symlink_dir(original, link),
+            USE_JUNCTION => junction::create(original, link),
+            _ => probe_and_cache(original, link),
+        }
+    }
+
+    fn probe_and_cache(original: &Path, link: &Path) -> io::Result<()> {
+        // Try the true directory symlink first — that's what users
+        // running in Developer Mode (or as Administrator) get, and
+        // it matches pnpm's preference for true symlinks over
+        // junctions when allowed. `CreateSymbolicLinkW` returns
+        // `ERROR_PRIVILEGE_NOT_HELD` (`PermissionDenied`) when the
+        // process can't create symlinks; junctions don't carry that
+        // constraint, so fall back to those.
+        match std::os::windows::fs::symlink_dir(original, link) {
+            Ok(()) => {
+                MODE.store(USE_SYMLINK, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
+                let result = junction::create(original, link);
+                if result.is_ok() {
+                    MODE.store(USE_JUNCTION, Ordering::Relaxed);
+                }
+                result
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -42,7 +42,6 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 /// absolute `original` so the kernel still gets a valid path. This
 /// matches upstream's behavior when `path.relative` returns an
 /// absolute path because the two arguments share no common root.
-#[cfg(any(unix, test))]
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
@@ -299,10 +298,21 @@ mod windows {
 
     pub fn create(original: &Path, link: &Path) -> io::Result<()> {
         match MODE.load(Ordering::Relaxed) {
-            USE_SYMLINK => std::os::windows::fs::symlink_dir(original, link),
+            USE_SYMLINK => create_true_symlink(original, link),
             USE_JUNCTION => junction::create(original, link),
             _ => probe_and_cache(original, link),
         }
+    }
+
+    /// True symlinks on Windows take a relative target — pnpm's
+    /// `resolveSrcOnTrueSymlink` (shared between Unix and Windows in
+    /// upstream `symlink-dir`) is `path.relative(dirname(dest), src)`.
+    /// Junctions take the absolute path with a trailing backslash, but
+    /// the `junction` crate handles that internally so we pass
+    /// `original` through unchanged for the junction branch.
+    fn create_true_symlink(original: &Path, link: &Path) -> io::Result<()> {
+        let rel = super::relative_target_for(original, link);
+        std::os::windows::fs::symlink_dir(&rel, link)
     }
 
     fn probe_and_cache(original: &Path, link: &Path) -> io::Result<()> {
@@ -313,7 +323,7 @@ mod windows {
         // `ERROR_PRIVILEGE_NOT_HELD` (`PermissionDenied`) when the
         // process can't create symlinks; junctions don't carry that
         // constraint, so fall back to those.
-        match std::os::windows::fs::symlink_dir(original, link) {
+        match create_true_symlink(original, link) {
             Ok(()) => {
                 MODE.store(USE_SYMLINK, Ordering::Relaxed);
                 Ok(())

--- a/pacquet/crates/fs/src/symlink_dir/tests.rs
+++ b/pacquet/crates/fs/src/symlink_dir/tests.rs
@@ -84,7 +84,7 @@ fn force_symlink_dir_retargets_a_stale_symlink() {
     force_symlink_dir(&stale_target, &link).expect("seed stale link");
     let outcome =
         force_symlink_dir(&fresh_target, &link).expect("force-overwrite to the fresh target");
-    assert!(!outcome.reused, "the link pointed at the wrong target, so this should be a rewrite",);
+    assert!(!outcome.reused, "the link pointed at the wrong target, so this should be a rewrite");
 
     // The new link must resolve to the fresh target. Use the
     // canonical paths to dodge `/private/tmp` vs `/tmp` aliasing.
@@ -107,8 +107,8 @@ fn force_symlink_dir_moves_non_symlink_occupant_to_ignored_name() {
     fs::write(&link, b"squatting on the link slot").expect("seed occupant file");
 
     let outcome = force_symlink_dir(&target, &link).expect("force_symlink_dir succeeds");
-    assert!(!outcome.reused, "we wrote a fresh link over an occupant — not a reuse",);
-    assert!(outcome.warning.is_some(), "warning must be set when an occupant was moved aside",);
+    assert!(!outcome.reused, "we wrote a fresh link over an occupant — not a reuse");
+    assert!(outcome.warning.is_some(), "warning must be set when an occupant was moved aside");
     let warning = outcome.warning.unwrap();
     assert!(
         warning.contains(".ignored_link"),
@@ -121,7 +121,7 @@ fn force_symlink_dir_moves_non_symlink_occupant_to_ignored_name() {
     assert_eq!(resolved_link, resolved_target);
     // The displaced file must live at the .ignored_<basename> path.
     let ignored_path = root.path().join(".ignored_link");
-    assert!(ignored_path.is_file(), "displaced occupant must live at {ignored_path:?}",);
+    assert!(ignored_path.is_file(), "displaced occupant must live at {ignored_path:?}");
 }
 
 /// When the link's parent directory doesn't exist yet,
@@ -135,7 +135,7 @@ fn force_symlink_dir_creates_missing_parent_directories() {
     let target = root.path().join("target");
     let link = root.path().join("deeply").join("nested").join("modules").join("link");
     fs::create_dir_all(&target).expect("create target");
-    assert!(!link.parent().unwrap().exists(), "parent chain must be missing before the call",);
+    assert!(!link.parent().unwrap().exists(), "parent chain must be missing before the call");
 
     let outcome =
         force_symlink_dir(&target, &link).expect("force_symlink_dir creates parents and link");

--- a/pacquet/crates/fs/src/symlink_dir/tests.rs
+++ b/pacquet/crates/fs/src/symlink_dir/tests.rs
@@ -1,0 +1,172 @@
+//! Tests for the [`crate::symlink_dir`] module.
+//!
+//! Pacquet's symlink writer is meant to be a faithful Rust port of the
+//! pnpm [`symlink-dir`](https://github.com/pnpm/symlink-dir) npm
+//! package. The tests here exercise the parity points that matter
+//! when an install lands on disk: relative-target encoding on Unix,
+//! idempotent re-symlink, retargeting a stale link, and renaming a
+//! non-symlink occupant out of the way.
+
+use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir, symlink_dir};
+use std::{fs, path::PathBuf};
+use tempfile::tempdir;
+
+/// On Unix, [`symlink_dir`] writes the symlink contents as a path
+/// relative to the link's parent directory, matching upstream's
+/// `resolveSrcOnTrueSymlink(src, dest) = path.relative(dirname(dest),
+/// src)`. Pre-fix the on-disk symlink stored the absolute target,
+/// which broke project-directory moves and made byte-for-byte
+/// comparisons against pnpm-installed `node_modules` diverge.
+#[cfg(unix)]
+#[test]
+fn unix_symlink_contents_are_relative_to_link_parent() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("packages").join("pkg-a");
+    let link = root.path().join("node_modules").join("pkg-a");
+    fs::create_dir_all(&target).expect("create target dir");
+    fs::create_dir_all(link.parent().unwrap()).expect("create link parent");
+
+    symlink_dir(&target, &link).expect("symlink_dir succeeds");
+
+    let contents = fs::read_link(&link).expect("read_link the symlink we just wrote");
+    // Upstream emits exactly this relative path.
+    assert_eq!(
+        contents,
+        PathBuf::from("..").join("packages").join("pkg-a"),
+        "symlink contents must be the relative path from link parent to target",
+    );
+    // Sanity: it must also still resolve to the real directory.
+    assert!(link.exists(), "symlink must resolve to an existing directory");
+}
+
+/// [`force_symlink_dir`] is idempotent: calling it twice with the
+/// same `(target, link)` pair returns `reused: true` on the second
+/// call without rewriting the on-disk symlink. Matches upstream's
+/// `forceSymlink` returning `{ reused: true }` when
+/// `isExistingSymlinkUpToDate` finds the link already points at the
+/// requested target.
+#[test]
+fn force_symlink_dir_returns_reused_when_already_pointing_at_target() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("real");
+    let link = root.path().join("link");
+    fs::create_dir_all(&target).expect("create target dir");
+
+    let first = force_symlink_dir(&target, &link).expect("first call");
+    assert_eq!(
+        first,
+        ForceSymlinkOutcome { reused: false, warning: None },
+        "first call creates the link, not reused",
+    );
+
+    let second = force_symlink_dir(&target, &link).expect("second call");
+    assert_eq!(
+        second,
+        ForceSymlinkOutcome { reused: true, warning: None },
+        "second call with the same target must be a no-op reuse",
+    );
+}
+
+/// When `link` already exists pointing at a *different* target,
+/// [`force_symlink_dir`] unlinks the stale symlink and re-creates it
+/// to point at the requested target. Mirrors upstream's
+/// `forceSymlink` "stale link" arm: `await fs.unlink(path); return
+/// forceSymlink(target, path, opts);`.
+#[test]
+fn force_symlink_dir_retargets_a_stale_symlink() {
+    let root = tempdir().expect("create temp dir");
+    let stale_target = root.path().join("old-target");
+    let fresh_target = root.path().join("new-target");
+    let link = root.path().join("link");
+    fs::create_dir_all(&stale_target).expect("create stale target");
+    fs::create_dir_all(&fresh_target).expect("create fresh target");
+
+    force_symlink_dir(&stale_target, &link).expect("seed stale link");
+    let outcome =
+        force_symlink_dir(&fresh_target, &link).expect("force-overwrite to the fresh target");
+    assert!(!outcome.reused, "the link pointed at the wrong target, so this should be a rewrite",);
+
+    // The new link must resolve to the fresh target. Use the
+    // canonical paths to dodge `/private/tmp` vs `/tmp` aliasing.
+    let resolved = fs::canonicalize(&link).expect("canonicalize the new link");
+    let want = fs::canonicalize(&fresh_target).expect("canonicalize fresh target");
+    assert_eq!(resolved, want, "symlink must now resolve to the fresh target");
+}
+
+/// When a regular file occupies the link path, [`force_symlink_dir`]
+/// renames it out of the way to `<parent>/.ignored_<basename>`, then
+/// creates the symlink. Matches upstream's
+/// `forceSymlink`+`renameOverwrite` flow. The returned `warning`
+/// carries the "Old entity moved" message a reporter can surface.
+#[test]
+fn force_symlink_dir_moves_non_symlink_occupant_to_ignored_name() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    fs::create_dir_all(&target).expect("create target");
+    fs::write(&link, b"squatting on the link slot").expect("seed occupant file");
+
+    let outcome = force_symlink_dir(&target, &link).expect("force_symlink_dir succeeds");
+    assert!(!outcome.reused, "we wrote a fresh link over an occupant — not a reuse",);
+    assert!(outcome.warning.is_some(), "warning must be set when an occupant was moved aside",);
+    let warning = outcome.warning.unwrap();
+    assert!(
+        warning.contains(".ignored_link"),
+        "warning should mention the .ignored_ rename: {warning:?}",
+    );
+
+    // The symlink must resolve to the real target.
+    let resolved_link = fs::canonicalize(&link).expect("canonicalize the new symlink");
+    let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
+    assert_eq!(resolved_link, resolved_target);
+    // The displaced file must live at the .ignored_<basename> path.
+    let ignored_path = root.path().join(".ignored_link");
+    assert!(ignored_path.is_file(), "displaced occupant must live at {ignored_path:?}",);
+}
+
+/// When the link's parent directory doesn't exist yet,
+/// [`force_symlink_dir`] creates the parent chain with
+/// `create_dir_all` and retries. Matches upstream's `forceSymlink`
+/// ENOENT branch: `await fs.mkdir(dirname(path), { recursive: true
+/// }); await forceSymlink(target, path, opts);`.
+#[test]
+fn force_symlink_dir_creates_missing_parent_directories() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("deeply").join("nested").join("modules").join("link");
+    fs::create_dir_all(&target).expect("create target");
+    assert!(!link.parent().unwrap().exists(), "parent chain must be missing before the call",);
+
+    let outcome =
+        force_symlink_dir(&target, &link).expect("force_symlink_dir creates parents and link");
+    assert_eq!(outcome, ForceSymlinkOutcome { reused: false, warning: None });
+    let resolved_link = fs::canonicalize(&link).expect("canonicalize the new symlink");
+    let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
+    assert_eq!(resolved_link, resolved_target);
+}
+
+/// After [`force_symlink_dir`] places a symlink, [`read_symlink_dir`]
+/// returns the same contents. The combination covers the round-trip
+/// pacquet's prune sweep needs (write a slot link with
+/// `force_symlink_dir`, later inspect it with `read_symlink_dir`).
+#[test]
+fn read_symlink_dir_reads_back_what_force_symlink_dir_wrote() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("real");
+    let link = root.path().join("link");
+    fs::create_dir_all(&target).expect("create target");
+
+    force_symlink_dir(&target, &link).expect("write link");
+    let read = read_symlink_dir(&link).expect("read back the link");
+    // On Unix the read-back content matches what `symlink_dir`
+    // computed (relative). On Windows true symlinks read back as
+    // absolute; junctions get normalized by the `junction` crate.
+    // Both must canonicalize to the same target.
+    let resolved_read = if read.is_absolute() {
+        fs::canonicalize(&read)
+    } else {
+        fs::canonicalize(link.parent().unwrap().join(&read))
+    }
+    .expect("canonicalize read-back path");
+    assert_eq!(resolved_read, fs::canonicalize(&target).expect("canonicalize target"));
+}

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -54,6 +54,7 @@ pacquet-testing-utils = { workspace = true }
 node-semver       = { workspace = true }
 dunce             = { workspace = true }
 insta             = { workspace = true }
+pathdiff          = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
 sha2              = { workspace = true }

--- a/pacquet/crates/package-manager/src/create_symlink_layout/tests.rs
+++ b/pacquet/crates/package-manager/src/create_symlink_layout/tests.rs
@@ -24,8 +24,13 @@ fn assert_symlink_shape(
     let symlink_path = virtual_node_modules_dir.join(alias);
     let read = fs::read_link(&symlink_path)
         .unwrap_or_else(|err| panic!("read_link {symlink_path:?}: {err}"));
-    let expected =
+    let target_path =
         layout.slot_dir(target_key).join("node_modules").join(target_key.name.to_string());
+    // pacquet writes the symlink contents as a path relative to the
+    // link's parent dir, matching upstream `symlink-dir`. The
+    // expected on-disk contents are the same relative form.
+    let expected = pathdiff::diff_paths(&target_path, virtual_node_modules_dir)
+        .expect("compute relative target");
     assert_eq!(read, expected);
 }
 
@@ -221,9 +226,13 @@ fn alias_dep_links_under_alias_but_resolves_via_target() {
 
     let symlink_path = virtual_node_modules_dir.join("string-width-cjs");
     let read = fs::read_link(&symlink_path).expect("read_link");
-    let expected = layout
+    let target_path = layout
         .slot_dir(&"string-width@4.2.3".parse().unwrap())
         .join("node_modules")
         .join("string-width");
+    // The on-disk contents are the path from the link's parent dir
+    // to the slot dir (relative encoding, matching `symlink-dir`).
+    let expected = pathdiff::diff_paths(&target_path, &virtual_node_modules_dir)
+        .expect("compute relative target");
     assert_eq!(read, expected);
 }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1514,18 +1514,18 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
     .expect("frozen-lockfile install under GVS should succeed");
 
     // `register_project` wrote `<store_dir>/projects/<short-hash>`
-    // pointing back at the project dir. Resolve the symlink and
-    // canonicalize both ends — the test temp dir may itself be a
-    // symlink (e.g. `/tmp` → `/private/tmp` on macOS), and the
-    // registry stores the absolute project path at write time.
+    // pointing back at the project dir. Canonicalize the *entry
+    // path* (not `read_link`'s output) so the kernel follows the
+    // symlink — pacquet, like upstream pnpm, writes the target as
+    // a path relative to the link's parent, so canonicalizing the
+    // raw `read_link` string from the CWD would never resolve.
     let projects_dir = store_dir.join("projects");
     assert!(projects_dir.is_dir(), "GVS-on install must create <store_dir>/projects/");
     let entries: Vec<_> =
         std::fs::read_dir(&projects_dir).unwrap().collect::<Result<_, _>>().unwrap();
     assert_eq!(entries.len(), 1, "exactly one project entry per `Install::run` invocation");
-    let entry_target = std::fs::read_link(entries[0].path()).expect("registry entry is a symlink");
     assert_eq!(
-        dunce::canonicalize(&entry_target).expect("canonicalize registry target"),
+        dunce::canonicalize(entries[0].path()).expect("canonicalize registry entry"),
         dunce::canonicalize(&project_root).expect("canonicalize project root"),
         "registry symlink must resolve back to the install's project root",
     );
@@ -1670,8 +1670,9 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
     let mut targets: Vec<PathBuf> = std::fs::read_dir(&projects_dir)
         .unwrap()
         .map(|entry| {
-            let target = std::fs::read_link(entry.unwrap().path()).expect("registry entry");
-            dunce::canonicalize(&target).expect("canonicalize registry target")
+            // Canonicalize the entry path so the kernel follows the
+            // (relative) symlink — see the sibling test for context.
+            dunce::canonicalize(entry.unwrap().path()).expect("canonicalize registry entry")
         })
         .collect();
     targets.sort();

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -8,7 +8,6 @@ use pacquet_store_dir::{SharedVerifiedFilesCache, StoreDir};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::{
-    fs,
     path::Path,
     sync::{Mutex, atomic::AtomicU8},
 };
@@ -114,8 +113,16 @@ pub async fn should_find_package_version_from_registry() {
     );
     assert!(virtual_store_path.is_dir());
 
-    // Make sure the symlink is resolving to the correct path
-    assert_eq!(fs::read_link(modules_dir.path().join(&package.name)).unwrap(), virtual_store_path);
+    // Make sure the symlink resolves to the correct path. pacquet
+    // writes the contents as a path relative to the link's parent
+    // (matching upstream `symlink-dir`), so canonicalize via the
+    // link itself rather than comparing `read_link` output against
+    // the absolute store path.
+    let symlink_path = modules_dir.path().join(&package.name);
+    assert_eq!(
+        dunce::canonicalize(&symlink_path).expect("canonicalize symlink"),
+        dunce::canonicalize(&virtual_store_path).expect("canonicalize virtual store path"),
+    );
 }
 
 /// `InstallPackageFromRegistry::run` (the no-lockfile path) emits

--- a/pacquet/crates/package-manager/src/symlink_package.rs
+++ b/pacquet/crates/package-manager/src/symlink_package.rs
@@ -1,9 +1,8 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_fs::symlink_dir;
+use pacquet_fs::force_symlink_dir;
 use std::{
-    fs,
-    io::{self, ErrorKind},
+    fs, io,
     path::{Path, PathBuf},
 };
 
@@ -26,34 +25,40 @@ pub enum SymlinkPackageError {
     },
 }
 
-/// Create symlink for a package.
+/// Create a `node_modules/<name>` symlink for a direct dependency.
 ///
-/// * If ancestors of `symlink_path` don't exist, they will be created recursively.
-/// * If `symlink_path` already exists, skip.
-/// * If `symlink_path` doesn't exist, a symlink pointing to `symlink_target` will be created.
+/// Wraps [`pacquet_fs::force_symlink_dir`] so the call site mirrors
+/// pnpm's `symlinkDependency` (which calls `symlinkDir(target, link)`
+/// with the library's default `{ overwrite: true }`). That means:
+///
+/// * Missing parent directories are created with `create_dir_all`.
+/// * An existing symlink already pointing at `symlink_target` is
+///   reused (no-op).
+/// * An existing symlink pointing elsewhere is replaced.
+/// * A regular file or non-empty directory squatting at
+///   `symlink_path` is renamed to
+///   `<parent>/.ignored_<basename>` and the symlink is created.
+///
+/// The pre-port version silently swallowed `AlreadyExists` from
+/// `pacquet_fs::symlink_dir`, which left stale symlinks in place
+/// across re-installs that retargeted a dependency — a divergence
+/// from upstream's overwrite-by-default behavior.
 pub fn symlink_package(
     symlink_target: &Path,
     symlink_path: &Path,
 ) -> Result<(), SymlinkPackageError> {
-    // NOTE: symlink target in pacquet is absolute yet in pnpm is relative
-    // TODO: change symlink target to relative
     if let Some(parent) = symlink_path.parent() {
         fs::create_dir_all(parent).map_err(|error| SymlinkPackageError::CreateParentDir {
             dir: parent.to_path_buf(),
             error,
         })?;
     }
-    if let Err(error) = symlink_dir(symlink_target, symlink_path) {
-        match error.kind() {
-            ErrorKind::AlreadyExists => {}
-            _ => {
-                return Err(SymlinkPackageError::SymlinkDir {
-                    symlink_target: symlink_target.to_path_buf(),
-                    symlink_path: symlink_path.to_path_buf(),
-                    error,
-                });
-            }
+    force_symlink_dir(symlink_target, symlink_path).map_err(|error| {
+        SymlinkPackageError::SymlinkDir {
+            symlink_target: symlink_target.to_path_buf(),
+            symlink_path: symlink_path.to_path_buf(),
+            error,
         }
-    }
+    })?;
     Ok(())
 }

--- a/pacquet/crates/store-dir/src/project_registry.rs
+++ b/pacquet/crates/store-dir/src/project_registry.rs
@@ -438,9 +438,11 @@ mod tests {
         let mut entries: Vec<_> = fs::read_dir(&registry_dir).unwrap().collect();
         assert_eq!(entries.len(), 1, "exactly one entry per project");
         let entry = entries.pop().unwrap().unwrap();
-        let target = fs::read_link(entry.path()).expect("entry is a symlink");
+        // `symlink_dir` writes a path relative to the link's parent
+        // (matching upstream `symlink-dir`), so canonicalize via the
+        // entry path itself rather than the raw `read_link` output.
         assert_eq!(
-            dunce::canonicalize(&target).unwrap(),
+            dunce::canonicalize(entry.path()).unwrap(),
             dunce::canonicalize(project.path()).unwrap(),
             "symlink resolves back to the project dir",
         );

--- a/pacquet/crates/testing-utils/src/fs.rs
+++ b/pacquet/crates/testing-utils/src/fs.rs
@@ -44,7 +44,18 @@ pub fn get_all_files(root: &Path) -> Vec<String> {
 // Helper function to check if a path is a symlink or junction
 pub fn is_symlink_or_junction(path: &Path) -> io::Result<bool> {
     #[cfg(windows)]
-    return junction::exists(path);
+    {
+        // True symlinks land here when the process has the
+        // `SeCreateSymbolicLinkPrivilege` (Developer Mode or admin),
+        // which is the case on GitHub Actions Windows runners.
+        // `junction::exists` only matches `IO_REPARSE_TAG_MOUNT_POINT`,
+        // so combine it with `Path::is_symlink` to cover both reparse
+        // tags `pacquet_fs::symlink_dir` can produce.
+        if junction::exists(path)? {
+            return Ok(true);
+        }
+        return Ok(path.is_symlink());
+    }
 
     #[cfg(not(windows))]
     return Ok(path.is_symlink());

--- a/pacquet/crates/testing-utils/src/fs.rs
+++ b/pacquet/crates/testing-utils/src/fs.rs
@@ -51,14 +51,11 @@ pub fn is_symlink_or_junction(path: &Path) -> io::Result<bool> {
         // `junction::exists` only matches `IO_REPARSE_TAG_MOUNT_POINT`,
         // so combine it with `Path::is_symlink` to cover both reparse
         // tags `pacquet_fs::symlink_dir` can produce.
-        if junction::exists(path)? {
-            return Ok(true);
-        }
-        return Ok(path.is_symlink());
+        Ok(junction::exists(path)? || path.is_symlink())
     }
 
     #[cfg(not(windows))]
-    return Ok(path.is_symlink());
+    Ok(path.is_symlink())
 }
 
 /// Check if a file is executable.


### PR DESCRIPTION
## Summary

Pacquet's `pacquet_fs::symlink_dir` was a thin wrapper over the
platform syscall and diverged from pnpm's
[`symlink-dir`](https://github.com/pnpm/symlink-dir) npm package (the
library `@pnpm/fs.symlink-dependency` uses) in three user-visible
ways. This PR closes those gaps and aligns pacquet's on-disk symlink
shape with what pnpm writes.

Per the cardinal rule in `pacquet/AGENTS.md` — \"any change in pacquet
must match how the same feature is implemented in the TypeScript pnpm
CLI\" — pacquet is the side moving toward pnpm here.

### Divergences fixed

1. **Unix symlinks were absolute.** Upstream writes the target as a
   path relative to the link's parent dir
   (`path.relative(dirname(link), src)`). Pacquet now does the same
   via `pathdiff::diff_paths`. The `symlink_package.rs` TODO calling
   this out is removed.

2. **Windows always created a junction.** Upstream tries a true
   directory symlink first and only falls back to a junction on
   `ERROR_PRIVILEGE_NOT_HELD` (`PermissionDenied`). Pacquet now
   mirrors that probe and caches the winning branch process-wide in
   an `AtomicU8`, matching how the JS module rebinds
   `createSymlinkAsync` / `createSymlinkSync` after the first call.

3. **Re-installs left stale links in place.** Upstream
   `symlinkDependency` uses `symlinkDir`'s default `{ overwrite: true
   }` — retarget stale symlinks, rename non-symlink occupants to
   `.ignored_<basename>`, `mkdir -p` missing parents. The pacquet
   primitive only exposed the bare syscall, and
   `symlink_package.rs` silently swallowed `AlreadyExists`. A new
   `force_symlink_dir` in `pacquet_fs` ports upstream's
   `forceSymlink` flow (including the macOS unlink fallback on the
   second-attempt path, per pnpm/pnpm#5909), and `symlink_package`
   now calls it.

Call sites that intentionally use `{ overwrite: false }`
semantics (`hoist::symlink_hoisted_dependencies`,
`register_project`'s heal path) stay on the bare `symlink_dir`
primitive.

### Test plan

- [x] `cargo test -p pacquet-fs` — 21 passed (6 new tests covering
      relative encoding, idempotent re-symlink, stale retarget,
      occupant rename, missing-parent mkdir, and read-back).
- [x] `cargo test -p pacquet-package-manager --lib` — 268 passed.
      Three existing tests (`install/tests.rs`,
      `create_symlink_layout/tests.rs`,
      `install_package_from_registry/tests.rs`) were updated to
      compare against the new relative encoding (via `pathdiff` /
      `canonicalize`) instead of the prior absolute string.
- [x] `cargo build --workspace` — clean.
- [x] `cargo clippy -p pacquet-fs -p pacquet-package-manager` — no
      new warnings from this PR (the 6 pre-existing
      `clippy::unnecessary_get_then_check` /
      `clippy::type_complexity` warnings in unrelated test files are
      out of scope).
- [ ] Windows CI — the symlink-first / junction-fallback branch is
      Linux-host-uncoverable; relying on CI to validate.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symlink directories now store relative targets for portability and pnpm compatibility.
  * Idempotent symlink creation: reuses correct links, replaces stale ones, and moves blocking files aside.
  * Automatically creates missing parent directories when creating symlinks.
  * Improved Windows handling with cached privilege/probe fallbacks.

* **Bug Fixes**
  * Stale or incorrect symlinks are reliably replaced during installs.

* **Tests**
  * Added/updated tests validating relative-link behavior, idempotent semantics, and read/write parity.

* **Chores**
  * Added pathdiff as a dev dependency for tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->