### PR TITLE
fix(cmd-shim): symlink node runtime binary instead of cmd-shimming it

### DIFF
--- a/pacquet/crates/cmd-shim/src/link_bins.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins.rs
@@ -155,6 +155,23 @@ pub enum LinkBinsError {
         #[error(source)]
         error: io::Error,
     },
+
+    #[display("Failed to remove stale bin at {path:?}: {error}")]
+    #[diagnostic(code(pacquet_cmd_shim::remove_stale_bin))]
+    RemoveStaleBin {
+        path: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
+
+    #[display("Failed to link node runtime binary {src:?} -> {dst:?}: {error}")]
+    #[diagnostic(code(pacquet_cmd_shim::link_node_bin))]
+    LinkNodeBin {
+        src: PathBuf,
+        dst: PathBuf,
+        #[error(source)]
+        error: io::Error,
+    },
 }
 
 /// Read `<location>/package.json` for each entry under `modules_dir` and link
@@ -402,6 +419,31 @@ fn write_shim<Api>(target_path: &Path, shim_path: &Path) -> Result<(), LinkBinsE
 where
     Api: FsReadString + FsReadHead + FsWrite + FsSetExecutable + FsEnsureExecutableBits,
 {
+    // The node runtime binary is special: never wrap it in a shell
+    // shim. Mirrors pnpm v11's `cmd.name === 'node'` short-circuit in
+    // [`bins/linker/src/index.ts`](https://github.com/pnpm/pnpm/blob/06d2d3deb2/bins/linker/src/index.ts#L281-L308),
+    // which symlinks the binary on Unix and hardlinks `node.exe` on
+    // Windows.
+    //
+    // Two reasons this matters:
+    //
+    // 1. Parity. pnpm install in the same workspace symlinks `.bin/node`
+    //    to the runtime binary; pacquet must do the same so the
+    //    `same_global_virtual_store_layout_*` checks see the same
+    //    dirent shape.
+    // 2. Robustness against accidental shim-wrapping. The node binary
+    //    itself has no shebang, but a prior bad install may leave a
+    //    cmd-shim text file with `#!/bin/sh` at `<pkg>/bin/node`. If
+    //    pacquet then cmd-shims that file, `search_script_runtime`
+    //    parses the shebang as `prog: "/bin/sh"` and emits a shim
+    //    whose target resolves to a non-existent path
+    //    (`$basedir/../node/bin/../node/bin/node` — the `node` segment
+    //    appears twice). A direct symlink / hardlink bypasses the
+    //    parser entirely.
+    if is_node_bin_name(shim_path) && link_node_bin(target_path, shim_path)? {
+        return Ok(());
+    }
+
     let runtime = search_script_runtime::<Api>(target_path).map_err(|error| {
         LinkBinsError::ProbeShimSource { path: target_path.to_path_buf(), error }
     })?;
@@ -489,6 +531,83 @@ where
     }
 
     Ok(())
+}
+
+/// Whether `shim_path`'s file name is exactly `node` — the trigger for the
+/// node-runtime short-circuit in [`write_shim`]. Lifted out so the check
+/// is unit-testable and the call site reads as a predicate.
+fn is_node_bin_name(shim_path: &Path) -> bool {
+    matches!(shim_path.file_name().and_then(|s| s.to_str()), Some("node"))
+}
+
+/// Link the node runtime binary `target_path` into the bin slot
+/// `shim_path` directly, without a cmd-shim wrapper. Returns `Ok(true)`
+/// when the special case took effect (the caller must skip the regular
+/// shim-writing path) and `Ok(false)` when it didn't apply and the
+/// caller should fall through (Windows non-`.exe` source).
+///
+/// Mirrors the two halves of pnpm's `cmd.name === 'node'` branch:
+///
+/// - **Unix** symlinks `shim_path` → absolute `target_path`. The
+///   existing dirent (if any) is removed first because `fs::symlink`
+///   rejects with `AlreadyExists` and we don't want to silently leave
+///   a stale shim in place.
+/// - **Windows** hardlinks `target_path` to `<shim_path>.exe`, falling
+///   back to `fs::copy` on hardlink failure (cross-device, ACL deny,
+///   …). The source must end in `.exe`; otherwise pnpm falls through
+///   to the cmd-shim path and so do we.
+///
+/// `remove_file` rather than `Api::write`-style truncation is
+/// load-bearing on both platforms: if `shim_path` is currently a
+/// regular file hardlinked to the source binary (a state an earlier
+/// pacquet revision could leave behind), truncating through the
+/// hardlink would corrupt the binary itself. Removing the dirent
+/// leaves the hardlinked content intact.
+#[cfg(unix)]
+fn link_node_bin(target_path: &Path, shim_path: &Path) -> Result<bool, LinkBinsError> {
+    use std::os::unix::fs::symlink;
+    remove_stale_bin(shim_path)?;
+    symlink(target_path, shim_path).map_err(|error| LinkBinsError::LinkNodeBin {
+        src: target_path.to_path_buf(),
+        dst: shim_path.to_path_buf(),
+        error,
+    })?;
+    Ok(true)
+}
+
+#[cfg(windows)]
+fn link_node_bin(target_path: &Path, shim_path: &Path) -> Result<bool, LinkBinsError> {
+    use std::fs;
+    let is_exe = target_path
+        .extension()
+        .and_then(|s| s.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
+    if !is_exe {
+        return Ok(false);
+    }
+    let exe_path = with_extension_appended(shim_path, "exe");
+    remove_stale_bin(&exe_path)?;
+    if fs::hard_link(target_path, &exe_path).is_err() {
+        fs::copy(target_path, &exe_path).map_err(|error| LinkBinsError::LinkNodeBin {
+            src: target_path.to_path_buf(),
+            dst: exe_path,
+            error,
+        })?;
+    }
+    Ok(true)
+}
+
+/// Remove an existing dirent at `path`, swallowing `NotFound`. Used by
+/// [`link_node_bin`] to clear any prior shim / symlink / hardlink
+/// before laying down the new one. Any other IO error (PermissionDenied,
+/// EROFS, AppArmor deny, …) surfaces as [`LinkBinsError::RemoveStaleBin`]
+/// so a real failure isn't hidden behind a silent skip.
+fn remove_stale_bin(path: &Path) -> Result<(), LinkBinsError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(LinkBinsError::RemoveStaleBin { path: path.to_path_buf(), error }),
+    }
 }
 
 /// Append `<ext>` to `path` as a *new* extension segment (`foo` becomes

--- a/pacquet/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins/tests.rs
@@ -1206,7 +1206,7 @@ fn link_node_bin_does_not_corrupt_hardlinked_target() {
 /// On Windows the canonical bin dirent for the node runtime is
 /// `<bin_dir>/node.exe` — a hardlink (or copy fallback) of the source
 /// `.exe`. No `.cmd` or `.ps1` shim is emitted, because npm's cmd
-/// shims call `node.exe` from `IF EXIST` blocks that mis-handle a
+/// shims call `node.exe` from `IF EXIST` blocks that mishandle a
 /// `.cmd` redirection.
 #[cfg(windows)]
 #[test]

--- a/pacquet/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins/tests.rs
@@ -1058,3 +1058,226 @@ fn hoisted_origin_loses_to_existing_direct() {
         "Direct incumbent must shut out Hoisted candidate, got body:\n{body}",
     );
 }
+
+/// Mirrors pnpm's `linkBinsOfPackages() symlinks node binary directly
+/// instead of creating a shell shim` at
+/// <https://github.com/pnpm/pnpm/blob/06d2d3deb2/bins/linker/test/index.ts#L643>.
+///
+/// The `node` bin must land as a symlink to the real binary, never a
+/// `/bin/sh`-wrapped shim. Wrapping is the recursion trap described in
+/// [`super::link_node_bin`]'s doc comment.
+#[cfg(unix)]
+#[test]
+fn link_node_bin_symlinks_directly_instead_of_writing_shim() {
+    let tmp = tempdir().unwrap();
+    let bin_target = tmp.path().join("bin_target");
+    let node_dir = tmp.path().join("node_pkg");
+    let node_bin_dir = node_dir.join("bin");
+    create_dir_all(&node_bin_dir).unwrap();
+    write_file(node_bin_dir.join("node"), "fake-node-binary").unwrap();
+    write_file(
+        node_dir.join("package.json"),
+        json!({"name": "node", "version": "20.0.0", "bin": {"node": "bin/node"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest: Value =
+        serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
+    link_bins_of_packages::<RealApi>(
+        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &bin_target,
+    )
+    .unwrap();
+
+    let bin_location = bin_target.join("node");
+    let meta = std::fs::symlink_metadata(&bin_location).unwrap();
+    assert!(meta.file_type().is_symlink(), "node bin must be a symlink, not a shim file");
+    assert_eq!(
+        std::fs::canonicalize(&bin_location).unwrap(),
+        std::fs::canonicalize(node_bin_dir.join("node")).unwrap(),
+        "symlink must resolve to the real binary",
+    );
+    // The target binary must not have been mutated to a sh-shim text.
+    assert_eq!(
+        read_to_string(node_bin_dir.join("node")).unwrap(),
+        "fake-node-binary",
+        "node bin special case must not rewrite the underlying binary",
+    );
+}
+
+/// Mirrors pnpm's `linkBinsOfPackages() replaces a dangling symlink
+/// when linking node binary` at
+/// <https://github.com/pnpm/pnpm/blob/06d2d3deb2/bins/linker/test/index.ts#L671>.
+///
+/// A previous install can leave a dangling symlink at `bin/node` when
+/// the prior store entry was pruned. The next install must overwrite
+/// it; `fs::symlink` would otherwise error with `AlreadyExists`.
+#[cfg(unix)]
+#[test]
+fn link_node_bin_replaces_dangling_symlink() {
+    use std::os::unix::fs::symlink;
+    let tmp = tempdir().unwrap();
+    let bin_target = tmp.path().join("bin_target");
+    create_dir_all(&bin_target).unwrap();
+    let dangling_target = tmp.path().join("does_not_exist");
+    symlink(&dangling_target, bin_target.join("node")).unwrap();
+    assert!(
+        std::fs::metadata(bin_target.join("node")).is_err(),
+        "precondition: symlink must be dangling",
+    );
+
+    let node_dir = tmp.path().join("node_pkg");
+    let node_bin_dir = node_dir.join("bin");
+    create_dir_all(&node_bin_dir).unwrap();
+    write_file(node_bin_dir.join("node"), "fake-node-binary").unwrap();
+    write_file(
+        node_dir.join("package.json"),
+        json!({"name": "node", "version": "20.0.0", "bin": {"node": "bin/node"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest: Value =
+        serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
+    link_bins_of_packages::<RealApi>(
+        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &bin_target,
+    )
+    .unwrap();
+
+    let stat = std::fs::symlink_metadata(bin_target.join("node")).unwrap();
+    assert!(stat.file_type().is_symlink());
+    assert_eq!(
+        std::fs::canonicalize(bin_target.join("node")).unwrap(),
+        std::fs::canonicalize(node_bin_dir.join("node")).unwrap(),
+    );
+}
+
+/// Regression test for the corruption pattern that motivated the
+/// node-bin short-circuit. Without the special case, if `bin/node` is
+/// hardlinked into a pacquet slot and `<bin_dir>/node` is also a
+/// regular file hardlinked to the same inode (e.g. a prior pacquet
+/// revision left it that way), then `fs::write` truncating the dirent
+/// would rewrite the underlying node binary as a 459-byte
+/// `/bin/sh`-wrapper text file — propagating to every project that
+/// reflinks from the same store.
+///
+/// The fix is `remove_file` followed by `fs::symlink`. `remove_file`
+/// drops only the dirent, leaving the hardlinked content intact.
+#[cfg(unix)]
+#[test]
+fn link_node_bin_does_not_corrupt_hardlinked_target() {
+    let tmp = tempdir().unwrap();
+    let bin_target = tmp.path().join("bin_target");
+    create_dir_all(&bin_target).unwrap();
+
+    let node_dir = tmp.path().join("node_pkg");
+    let node_bin_dir = node_dir.join("bin");
+    create_dir_all(&node_bin_dir).unwrap();
+    write_file(node_bin_dir.join("node"), "fake-node-binary").unwrap();
+    // Hardlink the binary into the would-be bin slot, simulating the
+    // disk state that produced the upstream corruption.
+    std::fs::hard_link(node_bin_dir.join("node"), bin_target.join("node")).unwrap();
+
+    write_file(
+        node_dir.join("package.json"),
+        json!({"name": "node", "version": "20.0.0", "bin": {"node": "bin/node"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest: Value =
+        serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
+    link_bins_of_packages::<RealApi>(
+        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &bin_target,
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_to_string(node_bin_dir.join("node")).unwrap(),
+        "fake-node-binary",
+        "real node binary must not be rewritten by the bin linker",
+    );
+}
+
+/// Mirrors pnpm's `linkBinsOfPackages() hardlinks node.exe instead of
+/// creating a cmd-shim` at
+/// <https://github.com/pnpm/pnpm/blob/06d2d3deb2/bins/linker/test/index.ts#L709>.
+///
+/// On Windows the canonical bin dirent for the node runtime is
+/// `<bin_dir>/node.exe` — a hardlink (or copy fallback) of the source
+/// `.exe`. No `.cmd` or `.ps1` shim is emitted, because npm's cmd
+/// shims call `node.exe` from `IF EXIST` blocks that mis-handle a
+/// `.cmd` redirection.
+#[cfg(windows)]
+#[test]
+fn link_node_bin_hardlinks_node_exe_on_windows() {
+    let tmp = tempdir().unwrap();
+    let bin_target = tmp.path().join("bin_target");
+    let node_dir = tmp.path().join("node_pkg");
+    create_dir_all(&node_dir).unwrap();
+    write_file(node_dir.join("node.exe"), "fake-node-binary").unwrap();
+    write_file(
+        node_dir.join("package.json"),
+        json!({"name": "node", "version": "20.0.0", "bin": {"node": "node.exe"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest: Value =
+        serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
+    link_bins_of_packages::<RealApi>(
+        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &bin_target,
+    )
+    .unwrap();
+
+    let exe = bin_target.join("node.exe");
+    assert!(exe.exists(), "node.exe must be created in the bin dir");
+    assert_eq!(read_to_string(&exe).unwrap(), "fake-node-binary");
+    // No canonical shim, .cmd, or .ps1 should be written.
+    assert!(
+        !bin_target.join("node").exists(),
+        "canonical shim must not be written for the node special case",
+    );
+    assert!(
+        !bin_target.join("node.cmd").exists(),
+        ".cmd shim must not be written for the node special case",
+    );
+    assert!(
+        !bin_target.join("node.ps1").exists(),
+        ".ps1 shim must not be written for the node special case",
+    );
+}
+
+/// Windows-only: when the node manifest declares a non-`.exe` source
+/// (uncommon but possible — e.g. a wrapper script), pnpm falls through
+/// to the regular cmd-shim path. Pacquet must too.
+#[cfg(windows)]
+#[test]
+fn link_node_bin_falls_through_to_cmd_shim_when_source_is_not_exe() {
+    let tmp = tempdir().unwrap();
+    let bin_target = tmp.path().join("bin_target");
+    let node_dir = tmp.path().join("node_pkg");
+    create_dir_all(node_dir.join("bin")).unwrap();
+    write_file(node_dir.join("bin/node"), "#!/usr/bin/env node\nconsole.log(1)\n").unwrap();
+    write_file(
+        node_dir.join("package.json"),
+        json!({"name": "node", "version": "20.0.0", "bin": {"node": "bin/node"}}).to_string(),
+    )
+    .unwrap();
+
+    let manifest: Value =
+        serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
+    link_bins_of_packages::<RealApi>(
+        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &bin_target,
+    )
+    .unwrap();
+
+    // The non-`.exe` node source falls through to the cmd-shim path,
+    // so the canonical sh shim, `.cmd`, and `.ps1` siblings all land
+    // exactly as for any other bin.
+    assert!(bin_target.join("node").exists());
+    assert!(bin_target.join("node.cmd").exists());
+    assert!(bin_target.join("node.ps1").exists());
+    assert!(!bin_target.join("node.exe").exists());
+}


### PR DESCRIPTION
## Summary

Ports pnpm v11's `cmd.name === 'node'` short-circuit (pnpm `bins/linker/src/index.ts:281-308`) into pacquet's `pacquet_cmd_shim::write_shim`:

- **Unix:** `remove_file` (swallow `NotFound`) then `std::os::unix::fs::symlink(target, shim_path)`.
- **Windows:** when the source ends in `.exe`, `fs::hard_link` to `<shim>.exe` with `fs::copy` fallback; non-`.exe` sources fall through to the regular cmd-shim path (matching pnpm).
- Two new `LinkBinsError` variants: `RemoveStaleBin`, `LinkNodeBin`.

Without this short-circuit, pacquet cmd-shimmed the node runtime binary like any other bin. That's both a parity gap and a recursion trap: on subsequent runs `search_script_runtime` parses the shim's `#!/bin/sh` as the runtime and emits a wrapper around the wrapper, with a self-referencing relative target (`node/bin/../node/bin/node` — `node` appears twice and resolves to a non-existent path). The `remove_file`-before-link sequence (rather than `fs::write` truncation) also prevents the source binary from being corrupted when the existing dirent is hardlinked into the GVS slot from the store.

A user-visible symptom of this gap surfaced in the pnpm/pnpm worktree: `bin/node` in the store ended up as a 459-byte `/bin/sh` shim referencing itself, breaking `pnpm install` on any worktree reflinked from the same store.

## Test plan

- [x] Mirrors `bins/linker/test/index.ts:643-735`:
  - `link_node_bin_symlinks_directly_instead_of_writing_shim` (Unix)
  - `link_node_bin_replaces_dangling_symlink` (Unix)
  - `link_node_bin_hardlinks_node_exe_on_windows` (Windows)
  - `link_node_bin_falls_through_to_cmd_shim_when_source_is_not_exe` (Windows)
- [x] Regression test for the corruption pattern: `link_node_bin_does_not_corrupt_hardlinked_target` pre-hardlinks the bin slot at the source binary, runs `link_bins_of_packages`, asserts the source content survives.
- [x] `cargo nextest run -p pacquet-cmd-shim` — 86 passed.
- [x] `cargo nextest run -p pacquet-package-manager` — 273 passed.
- [x] `cargo fmt --check`, `cargo check --locked`, `cargo clippy --locked -- --deny warnings` — clean across the workspace.

## Out of scope

- Pnpm's Windows path also removes a pre-existing `<binsDir>/<name>.exe` for *every* bin (not just node). Not ported here — it isn't required by the parity test set and didn't contribute to this corruption.
- Cleaning up store entries already corrupted by the prior behavior. Users with a poisoned `node` runtime in their store will need to remove the affected `links/@/node/<ver>/<hash>/` directory before reinstalling.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Node.js binary handling to prevent file corruption and ensure proper updates during reinstallation.

* **Performance**
  * Node.js binary now uses optimized platform-specific linking for improved startup performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->