### PR TITLE
test(pacquet): coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "pretty_assertions",
  "sha2",
  "tempfile",
+ "text-block-macros",
 ]
 
 [[package]]

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
 use std::fs;
 
 /// `pacquet run <script>` looks up the named entry under
@@ -14,14 +15,12 @@ fn run_executes_declared_script() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let manifest_path = workspace.join("package.json");
     let marker_path = workspace.join("marker.txt");
-    let manifest = format!(
-        r#"{{
-            "name": "test",
-            "version": "0.0.0",
-            "scripts": {{ "touch-marker": "touch {marker}" }}
-        }}"#,
-        marker = marker_path.display(),
-    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "touch-marker": format!("touch {}", marker_path.display()) },
+    })
+    .to_string();
     fs::write(&manifest_path, manifest).expect("write package.json");
 
     pacquet.with_arg("run").with_arg("touch-marker").assert().success();
@@ -42,14 +41,14 @@ fn run_passes_extra_arguments_to_the_script() {
     let marker_path = workspace.join("args.txt");
     // `printf %s "$1"` writes the first argument into the marker,
     // letting the assertion below pin the exact argument flow.
-    let manifest = format!(
-        r#"{{
-            "name": "test",
-            "version": "0.0.0",
-            "scripts": {{ "echo-args": "sh -c 'printf %s \"$1\" > {marker}' --" }}
-        }}"#,
-        marker = marker_path.display(),
-    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": {
+            "echo-args": format!(r#"sh -c 'printf %s "$1" > {}' --"#, marker_path.display()),
+        },
+    })
+    .to_string();
     fs::write(&manifest_path, manifest).expect("write package.json");
 
     pacquet.with_arg("run").with_arg("echo-args").with_arg("hello-world").assert().success();
@@ -67,11 +66,13 @@ fn run_passes_extra_arguments_to_the_script() {
 fn run_errors_on_missing_script_without_if_present() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        r#"{"name": "test", "version": "0.0.0", "scripts": {"build": "echo built"}}"#,
-    )
-    .expect("write package.json");
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "build": "echo built" },
+    })
+    .to_string();
+    fs::write(&manifest_path, manifest).expect("write package.json");
 
     let output =
         pacquet.with_arg("run").with_arg("nonexistent").output().expect("spawn pacquet run");
@@ -88,11 +89,13 @@ fn run_errors_on_missing_script_without_if_present() {
 fn run_with_if_present_is_a_noop_for_missing_script() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let manifest_path = workspace.join("package.json");
-    fs::write(
-        &manifest_path,
-        r#"{"name": "test", "version": "0.0.0", "scripts": {"build": "echo built"}}"#,
-    )
-    .expect("write package.json");
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "build": "echo built" },
+    })
+    .to_string();
+    fs::write(&manifest_path, manifest).expect("write package.json");
 
     pacquet.with_arg("run").with_arg("--if-present").with_arg("nonexistent").assert().success();
 

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -15,10 +15,16 @@ fn run_executes_declared_script() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let manifest_path = workspace.join("package.json");
     let marker_path = workspace.join("marker.txt");
+    // Path is double-quoted in the shell command so a tempdir
+    // path containing a space (rare on Linux, common on macOS
+    // under `/var/folders/...`) doesn't get split into two
+    // `touch` arguments.
     let manifest = json!({
         "name": "test",
         "version": "0.0.0",
-        "scripts": { "touch-marker": format!("touch {}", marker_path.display()) },
+        "scripts": {
+            "touch-marker": format!(r#"touch "{}""#, marker_path.display()),
+        },
     })
     .to_string();
     fs::write(&manifest_path, manifest).expect("write package.json");
@@ -41,11 +47,19 @@ fn run_passes_extra_arguments_to_the_script() {
     let marker_path = workspace.join("args.txt");
     // `printf %s "$1"` writes the first argument into the marker,
     // letting the assertion below pin the exact argument flow.
+    // Inner sh redirect quotes the temp path so a space in the
+    // path doesn't split the redirect target. Outer single
+    // quotes wrap the inner command; the embedded double quote
+    // around `{}` survives because it's inside the outer single
+    // quotes.
     let manifest = json!({
         "name": "test",
         "version": "0.0.0",
         "scripts": {
-            "echo-args": format!(r#"sh -c 'printf %s "$1" > {}' --"#, marker_path.display()),
+            "echo-args": format!(
+                r#"sh -c 'printf %s "$1" > "{}"' --"#,
+                marker_path.display(),
+            ),
         },
     })
     .to_string();

--- a/pacquet/crates/cli/tests/run.rs
+++ b/pacquet/crates/cli/tests/run.rs
@@ -1,0 +1,100 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::fs;
+
+/// `pacquet run <script>` looks up the named entry under
+/// `scripts` in the workspace's `package.json` and spawns it via
+/// the executor. A successful invocation should produce the side
+/// effect declared by the script (here, creating a marker file)
+/// and exit 0.
+#[cfg(unix)]
+#[test]
+fn run_executes_declared_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest_path = workspace.join("package.json");
+    let marker_path = workspace.join("marker.txt");
+    let manifest = format!(
+        r#"{{
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {{ "touch-marker": "touch {marker}" }}
+        }}"#,
+        marker = marker_path.display(),
+    );
+    fs::write(&manifest_path, manifest).expect("write package.json");
+
+    pacquet.with_arg("run").with_arg("touch-marker").assert().success();
+    assert!(marker_path.exists(), "script should have created the marker file");
+
+    drop(root);
+}
+
+/// Positional arguments after the script name flow through to the
+/// spawned shell verbatim, joined by spaces. Mirrors `pnpm run
+/// <script> -- <args>` minus the npm `--` separator (pacquet does
+/// not require it).
+#[cfg(unix)]
+#[test]
+fn run_passes_extra_arguments_to_the_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest_path = workspace.join("package.json");
+    let marker_path = workspace.join("args.txt");
+    // `printf %s "$1"` writes the first argument into the marker,
+    // letting the assertion below pin the exact argument flow.
+    let manifest = format!(
+        r#"{{
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {{ "echo-args": "sh -c 'printf %s \"$1\" > {marker}' --" }}
+        }}"#,
+        marker = marker_path.display(),
+    );
+    fs::write(&manifest_path, manifest).expect("write package.json");
+
+    pacquet.with_arg("run").with_arg("echo-args").with_arg("hello-world").assert().success();
+    let written = fs::read_to_string(&marker_path).expect("read marker");
+    assert_eq!(written, "hello-world");
+
+    drop(root);
+}
+
+/// Without `--if-present`, calling a script that does not exist
+/// fails. Mirrors `pnpm run` behavior — the missing-script error
+/// comes from `PackageManifest::script`, surfaced through the
+/// `RunArgs::run` `wrap_err` chain.
+#[test]
+fn run_errors_on_missing_script_without_if_present() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        r#"{"name": "test", "version": "0.0.0", "scripts": {"build": "echo built"}}"#,
+    )
+    .expect("write package.json");
+
+    let output =
+        pacquet.with_arg("run").with_arg("nonexistent").output().expect("spawn pacquet run");
+    assert!(!output.status.success(), "missing script must surface as a failure");
+
+    drop(root);
+}
+
+/// With `--if-present`, the same missing script becomes a no-op
+/// and pacquet exits cleanly. Required for orchestration tools
+/// that probe optional scripts without wanting to fail the
+/// pipeline.
+#[test]
+fn run_with_if_present_is_a_noop_for_missing_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        r#"{"name": "test", "version": "0.0.0", "scripts": {"build": "echo built"}}"#,
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("run").with_arg("--if-present").with_arg("nonexistent").assert().success();
+
+    drop(root);
+}

--- a/pacquet/crates/executor/src/lib.rs
+++ b/pacquet/crates/executor/src/lib.rs
@@ -34,3 +34,27 @@ pub fn execute_shell(command: &str) -> Result<(), ExecutorError> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::execute_shell;
+
+    /// `execute_shell` returns `Ok(())` when `sh -c <command>` runs
+    /// to completion. The unix-only guard mirrors the function
+    /// itself, which spawns `sh` unconditionally.
+    #[cfg(unix)]
+    #[test]
+    fn execute_shell_runs_successful_command() {
+        execute_shell("true").expect("`true` runs cleanly");
+    }
+
+    /// A non-zero exit from the spawned command still surfaces as
+    /// `Ok(())`: `execute_shell` only fails on I/O errors from
+    /// spawn or wait. Pnpm's `run` semantics treat the script's
+    /// exit code as its own concern, not a wrapper failure.
+    #[cfg(unix)]
+    #[test]
+    fn execute_shell_propagates_nonzero_exit_as_ok() {
+        execute_shell("exit 1").expect("wait succeeds even on nonzero exit");
+    }
+}

--- a/pacquet/crates/executor/src/lib.rs
+++ b/pacquet/crates/executor/src/lib.rs
@@ -35,26 +35,5 @@ pub fn execute_shell(command: &str) -> Result<(), ExecutorError> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::execute_shell;
-
-    /// `execute_shell` returns `Ok(())` when `sh -c <command>` runs
-    /// to completion. The unix-only guard mirrors the function
-    /// itself, which spawns `sh` unconditionally.
-    #[cfg(unix)]
-    #[test]
-    fn execute_shell_runs_successful_command() {
-        execute_shell("true").expect("`true` runs cleanly");
-    }
-
-    /// A non-zero exit from the spawned command still surfaces as
-    /// `Ok(())`: `execute_shell` only fails on I/O errors from
-    /// spawn or wait. Pnpm's `run` semantics treat the script's
-    /// exit code as its own concern, not a wrapper failure.
-    #[cfg(unix)]
-    #[test]
-    fn execute_shell_propagates_nonzero_exit_as_ok() {
-        execute_shell("exit 1").expect("wait succeeds even on nonzero exit");
-    }
-}
+#[cfg(all(test, unix))]
+mod tests;

--- a/pacquet/crates/executor/src/tests.rs
+++ b/pacquet/crates/executor/src/tests.rs
@@ -1,0 +1,11 @@
+use super::execute_shell;
+
+/// `execute_shell` returns `Ok(())` when `sh -c <command>` runs
+/// to completion. The whole `tests` module is `cfg(unix)`-gated
+/// at the declaration site because `execute_shell` spawns `sh`
+/// unconditionally and has no Windows equivalent worth covering
+/// here.
+#[test]
+fn execute_shell_runs_successful_command() {
+    execute_shell("true").expect("`true` runs cleanly");
+}

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -35,3 +35,47 @@ pub fn make_file_executable(file: &std::fs::File) -> io::Result<()> {
     #[cfg(windows)]
     return Ok(());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{EXEC_MASK, EXEC_MODE, is_executable, make_file_executable};
+
+    /// Sanity-pin the two on-disk constants. The mask is `--x--x--x`
+    /// and the canonical executable mode is `rwxr-xr-x` — these
+    /// match pnpm's `EXEC_MODE` and are part of the CAFS contract.
+    #[test]
+    fn exec_constants_pin_pnpm_layout() {
+        assert_eq!(EXEC_MASK, 0o111);
+        assert_eq!(EXEC_MODE, 0o755);
+    }
+
+    /// Every tarball-shipped exec bit (`u+x`, `g+x`, `o+x`) flips
+    /// `is_executable` to `true`. Any-bit semantics matches
+    /// upstream's `modeIsExecutable`.
+    #[test]
+    fn is_executable_matches_any_exec_bit() {
+        assert!(!is_executable(0o644));
+        assert!(is_executable(0o744)); // user-only exec, the common npm shape
+        assert!(is_executable(0o755));
+        assert!(is_executable(0o050)); // group-only — still executable
+        assert!(is_executable(0o001)); // other-only — still executable
+    }
+
+    /// `make_file_executable` flips the exec bits on a freshly
+    /// created non-executable file. On Unix the mode must include
+    /// all three exec bits afterward; on Windows the call is a
+    /// no-op and we just assert it returns `Ok`.
+    #[test]
+    fn make_file_executable_sets_exec_bits_on_unix() {
+        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+        let file = tmp.as_file();
+        make_file_executable(file).expect("set permissions");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = file.metadata().expect("stat").permissions().mode();
+            assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
+        }
+    }
+}

--- a/pacquet/crates/fs/src/file_mode.rs
+++ b/pacquet/crates/fs/src/file_mode.rs
@@ -37,45 +37,4 @@ pub fn make_file_executable(file: &std::fs::File) -> io::Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{EXEC_MASK, EXEC_MODE, is_executable, make_file_executable};
-
-    /// Sanity-pin the two on-disk constants. The mask is `--x--x--x`
-    /// and the canonical executable mode is `rwxr-xr-x` — these
-    /// match pnpm's `EXEC_MODE` and are part of the CAFS contract.
-    #[test]
-    fn exec_constants_pin_pnpm_layout() {
-        assert_eq!(EXEC_MASK, 0o111);
-        assert_eq!(EXEC_MODE, 0o755);
-    }
-
-    /// Every tarball-shipped exec bit (`u+x`, `g+x`, `o+x`) flips
-    /// `is_executable` to `true`. Any-bit semantics matches
-    /// upstream's `modeIsExecutable`.
-    #[test]
-    fn is_executable_matches_any_exec_bit() {
-        assert!(!is_executable(0o644));
-        assert!(is_executable(0o744)); // user-only exec, the common npm shape
-        assert!(is_executable(0o755));
-        assert!(is_executable(0o050)); // group-only — still executable
-        assert!(is_executable(0o001)); // other-only — still executable
-    }
-
-    /// `make_file_executable` flips the exec bits on a freshly
-    /// created non-executable file. On Unix the mode must include
-    /// all three exec bits afterward; on Windows the call is a
-    /// no-op and we just assert it returns `Ok`.
-    #[test]
-    fn make_file_executable_sets_exec_bits_on_unix() {
-        let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
-        let file = tmp.as_file();
-        make_file_executable(file).expect("set permissions");
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mode = file.metadata().expect("stat").permissions().mode();
-            assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
-        }
-    }
-}
+mod tests;

--- a/pacquet/crates/fs/src/file_mode/tests.rs
+++ b/pacquet/crates/fs/src/file_mode/tests.rs
@@ -1,0 +1,38 @@
+use super::{EXEC_MASK, EXEC_MODE, is_executable};
+
+/// Sanity-pin the two on-disk constants. The mask is `--x--x--x`
+/// and the canonical executable mode is `rwxr-xr-x` — these
+/// match pnpm's `EXEC_MODE` and are part of the CAFS contract.
+#[test]
+fn exec_constants_pin_pnpm_layout() {
+    assert_eq!(EXEC_MASK, 0o111);
+    assert_eq!(EXEC_MODE, 0o755);
+}
+
+/// Every tarball-shipped exec bit (`u+x`, `g+x`, `o+x`) flips
+/// `is_executable` to `true`. Any-bit semantics matches
+/// upstream's `modeIsExecutable`.
+#[test]
+fn is_executable_matches_any_exec_bit() {
+    assert!(!is_executable(0o644));
+    assert!(is_executable(0o744)); // user-only exec, the common npm shape
+    assert!(is_executable(0o755));
+    assert!(is_executable(0o050)); // group-only — still executable
+    assert!(is_executable(0o001)); // other-only — still executable
+}
+
+/// `make_file_executable` flips the exec bits on a freshly
+/// created non-executable file. Only meaningful on Unix — the
+/// Windows arm of the function is a no-op and there is no
+/// permissions field to observe.
+#[cfg(unix)]
+#[test]
+fn make_file_executable_sets_exec_bits() {
+    use super::make_file_executable;
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
+    let file = tmp.as_file();
+    make_file_executable(file).expect("set permissions");
+    let mode = file.metadata().expect("stat").permissions().mode();
+    assert_eq!(mode & EXEC_MASK, EXEC_MASK, "all exec bits should be set, got {mode:o}");
+}

--- a/pacquet/crates/graph-hasher/src/engine_name.rs
+++ b/pacquet/crates/graph-hasher/src/engine_name.rs
@@ -238,15 +238,12 @@ mod tests {
     }
 
     /// `detect_node_version` returns the full version string with
-    /// the leading `v` stripped when `node --version` is reachable.
-    /// Skips silently when there is no `node` on `PATH` (we can't
-    /// assert presence in every test runner).
+    /// the leading `v` stripped. `node` is a hard prerequisite for
+    /// the test suite — if it isn't on `PATH` that's a test-env
+    /// bug, so we `expect` rather than skip.
     #[test]
-    fn detect_node_version_strips_leading_v_when_node_is_available() {
-        let Some(version) = detect_node_version() else {
-            eprintln!("`node` not on PATH; skipping version-detect test");
-            return;
-        };
+    fn detect_node_version_strips_leading_v() {
+        let version = detect_node_version().expect("`node` must be on PATH for the test suite");
         assert!(!version.starts_with('v'), "leading `v` must be stripped: {version:?}");
         let major = version.split('.').next().expect("at least one component");
         assert!(major.parse::<u32>().is_ok(), "major must be numeric: {version:?}");
@@ -257,10 +254,8 @@ mod tests {
     /// matches the leading component of the full version string.
     #[test]
     fn detect_node_major_matches_detect_node_version_leading_component() {
-        let (Some(major), Some(version)) = (detect_node_major(), detect_node_version()) else {
-            eprintln!("`node` not on PATH; skipping version-detect test");
-            return;
-        };
+        let major = detect_node_major().expect("`node` must be on PATH for the test suite");
+        let version = detect_node_version().expect("`node` must be on PATH for the test suite");
         let leading: u32 =
             version.split('.').next().expect("non-empty version").parse().expect("major numeric");
         assert_eq!(major, leading);

--- a/pacquet/crates/graph-hasher/src/engine_name.rs
+++ b/pacquet/crates/graph-hasher/src/engine_name.rs
@@ -192,7 +192,7 @@ fn detect_host_libc() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{engine_name, parse_node_version_output};
+    use super::{detect_node_major, detect_node_version, engine_name, parse_node_version_output};
     use pretty_assertions::assert_eq;
 
     /// Format matches pnpm's `${platform};${arch};node${major}`
@@ -235,5 +235,34 @@ mod tests {
         assert_eq!(parts.len(), 3, "expected three parts, got {name:?}");
         assert!(parts[2].starts_with("node"), "third part must start with `node`: {name:?}");
         assert!(parts[2][4..].parse::<u32>().is_ok(), "node version must be numeric: {name:?}");
+    }
+
+    /// `detect_node_version` returns the full version string with
+    /// the leading `v` stripped when `node --version` is reachable.
+    /// Skips silently when there is no `node` on `PATH` (we can't
+    /// assert presence in every test runner).
+    #[test]
+    fn detect_node_version_strips_leading_v_when_node_is_available() {
+        let Some(version) = detect_node_version() else {
+            eprintln!("`node` not on PATH; skipping version-detect test");
+            return;
+        };
+        assert!(!version.starts_with('v'), "leading `v` must be stripped: {version:?}");
+        let major = version.split('.').next().expect("at least one component");
+        assert!(major.parse::<u32>().is_ok(), "major must be numeric: {version:?}");
+    }
+
+    /// `detect_node_major` round-trips through `detect_node_version` and
+    /// the parser. When both are wired correctly the integer major
+    /// matches the leading component of the full version string.
+    #[test]
+    fn detect_node_major_matches_detect_node_version_leading_component() {
+        let (Some(major), Some(version)) = (detect_node_major(), detect_node_version()) else {
+            eprintln!("`node` not on PATH; skipping version-detect test");
+            return;
+        };
+        let leading: u32 =
+            version.split('.').next().expect("non-empty version").parse().expect("major numeric");
+        assert_eq!(major, leading);
     }
 }

--- a/pacquet/crates/graph-hasher/src/tests.rs
+++ b/pacquet/crates/graph-hasher/src/tests.rs
@@ -111,8 +111,46 @@ fn hash_object_string_length_counts_utf16_code_units() {
     assert_ne!(one_unit, two_bytes_ascii, "utf-16 length must differ from byte length");
 }
 
+/// `null`, booleans, and arrays each go through their own arm of
+/// the `serialize` dispatcher. The bytestream prefixes (`Null`,
+/// `bool:true|false`, `array:<N>:`) are part of the on-disk
+/// cache-key contract and must produce stable, distinct hashes
+/// — pin them to guard against silent divergence from
+/// `@pnpm/crypto.object-hasher`.
+#[test]
+fn hash_object_handles_null_bool_and_array_variants() {
+    // Same scalar wrapped in a single-key object so we can hash
+    // each independently. Pacquet's call sites only ever feed
+    // top-level objects.
+    let null_hash = hash_object(&json!({ "v": null }));
+    let true_hash = hash_object(&json!({ "v": true }));
+    let false_hash = hash_object(&json!({ "v": false }));
+    let array_hash = hash_object(&json!({ "v": [1, 2, 3] }));
+
+    // Each variant produces a non-empty, distinct hash. Collisions
+    // across variants would mean the discriminator prefixes were
+    // lost.
+    let all = [&null_hash, &true_hash, &false_hash, &array_hash];
+    for a in all {
+        assert!(!a.is_empty());
+    }
+    for (i, a) in all.iter().enumerate() {
+        for (j, b) in all.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "variant prefixes must distinguish hashes");
+            }
+        }
+    }
+
+    // Stable across calls.
+    assert_eq!(null_hash, hash_object(&json!({ "v": null })));
+    assert_eq!(array_hash, hash_object(&json!({ "v": [1, 2, 3] })));
+    // Array element order matters: `[1,2,3]` and `[3,2,1]` differ.
+    assert_ne!(array_hash, hash_object(&json!({ "v": [3, 2, 1] })));
+}
+
 fn hex_decode(hex: &str) -> Vec<u8> {
-    assert!(hex.len() % 2 == 0);
+    assert!(hex.len().is_multiple_of(2));
     (0..hex.len())
         .step_by(2)
         .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("hex digit"))

--- a/pacquet/crates/lockfile/src/freshness/tests.rs
+++ b/pacquet/crates/lockfile/src/freshness/tests.rs
@@ -383,6 +383,30 @@ fn no_importer_message_uses_bracket_quoted_id() {
     );
 }
 
+/// Multi-element `removed` and `modified` buckets exercise the
+/// plural arm of `noun_verb_for` *and* the comma separator inside
+/// the per-bucket loops. The single-item display test above only
+/// hits the singular branch and the first-iteration of the loop.
+#[test]
+fn spec_diff_display_lists_plural_removed_and_modified_with_separators() {
+    let mut diff = super::SpecDiff::default();
+    diff.removed.insert("alpha".to_string(), "^1.0.0".to_string());
+    diff.removed.insert("beta".to_string(), "^2.0.0".to_string());
+    diff.modified.insert("gamma".to_string(), ("^3.0.0".to_string(), "^4.0.0".to_string()));
+    diff.modified.insert("delta".to_string(), ("^0.1.0".to_string(), "^0.2.0".to_string()));
+    let rendered = diff.to_string();
+    // Plural noun + plural verb for n>1 (`were`).
+    assert!(rendered.contains("2 dependencies were removed: "), "got: {rendered:?}");
+    // Comma separator inside the removed loop.
+    assert!(
+        rendered.contains("alpha@^1.0.0, beta@^2.0.0")
+            || rendered.contains("beta@^2.0.0, alpha@^1.0.0"),
+        "expected comma-joined removed entries, got: {rendered:?}",
+    );
+    // Plural noun + plural verb for n>1 `modified` (`are`).
+    assert!(rendered.contains("2 dependencies are mismatched:"), "got: {rendered:?}");
+}
+
 /// Pinpoint singular-vs-plural wording per bucket so the n==1 case
 /// doesn't silently regress.
 #[test]

--- a/pacquet/crates/lockfile/src/pkg_name/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name/tests.rs
@@ -1,6 +1,7 @@
 use super::{ParsePkgNameError, PkgName};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
+use std::borrow::Cow;
 
 #[test]
 fn parse_ok() {
@@ -77,4 +78,29 @@ fn serialize() {
 
     case(PkgName { scope: Some("foo".to_string()), bare: "bar".to_string() }, "\"@foo/bar\"\n");
     case(PkgName { scope: None, bare: "foo-bar".to_string() }, "foo-bar\n");
+}
+
+/// `TryFrom<String>` and `TryFrom<Cow<'_, str>>` route through
+/// the validating parser. Owned and borrowed input forms must
+/// behave identically, since both back the serde deserializer
+/// and the public constructor in different contexts.
+#[test]
+fn try_from_owned_and_cow_route_through_parse() {
+    let from_string = PkgName::try_from("@foo/bar".to_string()).expect("valid scoped name parses");
+    assert_eq!(from_string.scope.as_deref(), Some("foo"));
+    assert_eq!(from_string.bare, "bar");
+
+    let from_cow = PkgName::try_from(Cow::Borrowed("foo-bar")).expect("valid bare name parses");
+    assert!(from_cow.scope.is_none());
+    assert_eq!(from_cow.bare, "foo-bar");
+
+    // Invalid input still propagates `ParsePkgNameError` from both
+    // entry points — pin that the error type matches.
+    let owned_err =
+        PkgName::try_from(String::new()).expect_err("empty string must fail validation");
+    assert!(matches!(owned_err, ParsePkgNameError::EmptyName));
+
+    let cow_err =
+        PkgName::try_from(Cow::Owned(String::new())).expect_err("empty cow must fail validation");
+    assert!(matches!(cow_err, ParsePkgNameError::EmptyName));
 }

--- a/pacquet/crates/lockfile/src/resolved_dependency/tests.rs
+++ b/pacquet/crates/lockfile/src/resolved_dependency/tests.rs
@@ -1,6 +1,7 @@
-use super::{ImporterDepVersion, ResolvedDependencySpec};
-use crate::PkgName;
+use super::{ImporterDepVersion, ParseImporterDepVersionError, ResolvedDependencySpec};
+use crate::{PkgName, PkgNameVerPeer, PkgVerPeer};
 use pretty_assertions::assert_eq;
+use std::borrow::Cow;
 
 /// Bare semver versions parse into `Regular` and round-trip through
 /// the string form.
@@ -129,4 +130,133 @@ fn resolved_key_returns_alias_name_for_alias_variant() {
 
     let link: ImporterDepVersion = "link:../shared".parse().unwrap();
     assert!(link.resolved_key(&importer_key).is_none());
+}
+
+/// `as_alias` returns `None` for non-`Alias` variants. The
+/// installer's alias-rename branch relies on this to skip
+/// regular and link-typed deps without an extra `match`.
+#[test]
+fn as_alias_returns_none_for_non_alias_variants() {
+    let regular: ImporterDepVersion = "4.0.0".parse().unwrap();
+    assert!(regular.as_alias().is_none());
+
+    let link: ImporterDepVersion = "link:../shared".parse().unwrap();
+    assert!(link.as_alias().is_none());
+}
+
+/// `ver_peer` returns the snapshot-key version slot for `Regular`
+/// and the alias's suffix for `Alias`, and `None` for `Link`.
+/// Mirrors the snapshot lookup the build-sequence builder does.
+#[test]
+fn ver_peer_returns_snapshot_version_for_each_variant() {
+    let regular: ImporterDepVersion = "17.0.2(react@17.0.2)".parse().unwrap();
+    let regular_ver = regular.ver_peer().expect("regular ver_peer");
+    assert_eq!(regular_ver.to_string(), "17.0.2(react@17.0.2)");
+
+    let alias: ImporterDepVersion = "react-dom@17.0.2(react@17.0.2)".parse().unwrap();
+    let alias_ver = alias.ver_peer().expect("alias ver_peer");
+    assert_eq!(alias_ver.to_string(), "17.0.2(react@17.0.2)");
+
+    let link: ImporterDepVersion = "link:../shared".parse().unwrap();
+    assert!(link.ver_peer().is_none());
+}
+
+/// Garbage input that is not `link:`, not an alias shape, and not
+/// a valid semver-with-peer surfaces as the bare-parse variant of
+/// the error. The wrapped error keeps the original value for
+/// diagnostics.
+#[test]
+fn parse_errors_on_invalid_bare_version() {
+    let err = "not a version".parse::<ImporterDepVersion>().unwrap_err();
+    match err {
+        ParseImporterDepVersionError::Parse { value, .. } => {
+            assert_eq!(value, "not a version");
+        }
+        other => panic!("expected Parse variant, got {other:?}"),
+    }
+}
+
+/// Garbage input that does look like an alias (leading `@`)
+/// but does not actually parse as `<name>@<ver>` surfaces as the
+/// `ParseAlias` variant of the error.
+#[test]
+fn parse_errors_on_invalid_alias_shape() {
+    let err = "@scope/no-at-sign".parse::<ImporterDepVersion>().unwrap_err();
+    match err {
+        ParseImporterDepVersionError::ParseAlias { value, .. } => {
+            assert_eq!(value, "@scope/no-at-sign");
+        }
+        other => panic!("expected ParseAlias variant, got {other:?}"),
+    }
+}
+
+/// `TryFrom<Cow<'_, str>>` defers to `FromStr` so the same shapes
+/// parse identically regardless of whether the caller holds borrowed
+/// or owned data. This is the entry point serde uses internally.
+#[test]
+fn try_from_cow_parses_all_three_shapes() {
+    let regular = ImporterDepVersion::try_from(Cow::Borrowed("4.0.0")).unwrap();
+    assert!(regular.as_regular().is_some());
+
+    let alias = ImporterDepVersion::try_from(Cow::Owned("react-dom@17.0.2".to_string())).unwrap();
+    assert!(alias.as_alias().is_some());
+
+    let link = ImporterDepVersion::try_from(Cow::Borrowed("link:../shared")).unwrap();
+    assert_eq!(link.as_link_target(), Some("../shared"));
+}
+
+/// Serialize `Alias` writes the full `<name>@<ver>` string, not the
+/// inner `PkgNameVerPeer`'s nested encoding. This is the shape
+/// pnpm-lock.yaml expects for aliased importer deps.
+#[test]
+fn serialize_alias_writes_name_at_version_string() {
+    let alias: ImporterDepVersion = "@zkochan/js-yaml@0.0.11".parse().unwrap();
+    let yaml = serde_saphyr::to_string(&alias).unwrap();
+    assert!(yaml.contains("@zkochan/js-yaml@0.0.11"), "got: {yaml}");
+}
+
+/// Serialize `Link` writes the `link:` prefix back. Mirrors pnpm's
+/// behavior when re-emitting a workspace-sibling dependency.
+#[test]
+fn serialize_link_writes_link_prefix() {
+    let link = ImporterDepVersion::Link("../shared".to_string());
+    let yaml = serde_saphyr::to_string(&link).unwrap();
+    assert!(yaml.contains("link:../shared"), "got: {yaml}");
+}
+
+/// `From<PkgVerPeer>` and `From<PkgNameVerPeer>` cover the two
+/// non-link constructors so callers can avoid spelling the variants
+/// out. Used by the lockfile builder when promoting a parsed
+/// `PkgVerPeer` to an importer-dep value.
+#[test]
+fn from_typed_versions_into_importer_dep_version() {
+    let ver: PkgVerPeer = "4.0.0".parse().unwrap();
+    let regular: ImporterDepVersion = ver.into();
+    assert!(matches!(regular, ImporterDepVersion::Regular(_)));
+
+    let alias_inner: PkgNameVerPeer = "react-dom@17.0.2".parse().unwrap();
+    let alias: ImporterDepVersion = alias_inner.into();
+    assert!(matches!(alias, ImporterDepVersion::Alias(_)));
+}
+
+/// `Display` matches the wire-string form `From<ImporterDepVersion> for String`
+/// emits — both branches go through the same arms. Pinning both
+/// guards against a divergence that would surface as a lockfile
+/// formatting bug.
+#[test]
+fn display_matches_string_conversion() {
+    let cases = [
+        "4.0.0",
+        "17.0.2(react@17.0.2)",
+        "@zkochan/js-yaml@0.0.11",
+        "react-dom@17.0.2(react@17.0.2)",
+        "link:../shared",
+    ];
+    for case in cases {
+        let parsed: ImporterDepVersion = case.parse().unwrap();
+        let via_display = format!("{parsed}");
+        let via_into: String = parsed.into();
+        assert_eq!(via_display, via_into, "Display vs From<_> for {case}");
+        assert_eq!(via_display, case);
+    }
 }

--- a/pacquet/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/save_lockfile/tests.rs
@@ -250,3 +250,95 @@ fn write_current_is_a_noop_for_empty_lockfile_with_no_existing_file() {
         .expect("write should succeed when target is missing");
     assert!(!virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME).exists());
 }
+
+/// `create_dir_all` failures (here, attempting to create a
+/// directory under a path that is actually a regular file)
+/// surface as the typed `CreateDir` error. Pins the error
+/// classification so a regression that bubbled the raw
+/// `io::Error` as `WriteFile` would fail this test.
+#[test]
+fn write_current_surfaces_create_dir_error_when_parent_is_a_file() {
+    let tmp = tempdir().expect("create tempdir");
+    // Make `tmp/blocker` a regular file, then ask to write the
+    // lockfile under `tmp/blocker/.pacquet`. `create_dir_all` will
+    // fail with `NotADirectory` (or `AlreadyExists` on some
+    // platforms) — either way it must land as `CreateDir`.
+    let blocker = tmp.path().join("blocker");
+    std::fs::write(&blocker, b"not a dir").expect("seed blocker file");
+
+    let virtual_store_dir = blocker.join(".pacquet");
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    let err = lockfile
+        .save_current_to_virtual_store_dir(&virtual_store_dir)
+        .expect_err("create_dir_all should fail on a regular-file ancestor");
+    assert!(
+        matches!(err, SaveLockfileError::CreateDir { .. }),
+        "expected CreateDir error, got: {err:?}",
+    );
+}
+
+/// Trying to remove an existing entry that is a directory (rather
+/// than a regular file) surfaces as `RemoveFile`. Mirrors
+/// upstream's strict file/dir distinction at the rimraf-equivalent
+/// step. Tests the not-NotFound arm of the empty-lockfile branch.
+#[cfg(unix)]
+#[test]
+fn write_current_surfaces_remove_file_error_when_target_is_a_directory() {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    // Pre-seed `lock.yaml` as a directory rather than a file.
+    // `fs::remove_file` rejects this with `IsADirectory` on Unix.
+    let dir_at_target = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    std::fs::create_dir(&dir_at_target).expect("seed directory at lock.yaml path");
+
+    let empty: Lockfile =
+        serde_saphyr::from_str("lockfileVersion: '9.0'\n").expect("parse empty lockfile");
+    let err = empty
+        .save_current_to_virtual_store_dir(&virtual_store_dir)
+        .expect_err("remove_file on a directory should error");
+    assert!(
+        matches!(err, SaveLockfileError::RemoveFile { .. }),
+        "expected RemoveFile error, got: {err:?}",
+    );
+    // The directory is still there — the failure was reported, not silently swallowed.
+    assert!(dir_at_target.is_dir());
+}
+
+/// `write_atomic`'s rename step fails when the target is an
+/// existing non-empty directory: Unix `rename(2)` returns
+/// `ENOTEMPTY` / `EISDIR`. Pins that the error surfaces as
+/// `RenameFile`, not as a generic write failure, and that the
+/// temp blob is cleaned up on the way out.
+#[cfg(unix)]
+#[test]
+fn write_atomic_rename_failure_surfaces_as_rename_file_error() {
+    let tmp = tempdir().expect("create tempdir");
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+    std::fs::create_dir_all(&virtual_store_dir).unwrap();
+    // Plant a *non-empty* directory at the target. `rename` over
+    // it must fail on every supported platform.
+    let dir_at_target = virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+    std::fs::create_dir(&dir_at_target).unwrap();
+    std::fs::write(dir_at_target.join("decoy"), b"x").unwrap();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    let err = lockfile
+        .save_current_to_virtual_store_dir(&virtual_store_dir)
+        .expect_err("rename over a non-empty directory should fail");
+    assert!(
+        matches!(err, SaveLockfileError::RenameFile { .. }),
+        "expected RenameFile error, got: {err:?}",
+    );
+    // The temp file write_atomic created next to the target must
+    // not have been left behind.
+    let leftovers: Vec<_> = std::fs::read_dir(&virtual_store_dir)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .filter(|name| {
+            let s = name.to_string_lossy();
+            s != Lockfile::CURRENT_FILE_NAME
+        })
+        .collect();
+    assert!(leftovers.is_empty(), "temp file should have been cleaned up, found: {leftovers:?}");
+}

--- a/pacquet/crates/lockfile/src/snapshot_dep_ref/tests.rs
+++ b/pacquet/crates/lockfile/src/snapshot_dep_ref/tests.rs
@@ -100,3 +100,26 @@ fn looks_like_alias_rules() {
         assert_eq!(looks_like_alias(input), expected);
     }
 }
+
+/// `ver_peer` accesses the version-with-peer portion of either
+/// variant: the inner `PkgVerPeer` for `Plain`, and the alias's
+/// `suffix` for `Alias`. Used by snapshot lookups that only care
+/// about the version slot.
+#[test]
+fn ver_peer_returns_inner_version_for_each_variant() {
+    let plain: SnapshotDepRef = "17.0.2(react@17.0.2)".parse().unwrap();
+    assert_eq!(plain.ver_peer().to_string(), "17.0.2(react@17.0.2)");
+
+    let alias: SnapshotDepRef = "react-dom@17.0.2(react@17.0.2)".parse().unwrap();
+    assert_eq!(alias.ver_peer().to_string(), "17.0.2(react@17.0.2)");
+}
+
+/// `From<PkgVerPeer>` is the infallible promotion path used by
+/// snapshot builders that already hold a parsed version. The
+/// resulting `SnapshotDepRef` is always `Plain`.
+#[test]
+fn from_pkg_ver_peer_produces_plain_variant() {
+    let ver = ver_peer("17.0.2(react@17.0.2)");
+    let dep: SnapshotDepRef = ver.clone().into();
+    assert_eq!(dep, SnapshotDepRef::Plain(ver));
+}

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -5,7 +5,10 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use tempfile::{NamedTempFile, tempdir};
 
-use super::{BundleDependencies, PackageManifest, convert_engines_runtime_to_dependencies};
+use super::{
+    BundleDependencies, PackageManifest, PackageManifestError,
+    convert_engines_runtime_to_dependencies, safe_read_package_json_from_dir,
+};
 use crate::DependencyGroup;
 use serde_json::json;
 use std::io::Write;
@@ -353,4 +356,85 @@ fn from_path_applies_convert_engines_runtime() {
         .and_then(|d| d.get("node"))
         .and_then(|v| v.as_str());
     assert_eq!(node_spec, Some("runtime:24.6.0"));
+}
+
+/// `from_path` surfaces `NoImporterManifestFound` (the typed
+/// equivalent of pnpm's `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`)
+/// when the path does not exist, rather than letting the
+/// underlying ENOENT escape as a generic IO error.
+#[test]
+fn from_path_errors_no_importer_when_missing() {
+    let dir = tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist").join("package.json");
+    let result = PackageManifest::from_path(missing.clone());
+    let err = match result {
+        Err(err) => err,
+        Ok(_) => panic!("missing package.json should not parse"),
+    };
+    assert!(
+        matches!(err, PackageManifestError::NoImporterManifestFound(_)),
+        "expected NoImporterManifestFound, got {err:?}",
+    );
+}
+
+/// `add_dependency` rejects manifests where the target
+/// dependency group exists but holds a non-object value (a quirk
+/// upstream allows on disk but cannot insert into). Pin that the
+/// error is the typed `InvalidAttribute` and not a panic.
+#[test]
+fn add_dependency_errors_when_field_is_not_an_object() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    // Pre-seed `dependencies` as a string instead of an object.
+    let raw = json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": "not an object",
+    });
+    std::fs::write(&path, serde_json::to_string_pretty(&raw).unwrap()).unwrap();
+
+    let mut manifest = PackageManifest::from_path(path).unwrap();
+    let err = manifest
+        .add_dependency("foo", "1.0.0", DependencyGroup::Prod)
+        .expect_err("non-object `dependencies` should reject insert");
+    match err {
+        PackageManifestError::InvalidAttribute(msg) => {
+            assert!(msg.contains("dependencies"), "got: {msg:?}");
+        }
+        other => panic!("expected InvalidAttribute, got {other:?}"),
+    }
+}
+
+/// `safe_read_package_json_from_dir` surfaces non-NotFound IO
+/// errors via `PackageManifestError::Io`, rather than swallowing
+/// them as `Ok(None)`. Mirrors upstream's contract: `null` is
+/// returned only on ENOENT.
+#[cfg(unix)]
+#[test]
+fn safe_read_surfaces_non_not_found_io_errors() {
+    let dir = tempdir().unwrap();
+    // Plant `package.json` as a directory rather than a file.
+    // `fs::read_to_string` returns `IsADirectory`, never `NotFound`.
+    std::fs::create_dir(dir.path().join("package.json")).unwrap();
+
+    let err = safe_read_package_json_from_dir(dir.path())
+        .expect_err("read_to_string on a directory should fail");
+    assert!(matches!(err, PackageManifestError::Io(_)), "expected Io error, got {err:?}",);
+}
+
+/// `convert_engines_runtime_to_dependencies` ignores `devEngines.runtime`
+/// entries whose value is neither an array nor a single object.
+/// Pin that the function returns without mutating the manifest in
+/// that case, instead of panicking.
+#[test]
+fn convert_engines_ignores_non_array_non_object_runtime_entries() {
+    let mut manifest = json!({
+        "name": "x",
+        "version": "1.0.0",
+        // `runtime` is a bare string — neither an object nor an array.
+        "devEngines": { "runtime": "not-supported" },
+    });
+    let before = manifest.clone();
+    convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+    assert_eq!(manifest, before, "manifest must be unchanged for unsupported `runtime` shape");
 }

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -419,7 +419,7 @@ fn safe_read_surfaces_non_not_found_io_errors() {
 
     let err = safe_read_package_json_from_dir(dir.path())
         .expect_err("read_to_string on a directory should fail");
-    assert!(matches!(err, PackageManifestError::Io(_)), "expected Io error, got {err:?}",);
+    assert!(matches!(err, PackageManifestError::Io(_)), "expected Io error, got {err:?}");
 }
 
 /// `convert_engines_runtime_to_dependencies` ignores `devEngines.runtime`

--- a/pacquet/crates/patching/Cargo.toml
+++ b/pacquet/crates/patching/Cargo.toml
@@ -21,3 +21,4 @@ sha2        = { workspace = true }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }
+text-block-macros = { workspace = true }

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -338,3 +338,122 @@ deleted file mode 100644
     apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
     assert!(!target.exists(), "deleted target must be gone");
 }
+
+/// Reading the patch-file path itself can fail with errors other
+/// than `NotFound` — here, the patch path is a directory rather
+/// than a file. The classifier must surface this as `ReadPatchFile`
+/// (not `PatchNotFound`).
+#[cfg(unix)]
+#[test]
+fn read_patch_file_surfaces_non_not_found_error() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    // Pass the directory itself as the patch path. `fs::read` on a
+    // directory returns `IsADirectory`, never `NotFound`.
+    let err = apply_patch_to_dir(patched.path(), patch_dir.path())
+        .expect_err("reading a directory as a patch file should fail");
+    assert!(
+        matches!(err, PatchApplyError::ReadPatchFile { .. }),
+        "expected ReadPatchFile error, got {err:?}",
+    );
+}
+
+/// A delete patch that does not consume the entire file leaves
+/// non-empty content behind after `diffy::apply`. The implementation
+/// must refuse to remove the file in that case rather than silently
+/// dropping the unpatched tail. Tests the `if !after.is_empty()`
+/// guard in the Delete arm.
+#[test]
+fn delete_patch_leaving_non_empty_result_errors_without_unlinking() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("partial.txt");
+    // Two lines on disk. The patch below claims to delete the file
+    // but only removes the first line — `diffy::apply` applies the
+    // single hunk and returns the unpatched tail (`stay\n`), which
+    // is non-empty, so the implementation must error.
+    fs::write(&target, "going away\nstay\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/partial.txt b/partial.txt
+deleted file mode 100644
+--- a/partial.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-going away
+",
+    );
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must refuse partial delete");
+    match err {
+        PatchApplyError::PatchFailed { message, .. } => {
+            assert!(message.contains("non-empty"), "got: {message:?}");
+        }
+        other => panic!("expected PatchFailed, got {other:?}"),
+    }
+    assert!(target.exists(), "target must NOT be unlinked when content remains");
+}
+
+/// Rename and copy file operations are not yet supported. A patch
+/// that contains one of these headers must error cleanly via
+/// `PatchFailed`, not silently no-op.
+#[test]
+fn rename_operation_errors_as_unsupported() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("from.txt"), "hello\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/from.txt b/to.txt
+similarity index 100%
+rename from from.txt
+rename to to.txt
+",
+    );
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("rename must error");
+    match err {
+        PatchApplyError::PatchFailed { message, .. } => {
+            assert!(
+                message.contains("rename/copy operations in patches are not yet supported"),
+                "got: {message:?}",
+            );
+        }
+        other => panic!("expected PatchFailed, got {other:?}"),
+    }
+}
+
+/// `Create` resolves the parent dir via `create_dir_all`. When the
+/// parent path is a regular file rather than a directory, that call
+/// fails and must surface as `PatchFailed` with a `create parent of`
+/// prefix.
+#[cfg(unix)]
+#[test]
+fn create_with_unwritable_parent_path_errors() {
+    let patched = tempdir().unwrap();
+    // Plant a regular file where the patch wants to create the
+    // nested target's parent directory.
+    fs::write(patched.path().join("blocker"), b"not a dir").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/blocker/nested.txt b/blocker/nested.txt
+new file mode 100644
+--- /dev/null
++++ b/blocker/nested.txt
+@@ -0,0 +1 @@
++hi
+",
+    );
+
+    let err = apply_patch_to_dir(patched.path(), &patch).expect_err("create_dir_all must fail");
+    match err {
+        PatchApplyError::PatchFailed { message, .. } => {
+            assert!(message.contains("create parent of"), "got: {message:?}");
+        }
+        other => panic!("expected PatchFailed, got {other:?}"),
+    }
+}

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -2,6 +2,7 @@ use crate::apply::{PatchApplyError, apply_patch_to_dir};
 use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::tempdir;
+use text_block_macros::text_block_fnl;
 
 /// Mirrors the upstream `is-positive` fixture at
 /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/installing/deps-restorer/test/fixtures/simple-with-patch/patches/is-positive.patch>:
@@ -375,14 +376,14 @@ fn delete_patch_leaving_non_empty_result_errors_without_unlinking() {
     let patch_dir = tempdir().unwrap();
     let patch = write_patch(
         patch_dir.path(),
-        "\
-diff --git a/partial.txt b/partial.txt
-deleted file mode 100644
---- a/partial.txt
-+++ /dev/null
-@@ -1 +0,0 @@
--going away
-",
+        text_block_fnl! {
+            "diff --git a/partial.txt b/partial.txt"
+            "deleted file mode 100644"
+            "--- a/partial.txt"
+            "+++ /dev/null"
+            "@@ -1 +0,0 @@"
+            "-going away"
+        },
     );
 
     let err = apply_patch_to_dir(patched.path(), &patch).expect_err("must refuse partial delete");
@@ -405,12 +406,12 @@ fn rename_operation_errors_as_unsupported() {
     let patch_dir = tempdir().unwrap();
     let patch = write_patch(
         patch_dir.path(),
-        "\
-diff --git a/from.txt b/to.txt
-similarity index 100%
-rename from from.txt
-rename to to.txt
-",
+        text_block_fnl! {
+            "diff --git a/from.txt b/to.txt"
+            "similarity index 100%"
+            "rename from from.txt"
+            "rename to to.txt"
+        },
     );
 
     let err = apply_patch_to_dir(patched.path(), &patch).expect_err("rename must error");
@@ -439,14 +440,14 @@ fn create_with_unwritable_parent_path_errors() {
     let patch_dir = tempdir().unwrap();
     let patch = write_patch(
         patch_dir.path(),
-        "\
-diff --git a/blocker/nested.txt b/blocker/nested.txt
-new file mode 100644
---- /dev/null
-+++ b/blocker/nested.txt
-@@ -0,0 +1 @@
-+hi
-",
+        text_block_fnl! {
+            "diff --git a/blocker/nested.txt b/blocker/nested.txt"
+            "new file mode 100644"
+            "--- /dev/null"
+            "+++ b/blocker/nested.txt"
+            "@@ -0,0 +1 @@"
+            "+hi"
+        },
     );
 
     let err = apply_patch_to_dir(patched.path(), &patch).expect_err("create_dir_all must fail");

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -77,3 +77,67 @@ async fn fetch_from_registry_attaches_authorization_header() {
     assert_eq!(pkg.name, "acme");
     mock.assert_async().await;
 }
+
+fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package {
+    let versions_map = versions
+        .iter()
+        .map(|v| {
+            (
+                v.to_string(),
+                PackageVersion {
+                    name: name.to_string(),
+                    version: Version::parse(v).unwrap(),
+                    dist: PackageDistribution::default(),
+                    dependencies: None,
+                    dev_dependencies: None,
+                    peer_dependencies: None,
+                },
+            )
+        })
+        .collect();
+    let mut dist_tags = HashMap::new();
+    dist_tags.insert("latest".to_string(), latest.to_string());
+    Package { name: name.to_string(), dist_tags, versions: versions_map, mutex: Default::default() }
+}
+
+/// `Package` equality is by `name` only; the mutex and versions
+/// HashMap (whose iteration order is non-deterministic) are
+/// excluded. Two packages with the same name compare equal even
+/// when their `versions` maps differ — this lets call sites
+/// dedupe in-flight metadata fetches against the package name.
+#[test]
+fn package_equality_compares_by_name_only() {
+    let lhs = package_with_versions("acme", &["1.0.0"], "1.0.0");
+    let rhs = package_with_versions("acme", &["2.0.0"], "2.0.0");
+    assert_eq!(lhs, rhs);
+
+    let other = package_with_versions("widget", &["1.0.0"], "1.0.0");
+    assert!(lhs != other);
+}
+
+/// `latest()` looks up the version named under the `latest`
+/// dist-tag and returns the corresponding `PackageVersion`.
+#[test]
+fn latest_returns_version_pointed_to_by_dist_tag() {
+    let pkg = package_with_versions("acme", &["1.0.0", "2.0.0", "3.0.0"], "2.0.0");
+    let latest = pkg.latest();
+    assert_eq!(latest.version.to_string(), "2.0.0");
+}
+
+/// `pinned_version` picks the highest version inside the given
+/// range, mirroring `node-semver`'s `maxSatisfying`.
+#[test]
+fn pinned_version_picks_highest_matching() {
+    let pkg = package_with_versions("acme", &["1.0.0", "1.2.0", "1.5.3", "2.0.0"], "2.0.0");
+    let picked =
+        pkg.pinned_version("^1.0.0").expect("at least one 1.x version satisfies the range");
+    assert_eq!(picked.version.to_string(), "1.5.3");
+}
+
+/// `pinned_version` returns `None` when no version satisfies the
+/// range, rather than panicking or falling back to `latest`.
+#[test]
+fn pinned_version_returns_none_when_no_match() {
+    let pkg = package_with_versions("acme", &["1.0.0", "1.2.0"], "1.2.0");
+    assert!(pkg.pinned_version("^2.0.0").is_none());
+}

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -112,7 +112,7 @@ fn package_equality_compares_by_name_only() {
     assert_eq!(lhs, rhs);
 
     let other = package_with_versions("widget", &["1.0.0"], "1.0.0");
-    assert!(lhs != other);
+    assert_ne!(lhs, other);
 }
 
 /// `latest()` looks up the version named under the `latest`

--- a/pacquet/crates/workspace-state/src/tests.rs
+++ b/pacquet/crates/workspace-state/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    NodeLinker, ProjectEntry, WorkspaceState, WorkspaceStateSettings, get_file_path,
-    load_workspace_state, now_millis, update_workspace_state,
+    LoadWorkspaceStateError, NodeLinker, ProjectEntry, UpdateWorkspaceStateError, WorkspaceState,
+    WorkspaceStateSettings, get_file_path, load_workspace_state, now_millis,
+    update_workspace_state,
 };
 use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
@@ -94,4 +95,74 @@ fn node_linker_serializes_lowercase() {
     assert_eq!(value, serde_json::Value::from("hoisted"));
     let value = serde_json::to_value(NodeLinker::Pnp).expect("serialize");
     assert_eq!(value, serde_json::Value::from("pnp"));
+}
+
+/// `update_workspace_state` fails with the typed `CreateDir`
+/// variant when `node_modules` can't be created — here, because
+/// the workspace dir is itself a regular file blocking the
+/// parent path. Pins that the error is classified as a directory
+/// failure and not collapsed into `WriteFile`.
+#[test]
+fn update_surfaces_create_dir_error_when_workspace_is_a_regular_file() {
+    let tmp = tempdir().expect("create temp dir");
+    // The "workspace dir" is actually a file, so create_dir_all on
+    // `<file>/node_modules` must fail.
+    let blocker = tmp.path().join("blocker");
+    std::fs::write(&blocker, b"not a dir").expect("seed blocker file");
+
+    let state = WorkspaceState {
+        last_validated_timestamp: 0,
+        projects: BTreeMap::new(),
+        pnpmfiles: vec![],
+        filtered_install: false,
+        config_dependencies: None,
+        settings: WorkspaceStateSettings::default(),
+    };
+    let err = update_workspace_state(&blocker, &state)
+        .expect_err("create_dir_all on a regular-file ancestor should fail");
+    assert!(
+        matches!(err, UpdateWorkspaceStateError::CreateDir { .. }),
+        "expected CreateDir error, got {err:?}",
+    );
+}
+
+/// `load_workspace_state` surfaces non-NotFound read errors via
+/// the typed `ReadFile` variant. Here we make the target a
+/// directory: `read_to_string` on a directory returns
+/// `IsADirectory` (or `Other`) on Unix, never `NotFound`, which
+/// keeps the early-return arm out of the way.
+#[cfg(unix)]
+#[test]
+fn load_surfaces_read_file_error_when_target_is_a_directory() {
+    let tmp = tempdir().expect("create temp dir");
+    let workspace_dir = tmp.path();
+    let target = get_file_path(workspace_dir);
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    // Plant a directory where the state file should be.
+    std::fs::create_dir(&target).expect("seed directory at state path");
+
+    let err =
+        load_workspace_state(workspace_dir).expect_err("read_to_string on a directory should fail");
+    assert!(
+        matches!(err, LoadWorkspaceStateError::ReadFile { .. }),
+        "expected ReadFile error, got {err:?}",
+    );
+}
+
+/// `load_workspace_state` surfaces malformed JSON via the typed
+/// `ParseJson` variant. Pins that a corrupt state file doesn't
+/// collapse into `ReadFile` or `Ok(None)`.
+#[test]
+fn load_surfaces_parse_json_error_on_malformed_state() {
+    let tmp = tempdir().expect("create temp dir");
+    let workspace_dir = tmp.path();
+    let target = get_file_path(workspace_dir);
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    std::fs::write(&target, b"{ not valid json").expect("seed malformed state");
+
+    let err = load_workspace_state(workspace_dir).expect_err("malformed JSON should fail to parse");
+    assert!(
+        matches!(err, LoadWorkspaceStateError::ParseJson { .. }),
+        "expected ParseJson error, got {err:?}",
+    );
 }


### PR DESCRIPTION
Adds 44 unit + integration tests to close the easier targets from a `cargo llvm-cov` pass over the `pacquet/` workspace, lifting line coverage on the touched files without refactoring any production code.

## What's covered now

- **Pure logic** — `lockfile::resolved_dependency` (`From` / `Display` / `Serialize` / `TryFrom<Cow>` arms), `lockfile::{freshness, pkg_name, snapshot_dep_ref}`, `registry::package` (`PartialEq` / `latest` / `pinned_version`), `graph-hasher::{engine_name, object_hasher}` (Node-version detection + null / bool / array dispatch), `package-manifest` (engines-runtime conversion edge cases), `fs::file_mode`, `executor::execute_shell`.
- **I/O error classifications via real fixtures** — `lockfile::save_lockfile`, `workspace-state`, `patching::apply`, and `package-manifest::safe_read_package_json_from_dir` get coverage for their typed `CreateDir` / `RemoveFile` / `RenameFile` / `ReadFile` / `ParseJson` arms by planting a regular file or directory where the writer expects something else. No DI fakes needed — these branches are reachable through real filesystem state, which matches the "prefer real fixtures" rule the new style guide added in #11708.
- **New integration tests** — `pacquet run <script>` (happy path, extra-arg forwarding, missing-script with and without `--if-present`).

## Out of scope

The bigger gaps that *do* need the `Sys: <FsCapability + …>` seam from the [DI section of `CODE_STYLE_GUIDE.md`](https://github.com/pnpm/pnpm/blob/02f8138f/pacquet/CODE_STYLE_GUIDE.md#dependency-injection-for-tests) — `fs::ensure_file` rename retry / exhausted temp paths, `install_package_by_snapshot.rs` binary / git / directory resolution, `cmd-shim::link_bins` remaining error arms — are left for follow-ups. They need new `Fs*` capabilities on `Host` or fetcher fakes, which is more invasive than a tests-only PR should be.

## Drive-by

- Bumped `hex_decode` in `graph-hasher::tests` to `is_multiple_of` so test-time clippy stays clean on Rust 1.95.
- Dropped a trailing comma in a single-line `assert!` in `package-manifest/src/tests.rs` to satisfy Dylint's `perfectionist::macro-trailing-comma`.
- Merged `main` to pick up #11708.

## Test plan

- [x] `cargo nextest run` on every touched crate after merging `main` — 321 tests pass, including all the new ones.
- [x] `cargo clippy --locked --tests` on touched crates passes with `--deny warnings`.
- [x] `cargo fmt --check` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added many unit and integration tests across the project: CLI script execution and argument forwarding, Unix-gated shell/engine detection checks, file-mode and filesystem edge cases, hash/serialization/manifest/lockfile behaviors, patch-application error cases, package/version selection, and workspace state error handling.

* **Chores**
  * Added a development dependency for test utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->