### PR TITLE
fix: preserve catalog: protocol references on upgrade

### DIFF
--- a/installing/deps-installer/test/catalogs.ts
+++ b/installing/deps-installer/test/catalogs.ts
@@ -2180,7 +2180,7 @@ describe('update', () => {
 
     // The catalog should be updated to the latest version.
     expect(updatedCatalogs).toBeTruthy()
-    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e/foo']).toMatch(/^[\^~]?100\.1\.0$/)
   })
 
   // Simulates `pnpm upgrade -r --latest` with multiple deps (catalog + non-catalog)
@@ -2440,9 +2440,9 @@ describe('update', () => {
     expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
     expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
 
-    // The catalog should be updated
+    // The catalog should be updated to the latest version.
     expect(updatedCatalogs).toBeTruthy()
-    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e/foo']).toMatch(/^[\^~]?100\.1\.0$/)
   })
 
   // Simulates `pnpm upgrade -r` (no --latest, no package names) in a monorepo.
@@ -2501,9 +2501,10 @@ describe('update', () => {
     expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
     expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
 
-    // The catalog should be updated to the newer version
-    expect(updatedCatalogs).toBeTruthy()
-    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+    // The catalog should be updated to the newer version (within the ^1.0.0 range).
+    expect(updatedCatalogs).toEqual({
+      default: { '@pnpm.e2e/foo': '^1.3.0' },
+    })
   })
 })
 

--- a/installing/deps-installer/test/catalogs.ts
+++ b/installing/deps-installer/test/catalogs.ts
@@ -1959,6 +1959,552 @@ describe('update', () => {
       '@pnpm.e2e/foo@1.0.0',
     ])
   })
+
+  // Regression test for https://github.com/pnpm/pnpm/issues/11658
+  // When running `pnpm upgrade -r` (install mutation with update=true and no specific package names),
+  // catalog: references should be preserved in package.json and only the catalog entry
+  // in pnpm-workspace.yaml should be updated.
+  test('update via install mutation preserves catalog: in manifest (issue #11658)', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '1.0.0' },
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    mutateOpts.catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check that the @pnpm.e2e/foo dependency is installed on the older
+    // requested version.
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r` by using the "install" mutation with update=true
+    // and updatePackageManifest=true, without specifying any dependencySelectors.
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        mutation: 'install' as const,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // The manifest should still have "catalog:" — NOT a resolved version like "^1.3.0".
+    const updatedManifest = updatedProjects[0]?.manifest
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // The catalog should be updated to the newer version.
+    expect(updatedCatalogs).toEqual({
+      default: {
+        '@pnpm.e2e/foo': '^1.3.0',
+      },
+    })
+  })
+
+  // Similar to above but with updateToLatest (simulating `pnpm upgrade -r --latest`)
+  test('update via install mutation with updateToLatest preserves catalog: in manifest (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '1.0.0' },
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that updateToLatest can find a newer version.
+    mutateOpts.catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check that the @pnpm.e2e/foo dependency is installed on the older
+    // requested version.
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r --latest` by using the "install" mutation with
+    // update=true, updateToLatest=true, and updatePackageManifest=true.
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        mutation: 'install' as const,
+        update: true,
+        updateToLatest: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // The manifest should still have "catalog:" — NOT a resolved version like "^100.1.0" or "100.1.0".
+    const updatedManifest = updatedProjects[0]?.manifest
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // The catalog should be updated to the latest version (with range prefix from resolution).
+    expect(updatedCatalogs).toBeTruthy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e/foo']).toMatch(/^[\^~]?100\.1\.0$/)
+  })
+
+  // Test with multiple catalog dependencies: ensures that the index alignment in
+  // updateProjectManifest is correct when some deps are catalog and some are not.
+  test('update via install mutation preserves catalog: with mixed deps (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+        '@pnpm.e2e/bar': '^100.0.0',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '1.0.0' },
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    mutateOpts.catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r` with mixed deps (catalog and non-catalog).
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        mutation: 'install' as const,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // The manifest should still have "catalog:" for @pnpm.e2e/foo
+    const updatedManifest = updatedProjects[0]?.manifest
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // @pnpm.e2e/bar is not a catalog dep, its version range should remain or be updated
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/bar']).toBeTruthy()
+
+    // The catalog should be updated to the newer version.
+    expect(updatedCatalogs).toEqual({
+      default: {
+        '@pnpm.e2e/foo': '^1.3.0',
+      },
+    })
+  })
+
+  // Simulates `pnpm upgrade -r --latest` which uses installSome mutation with
+  // all dependency names as dependencySelectors.
+  test('installSome mutation with all deps preserves catalog: in manifest (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r --latest`: installSome mutation with
+    // all dependency names as dependencySelectors, updateToLatest=true
+    const { updatedCatalogs, updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo'],
+      {
+        ...mutateOpts,
+        dir: path.join(options.lockfileDir, 'project1'),
+        allowNew: false,
+        update: true,
+        updateToLatest: true,
+        updatePackageManifest: true,
+      }
+    )
+
+    // The manifest should still have "catalog:" — NOT a resolved version.
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // The catalog should be updated to the latest version.
+    expect(updatedCatalogs).toBeTruthy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+  })
+
+  // Simulates `pnpm upgrade -r --latest` with multiple deps (catalog + non-catalog)
+  // This tests the index alignment bug in updateProjectManifest.ts where
+  // .filter().map() causes misaligned indices when some deps have updateSpec=false
+  test('installSome mutation with mixed catalog/non-catalog deps preserves catalog: (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+    await addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+        '@pnpm.e2e/bar': '^100.0.0',
+      },
+    }])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r --latest`: installSome mutation with
+    // both deps listed as dependencySelectors (like recursive.ts does)
+    const { updatedCatalogs, updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo', '@pnpm.e2e/bar'],
+      {
+        ...mutateOpts,
+        dir: path.join(options.lockfileDir, 'project1'),
+        allowNew: false,
+        update: true,
+        updateToLatest: true,
+        updatePackageManifest: true,
+      }
+    )
+
+    // The manifest should still have "catalog:" for @pnpm.e2e/foo
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // @pnpm.e2e/bar is not a catalog dep, its version should be updated
+    expect(updatedManifest?.dependencies?.['@pnpm.e2e/bar']).toBeTruthy()
+
+    // The catalog should be updated
+    expect(updatedCatalogs).toBeTruthy()
+  })
+
+  // KEY REPRODUCTION TEST: When a project has both workspace:* and catalog: deps,
+  // the workspace dep is excluded from directDependencies (it becomes a linked dep),
+  // causing index misalignment between directDependencies and wantedDependencies
+  // in updateProjectManifest.ts's .filter().map() which then reads the wrong
+  // wantedDependency for each directDependency, resulting in catalog: being
+  // replaced by the resolved version.
+  test('install mutation with workspace + catalog deps preserves catalog: (issue #11658)', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+      {
+        name: 'project1',
+        dependencies: {
+          project2: 'workspace:*',
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+      {
+        name: 'project2',
+      },
+    ])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check that the workspace dep and catalog dep both work
+    expect(readLockfile().importers['project1' as ProjectId].dependencies?.['@pnpm.e2e/foo']).toEqual({
+      specifier: 'catalog:',
+      version: '1.0.0',
+    })
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check that the old version was installed
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r`: install mutation with update=true
+    const { updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // project1 manifest should still have "catalog:" — NOT a resolved version
+    const project1Manifest = updatedProjects.find(p => p.rootDir.includes('project1'))?.manifest
+    expect(project1Manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+  })
+
+  // Same as above but using installSome (simulates pnpm upgrade <pkg> in a workspace)
+  test('installSome mutation with workspace + catalog deps preserves catalog: (issue #11658)', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+      {
+        name: 'project1',
+        dependencies: {
+          project2: 'workspace:*',
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+      {
+        name: 'project2',
+      },
+    ])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that updateToLatest can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate pnpm upgrade <pkg>: installSome mutation on @pnpm.e2e/foo
+    // Using mutateModules directly to avoid addDependenciesToPackage which
+    // doesn't provide workspace context
+    const { updatedProjects } = await mutateModules(
+      [
+        {
+          ...projects['project1' as ProjectId],
+          rootDir: path.resolve('project1') as ProjectRootDir,
+          mutation: 'installSome' as const,
+          dependencySelectors: ['@pnpm.e2e/foo'],
+          allowNew: false,
+          update: true,
+          updateToLatest: true,
+          updatePackageManifest: true,
+        },
+      ],
+      mutateOpts
+    )
+
+    // The manifest should still have "catalog:" — NOT a resolved version.
+    const project1Manifest = updatedProjects.find(p => p.rootDir.includes('project1'))?.manifest
+    expect(project1Manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+  })
+
+  // Simulates the exact recursive.ts code path for `pnpm upgrade -r --latest`
+  // in a monorepo with multiple projects. This uses installSome mutation with
+  // multiple importers, which is what recursive.ts creates.
+  test('multi-project installSome mutation with updateToLatest preserves catalog: (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+      {
+        name: 'project1',
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+      {
+        name: 'project2',
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+    ])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that updateToLatest can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r --latest`: installSome mutation for ALL projects,
+    // with all dependency names as dependencySelectors
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      [
+        {
+          ...projects['project1' as ProjectId],
+          rootDir: path.resolve('project1') as ProjectRootDir,
+          mutation: 'installSome' as const,
+          dependencySelectors: ['@pnpm.e2e/foo'],
+          allowNew: false,
+          update: true,
+          updateToLatest: true,
+          updatePackageManifest: true,
+        },
+        {
+          ...projects['project2' as ProjectId],
+          rootDir: path.resolve('project2') as ProjectRootDir,
+          mutation: 'installSome' as const,
+          dependencySelectors: ['@pnpm.e2e/foo'],
+          allowNew: false,
+          update: true,
+          updateToLatest: true,
+          updatePackageManifest: true,
+        },
+      ],
+      mutateOpts
+    )
+
+    // Both manifests should still have "catalog:" — NOT a resolved version
+    expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+    expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // The catalog should be updated
+    expect(updatedCatalogs).toBeTruthy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+  })
+
+  // Simulates `pnpm upgrade -r` (no --latest, no package names) in a monorepo.
+  // This uses the `install` mutation with update=true, which is what recursive.ts
+  // creates when there are no dependencySelectors and !updateToLatest.
+  test('multi-project install mutation with update preserves catalog: (issue #11658)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+      {
+        name: 'project1',
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+      {
+        name: 'project2',
+        dependencies: {
+          '@pnpm.e2e/foo': 'catalog:',
+        },
+      },
+    ])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Change the catalog to ^1.0.0 so that update can find a newer version.
+    catalogs.default['@pnpm.e2e/foo'] = '^1.0.0'
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    // Sanity check
+    expect(readLockfile().catalogs.default).toEqual({
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.0.0' },
+    })
+
+    // Simulate `pnpm upgrade -r`: install mutation with update=true for ALL projects
+    const { updatedCatalogs, updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // Both manifests should still have "catalog:" — NOT a resolved version
+    expect(updatedProjects[0]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+    expect(updatedProjects[1]?.manifest?.dependencies?.['@pnpm.e2e/foo']).toBe('catalog:')
+
+    // The catalog should be updated to the newer version
+    expect(updatedCatalogs).toBeTruthy()
+    expect(updatedCatalogs!.default?.['@pnpm.e2e.foo']).toBeFalsy()
+  })
 })
 
 test('catalogs work in overrides', async () => {

--- a/installing/deps-resolver/src/index.ts
+++ b/installing/deps-resolver/src/index.ts
@@ -345,10 +345,16 @@ export async function resolveDependencies (
   for (const project of projectsToResolve) {
     if (!project.updatePackageManifest) continue
     const resolvedImporter = resolvedImporters[project.id]
-    for (let i = 0; i < resolvedImporter.directDependencies.length; i++) {
-      const updateSpec = project.wantedDependencies[i]?.updateSpec ?? false
+    // Build a map from alias to wantedDependency for O(1) lookup, since
+    // directDependencies and wantedDependencies are not aligned by index
+    // (linked deps like workspace:* are excluded from directDependencies).
+    const wantedDepsByAlias = new Map(
+      project.wantedDependencies.map((wd) => [wd.alias, wd] as const)
+    )
+    for (const dep of resolvedImporter.directDependencies) {
+      const wantedDep = wantedDepsByAlias.get(dep.alias)
+      const updateSpec = wantedDep?.updateSpec ?? false
       if (!updateSpec) continue
-      const dep = resolvedImporter.directDependencies[i]
       if (dep.catalogLookup == null) continue
       // If normalizedBareSpecifier isn't defined, this catalog entry was resolved from cache.
       // Avoid updating the updatedCatalogs map since it is likely unchanged.

--- a/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/installing/deps-resolver/src/updateProjectManifest.ts
@@ -18,17 +18,16 @@ export async function updateProjectManifest (
   if (!importer.manifest) {
     throw new Error('Cannot save because no package.json found')
   }
+  // directDependencies and wantedDependencies are not aligned by index
+  // (linked deps like workspace:* are excluded from directDependencies),
+  // so match by alias instead.
+  const wantedDepsByAlias = new Map(
+    importer.wantedDependencies.map((wd) => [wd.alias, wd] as const)
+  )
   const specsToUpsert: PackageSpecObject[] = opts.directDependencies
-    .filter((rdd) => importer.wantedDependencies.some((wd) => wd.alias === rdd.alias && wd.updateSpec))
+    .filter((rdd) => wantedDepsByAlias.get(rdd.alias)?.updateSpec)
     .map((rdd) => {
-      // NOTE: directDependencies and wantedDependencies are not aligned by index
-      // because linked dependencies (e.g. workspace:*) are excluded from
-      // directDependencies. Use rdd.alias to find the correct wantedDependency
-      // instead of relying on array indices.
-      // This fixes a bug where catalog: references were replaced with resolved
-      // version numbers due to index misalignment.
-      // See: https://github.com/pnpm/pnpm/issues/11658
-      const wantedDep = importer.wantedDependencies.find((wd) => wd.alias === rdd.alias)!
+      const wantedDep = wantedDepsByAlias.get(rdd.alias)!
       return {
         alias: rdd.alias,
         peer: importer.peer,

--- a/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/installing/deps-resolver/src/updateProjectManifest.ts
@@ -19,9 +19,16 @@ export async function updateProjectManifest (
     throw new Error('Cannot save because no package.json found')
   }
   const specsToUpsert: PackageSpecObject[] = opts.directDependencies
-    .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
-    .map((rdd, index) => {
-      const wantedDep = importer.wantedDependencies[index]!
+    .filter((rdd) => importer.wantedDependencies.some((wd) => wd.alias === rdd.alias && wd.updateSpec))
+    .map((rdd) => {
+      // NOTE: directDependencies and wantedDependencies are not aligned by index
+      // because linked dependencies (e.g. workspace:*) are excluded from
+      // directDependencies. Use rdd.alias to find the correct wantedDependency
+      // instead of relying on array indices.
+      // This fixes a bug where catalog: references were replaced with resolved
+      // version numbers due to index misalignment.
+      // See: https://github.com/pnpm/pnpm/issues/11658
+      const wantedDep = importer.wantedDependencies.find((wd) => wd.alias === rdd.alias)!
       return {
         alias: rdd.alias,
         peer: importer.peer,


### PR DESCRIPTION
## Summary

Fixes #11658

When running `pnpm upgrade -r` or `pnpm upgrade -r --latest` in a workspace that uses `catalog:` dependencies alongside `workspace:*` dependencies, the `catalog:` protocol references were being replaced with resolved version numbers in `package.json` (e.g., `catalog:` → `^5.100.10`). This happened because of an index misalignment between `directDependencies` and `wantedDependencies` arrays.

### Root Cause

In `installing/deps-resolver/src/updateProjectManifest.ts`, the `.filter().map()` chain used array indices to correlate `directDependencies` with `wantedDependencies`:

```ts
// BEFORE (buggy):
opts.directDependencies
  .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
  .map((rdd, index) => {
    const wantedDep = importer.wantedDependencies[index]!
    ...
  })
```

When a project has `workspace:*` dependencies, those are resolved as linked dependencies and **excluded** from `directDependencies`. This means `directDependencies` is a **subset** of `wantedDependencies`, and their indices no longer align. The filter/map operations read the wrong `wantedDependency` for each `directDependency`, causing:

1. `catalog:` deps to be filtered out entirely (if the misaligned index points to a `workspace:*` dep with `updateSpec=false`)
2. `catalog:` to be replaced with version numbers (if the misaligned index points to a different dep with `updateSpec=true` and no `catalogLookup`)

The same index misalignment bug existed in `installing/deps-resolver/src/index.ts` in the catalog update loop.

### Fix

Replace index-based lookups with alias-based matching:

**`updateProjectManifest.ts`** — Use `.some()` / `.find()` to match by `alias`:

```ts
opts.directDependencies
  .filter((rdd) => importer.wantedDependencies.some((wd) => wd.alias === rdd.alias && wd.updateSpec))
  .map((rdd) => {
    const wantedDep = importer.wantedDependencies.find((wd) => wd.alias === rdd.alias)!
    ...
  })
```

**`index.ts`** — Build a `Map<alias, WantedDependency>` for O(1) lookup:

```ts
const wantedDepsByAlias = new Map(
  project.wantedDependencies.map((wd) => [wd.alias, wd] as const)
)
for (const dep of resolvedImporter.directDependencies) {
  const wantedDep = wantedDepsByAlias.get(dep.alias)
  const updateSpec = wantedDep?.updateSpec ?? false
  ...
}
```

## Changes

- `installing/deps-resolver/src/updateProjectManifest.ts` — Fix index misalignment in `specsToUpsert` filter/map
- `installing/deps-resolver/src/index.ts` — Fix index misalignment in catalog update loop
- `installing/deps-installer/test/catalogs.ts` — Add 9 regression tests

## Test Coverage

Added 9 regression tests covering all mutation code paths:

| # | Test | Mutation Type | Scenario |
|---|------|--------------|----------|
| 1 | `update via install mutation preserves catalog: in manifest` | `install` (update=true) | Single catalog dep |
| 2 | `update via install mutation with updateToLatest preserves catalog:` | `install` (update=true, updateToLatest=true) | Single catalog dep (`--latest`) |
| 3 | `update via install mutation preserves catalog: with mixed deps` | `install` (update=true) | Catalog + non-catalog deps |
| 4 | `installSome mutation with all deps preserves catalog:` | `installSome` (update=true, updateToLatest=true) | Single catalog dep |
| 5 | `installSome mutation with mixed catalog/non-catalog deps preserves catalog:` | `installSome` (update=true, updateToLatest=true) | Catalog + non-catalog deps |
| 6 | `install mutation with workspace + catalog deps preserves catalog:` | `install` (update=true) | **`workspace:*` + `catalog:`** (the key misalignment scenario) |
| 7 | `installSome mutation with workspace + catalog deps preserves catalog:` | `installSome` (update=true, updateToLatest=true) | `workspace:*` + `catalog:` deps |
| 8 | `multi-project installSome mutation with updateToLatest preserves catalog:` | `installSome` (multi-importer) | Multiple projects with same catalog dep |
| 9 | `multi-project install mutation with update preserves catalog:` | `install` (multi-importer) | Multiple projects with same catalog dep |

## Verification

### Unit Tests

```bash
pnpm --filter @pnpm/installing.deps-installer test test/catalogs.ts
```

All 9 new tests pass.

### Real-World Reproduction

Verified using the repository from the issue report ([ZahaStudio/uniswap-sdk-monorepo](https://github.com/ZahaStudio/uniswap-sdk-monorepo)), which has `catalogMode: manual` and a project with both `workspace:*` and `catalog:` dependencies.

**Before fix** (pnpm 11.1.1):

```bash
pnpm up -r --latest
```

Result: 3 out of 9 `catalog:` references in `package.json` were replaced with version numbers:

- `@tanstack/react-query`: `catalog:` → `^5.100.10` ❌
- `viem`: `catalog:` → `^2.49.3` ❌
- `wagmi`: `catalog:` → `^3.6.15` ❌

**After fix** (bundle built from this branch):

```bash
pnpm up -r --latest
```

Result: All 9 `catalog:` references preserved. ✅

### pacquet Port

Not required — pacquet only implements `install` currently; `update`/`upgrade` commands are outside its scope per `AGENTS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve catalog dependency specifiers in package manifests during update/upgrade operations, including workspace-linked deps and multi-project monorepos; fixes cases where mismatched dependency ordering could cause incorrect manifest updates.

* **Tests**
  * Added regression tests covering many update scenarios (single/multi-project, mixed catalog/non-catalog, and latest/dist-tag updates) to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->