### PR TITLE
fix(pacquet/fs): fall back to absolute target across Windows drives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,7 @@ name = "pacquet-fs"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "dunce",
  "junction",
  "miette 7.6.0",
  "pathdiff",

--- a/pacquet/AGENTS.md
+++ b/pacquet/AGENTS.md
@@ -295,6 +295,7 @@ Rust-specific defaults:
 
 -   **Doc comments (`///`, `//!`) document the contract.** Preconditions, postconditions, panics, the reason the function exists. They are not a re-narration of the body.
 -   **Do not restate at call sites what the callee's doc comment already says.** If `///` on the function says "no-op when …", the caller should not repeat that. Update the doc once; let every call site benefit.
+-   **Tests are documentation. Do not duplicate them in prose.** If a behavioral scenario, edge case, failure mode, or worked example is already captured by a test (its name, its setup, its assertions), do not also narrate it in the doc comment on the implementation. The doc comment should state the contract once; the test demonstrates the behavior. The same applies in reverse: a test's own doc comment should not re-explain what the asserts already say, only the *why* if it is not obvious.
 -   **`// SAFETY:`, `// TODO:`, and similar prefixes are the exception.** They signal hidden invariants or known follow-ups that a reader cannot recover from the code alone.
 
 Prefer renaming, restructuring, or extracting a helper over leaving a comment. Reach for prose only when the right names and types genuinely cannot carry the information.

--- a/pacquet/crates/fs/Cargo.toml
+++ b/pacquet/crates/fs/Cargo.toml
@@ -19,6 +19,7 @@ pathdiff    = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
+dunce    = { workspace = true }
 junction = { workspace = true }
 
 [lints]

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -82,11 +82,23 @@ fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
 
 /// Whether `a` and `b` share a Windows path root, meaning the same
 /// drive letter, the same UNC share, or both rootless. Drive letters
-/// are compared case-insensitively because NTFS is case-insensitive
+/// are uppercased before comparing because NTFS is case-insensitive
 /// and Node.js's `path.win32.relative` lowercases before comparing.
-/// Callers should pre-simplify inputs with `dunce::simplified` so
-/// `Prefix::Disk('C')` and `Prefix::VerbatimDisk('C')` (and the UNC
-/// analogues) don't fall on opposite sides of this check.
+///
+/// The comparison is *variant-strict*: `Prefix::Disk('C')` and
+/// `Prefix::VerbatimDisk('C')` are treated as different roots, and
+/// the same goes for `UNC` vs. `VerbatimUNC`. Callers should pre-
+/// simplify inputs with `dunce::simplified` so the common
+/// short-path mixed-form case (e.g., `\\?\C:\foo` paired with
+/// `C:\bar`) collapses onto a common variant before this check.
+/// Collapsing the variants in this function instead would be
+/// unsafe: `pathdiff::diff_paths` itself walks `Component::Prefix`
+/// for equality, so a variant-tolerant `same_path_root` would
+/// declare two paths same-root but the downstream diff would still
+/// emit a re-anchored garbage path on the verbatim-vs-plain pair
+/// `dunce::simplified` declined to simplify (e.g., a verbatim path
+/// past the non-verbatim length limit). Falling back to the
+/// absolute target is the safe outcome in that edge case.
 #[cfg(windows)]
 fn same_path_root(a: &Path, b: &Path) -> bool {
     fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {
@@ -98,7 +110,8 @@ fn same_path_root(a: &Path, b: &Path) -> bool {
     fn case_normalize(prefix: std::path::Prefix<'_>) -> std::path::Prefix<'_> {
         use std::path::Prefix::{Disk, VerbatimDisk};
         match prefix {
-            Disk(d) | VerbatimDisk(d) => Disk(d.to_ascii_uppercase()),
+            Disk(d) => Disk(d.to_ascii_uppercase()),
+            VerbatimDisk(d) => VerbatimDisk(d.to_ascii_uppercase()),
             other => other,
         }
     }

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -53,12 +53,25 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 /// on `D:` and the global store (installed by `setup-pnpm`) lives on
 /// `C:`. Node.js's `path.win32.relative` returns the absolute `to`
 /// argument in this case; we do the same.
+///
+/// Inputs are run through [`dunce::simplified`](https://docs.rs/dunce/latest/dunce/fn.simplified.html)
+/// before the prefix comparison so that mixed verbatim and non-verbatim
+/// forms of the same drive (`\\?\C:\foo` and `C:\bar`) normalize to a
+/// common `Prefix::Disk`. Without that, `pathdiff::diff_paths` would
+/// emit garbage even when both paths name the same physical drive, and
+/// the relative-target branch would never be taken.
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
     #[cfg(windows)]
-    if !same_path_root(original, parent) {
-        return original.to_path_buf();
+    {
+        let original = dunce::simplified(original);
+        let parent = dunce::simplified(parent);
+        if !same_path_root(original, parent) {
+            return original.to_path_buf();
+        }
+        return pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf());
     }
+    #[cfg(not(windows))]
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
 }
 
@@ -66,6 +79,9 @@ fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
 /// drive letter, the same UNC share, or both rootless. Drive letters
 /// are compared case-insensitively because NTFS is case-insensitive
 /// and Node.js's `path.win32.relative` lowercases before comparing.
+/// Callers should pre-simplify inputs with `dunce::simplified` so
+/// `Prefix::Disk('C')` and `Prefix::VerbatimDisk('C')` (and the UNC
+/// analogues) don't fall on opposite sides of this check.
 #[cfg(windows)]
 fn same_path_root(a: &Path, b: &Path) -> bool {
     fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {
@@ -77,8 +93,7 @@ fn same_path_root(a: &Path, b: &Path) -> bool {
     fn case_normalize(prefix: std::path::Prefix<'_>) -> std::path::Prefix<'_> {
         use std::path::Prefix::{Disk, VerbatimDisk};
         match prefix {
-            Disk(d) => Disk(d.to_ascii_uppercase()),
-            VerbatimDisk(d) => VerbatimDisk(d.to_ascii_uppercase()),
+            Disk(d) | VerbatimDisk(d) => Disk(d.to_ascii_uppercase()),
             other => other,
         }
     }

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -60,16 +60,13 @@ fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
 }
 
-/// Whether `a` and `b` share a Windows path root: same drive letter
-/// (case-insensitive), same UNC share, or both rootless.
-///
-/// Comparison is variant-strict — `Prefix::Disk` and
-/// `Prefix::VerbatimDisk` (and the UNC analogues) are different roots
-/// here. Collapsing the variants would let `pathdiff::diff_paths`
-/// downstream walk into a verbatim-vs-plain pair it cannot relate,
-/// emitting a re-anchored garbage path. Callers should run inputs
-/// through `dunce::simplified` first to collapse the common
-/// short-path mixed-form case onto a single variant before this check.
+/// Whether `a` and `b` have an identical `Component::Prefix` after
+/// `dunce::simplified`, with drive letters case-folded. UNC shares
+/// only match when their server/share are written with identical
+/// casing and variant — the check has to stay in lockstep with what
+/// `pathdiff::diff_paths` will tolerate, since a variant-tolerant or
+/// case-tolerant comparison here would let the downstream diff emit
+/// a re-anchored garbage path on a `Prefix` mismatch it cannot relate.
 #[cfg(windows)]
 fn same_path_root(a: &Path, b: &Path) -> bool {
     fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -36,30 +36,10 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 /// link's parent directory to `original`. Mirrors upstream's
 /// `resolveSrcOnTrueSymlink(src, dest) = path.relative(path.dirname(dest), src)`.
 ///
-/// Callers in pacquet always pass absolute paths; if `pathdiff` cannot
-/// produce a relative form (one side is relative, or they live on
-/// different roots), fall back to the absolute `original` so the kernel
-/// still gets a valid path. This matches upstream's behavior when
-/// `path.relative` returns an absolute path because the two arguments
-/// share no common root.
-///
-/// On Windows the "different roots" guard has to be explicit:
-/// `pathdiff::diff_paths` walks components and treats two unequal
-/// `Component::Prefix` values (e.g. `C:` vs. `D:`) as just another
-/// mismatch, producing a path that climbs out with `..` and then
-/// re-anchors with a drive letter (`..\..\C:\Users\...`). Windows
-/// rejects such a target with `ERROR_INVALID_PARAMETER` (os error 87),
-/// which is the failure mode CI on Windows hits when the project lives
-/// on `D:` and the global store (installed by `setup-pnpm`) lives on
-/// `C:`. Node.js's `path.win32.relative` returns the absolute `to`
-/// argument in this case; we do the same.
-///
-/// Inputs are run through [`dunce::simplified`](https://docs.rs/dunce/latest/dunce/fn.simplified.html)
-/// before the prefix comparison so that mixed verbatim and non-verbatim
-/// forms of the same drive (`\\?\C:\foo` and `C:\bar`) normalize to a
-/// common `Prefix::Disk`. Without that, `pathdiff::diff_paths` would
-/// emit garbage even when both paths name the same physical drive, and
-/// the relative-target branch would never be taken.
+/// Returns an absolute path when no relative form exists between the
+/// two arguments. This matches Node.js's `path.win32.relative`, which
+/// returns the absolute `to` argument when the paths share no common
+/// root (different drives, different UNC shares).
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
     relative_target_inner(original, parent)
@@ -80,25 +60,16 @@ fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
 }
 
-/// Whether `a` and `b` share a Windows path root, meaning the same
-/// drive letter, the same UNC share, or both rootless. Drive letters
-/// are uppercased before comparing because NTFS is case-insensitive
-/// and Node.js's `path.win32.relative` lowercases before comparing.
+/// Whether `a` and `b` share a Windows path root: same drive letter
+/// (case-insensitive), same UNC share, or both rootless.
 ///
-/// The comparison is *variant-strict*: `Prefix::Disk('C')` and
-/// `Prefix::VerbatimDisk('C')` are treated as different roots, and
-/// the same goes for `UNC` vs. `VerbatimUNC`. Callers should pre-
-/// simplify inputs with `dunce::simplified` so the common
-/// short-path mixed-form case (e.g., `\\?\C:\foo` paired with
-/// `C:\bar`) collapses onto a common variant before this check.
-/// Collapsing the variants in this function instead would be
-/// unsafe: `pathdiff::diff_paths` itself walks `Component::Prefix`
-/// for equality, so a variant-tolerant `same_path_root` would
-/// declare two paths same-root but the downstream diff would still
-/// emit a re-anchored garbage path on the verbatim-vs-plain pair
-/// `dunce::simplified` declined to simplify (e.g., a verbatim path
-/// past the non-verbatim length limit). Falling back to the
-/// absolute target is the safe outcome in that edge case.
+/// Comparison is variant-strict — `Prefix::Disk` and
+/// `Prefix::VerbatimDisk` (and the UNC analogues) are different roots
+/// here. Collapsing the variants would let `pathdiff::diff_paths`
+/// downstream walk into a verbatim-vs-plain pair it cannot relate,
+/// emitting a re-anchored garbage path. Callers should run inputs
+/// through `dunce::simplified` first to collapse the common
+/// short-path mixed-form case onto a single variant before this check.
 #[cfg(windows)]
 fn same_path_root(a: &Path, b: &Path) -> bool {
     fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -38,13 +38,55 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 ///
 /// Callers in pacquet always pass absolute paths; if `pathdiff` cannot
 /// produce a relative form (one side is relative, or they live on
-/// different roots — only possible on Windows), fall back to the
-/// absolute `original` so the kernel still gets a valid path. This
-/// matches upstream's behavior when `path.relative` returns an
-/// absolute path because the two arguments share no common root.
+/// different roots), fall back to the absolute `original` so the kernel
+/// still gets a valid path. This matches upstream's behavior when
+/// `path.relative` returns an absolute path because the two arguments
+/// share no common root.
+///
+/// On Windows the "different roots" guard has to be explicit:
+/// `pathdiff::diff_paths` walks components and treats two unequal
+/// `Component::Prefix` values (e.g. `C:` vs. `D:`) as just another
+/// mismatch, producing a path that climbs out with `..` and then
+/// re-anchors with a drive letter (`..\..\C:\Users\...`). Windows
+/// rejects such a target with `ERROR_INVALID_PARAMETER` (os error 87),
+/// which is the failure mode CI on Windows hits when the project lives
+/// on `D:` and the global store (installed by `setup-pnpm`) lives on
+/// `C:`. Node.js's `path.win32.relative` returns the absolute `to`
+/// argument in this case; we do the same.
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
+    #[cfg(windows)]
+    if !same_path_root(original, parent) {
+        return original.to_path_buf();
+    }
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
+}
+
+/// Whether `a` and `b` share a Windows path root, meaning the same
+/// drive letter, the same UNC share, or both rootless. Drive letters
+/// are compared case-insensitively because NTFS is case-insensitive
+/// and Node.js's `path.win32.relative` lowercases before comparing.
+#[cfg(windows)]
+fn same_path_root(a: &Path, b: &Path) -> bool {
+    fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {
+        match path.components().next()? {
+            std::path::Component::Prefix(p) => Some(p.kind()),
+            _ => None,
+        }
+    }
+    fn case_normalize(prefix: std::path::Prefix<'_>) -> std::path::Prefix<'_> {
+        use std::path::Prefix::{Disk, VerbatimDisk};
+        match prefix {
+            Disk(d) => Disk(d.to_ascii_uppercase()),
+            VerbatimDisk(d) => VerbatimDisk(d.to_ascii_uppercase()),
+            other => other,
+        }
+    }
+    match (first_prefix(a), first_prefix(b)) {
+        (Some(pa), Some(pb)) => case_normalize(pa) == case_normalize(pb),
+        (None, None) => true,
+        _ => false,
+    }
 }
 
 /// Remove a symlink (or junction on Windows) previously created with

--- a/pacquet/crates/fs/src/symlink_dir.rs
+++ b/pacquet/crates/fs/src/symlink_dir.rs
@@ -62,16 +62,21 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 /// the relative-target branch would never be taken.
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
-    #[cfg(windows)]
-    {
-        let original = dunce::simplified(original);
-        let parent = dunce::simplified(parent);
-        if !same_path_root(original, parent) {
-            return original.to_path_buf();
-        }
-        return pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf());
+    relative_target_inner(original, parent)
+}
+
+#[cfg(windows)]
+fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
+    let original = dunce::simplified(original);
+    let parent = dunce::simplified(parent);
+    if !same_path_root(original, parent) {
+        return original.to_path_buf();
     }
-    #[cfg(not(windows))]
+    pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
+}
+
+#[cfg(not(windows))]
+fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
     pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
 }
 

--- a/pacquet/crates/fs/src/symlink_dir/tests.rs
+++ b/pacquet/crates/fs/src/symlink_dir/tests.rs
@@ -7,7 +7,11 @@
 //! idempotent re-symlink, retargeting a stale link, and renaming a
 //! non-symlink occupant out of the way.
 
+#[cfg(windows)]
+use super::relative_target_for;
 use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir, symlink_dir};
+#[cfg(windows)]
+use std::path::Path;
 use std::{fs, path::PathBuf};
 use tempfile::tempdir;
 
@@ -143,6 +147,50 @@ fn force_symlink_dir_creates_missing_parent_directories() {
     let resolved_link = fs::canonicalize(&link).expect("canonicalize the new symlink");
     let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
     assert_eq!(resolved_link, resolved_target);
+}
+
+/// On Windows, a target and link that live on different drives have
+/// no relative path between them. Node.js's `path.win32.relative`
+/// returns the absolute target in that case, and so must pacquet.
+/// Pre-fix, `pathdiff::diff_paths` would walk the components and emit
+/// a nonsense path that re-anchored mid-string (`..\..\C:\Users\...`),
+/// which Windows rejects with `ERROR_INVALID_PARAMETER` (os error 87).
+/// This is the failure mode CI hits when the workspace lives on `D:`
+/// and the global store (set up by `setup-pnpm`) lives on `C:`.
+///
+/// The test runs as a pure-function check, with no real symlink
+/// created, so it stays portable across hosts. Only the Windows
+/// path-parser arithmetic is being exercised, and `Path` parses
+/// drive-letter prefixes on every target.
+#[cfg(windows)]
+#[test]
+fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
+    let target = Path::new(r"C:\Users\runneradmin\setup-pnpm\store\@babel\plugin-x");
+    let link = Path::new(r"D:\a\pnpm\pnpm\node_modules\@babel\plugin-x");
+
+    let computed = relative_target_for(target, link);
+
+    assert_eq!(
+        computed, target,
+        "cross-drive target must be passed through as absolute, not a fabricated `..` chain",
+    );
+}
+
+/// Sanity-check the same-drive happy path: when target and link share
+/// a drive root, `relative_target_for` still emits a relative path
+/// (the pnpm `symlink-dir` parity that the Unix tests exercise too).
+#[cfg(windows)]
+#[test]
+fn windows_same_drive_symlink_target_stays_relative() {
+    let target = Path::new(r"C:\workspace\packages\pkg-a");
+    let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
+
+    let computed = relative_target_for(target, link);
+
+    assert!(
+        computed.is_relative(),
+        "same-drive target should still be encoded relative to the link parent, got {computed:?}",
+    );
 }
 
 /// After [`force_symlink_dir`] places a symlink, [`read_symlink_dir`]

--- a/pacquet/crates/fs/src/symlink_dir/tests.rs
+++ b/pacquet/crates/fs/src/symlink_dir/tests.rs
@@ -193,6 +193,29 @@ fn windows_same_drive_symlink_target_stays_relative() {
     );
 }
 
+/// When one side is a verbatim Windows path (`\\?\C:\...`) and the
+/// other is the plain form (`C:\...`), `relative_target_for` must
+/// still recognize them as the same physical drive and emit a
+/// relative target. Pre-fix, `Prefix::VerbatimDisk('C')` and
+/// `Prefix::Disk('C')` compared unequal, so the cross-root fallback
+/// would fire and the symlink would carry an absolute target even
+/// though the two paths share a drive. The `dunce::simplified`
+/// normalization in `relative_target_for` collapses both forms onto
+/// `Prefix::Disk`.
+#[cfg(windows)]
+#[test]
+fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
+    let target = Path::new(r"\\?\C:\workspace\packages\pkg-a");
+    let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
+
+    let computed = relative_target_for(target, link);
+
+    assert!(
+        computed.is_relative(),
+        "verbatim and plain disk forms of the same drive must produce a relative target, got {computed:?}",
+    );
+}
+
 /// After [`force_symlink_dir`] places a symlink, [`read_symlink_dir`]
 /// returns the same contents. The combination covers the round-trip
 /// pacquet's prune sweep needs (write a slot link with

--- a/pacquet/crates/fs/src/symlink_dir/tests.rs
+++ b/pacquet/crates/fs/src/symlink_dir/tests.rs
@@ -149,71 +149,35 @@ fn force_symlink_dir_creates_missing_parent_directories() {
     assert_eq!(resolved_link, resolved_target);
 }
 
-/// On Windows, a target and link that live on different drives have
-/// no relative path between them. Node.js's `path.win32.relative`
-/// returns the absolute target in that case, and so must pacquet.
-/// Pre-fix, `pathdiff::diff_paths` would walk the components and emit
-/// a nonsense path that re-anchored mid-string (`..\..\C:\Users\...`),
-/// which Windows rejects with `ERROR_INVALID_PARAMETER` (os error 87).
-/// This is the failure mode CI hits when the workspace lives on `D:`
-/// and the global store (set up by `setup-pnpm`) lives on `C:`.
-///
-/// The test runs as a pure-function check, with no real symlink
-/// created, so it stays portable across hosts. Only the Windows
-/// path-parser arithmetic is being exercised, and `Path` parses
-/// drive-letter prefixes on every target.
+/// Regression for the Windows CI failure where the workspace lives
+/// on `D:` and the global store (installed by `setup-pnpm`) lives on
+/// `C:`: `pathdiff::diff_paths` produced a re-anchored garbage path
+/// that Windows rejected with `ERROR_INVALID_PARAMETER` (os error 87).
 #[cfg(windows)]
 #[test]
 fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
     let target = Path::new(r"C:\Users\runneradmin\setup-pnpm\store\@babel\plugin-x");
     let link = Path::new(r"D:\a\pnpm\pnpm\node_modules\@babel\plugin-x");
 
-    let computed = relative_target_for(target, link);
-
-    assert_eq!(
-        computed, target,
-        "cross-drive target must be passed through as absolute, not a fabricated `..` chain",
-    );
+    assert_eq!(relative_target_for(target, link), target);
 }
 
-/// Sanity-check the same-drive happy path: when target and link share
-/// a drive root, `relative_target_for` still emits a relative path
-/// (the pnpm `symlink-dir` parity that the Unix tests exercise too).
 #[cfg(windows)]
 #[test]
 fn windows_same_drive_symlink_target_stays_relative() {
     let target = Path::new(r"C:\workspace\packages\pkg-a");
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
-    let computed = relative_target_for(target, link);
-
-    assert!(
-        computed.is_relative(),
-        "same-drive target should still be encoded relative to the link parent, got {computed:?}",
-    );
+    assert!(relative_target_for(target, link).is_relative());
 }
 
-/// When one side is a verbatim Windows path (`\\?\C:\...`) and the
-/// other is the plain form (`C:\...`), `relative_target_for` must
-/// still recognize them as the same physical drive and emit a
-/// relative target. Pre-fix, `Prefix::VerbatimDisk('C')` and
-/// `Prefix::Disk('C')` compared unequal, so the cross-root fallback
-/// would fire and the symlink would carry an absolute target even
-/// though the two paths share a drive. The `dunce::simplified`
-/// normalization in `relative_target_for` collapses both forms onto
-/// `Prefix::Disk`.
 #[cfg(windows)]
 #[test]
 fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
     let target = Path::new(r"\\?\C:\workspace\packages\pkg-a");
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
-    let computed = relative_target_for(target, link);
-
-    assert!(
-        computed.is_relative(),
-        "verbatim and plain disk forms of the same drive must produce a relative target, got {computed:?}",
-    );
+    assert!(relative_target_for(target, link).is_relative());
 }
 
 /// After [`force_symlink_dir`] places a symlink, [`read_symlink_dir`]


### PR DESCRIPTION
## Summary

- pacquet's `relative_target_for` (used by `symlink_dir` to mirror pnpm's [`symlink-dir`](https://github.com/pnpm/symlink-dir/blob/v10.0.1/src/index.ts)) computed a relative symlink target via `pathdiff::diff_paths`. On Windows, when the target and link live on different drives, `pathdiff` does not return `None`; it walks components and emits a re-anchored garbage path like `..\..\C:\Users\...`, which Windows rejects with `ERROR_INVALID_PARAMETER` (os error 87).
- This is the failure mode the Windows CI hit (e.g. [run 26037300862, job 76557020777](https://github.com/pnpm/pnpm/actions/runs/26037300862/job/76557020777)), where the workspace lives on `D:` and the global store installed by `setup-pnpm` lives on `C:`.
- Mirror Node.js's `path.win32.relative`, which returns the absolute `to` argument when the two paths share no common root: detect unequal `Component::Prefix` values up front and pass the absolute target through unchanged. Drive-letter comparison is case-insensitive to match NTFS and Node.js semantics.

## Test plan

- [x] `cargo check -p pacquet-fs --tests --locked`
- [x] `cargo clippy -p pacquet-fs --tests --locked -- --deny warnings`
- [x] `cargo fmt --check`
- [x] `cargo nextest run -p pacquet-fs` (24/24 pass on macOS; the two Windows-gated unit tests exercise `relative_target_for` directly without a real symlink syscall, and run when CI compiles for `*-windows-*`)
- [x] Windows CI passes on this branch

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows symlink handling so targets on different roots (e.g., cross-drive/UNC mismatches) return a safe absolute path instead of an invalid relative path.

* **Tests**
  * Added Windows-specific unit tests for cross-drive handling, same-drive relative targets, and verbatim vs plain path equivalence.

* **Chores**
  * Added a Windows-only build dependency to support path-root handling.

* **Style**
  * Clarified guidance to avoid duplicating tests inside implementation doc comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->