### PR TITLE
feat(config-deps): support optionalDependencies with platform filtering

### DIFF
--- a/.changeset/config-deps-optional-subdeps.md
+++ b/.changeset/config-deps-optional-subdeps.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.env-installer": minor
+"pnpm": minor
+---
+
+`configDependencies` now resolve and install one level of `optionalDependencies` declared by the config dependency, with `os`/`cpu`/`libc` platform filtering applied at install time. This unlocks the esbuild/swc-style pattern where a package ships platform-specific binaries via `optionalDependencies` — a config dependency can now do the same and have the matching binary symlinked next to it in the global virtual store, so `require('pkg-platform-arch')` from inside the config dependency resolves correctly.
+
+The env lockfile records all platform variants regardless of host platform, so it remains portable across machines.

--- a/.changeset/config-deps-optional-subdeps.md
+++ b/.changeset/config-deps-optional-subdeps.md
@@ -5,4 +5,4 @@
 
 `configDependencies` now resolve and install one level of `optionalDependencies` declared by the config dependency, with `os`/`cpu`/`libc` platform filtering applied at install time. This unlocks the esbuild/swc-style pattern where a package ships platform-specific binaries via `optionalDependencies` — a config dependency can now do the same and have the matching binary symlinked next to it in the global virtual store, so `require('pkg-platform-arch')` from inside the config dependency resolves correctly.
 
-The env lockfile records all platform variants regardless of host platform, so it remains portable across machines.
+The env lockfile records all platform variants regardless of host platform, so it remains portable across machines. Each entry in a config dependency's `optionalDependencies` must declare an exact version — ranges and tags are rejected to keep installs reproducible.

--- a/deps/graph-hasher/src/index.ts
+++ b/deps/graph-hasher/src/index.ts
@@ -249,8 +249,24 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   return formatGlobalVirtualStorePath(name, version, hexDigest)
 }
 
-export function calcLeafGlobalVirtualStorePath (fullPkgId: string, name: string, version: string): string {
-  const depsHash = hashObject({ id: fullPkgId, deps: {} })
+/**
+ * `deps` maps each direct child's alias to its full pkg id
+ * (`${name}@${version}:${integrity}`); pass `{}` when the package has no
+ * traversable dependency subtree. Children themselves are treated as leaves —
+ * one level deep only, matching the config-dependency surface where this is
+ * used today.
+ */
+export function calcLeafGlobalVirtualStorePath (
+  fullPkgId: string,
+  name: string,
+  version: string,
+  deps: Record<string, string> = {}
+): string {
+  const childHashes: Record<string, string> = {}
+  for (const [alias, childFullPkgId] of Object.entries(deps)) {
+    childHashes[alias] = hashObject({ id: childFullPkgId, deps: {} })
+  }
+  const depsHash = hashObject({ id: fullPkgId, deps: childHashes })
   const hexDigest = hashObjectWithoutSorting({ engine: null, deps: depsHash }, { encoding: 'hex' })
   return formatGlobalVirtualStorePath(name, version, hexDigest)
 }

--- a/deps/graph-hasher/src/index.ts
+++ b/deps/graph-hasher/src/index.ts
@@ -249,21 +249,27 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   return formatGlobalVirtualStorePath(name, version, hexDigest)
 }
 
+export function calcLeafGlobalVirtualStorePath (fullPkgId: string, name: string, version: string): string {
+  const depsHash = hashObject({ id: fullPkgId, deps: {} })
+  const hexDigest = hashObjectWithoutSorting({ engine: null, deps: depsHash }, { encoding: 'hex' })
+  return formatGlobalVirtualStorePath(name, version, hexDigest)
+}
+
 /**
- * `deps` maps each direct child's alias to its full pkg id
- * (`${name}@${version}:${integrity}`); pass `{}` when the package has no
- * traversable dependency subtree. Children themselves are treated as leaves —
- * one level deep only, matching the config-dependency surface where this is
- * used today.
+ * `subdepIds` maps each direct child's alias to its full pkg id
+ * (`${name}@${version}:${integrity}`). Each child contributes a leaf hash
+ * (no transitive walk) to the parent's hash, so the resulting path differs
+ * whenever the set or versions of children change. One level deep only —
+ * use {@link calcGraphNodeHash} when full graph traversal is needed.
  */
-export function calcLeafGlobalVirtualStorePath (
+export function calcGlobalVirtualStorePathWithSubdeps (
   fullPkgId: string,
   name: string,
   version: string,
-  deps: Record<string, string> = {}
+  subdepIds: Record<string, string>
 ): string {
   const childHashes: Record<string, string> = {}
-  for (const [alias, childFullPkgId] of Object.entries(deps)) {
+  for (const [alias, childFullPkgId] of Object.entries(subdepIds)) {
     childHashes[alias] = hashObject({ id: childFullPkgId, deps: {} })
   }
   const depsHash = hashObject({ id: fullPkgId, deps: childHashes })

--- a/deps/graph-hasher/test/calcLeafGlobalVirtualStorePath.test.ts
+++ b/deps/graph-hasher/test/calcLeafGlobalVirtualStorePath.test.ts
@@ -1,28 +1,35 @@
 import { describe, expect, it } from '@jest/globals'
-import { calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
+import { calcGlobalVirtualStorePathWithSubdeps, calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
 
 describe('calcLeafGlobalVirtualStorePath', () => {
-  it('returns the same path when deps is omitted vs. passed as empty', () => {
-    const withoutDeps = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0')
-    const withEmptyDeps = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0', {})
-    expect(withoutDeps).toBe(withEmptyDeps)
+  it('returns a stable path for a leaf package', () => {
+    const path = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0')
+    expect(path).toMatch(/^@\/foo\/1\.0\.0\/[a-f0-9]+$/)
+  })
+})
+
+describe('calcGlobalVirtualStorePathWithSubdeps', () => {
+  it('equals the leaf path when no subdeps are passed', () => {
+    const leafPath = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0')
+    const withEmptySubdeps = calcGlobalVirtualStorePathWithSubdeps('foo@1.0.0:sha512-abc', 'foo', '1.0.0', {})
+    expect(withEmptySubdeps).toBe(leafPath)
   })
 
-  it('produces a different hash when an optional subdep changes version', () => {
+  it('produces a different path when an optional subdep changes version', () => {
     const fullPkgId = 'foo@1.0.0:sha512-abc'
-    const withSubdepV1 = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+    const withSubdepV1 = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {
       'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
     })
-    const withSubdepV2 = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+    const withSubdepV2 = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {
       'foo-darwin-arm64': 'foo-darwin-arm64@1.1.0:sha512-bbb',
     })
     expect(withSubdepV1).not.toBe(withSubdepV2)
   })
 
-  it('produces a different hash when an optional subdep is added', () => {
+  it('produces a different path when an optional subdep is added', () => {
     const fullPkgId = 'foo@1.0.0:sha512-abc'
-    const noSubdeps = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0')
-    const withSubdep = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+    const noSubdeps = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {})
+    const withSubdep = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {
       'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
     })
     expect(noSubdeps).not.toBe(withSubdep)
@@ -30,11 +37,11 @@ describe('calcLeafGlobalVirtualStorePath', () => {
 
   it('is order-independent across multiple subdeps', () => {
     const fullPkgId = 'foo@1.0.0:sha512-abc'
-    const orderA = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+    const orderA = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {
       'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
       'foo-linux-x64': 'foo-linux-x64@1.0.0:sha512-bbb',
     })
-    const orderB = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+    const orderB = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, 'foo', '1.0.0', {
       'foo-linux-x64': 'foo-linux-x64@1.0.0:sha512-bbb',
       'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
     })

--- a/deps/graph-hasher/test/calcLeafGlobalVirtualStorePath.test.ts
+++ b/deps/graph-hasher/test/calcLeafGlobalVirtualStorePath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals'
+import { calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
+
+describe('calcLeafGlobalVirtualStorePath', () => {
+  it('returns the same path when deps is omitted vs. passed as empty', () => {
+    const withoutDeps = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0')
+    const withEmptyDeps = calcLeafGlobalVirtualStorePath('foo@1.0.0:sha512-abc', 'foo', '1.0.0', {})
+    expect(withoutDeps).toBe(withEmptyDeps)
+  })
+
+  it('produces a different hash when an optional subdep changes version', () => {
+    const fullPkgId = 'foo@1.0.0:sha512-abc'
+    const withSubdepV1 = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+      'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
+    })
+    const withSubdepV2 = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+      'foo-darwin-arm64': 'foo-darwin-arm64@1.1.0:sha512-bbb',
+    })
+    expect(withSubdepV1).not.toBe(withSubdepV2)
+  })
+
+  it('produces a different hash when an optional subdep is added', () => {
+    const fullPkgId = 'foo@1.0.0:sha512-abc'
+    const noSubdeps = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0')
+    const withSubdep = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+      'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
+    })
+    expect(noSubdeps).not.toBe(withSubdep)
+  })
+
+  it('is order-independent across multiple subdeps', () => {
+    const fullPkgId = 'foo@1.0.0:sha512-abc'
+    const orderA = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+      'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
+      'foo-linux-x64': 'foo-linux-x64@1.0.0:sha512-bbb',
+    })
+    const orderB = calcLeafGlobalVirtualStorePath(fullPkgId, 'foo', '1.0.0', {
+      'foo-linux-x64': 'foo-linux-x64@1.0.0:sha512-bbb',
+      'foo-darwin-arm64': 'foo-darwin-arm64@1.0.0:sha512-aaa',
+    })
+    expect(orderA).toBe(orderB)
+  })
+})

--- a/installing/env-installer/package.json
+++ b/installing/env-installer/package.json
@@ -56,6 +56,7 @@
     "@pnpm/types": "workspace:*",
     "@zkochan/rimraf": "catalog:",
     "get-npm-tarball-url": "catalog:",
+    "semver": "catalog:",
     "symlink-dir": "catalog:"
   },
   "peerDependencies": {
@@ -68,6 +69,7 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-mock": "catalog:",
     "@pnpm/testing.temp-store": "workspace:*",
+    "@types/semver": "catalog:",
     "load-json-file": "catalog:",
     "read-yaml-file": "catalog:"
   },

--- a/installing/env-installer/package.json
+++ b/installing/env-installer/package.json
@@ -33,6 +33,7 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/config.package-is-installable": "workspace:*",
     "@pnpm/config.pick-registry-for-package": "workspace:*",
     "@pnpm/config.writer": "workspace:*",
     "@pnpm/constants": "workspace:*",

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -300,8 +300,15 @@ async function installOptionalSubdeps (opts: InstallOptionalSubdepsOpts): Promis
 
 async function symlinkPointsTo (linkPath: string, expectedTarget: string): Promise<boolean> {
   try {
-    const realPath = await fs.promises.realpath(linkPath)
-    return realPath === expectedTarget
+    // Realpath both sides: the expected target itself may live under a
+    // symlinked storeDir, and on case-insensitive filesystems the literal
+    // string forms can disagree about casing even when they refer to the
+    // same inode.
+    const [linkReal, targetReal] = await Promise.all([
+      fs.promises.realpath(linkPath),
+      fs.promises.realpath(expectedTarget),
+    ])
+    return linkReal === targetReal
   } catch {
     return false
   }

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -8,7 +8,6 @@ import { calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
 import { PnpmError } from '@pnpm/error'
 import { readModulesDir } from '@pnpm/fs.read-modules-dir'
 import { type EnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
-import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import type { StoreController } from '@pnpm/store.controller'
 import type { ConfigDependencies, Registries } from '@pnpm/types'
 import { rimraf } from '@zkochan/rimraf'
@@ -49,13 +48,6 @@ export async function installConfigDeps (
   const installedConfigDeps: Array<{ name: string, version: string }> = []
   await Promise.all(Object.entries(normalizedDeps).map(async ([pkgName, pkg]) => {
     const configDepPath = path.join(configModulesDir, pkgName)
-    const existingPkgJson = existingConfigDeps.includes(pkgName)
-      ? await safeReadPackageJsonFromDir(configDepPath)
-      : null
-    if (existingPkgJson != null && existingPkgJson.name === pkgName && existingPkgJson.version === pkg.version) {
-      return
-    }
-    installingConfigDepsLogger.debug({ status: 'started' })
     const fullPkgId = `${pkgName}@${pkg.version}:${pkg.resolution.integrity}`
     // The parent's GVS hash must incorporate its optional subdeps; otherwise
     // changing a subdep version while keeping the parent pinned would collide
@@ -66,6 +58,14 @@ export async function installConfigDeps (
     }
     const relPath = calcLeafGlobalVirtualStorePath(fullPkgId, pkgName, pkg.version, optionalSubdepIds)
     const pkgDirInGlobalVirtualStore = path.join(globalVirtualStoreDir, relPath, 'node_modules', pkgName)
+    // The package.json name/version match isn't sufficient: a subdep version
+    // change (or a platform change) keeps name/version stable but moves the
+    // expected leaf. Compare the symlink's realpath against the expected leaf
+    // so we re-install whenever any input that feeds the leaf hash changed.
+    if (existingConfigDeps.includes(pkgName) && await symlinkPointsTo(configDepPath, pkgDirInGlobalVirtualStore)) {
+      return
+    }
+    installingConfigDepsLogger.debug({ status: 'started' })
     if (!fs.existsSync(path.join(pkgDirInGlobalVirtualStore, 'package.json'))) {
       const { fetching } = await opts.store.fetchPackage({
         force: true,
@@ -274,4 +274,13 @@ async function installOptionalSubdeps (opts: InstallOptionalSubdepsOpts): Promis
     await fs.promises.mkdir(path.dirname(linkPath), { recursive: true })
     await symlinkDir(subdepDirInGlobalVirtualStore, linkPath)
   }))
+}
+
+async function symlinkPointsTo (linkPath: string, expectedTarget: string): Promise<boolean> {
+  try {
+    const realPath = await fs.promises.realpath(linkPath)
+    return realPath === expectedTarget
+  } catch {
+    return false
+  }
 }

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -57,7 +57,14 @@ export async function installConfigDeps (
     }
     installingConfigDepsLogger.debug({ status: 'started' })
     const fullPkgId = `${pkgName}@${pkg.version}:${pkg.resolution.integrity}`
-    const relPath = calcLeafGlobalVirtualStorePath(fullPkgId, pkgName, pkg.version)
+    // The parent's GVS hash must incorporate its optional subdeps; otherwise
+    // changing a subdep version while keeping the parent pinned would collide
+    // on the same leaf and silently overwrite the previous sibling symlinks.
+    const optionalSubdepIds: Record<string, string> = {}
+    for (const subdep of pkg.optionalSubdeps ?? []) {
+      optionalSubdepIds[subdep.name] = `${subdep.name}@${subdep.version}:${subdep.resolution.integrity}`
+    }
+    const relPath = calcLeafGlobalVirtualStorePath(fullPkgId, pkgName, pkg.version, optionalSubdepIds)
     const pkgDirInGlobalVirtualStore = path.join(globalVirtualStoreDir, relPath, 'node_modules', pkgName)
     if (!fs.existsSync(path.join(pkgDirInGlobalVirtualStore, 'package.json'))) {
       const { fetching } = await opts.store.fetchPackage({

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -58,13 +58,16 @@ export async function installConfigDeps (
     }
     const relPath = calcLeafGlobalVirtualStorePath(fullPkgId, pkgName, pkg.version, optionalSubdepIds)
     const pkgDirInGlobalVirtualStore = path.join(globalVirtualStoreDir, relPath, 'node_modules', pkgName)
-    // The package.json name/version match isn't sufficient: a subdep version
-    // change (or a platform change) keeps name/version stable but moves the
-    // expected leaf. Compare the symlink's realpath against the expected leaf
-    // so we re-install whenever any input that feeds the leaf hash changed.
-    if (existingConfigDeps.includes(pkgName) && await symlinkPointsTo(configDepPath, pkgDirInGlobalVirtualStore)) {
-      return
-    }
+    // The leaf hash captures parent+subdep identities from the lockfile but
+    // not the host's `process.arch`/`process.platform` selection. So even if
+    // the symlink target is already the expected leaf, the sibling links
+    // inside that leaf may target the wrong platform binary if the host's
+    // effective arch changed between runs (e.g. Rosetta x64 vs arm64 on
+    // macOS). Short-circuit only the parent's re-import/re-symlink in that
+    // case; always run installOptionalSubdeps so platform-specific siblings
+    // get pruned and relinked.
+    const parentSymlinkAlreadyCorrect = existingConfigDeps.includes(pkgName) &&
+      await symlinkPointsTo(configDepPath, pkgDirInGlobalVirtualStore)
     installingConfigDepsLogger.debug({ status: 'started' })
     if (!fs.existsSync(path.join(pkgDirInGlobalVirtualStore, 'package.json'))) {
       const { fetching } = await opts.store.fetchPackage({
@@ -93,6 +96,9 @@ export async function installConfigDeps (
         rootDir: opts.rootDir,
         store: opts.store,
       })
+    }
+    if (parentSymlinkAlreadyCorrect) {
+      return
     }
     if (existingConfigDeps.includes(pkgName)) {
       await rimraf(configDepPath)

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { packageIsInstallable } from '@pnpm/config.package-is-installable'
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { installingConfigDepsLogger } from '@pnpm/core-loggers'
-import { calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
+import { calcGlobalVirtualStorePathWithSubdeps, calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
 import { PnpmError } from '@pnpm/error'
 import { readModulesDir } from '@pnpm/fs.read-modules-dir'
 import { type EnvLockfile, readEnvLockfile } from '@pnpm/lockfile.fs'
@@ -56,7 +56,7 @@ export async function installConfigDeps (
     for (const subdep of pkg.optionalSubdeps ?? []) {
       optionalSubdepIds[subdep.name] = `${subdep.name}@${subdep.version}:${subdep.resolution.integrity}`
     }
-    const relPath = calcLeafGlobalVirtualStorePath(fullPkgId, pkgName, pkg.version, optionalSubdepIds)
+    const relPath = calcGlobalVirtualStorePathWithSubdeps(fullPkgId, pkgName, pkg.version, optionalSubdepIds)
     const pkgDirInGlobalVirtualStore = path.join(globalVirtualStoreDir, relPath, 'node_modules', pkgName)
     // The leaf hash captures parent+subdep identities from the lockfile but
     // not the host's `process.arch`/`process.platform` selection. So even if

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { packageIsInstallable } from '@pnpm/config.package-is-installable'
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { installingConfigDepsLogger } from '@pnpm/core-loggers'
 import { calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
@@ -15,7 +16,7 @@ import getNpmTarballUrl from 'get-npm-tarball-url'
 import { symlinkDir } from 'symlink-dir'
 
 import { migrateConfigDepsToLockfile } from './migrateConfigDeps.js'
-import type { NormalizedConfigDep } from './parseIntegrity.js'
+import type { NormalizedConfigDep, NormalizedSubdep } from './parseIntegrity.js'
 
 export interface InstallConfigDepsOpts {
   frozenLockfile?: boolean
@@ -72,6 +73,16 @@ export async function installConfigDeps (
         force: true,
         requiresBuild: false,
         filesResponse,
+      })
+    }
+    if (pkg.optionalSubdeps?.length) {
+      await installOptionalSubdeps({
+        parentName: pkgName,
+        subdeps: pkg.optionalSubdeps,
+        parentNodeModulesDir: path.dirname(pkgDirInGlobalVirtualStore),
+        globalVirtualStoreDir,
+        rootDir: opts.rootDir,
+        store: opts.store,
       })
     }
     if (existingConfigDeps.includes(pkgName)) {
@@ -149,13 +160,109 @@ function normalizeFromLockfile (
       )
     }
     const registry = pickRegistryForPackage(registries, pkgName)
+    const snapshot = lockfile.snapshots[pkgKey]
+    const optionalSubdeps = snapshot?.optionalDependencies
+      ? readOptionalSubdepsFromLockfile(pkgName, snapshot.optionalDependencies, lockfile, registries)
+      : undefined
     deps[pkgName] = {
       version,
       resolution: {
         integrity: resolution.integrity,
         tarball: resolution.tarball ?? getNpmTarballUrl(pkgName, version, { registry }),
       },
+      optionalSubdeps,
     }
   }
   return deps
+}
+
+function readOptionalSubdepsFromLockfile (
+  parentName: string,
+  optionalDeps: Record<string, string>,
+  lockfile: EnvLockfile,
+  registries: Registries
+): NormalizedSubdep[] {
+  const subdeps: NormalizedSubdep[] = []
+  for (const [subdepName, subdepVersion] of Object.entries(optionalDeps)) {
+    const subdepKey = `${subdepName}@${subdepVersion}`
+    const subdepInfo = lockfile.packages[subdepKey]
+    if (!subdepInfo) {
+      throw new PnpmError(
+        'ENV_LOCKFILE_CORRUPTED',
+        `pnpm-lock.yaml is corrupted or incomplete: missing packages entry for "${subdepKey}" ` +
+        `referenced from optionalDependencies of config dependency "${parentName}"`
+      )
+    }
+    const subdepResolution = subdepInfo.resolution as { integrity?: string; tarball?: string }
+    if (!subdepResolution.integrity) {
+      throw new PnpmError(
+        'ENV_LOCKFILE_CORRUPTED',
+        `pnpm-lock.yaml is corrupted or incomplete: missing integrity for "${subdepKey}"`
+      )
+    }
+    const registry = pickRegistryForPackage(registries, subdepName)
+    subdeps.push({
+      name: subdepName,
+      version: subdepVersion,
+      resolution: {
+        integrity: subdepResolution.integrity,
+        tarball: subdepResolution.tarball ?? getNpmTarballUrl(subdepName, subdepVersion, { registry }),
+      },
+      os: subdepInfo.os,
+      cpu: subdepInfo.cpu,
+      libc: subdepInfo.libc,
+    })
+  }
+  return subdeps
+}
+
+interface InstallOptionalSubdepsOpts {
+  parentName: string
+  subdeps: NormalizedSubdep[]
+  parentNodeModulesDir: string
+  globalVirtualStoreDir: string
+  rootDir: string
+  store: StoreController
+}
+
+async function installOptionalSubdeps (opts: InstallOptionalSubdepsOpts): Promise<void> {
+  const compatibleSubdeps = opts.subdeps.filter((subdep) => {
+    if (!subdep.os && !subdep.cpu && !subdep.libc) return true
+    return packageIsInstallable(
+      `${subdep.name}@${subdep.version}`,
+      { name: subdep.name, version: subdep.version, os: subdep.os, cpu: subdep.cpu, libc: subdep.libc },
+      { optional: true, lockfileDir: opts.rootDir }
+    ) === true
+  })
+
+  const expectedSiblings = new Set([opts.parentName, ...compatibleSubdeps.map((s) => s.name)])
+  const existingSiblings = await readModulesDir(opts.parentNodeModulesDir) ?? []
+  await Promise.all(existingSiblings
+    .filter((name) => !expectedSiblings.has(name))
+    .map((name) => rimraf(path.join(opts.parentNodeModulesDir, name))))
+
+  await Promise.all(compatibleSubdeps.map(async (subdep) => {
+    const subdepFullPkgId = `${subdep.name}@${subdep.version}:${subdep.resolution.integrity}`
+    const subdepRelPath = calcLeafGlobalVirtualStorePath(subdepFullPkgId, subdep.name, subdep.version)
+    const subdepDirInGlobalVirtualStore = path.join(opts.globalVirtualStoreDir, subdepRelPath, 'node_modules', subdep.name)
+    if (!fs.existsSync(path.join(subdepDirInGlobalVirtualStore, 'package.json'))) {
+      const { fetching } = await opts.store.fetchPackage({
+        force: true,
+        lockfileDir: opts.rootDir,
+        pkg: {
+          id: `${subdep.name}@${subdep.version}`,
+          resolution: subdep.resolution,
+        },
+      })
+      const { files: filesResponse } = await fetching()
+      await opts.store.importPackage(subdepDirInGlobalVirtualStore, {
+        force: true,
+        requiresBuild: false,
+        filesResponse,
+      })
+    }
+    const linkPath = path.join(opts.parentNodeModulesDir, subdep.name)
+    await fs.promises.mkdir(path.dirname(linkPath), { recursive: true })
+    await symlinkDir(subdepDirInGlobalVirtualStore, linkPath)
+  }))
 }

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -79,7 +79,9 @@ export async function installConfigDeps (
       await installOptionalSubdeps({
         parentName: pkgName,
         subdeps: pkg.optionalSubdeps,
-        parentNodeModulesDir: path.dirname(pkgDirInGlobalVirtualStore),
+        // path.dirname would land in the scope subdir for scoped parents; use
+        // the leaf's node_modules root so sibling symlinks resolve correctly.
+        parentNodeModulesDir: path.join(globalVirtualStoreDir, relPath, 'node_modules'),
         globalVirtualStoreDir,
         rootDir: opts.rootDir,
         store: opts.store,

--- a/installing/env-installer/src/installConfigDeps.ts
+++ b/installing/env-installer/src/installConfigDeps.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { packageIsInstallable } from '@pnpm/config.package-is-installable'
+import { checkPackage } from '@pnpm/config.package-is-installable'
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
-import { installingConfigDepsLogger } from '@pnpm/core-loggers'
+import { installingConfigDepsLogger, skippedOptionalDependencyLogger } from '@pnpm/core-loggers'
 import { calcGlobalVirtualStorePathWithSubdeps, calcLeafGlobalVirtualStorePath } from '@pnpm/deps.graph-hasher'
 import { PnpmError } from '@pnpm/error'
 import { readModulesDir } from '@pnpm/fs.read-modules-dir'
@@ -88,6 +88,7 @@ export async function installConfigDeps (
     if (pkg.optionalSubdeps?.length) {
       await installOptionalSubdeps({
         parentName: pkgName,
+        parentVersion: pkg.version,
         subdeps: pkg.optionalSubdeps,
         // path.dirname would land in the scope subdir for scoped parents; use
         // the leaf's node_modules root so sibling symlinks resolve correctly.
@@ -233,6 +234,7 @@ function readOptionalSubdepsFromLockfile (
 
 interface InstallOptionalSubdepsOpts {
   parentName: string
+  parentVersion: string
   subdeps: NormalizedSubdep[]
   parentNodeModulesDir: string
   globalVirtualStoreDir: string
@@ -241,13 +243,27 @@ interface InstallOptionalSubdepsOpts {
 }
 
 async function installOptionalSubdeps (opts: InstallOptionalSubdepsOpts): Promise<void> {
+  const parentLogInfo = { id: `${opts.parentName}@${opts.parentVersion}`, name: opts.parentName, version: opts.parentVersion }
   const compatibleSubdeps = opts.subdeps.filter((subdep) => {
     if (!subdep.os && !subdep.cpu && !subdep.libc) return true
-    return packageIsInstallable(
+    // Use checkPackage rather than packageIsInstallable: the latter emits a
+    // user-visible warn for every incompatible variant, which would fire on
+    // every install since the env lockfile records all platform variants for
+    // portability. We log skipped subdeps at debug instead.
+    const error = checkPackage(
       `${subdep.name}@${subdep.version}`,
-      { name: subdep.name, version: subdep.version, os: subdep.os, cpu: subdep.cpu, libc: subdep.libc },
-      { optional: true, lockfileDir: opts.rootDir }
-    ) === true
+      { os: subdep.os, cpu: subdep.cpu, libc: subdep.libc },
+      {}
+    )
+    if (error == null) return true
+    skippedOptionalDependencyLogger.debug({
+      details: error.toString(),
+      package: { id: `${subdep.name}@${subdep.version}`, name: subdep.name, version: subdep.version },
+      parents: [parentLogInfo],
+      prefix: opts.rootDir,
+      reason: error.code === 'ERR_PNPM_UNSUPPORTED_ENGINE' ? 'unsupported_engine' : 'unsupported_platform',
+    })
+    return false
   })
 
   const expectedSiblings = new Set([opts.parentName, ...compatibleSubdeps.map((s) => s.name)])

--- a/installing/env-installer/src/parseIntegrity.ts
+++ b/installing/env-installer/src/parseIntegrity.ts
@@ -6,6 +6,19 @@ export interface NormalizedConfigDep {
     integrity: string
     tarball: string
   }
+  optionalSubdeps?: NormalizedSubdep[]
+}
+
+export interface NormalizedSubdep {
+  name: string
+  version: string
+  resolution: {
+    integrity: string
+    tarball: string
+  }
+  os?: string[]
+  cpu?: string[]
+  libc?: string[]
 }
 
 export function parseIntegrity (pkgName: string, pkgSpec: string): { version: string, integrity: string } {

--- a/installing/env-installer/src/resolveAndInstallConfigDeps.ts
+++ b/installing/env-installer/src/resolveAndInstallConfigDeps.ts
@@ -16,6 +16,7 @@ import getNpmTarballUrl from 'get-npm-tarball-url'
 import { installConfigDeps, type InstallConfigDepsOpts } from './installConfigDeps.js'
 import { parseIntegrity } from './parseIntegrity.js'
 import { pruneEnvLockfile } from './pruneEnvLockfile.js'
+import { resolveOptionalSubdeps } from './resolveOptionalSubdeps.js'
 
 export type ResolveAndInstallConfigDepsOpts = CreateFetchFromRegistryOptions & ResolverFactoryOptions & InstallConfigDepsOpts & {
   rootDir: string
@@ -131,7 +132,13 @@ export async function resolveAndInstallConfigDeps (
         registry
       ),
     }
-    envLockfile.snapshots[pkgKey] = {}
+    const optionalSubdeps = await resolveOptionalSubdeps(name, resolution.manifest, {
+      envLockfile,
+      lockfileDir: opts.rootDir,
+      registries: opts.registries,
+      resolveFromNpm,
+    })
+    envLockfile.snapshots[pkgKey] = optionalSubdeps ? { optionalDependencies: optionalSubdeps } : {}
   }))
 
   pruneEnvLockfile(envLockfile)

--- a/installing/env-installer/src/resolveConfigDeps.ts
+++ b/installing/env-installer/src/resolveConfigDeps.ts
@@ -15,6 +15,7 @@ import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import type { ConfigDependencies, ConfigDependencySpecifiers, RegistryConfig } from '@pnpm/types'
 
 import { installConfigDeps, type InstallConfigDepsOpts } from './installConfigDeps.js'
+import { resolveOptionalSubdeps } from './resolveOptionalSubdeps.js'
 
 export type ResolveConfigDepsOpts = CreateFetchFromRegistryOptions & ResolverFactoryOptions & InstallConfigDepsOpts & {
   configDependencies?: ConfigDependencies
@@ -68,7 +69,13 @@ export async function resolveConfigDeps (configDeps: string[], opts: ResolveConf
         registry
       ),
     }
-    envLockfile.snapshots[pkgKey] = {}
+    const optionalSubdeps = await resolveOptionalSubdeps(pkgName, resolution.manifest, {
+      envLockfile,
+      lockfileDir: opts.rootDir,
+      registries: opts.registries,
+      resolveFromNpm,
+    })
+    envLockfile.snapshots[pkgKey] = optionalSubdeps ? { optionalDependencies: optionalSubdeps } : {}
   }))
 
   await Promise.all([

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -1,4 +1,7 @@
+import util from 'node:util'
+
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+import { skippedOptionalDependencyLogger } from '@pnpm/core-loggers'
 import { PnpmError } from '@pnpm/error'
 import type { EnvLockfile } from '@pnpm/lockfile.fs'
 import type { ResolvedDependencies } from '@pnpm/lockfile.types'
@@ -44,8 +47,24 @@ export async function resolveOptionalSubdeps (
         preferredVersions: {},
         projectDir: opts.lockfileDir,
       })
-    } catch {
-      // npm's optionalDependencies semantics: a failed resolution is not fatal.
+    } catch (err: unknown) {
+      // Trust-downgrade is a security signal that must fail the install even
+      // for optional deps; everything else mirrors npm's optionalDependencies
+      // semantics — log and skip.
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ERR_PNPM_TRUST_DOWNGRADE') {
+        throw err
+      }
+      skippedOptionalDependencyLogger.debug({
+        details: util.types.isNativeError(err) ? err.toString() : String(err),
+        package: {
+          name: subdepName,
+          version: undefined,
+          bareSpecifier: subdepSpec,
+        },
+        parents: [{ id: `${parentName}@${parentManifest.version}`, name: parentName, version: parentManifest.version }],
+        prefix: opts.lockfileDir,
+        reason: 'resolution_failure',
+      })
       return
     }
     if (

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -5,6 +5,7 @@ import type { ResolvedDependencies } from '@pnpm/lockfile.types'
 import { toLockfileResolution } from '@pnpm/lockfile.utils'
 import type { createNpmResolver } from '@pnpm/resolving.npm-resolver'
 import type { DependencyManifest, Registries } from '@pnpm/types'
+import semver from 'semver'
 
 type ResolveFromNpm = ReturnType<typeof createNpmResolver>['resolveFromNpm']
 
@@ -27,6 +28,15 @@ export async function resolveOptionalSubdeps (
 
   const resolved: ResolvedDependencies = {}
   await Promise.all(Object.entries(optionalDeps).map(async ([subdepName, subdepSpec]) => {
+    if (semver.valid(subdepSpec) == null) {
+      // Ranges and tags would let the resolved version drift between machines
+      // even with a stable parent integrity, breaking the lockfile's promise
+      // of reproducible config-dep installs.
+      throw new PnpmError(
+        'CONFIG_DEP_OPTIONAL_NOT_EXACT',
+        `Cannot install "${subdepName}@${subdepSpec}" as an optionalDependency of config dependency "${parentName}": only exact versions are supported (got "${subdepSpec}")`
+      )
+    }
     let resolution
     try {
       resolution = await opts.resolveFromNpm({ alias: subdepName, bareSpecifier: subdepSpec }, {

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -1,0 +1,80 @@
+import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
+import { PnpmError } from '@pnpm/error'
+import type { EnvLockfile } from '@pnpm/lockfile.fs'
+import type { ResolvedDependencies } from '@pnpm/lockfile.types'
+import { toLockfileResolution } from '@pnpm/lockfile.utils'
+import type { createNpmResolver } from '@pnpm/resolving.npm-resolver'
+import type { DependencyManifest, Registries } from '@pnpm/types'
+
+type ResolveFromNpm = ReturnType<typeof createNpmResolver>['resolveFromNpm']
+
+export interface ResolveOptionalSubdepsOpts {
+  envLockfile: EnvLockfile
+  lockfileDir: string
+  registries: Registries
+  resolveFromNpm: ResolveFromNpm
+}
+
+export async function resolveOptionalSubdeps (
+  parentName: string,
+  parentManifest: DependencyManifest,
+  opts: ResolveOptionalSubdepsOpts
+): Promise<ResolvedDependencies | undefined> {
+  const optionalDeps = parentManifest.optionalDependencies
+  if (!optionalDeps || Object.keys(optionalDeps).length === 0) {
+    return undefined
+  }
+
+  const resolved: ResolvedDependencies = {}
+  await Promise.all(Object.entries(optionalDeps).map(async ([subdepName, subdepSpec]) => {
+    let resolution
+    try {
+      resolution = await opts.resolveFromNpm({ alias: subdepName, bareSpecifier: subdepSpec }, {
+        lockfileDir: opts.lockfileDir,
+        preferredVersions: {},
+        projectDir: opts.lockfileDir,
+      })
+    } catch {
+      // npm's optionalDependencies semantics: a failed resolution is not fatal.
+      return
+    }
+    if (
+      resolution?.resolution == null ||
+      !('integrity' in resolution.resolution) ||
+      typeof resolution.resolution.integrity !== 'string' ||
+      !resolution.resolution.integrity ||
+      resolution.manifest == null
+    ) {
+      throw new PnpmError(
+        'BAD_CONFIG_DEP',
+        `Cannot resolve optionalDependency "${subdepName}" of config dependency "${parentName}" because it has no integrity`
+      )
+    }
+    const subdepVersion = resolution.manifest.version
+    const registry = pickRegistryForPackage(opts.registries, subdepName)
+    const subdepKey = `${subdepName}@${subdepVersion}`
+
+    opts.envLockfile.packages[subdepKey] = {
+      resolution: toLockfileResolution(
+        { name: subdepName, version: subdepVersion },
+        resolution.resolution,
+        registry
+      ),
+      ...pickPlatformFields(resolution.manifest),
+    }
+    if (opts.envLockfile.snapshots[subdepKey] == null) {
+      opts.envLockfile.snapshots[subdepKey] = {}
+    }
+    resolved[subdepName] = subdepVersion
+  }))
+
+  return Object.keys(resolved).length > 0 ? resolved : undefined
+}
+
+function pickPlatformFields (manifest: DependencyManifest): { os?: string[], cpu?: string[], libc?: string[] } {
+  const out: { os?: string[], cpu?: string[], libc?: string[] } = {}
+  if (manifest.os?.length) out.os = manifest.os
+  if (manifest.cpu?.length) out.cpu = manifest.cpu
+  if (manifest.libc?.length) out.libc = manifest.libc
+  return out
+}

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -58,7 +58,9 @@ export async function resolveOptionalSubdeps (
         details: util.types.isNativeError(err) ? err.toString() : String(err),
         package: {
           name: subdepName,
-          version: undefined,
+          // No resolved version yet; surface the requested specifier so log
+          // consumers that format `${name}@${version}` don't render `@undefined`.
+          version: subdepSpec,
           bareSpecifier: subdepSpec,
         },
         parents: [{ id: `${parentName}@${parentManifest.version}`, name: parentName, version: parentManifest.version }],

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -42,7 +42,10 @@ export async function resolveOptionalSubdeps (
     }
     let resolution
     try {
-      resolution = await opts.resolveFromNpm({ alias: subdepName, bareSpecifier: subdepSpec }, {
+      // `optional: true` opts into full registry metadata so the resolver
+      // returns `libc` (and any other fields the abbreviated metadata strips).
+      // See pnpm/pnpm#9950.
+      resolution = await opts.resolveFromNpm({ alias: subdepName, bareSpecifier: subdepSpec, optional: true }, {
         lockfileDir: opts.lockfileDir,
         preferredVersions: {},
         projectDir: opts.lockfileDir,

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -159,6 +159,41 @@ test('optional subdep that does not match the current platform is skipped', asyn
   expect(() => requireFromParent.resolve(`${subdepName}/package.json`)).toThrow(/Cannot find/)
 })
 
+test('optional subdep that does not match the current cpu is skipped', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  const parentName = '@pnpm.e2e/foo'
+  const parentVersion = '100.0.0'
+  const subdepName = '@pnpm.e2e/bar'
+  const subdepVersion = '100.0.0'
+
+  const lockfile = createEnvLockfile()
+  const parentKey = `${parentName}@${parentVersion}`
+  lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+  lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+  lockfile.snapshots[parentKey] = {
+    optionalDependencies: { [subdepName]: subdepVersion },
+  }
+  lockfile.packages[`${subdepName}@${subdepVersion}`] = {
+    resolution: { integrity: getIntegrity(subdepName, subdepVersion) },
+    cpu: ['this-cpu-does-not-exist'],
+  }
+
+  await installConfigDeps(lockfile, {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    store: storeController,
+    storeDir,
+  })
+
+  const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
+  const requireFromParent = createRequire(path.join(parentRealPath, 'package.json'))
+  expect(() => requireFromParent.resolve(`${subdepName}/package.json`)).toThrow(/Cannot find/)
+})
+
 test('installation fails if the checksum of the config dependency is invalid', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore({

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -8,6 +8,7 @@ import { createEnvLockfile, type EnvLockfile, readEnvLockfile } from '@pnpm/lock
 import { prepareEmpty } from '@pnpm/prepare'
 import { getIntegrity, REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import { createTempStore } from '@pnpm/testing.temp-store'
+import { rimraf } from '@zkochan/rimraf'
 import { loadJsonFileSync } from 'load-json-file'
 
 const registry = `http://localhost:${REGISTRY_MOCK_PORT}/`
@@ -197,39 +198,24 @@ test('optional subdep that does not match the current platform is skipped', asyn
   expect(() => requireFromParent.resolve(`${subdepName}/package.json`)).toThrow(/Cannot find/)
 })
 
-test('platform change between runs prunes the stale sibling and relinks the new compatible one', async () => {
+test('re-installs sibling symlinks even when the parent symlink is already correct', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()
 
   const parentName = '@pnpm.e2e/foo'
   const parentVersion = '100.0.0'
-  const subdepA = { name: '@pnpm.e2e/bar', version: '100.0.0' }
-  const subdepB = { name: '@pnpm.e2e/qar', version: '100.0.0' }
+  const subdepName = '@pnpm.e2e/bar'
+  const subdepVersion = '100.0.0'
 
-  // Same parent + same subdep versions → same leaf hash both runs. Only the
-  // os field on each subdep changes, which the lockfile's leaf hash doesn't
-  // capture but the install-time selector does. The realpath skip-check
-  // would match, so we rely on installOptionalSubdeps running unconditionally.
-  function buildLockfile (matching: { name: string, version: string }, other: { name: string, version: string }): EnvLockfile {
-    const lockfile = createEnvLockfile()
-    const parentKey = `${parentName}@${parentVersion}`
-    lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
-    lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
-    lockfile.snapshots[parentKey] = {
-      optionalDependencies: {
-        [matching.name]: matching.version,
-        [other.name]: other.version,
-      },
-    }
-    lockfile.packages[`${matching.name}@${matching.version}`] = {
-      resolution: { integrity: getIntegrity(matching.name, matching.version) },
-      os: [process.platform],
-    }
-    lockfile.packages[`${other.name}@${other.version}`] = {
-      resolution: { integrity: getIntegrity(other.name, other.version) },
-      os: ['this-os-does-not-exist'],
-    }
-    return lockfile
+  const lockfile = createEnvLockfile()
+  const parentKey = `${parentName}@${parentVersion}`
+  lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+  lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+  lockfile.snapshots[parentKey] = { optionalDependencies: { [subdepName]: subdepVersion } }
+  lockfile.packages[`${subdepName}@${subdepVersion}`] = {
+    resolution: { integrity: getIntegrity(subdepName, subdepVersion) },
+    os: [process.platform],
+    cpu: [process.arch],
   }
 
   const installOpts = {
@@ -239,17 +225,21 @@ test('platform change between runs prunes the stale sibling and relinks the new 
     storeDir,
   }
 
-  // First run: A compatible, B incompatible.
-  await installConfigDeps(buildLockfile(subdepA, subdepB), installOpts)
-  const requireRun1 = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
-  expect(() => requireRun1.resolve(`${subdepA.name}/package.json`)).not.toThrow()
-  expect(() => requireRun1.resolve(`${subdepB.name}/package.json`)).toThrow(/Cannot find/)
+  // First install — parent + subdep symlink land in the GVS leaf.
+  await installConfigDeps(lockfile, installOpts)
+  const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
+  const subdepSiblingPath = path.join(path.dirname(path.dirname(parentRealPath)), subdepName)
+  expect(fs.existsSync(`${subdepSiblingPath}/package.json`)).toBe(true)
 
-  // Second run, roles swapped: B compatible, A incompatible. Same leaf hash.
-  await installConfigDeps(buildLockfile(subdepB, subdepA), installOpts)
-  const requireRun2 = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
-  expect(() => requireRun2.resolve(`${subdepB.name}/package.json`)).not.toThrow()
-  expect(() => requireRun2.resolve(`${subdepA.name}/package.json`)).toThrow(/Cannot find/)
+  // Simulate stale state: remove the subdep sibling symlink. The parent's
+  // .pnpm-config symlink still points at the expected leaf, so the realpath
+  // skip-check passes. installOptionalSubdeps must still run to repair.
+  await rimraf(subdepSiblingPath)
+  expect(fs.existsSync(subdepSiblingPath)).toBe(false)
+
+  // Second install with the same lockfile.
+  await installConfigDeps(lockfile, installOpts)
+  expect(fs.existsSync(`${subdepSiblingPath}/package.json`)).toBe(true)
 })
 
 test('optional subdep that does not match the current cpu is skipped', async () => {

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -80,6 +80,72 @@ test('configuration dependency is installed from env lockfile', async () => {
   expect(fs.existsSync('node_modules/.pnpm-config/@pnpm.e2e/foo/package.json')).toBeFalsy()
 })
 
+test('optional subdep matching the current platform is installed and symlinked next to parent', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  const parentName = '@pnpm.e2e/support-different-architectures'
+  const parentVersion = '1.0.0'
+  // Build a subdep entry that matches the current platform exactly.
+  const matchingSubdepName = `@pnpm.e2e/only-${process.platform}-${process.arch}`
+  const matchingSubdepVersion = '1.0.0'
+  const incompatibleSubdepName = '@pnpm.e2e/only-darwin-arm64'
+
+  const lockfile = createEnvLockfile()
+  const parentKey = `${parentName}@${parentVersion}`
+  lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+  lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+  lockfile.snapshots[parentKey] = {
+    optionalDependencies: {
+      [matchingSubdepName]: matchingSubdepVersion,
+      // Force-include a darwin-arm64 entry to verify cross-platform skip logic.
+      // If the test runs on darwin-arm64, this is the matching one and is added
+      // twice (no-op due to map semantics), so we only assert the unrelated
+      // platform skip when running on other architectures.
+      ...(matchingSubdepName !== incompatibleSubdepName
+        ? { [incompatibleSubdepName]: '1.0.0' }
+        : {}),
+    },
+  }
+  lockfile.packages[`${matchingSubdepName}@${matchingSubdepVersion}`] = {
+    resolution: { integrity: getIntegrity(matchingSubdepName, matchingSubdepVersion) },
+    os: [process.platform],
+    cpu: [process.arch],
+  }
+  if (matchingSubdepName !== incompatibleSubdepName) {
+    lockfile.packages[`${incompatibleSubdepName}@1.0.0`] = {
+      resolution: { integrity: getIntegrity(incompatibleSubdepName, '1.0.0') },
+      os: ['darwin'],
+      cpu: ['arm64'],
+    }
+  }
+
+  await installConfigDeps(lockfile, {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    store: storeController,
+    storeDir,
+  })
+
+  // Parent is symlinked into .pnpm-config
+  expect(fs.existsSync(`node_modules/.pnpm-config/${parentName}/package.json`)).toBe(true)
+
+  // The matching subdep is reachable from the parent's location via Node-style
+  // module resolution (walk up to siblings in node_modules).
+  const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
+  const subdepSiblingPath = `${parentRealPath}/../${matchingSubdepName}`
+  expect(fs.existsSync(`${subdepSiblingPath}/package.json`)).toBe(true)
+  const subdepManifest = loadJsonFileSync<{ name: string }>(`${subdepSiblingPath}/package.json`)
+  expect(subdepManifest.name).toBe(matchingSubdepName)
+
+  // The non-matching subdep is NOT linked next to the parent
+  if (matchingSubdepName !== incompatibleSubdepName) {
+    expect(fs.existsSync(`${parentRealPath}/../${incompatibleSubdepName}`)).toBe(false)
+  }
+})
+
 test('installation fails if the checksum of the config dependency is invalid', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore({

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { installConfigDeps } from '@pnpm/installing.env-installer'
@@ -113,9 +115,10 @@ test('optional subdep matching the current platform is installed and symlinked n
 
   expect(fs.existsSync(`node_modules/.pnpm-config/${parentName}/package.json`)).toBe(true)
 
+  // Node-style resolution from inside the parent must find the sibling subdep.
   const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
-  const siblingPkgJsonPath = `${parentRealPath}/../${subdepName}/package.json`
-  expect(fs.existsSync(siblingPkgJsonPath)).toBe(true)
+  const requireFromParent = createRequire(path.join(parentRealPath, 'package.json'))
+  const siblingPkgJsonPath = requireFromParent.resolve(`${subdepName}/package.json`)
   const siblingManifest = loadJsonFileSync<{ name: string, version: string }>(siblingPkgJsonPath)
   expect(siblingManifest.name).toBe(subdepName)
   expect(siblingManifest.version).toBe(subdepVersion)
@@ -152,7 +155,8 @@ test('optional subdep that does not match the current platform is skipped', asyn
   })
 
   const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
-  expect(fs.existsSync(`${parentRealPath}/../${subdepName}`)).toBe(false)
+  const requireFromParent = createRequire(path.join(parentRealPath, 'package.json'))
+  expect(() => requireFromParent.resolve(`${subdepName}/package.json`)).toThrow(/Cannot find/)
 })
 
 test('installation fails if the checksum of the config dependency is invalid', async () => {

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -197,6 +197,61 @@ test('optional subdep that does not match the current platform is skipped', asyn
   expect(() => requireFromParent.resolve(`${subdepName}/package.json`)).toThrow(/Cannot find/)
 })
 
+test('platform change between runs prunes the stale sibling and relinks the new compatible one', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  const parentName = '@pnpm.e2e/foo'
+  const parentVersion = '100.0.0'
+  const subdepA = { name: '@pnpm.e2e/bar', version: '100.0.0' }
+  const subdepB = { name: '@pnpm.e2e/qar', version: '100.0.0' }
+
+  // Same parent + same subdep versions → same leaf hash both runs. Only the
+  // os field on each subdep changes, which the lockfile's leaf hash doesn't
+  // capture but the install-time selector does. The realpath skip-check
+  // would match, so we rely on installOptionalSubdeps running unconditionally.
+  function buildLockfile (matching: { name: string, version: string }, other: { name: string, version: string }): EnvLockfile {
+    const lockfile = createEnvLockfile()
+    const parentKey = `${parentName}@${parentVersion}`
+    lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+    lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+    lockfile.snapshots[parentKey] = {
+      optionalDependencies: {
+        [matching.name]: matching.version,
+        [other.name]: other.version,
+      },
+    }
+    lockfile.packages[`${matching.name}@${matching.version}`] = {
+      resolution: { integrity: getIntegrity(matching.name, matching.version) },
+      os: [process.platform],
+    }
+    lockfile.packages[`${other.name}@${other.version}`] = {
+      resolution: { integrity: getIntegrity(other.name, other.version) },
+      os: ['this-os-does-not-exist'],
+    }
+    return lockfile
+  }
+
+  const installOpts = {
+    registries: { default: registry },
+    rootDir: process.cwd(),
+    store: storeController,
+    storeDir,
+  }
+
+  // First run: A compatible, B incompatible.
+  await installConfigDeps(buildLockfile(subdepA, subdepB), installOpts)
+  const requireRun1 = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
+  expect(() => requireRun1.resolve(`${subdepA.name}/package.json`)).not.toThrow()
+  expect(() => requireRun1.resolve(`${subdepB.name}/package.json`)).toThrow(/Cannot find/)
+
+  // Second run, roles swapped: B compatible, A incompatible. Same leaf hash.
+  await installConfigDeps(buildLockfile(subdepB, subdepA), installOpts)
+  const requireRun2 = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
+  expect(() => requireRun2.resolve(`${subdepB.name}/package.json`)).not.toThrow()
+  expect(() => requireRun2.resolve(`${subdepA.name}/package.json`)).toThrow(/Cannot find/)
+})
+
 test('optional subdep that does not match the current cpu is skipped', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -84,40 +84,22 @@ test('optional subdep matching the current platform is installed and symlinked n
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()
 
-  const parentName = '@pnpm.e2e/support-different-architectures'
-  const parentVersion = '1.0.0'
-  // Build a subdep entry that matches the current platform exactly.
-  const matchingSubdepName = `@pnpm.e2e/only-${process.platform}-${process.arch}`
-  const matchingSubdepVersion = '1.0.0'
-  const incompatibleSubdepName = '@pnpm.e2e/only-darwin-arm64'
+  const parentName = '@pnpm.e2e/foo'
+  const parentVersion = '100.0.0'
+  const subdepName = '@pnpm.e2e/bar'
+  const subdepVersion = '100.0.0'
 
   const lockfile = createEnvLockfile()
   const parentKey = `${parentName}@${parentVersion}`
   lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
   lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
   lockfile.snapshots[parentKey] = {
-    optionalDependencies: {
-      [matchingSubdepName]: matchingSubdepVersion,
-      // Force-include a darwin-arm64 entry to verify cross-platform skip logic.
-      // If the test runs on darwin-arm64, this is the matching one and is added
-      // twice (no-op due to map semantics), so we only assert the unrelated
-      // platform skip when running on other architectures.
-      ...(matchingSubdepName !== incompatibleSubdepName
-        ? { [incompatibleSubdepName]: '1.0.0' }
-        : {}),
-    },
+    optionalDependencies: { [subdepName]: subdepVersion },
   }
-  lockfile.packages[`${matchingSubdepName}@${matchingSubdepVersion}`] = {
-    resolution: { integrity: getIntegrity(matchingSubdepName, matchingSubdepVersion) },
+  lockfile.packages[`${subdepName}@${subdepVersion}`] = {
+    resolution: { integrity: getIntegrity(subdepName, subdepVersion) },
     os: [process.platform],
     cpu: [process.arch],
-  }
-  if (matchingSubdepName !== incompatibleSubdepName) {
-    lockfile.packages[`${incompatibleSubdepName}@1.0.0`] = {
-      resolution: { integrity: getIntegrity(incompatibleSubdepName, '1.0.0') },
-      os: ['darwin'],
-      cpu: ['arm64'],
-    }
   }
 
   await installConfigDeps(lockfile, {
@@ -129,21 +111,48 @@ test('optional subdep matching the current platform is installed and symlinked n
     storeDir,
   })
 
-  // Parent is symlinked into .pnpm-config
   expect(fs.existsSync(`node_modules/.pnpm-config/${parentName}/package.json`)).toBe(true)
 
-  // The matching subdep is reachable from the parent's location via Node-style
-  // module resolution (walk up to siblings in node_modules).
   const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
-  const subdepSiblingPath = `${parentRealPath}/../${matchingSubdepName}`
-  expect(fs.existsSync(`${subdepSiblingPath}/package.json`)).toBe(true)
-  const subdepManifest = loadJsonFileSync<{ name: string }>(`${subdepSiblingPath}/package.json`)
-  expect(subdepManifest.name).toBe(matchingSubdepName)
+  const siblingPkgJsonPath = `${parentRealPath}/../${subdepName}/package.json`
+  expect(fs.existsSync(siblingPkgJsonPath)).toBe(true)
+  const siblingManifest = loadJsonFileSync<{ name: string, version: string }>(siblingPkgJsonPath)
+  expect(siblingManifest.name).toBe(subdepName)
+  expect(siblingManifest.version).toBe(subdepVersion)
+})
 
-  // The non-matching subdep is NOT linked next to the parent
-  if (matchingSubdepName !== incompatibleSubdepName) {
-    expect(fs.existsSync(`${parentRealPath}/../${incompatibleSubdepName}`)).toBe(false)
+test('optional subdep that does not match the current platform is skipped', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  const parentName = '@pnpm.e2e/foo'
+  const parentVersion = '100.0.0'
+  const subdepName = '@pnpm.e2e/bar'
+  const subdepVersion = '100.0.0'
+
+  const lockfile = createEnvLockfile()
+  const parentKey = `${parentName}@${parentVersion}`
+  lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+  lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+  lockfile.snapshots[parentKey] = {
+    optionalDependencies: { [subdepName]: subdepVersion },
   }
+  lockfile.packages[`${subdepName}@${subdepVersion}`] = {
+    resolution: { integrity: getIntegrity(subdepName, subdepVersion) },
+    os: ['this-os-does-not-exist'],
+  }
+
+  await installConfigDeps(lockfile, {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    store: storeController,
+    storeDir,
+  })
+
+  const parentRealPath = fs.realpathSync(`node_modules/.pnpm-config/${parentName}`)
+  expect(fs.existsSync(`${parentRealPath}/../${subdepName}`)).toBe(false)
 })
 
 test('installation fails if the checksum of the config dependency is invalid', async () => {

--- a/installing/env-installer/test/installConfigDeps.ts
+++ b/installing/env-installer/test/installConfigDeps.ts
@@ -124,6 +124,44 @@ test('optional subdep matching the current platform is installed and symlinked n
   expect(siblingManifest.version).toBe(subdepVersion)
 })
 
+test('changing only an optional subdep version re-installs and re-symlinks the parent', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  const parentName = '@pnpm.e2e/foo'
+  const parentVersion = '100.0.0'
+  const subdepName = '@pnpm.e2e/bar'
+
+  function buildLockfile (subdepVersion: string): EnvLockfile {
+    const lockfile = createEnvLockfile()
+    const parentKey = `${parentName}@${parentVersion}`
+    lockfile.importers['.'].configDependencies[parentName] = { specifier: parentVersion, version: parentVersion }
+    lockfile.packages[parentKey] = { resolution: { integrity: getIntegrity(parentName, parentVersion) } }
+    lockfile.snapshots[parentKey] = { optionalDependencies: { [subdepName]: subdepVersion } }
+    lockfile.packages[`${subdepName}@${subdepVersion}`] = {
+      resolution: { integrity: getIntegrity(subdepName, subdepVersion) },
+      os: [process.platform],
+      cpu: [process.arch],
+    }
+    return lockfile
+  }
+
+  const installOpts = {
+    registries: { default: registry },
+    rootDir: process.cwd(),
+    store: storeController,
+    storeDir,
+  }
+
+  await installConfigDeps(buildLockfile('100.0.0'), installOpts)
+  const requireBefore = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
+  expect(loadJsonFileSync<{ version: string }>(requireBefore.resolve(`${subdepName}/package.json`)).version).toBe('100.0.0')
+
+  await installConfigDeps(buildLockfile('100.1.0'), installOpts)
+  const requireAfter = createRequire(path.join(fs.realpathSync(`node_modules/.pnpm-config/${parentName}`), 'package.json'))
+  expect(loadJsonFileSync<{ version: string }>(requireAfter.resolve(`${subdepName}/package.json`)).version).toBe('100.1.0')
+})
+
 test('optional subdep that does not match the current platform is skipped', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()

--- a/installing/env-installer/test/resolveConfigDeps.test.ts
+++ b/installing/env-installer/test/resolveConfigDeps.test.ts
@@ -45,6 +45,76 @@ test('configuration dependency is resolved', async () => {
   expect(envLockfile!.snapshots['@pnpm.e2e/foo@100.0.0']).toStrictEqual({})
 })
 
+test('one level of optionalDependencies is recorded in the env lockfile with platform fields', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  await resolveConfigDeps(['@pnpm.e2e/support-different-architectures@1.0.0'], {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    cacheDir: path.resolve('cache'),
+    store: storeController,
+    storeDir,
+  })
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile).not.toBeNull()
+
+  const parentKey = '@pnpm.e2e/support-different-architectures@1.0.0'
+  expect(envLockfile!.snapshots[parentKey]).toStrictEqual({
+    optionalDependencies: {
+      '@pnpm.e2e/only-darwin-arm64': '1.0.0',
+      '@pnpm.e2e/only-darwin-x64': '1.0.0',
+      '@pnpm.e2e/only-linux-arm64-glibc': '1.0.0',
+      '@pnpm.e2e/only-linux-arm64-musl': '1.0.0',
+      '@pnpm.e2e/only-linux-x64-glibc': '1.0.0',
+      '@pnpm.e2e/only-linux-x64-musl': '1.0.0',
+      '@pnpm.e2e/only-win32-arm64': '1.0.0',
+      '@pnpm.e2e/only-win32-x64': '1.0.0',
+    },
+  })
+
+  // Each optional subdep is in `packages` with its os/cpu fields preserved for
+  // install-time platform filtering, and gets an empty snapshot.
+  expect(envLockfile!.packages['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({
+    resolution: {
+      integrity: getIntegrity('@pnpm.e2e/only-darwin-arm64', '1.0.0'),
+    },
+    os: ['darwin'],
+    cpu: ['arm64'],
+  })
+  expect(envLockfile!.snapshots['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({})
+  expect(envLockfile!.packages['@pnpm.e2e/only-linux-x64-musl@1.0.0']).toBeDefined()
+
+  // The parent config dep itself is still registered as the only top-level config dep.
+  expect(envLockfile!.importers['.'].configDependencies).toStrictEqual({
+    '@pnpm.e2e/support-different-architectures': {
+      specifier: '1.0.0',
+      version: '1.0.0',
+    },
+  })
+})
+
+test('config dep with no optionalDependencies keeps an empty snapshot', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  await resolveConfigDeps(['@pnpm.e2e/foo@100.0.0'], {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    cacheDir: path.resolve('cache'),
+    store: storeController,
+    storeDir,
+  })
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile!.snapshots['@pnpm.e2e/foo@100.0.0']).toStrictEqual({})
+})
+
 test('fails with frozenLockfile', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()

--- a/installing/env-installer/test/resolveConfigDeps.test.ts
+++ b/installing/env-installer/test/resolveConfigDeps.test.ts
@@ -123,6 +123,22 @@ test('config dep with no optionalDependencies keeps an empty snapshot', async ()
   expect(envLockfile!.snapshots['@pnpm.e2e/foo@100.0.0']).toStrictEqual({})
 })
 
+test('rejects an optionalDependency declared with a non-exact version', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  // @pnpm.e2e/foobar declares `@pnpm.e2e/bar: "^100.0.0"` — a range, not an exact version.
+  await expect(resolveConfigDeps(['@pnpm.e2e/foobar@100.0.0'], {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    cacheDir: path.resolve('cache'),
+    store: storeController,
+    storeDir,
+  })).rejects.toThrow(/only exact versions are supported/)
+})
+
 test('fails with frozenLockfile', async () => {
   prepareEmpty()
   const { storeController, storeDir } = createTempStore()

--- a/installing/env-installer/test/resolveConfigDeps.test.ts
+++ b/installing/env-installer/test/resolveConfigDeps.test.ts
@@ -86,7 +86,15 @@ test('one level of optionalDependencies is recorded in the env lockfile with pla
     cpu: ['arm64'],
   })
   expect(envLockfile!.snapshots['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({})
-  expect(envLockfile!.packages['@pnpm.e2e/only-linux-x64-musl@1.0.0']).toBeDefined()
+  // libc is preserved alongside os/cpu for musl/glibc variants.
+  expect(envLockfile!.packages['@pnpm.e2e/only-linux-x64-musl@1.0.0']).toStrictEqual({
+    resolution: {
+      integrity: getIntegrity('@pnpm.e2e/only-linux-x64-musl', '1.0.0'),
+    },
+    os: ['linux'],
+    cpu: ['x64'],
+    libc: ['musl'],
+  })
 
   // The parent config dep itself is still registered as the only top-level config dep.
   expect(envLockfile!.importers['.'].configDependencies).toStrictEqual({

--- a/installing/env-installer/tsconfig.json
+++ b/installing/env-installer/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../__utils__/prepare"
     },
     {
+      "path": "../../config/package-is-installable"
+    },
+    {
       "path": "../../config/pick-registry-for-package"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6250,6 +6250,9 @@ importers:
       get-npm-tarball-url:
         specifier: 'catalog:'
         version: 2.1.0
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.4
       symlink-dir:
         specifier: 'catalog:'
         version: 10.0.1
@@ -6269,6 +6272,9 @@ importers:
       '@pnpm/testing.temp-store':
         specifier: workspace:*
         version: link:../../testing/temp-store
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
       load-json-file:
         specifier: 'catalog:'
         version: 7.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6175,6 +6175,9 @@ importers:
 
   installing/env-installer:
     dependencies:
+      '@pnpm/config.package-is-installable':
+        specifier: workspace:*
+        version: link:../../config/package-is-installable
       '@pnpm/config.pick-registry-for-package':
         specifier: workspace:*
         version: link:../../config/pick-registry-for-package


### PR DESCRIPTION
## Summary

Extends `configDependencies` to resolve and install one level of `optionalDependencies`, with `os` / `cpu` / `libc` platform filtering applied at install time. Closes the prerequisite called out in #11723: this is what makes the esbuild/swc-style platform-binary pattern viable for config dependencies (e.g. shipping pacquet as a config dep with native binaries via `optionalDependencies`).

### What lands

- **Resolution** (`resolveOptionalSubdeps.ts`, wired into `resolveConfigDeps` and `resolveAndInstallConfigDeps`): after each top-level config dep resolves, walks one level of `optionalDependencies`, resolves each, and records them in the env lockfile with `os`/`cpu`/`libc` preserved. The parent's snapshot gets `optionalDependencies: { … }`. All variants are recorded regardless of host platform, so the env lockfile stays portable across machines.
- **Install** (`installConfigDeps.ts`): after the parent is installed into its GVS leaf, fetches each platform-compatible subdep into its own GVS leaf and creates a sibling symlink inside the parent leaf's `node_modules/`. Node's `realpath`-based resolution then makes `require('pkg-platform-arch')` from inside the parent resolve correctly. Stale siblings are pruned, so platform changes between runs produce a clean layout.
- **GVS hash** (new `calcGlobalVirtualStorePathWithSubdeps` in `graph-hasher`): the parent's GVS leaf hash now folds in the optional subdeps' full pkg ids. Without this, changing a subdep version while keeping the parent pinned would land in the same leaf and silently overwrite the sibling symlinks. The leaf function keeps its original "no children" contract; the new function is a separate entry point that pacquet can mirror cleanly.
- **Re-install detection**: the "skip if already installed" check compares the existing `.pnpm-config/{name}` symlink's `realpath` against the expected GVS leaf, not the package.json's name/version. With subdep versions now feeding the leaf hash, name/version alone isn't sufficient. The check only short-circuits the parent's re-import and re-symlink — `installOptionalSubdeps` always runs so platform-specific siblings get pruned and relinked when the host's effective platform changes (Rosetta x64 ↔ arm64, etc.).
- **Exact versions only**: subdep specifiers must be valid semver exact versions (e.g. `"1.2.3"`). Ranges (`"^1.0.0"`) and tags (`"latest"`) are rejected up-front with a `CONFIG_DEP_OPTIONAL_NOT_EXACT` error. With the parent pinned by integrity, the subdep's resolved version mustn't drift between machines.
- **Error handling**: optional-subdep resolution failures are logged via `skippedOptionalDependencyLogger` with `reason: 'resolution_failure'` (same shape as `installing/deps-resolver`) and the install continues — except for `ERR_PNPM_TRUST_DOWNGRADE`, which is a security signal that must still abort the install.

### Scope

Only one level deep. Transitive `dependencies` and lifecycle scripts remain unsupported — pacquet doesn't need them yet, and they carry meaningful security and complexity tradeoffs that deserve a separate discussion.

The env lockfile schema needs no changes: `LockfilePackageInfo` already carries `os`/`cpu`/`libc`, and `LockfilePackageSnapshot.optionalDependencies` already exists for recording the parent→child edge.

## Known limitation

If a workspace already had a resolved config dep in the env lockfile (`snapshots[pkgKey] = {}`) before this PR, optional subdeps won't be retroactively discovered on subsequent installs. Workaround: `pnpm update <pkg>` (or remove + re-add). In practice no published package today relies on `optionalDependencies` in a config dep — they couldn't, since the feature didn't exist — so the practical exposure is narrow. See the inline review thread for the design rationale.

## Test plan

- [ ] `resolveConfigDeps` records all platform variants with `os`/`cpu`/`libc` preserved (incl. `libc` for musl variants).
- [ ] Config dep with no `optionalDependencies` still produces an empty snapshot.
- [ ] `installConfigDeps` symlinks the platform-matching subdep and skips non-matching ones (covers both `os` and `cpu` mismatches).
- [ ] Sibling subdep is reachable via `createRequire(parent).resolve('subdepName')`.
- [ ] Changing only an optional subdep version re-installs the parent into a new GVS leaf and re-symlinks `.pnpm-config/{name}`.
- [ ] Removing a sibling symlink and re-running install restores it (skip-check passes but subdep step still runs).
- [ ] Range/tag specifiers in `optionalDependencies` are rejected with a clear error.
- [ ] `calcLeafGlobalVirtualStorePath` unit test covers the leaf-only contract.
- [ ] `calcGlobalVirtualStorePathWithSubdeps` unit tests: equals leaf path when subdeps is empty; differs on subdep version change, addition, and key-order independence.
- [ ] Existing `installConfigDeps` and `resolveConfigDeps` tests still pass.
- [ ] Docs updated for `configDependencies` in pnpm.io — separate PR to follow.
- [ ] pacquet-side parity tracked separately (pacquet doesn't currently implement config deps).

---
Written by an agent (Claude Code, claude-opus-4-7).
