### PR TITLE
feat(auth): implement `pnpm login --scope`

### DIFF
--- a/.changeset/login-scope-flag.md
+++ b/.changeset/login-scope-flag.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/auth.commands": minor
+"pnpm": minor
+---
+
+Implement the documented `pnpm login --scope <scope>` flag. The scope is normalized (a leading `@` is added if missing; blank values are ignored) and an `@<scope>:registry=<registry>` mapping is written to the pnpm auth file alongside the auth token. Subsequent installs of `@<scope>/*` packages then route to the chosen registry. Previously `pnpm login --scope foo` errored with `Unknown option: 'scope'` despite the flag being listed in the online documentation [#11716](https://github.com/pnpm/pnpm/issues/11716).

--- a/auth/commands/src/login.ts
+++ b/auth/commands/src/login.ts
@@ -24,7 +24,10 @@ import { writeIniFile } from 'write-ini-file'
 import { getRegistryConfigKey, safeReadIniFile } from './shared.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
-  return { registry: allTypes.registry }
+  return {
+    registry: allTypes.registry,
+    scope: allTypes.scope,
+  }
 }
 
 export function cliOptionsTypes (): Record<string, unknown> {
@@ -46,11 +49,15 @@ export function help (): string {
             description: 'The registry to log in to',
             name: '--registry <url>',
           },
+          {
+            description: 'Associate an operation with a scope for a scoped registry. The scope-to-registry mapping is recorded so future installs in the same scope use the chosen registry.',
+            name: '--scope <scope>',
+          },
         ],
       },
     ],
     url: docsUrl('login'),
-    usages: ['pnpm login [--registry <url>]'],
+    usages: ['pnpm login [--registry <url>] [--scope <scope>]'],
   })
 }
 
@@ -65,6 +72,7 @@ export type LoginCommandOptions = Pick<Config,
 | 'authConfig'
 > & {
   registry?: string
+  scope?: string
 }
 
 export async function handler (
@@ -202,9 +210,26 @@ export async function login ({ context = DEFAULT_CONTEXT, opts }: LoginParams): 
   const settings = await safeReadIniFile(readIniFile, configPath) as Record<string, unknown>
   const registryConfigKey = getRegistryConfigKey(registry)
   settings[`${registryConfigKey}:_authToken`] = token
+  // Persist the scope → registry mapping next to the auth token so subsequent
+  // installs for `@scope/*` packages route to this registry. `auth.ini` is
+  // already an allowed source of `@scope:registry=` (see config/reader).
+  const scopeKey = normalizeScope(opts.scope)
+  if (scopeKey != null) {
+    settings[`${scopeKey}:registry`] = registry
+  }
   await writeIniFile(configPath, settings)
 
   return `Logged in on ${registry}`
+}
+
+// `--scope foo` and `--scope @foo` should both produce `@foo`. Empty / blank
+// values are treated as unset so accidental whitespace doesn't write a broken
+// `@:registry=` entry.
+function normalizeScope (scope: string | undefined): string | undefined {
+  if (scope == null) return undefined
+  const trimmed = scope.trim()
+  if (trimmed === '' || trimmed === '@') return undefined
+  return trimmed.startsWith('@') ? trimmed : `@${trimmed}`
 }
 
 interface WebLoginParams {

--- a/auth/commands/test/login.test.ts
+++ b/auth/commands/test/login.test.ts
@@ -141,6 +141,103 @@ describe('login', () => {
     ])
   })
 
+  it('should persist a scope→registry mapping when --scope is provided', async () => {
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo: jest.fn(),
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        if (url === 'https://my-org.example/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://my-org.example/auth/login',
+              doneUrl: 'https://my-org.example/auth/done',
+            },
+          })
+        }
+        if (url === 'https://my-org.example/auth/done') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: { token: 'scoped-token' },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    // `--scope my-org` (no `@`) should be normalized to `@my-org` when written.
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://my-org.example', scope: 'my-org' }
+    const result = await login({ context, opts })
+    expect(result).toBe('Logged in on https://my-org.example/')
+    expect(savedSettings).toMatchObject({
+      '//my-org.example/:_authToken': 'scoped-token',
+      '@my-org:registry': 'https://my-org.example/',
+    })
+  })
+
+  it('should accept --scope with a leading @ and not double-prefix', async () => {
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo: jest.fn(),
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        if (url === 'https://my-org.example/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://my-org.example/auth/login',
+              doneUrl: 'https://my-org.example/auth/done',
+            },
+          })
+        }
+        return createMockResponse({ ok: true, status: 200, json: { token: 'tok' } })
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://my-org.example', scope: '@my-org' }
+    await login({ context, opts })
+    expect(savedSettings['@my-org:registry']).toBe('https://my-org.example/')
+    expect(savedSettings['@@my-org:registry']).toBeUndefined()
+  })
+
+  it('should not write a scope mapping when --scope is omitted', async () => {
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo: jest.fn(),
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        if (url === 'https://example.com/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://example.com/auth/login',
+              doneUrl: 'https://example.com/auth/done',
+            },
+          })
+        }
+        return createMockResponse({ ok: true, status: 200, json: { token: 'tok' } })
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.com' }
+    await login({ context, opts })
+    // No `@…:registry` key should be added when scope isn't passed.
+    for (const key of Object.keys(savedSettings)) {
+      expect(key.startsWith('@')).toBe(false)
+    }
+  })
+
   it('should fall back to classic login when web login returns 404', async () => {
     const fetchedUrls: string[] = []
     const globalInfo = jest.fn()


### PR DESCRIPTION
## What

[pnpm.io's `cli/login` page](https://pnpm.io/cli/login) has long shown the usage as

    pnpm login [--registry <url>] [--scope <scope>]

but in the CLI only `--registry` was actually wired up — `pnpm login --scope foo` errored with `Unknown option: 'scope'`. This PR implements the documented flag.

When `--scope <scope>` is passed, after the auth token is written, an `@<scope>:registry=<registry>` mapping is appended to the same pnpm auth file (`~/.config/pnpm/auth.ini`). `config.reader` already accepts `@scope:registry=` from that file (see [Auth file read order](https://github.com/pnpm/pnpm/blob/main/config/reader/CHANGELOG.md)), so subsequent installs of `@<scope>/*` packages route to the chosen registry without any further configuration.

Closes #11716.

## Behavior summary

| Invocation | Result written to `auth.ini` |
| --- | --- |
| `pnpm login --registry https://example.com/` | `//example.com/:_authToken=<token>` |
| `pnpm login --scope my-org --registry https://example.com/` | `//example.com/:_authToken=<token>` + `@my-org:registry=https://example.com/` |
| `pnpm login --scope @my-org --registry https://example.com/` | same as above (no double `@@`) |
| `pnpm login --scope " " --registry …` / `--scope @` | blank scope is dropped — no broken `@:registry=` line |

## Files touched

- `auth/commands/src/login.ts` — declare `scope: allTypes.scope` in `rcOptionsTypes`, document it in `help()`, normalize the value, write `@<scope>:registry=<registry>` alongside the token in `login()`.
- `auth/commands/test/login.test.ts` — three new tests:
  1. `--scope my-org` normalizes to `@my-org` and writes the mapping.
  2. `--scope @my-org` does not double-prefix.
  3. Omitting `--scope` writes no `@…:registry` key.

## Notes

- I went with `auth.ini` rather than `~/.npmrc` because that's where pnpm 11 already writes auth-adjacent config (`config.reader` reads `@scope:registry=` from it) and it keeps everything `pnpm login` writes in one file. Happy to switch to `~/.npmrc` if maintainers prefer the npm-compatible target — let me know and I'll push a follow-up commit.
- A `cafile` repro and fix in `config.reader` is up as #11726 separately; the two PRs are independent.

## Test plan

- [x] Three new login unit tests cover scope normalization and the no-scope case.
- [x] Standalone repro (script in PR thread for #11716 if helpful) confirms each edge case writes the expected `auth.ini` entries.
- [x] Existing `pnpm login` tests (web auth, classic fallback, OTP, etc.) are unchanged and continue to pass through the same code path.
- [x] Changeset added (minor bump for `@pnpm/auth.commands` and `pnpm`).

## Notes

This contribution was prepared with the assistance of Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--scope` flag to `pnpm login` command, allowing users to authenticate with specific npm scopes and their dedicated registries. Scope values are automatically normalized with an `@` prefix if needed.

* **Bug Fixes**
  * Fixed `pnpm login --scope` command that previously resulted in an "Unknown option" error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->