### PR TITLE
perf(license-scanner): share decoded store index across one scan

### DIFF
--- a/.changeset/scoped-pkg-finder-cache.md
+++ b/.changeset/scoped-pkg-finder-cache.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/store.pkg-finder": patch
+"@pnpm/deps.compliance.license-scanner": patch
+---
+
+`readPackageFileMap` accepts an optional `indexCache` map. Callers that walk a
+dependency graph can share one decoded `PackageFilesIndex` across visits to
+peer-dep variants that resolve to the same store entry, avoiding repeated
+SQLite reads and msgpack decodes. The license scanner now passes one such
+cache for the lifetime of a single `lockfileToLicenseNodeTree` call.

--- a/deps/compliance/license-scanner/src/getPkgInfo.ts
+++ b/deps/compliance/license-scanner/src/getPkgInfo.ts
@@ -5,6 +5,7 @@ import { depPathToFilename } from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import { type PackageSnapshot, pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 import { readPackageJson } from '@pnpm/pkg-manifest.reader'
+import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import type { StoreIndex } from '@pnpm/store.index'
 import { readPackageFileMap } from '@pnpm/store.pkg-finder'
 import type { PackageManifest, Registries } from '@pnpm/types'
@@ -35,6 +36,7 @@ export interface GetPackageInfoOptions {
   virtualStoreDirMaxLength: number
   dir: string
   modulesDir: string
+  indexCache?: Map<string, PackageFilesIndex>
 }
 
 export type PkgInfo = {
@@ -68,6 +70,7 @@ export async function getPkgInfo (
         storeIndex: opts.storeIndex,
         lockfileDir: opts.dir,
         virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+        indexCache: opts.indexCache,
       }
     )
     if (!result) {

--- a/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
+++ b/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
@@ -135,7 +135,7 @@ export async function lockfileToLicenseNodeTree (
   opts: {
     include?: { [dependenciesField in DependenciesField]: boolean }
     includedImporterIds?: ProjectId[]
-  } & Omit<LicenseExtractOptions, 'storeIndex'>
+  } & Omit<LicenseExtractOptions, 'storeIndex' | 'indexCache'>
 ): Promise<LicenseNodeTree> {
   const importerWalkers = lockfileWalkerGroupImporterSteps(
     lockfile,

--- a/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
+++ b/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
@@ -6,6 +6,7 @@ import {
   lockfileWalkerGroupImporterSteps,
   type LockfileWalkerStep,
 } from '@pnpm/lockfile.walker'
+import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { StoreIndex } from '@pnpm/store.index'
 import type { DependenciesField, ProjectId, Registries, SupportedArchitectures } from '@pnpm/types'
 import { map as mapValues } from 'ramda'
@@ -43,6 +44,7 @@ export interface LicenseExtractOptions {
   registries: Registries
   supportedArchitectures?: SupportedArchitectures
   depTypes: DepTypes
+  indexCache?: Map<string, PackageFilesIndex>
 }
 
 export async function lockfileToLicenseNode (
@@ -88,6 +90,7 @@ export async function lockfileToLicenseNode (
           virtualStoreDirMaxLength: options.virtualStoreDirMaxLength,
           dir: options.dir,
           modulesDir: options.modulesDir ?? 'node_modules',
+          indexCache: options.indexCache,
         }
       )
 
@@ -141,6 +144,10 @@ export async function lockfileToLicenseNodeTree (
   )
   const depTypes = detectDepTypes(lockfile)
   const storeIndex = new StoreIndex(opts.storeDir)
+  // Peer-dep variants produce distinct depPaths that share one store entry.
+  // Reuse the decoded index across the walk so the second visit skips the
+  // SQLite read and msgpack decode. The cache lives only for this call.
+  const indexCache = new Map<string, PackageFilesIndex>()
   const dependencies = Object.fromEntries(
     await Promise.all(
       importerWalkers.map(async (importerWalker) => {
@@ -154,6 +161,7 @@ export async function lockfileToLicenseNodeTree (
           registries: opts.registries,
           supportedArchitectures: opts.supportedArchitectures,
           depTypes,
+          indexCache,
         })
         return [importerWalker.importerId, {
           dependencies: importerDeps,

--- a/store/pkg-finder/src/index.ts
+++ b/store/pkg-finder/src/index.ts
@@ -10,6 +10,14 @@ export interface ReadPackageFileMapOptions {
   storeIndex: StoreIndex
   lockfileDir: string
   virtualStoreDirMaxLength: number
+  /**
+   * Optional cache of decoded package-file indexes shared across one
+   * traversal. When two depPaths resolve to the same store entry (peer-dep
+   * variants), the second read sees a hit and skips the SQLite read +
+   * msgpack decode. The caller owns the map's lifetime — drop it when the
+   * traversal ends.
+   */
+  indexCache?: Map<string, PackageFilesIndex>
 }
 
 /**
@@ -65,14 +73,18 @@ export async function readPackageFileMap (
     return undefined
   }
 
-  const pkgFilesIndex = opts.storeIndex.get(pkgIndexFilePath) as PackageFilesIndex | undefined
-  if (!pkgFilesIndex) {
-    const err: NodeJS.ErrnoException = new Error(
-      `ENOENT: package index not found for '${pkgIndexFilePath}'`
-    )
-    err.code = 'ENOENT'
-    err.path = pkgIndexFilePath
-    throw err
+  let pkgFilesIndex = opts.indexCache?.get(pkgIndexFilePath)
+  if (pkgFilesIndex == null) {
+    pkgFilesIndex = opts.storeIndex.get(pkgIndexFilePath) as PackageFilesIndex | undefined
+    if (!pkgFilesIndex) {
+      const err: NodeJS.ErrnoException = new Error(
+        `ENOENT: package index not found for '${pkgIndexFilePath}'`
+      )
+      err.code = 'ENOENT'
+      err.path = pkgIndexFilePath
+      throw err
+    }
+    opts.indexCache?.set(pkgIndexFilePath, pkgFilesIndex)
   }
   const { files: indexFiles } = pkgFilesIndex
   const files = new Map<string, string>()

--- a/store/pkg-finder/test/readPackageFileMap.test.ts
+++ b/store/pkg-finder/test/readPackageFileMap.test.ts
@@ -160,4 +160,28 @@ describe('readPackageFileMap', () => {
 
     expect(result).toBeUndefined()
   })
+
+  it('should reuse decoded indexes via the indexCache option without touching the store on the second call', async () => {
+    const integrity = 'sha512-abc123cache'
+    const pkgId = 'cache-pkg@1.0.0'
+    const key = storeIndexKey(integrity, pkgId)
+    storeIndex.set(key, createFilesIndex())
+
+    const resolution: TarballResolution = {
+      integrity,
+      tarball: 'https://registry.npmjs.org/cache-pkg/-/cache-pkg-1.0.0.tgz',
+    }
+    const indexCache = new Map<string, PackageFilesIndex>()
+    const opts = { ...defaultOpts(), indexCache }
+
+    await readPackageFileMap(resolution, pkgId, opts)
+    expect(indexCache.has(key)).toBe(true)
+
+    // Drop the entry from the store; if the cache is consulted, the second
+    // call still succeeds. If the store is consulted, it would throw ENOENT.
+    storeIndex.delete(key)
+    const second = await readPackageFileMap(resolution, pkgId, opts)
+    expect(second).toBeDefined()
+    expect(second!.has('package.json')).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

Alternative to #11695. Caches decoded `PackageFilesIndex` entries at the caller side, scoped to one operation, instead of inside `StoreIndex`.

- `readPackageFileMap` accepts an optional `indexCache?: Map<string, PackageFilesIndex>`. When provided, it is consulted before `storeIndex.get(...)` and populated on miss. Without it, behavior is unchanged.
- `lockfileToLicenseNodeTree` creates one cache per call and threads it through `getPkgInfo` → `readPackageFileMap`. Peer-dep variants share a single store entry but produce distinct depPaths under the walker, so each variant currently re-decodes the same index. With the cache, the second visit is a Map lookup.

## Why not the StoreIndex-level cache from #11695

- `install` doesn't read the same `filesIndexFile` twice in the same process: `peekLockerForPeek` (resolver) and `fetchingLocker` (package-requester) already dedupe. The PR's own benchmarks show install is within noise.
- The verified duplicate-read site is the license scanner's tree walk over peer-dep variants. `sbom` already dedupes by `purl`; `deploy` doesn't call `readPackageFileMap` directly.
- A scoped, caller-owned cache has no global LRU to tune, dies with the operation, and can't go stale across processes.
- This avoids adding mutation-sensitive state inside `@pnpm/store.index` (a low-level primitive).

## Test plan

- [x] `pnpm --filter @pnpm/store.pkg-finder --filter @pnpm/deps.compliance.license-scanner run compile`
- [x] New jest test in `store/pkg-finder/test/readPackageFileMap.test.ts` covers the cache hit/miss/absent paths. The pre-existing `module is already linked` issue in this package's jest+ESM+`node:sqlite` setup blocks running it locally; validated the same logic via a direct Node script against the compiled `lib/`.

---
Written by an agent (Claude Code, claude-opus-4-7).