### PR TITLE
fix: synchronize default registry from pnpm-workspace.yaml for login/logout commands

### DIFF
--- a/.changeset/login-workspace-registry.md
+++ b/.changeset/login-workspace-registry.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": patch
+"@pnpm/registry-access.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm login` and `pnpm logout` ignoring `registries.default` from `pnpm-workspace.yaml` [#10099](https://github.com/pnpm/pnpm/issues/10099).

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -461,6 +461,14 @@ export async function getConfig (opts: {
     }
   }
 
+  // Sync registries.default to the top-level registry property so that
+  // commands like login/logout that use opts.registry pick up the default
+  // registry configured in pnpm-workspace.yaml.
+  // Only sync when registry was not explicitly set via CLI.
+  if (!explicitlySetKeys.has('registry')) {
+    pnpmConfig.registry = pnpmConfig.registries.default
+  }
+
   // omit some schema that the custom parser can't yet handle
   const envPnpmTypes = omit([
     'init-version', // the type is a private function named 'semver'

--- a/config/reader/test/index.ts
+++ b/config/reader/test/index.ts
@@ -622,6 +622,43 @@ test('pnpm-workspace.yaml registries override the same scope from .npmrc (#11492
   expect(config.registries['@my-org']).toBe('https://from-workspace-yaml.example.com/')
 })
 
+test('pnpm-workspace.yaml registries.default is reflected in config.registry (#10099)', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      default: 'https://private.example.com/',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.registry).toBe('https://private.example.com/')
+  expect(config.registries.default).toBe('https://private.example.com/')
+})
+
+test('CLI --registry overrides pnpm-workspace.yaml registries.default (#10099)', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: {
+      default: 'https://workspace.example.com/',
+    },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: { registry: 'https://cli.example.com/' },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.registry).toBe('https://cli.example.com/')
+})
+
 test('auth tokens from pnpm auth file override ~/.npmrc', async () => {
   prepareEmpty()
 

--- a/registry-access/commands/src/ping.ts
+++ b/registry-access/commands/src/ping.ts
@@ -4,7 +4,7 @@ import { docsUrl } from '@pnpm/cli.utils'
 import { PnpmError } from '@pnpm/error'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions } from '@pnpm/network.fetch'
-import type { Registries, RegistryConfig } from '@pnpm/types'
+import type { RegistryConfig } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 
 import { rcOptionsTypes as commonRcOptionsTypes } from './common.js'
@@ -21,7 +21,6 @@ export function rcOptionsTypes (): Record<string, unknown> {
 
 export interface PingOptions extends CreateFetchFromRegistryOptions {
   registry?: string
-  registries?: Registries
   configByUri?: Record<string, RegistryConfig>
 }
 
@@ -47,7 +46,7 @@ export function help (): string {
 }
 
 export async function handler (opts: PingOptions): Promise<string> {
-  const registryUrl = opts.registry ?? opts.registries?.default ?? 'https://registry.npmjs.org/'
+  const registryUrl = opts.registry ?? 'https://registry.npmjs.org/'
   const normalizedRegistryUrl = registryUrl.endsWith('/') ? registryUrl : `${registryUrl}/`
   const pingUrlObject = new URL('./-/ping', normalizedRegistryUrl)
   pingUrlObject.searchParams.set('write', 'true')

--- a/registry-access/commands/test/ping.ts
+++ b/registry-access/commands/test/ping.ts
@@ -41,9 +41,6 @@ describe('ping command', () => {
 
     const result = await ping.handler({
       registry: 'https://registry.npmjs.org/',
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
     })
     expect(result).toMatch(/^PING https:\/\/registry\.npmjs\.org\/\nPONG \d+ms$/)
   })
@@ -57,9 +54,6 @@ describe('ping command', () => {
 
     const result = await ping.handler({
       registry: 'https://registry.npmjs.org/',
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
     })
     expect(result).toContain('PING https://registry.npmjs.org/')
     expect(result).toMatch(/PONG \d+ms/)
@@ -73,11 +67,7 @@ describe('ping command', () => {
       path: '/-/ping?write=true',
     }).reply(200, '{}')
 
-    const result = await ping.handler({
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
-    })
+    const result = await ping.handler({})
     expect(result).toContain('PING https://registry.npmjs.org/')
   })
 
@@ -90,9 +80,6 @@ describe('ping command', () => {
 
     await expect(ping.handler({
       registry: 'https://registry.npmjs.org/',
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
     })).rejects.toThrow('Failed to reach registry')
   })
 
@@ -105,9 +92,6 @@ describe('ping command', () => {
 
     const result = await ping.handler({
       registry: 'https://registry.npmjs.org/custom-prefix',
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
     })
     expect(result).toContain('PING https://registry.npmjs.org/custom-prefix')
     expect(result).toMatch(/PONG \d+ms/)
@@ -122,9 +106,6 @@ describe('ping command', () => {
 
     await expect(ping.handler({
       registry: 'https://invalid-registry-that-does-not-exist-12345.com/',
-      registries: {
-        default: 'https://registry.npmjs.org/',
-      },
     })).rejects.toThrow('Failed to reach registry')
   })
 })


### PR DESCRIPTION
Closes #10099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* `pnpm login` and `pnpm logout` now correctly respect the default registry configuration specified in `pnpm-workspace.yaml`, ensuring consistent registry behavior across workspace commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->