### PR TITLE
fix(pacquet/config): default publicHoistPattern to [] to match pnpm v11

### DIFF
--- a/pacquet/crates/cli/tests/hoist.rs
+++ b/pacquet/crates/cli/tests/hoist.rs
@@ -98,9 +98,8 @@ fn private_hoist_default_pattern_hoists_transitives() {
         is_symlink_or_junction(&private_hoist).unwrap(),
         "transitive `@pnpm.e2e/hello-world-js-bin` should be hoisted to {private_hoist:?}",
     );
-    // Public-hoist patterns default to `["*eslint*", "*prettier*"]`,
-    // neither of which match this transitive — so it should NOT be at
-    // the root.
+    // Public-hoist patterns default to `[]` (matching pnpm v11), so
+    // no transitive can match — it should NOT be at the root.
     assert!(
         !workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin").exists(),
         "transitive should not be publicly hoisted under default patterns",
@@ -245,6 +244,38 @@ fn modules_yaml_records_hoisted_dependencies() {
     assert!(
         modules_yaml_text.contains(r#""@pnpm.e2e/hello-world-js-bin": "private""#),
         "transitive should be marked as `private` hoist; got:\n{modules_yaml_text}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Regression for [pnpm/pnpm#11750](https://github.com/pnpm/pnpm/issues/11750):
+/// pacquet's default `publicHoistPattern` must match pnpm v11's
+/// (empty list) so a follow-up `pnpm` invocation in the same project
+/// doesn't reject the `.modules.yaml` with
+/// `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF`. See pnpm's default at
+/// <https://github.com/pnpm/pnpm/blob/1627943d2a/config/reader/src/index.ts#L184>
+/// and the comparison site at
+/// <https://github.com/pnpm/pnpm/blob/1627943d2a/installing/deps-installer/src/install/validateModules.ts#L67-L80>.
+#[test]
+fn modules_yaml_public_hoist_pattern_matches_pnpm_default() {
+    let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        serde_json::json!({ "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" }),
+    );
+    generate_lockfile(pnpm);
+
+    pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let modules_yaml_text = fs::read_to_string(workspace.join("node_modules/.modules.yaml"))
+        .expect("read .modules.yaml");
+    assert!(
+        modules_yaml_text.contains(r#""publicHoistPattern": []"#),
+        "publicHoistPattern should serialize as an empty list (pnpm default); got:\n{modules_yaml_text}",
     );
 
     drop((root, mock_instance));

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -23,8 +23,16 @@ pub fn default_git_shallow_hosts() -> Vec<String> {
     ]
 }
 
+/// Default for `public-hoist-pattern`. Matches pnpm v11's empty-list
+/// default at
+/// <https://github.com/pnpm/pnpm/blob/1627943d2a/config/reader/src/index.ts#L184>.
+/// Writing a non-empty list on a fresh install would record a
+/// `publicHoistPattern` in `.modules.yaml` that the next `pnpm`
+/// invocation in the same project rejects with
+/// `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF` — see
+/// [pnpm/pnpm#11750](https://github.com/pnpm/pnpm/issues/11750).
 pub fn default_public_hoist_pattern() -> Vec<String> {
-    vec!["*eslint*".to_string(), "*prettier*".to_string()]
+    Vec::new()
 }
 
 // Get the drive letter from a path on Windows. If it's not a Windows path, return None.

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -193,7 +193,12 @@ pub struct Config {
     /// Same `Option` semantics as [`Self::hoist_pattern`] — `None`
     /// disables public hoisting, `Some([])` runs the hoist pass with
     /// no public matches, `Some(non-empty)` is the standard case.
-    /// Default is `Some(["*eslint*", "*prettier*"])`.
+    /// Default is `Some([])`, mirroring pnpm v11's
+    /// [`'public-hoist-pattern': []`](https://github.com/pnpm/pnpm/blob/1627943d2a/config/reader/src/index.ts#L184)
+    /// — any non-empty default would write a `publicHoistPattern`
+    /// into `.modules.yaml` that the next `pnpm` invocation rejects
+    /// with `ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF`
+    /// ([pnpm/pnpm#11750](https://github.com/pnpm/pnpm/issues/11750)).
     #[default(_code = "Some(default_public_hoist_pattern())")]
     pub public_hoist_pattern: Option<Vec<String>>,
 


### PR DESCRIPTION
## Summary

Fixes #11750.

Pacquet's default `public_hoist_pattern` was `["*eslint*", "*prettier*"]`, but pnpm v11 defaults to `[]` ([`config/reader/src/index.ts:184`](https://github.com/pnpm/pnpm/blob/1627943d2a/config/reader/src/index.ts#L184)). On any project that ran `pacquet install` and then a follow-up `pnpm` command in the same directory, [`validateModules`](https://github.com/pnpm/pnpm/blob/1627943d2a/installing/deps-installer/src/install/validateModules.ts#L67-L80) read pacquet's `.modules.yaml`, compared `publicHoistPattern` against the value pnpm derives from config, saw `["*eslint*", "*prettier*"]` vs `[]`, and aborted with:

```
[ERR_PNPM_PUBLIC_HOIST_PATTERN_DIFF] This modules directory was created using a different public-hoist-pattern value. Run "pnpm install" to recreate the modules directory.
```

That blocked `pnpm add`, `pnpm update`, and bare `pnpm install` against a node_modules tree pacquet had materialized — the `pacquet` e2e tests in [#11734](https://github.com/pnpm/pnpm/pull/11734) had to `test.skip` both `add` and `update` for this reason.

The fix is the smallest possible one: make pacquet's default match pnpm v11 (an empty `Vec<String>`). The hoist-time guard `hoist_pattern.is_some() || public_hoist_pattern.is_some()` is still satisfied by `Some(vec![])`, and the existing fast path in `install_frozen_lockfile.rs` short-circuits the BFS when both compiled matchers are empty — so the change is behaviorally a no-op for the install itself, and only affects what lands in `.modules.yaml`.

Other `validateModules` fields with the same comparison shape (`hoistPattern`, `virtualStoreDirMaxLength`) already match pnpm's defaults — verified during the investigation; nothing else needs adjustment here.

## Test plan

- [x] New regression test `modules_yaml_public_hoist_pattern_matches_pnpm_default` in `pacquet/crates/cli/tests/hoist.rs` asserts `.modules.yaml` contains `"publicHoistPattern": []` after `pacquet install --frozen-lockfile`. Verified it fails on `main` (sees `["*eslint*", "*prettier*"]`) and passes on this branch.
- [x] `cargo nextest run -p pacquet-config` — 181 tests pass.
- [x] `cargo nextest run -p pacquet-modules-yaml` — 20 tests pass.
- [x] `cargo nextest run -p pacquet-package-manager` — 263 tests pass.
- [x] `cargo nextest run -p pacquet-cli --test hoist` — 37 tests pass (including the updated `private_hoist_default_pattern_hoists_transitives` whose comment was outdated, and the new regression test).
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean.
- [x] `cargo fmt --check` — clean.

Once this lands, the `test.skip`s on `pnpm add` / `pnpm update` in `pnpm/test/install/pacquet.ts` (added on `feat/11723` in the pacquet-delegation PR) can be re-enabled.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default public hoist pattern to align with pnpm v11 behavior, preventing `.modules.yaml` file mismatch errors when used with pnpm.

* **Tests**
  * Added regression test validating public hoist pattern matches pnpm v11 defaults in `.modules.yaml` output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->