### PR TITLE
fix(pacquet/config): read global config.yaml and PNPM_CONFIG_* env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde-saphyr",
+ "serde_json",
  "smart-default",
  "tempfile",
  "tracing",

--- a/pacquet/crates/config/Cargo.toml
+++ b/pacquet/crates/config/Cargo.toml
@@ -24,6 +24,7 @@ node-semver   = { workspace = true }
 pipe-trait    = { workspace = true }
 serde         = { workspace = true }
 serde-saphyr  = { workspace = true }
+serde_json    = { workspace = true }
 smart-default = { workspace = true }
 tracing       = { workspace = true }
 

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -105,6 +105,41 @@ pub fn default_modules_dir() -> PathBuf {
     env::current_dir().expect("current directory is unavailable").join("node_modules")
 }
 
+/// Resolve the directory pnpm reads `config.yaml` (the global config
+/// file) from.
+///
+/// Port of pnpm's
+/// [`getConfigDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L67-L86).
+/// Resolution order:
+///
+/// 1. `$XDG_CONFIG_HOME/pnpm`.
+/// 2. macOS: `~/Library/Preferences/pnpm`.
+/// 3. Other non-Windows: `~/.config/pnpm`.
+/// 4. Windows: `%LOCALAPPDATA%/pnpm/config`, falling back to
+///    `~/.config/pnpm` when `LOCALAPPDATA` is unset.
+///
+/// Returns `None` when the home directory is unavailable and the env
+/// vars that bypass it are also unset — the caller treats that as
+/// "no global config file."
+pub fn default_config_dir<Sys>() -> Option<PathBuf>
+where
+    Sys: EnvVar + GetHomeDir,
+{
+    if let Some(xdg_config_home) = Sys::var("XDG_CONFIG_HOME") {
+        return Some(PathBuf::from(xdg_config_home).join("pnpm"));
+    }
+    if env::consts::OS == "windows"
+        && let Some(local_app_data) = Sys::var("LOCALAPPDATA")
+    {
+        return Some(PathBuf::from(local_app_data).join("pnpm/config"));
+    }
+    let home_dir = Sys::home_dir()?;
+    Some(match env::consts::OS {
+        "macos" => home_dir.join("Library/Preferences/pnpm"),
+        _ => home_dir.join(".config/pnpm"),
+    })
+}
+
 /// Resolve the default packument-cache directory.
 ///
 /// Port of pnpm's

--- a/pacquet/crates/config/src/defaults/tests.rs
+++ b/pacquet/crates/config/src/defaults/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    default_cache_dir, default_child_concurrency_with_parallelism, default_store_dir,
-    default_unsafe_perm, is_unsafe_perm_posix, resolve_child_concurrency,
+    default_cache_dir, default_child_concurrency_with_parallelism, default_config_dir,
+    default_store_dir, default_unsafe_perm, is_unsafe_perm_posix, resolve_child_concurrency,
     resolve_child_concurrency_with_parallelism,
 };
 use crate::api::{EnvVar, GetCurrentDir, GetHomeDir};
@@ -171,6 +171,83 @@ fn test_default_cache_dir_falls_back_to_platform_default() {
         PathBuf::from("/home/test-user/.cache/pnpm")
     };
     assert_eq!(cache_dir, expected);
+}
+
+/// `$XDG_CONFIG_HOME/pnpm` wins the config-dir resolution chain,
+/// matching upstream's
+/// [`getConfigDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L67-L86).
+/// The `XDG_CONFIG_HOME` branch is checked first so home-dir
+/// resolution can be short-circuited entirely; the `home_dir` impl
+/// uses `unreachable!` to document that precondition.
+#[test]
+fn test_default_config_dir_with_xdg_config_home_env() {
+    struct EnvWithXdgConfigHome;
+    impl EnvVar for EnvWithXdgConfigHome {
+        fn var(name: &str) -> Option<String> {
+            (name == "XDG_CONFIG_HOME").then(|| "/tmp/xdg-config-home".to_owned())
+        }
+    }
+    impl GetHomeDir for EnvWithXdgConfigHome {
+        fn home_dir() -> Option<PathBuf> {
+            unreachable!("home_dir must not be called when XDG_CONFIG_HOME is set");
+        }
+    }
+    let config_dir =
+        default_config_dir::<EnvWithXdgConfigHome>().expect("XDG_CONFIG_HOME bypasses home_dir");
+    let display = config_dir.display().to_string().replace('\\', "/");
+    assert_eq!(display, "/tmp/xdg-config-home/pnpm");
+}
+
+/// Without `XDG_CONFIG_HOME` (or `LOCALAPPDATA` on Windows), the
+/// resolver falls back to the platform default. On macOS that's
+/// `~/Library/Preferences/pnpm`; on other Unix-y platforms it's
+/// `~/.config/pnpm`. The Windows-without-`LOCALAPPDATA` branch
+/// also lands on `~/.config/pnpm` (matching upstream's `else`
+/// branch at
+/// [`dirs.ts:85`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L85)).
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[test]
+fn test_default_config_dir_falls_back_to_platform_default() {
+    struct NoEnvWithHome;
+    impl EnvVar for NoEnvWithHome {
+        fn var(_: &str) -> Option<String> {
+            None
+        }
+    }
+    impl GetHomeDir for NoEnvWithHome {
+        fn home_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/home/test-user"))
+        }
+    }
+    let config_dir = default_config_dir::<NoEnvWithHome>().expect("home dir supplied");
+    let expected = if cfg!(target_os = "macos") {
+        PathBuf::from("/home/test-user/Library/Preferences/pnpm")
+    } else {
+        PathBuf::from("/home/test-user/.config/pnpm")
+    };
+    assert_eq!(config_dir, expected);
+}
+
+/// When neither `XDG_CONFIG_HOME` nor `LOCALAPPDATA` is set AND the
+/// home directory is unavailable, `default_config_dir` returns
+/// `None` — the caller treats that as "no global config file."
+/// Differs from `default_store_dir` / `default_cache_dir`, which
+/// panic on missing home, because the global `config.yaml` is
+/// strictly optional whereas a store path must always exist.
+#[test]
+fn test_default_config_dir_without_home_returns_none() {
+    struct NoEnvNoHome;
+    impl EnvVar for NoEnvNoHome {
+        fn var(_: &str) -> Option<String> {
+            None
+        }
+    }
+    impl GetHomeDir for NoEnvNoHome {
+        fn home_dir() -> Option<PathBuf> {
+            None
+        }
+    }
+    assert_eq!(default_config_dir::<NoEnvNoHome>(), None);
 }
 
 /// Port of upstream

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -1,0 +1,262 @@
+//! Read `PNPM_CONFIG_*` / `pnpm_config_*` environment variables into a
+//! [`WorkspaceSettings`] overlay.
+//!
+//! Mirrors pnpm v11's
+//! [`parseEnvVars`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L42)
+//! loop in `config/reader/src/index.ts`, which reads `pnpm_config_<key>`
+//! (or its `PNPM_CONFIG_<KEY>` uppercase form) for every key in the
+//! schema and applies it to the config *after* `pnpm-workspace.yaml`.
+//! That ordering means env vars override yaml — matching the order
+//! upstream's loop runs in.
+//!
+//! Pacquet does NOT read `npm_config_*` / `NPM_CONFIG_*` env vars (with
+//! the exception of `NPM_CONFIG_WORKSPACE_DIR`, which has its own narrow
+//! handler in [`crate::Config::current`]). Pnpm v11 stopped honouring
+//! those too; the only remaining `npm_config_*` lookup in pnpm is
+//! `userconfig` as a low-priority auth-file fallback. See
+//! [`config/reader/src/index.ts:719-722`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L719-L722).
+
+use crate::{
+    NodeLinker, PackageImportMethod, ScriptsPrependNodePath, TrustPolicy, WorkspaceSettings,
+    api::EnvVar,
+};
+use serde::de::DeserializeOwned;
+
+/// Read an env var by suffix, accepting both `PNPM_CONFIG_<UPPER>` and
+/// `pnpm_config_<lower>`. Empty values are treated as unset, matching
+/// upstream's
+/// [`if (envValue == null) continue`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L46)
+/// + the [`!== ''` filter in `readEnvVar`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L713).
+fn read_env<Sys: EnvVar>(suffix: &str) -> Option<String> {
+    let upper = format!("PNPM_CONFIG_{suffix}");
+    let lower = format!("pnpm_config_{}", suffix.to_lowercase());
+    Sys::var(&upper).or_else(|| Sys::var(&lower)).filter(|s| !s.is_empty())
+}
+
+/// Parse `s` as JSON. Returns `None` on parse failure so caller falls
+/// through to its default (skip the field).
+fn parse_json<T: DeserializeOwned>(s: &str) -> Option<T> {
+    serde_json::from_str(s).ok()
+}
+
+/// Parse `s` as JSON; if that fails, retry with the value wrapped as a
+/// JSON string. Used for enum fields whose serde representation is a
+/// bare identifier (`hoisted`, `warn-only`, `no-downgrade`, …) — the
+/// raw env var value isn't valid JSON on its own but becomes valid once
+/// quoted.
+fn parse_json_or_string<T: DeserializeOwned>(s: &str) -> Option<T> {
+    parse_json(s).or_else(|| {
+        let quoted = serde_json::to_string(s).ok()?;
+        parse_json(&quoted)
+    })
+}
+
+/// Specialised parser for the tri-state `Option<Option<Vec<String>>>`
+/// shape used by `hoist_pattern` / `public_hoist_pattern`. The env-var
+/// surface only supports the "explicit list" and "explicit null" cases
+/// — there is no fourth state for "leave the config default in place"
+/// because not setting the env var already does that.
+fn parse_tri_array(s: &str) -> Option<Option<Vec<String>>> {
+    if s == "null" {
+        return Some(None);
+    }
+    parse_json::<Vec<String>>(s).map(Some)
+}
+
+impl WorkspaceSettings {
+    /// Build a [`WorkspaceSettings`] from `PNPM_CONFIG_*` env vars.
+    ///
+    /// Pnpm reads env vars for the full schema, not just config-file
+    /// keys — `PNPM_CONFIG_HOIST=false`, `PNPM_CONFIG_NODE_LINKER=hoisted`
+    /// etc. all work upstream, so they work here too (no
+    /// [`Self::clear_workspace_only_fields`] call). Apply the returned
+    /// settings via [`Self::apply_to`] *after* `pnpm-workspace.yaml` so
+    /// env vars win over yaml, mirroring upstream's order at
+    /// [`config/reader/src/index.ts:471-488`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L471-L488).
+    pub fn from_pnpm_config_env<Sys: EnvVar>() -> Self {
+        let mut settings = WorkspaceSettings::default();
+
+        macro_rules! json_field {
+            ($field:ident, $suffix:literal) => {
+                if let Some(s) = read_env::<Sys>($suffix)
+                    && let Some(v) = parse_json(&s)
+                {
+                    settings.$field = Some(v);
+                }
+            };
+        }
+        macro_rules! string_field {
+            ($field:ident, $suffix:literal) => {
+                if let Some(s) = read_env::<Sys>($suffix) {
+                    settings.$field = Some(s);
+                }
+            };
+        }
+        macro_rules! enum_field {
+            ($field:ident, $suffix:literal, $ty:ty) => {
+                if let Some(s) = read_env::<Sys>($suffix)
+                    && let Some(v) = parse_json_or_string::<$ty>(&s)
+                {
+                    settings.$field = Some(v);
+                }
+            };
+        }
+        macro_rules! tri_array_field {
+            ($field:ident, $suffix:literal) => {
+                if let Some(s) = read_env::<Sys>($suffix)
+                    && let Some(v) = parse_tri_array(&s)
+                {
+                    settings.$field = Some(v);
+                }
+            };
+        }
+
+        json_field!(hoist, "HOIST");
+        tri_array_field!(hoist_pattern, "HOIST_PATTERN");
+        tri_array_field!(public_hoist_pattern, "PUBLIC_HOIST_PATTERN");
+        json_field!(shamefully_hoist, "SHAMEFULLY_HOIST");
+        string_field!(store_dir, "STORE_DIR");
+        string_field!(modules_dir, "MODULES_DIR");
+        enum_field!(node_linker, "NODE_LINKER", NodeLinker);
+        json_field!(symlink, "SYMLINK");
+        string_field!(virtual_store_dir, "VIRTUAL_STORE_DIR");
+        json_field!(enable_global_virtual_store, "ENABLE_GLOBAL_VIRTUAL_STORE");
+        string_field!(global_virtual_store_dir, "GLOBAL_VIRTUAL_STORE_DIR");
+        enum_field!(package_import_method, "PACKAGE_IMPORT_METHOD", PackageImportMethod);
+        json_field!(modules_cache_max_age, "MODULES_CACHE_MAX_AGE");
+        json_field!(lockfile, "LOCKFILE");
+        json_field!(prefer_frozen_lockfile, "PREFER_FROZEN_LOCKFILE");
+        json_field!(offline, "OFFLINE");
+        json_field!(prefer_offline, "PREFER_OFFLINE");
+        json_field!(lockfile_include_tarball_url, "LOCKFILE_INCLUDE_TARBALL_URL");
+        string_field!(registry, "REGISTRY");
+        json_field!(auto_install_peers, "AUTO_INSTALL_PEERS");
+        json_field!(hoist_workspace_packages, "HOIST_WORKSPACE_PACKAGES");
+        json_field!(hoisting_limits, "HOISTING_LIMITS");
+        json_field!(external_dependencies, "EXTERNAL_DEPENDENCIES");
+        json_field!(dedupe_peer_dependents, "DEDUPE_PEER_DEPENDENTS");
+        json_field!(strict_peer_dependencies, "STRICT_PEER_DEPENDENCIES");
+        json_field!(resolve_peers_from_workspace_root, "RESOLVE_PEERS_FROM_WORKSPACE_ROOT");
+        json_field!(verify_store_integrity, "VERIFY_STORE_INTEGRITY");
+        json_field!(side_effects_cache, "SIDE_EFFECTS_CACHE");
+        json_field!(side_effects_cache_readonly, "SIDE_EFFECTS_CACHE_READONLY");
+        json_field!(fetch_retries, "FETCH_RETRIES");
+        json_field!(fetch_retry_factor, "FETCH_RETRY_FACTOR");
+        json_field!(fetch_retry_mintimeout, "FETCH_RETRY_MINTIMEOUT");
+        json_field!(fetch_retry_maxtimeout, "FETCH_RETRY_MAXTIMEOUT");
+        json_field!(patched_dependencies, "PATCHED_DEPENDENCIES");
+        json_field!(allow_builds, "ALLOW_BUILDS");
+        json_field!(dangerously_allow_all_builds, "DANGEROUSLY_ALLOW_ALL_BUILDS");
+        enum_field!(scripts_prepend_node_path, "SCRIPTS_PREPEND_NODE_PATH", ScriptsPrependNodePath);
+        json_field!(unsafe_perm, "UNSAFE_PERM");
+        json_field!(child_concurrency, "CHILD_CONCURRENCY");
+        json_field!(git_shallow_hosts, "GIT_SHALLOW_HOSTS");
+        json_field!(supported_architectures, "SUPPORTED_ARCHITECTURES");
+        json_field!(ignored_optional_dependencies, "IGNORED_OPTIONAL_DEPENDENCIES");
+        string_field!(cache_dir, "CACHE_DIR");
+        json_field!(minimum_release_age, "MINIMUM_RELEASE_AGE");
+        json_field!(minimum_release_age_exclude, "MINIMUM_RELEASE_AGE_EXCLUDE");
+        json_field!(
+            minimum_release_age_ignore_missing_time,
+            "MINIMUM_RELEASE_AGE_IGNORE_MISSING_TIME"
+        );
+        json_field!(minimum_release_age_strict, "MINIMUM_RELEASE_AGE_STRICT");
+        enum_field!(trust_policy, "TRUST_POLICY", TrustPolicy);
+        json_field!(trust_policy_exclude, "TRUST_POLICY_EXCLUDE");
+        json_field!(trust_policy_ignore_after, "TRUST_POLICY_IGNORE_AFTER");
+
+        settings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WorkspaceSettings, parse_json_or_string, parse_tri_array};
+    use crate::{NodeLinker, ScriptsPrependNodePath, TrustPolicy, api::EnvVar};
+    use pretty_assertions::assert_eq;
+
+    /// Boolean env var values must be exact `true`/`false`. Anything
+    /// else (capitalised, `yes`, `1`) silently falls through to the
+    /// default — matching pnpm's
+    /// [`parseValueByConstructor`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L117-L122)
+    /// Boolean branch.
+    #[test]
+    fn bool_env_var_only_accepts_lowercase_true_false() {
+        struct EnvBadBool;
+        impl EnvVar for EnvBadBool {
+            fn var(name: &str) -> Option<String> {
+                (name == "PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE").then(|| "yes".to_owned())
+            }
+        }
+        let settings = WorkspaceSettings::from_pnpm_config_env::<EnvBadBool>();
+        assert_eq!(settings.enable_global_virtual_store, None);
+    }
+
+    /// Empty env var values are treated as unset, matching upstream's
+    /// [`readEnvVar`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L711-L714)
+    /// `value !== ''` filter — an exported-but-empty
+    /// `PNPM_CONFIG_STORE_DIR=` shouldn't clobber the configured
+    /// store path.
+    #[test]
+    fn empty_env_var_is_treated_as_unset() {
+        struct EnvEmpty;
+        impl EnvVar for EnvEmpty {
+            fn var(name: &str) -> Option<String> {
+                (name == "PNPM_CONFIG_STORE_DIR").then(String::new)
+            }
+        }
+        let settings = WorkspaceSettings::from_pnpm_config_env::<EnvEmpty>();
+        assert_eq!(settings.store_dir, None);
+    }
+
+    /// Enums parse from their kebab-case identifier without JSON
+    /// quotes (`PNPM_CONFIG_NODE_LINKER=hoisted`) — `parse_json_or_string`
+    /// retries the JSON parse with the value quoted when the bare
+    /// parse fails, which is what makes the bare-identifier form work.
+    #[test]
+    fn enum_env_var_accepts_bare_identifier() {
+        assert_eq!(parse_json_or_string::<NodeLinker>("hoisted"), Some(NodeLinker::Hoisted));
+        assert_eq!(
+            parse_json_or_string::<TrustPolicy>("no-downgrade"),
+            Some(TrustPolicy::NoDowngrade)
+        );
+    }
+
+    /// `ScriptsPrependNodePath` has a custom serde visitor that
+    /// accepts `true` / `false` (booleans) or `"warn-only"` (string).
+    /// The env-var path must hit all three — the JSON-first retry
+    /// in `parse_json_or_string` ensures `true`/`false` reach the
+    /// `visit_bool` arm and `warn-only` reaches the `visit_str` arm
+    /// after the second pass quotes it.
+    #[test]
+    fn scripts_prepend_node_path_env_var_round_trips_all_three_shapes() {
+        assert_eq!(
+            parse_json_or_string::<ScriptsPrependNodePath>("true"),
+            Some(ScriptsPrependNodePath::Always),
+        );
+        assert_eq!(
+            parse_json_or_string::<ScriptsPrependNodePath>("false"),
+            Some(ScriptsPrependNodePath::Never),
+        );
+        assert_eq!(
+            parse_json_or_string::<ScriptsPrependNodePath>("warn-only"),
+            Some(ScriptsPrependNodePath::WarnOnly),
+        );
+    }
+
+    /// Tri-state arrays (used by `hoist_pattern` /
+    /// `public_hoist_pattern`): a literal `null` env var
+    /// distinguishes "disable hoisting on this side" from "explicit
+    /// list," matching pnpm's `Option<Option<Vec<String>>>` shape.
+    /// Plain non-JSON garbage falls through to `None` rather than
+    /// being mistaken for a list.
+    #[test]
+    fn tri_array_env_var_parses_null_and_arrays() {
+        assert_eq!(parse_tri_array("null"), Some(None));
+        assert_eq!(
+            parse_tri_array(r#"["a","b"]"#),
+            Some(Some(vec!["a".to_owned(), "b".to_owned()])),
+        );
+        assert_eq!(parse_tri_array("not-json"), None);
+    }
+}

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -30,37 +30,42 @@ use serde::de::DeserializeOwned;
 fn read_env<Sys: EnvVar>(suffix: &str) -> Option<String> {
     let upper = format!("PNPM_CONFIG_{suffix}");
     let lower = format!("pnpm_config_{}", suffix.to_lowercase());
-    Sys::var(&upper).or_else(|| Sys::var(&lower)).filter(|s| !s.is_empty())
+    Sys::var(&upper).or_else(|| Sys::var(&lower)).filter(|value| !value.is_empty())
 }
 
-/// Parse `s` as JSON. Returns `None` on parse failure so caller falls
-/// through to its default (skip the field).
-fn parse_json<T: DeserializeOwned>(s: &str) -> Option<T> {
-    serde_json::from_str(s).ok()
+/// Parse `value` as JSON. Returns `None` on parse failure so the
+/// caller falls through to its default (skip the field).
+fn parse_json<Target: DeserializeOwned>(value: &str) -> Option<Target> {
+    serde_json::from_str(value).ok()
 }
 
-/// Parse `s` as JSON; if that fails, retry with the value wrapped as a
-/// JSON string. Used for enum fields whose serde representation is a
+/// Parse `value` as JSON; if that fails, retry with `value` wrapped as
+/// a JSON string. Used for enum fields whose serde representation is a
 /// bare identifier (`hoisted`, `warn-only`, `no-downgrade`, …) — the
-/// raw env var value isn't valid JSON on its own but becomes valid once
-/// quoted.
-fn parse_json_or_string<T: DeserializeOwned>(s: &str) -> Option<T> {
-    parse_json(s).or_else(|| {
-        let quoted = serde_json::to_string(s).ok()?;
+/// raw env var value isn't valid JSON on its own but becomes valid
+/// once quoted.
+fn parse_json_or_string<Target: DeserializeOwned>(value: &str) -> Option<Target> {
+    parse_json(value).or_else(|| {
+        let quoted = serde_json::to_string(value).ok()?;
         parse_json(&quoted)
     })
 }
 
-/// Specialised parser for the tri-state `Option<Option<Vec<String>>>`
-/// shape used by `hoist_pattern` / `public_hoist_pattern`. The env-var
-/// surface only supports the "explicit list" and "explicit null" cases
-/// — there is no fourth state for "leave the config default in place"
-/// because not setting the env var already does that.
-fn parse_tri_array(s: &str) -> Option<Option<Vec<String>>> {
-    if s == "null" {
-        return Some(None);
-    }
-    parse_json::<Vec<String>>(s).map(Some)
+/// Parse a `hoist_pattern` / `public_hoist_pattern` env var into the
+/// tri-state `Option<Option<Vec<String>>>` shape used by
+/// [`WorkspaceSettings`].
+///
+/// Env vars cannot express the "explicit null disable" state that yaml
+/// supports — pnpm's
+/// [`parseValueByConstructor`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L111-L115)
+/// for the `Array` schema runs `JSON.parse(envVar)` and then requires
+/// `Array.isArray(value)`. `PNPM_CONFIG_HOIST_PATTERN=null` therefore
+/// fails the `Array.isArray` check upstream and the value is silently
+/// dropped. The tri-state's `Some(None)` branch stays reachable
+/// through yaml only; from env we either return `None` (parse failed,
+/// leave config default) or `Some(Some(vec))` (explicit list).
+fn parse_tri_array(value: &str) -> Option<Option<Vec<String>>> {
+    parse_json::<Vec<String>>(value).map(Some)
 }
 
 impl WorkspaceSettings {
@@ -218,7 +223,7 @@ mod tests {
         assert_eq!(parse_json_or_string::<NodeLinker>("hoisted"), Some(NodeLinker::Hoisted));
         assert_eq!(
             parse_json_or_string::<TrustPolicy>("no-downgrade"),
-            Some(TrustPolicy::NoDowngrade)
+            Some(TrustPolicy::NoDowngrade),
         );
     }
 
@@ -245,18 +250,20 @@ mod tests {
     }
 
     /// Tri-state arrays (used by `hoist_pattern` /
-    /// `public_hoist_pattern`): a literal `null` env var
-    /// distinguishes "disable hoisting on this side" from "explicit
-    /// list," matching pnpm's `Option<Option<Vec<String>>>` shape.
-    /// Plain non-JSON garbage falls through to `None` rather than
-    /// being mistaken for a list.
+    /// `public_hoist_pattern`): env vars carrying a JSON array
+    /// populate the explicit-list slot. Pnpm's `Array` schema
+    /// rejects `null` via its `Array.isArray` check at
+    /// [`env.ts:111-115`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L111-L115),
+    /// so `parse_tri_array("null")` returns `None` (= "leave the
+    /// config default in place"), matching upstream. Plain non-JSON
+    /// strings fall through the same way.
     #[test]
-    fn tri_array_env_var_parses_null_and_arrays() {
-        assert_eq!(parse_tri_array("null"), Some(None));
+    fn tri_array_env_var_parses_arrays_and_rejects_null() {
         assert_eq!(
             parse_tri_array(r#"["a","b"]"#),
             Some(Some(vec!["a".to_owned(), "b".to_owned()])),
         );
+        assert_eq!(parse_tri_array("null"), None);
         assert_eq!(parse_tri_array("not-json"), None);
     }
 }

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 mod defaults;
+mod env_overlay;
 mod env_replace;
 pub mod matcher;
 mod npmrc_auth;
@@ -25,14 +26,15 @@ pub use crate::defaults::{
     resolve_child_concurrency,
 };
 use crate::defaults::{
-    default_cache_dir, default_child_concurrency, default_enable_global_virtual_store,
-    default_fetch_retries, default_fetch_retry_factor, default_fetch_retry_maxtimeout,
-    default_fetch_retry_mintimeout, default_hoist_pattern, default_modules_cache_max_age,
-    default_modules_dir, default_public_hoist_pattern, default_registry, default_store_dir,
-    default_virtual_store_dir,
+    default_cache_dir, default_child_concurrency, default_config_dir,
+    default_enable_global_virtual_store, default_fetch_retries, default_fetch_retry_factor,
+    default_fetch_retry_maxtimeout, default_fetch_retry_mintimeout, default_hoist_pattern,
+    default_modules_cache_max_age, default_modules_dir, default_public_hoist_pattern,
+    default_registry, default_store_dir, default_virtual_store_dir,
 };
 pub use workspace_yaml::{
-    LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, workspace_root_or,
+    GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME,
+    WorkspaceSettings, workspace_root_or,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -945,6 +947,38 @@ impl Config {
         // already-default `self.tls`.
         npmrc_auth.apply_tls_and_local_address(&mut self);
 
+        // Layer pnpm's global config.yaml (at `<configDir>/config.yaml`)
+        // between `.npmrc` and `pnpm-workspace.yaml`, matching upstream's
+        // [`index.ts:228 / 297-316`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L228).
+        // Workspace-only keys are stripped inside [`WorkspaceSettings::load_global`]
+        // so a user can't set `nodeLinker` or `hoist` globally — pnpm
+        // rejects those in `config.yaml` and pacquet must too.
+        //
+        // Path-valued fields use `start_dir` as the base for relative
+        // resolution — pnpm passes `workspaceDir: undefined` for the
+        // global manifest, which leaves paths un-anchored. Using
+        // `start_dir` here is a small pacquet-specific extension that
+        // keeps relative paths well-defined; users putting absolute
+        // paths (the recommended pattern) see no difference.
+        //
+        // `workspace_dir` is intentionally NOT set from the global
+        // config — it must reflect the location of `pnpm-workspace.yaml`
+        // alone. Save/restore around the call so `apply_to`'s
+        // unconditional `config.workspace_dir = Some(base_dir)` write
+        // doesn't leak.
+        let mut virtual_store_dir_explicit = false;
+        let mut global_virtual_store_dir_explicit = false;
+        let global_config_dir = default_config_dir::<Sys>();
+        let global_settings =
+            global_config_dir.as_deref().map(WorkspaceSettings::load_global).transpose()?.flatten();
+        if let Some(global_settings) = global_settings {
+            virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
+            global_virtual_store_dir_explicit |= global_settings.global_virtual_store_dir.is_some();
+            let saved_workspace_dir = self.workspace_dir.take();
+            global_settings.apply_to(&mut self, start_dir);
+            self.workspace_dir = saved_workspace_dir;
+        }
+
         // Layer pnpm-workspace.yaml overrides on top. A missing file is
         // silent. Read or parse failures propagate to the caller.
         //
@@ -999,8 +1033,6 @@ impl Config {
             })
         };
 
-        let mut virtual_store_dir_explicit = false;
-        let mut global_virtual_store_dir_explicit = false;
         if let Some((base_dir, settings)) = workspace_yaml {
             // Re-anchor the path-valued defaults to the workspace root
             // before applying settings. Without this, a `pacquet install`
@@ -1019,11 +1051,37 @@ impl Config {
             self.modules_dir = base_dir.join("node_modules");
             self.virtual_store_dir = base_dir.join("node_modules/.pnpm");
             if let Some(settings) = settings {
-                virtual_store_dir_explicit = settings.virtual_store_dir.is_some();
-                global_virtual_store_dir_explicit = settings.global_virtual_store_dir.is_some();
+                // `|=` rather than `=` so an `enableGlobalVirtualStore` /
+                // `virtualStoreDir` set in the global `config.yaml` still
+                // counts as "explicitly set" when the workspace yaml
+                // leaves it unset.
+                virtual_store_dir_explicit |= settings.virtual_store_dir.is_some();
+                global_virtual_store_dir_explicit |= settings.global_virtual_store_dir.is_some();
                 settings.apply_to(&mut self, &base_dir);
             }
         }
+
+        // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`,
+        // mirroring pnpm v11's loop at
+        // [`config/reader/src/index.ts:471-488`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L471-L488):
+        // env vars override yaml. The `WorkspaceSettings::apply_to`
+        // call also runs the post-processing (Windows `unsafe_perm`
+        // override, `hoist: false` short-circuit on `hoist_pattern`)
+        // regardless of where the values came from, so env-var-set
+        // values still go through the same hardening yaml-set values
+        // do.
+        //
+        // `workspace_dir` save/restore is the same trick used for the
+        // global config above — `apply_to` would otherwise clobber
+        // `workspace_dir` with `start_dir`, hiding the workspace yaml's
+        // location (or, if there was no yaml, setting it to a value
+        // that doesn't actually correspond to a discovered workspace).
+        let env_settings = WorkspaceSettings::from_pnpm_config_env::<Sys>();
+        virtual_store_dir_explicit |= env_settings.virtual_store_dir.is_some();
+        global_virtual_store_dir_explicit |= env_settings.global_virtual_store_dir.is_some();
+        let saved_workspace_dir = self.workspace_dir.clone();
+        env_settings.apply_to(&mut self, start_dir);
+        self.workspace_dir = saved_workspace_dir;
 
         // Now that `registry` has been finalised (yaml may have
         // overridden the `.npmrc` value), build the per-URI auth
@@ -1078,6 +1136,32 @@ mod tests {
         store_dir.display().to_string().replace('\\', "/")
     }
 
+    /// Delegate to [`Host::var`] but mask the env vars that would
+    /// otherwise let the developer's real shell steer pacquet's global
+    /// `config.yaml` loader or its `PNPM_CONFIG_*` overlay:
+    ///
+    /// - `XDG_CONFIG_HOME` / `LOCALAPPDATA` — both feed
+    ///   [`crate::defaults::default_config_dir`], so a value set on the
+    ///   dev box would point the global-config loader at a real
+    ///   `config.yaml` on disk.
+    /// - `PNPM_CONFIG_*` / `pnpm_config_*` — the env-var overlay reads
+    ///   the entire schema, so a stray `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE`
+    ///   in the developer's shell would flip GVS in every test that
+    ///   otherwise expects defaults.
+    ///
+    /// Tests that exercise those code paths declare per-test fakes
+    /// that satisfy [`EnvVar`] with their own response logic — they
+    /// don't go through this helper.
+    fn safe_host_var(name: &str) -> Option<String> {
+        if name == "XDG_CONFIG_HOME" || name == "LOCALAPPDATA" {
+            return None;
+        }
+        if name.starts_with("PNPM_CONFIG_") || name.starts_with("pnpm_config_") {
+            return None;
+        }
+        Host::var(name)
+    }
+
     /// Common test [`crate::api::Sys`]-shaped fake: env reads delegate
     /// to [`Host`], home dir resolves to `None`. Lets a test exercise
     /// `Config::current`'s `.npmrc`-in-`start_dir` and yaml-walk paths
@@ -1085,7 +1169,7 @@ mod tests {
     struct HostNoHome;
     impl EnvVar for HostNoHome {
         fn var(name: &str) -> Option<String> {
-            Host::var(name)
+            safe_host_var(name)
         }
     }
     impl EnvVarOs for HostNoHome {
@@ -1101,29 +1185,6 @@ mod tests {
     impl GetHomeDir for HostNoHome {
         fn home_dir() -> Option<PathBuf> {
             None
-        }
-    }
-
-    /// Variant of [`HostNoHome`] that panics if [`GetHomeDir::home_dir`]
-    /// is consulted — documents the precondition that
-    /// [`Config::current`] should not fall through to the home-dir
-    /// lookup on the input the test supplies.
-    struct HostUnreachableHome;
-    impl EnvVar for HostUnreachableHome {
-        fn var(name: &str) -> Option<String> {
-            Host::var(name)
-        }
-    }
-    impl EnvVarOs for HostUnreachableHome {
-        fn var_os(_: &str) -> Option<OsString> {
-            // See [`HostNoHome`]'s [`EnvVarOs`] impl for the
-            // ambient-env-isolation rationale.
-            None
-        }
-    }
-    impl GetHomeDir for HostUnreachableHome {
-        fn home_dir() -> Option<PathBuf> {
-            unreachable!("shouldn't reach home dir");
         }
     }
 
@@ -1230,7 +1291,7 @@ mod tests {
         fs::write(tmp.path().join(".npmrc"), "registry=https://cwd.example")
             .expect("write to .npmrc");
         let config = Config::new()
-            .current::<HostUnreachableHome>(tmp.path())
+            .current::<HostNoHome>(tmp.path())
             .expect("workspace yaml absent => no error");
         assert_eq!(config.registry, "https://cwd.example/");
     }
@@ -1300,7 +1361,7 @@ mod tests {
         struct HostWithHome;
         impl EnvVar for HostWithHome {
             fn var(name: &str) -> Option<String> {
-                Host::var(name)
+                safe_host_var(name)
             }
         }
         impl EnvVarOs for HostWithHome {
@@ -1329,8 +1390,7 @@ mod tests {
             .expect("write to .npmrc");
         fs::write(tmp.path().join("pnpm-workspace.yaml"), "registry: https://from-yaml.test\n")
             .expect("write to pnpm-workspace.yaml");
-        let config =
-            Config::new().current::<HostUnreachableHome>(tmp.path()).expect("yaml is valid");
+        let config = Config::new().current::<HostNoHome>(tmp.path()).expect("yaml is valid");
         assert_eq!(config.registry, "https://from-yaml.test/");
     }
 
@@ -1359,7 +1419,7 @@ mod tests {
         struct HostWithHome;
         impl EnvVar for HostWithHome {
             fn var(name: &str) -> Option<String> {
-                Host::var(name)
+                safe_host_var(name)
             }
         }
         impl EnvVarOs for HostWithHome {
@@ -1621,7 +1681,7 @@ mod tests {
         struct HostWithEnvWorkspaceDir;
         impl EnvVar for HostWithEnvWorkspaceDir {
             fn var(name: &str) -> Option<String> {
-                Host::var(name)
+                safe_host_var(name)
             }
         }
         impl EnvVarOs for HostWithEnvWorkspaceDir {
@@ -1665,7 +1725,7 @@ mod tests {
         struct HostWithEmptyEnvWorkspaceDir;
         impl EnvVar for HostWithEmptyEnvWorkspaceDir {
             fn var(name: &str) -> Option<String> {
-                Host::var(name)
+                safe_host_var(name)
             }
         }
         impl EnvVarOs for HostWithEmptyEnvWorkspaceDir {
@@ -1686,5 +1746,309 @@ mod tests {
         // No yaml in tmp → no re-anchor → cwd-anchored defaults.
         assert_eq!(config.modules_dir, tmp.path().join("node_modules"));
         assert_eq!(config.virtual_store_dir, tmp.path().join("node_modules/.pnpm"));
+    }
+
+    /// `enableGlobalVirtualStore: true` set in the global
+    /// `<configDir>/config.yaml` is honored by `Config::current` —
+    /// the exact scenario from pnpm/pnpm#11738 where a user has
+    /// the setting in `~/.config/pnpm/config.yaml` and runs an
+    /// install in a project whose `pnpm-workspace.yaml` doesn't
+    /// repeat it.
+    ///
+    /// Drives the [`EnvVar`] + [`GetHomeDir`] DI seams: the fake
+    /// returns the test's tempdir for `XDG_CONFIG_HOME`, so
+    /// [`crate::defaults::default_config_dir`] resolves to
+    /// `<tempdir>/pnpm/config.yaml` rather than touching the
+    /// developer's real config dir.
+    #[test]
+    pub fn global_config_yaml_enables_gvs() {
+        let xdg = tempdir().unwrap();
+        let config_dir = xdg.path().join("pnpm");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join("config.yaml"), "enableGlobalVirtualStore: true\n")
+            .expect("write to global config.yaml");
+
+        static XDG_CONFIG_HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        XDG_CONFIG_HOME_PATH.set(xdg.path().to_path_buf()).expect("set once");
+
+        struct HostWithXdgConfigHome;
+        impl EnvVar for HostWithXdgConfigHome {
+            fn var(name: &str) -> Option<String> {
+                if name == "XDG_CONFIG_HOME" {
+                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithXdgConfigHome {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithXdgConfigHome {
+            fn home_dir() -> Option<PathBuf> {
+                // XDG_CONFIG_HOME short-circuits the home_dir lookup
+                // inside `default_config_dir`, but `Config::current`'s
+                // home-dir `.npmrc` fallback still consults it. The
+                // fallback gracefully tolerates `None`, so returning
+                // `None` keeps the test hermetic without forcing a
+                // tempdir for the unrelated `.npmrc` path.
+                None
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let config =
+            Config::new().current::<HostWithXdgConfigHome>(tmp.path()).expect("config loads");
+        assert!(
+            config.enable_global_virtual_store,
+            "enableGlobalVirtualStore from global config.yaml must apply",
+        );
+    }
+
+    /// `pnpm-workspace.yaml` overrides the global `config.yaml` —
+    /// global enables GVS, workspace disables it, the install
+    /// resolves to GVS-off. Matches pnpm's
+    /// [`index.ts:421-444`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L421-L444),
+    /// which applies workspace yaml after the global yaml.
+    #[test]
+    pub fn pnpm_workspace_yaml_overrides_global_config_yaml() {
+        let xdg = tempdir().unwrap();
+        let config_dir = xdg.path().join("pnpm");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join("config.yaml"), "enableGlobalVirtualStore: true\n")
+            .expect("write to global config.yaml");
+
+        let project = tempdir().unwrap();
+        fs::write(project.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
+            .expect("write to pnpm-workspace.yaml");
+
+        static XDG_CONFIG_HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        XDG_CONFIG_HOME_PATH.set(xdg.path().to_path_buf()).expect("set once");
+
+        struct HostWithXdgConfigHome;
+        impl EnvVar for HostWithXdgConfigHome {
+            fn var(name: &str) -> Option<String> {
+                if name == "XDG_CONFIG_HOME" {
+                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithXdgConfigHome {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithXdgConfigHome {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let config =
+            Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
+        assert!(
+            !config.enable_global_virtual_store,
+            "pnpm-workspace.yaml must win over global config.yaml",
+        );
+    }
+
+    /// Workspace-only keys in the global `config.yaml` are silently
+    /// ignored, matching pnpm's
+    /// [`isConfigFileKey`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/configFileKey.ts#L187)
+    /// filter at
+    /// [`index.ts:299-309`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L299-L309).
+    /// A `nodeLinker: hoisted` in the global yaml would change the
+    /// installer's layout strategy if applied — pnpm rejects it, and
+    /// pacquet must too.
+    #[test]
+    pub fn global_config_yaml_workspace_only_keys_are_ignored() {
+        let xdg = tempdir().unwrap();
+        let config_dir = xdg.path().join("pnpm");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.yaml"),
+            // `nodeLinker`, `hoist`, `symlink`, and `lockfile` are
+            // all in pnpm's `excludedPnpmKeys`. None should apply
+            // when set in the global config.
+            "nodeLinker: hoisted\nhoist: false\nsymlink: false\nlockfile: false\n",
+        )
+        .expect("write to global config.yaml");
+
+        static XDG_CONFIG_HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        XDG_CONFIG_HOME_PATH.set(xdg.path().to_path_buf()).expect("set once");
+
+        struct HostWithXdgConfigHome;
+        impl EnvVar for HostWithXdgConfigHome {
+            fn var(name: &str) -> Option<String> {
+                if name == "XDG_CONFIG_HOME" {
+                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithXdgConfigHome {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithXdgConfigHome {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let defaults = Config::new();
+        let config =
+            Config::new().current::<HostWithXdgConfigHome>(tmp.path()).expect("config loads");
+        assert_eq!(config.node_linker, defaults.node_linker);
+        assert_eq!(config.hoist, defaults.hoist);
+        assert_eq!(config.symlink, defaults.symlink);
+        assert_eq!(config.lockfile, defaults.lockfile);
+    }
+
+    /// `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=true` is read into
+    /// the config — drives the env-overlay introduced alongside
+    /// global `config.yaml` support. Mirrors pnpm's `parseEnvVars`
+    /// loop at
+    /// [`index.ts:471-488`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L471-L488)
+    /// for the `PNPM_CONFIG_*` family (pnpm doesn't read general
+    /// `NPM_CONFIG_*` env vars; see
+    /// [`feedback_pnpm_settings_not_in_npmrc`](https://github.com/pnpm/pnpm/blob/main/config/reader/src/localConfig.ts)).
+    #[test]
+    pub fn pnpm_config_env_var_enables_gvs() {
+        struct HostWithPnpmConfigEnv;
+        impl EnvVar for HostWithPnpmConfigEnv {
+            fn var(name: &str) -> Option<String> {
+                if name == "PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE" {
+                    return Some("true".to_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithPnpmConfigEnv {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithPnpmConfigEnv {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
+        assert!(config.enable_global_virtual_store);
+    }
+
+    /// Lowercase `pnpm_config_*` spelling also works, matching
+    /// upstream's
+    /// [`getEnvKeySuffix`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L185-L195)
+    /// which accepts both case forms.
+    #[test]
+    pub fn pnpm_config_env_var_lowercase_works() {
+        struct HostWithLowercaseEnv;
+        impl EnvVar for HostWithLowercaseEnv {
+            fn var(name: &str) -> Option<String> {
+                if name == "pnpm_config_enable_global_virtual_store" {
+                    return Some("true".to_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithLowercaseEnv {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithLowercaseEnv {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let config = Config::new().current::<HostWithLowercaseEnv>(tmp.path()).expect("loads");
+        assert!(config.enable_global_virtual_store);
+    }
+
+    /// `PNPM_CONFIG_*` overrides `pnpm-workspace.yaml` — the env
+    /// var is applied after yaml in pnpm's reader cascade. Without
+    /// this ordering a CI override via env var couldn't beat a
+    /// committed yaml setting, which is the whole reason to expose
+    /// env vars at all.
+    #[test]
+    pub fn pnpm_config_env_var_overrides_workspace_yaml() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("pnpm-workspace.yaml"), "enableGlobalVirtualStore: false\n")
+            .expect("write to pnpm-workspace.yaml");
+
+        struct HostWithPnpmConfigEnv;
+        impl EnvVar for HostWithPnpmConfigEnv {
+            fn var(name: &str) -> Option<String> {
+                if name == "PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE" {
+                    return Some("true".to_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithPnpmConfigEnv {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithPnpmConfigEnv {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
+        assert!(
+            config.enable_global_virtual_store,
+            "PNPM_CONFIG_* env var must win over pnpm-workspace.yaml",
+        );
+    }
+
+    /// `PNPM_CONFIG_HOIST=false` runs the same post-processing as
+    /// yaml-set `hoist: false` — it short-circuits `hoist_pattern`
+    /// to `None`, mirroring upstream's
+    /// [`projectConfig.ts:72-75`](https://github.com/pnpm/pnpm/blob/94240bc046/config/reader/src/projectConfig.ts#L72-L75)
+    /// rule (`hoist === false ⇒ hoistPattern: undefined`). Without
+    /// this, the install-time `hoist_pattern.is_some() ||
+    /// public_hoist_pattern.is_some()` guard would still enable
+    /// hoisting even after the user disabled it via env var.
+    #[test]
+    pub fn pnpm_config_hoist_false_clears_hoist_pattern() {
+        struct HostWithHoistEnv;
+        impl EnvVar for HostWithHoistEnv {
+            fn var(name: &str) -> Option<String> {
+                if name == "PNPM_CONFIG_HOIST" {
+                    return Some("false".to_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithHoistEnv {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithHoistEnv {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let config = Config::new().current::<HostWithHoistEnv>(tmp.path()).expect("loads");
+        assert!(!config.hoist);
+        assert_eq!(
+            config.hoist_pattern, None,
+            "hoist: false must clear hoist_pattern, even when set via env var",
+        );
     }
 }

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1048,8 +1048,21 @@ impl Config {
             // Applied *before* `settings.apply_to` so an explicit
             // `modulesDir` / `virtualStoreDir` in `pnpm-workspace.yaml`
             // still wins.
+            //
+            // `virtual_store_dir_explicit` guards the re-anchor for
+            // `virtual_store_dir` — without it, a `virtualStoreDir`
+            // already set in the global `config.yaml` would be
+            // clobbered by the workspace-root default whenever the
+            // workspace yaml itself leaves the field unset. `modules_dir`
+            // needs no such guard because pnpm's `excludedPnpmKeys`
+            // (and pacquet's `clear_workspace_only_fields`) keep it
+            // out of the global-config surface, so it can only come
+            // from workspace yaml or env vars, and env vars haven't
+            // been applied yet at this point in the cascade.
             self.modules_dir = base_dir.join("node_modules");
-            self.virtual_store_dir = base_dir.join("node_modules/.pnpm");
+            if !virtual_store_dir_explicit {
+                self.virtual_store_dir = base_dir.join("node_modules/.pnpm");
+            }
             if let Some(settings) = settings {
                 // `|=` rather than `=` so an `enableGlobalVirtualStore` /
                 // `virtualStoreDir` set in the global `config.yaml` still
@@ -1775,7 +1788,9 @@ mod tests {
         impl EnvVar for HostWithXdgConfigHome {
             fn var(name: &str) -> Option<String> {
                 if name == "XDG_CONFIG_HOME" {
-                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                    return XDG_CONFIG_HOME_PATH
+                        .get()
+                        .map(|path| path.to_string_lossy().into_owned());
                 }
                 safe_host_var(name)
             }
@@ -1830,7 +1845,9 @@ mod tests {
         impl EnvVar for HostWithXdgConfigHome {
             fn var(name: &str) -> Option<String> {
                 if name == "XDG_CONFIG_HOME" {
-                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                    return XDG_CONFIG_HOME_PATH
+                        .get()
+                        .map(|path| path.to_string_lossy().into_owned());
                 }
                 safe_host_var(name)
             }
@@ -1851,6 +1868,67 @@ mod tests {
         assert!(
             !config.enable_global_virtual_store,
             "pnpm-workspace.yaml must win over global config.yaml",
+        );
+    }
+
+    /// `virtualStoreDir` set in the global `config.yaml` is preserved
+    /// even when the workspace yaml doesn't repeat it. Without the
+    /// `!virtual_store_dir_explicit` guard on the re-anchor, the
+    /// workspace-root default (`<workspace>/node_modules/.pnpm`)
+    /// would overwrite the global value any time a `pnpm-workspace.yaml`
+    /// is present. Regression test for a CodeRabbit review finding on
+    /// pnpm/pnpm#11752.
+    #[test]
+    pub fn global_virtual_store_dir_survives_workspace_yaml_anchor() {
+        let xdg = tempdir().unwrap();
+        let config_dir = xdg.path().join("pnpm");
+        fs::create_dir_all(&config_dir).unwrap();
+        let global_path = xdg.path().join("shared-virtual-store");
+        fs::write(
+            config_dir.join("config.yaml"),
+            format!(
+                "enableGlobalVirtualStore: true\nvirtualStoreDir: {}\n",
+                global_path.display(),
+            ),
+        )
+        .expect("write global config.yaml");
+
+        let project = tempdir().unwrap();
+        // Empty workspace yaml — present so the workspace block fires,
+        // but it doesn't redeclare `virtualStoreDir`.
+        fs::write(project.path().join("pnpm-workspace.yaml"), "packages:\n  - .\n")
+            .expect("write workspace yaml");
+
+        static XDG_CONFIG_HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+        XDG_CONFIG_HOME_PATH.set(xdg.path().to_path_buf()).expect("set once");
+
+        struct HostWithXdgConfigHome;
+        impl EnvVar for HostWithXdgConfigHome {
+            fn var(name: &str) -> Option<String> {
+                if name == "XDG_CONFIG_HOME" {
+                    return XDG_CONFIG_HOME_PATH
+                        .get()
+                        .map(|path| path.to_string_lossy().into_owned());
+                }
+                safe_host_var(name)
+            }
+        }
+        impl EnvVarOs for HostWithXdgConfigHome {
+            fn var_os(_: &str) -> Option<OsString> {
+                None
+            }
+        }
+        impl GetHomeDir for HostWithXdgConfigHome {
+            fn home_dir() -> Option<PathBuf> {
+                None
+            }
+        }
+
+        let config =
+            Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
+        assert_eq!(
+            config.virtual_store_dir, global_path,
+            "virtualStoreDir from global config.yaml must survive the workspace-root re-anchor",
         );
     }
 
@@ -1883,7 +1961,9 @@ mod tests {
         impl EnvVar for HostWithXdgConfigHome {
             fn var(name: &str) -> Option<String> {
                 if name == "XDG_CONFIG_HOME" {
-                    return XDG_CONFIG_HOME_PATH.get().map(|p| p.to_string_lossy().into_owned());
+                    return XDG_CONFIG_HOME_PATH
+                        .get()
+                        .map(|path| path.to_string_lossy().into_owned());
                 }
                 safe_host_var(name)
             }

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -257,6 +257,11 @@ pub struct WorkspaceSettings {
 /// Basename of the file pnpm reads; exported for test use.
 pub const WORKSPACE_MANIFEST_FILENAME: &str = "pnpm-workspace.yaml";
 
+/// Basename of pnpm's global config file inside `<configDir>`. Matches
+/// upstream's
+/// [`GLOBAL_CONFIG_YAML_FILENAME`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/core/constants/src/index.ts#L12).
+pub const GLOBAL_CONFIG_YAML_FILENAME: &str = "config.yaml";
+
 /// Error when reading `pnpm-workspace.yaml`.
 ///
 /// Pnpm's
@@ -282,6 +287,71 @@ pub enum LoadWorkspaceYamlError {
 }
 
 impl WorkspaceSettings {
+    /// Read the global config.yaml at `<config_dir>/config.yaml`, if
+    /// present.
+    ///
+    /// Pnpm v11's
+    /// [`index.ts:228`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L228)
+    /// reads this file with the same parser as `pnpm-workspace.yaml`,
+    /// but applies it through a key-filter pass
+    /// ([`isConfigFileKey`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/configFileKey.ts#L187))
+    /// so workspace-only knobs (`nodeLinker`, `hoist`, `lockfile`, …)
+    /// cannot be set globally. Mirrors that filter via
+    /// [`Self::clear_workspace_only_fields`].
+    ///
+    /// Returns `Ok(None)` when the file does not exist. Read or parse
+    /// failures propagate.
+    pub fn load_global(config_dir: &Path) -> Result<Option<Self>, LoadWorkspaceYamlError> {
+        let path = config_dir.join(GLOBAL_CONFIG_YAML_FILENAME);
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(LoadWorkspaceYamlError::ReadFile { path, source }),
+        };
+        let mut settings: WorkspaceSettings = serde_saphyr::from_str(&text)
+            .map_err(Box::new)
+            .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path, source })?;
+        settings.clear_workspace_only_fields();
+        Ok(Some(settings))
+    }
+
+    /// Zero out fields not permitted in the global `config.yaml`.
+    ///
+    /// Mirrors pnpm's
+    /// [`isConfigFileKey`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/configFileKey.ts#L187)
+    /// filter — every field listed here corresponds to a key in
+    /// upstream's `excludedPnpmKeys`, plus the programmatic-only and
+    /// workspace-only knobs (`patchedDependencies`, `allowBuilds`,
+    /// `supportedArchitectures`, `ignoredOptionalDependencies`,
+    /// `hoistingLimits`, `externalDependencies`) that pnpm only reads
+    /// from `pnpm-workspace.yaml` or the legacy `package.json#pnpm`
+    /// field. Without this filter a user could put `nodeLinker:
+    /// hoisted` in `~/.config/pnpm/config.yaml` and pacquet would
+    /// honor it while pnpm wouldn't — anti-parity.
+    pub fn clear_workspace_only_fields(&mut self) {
+        self.hoist = None;
+        self.hoist_pattern = None;
+        self.public_hoist_pattern = None;
+        self.shamefully_hoist = None;
+        self.modules_dir = None;
+        self.node_linker = None;
+        self.symlink = None;
+        self.lockfile = None;
+        self.offline = None;
+        self.lockfile_include_tarball_url = None;
+        self.auto_install_peers = None;
+        self.hoist_workspace_packages = None;
+        self.dedupe_peer_dependents = None;
+        self.strict_peer_dependencies = None;
+        self.resolve_peers_from_workspace_root = None;
+        self.hoisting_limits = None;
+        self.external_dependencies = None;
+        self.patched_dependencies = None;
+        self.allow_builds = None;
+        self.supported_architectures = None;
+        self.ignored_optional_dependencies = None;
+    }
+
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.
     /// Returns `Ok(None)` if no ancestor has one. Read or parse failures
     /// other than `ENOENT` propagate, matching pnpm's


### PR DESCRIPTION
## Summary

Brings pacquet's config loader closer to pnpm v11 parity by filling two real source-reading gaps surfaced in #11738:

- **Global `<configDir>/config.yaml`** — e.g. `~/.config/pnpm/config.yaml` (Linux), `~/Library/Preferences/pnpm/config.yaml` (macOS), `%LOCALAPPDATA%/pnpm/config/config.yaml` (Windows). Loaded between `.npmrc` and `pnpm-workspace.yaml`, with workspace-only keys (`nodeLinker`, `hoist`, `lockfile`, …) filtered out to mirror upstream's [`isConfigFileKey`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/configFileKey.ts#L187) allowlist at [`index.ts:299-309`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L299-L309).
- **`PNPM_CONFIG_*` / `pnpm_config_*` env vars** for the whole schema (pacquet previously honored only `NPM_CONFIG_WORKSPACE_DIR`). Read for every `WorkspaceSettings` field and applied after `pnpm-workspace.yaml` so env vars win — matching upstream's [`parseEnvVars`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts#L42) loop at [`index.ts:471-488`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L471-L488).

Closes the scenario in #11738: a user with `enableGlobalVirtualStore: true` in `~/.config/pnpm/config.yaml` who runs an install in a project whose `pnpm-workspace.yaml` doesn't repeat the setting now lands in the global virtual store, same as pnpm.

## What I deliberately did NOT change

The issue (which I [wrote in a prior session](https://github.com/pnpm/pnpm/issues/11738#issue-number)) proposed reading `.npmrc`, `~/.pnpmrc`, `~/.config/pnpm/rc`, and `npm_config_*` env vars for the full setting surface. Three of those four are anti-parity:

| Proposal | Pnpm v11 actually... | Decision |
|---|---|---|
| Read all settings from `.npmrc` | filters to auth + network only via [`isNpmrcReadableKey`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/localConfig.ts#L197-L198) | **skip** — would diverge from pnpm |
| Read `~/.pnpmrc` and `~/.config/pnpm/rc` | doesn't read either; they aren't pnpm files | **skip** — would invent behavior |
| Read all `npm_config_*` env vars | reads only `npm_config_userconfig` as an auth-file fallback | **skip** — `PNPM_CONFIG_*` is the documented path |
| Read `<configDir>/config.yaml` | reads it via [`index.ts:228 / 297-316`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/index.ts#L228) | **implemented** |
| Read `PNPM_CONFIG_*` env vars | reads them for every schema key via [`env.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/env.ts) | **implemented** |

## Code map

- `pacquet/crates/config/src/defaults.rs` — `default_config_dir<Sys>` mirroring upstream's [`getConfigDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L67-L86).
- `pacquet/crates/config/src/workspace_yaml.rs` — `WorkspaceSettings::load_global` + `clear_workspace_only_fields`, and the `GLOBAL_CONFIG_YAML_FILENAME` constant.
- `pacquet/crates/config/src/env_overlay.rs` *(new)* — `WorkspaceSettings::from_pnpm_config_env::<Sys>()` with per-type JSON / string / enum / tri-array parsers.
- `pacquet/crates/config/src/lib.rs` — wired both into `Config::current`, `|=` the GVS-explicit flags across all three sources (global yaml, workspace yaml, env vars), hardened the existing test fakes with a `safe_host_var` helper so a developer's real shell env can't leak into hermetic tests.

## Test plan

- [x] `cargo nextest run -p pacquet-config` — 196/196 pass, including new tests for the issue's exact scenario, workspace-yaml-overrides-global, workspace-only-keys-stripped, env-var-overrides-workspace, lowercase env var spelling, and `PNPM_CONFIG_HOIST=false` post-processing parity.
- [x] `cargo nextest run` (full pacquet workspace) — 1486/1486 pass.
- [x] `just check` / `just lint` / `just fmt` — all clean.
- [x] `typos` failures are pre-existing on `main` (unrelated CHANGELOG strings + one comment in `verifyLockfileResolutions.ts`).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load and apply a global config.yaml with correct precedence relative to workspace config and env vars.
  * Apply PNPM_CONFIG_* / pnpm_config_* environment overrides after workspace settings.
  * Platform-aware default global config directory resolution.

* **Behavior**
  * Global config now ignores workspace-only keys so workspace behavior isn't overwritten.
  * Environment parsing tightened for stricter/safer overrides.

* **Tests**
  * Expanded tests covering global config, env overrides, and platform cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->