### PR TITLE
fix(config/reader): only sync registries.default to registry when workspace contributes it

### DIFF
--- a/.changeset/config-reader-registry-sync-npmrc.md
+++ b/.changeset/config-reader-registry-sync-npmrc.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fix `config.registry` getting a trailing slash appended when `registry` is set in `.npmrc` and no `registries.default` is provided by `pnpm-workspace.yaml`. The sync from `registries.default` to `config.registry` introduced in #11744 now only fires when the workspace manifest actually contributes a different default.

--- a/config/reader/src/index.ts
+++ b/config/reader/src/index.ts
@@ -463,9 +463,10 @@ export async function getConfig (opts: {
 
   // Sync registries.default to the top-level registry property so that
   // commands like login/logout that use opts.registry pick up the default
-  // registry configured in pnpm-workspace.yaml.
-  // Only sync when registry was not explicitly set via CLI.
-  if (!explicitlySetKeys.has('registry')) {
+  // registry configured in pnpm-workspace.yaml. Only sync when the workspace
+  // manifest actually contributed a different default than what .npmrc provided,
+  // and when registry was not explicitly set via CLI.
+  if (!explicitlySetKeys.has('registry') && pnpmConfig.registries.default !== registriesFromNpmrc.default) {
     pnpmConfig.registry = pnpmConfig.registries.default
   }
 


### PR DESCRIPTION
## Summary

- Restricts the `registries.default` → `pnpmConfig.registry` sync introduced in #11744 to cases where `pnpm-workspace.yaml` actually contributes a default different from what `.npmrc` provided.
- Previously the sync also overwrote the unnormalized `registry` value parsed straight from `.npmrc` with the normalized form (with a trailing slash), causing `config.registry` to gain an unexpected trailing slash whenever a user set `registry = …` in `.npmrc`.

## Repro

The test `config/reader/test/index.ts: "getConfig() returns the userconfig even when overridden locally"` started failing on `main`:

```
Expected: "https://project-local.example.test"
Received: "https://project-local.example.test/"
```

The user has `registry = https://project-local.example.test` in `.npmrc`, no `pnpm-workspace.yaml`, and the new sync fired anyway because `registry` wasn't on the CLI.

## Test plan

- [x] `config.registry` stays unnormalized when only `.npmrc` provides it (existing test re-passes).
- [x] `pnpm-workspace.yaml` `registries.default` still flows into `config.registry` (covered by `"pnpm-workspace.yaml registries.default is reflected in config.registry (#10099)"`).
- [x] CLI `--registry` still wins over both (covered by `"CLI --registry overrides pnpm-workspace.yaml registries.default (#10099)"`).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace configuration syncing to prevent unnecessary modifications to registry settings when using `.npmrc` without explicit workspace manifest defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->