### PR TITLE
fix(installing.commands): clarify "loose mode" wording in minimumReleaseAge log

### DIFF
--- a/.changeset/policy-handlers-loose-mode-message.md
+++ b/.changeset/policy-handlers-loose-mode-message.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+Improve the log message that pnpm prints after auto-adding entries to `minimumReleaseAgeExclude` when `minimumReleaseAge` is set without `minimumReleaseAgeStrict`. The message previously referred to the internal "loose mode" terminology, which wasn't searchable in the docs; it now tells the user to set `minimumReleaseAgeStrict` to `true` if they want to disable this behavior [#11747](https://github.com/pnpm/pnpm/issues/11747).

--- a/.changeset/policy-handlers-loose-mode-message.md
+++ b/.changeset/policy-handlers-loose-mode-message.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Improve the log message that pnpm prints after auto-adding entries to `minimumReleaseAgeExclude` when `minimumReleaseAge` is set without `minimumReleaseAgeStrict`. The message previously referred to the internal "loose mode" terminology, which wasn't searchable in the docs; it now tells the user to set `minimumReleaseAgeStrict` to `true` if they want to disable this behavior [#11747](https://github.com/pnpm/pnpm/issues/11747).
+Improve the log message that pnpm prints after auto-adding entries to `minimumReleaseAgeExclude` when `minimumReleaseAge` is set without `minimumReleaseAgeStrict`. The message previously referred to the internal "loose mode" terminology, which wasn't searchable in the docs; it now tells the user to set `minimumReleaseAgeStrict` to `true` if they want these updates gated behind a prompt instead [#11747](https://github.com/pnpm/pnpm/issues/11747).

--- a/installing/commands/src/policyHandlers.ts
+++ b/installing/commands/src/policyHandlers.ts
@@ -213,7 +213,7 @@ function pickImmatureEntries (
   // the discovery notice.
   const reason = promptRequired
     ? '(approved at the prompt)'
-    : '(set minimumReleaseAgeStrict to gate these updates with a prompt)'
+    : '(set minimumReleaseAgeStrict to true to gate these updates with a prompt)'
   globalInfo(
     `Added ${sorted.length} ${sorted.length === 1 ? 'entry' : 'entries'} to minimumReleaseAgeExclude in pnpm-workspace.yaml ` +
     `${reason}:\n  ${sorted.join('\n  ')}`

--- a/installing/commands/src/policyHandlers.ts
+++ b/installing/commands/src/policyHandlers.ts
@@ -213,7 +213,7 @@ function pickImmatureEntries (
   // the discovery notice.
   const reason = promptRequired
     ? '(approved at the prompt)'
-    : '(set minimumReleaseAgeStrict to true to disable this behavior)'
+    : '(set minimumReleaseAgeStrict to gate these updates with a prompt)'
   globalInfo(
     `Added ${sorted.length} ${sorted.length === 1 ? 'entry' : 'entries'} to minimumReleaseAgeExclude in pnpm-workspace.yaml ` +
     `${reason}:\n  ${sorted.join('\n  ')}`

--- a/installing/commands/src/policyHandlers.ts
+++ b/installing/commands/src/policyHandlers.ts
@@ -213,7 +213,7 @@ function pickImmatureEntries (
   // the discovery notice.
   const reason = promptRequired
     ? '(approved at the prompt)'
-    : '(loose mode allowed these immature versions)'
+    : '(set minimumReleaseAgeStrict to true to disable this behavior)'
   globalInfo(
     `Added ${sorted.length} ${sorted.length === 1 ? 'entry' : 'entries'} to minimumReleaseAgeExclude in pnpm-workspace.yaml ` +
     `${reason}:\n  ${sorted.join('\n  ')}`


### PR DESCRIPTION
## Summary

The log line printed when pnpm auto-adds entries to `minimumReleaseAgeExclude` (because `minimumReleaseAge` is set but `minimumReleaseAgeStrict` is not) currently reads:

> Added 1 entry to minimumReleaseAgeExclude in pnpm-workspace.yaml (loose mode allowed these immature versions)

Per #11747, the "loose mode" phrasing doesn't appear in the docs, isn't searchable, and doesn't tell the user how to change the behaviour. This PR replaces that fragment with the actual setting name:

> Added 1 entry to minimumReleaseAgeExclude in pnpm-workspace.yaml (set minimumReleaseAgeStrict to true to disable this behavior)

Closes #11747

## Changes

- `installing/commands/src/policyHandlers.ts` — replace the "loose mode" log message fragment with one that references `minimumReleaseAgeStrict`.
- Added a changeset (`@pnpm/installing.commands` patch, `pnpm` patch).

The internal comment in the same file still uses "loose mode" / "strict mode" — that's developer-facing terminology, and the issue is specifically about user-facing log output.

## Pacquet parity

Pacquet has the data types for `minimumReleaseAgeExclude` (`pacquet/crates/config/src/version_policy.rs`) but hasn't yet ported the policy-violation log-emission path (the `pickImmatureEntries` / `globalInfo` call). No equivalent user-facing string exists in pacquet to update — this change is TS-only, consistent with pacquet's current scope.

## Test plan

- [ ] Manual: trigger the message — run `pnpm install` on a workspace with `minimumReleaseAge` set (but no `minimumReleaseAgeStrict`) and a dependency newer than the threshold; confirm the new wording appears in the info output.
- [ ] No new automated tests added: the existing tests in `installing/commands/test/policyHandlers.ts` don't assert on the log message text, and a string-literal assertion would be churn for the next reword.

## Breaking changes

None — log output text only.

---

Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved release policy messaging: removed internal "loose mode" terminology and clarified post-add guidance when minimumReleaseAge is set without minimumReleaseAgeStrict, instructing users to set minimumReleaseAgeStrict: true to require prompt gating for such updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->