### PR TITLE
fix(env-installer): mark optional config subdep snapshots with optional: true

### DIFF
--- a/.changeset/config-deps-optional-subdep-snapshot-flag.md
+++ b/.changeset/config-deps-optional-subdep-snapshot-flag.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.env-installer": patch
+"pnpm": patch
+---
+
+Mark optional subdependency snapshots of config dependencies with `optional: true` in the env lockfile, matching how optional dependencies are recorded elsewhere in `pnpm-lock.yaml`. Previously, snapshots for the platform-specific subdeps pulled in via a config dep's `optionalDependencies` were written as empty objects, which was inconsistent with the rest of the lockfile and made it look like those non-host platform variants were required.

--- a/installing/env-installer/src/resolveOptionalSubdeps.ts
+++ b/installing/env-installer/src/resolveOptionalSubdeps.ts
@@ -97,7 +97,7 @@ export async function resolveOptionalSubdeps (
       ...pickPlatformFields(resolution.manifest),
     }
     if (opts.envLockfile.snapshots[subdepKey] == null) {
-      opts.envLockfile.snapshots[subdepKey] = {}
+      opts.envLockfile.snapshots[subdepKey] = { optional: true }
     }
     resolved[subdepName] = subdepVersion
   }))

--- a/installing/env-installer/test/resolveConfigDeps.test.ts
+++ b/installing/env-installer/test/resolveConfigDeps.test.ts
@@ -77,7 +77,8 @@ test('one level of optionalDependencies is recorded in the env lockfile with pla
   })
 
   // Each optional subdep is in `packages` with its os/cpu fields preserved for
-  // install-time platform filtering, and gets an empty snapshot.
+  // install-time platform filtering, and gets an `optional: true` snapshot
+  // to match how optional packages are recorded elsewhere in the lockfile.
   expect(envLockfile!.packages['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({
     resolution: {
       integrity: getIntegrity('@pnpm.e2e/only-darwin-arm64', '1.0.0'),
@@ -85,7 +86,7 @@ test('one level of optionalDependencies is recorded in the env lockfile with pla
     os: ['darwin'],
     cpu: ['arm64'],
   })
-  expect(envLockfile!.snapshots['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({})
+  expect(envLockfile!.snapshots['@pnpm.e2e/only-darwin-arm64@1.0.0']).toStrictEqual({ optional: true })
   // libc is preserved alongside os/cpu for musl/glibc variants.
   expect(envLockfile!.packages['@pnpm.e2e/only-linux-x64-musl@1.0.0']).toStrictEqual({
     resolution: {


### PR DESCRIPTION
## Summary

- When `resolveOptionalSubdeps` records a subdep snapshot in the env lockfile, it now writes `{ optional: true }` instead of `{}`, matching how all other optional packages are recorded in `pnpm-lock.yaml`.
- Addresses the Copilot review comment on #11765: the `@pacquet/*` platform packages pulled in via `@pnpm/pacquet`'s `optionalDependencies` were recorded as plain empty snapshots, inconsistent with how `@reflink/*`, `@esbuild/*`, and friends are marked elsewhere in the lockfile.

## Notes

- Pure serialization fix on the writer side; the reader (`installConfigDeps`) doesn't consume this flag.
- Existing env lockfiles that already have empty-object snapshots for config-dep optional subdeps will need a regen (`pnpm update <config-dep>` or remove + re-add) for the flag to land.

## Test plan

- [x] Updated `resolveConfigDeps.test.ts` to assert `{ optional: true }` on the subdep snapshot.
- [ ] CI: build + jest.
- [ ] Once #11765 lands, regenerate `pnpm-lock.yaml` so the `@pacquet/*` snapshots pick up `optional: true`.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Resolved inconsistency in lockfile snapshot generation for optional subdependencies. Platform-specific optional dependency snapshots are now properly marked with metadata instead of being emitted as empty objects, ensuring consistency across the lockfile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->