### PR TITLE
feat(pacquet): port JSR specifier parser and wire resolve_jsr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,6 +2439,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-resolving-jsr-specifier-parser"
+version = "0.0.1"
+dependencies = [
+ "derive_more",
+ "miette 7.6.0",
+]
+
+[[package]]
 name = "pacquet-resolving-npm-resolver"
 version = "0.0.1"
 dependencies = [
@@ -2453,6 +2461,7 @@ dependencies = [
  "pacquet-lockfile",
  "pacquet-network",
  "pacquet-registry",
+ "pacquet-resolving-jsr-specifier-parser",
  "pacquet-resolving-resolver-base",
  "pipe-trait",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ pacquet-patching                          = { path = "pacquet/crates/patching" }
 pacquet-real-hoist                        = { path = "pacquet/crates/real-hoist" }
 pacquet-resolving-default-resolver        = { path = "pacquet/crates/resolving-default-resolver" }
 pacquet-resolving-deps-resolver           = { path = "pacquet/crates/resolving-deps-resolver" }
+pacquet-resolving-jsr-specifier-parser    = { path = "pacquet/crates/resolving-jsr-specifier-parser" }
 pacquet-resolving-npm-resolver            = { path = "pacquet/crates/resolving-npm-resolver" }
 pacquet-resolving-parse-wanted-dependency = { path = "pacquet/crates/resolving-parse-wanted-dependency" }
 pacquet-resolving-resolver-base           = { path = "pacquet/crates/resolving-resolver-base" }

--- a/pacquet/crates/resolving-jsr-specifier-parser/Cargo.toml
+++ b/pacquet/crates/resolving-jsr-specifier-parser/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name                  = "pacquet-resolving-jsr-specifier-parser"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+derive_more = { workspace = true }
+miette      = { workspace = true }
+
+[lints]
+workspace = true

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
@@ -1,0 +1,147 @@
+//! Pacquet port of pnpm's
+//! [`@pnpm/resolving.jsr-specifier-parser`](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts).
+//!
+//! Splits a `jsr:` specifier into its `(jsrPkgName, npmPkgName,
+//! versionSelector)` triple. JSR ships every package on the npm
+//! registry under the `@jsr` scope with the JSR scope folded into the
+//! name (`@foo/bar` → `@jsr/foo__bar`), so the npm resolver needs the
+//! npm-style name to drive metadata fetches and the JSR-style name to
+//! restore the original alias.
+//!
+//! Returns `None` for non-`jsr:` specifiers so the caller can chain
+//! into another parser (npm-style bare specifier, named-registry,
+//! etc.) without sniffing the prefix itself.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+
+/// Parsed `jsr:` specifier.
+///
+/// Mirrors upstream's `JsrSpec`
+/// ([source](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts#L3-L8)).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsrSpec {
+    /// Original JSR-style scoped name (e.g. `@foo/bar`). Used by the
+    /// resolver to record the dependency under its JSR alias so the
+    /// lockfile and `node_modules` layout match how the user wrote
+    /// the dependency.
+    pub jsr_pkg_name: String,
+    /// Folded npm-registry name (`@jsr/<scope>__<name>`) the npm
+    /// metadata + tarball endpoints actually serve under.
+    pub npm_pkg_name: String,
+    /// Semver range, exact version, or dist-tag. `None` when the
+    /// specifier omits a selector (`jsr:@foo/bar`), in which case the
+    /// caller substitutes the default tag.
+    pub version_selector: Option<String>,
+}
+
+/// Failures from [`parse_jsr_specifier`]. Mirrors the three upstream
+/// `PnpmError` codes the TypeScript parser raises
+/// ([source](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts#L38-L60)).
+#[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseJsrSpecifierError {
+    /// Specifier names a package without a scope (e.g. `jsr:foo@^1`).
+    /// JSR packages are always scoped, so this is a hard error rather
+    /// than a fallthrough.
+    #[display("Package names from JSR must have a scope")]
+    #[diagnostic(code(ERR_PNPM_MISSING_JSR_PACKAGE_SCOPE))]
+    MissingScope,
+
+    /// Specifier carries a scope but no `/name` segment
+    /// (e.g. `jsr:@foo` or `jsr:@foo@^1`).
+    #[display("The package name '{pkg_name}' is invalid")]
+    #[diagnostic(code(ERR_PNPM_INVALID_JSR_PACKAGE_NAME))]
+    InvalidPackageName {
+        #[error(not(source))]
+        pkg_name: String,
+    },
+
+    /// Specifier supplies only a version selector and the caller has
+    /// no `alias` to borrow the package name from
+    /// (e.g. raw `jsr:^1.0.0` outside an aliased dependency).
+    #[display("JSR specifier '{specifier}' is missing a package name")]
+    #[diagnostic(code(ERR_PNPM_INVALID_JSR_SPECIFIER))]
+    MissingPackageName {
+        #[error(not(source))]
+        specifier: String,
+    },
+}
+
+/// Parse a `jsr:` specifier into [`JsrSpec`].
+///
+/// Returns `Ok(None)` for any specifier that doesn't start with
+/// `jsr:` so the resolver chain can fall through to the next parser.
+/// `alias` supplies the package name when the specifier is a bare
+/// `jsr:<version_selector>` and would otherwise be unresolvable.
+///
+/// Mirrors upstream's `parseJsrSpecifier`
+/// ([source](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts#L10-L51)).
+pub fn parse_jsr_specifier(
+    raw_specifier: &str,
+    alias: Option<&str>,
+) -> Result<Option<JsrSpec>, ParseJsrSpecifierError> {
+    let Some(rest) = raw_specifier.strip_prefix("jsr:") else {
+        return Ok(None);
+    };
+
+    // Syntax: jsr:@<scope>/<name>[@<version_selector>]
+    if rest.starts_with('@') {
+        // `rest` starts with `@`, so `rfind` is guaranteed to return
+        // at least `0` — matching upstream's `lastIndexOf('@') === 0`
+        // discriminator between the no-selector and selector cases.
+        let last_at = rest.rfind('@').expect("rest starts with '@'");
+
+        // Syntax: jsr:@<scope>/<name>
+        if last_at == 0 {
+            let npm_pkg_name = jsr_to_npm_package_name(rest)?;
+            return Ok(Some(JsrSpec {
+                jsr_pkg_name: rest.to_string(),
+                npm_pkg_name,
+                version_selector: None,
+            }));
+        }
+
+        // Syntax: jsr:@<scope>/<name>@<version_selector>
+        let jsr_pkg_name = &rest[..last_at];
+        let npm_pkg_name = jsr_to_npm_package_name(jsr_pkg_name)?;
+        return Ok(Some(JsrSpec {
+            jsr_pkg_name: jsr_pkg_name.to_string(),
+            npm_pkg_name,
+            version_selector: Some(rest[last_at + 1..].to_string()),
+        }));
+    }
+
+    // Syntax: jsr:<name>@<version_selector> (invalid — JSR requires a scope)
+    if rest.contains('@') {
+        return Err(ParseJsrSpecifierError::MissingScope);
+    }
+
+    let Some(alias) = alias else {
+        return Err(ParseJsrSpecifierError::MissingPackageName { specifier: rest.to_string() });
+    };
+
+    // Syntax: jsr:<version_selector>
+    Ok(Some(JsrSpec {
+        version_selector: Some(rest.to_string()),
+        jsr_pkg_name: alias.to_string(),
+        npm_pkg_name: jsr_to_npm_package_name(alias)?,
+    }))
+}
+
+/// Fold a JSR-scoped name (`@foo/bar`) into the npm-scoped name JSR
+/// serves it under (`@jsr/foo__bar`).
+fn jsr_to_npm_package_name(jsr_pkg_name: &str) -> Result<String, ParseJsrSpecifierError> {
+    let Some(after_at) = jsr_pkg_name.strip_prefix('@') else {
+        return Err(ParseJsrSpecifierError::MissingScope);
+    };
+    let Some((scope, name)) = after_at.split_once('/') else {
+        return Err(ParseJsrSpecifierError::InvalidPackageName {
+            pkg_name: jsr_pkg_name.to_string(),
+        });
+    };
+    Ok(format!("@jsr/{scope}__{name}"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/lib.rs
@@ -117,7 +117,11 @@ pub fn parse_jsr_specifier(
         return Err(ParseJsrSpecifierError::MissingScope);
     }
 
-    let Some(alias) = alias else {
+    // Match upstream's JS-truthiness check on `alias`
+    // ([source](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts#L41-L43)):
+    // an empty string is falsy in JS and triggers `MissingPackageName`,
+    // not a fall-through into the version-only branch.
+    let Some(alias) = alias.filter(|alias| !alias.is_empty()) else {
         return Err(ParseJsrSpecifierError::MissingPackageName { specifier: rest.to_string() });
     };
 

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
@@ -1,0 +1,97 @@
+//! Ports of `resolving/jsr-specifier-parser/test/parse.test.ts`
+//! ([source](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/test/parse.test.ts)).
+
+use super::{JsrSpec, ParseJsrSpecifierError, parse_jsr_specifier};
+
+#[test]
+fn skips_on_non_jsr_specifiers() {
+    for input in [
+        "^1.0.0",
+        "1.0.0",
+        "latest",
+        "npm:foo",
+        "npm:@foo/bar",
+        "npm:@jsr/foo__bar",
+        "catalog:",
+        "workspace:*",
+    ] {
+        assert_eq!(parse_jsr_specifier(input, None), Ok(None), "input: {input}");
+    }
+}
+
+#[test]
+fn version_only_specifier_borrows_alias_for_name() {
+    for selector in ["^1.0.0", "1.0.0", "latest"] {
+        let input = format!("jsr:{selector}");
+        let spec = parse_jsr_specifier(&input, Some("@foo/bar"))
+            .unwrap_or_else(|err| panic!("parse failed for {input}: {err}"))
+            .unwrap_or_else(|| panic!("expected Some for {input}"));
+        assert_eq!(
+            spec,
+            JsrSpec {
+                version_selector: Some(selector.to_string()),
+                jsr_pkg_name: "@foo/bar".to_string(),
+                npm_pkg_name: "@jsr/foo__bar".to_string(),
+            },
+            "input: {input}",
+        );
+    }
+}
+
+#[test]
+fn scope_and_name_only() {
+    let spec = parse_jsr_specifier("jsr:@foo/bar", None).unwrap().unwrap();
+    assert_eq!(
+        spec,
+        JsrSpec {
+            jsr_pkg_name: "@foo/bar".to_string(),
+            npm_pkg_name: "@jsr/foo__bar".to_string(),
+            version_selector: None,
+        },
+    );
+}
+
+#[test]
+fn scope_name_and_selector() {
+    for selector in ["^1.0.0", "1.0.0", "latest"] {
+        let input = format!("jsr:@foo/bar@{selector}");
+        let spec = parse_jsr_specifier(&input, None).unwrap().unwrap();
+        assert_eq!(
+            spec,
+            JsrSpec {
+                jsr_pkg_name: "@foo/bar".to_string(),
+                npm_pkg_name: "@jsr/foo__bar".to_string(),
+                version_selector: Some(selector.to_string()),
+            },
+            "input: {input}",
+        );
+    }
+}
+
+#[test]
+fn name_without_scope_is_an_error() {
+    assert_eq!(
+        parse_jsr_specifier("jsr:foo@^1.0.0", None),
+        Err(ParseJsrSpecifierError::MissingScope),
+    );
+}
+
+#[test]
+fn scope_without_name_is_an_error() {
+    assert_eq!(
+        parse_jsr_specifier("jsr:@foo@^1.0.0", None),
+        Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@foo".to_string() }),
+    );
+    assert_eq!(
+        parse_jsr_specifier("jsr:@foo", None),
+        Err(ParseJsrSpecifierError::InvalidPackageName { pkg_name: "@foo".to_string() }),
+    );
+}
+
+#[test]
+fn version_only_specifier_without_alias_errors() {
+    assert_eq!(
+        parse_jsr_specifier("jsr:^1.0.0", None),
+        Err(ParseJsrSpecifierError::MissingPackageName { specifier: "^1.0.0".to_string() }),
+    );
+}

--- a/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
+++ b/pacquet/crates/resolving-jsr-specifier-parser/src/tests.rs
@@ -95,3 +95,15 @@ fn version_only_specifier_without_alias_errors() {
         Err(ParseJsrSpecifierError::MissingPackageName { specifier: "^1.0.0".to_string() }),
     );
 }
+
+#[test]
+fn version_only_specifier_with_empty_alias_errors() {
+    // Mirrors upstream's JS truthiness check `if (!alias)` — an empty
+    // string is falsy in JS so the version-only branch raises
+    // `MissingPackageName` instead of attempting to fold `""` into a
+    // package name.
+    assert_eq!(
+        parse_jsr_specifier("jsr:^1.0.0", Some("")),
+        Err(ParseJsrSpecifierError::MissingPackageName { specifier: "^1.0.0".to_string() }),
+    );
+}

--- a/pacquet/crates/resolving-npm-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-npm-resolver/Cargo.toml
@@ -11,11 +11,12 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-config                  = { workspace = true }
-pacquet-lockfile                = { workspace = true }
-pacquet-network                 = { workspace = true }
-pacquet-registry                = { workspace = true }
-pacquet-resolving-resolver-base = { workspace = true }
+pacquet-config                         = { workspace = true }
+pacquet-lockfile                       = { workspace = true }
+pacquet-network                        = { workspace = true }
+pacquet-registry                       = { workspace = true }
+pacquet-resolving-jsr-specifier-parser = { workspace = true }
+pacquet-resolving-resolver-base        = { workspace = true }
 
 chrono      = { workspace = true }
 dashmap     = { workspace = true }

--- a/pacquet/crates/resolving-npm-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lib.rs
@@ -47,7 +47,9 @@ pub use named_registry::{
     pick_registry_for_version,
 };
 pub use npm_resolver::NpmResolver;
-pub use parse_bare_specifier::parse_bare_specifier;
+pub use parse_bare_specifier::{
+    JsrRegistryPackageSpec, parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec,
+};
 pub use pick_package::{
     InMemoryPackageMetaCache, MirrorPersistError, PackageMetaCache, PickPackageContext,
     PickPackageError, PickPackageOptions, PickPackageResult, persist_meta_to_mirror, pick_package,

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -37,11 +37,29 @@ use pacquet_resolving_resolver_base::{
 
 use crate::{
     named_registry::pick_registry_for_package,
-    parse_bare_specifier::parse_bare_specifier,
+    parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
 };
+
+/// Default `@jsr` registry URL. Mirrors upstream's
+/// [`DEFAULT_REGISTRIES['@jsr']`](https://github.com/pnpm/pnpm/blob/1627943d2a/config/normalize-registries/src/index.ts#L5-L8):
+/// every `normalizeRegistries` call always populates `'@jsr'`, so the
+/// TS dispatcher reads `ctx.registries['@jsr']!` unconditionally. This
+/// constant is the fallback for pacquet callers that haven't routed
+/// the `@jsr` entry through their `registries` map yet.
+const DEFAULT_JSR_REGISTRY: &str = "https://npm.jsr.io/";
+
+/// Provenance tag for [`ResolveResult::resolved_via`] when the picker
+/// drove a JSR-prefixed specifier through the `@jsr` registry. Mirrors
+/// upstream's
+/// [`resolveJsr`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/index.ts#L629).
+const JSR_REGISTRY_RESOLVED_VIA: &str = "jsr-registry";
+
+/// Provenance tag for npm-registry resolutions. Mirrors upstream's
+/// [`resolveNpm`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/index.ts#L595-L601).
+const NPM_REGISTRY_RESOLVED_VIA: &str = "npm-registry";
 
 /// npm-registry resolver.
 ///
@@ -114,6 +132,17 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             return Ok(None);
         }
 
+        // `jsr:` resolves through the `@jsr` registry under the
+        // `@jsr/<scope>__<name>` folded name. Mirrors upstream's
+        // [`resolveJsr`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/index.ts#L613-L632),
+        // which is dispatched alongside `resolveNpm` from the same
+        // factory.
+        if let Some(bare) = wanted_dependency.bare_specifier.as_deref()
+            && bare.starts_with("jsr:")
+        {
+            return self.resolve_jsr_impl(wanted_dependency, opts, bare, default_tag).await;
+        }
+
         // Pick registry from `(alias, bare_specifier)` so an npm-alias
         // entry like `"foo": "npm:@scope/bar@^1"` routes through
         // `registries[@scope]` instead of the alias's own scope.
@@ -143,8 +172,80 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             },
         };
 
+        let picked = match self.pick_from_registry(&registry, &spec, opts).await? {
+            Some(picked) => picked,
+            None => return Ok(None),
+        };
+
+        let result = build_resolve_result(
+            &picked.meta,
+            &picked.version,
+            &spec,
+            wanted_dependency.alias.as_deref(),
+            NPM_REGISTRY_RESOLVED_VIA,
+            opts.published_by,
+            opts.published_by_exclude.as_ref(),
+        )?;
+
+        Ok(Some(result))
+    }
+
+    /// JSR counterpart to the npm path. Mirrors upstream's
+    /// [`resolveJsr`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/index.ts#L613-L632):
+    /// runs the JSR-specifier parser, picks against the `@jsr`
+    /// registry, then stamps `resolved_via = "jsr-registry"` and
+    /// `alias = spec.jsr_pkg_name` on the result so the install layer
+    /// records the dependency under its JSR-style name.
+    async fn resolve_jsr_impl(
+        &self,
+        wanted_dependency: &WantedDependency,
+        opts: &ResolveOptions,
+        bare_specifier: &str,
+        default_tag: &str,
+    ) -> Result<Option<ResolveResult>, ResolveError> {
+        let jsr_spec = parse_jsr_specifier_to_registry_package_spec(
+            bare_specifier,
+            wanted_dependency.alias.as_deref(),
+            default_tag,
+        )
+        .map_err(|err| Box::new(err) as ResolveError)?;
+        let Some(jsr_spec) = jsr_spec else {
+            return Ok(None);
+        };
+
+        let registry =
+            self.registries.get("@jsr").map(String::as_str).unwrap_or(DEFAULT_JSR_REGISTRY);
+
+        let picked = match self.pick_from_registry(registry, &jsr_spec.spec, opts).await? {
+            Some(picked) => picked,
+            None => return Ok(None),
+        };
+
+        let result = build_resolve_result(
+            &picked.meta,
+            &picked.version,
+            &jsr_spec.spec,
+            Some(jsr_spec.jsr_pkg_name.as_str()),
+            JSR_REGISTRY_RESOLVED_VIA,
+            opts.published_by,
+            opts.published_by_exclude.as_ref(),
+        )?;
+
+        Ok(Some(result))
+    }
+
+    /// Common picker invocation shared by [`Self::resolve_impl`] and
+    /// [`Self::resolve_jsr_impl`]. Returns `Ok(None)` when the picker
+    /// finds no matching version so each caller can fold that into
+    /// its own `Ok(None)` short-circuit.
+    async fn pick_from_registry(
+        &self,
+        registry: &str,
+        spec: &RegistryPackageSpec,
+        opts: &ResolveOptions,
+    ) -> Result<Option<PickedFromRegistry>, ResolveError> {
         let pick_opts = PickPackageOptions {
-            registry: &registry,
+            registry,
             preferred_version_selectors: opts.preferred_versions.get(&spec.name),
             published_by: opts.published_by,
             published_by_exclude: opts.published_by_exclude.as_ref(),
@@ -163,24 +264,15 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             ignore_missing_time_field: self.ignore_missing_time_field,
         };
 
-        let pick_result = pick_package(&ctx, &spec, &pick_opts)
+        let pick_result = pick_package(&ctx, spec, &pick_opts)
             .await
             .map_err(|err| Box::new(err) as ResolveError)?;
 
-        let Some(picked) = pick_result.picked_package else {
+        let Some(version) = pick_result.picked_package else {
             return Ok(None);
         };
 
-        let result = build_resolve_result(
-            &pick_result.meta,
-            &picked,
-            &spec,
-            wanted_dependency.alias.as_deref(),
-            opts.published_by,
-            opts.published_by_exclude.as_ref(),
-        )?;
-
-        Ok(Some(result))
+        Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }))
     }
 
     /// Latest-version companion. Mirrors upstream's
@@ -234,11 +326,18 @@ fn default_tag_spec(alias: &str, default_tag: &str) -> RegistryPackageSpec {
     }
 }
 
+/// Picker output threaded through to [`build_resolve_result`].
+struct PickedFromRegistry {
+    meta: Package,
+    version: PackageVersion,
+}
+
 fn build_resolve_result(
     meta: &Package,
     picked: &PackageVersion,
     spec: &RegistryPackageSpec,
     alias: Option<&str>,
+    resolved_via: &str,
     published_by: Option<DateTime<Utc>>,
     published_by_exclude: Option<&PackageVersionPolicy>,
 ) -> Result<ResolveResult, ResolveError> {
@@ -275,7 +374,7 @@ fn build_resolve_result(
         published_at,
         manifest,
         resolution,
-        resolved_via: "npm-registry".to_string(),
+        resolved_via: resolved_via.to_string(),
         normalized_bare_specifier: spec.normalized_bare_specifier.clone(),
         alias: alias.map(str::to_string),
         policy_violation,

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -294,5 +294,9 @@ async fn jsr_specifier_with_invalid_scope_propagates_parser_error() {
     };
     let err = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("JSR"), "unexpected error message: {msg}");
+    // Asserting the upstream-defined error message ties the test to
+    // the public `ERR_PNPM_MISSING_JSR_PACKAGE_SCOPE` contract; the
+    // resolver seam returns the parser error as a boxed `dyn Error`
+    // so we can't downcast to the variant directly.
+    assert_eq!(msg, "Package names from JSR must have a scope", "unexpected error message: {msg}");
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -45,9 +45,15 @@ const PACKAGE_BODY: &str = r#"{
 }"#;
 
 fn build_resolver(registry: &str) -> (NpmResolver<InMemoryPackageMetaCache>, TempDir) {
-    let cache_dir = TempDir::new().expect("tempdir");
     let mut registries = HashMap::new();
     registries.insert("default".to_string(), registry.to_string());
+    build_resolver_with_registries(registries)
+}
+
+fn build_resolver_with_registries(
+    registries: HashMap<String, String>,
+) -> (NpmResolver<InMemoryPackageMetaCache>, TempDir) {
+    let cache_dir = TempDir::new().expect("tempdir");
     let resolver = NpmResolver {
         registries,
         named_registries: HashMap::new(),
@@ -61,6 +67,39 @@ fn build_resolver(registry: &str) -> (NpmResolver<InMemoryPackageMetaCache>, Tem
     };
     (resolver, cache_dir)
 }
+
+/// Packument body for `@jsr/foo__bar` — the npm-shaped name JSR
+/// serves `@foo/bar` under
+/// ([source](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/jsr-specifier-parser/src/index.ts#L53-L64)).
+const JSR_PACKAGE_BODY: &str = r#"{
+    "name": "@jsr/foo__bar",
+    "dist-tags": { "latest": "1.1.0" },
+    "modified": "2025-01-15T12:00:00.000Z",
+    "time": {
+        "1.0.0": "2024-01-10T08:30:00.000Z",
+        "1.1.0": "2024-12-10T08:30:00.000Z"
+    },
+    "versions": {
+        "1.0.0": {
+            "name": "@jsr/foo__bar",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC==",
+                "shasum": "2222222222222222222222222222222222222222",
+                "tarball": "https://registry/foo__bar-1.0.0.tgz"
+            }
+        },
+        "1.1.0": {
+            "name": "@jsr/foo__bar",
+            "version": "1.1.0",
+            "dist": {
+                "integrity": "sha512-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD==",
+                "shasum": "3333333333333333333333333333333333333333",
+                "tarball": "https://registry/foo__bar-1.1.0.tgz"
+            }
+        }
+    }
+}"#;
 
 #[tokio::test]
 async fn range_specifier_picks_max_in_range() {
@@ -183,4 +222,77 @@ async fn resolve_latest_under_compatible_does_not_override_update_to_latest() {
     let info = resolver.resolve_latest(&query, &opts).await.unwrap().expect("latest info");
     let manifest = info.latest_manifest.expect("manifest present");
     assert_eq!(manifest["version"].as_str(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn jsr_specifier_routes_through_jsr_registry() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/@jsr%2Ffoo__bar")
+        .with_status(200)
+        .with_body(JSR_PACKAGE_BODY)
+        .create_async()
+        .await;
+    let jsr_registry = format!("{}/", server.url());
+    let mut registries = HashMap::new();
+    registries.insert("default".to_string(), "https://registry.npmjs.org/".to_string());
+    registries.insert("@jsr".to_string(), jsr_registry);
+    let (resolver, _tempdir) = build_resolver_with_registries(registries);
+
+    let wanted = WantedDependency {
+        // The user-facing dependency alias is the JSR-style scoped
+        // name. The resolver folds it into `@jsr/foo__bar` for the
+        // metadata fetch but restores `@foo/bar` on the result.
+        alias: Some("@foo/bar".to_string()),
+        bare_specifier: Some("jsr:@foo/bar@^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.name.to_string(), "@jsr/foo__bar");
+    assert_eq!(result.id.suffix.to_string(), "1.1.0");
+    assert_eq!(result.resolved_via, "jsr-registry");
+    assert_eq!(result.alias.as_deref(), Some("@foo/bar"));
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+    assert!(matches!(result.resolution, LockfileResolution::Tarball(_)));
+}
+
+#[tokio::test]
+async fn jsr_specifier_without_selector_uses_default_tag() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/@jsr%2Ffoo__bar")
+        .with_status(200)
+        .with_body(JSR_PACKAGE_BODY)
+        .create_async()
+        .await;
+    let jsr_registry = format!("{}/", server.url());
+    let mut registries = HashMap::new();
+    registries.insert("default".to_string(), "https://registry.npmjs.org/".to_string());
+    registries.insert("@jsr".to_string(), jsr_registry);
+    let (resolver, _tempdir) = build_resolver_with_registries(registries);
+
+    let wanted = WantedDependency {
+        alias: Some("@foo/bar".to_string()),
+        bare_specifier: Some("jsr:@foo/bar".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.id.suffix.to_string(), "1.1.0");
+    assert_eq!(result.resolved_via, "jsr-registry");
+}
+
+#[tokio::test]
+async fn jsr_specifier_with_invalid_scope_propagates_parser_error() {
+    let server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted = WantedDependency {
+        alias: Some("foo".to_string()),
+        bare_specifier: Some("jsr:foo@^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("JSR"), "unexpected error message: {msg}");
 }

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier.rs
@@ -1,13 +1,19 @@
 //! Pacquet port of pnpm's
-//! [`parseBareSpecifier`](https://github.com/pnpm/pnpm/blob/f657b5cb44/resolving/npm-resolver/src/parseBareSpecifier.ts).
+//! [`parseBareSpecifier`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/parseBareSpecifier.ts).
 //!
 //! Routes a raw bare specifier (`"^1.0.0"`, `"latest"`,
 //! `"npm:lodash@^4"`, `"https://registry.npmjs.org/foo/-/foo-1.0.0.tgz"`)
 //! to a [`RegistryPackageSpec`] the npm picker can consume, or `None`
 //! when no npm-shaped interpretation applies — that's the signal to the
 //! resolver chain to try the next resolver in the chain.
+//!
+//! The sibling [`parse_jsr_specifier_to_registry_package_spec`] routes
+//! `jsr:` specifiers the same way: parser-package output through the
+//! version-selector classifier, then folded into an npm-shaped spec
+//! the picker can drive against the `@jsr` registry.
 
 use node_semver::{Range, Version};
+use pacquet_resolving_jsr_specifier_parser::{ParseJsrSpecifierError, parse_jsr_specifier};
 use reqwest::Url;
 
 use crate::pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType};
@@ -90,6 +96,56 @@ pub fn parse_bare_specifier(
     }
 
     None
+}
+
+/// JSR-specifier counterpart of [`RegistryPackageSpec`]. Carries the
+/// JSR-style scoped name alongside the npm-shaped fields so the
+/// resolver can record the dependency under its JSR alias while
+/// driving the picker against the `@jsr` registry.
+///
+/// Mirrors upstream's `JsrRegistryPackageSpec`
+/// ([source](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/parseBareSpecifier.ts#L64-L66)).
+#[derive(Debug, Clone)]
+pub struct JsrRegistryPackageSpec {
+    pub spec: RegistryPackageSpec,
+    pub jsr_pkg_name: String,
+}
+
+/// Parse a `jsr:` specifier into a picker-ready
+/// [`JsrRegistryPackageSpec`].
+///
+/// Defers the `jsr:` syntax to the
+/// [`pacquet_resolving_jsr_specifier_parser`] crate, then runs the
+/// version-selector classifier on the parsed selector (falling back
+/// to `default_tag` when the specifier omits one). Returns
+/// `Ok(None)` for any non-`jsr:` specifier so the caller can fall
+/// through to the npm bare-specifier parser.
+///
+/// Mirrors upstream's
+/// [`parseJsrSpecifierToRegistryPackageSpec`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/parseBareSpecifier.ts#L68-L85).
+pub fn parse_jsr_specifier_to_registry_package_spec(
+    raw_specifier: &str,
+    alias: Option<&str>,
+    default_tag: &str,
+) -> Result<Option<JsrRegistryPackageSpec>, ParseJsrSpecifierError> {
+    let Some(spec) = parse_jsr_specifier(raw_specifier, alias)? else {
+        return Ok(None);
+    };
+
+    let selector_input = spec.version_selector.as_deref().unwrap_or(default_tag);
+    let Some(selector) = get_version_selector_type(selector_input) else {
+        return Ok(None);
+    };
+
+    Ok(Some(JsrRegistryPackageSpec {
+        spec: RegistryPackageSpec {
+            name: spec.npm_pkg_name,
+            fetch_spec: selector.normalized,
+            spec_type: selector.spec_type,
+            normalized_bare_specifier: None,
+        },
+        jsr_pkg_name: spec.jsr_pkg_name,
+    }))
 }
 
 /// Discriminate between an exact version, a semver range, and a

--- a/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/parse_bare_specifier/tests.rs
@@ -1,5 +1,8 @@
+use pacquet_resolving_jsr_specifier_parser::ParseJsrSpecifierError;
+
 use crate::{
-    parse_bare_specifier::parse_bare_specifier, pick_package_from_meta::RegistryPackageSpecType,
+    parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
+    pick_package_from_meta::RegistryPackageSpecType,
 };
 
 const DEFAULT_TAG: &str = "latest";
@@ -148,4 +151,59 @@ fn npm_prefix_without_alias_uses_bare_as_name_and_falls_back_to_default_tag() {
     assert_eq!(spec.name, "^1.0.0");
     assert_eq!(spec.fetch_spec, "latest");
     assert_eq!(spec.spec_type, RegistryPackageSpecType::Tag);
+}
+
+#[test]
+fn jsr_specifier_with_scope_name_and_range() {
+    let spec = parse_jsr_specifier_to_registry_package_spec("jsr:@foo/bar@^1.0.0", None, "latest")
+        .unwrap()
+        .unwrap();
+    assert_eq!(spec.spec.name, "@jsr/foo__bar");
+    assert_eq!(spec.spec.fetch_spec, "^1.0.0");
+    assert_eq!(spec.spec.spec_type, RegistryPackageSpecType::Range);
+    assert_eq!(spec.jsr_pkg_name, "@foo/bar");
+}
+
+#[test]
+fn jsr_specifier_without_selector_falls_back_to_default_tag() {
+    let spec = parse_jsr_specifier_to_registry_package_spec("jsr:@foo/bar", None, "latest")
+        .unwrap()
+        .unwrap();
+    assert_eq!(spec.spec.name, "@jsr/foo__bar");
+    assert_eq!(spec.spec.fetch_spec, "latest");
+    assert_eq!(spec.spec.spec_type, RegistryPackageSpecType::Tag);
+    assert_eq!(spec.jsr_pkg_name, "@foo/bar");
+}
+
+#[test]
+fn jsr_version_only_specifier_borrows_alias_for_jsr_pkg_name() {
+    let spec =
+        parse_jsr_specifier_to_registry_package_spec("jsr:^1.0.0", Some("@foo/bar"), "latest")
+            .unwrap()
+            .unwrap();
+    assert_eq!(spec.spec.name, "@jsr/foo__bar");
+    assert_eq!(spec.spec.fetch_spec, "^1.0.0");
+    assert_eq!(spec.spec.spec_type, RegistryPackageSpecType::Range);
+    assert_eq!(spec.jsr_pkg_name, "@foo/bar");
+}
+
+#[test]
+fn jsr_specifier_declines_for_non_jsr_input() {
+    assert!(
+        parse_jsr_specifier_to_registry_package_spec("npm:lodash@^4", None, "latest")
+            .unwrap()
+            .is_none(),
+    );
+    assert!(
+        parse_jsr_specifier_to_registry_package_spec("^1.0.0", Some("foo"), "latest")
+            .unwrap()
+            .is_none(),
+    );
+}
+
+#[test]
+fn jsr_specifier_with_unscoped_name_errors() {
+    let err = parse_jsr_specifier_to_registry_package_spec("jsr:foo@^1.0.0", None, "latest")
+        .expect_err("unscoped JSR name must error");
+    assert!(matches!(err, ParseJsrSpecifierError::MissingScope), "got {err:?}");
 }


### PR DESCRIPTION
## Summary

- Adds a new `pacquet-resolving-jsr-specifier-parser` crate that ports [`@pnpm/resolving.jsr-specifier-parser`](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/src/index.ts) (`parseJsrSpecifier` + `JsrSpec`), mirroring upstream's `ERR_PNPM_MISSING_JSR_PACKAGE_SCOPE` / `ERR_PNPM_INVALID_JSR_PACKAGE_NAME` / `ERR_PNPM_INVALID_JSR_SPECIFIER` codes 1:1.
- Adds `parse_jsr_specifier_to_registry_package_spec` alongside `parse_bare_specifier`, matching upstream's same-file shape in [`resolving/npm-resolver/src/parseBareSpecifier.ts`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/parseBareSpecifier.ts#L68-L85).
- Routes `jsr:` specifiers through a new `NpmResolver::resolve_jsr_impl` that picks against `registries['@jsr']` (with the `https://npm.jsr.io/` [`DEFAULT_REGISTRIES`](https://github.com/pnpm/pnpm/blob/1627943d2a/config/normalize-registries/src/index.ts#L5-L8) fallback) and stamps `resolved_via = "jsr-registry"` plus `alias = spec.jsr_pkg_name`, mirroring upstream's [`resolveJsr`](https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/npm-resolver/src/index.ts#L613-L632).
- Extracts a shared `pick_from_registry` helper so the npm and JSR paths share the picker invocation; `build_resolve_result` now takes a `resolved_via` parameter.

### Out of scope (matches existing pacquet gaps)

- `calcSpecifier` / `calcPrefixedSpecifier` — no pacquet caller yet, mirrors the npm path's behavior.
- JSR-specific `createResolveLatest` closure — pacquet's `resolve_latest_impl` is unified and just forwards through `resolve_impl`, so `jsr:` queries already route correctly without a separate JSR-only path.

## Test plan

- [x] `cargo nextest run` — 1599 tests pass workspace-wide; 7 new parser tests (1:1 port of [`resolving/jsr-specifier-parser/test/parse.test.ts`](https://github.com/pnpm/pnpm/blob/05dd45ea82/resolving/jsr-specifier-parser/test/parse.test.ts)), 5 new adapter tests in `parse_bare_specifier/tests.rs`, 3 new integration tests in `npm_resolver/tests.rs` covering the JSR happy path, default-tag fallback, and parser-error propagation through the resolver.
- [x] `just lint` clean (`--deny warnings`).
- [x] `just check` clean.
- [x] `just fmt` clean.
- [ ] `just ready` end-to-end (typos step trips on pre-existing CHANGELOG.md typos in the broader tree — none in the files touched here).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for JSR package specifiers: parsing, alias handling, and routing through the JSR registry with version-selector and default-tag behavior; clearer errors for invalid JSR inputs.
* **Tests**
  * Adds comprehensive unit and integration tests covering JSR specifier parsing, resolution flows, default-tag fallback, alias behavior, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->