### PR TITLE
feat(pacquet): port resolving/tarball-resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "pacquet-resolving-git-resolver",
  "pacquet-resolving-npm-resolver",
  "pacquet-resolving-resolver-base",
+ "pacquet-resolving-tarball-resolver",
  "pacquet-store-dir",
  "pacquet-tarball",
  "pacquet-testing-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-resolving-tarball-resolver"
+version = "0.0.1"
+dependencies = [
+ "mockito",
+ "pacquet-lockfile",
+ "pacquet-network",
+ "pacquet-resolving-resolver-base",
+ "pretty_assertions",
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "pacquet-store-dir"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pacquet-resolving-jsr-specifier-parser    = { path = "pacquet/crates/resolving-j
 pacquet-resolving-npm-resolver            = { path = "pacquet/crates/resolving-npm-resolver" }
 pacquet-resolving-parse-wanted-dependency = { path = "pacquet/crates/resolving-parse-wanted-dependency" }
 pacquet-resolving-resolver-base           = { path = "pacquet/crates/resolving-resolver-base" }
+pacquet-resolving-tarball-resolver        = { path = "pacquet/crates/resolving-tarball-resolver" }
 pacquet-workspace                         = { path = "pacquet/crates/workspace" }
 pacquet-workspace-state                   = { path = "pacquet/crates/workspace-state" }
 

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -35,6 +35,7 @@ pacquet-resolving-deps-resolver    = { workspace = true }
 pacquet-resolving-git-resolver     = { workspace = true }
 pacquet-resolving-npm-resolver     = { workspace = true }
 pacquet-resolving-resolver-base    = { workspace = true }
+pacquet-resolving-tarball-resolver = { workspace = true }
 pacquet-store-dir                  = { workspace = true }
 pacquet-tarball                    = { workspace = true }
 pacquet-workspace                  = { workspace = true }

--- a/pacquet/crates/package-manager/src/install_without_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_without_lockfile.rs
@@ -20,6 +20,7 @@ use pacquet_resolving_deps_resolver::{
 use pacquet_resolving_git_resolver::{GitResolver, RealGitProbe, RealGitRunner};
 use pacquet_resolving_npm_resolver::{InMemoryPackageMetaCache, NpmResolver};
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver};
+use pacquet_resolving_tarball_resolver::TarballResolver;
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
@@ -177,12 +178,16 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
             Arc::new(RealGitRunner::new()),
         );
+        let tarball_resolver = TarballResolver { http_client: Arc::clone(&http_client_arc) };
         // Order mirrors upstream's chain at
         // <https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/default-resolver/src/index.ts#L97-L173>:
-        // npm before git. Local/tarball/workspace/runtimes will slot
-        // in as those crates land.
-        let resolver: Box<dyn Resolver> =
-            Box::new(DefaultResolver::new(vec![Box::new(npm_resolver), Box::new(git_resolver)]));
+        // npm, then git, then tarball. Local/workspace/runtimes will
+        // slot in as those crates land.
+        let resolver: Box<dyn Resolver> = Box::new(DefaultResolver::new(vec![
+            Box::new(npm_resolver),
+            Box::new(git_resolver),
+            Box::new(tarball_resolver),
+        ]));
 
         // Compile `minimumReleaseAge` (and its exclude pattern set)
         // for the resolve pass. Mirrors the verifier wiring in

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -62,6 +62,7 @@ impl From<PkgNameVer> for PkgResolutionId {
     }
 }
 
+
 /// An entry from a project's manifest that the resolver chain will
 /// route to a concrete protocol. Mirrors pnpm's
 /// [`WantedDependency`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L304-L313).

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -62,7 +62,6 @@ impl From<PkgNameVer> for PkgResolutionId {
     }
 }
 
-
 /// An entry from a project's manifest that the resolver chain will
 /// route to a concrete protocol. Mirrors pnpm's
 /// [`WantedDependency`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/resolver-base/src/index.ts#L304-L313).

--- a/pacquet/crates/resolving-tarball-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-tarball-resolver/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name                  = "pacquet-resolving-tarball-resolver"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-lockfile                = { workspace = true }
+pacquet-network                 = { workspace = true }
+pacquet-resolving-resolver-base = { workspace = true }
+
+reqwest = { workspace = true }
+
+[dev-dependencies]
+mockito           = { workspace = true }
+pretty_assertions = { workspace = true }
+tokio             = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/pacquet/crates/resolving-tarball-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/lib.rs
@@ -1,0 +1,26 @@
+//! Pacquet port of pnpm's
+//! [`@pnpm/resolving.tarball-resolver`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/tarball-resolver/src/index.ts).
+//!
+//! Claims any wanted dependency whose bare specifier starts with
+//! `http://` or `https://` and resolves it to a tarball URL. Two
+//! pieces of upstream behavior the port preserves:
+//!
+//! - **URL normalization.** The bare specifier is round-tripped
+//!   through `url::Url` so a redundant default port
+//!   (`registry.npmjs.org:443`) is dropped before it reaches the
+//!   lockfile.
+//! - **Immutable-redirect follow.** A HEAD request runs against the
+//!   normalized URL; if the response carries `cache-control:
+//!   immutable`, the *post-redirect* URL is stored in the
+//!   resolution. Mutable hosts (e.g. `github.com/.../tarball/master`)
+//!   keep the original URL so subsequent installs revalidate the
+//!   moving target.
+//!
+//! The resolver doesn't compute or stamp `integrity` — that work
+//! happens later in the package-requester after the tarball is
+//! downloaded. See pnpm's
+//! [`packageRequester.ts`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/installing/package-requester/src/packageRequester.ts).
+
+mod tarball_resolver;
+
+pub use tarball_resolver::TarballResolver;

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -72,8 +72,8 @@ impl TarballResolver {
         let resolved_url = if response
             .headers()
             .get(reqwest::header::CACHE_CONTROL)
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|v| v.contains("immutable"))
+            .and_then(|header| header.to_str().ok())
+            .is_some_and(|header| header.contains("immutable"))
         {
             response.url().to_string()
         } else {

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -1,0 +1,125 @@
+//! Pacquet port of pnpm's
+//! [`resolveFromTarball`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/tarball-resolver/src/index.ts#L10-L38)
+//! plus the `resolveLatestFromTarball` companion at the same file's
+//! lines 43-47.
+
+use std::sync::Arc;
+
+use pacquet_lockfile::{LockfileResolution, TarballResolution};
+use pacquet_network::ThrottledClient;
+use pacquet_resolving_resolver_base::{
+    LatestInfo, LatestQuery, PkgResolutionId, ResolveError, ResolveFuture, ResolveLatestFuture,
+    ResolveOptions, ResolveResult, Resolver, WantedDependency,
+};
+
+/// Resolves `http://...` / `https://...` tarball URLs from a project's
+/// manifest. One instance per install — the throttled HTTP client is
+/// shared with the rest of the install pipeline so the HEAD
+/// pre-flight respects the same concurrency cap as metadata fetches
+/// and tarball downloads.
+pub struct TarballResolver {
+    pub http_client: Arc<ThrottledClient>,
+}
+
+impl Resolver for TarballResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted_dependency: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        Box::pin(self.resolve_impl(wanted_dependency))
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async move { Ok(resolve_latest(query)) })
+    }
+}
+
+impl TarballResolver {
+    async fn resolve_impl(
+        &self,
+        wanted_dependency: &WantedDependency,
+    ) -> Result<Option<ResolveResult>, ResolveError> {
+        let Some(bare) = wanted_dependency.bare_specifier.as_deref() else {
+            return Ok(None);
+        };
+        if !is_http_url(bare) {
+            return Ok(None);
+        }
+
+        // Round-trip through `Url::parse` to drop a redundant default
+        // port (`registry.npmjs.org:443` → `registry.npmjs.org`),
+        // matching upstream's `new URL(spec).toString()`.
+        let normalized_bare_specifier =
+            reqwest::Url::parse(bare).map_err(|err| Box::new(err) as ResolveError)?.to_string();
+
+        let client = self.http_client.acquire_for_url(&normalized_bare_specifier).await;
+        let response = client
+            .head(&normalized_bare_specifier)
+            .send()
+            .await
+            .map_err(|err| Box::new(err) as ResolveError)?;
+
+        // If the upstream marks the response immutable, store the
+        // *post-redirect* URL so subsequent installs hit the
+        // canonical location directly. Mutable responses (and
+        // missing headers) keep the normalized request URL so the
+        // moving target gets revalidated next run.
+        let resolved_url = if response
+            .headers()
+            .get(reqwest::header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("immutable"))
+        {
+            response.url().to_string()
+        } else {
+            normalized_bare_specifier.clone()
+        };
+
+        Ok(Some(ResolveResult {
+            id: PkgResolutionId::from(normalized_bare_specifier.clone()),
+            // Tarball URLs carry no `name@version` at resolve time —
+            // the canonical name/version come from the manifest after
+            // the tarball is fetched. Downstream consumers fall back
+            // to reading the manifest when `name_ver` is `None`.
+            name_ver: None,
+            latest: None,
+            published_at: None,
+            manifest: None,
+            resolution: LockfileResolution::Tarball(TarballResolution {
+                tarball: resolved_url,
+                integrity: None,
+                git_hosted: None,
+                path: None,
+            }),
+            resolved_via: "url".to_string(),
+            normalized_bare_specifier: Some(normalized_bare_specifier),
+            alias: None,
+            policy_violation: None,
+        }))
+    }
+}
+
+/// URL tarballs lock to the exact URL — no concept of "latest". When
+/// the wanted dep names an http(s) URL, claim it so the dispatcher
+/// stops; the caller still surfaces a ref-mismatch report if the
+/// lockfile points at a different URL than before. Mirrors upstream's
+/// [`resolveLatestFromTarball`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/tarball-resolver/src/index.ts#L43-L47).
+fn resolve_latest(query: &LatestQuery) -> Option<LatestInfo> {
+    let bare = query.wanted_dependency.bare_specifier.as_deref()?;
+    if !is_http_url(bare) {
+        return None;
+    }
+    Some(LatestInfo { latest_manifest: None })
+}
+
+fn is_http_url(bare: &str) -> bool {
+    bare.starts_with("http:") || bare.starts_with("https:")
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -98,7 +98,7 @@ impl TarballResolver {
             }),
             resolved_via: "url".to_string(),
             normalized_bare_specifier: Some(normalized_bare_specifier),
-            alias: None,
+            alias: wanted_dependency.alias.clone(),
             policy_violation: None,
         }))
     }

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver/tests.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver/tests.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use pacquet_lockfile::LockfileResolution;
+use pacquet_network::ThrottledClient;
+use pacquet_resolving_resolver_base::{LatestQuery, ResolveOptions, Resolver, WantedDependency};
+use pretty_assertions::assert_eq;
+
+use crate::TarballResolver;
+
+fn build_resolver() -> TarballResolver {
+    TarballResolver { http_client: Arc::new(ThrottledClient::default()) }
+}
+
+fn tarball_url(resolution: &LockfileResolution) -> &str {
+    match resolution {
+        LockfileResolution::Tarball(t) => t.tarball.as_str(),
+        other => panic!("expected Tarball resolution, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn non_http_bare_specifier_returns_none_so_the_chain_falls_through() {
+    let resolver = build_resolver();
+    let wanted = WantedDependency {
+        alias: Some("foo".to_string()),
+        bare_specifier: Some("git+ssh://git@github.com/foo/bar.git".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn missing_bare_specifier_returns_none() {
+    let resolver = build_resolver();
+    let wanted = WantedDependency { alias: Some("foo".to_string()), ..WantedDependency::default() };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn mutable_response_stores_normalized_request_url() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("HEAD", "/pkg-1.0.0.tgz").with_status(200).create_async().await;
+    let url = format!("{}/pkg-1.0.0.tgz", server.url());
+
+    let resolver = build_resolver();
+    let wanted = WantedDependency {
+        alias: Some("pkg".to_string()),
+        bare_specifier: Some(url.clone()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claim");
+
+    assert_eq!(result.id.to_string(), url);
+    assert_eq!(result.normalized_bare_specifier.as_deref(), Some(url.as_str()));
+    assert_eq!(tarball_url(&result.resolution), url);
+    assert_eq!(result.resolved_via, "url");
+}
+
+#[tokio::test]
+async fn immutable_response_without_redirect_keeps_the_requested_url() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("HEAD", "/pkg-1.0.0.tgz")
+        .with_status(200)
+        .with_header("cache-control", "public, max-age=31536000, immutable")
+        .create_async()
+        .await;
+    let url = format!("{}/pkg-1.0.0.tgz", server.url());
+
+    let resolver = build_resolver();
+    let wanted = WantedDependency {
+        alias: Some("pkg".to_string()),
+        bare_specifier: Some(url.clone()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claim");
+
+    assert_eq!(tarball_url(&result.resolution), url);
+}
+
+#[tokio::test]
+async fn immutable_response_after_redirect_records_the_final_url() {
+    let mut server = mockito::Server::new_async().await;
+    let final_path = "/canonical-1.0.0.tgz";
+    let final_url = format!("{}{}", server.url(), final_path);
+    let _redirect = server
+        .mock("HEAD", "/redirected-1.0.0.tgz")
+        .with_status(301)
+        .with_header("location", &final_url)
+        .create_async()
+        .await;
+    let _final = server
+        .mock("HEAD", final_path)
+        .with_status(200)
+        .with_header("cache-control", "immutable")
+        .create_async()
+        .await;
+    let requested_url = format!("{}/redirected-1.0.0.tgz", server.url());
+
+    let resolver = build_resolver();
+    let wanted = WantedDependency {
+        alias: Some("pkg".to_string()),
+        bare_specifier: Some(requested_url.clone()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claim");
+
+    // The id and normalized specifier echo the *requested* URL; the
+    // resolution tarball follows the redirect because the final
+    // response is marked immutable.
+    assert_eq!(result.id.to_string(), requested_url);
+    assert_eq!(result.normalized_bare_specifier.as_deref(), Some(requested_url.as_str()));
+    assert_eq!(tarball_url(&result.resolution), final_url);
+}
+
+#[tokio::test]
+async fn resolve_latest_claims_http_specifiers() {
+    let resolver = build_resolver();
+    let query = LatestQuery {
+        wanted_dependency: WantedDependency {
+            alias: Some("pkg".to_string()),
+            bare_specifier: Some("https://example.invalid/pkg.tgz".to_string()),
+            ..WantedDependency::default()
+        },
+        compatible: false,
+    };
+    let info = resolver
+        .resolve_latest(&query, &ResolveOptions::default())
+        .await
+        .unwrap()
+        .expect("latest claim");
+    assert!(info.latest_manifest.is_none());
+}
+
+#[tokio::test]
+async fn resolve_latest_returns_none_for_non_http_specifiers() {
+    let resolver = build_resolver();
+    let query = LatestQuery {
+        wanted_dependency: WantedDependency {
+            alias: Some("pkg".to_string()),
+            bare_specifier: Some("git+ssh://git@github.com/foo/bar.git".to_string()),
+            ..WantedDependency::default()
+        },
+        compatible: false,
+    };
+    let info = resolver.resolve_latest(&query, &ResolveOptions::default()).await.unwrap();
+    assert!(info.is_none());
+}


### PR DESCRIPTION
## Summary

- Adds `pacquet-resolving-tarball-resolver`, the Rust port of [`resolving/tarball-resolver/src/index.ts`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/tarball-resolver/src/index.ts). Claims any `WantedDependency` whose bare specifier starts with `http://` or `https://`, normalizes the URL through `reqwest::Url::parse`, runs a HEAD pre-flight that follows redirects, and stores the post-redirect URL in the resolution when the response carries `cache-control: immutable`. Mutable responses keep the normalized request URL.
- Leaves `name_ver: None` on the `ResolveResult` and `integrity: None` on the `TarballResolution`. Tarball URLs carry no `name@version` at resolve time — the canonical name/version come from the manifest after the tarball is fetched. Integrity is computed later by `package-requester`. Matches upstream.
- Wires `TarballResolver` into the `install_without_lockfile` resolver chain after the npm and git resolvers. Order mirrors upstream's [`createResolver`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/default-resolver/src/index.ts#L97-L173) chain: `npm → git → tarball → local/runtimes/...` (those slot in as their crates land).

This PR previously also introduced `PkgResolutionId` in `resolving-resolver-base`, but that landed first via the git-resolver port in #11779.

## Test plan

- [x] `just check` — workspace passes
- [x] `just test` — 434 tests pass across the affected crates (7 new in `pacquet-resolving-tarball-resolver`: http(s) claim vs decline, mutable vs immutable response, immutable-after-redirect follow, `resolve_latest` for http(s) vs non-http(s))
- [x] `just lint` — no clippy warnings
- [x] `just fmt` — clean
- [ ] CI

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/HTTPS tarball URL resolver to the dependency resolution chain, enabling native resolution of tarball dependencies alongside existing npm and git resolvers.
  * Features automatic URL normalization, intelligent cache directive handling, and automatic redirect resolution to improve dependency caching behavior and resolution accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->