### PR TITLE
feat(pacquet): peer-dependency resolution stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-deps-path"
+version = "0.0.1"
+dependencies = [
+ "pacquet-crypto-hash",
+]
+
+[[package]]
 name = "pacquet-diagnostics"
 version = "0.0.1"
 dependencies = [
@@ -2279,6 +2286,7 @@ dependencies = [
  "pacquet-cmd-shim",
  "pacquet-config",
  "pacquet-crypto-hash",
+ "pacquet-deps-path",
  "pacquet-directory-fetcher",
  "pacquet-executor",
  "pacquet-fs",
@@ -2428,6 +2436,7 @@ dependencies = [
  "futures-util",
  "miette 7.6.0",
  "node-semver",
+ "pacquet-deps-path",
  "pacquet-lockfile",
  "pacquet-package-manifest",
  "pacquet-resolving-resolver-base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ pacquet-config                            = { path = "pacquet/crates/config" }
 pacquet-executor                          = { path = "pacquet/crates/executor" }
 pacquet-directory-fetcher                 = { path = "pacquet/crates/directory-fetcher" }
 pacquet-git-fetcher                       = { path = "pacquet/crates/git-fetcher" }
+pacquet-deps-path                         = { path = "pacquet/crates/deps-path" }
 pacquet-diagnostics                       = { path = "pacquet/crates/diagnostics" }
 pacquet-graph-hasher                      = { path = "pacquet/crates/graph-hasher" }
 pacquet-store-dir                         = { path = "pacquet/crates/store-dir" }

--- a/pacquet/crates/deps-path/Cargo.toml
+++ b/pacquet/crates/deps-path/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name                  = "pacquet-deps-path"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+pacquet-crypto-hash = { workspace = true }
+
+[lints]
+workspace = true

--- a/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
+++ b/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn dep_path_strings_with_leading_slash_have_it_stripped() {
         let got = create_peer_dep_graph_hash(
-            &[PeerId::DepPath("/foo@1.0.0(bar@2.0.0)".to_string())],
+            &[PeerId::DepPath("/foo@1.0.0(bar@2.0.0)".into())],
             1000,
         );
         assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn dep_path_strings_without_leading_slash_pass_through() {
         let got = create_peer_dep_graph_hash(
-            &[PeerId::DepPath("foo@1.0.0(bar@2.0.0)".to_string())],
+            &[PeerId::DepPath("foo@1.0.0(bar@2.0.0)".into())],
             1000,
         );
         assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");

--- a/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
+++ b/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
@@ -64,19 +64,15 @@ mod tests {
 
     #[test]
     fn dep_path_strings_with_leading_slash_have_it_stripped() {
-        let got = create_peer_dep_graph_hash(
-            &[PeerId::DepPath("/foo@1.0.0(bar@2.0.0)".into())],
-            1000,
-        );
+        let got =
+            create_peer_dep_graph_hash(&[PeerId::DepPath("/foo@1.0.0(bar@2.0.0)".into())], 1000);
         assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");
     }
 
     #[test]
     fn dep_path_strings_without_leading_slash_pass_through() {
-        let got = create_peer_dep_graph_hash(
-            &[PeerId::DepPath("foo@1.0.0(bar@2.0.0)".into())],
-            1000,
-        );
+        let got =
+            create_peer_dep_graph_hash(&[PeerId::DepPath("foo@1.0.0(bar@2.0.0)".into())], 1000);
         assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");
     }
 

--- a/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
+++ b/pacquet/crates/deps-path/src/create_peer_dep_graph_hash.rs
@@ -1,0 +1,93 @@
+use pacquet_crypto_hash::create_short_hash;
+
+use crate::peer_id::PeerId;
+
+/// Build the peer-suffix that appended to a `pkgIdWithPatchHash` produces
+/// a full depPath. Mirrors pnpm's
+/// [`createPeerDepGraphHash`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L197-L213).
+///
+/// Rendering rules:
+///
+/// 1. Each [`PeerId`] becomes one segment via
+///    [`PeerId::as_segment`].
+/// 2. Segments are sorted lexicographically so the result is stable
+///    regardless of resolution order.
+/// 3. Segments are joined with `")("`, then wrapped with `(...)` to
+///    produce e.g. `(bar@2.0.0)(baz@3.0.0)`.
+/// 4. If the joined body exceeds `max_length`, the body is replaced with
+///    its short hash (still wrapped in `(...)`).
+///
+/// `max_length` is upstream's `peersSuffixMaxLength` (default 1000) —
+/// the cap is applied to the *body* (segments joined), not the wrapped
+/// form, matching the JS comparison `dirName.length > maxLength` before
+/// the leading `(` is prepended.
+pub fn create_peer_dep_graph_hash(peer_ids: &[PeerId], max_length: usize) -> String {
+    let mut segments: Vec<String> = peer_ids.iter().map(PeerId::as_segment).collect();
+    segments.sort();
+    let body = segments.join(")(");
+    if body.len() > max_length {
+        format!("({})", create_short_hash(&body))
+    } else {
+        format!("({body})")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PeerId, create_peer_dep_graph_hash};
+
+    fn pair(name: &str, version: &str) -> PeerId {
+        PeerId::Pair { name: name.to_string(), version: version.to_string() }
+    }
+
+    #[test]
+    fn empty_input_renders_a_single_pair_of_parens() {
+        let got = create_peer_dep_graph_hash(&[], 1000);
+        assert_eq!(got, "()");
+    }
+
+    #[test]
+    fn pairs_render_as_name_at_version_joined_with_paren_paren() {
+        let got = create_peer_dep_graph_hash(&[pair("bar", "2.0.0"), pair("baz", "3.0.0")], 1000);
+        assert_eq!(got, "(bar@2.0.0)(baz@3.0.0)");
+    }
+
+    #[test]
+    fn segments_are_sorted_for_stability() {
+        let unsorted =
+            create_peer_dep_graph_hash(&[pair("zzz", "1.0.0"), pair("aaa", "1.0.0")], 1000);
+        let sorted =
+            create_peer_dep_graph_hash(&[pair("aaa", "1.0.0"), pair("zzz", "1.0.0")], 1000);
+        assert_eq!(unsorted, sorted);
+        assert_eq!(unsorted, "(aaa@1.0.0)(zzz@1.0.0)");
+    }
+
+    #[test]
+    fn dep_path_strings_with_leading_slash_have_it_stripped() {
+        let got = create_peer_dep_graph_hash(
+            &[PeerId::DepPath("/foo@1.0.0(bar@2.0.0)".to_string())],
+            1000,
+        );
+        assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");
+    }
+
+    #[test]
+    fn dep_path_strings_without_leading_slash_pass_through() {
+        let got = create_peer_dep_graph_hash(
+            &[PeerId::DepPath("foo@1.0.0(bar@2.0.0)".to_string())],
+            1000,
+        );
+        assert_eq!(got, "(foo@1.0.0(bar@2.0.0))");
+    }
+
+    #[test]
+    fn long_body_is_replaced_with_short_hash() {
+        let segments: Vec<PeerId> = (0..50).map(|i| pair(&format!("pkg-{i}"), "1.0.0")).collect();
+        let got = create_peer_dep_graph_hash(&segments, 100);
+        assert!(got.starts_with('('));
+        assert!(got.ends_with(')'));
+        let body = &got[1..got.len() - 1];
+        assert_eq!(body.len(), 32);
+        assert!(body.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/pacquet/crates/deps-path/src/dep_path.rs
+++ b/pacquet/crates/deps-path/src/dep_path.rs
@@ -1,0 +1,40 @@
+/// Branded depPath string. Mirrors pnpm's
+/// [`DepPath`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/misc.ts).
+///
+/// Upstream's `DepPath` is a `string` brand — it's never validated at
+/// the boundary, just used to keep depPath strings from getting mixed
+/// up with arbitrary strings in the type system. Pacquet's port
+/// therefore exposes infallible `From<String>` / `From<&str>`
+/// constructors and skips a validating `TryFrom`.
+///
+/// The newtype lives in `pacquet-deps-path` (not in the higher-level
+/// resolver crate) so that lower-level helpers (peer-id construction,
+/// suffix scanning, filename escaping) can speak in depPath terms
+/// without forcing a back-dependency from `deps-path` to the resolver.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DepPath(String);
+
+impl DepPath {
+    /// Borrow the underlying depPath string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for DepPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for DepPath {
+    fn from(value: String) -> DepPath {
+        DepPath(value)
+    }
+}
+
+impl From<&str> for DepPath {
+    fn from(value: &str) -> DepPath {
+        DepPath(value.to_string())
+    }
+}

--- a/pacquet/crates/deps-path/src/dep_path_to_filename.rs
+++ b/pacquet/crates/deps-path/src/dep_path_to_filename.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn file_scheme_keeps_path_separators_via_plus_escape() {
-        assert_eq!(dep_path_to_filename("file:packages/foo", 120), "file+packages+foo",);
+        assert_eq!(dep_path_to_filename("file:packages/foo", 120), "file+packages+foo");
     }
 
     #[test]

--- a/pacquet/crates/deps-path/src/dep_path_to_filename.rs
+++ b/pacquet/crates/deps-path/src/dep_path_to_filename.rs
@@ -1,0 +1,114 @@
+use pacquet_crypto_hash::shorten_virtual_store_name;
+
+/// Turn a depPath into a filesystem-safe directory name. Mirrors pnpm's
+/// [`depPathToFilename`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L169-L180).
+///
+/// Pipeline:
+///
+/// 1. **Escape the scheme prefix.** A `file:` prefix has its `:`
+///    rewritten to `+`. The unescape branch upstream calls
+///    `depPathToFilenameUnescaped`.
+/// 2. **Strip a leading `/`** for the relative-depPath shape (legacy
+///    pre-v9 lockfiles), then re-join the `@version` half so the
+///    resulting name still has the `name@version` shape — upstream's
+///    `${first}@${rest}` rebuild is a no-op for already-flat depPaths
+///    and pacquet's port matches it directly.
+/// 3. **Replace path-unsafe characters** (`\\ / : * ? " < > | #`) with
+///    `+`.
+/// 4. **Flatten parens** — strip the trailing `)`, then rewrite `)(`,
+///    `(`, and `)` to `_`. After this step a depPath like
+///    `foo@1.0.0(bar@2.0.0)` becomes `foo@1.0.0_bar@2.0.0`.
+/// 5. **Cap length / case** via
+///    [`pacquet_crypto_hash::shorten_virtual_store_name`]. Same trailing
+///    branch the flat-name call sites already consume — single source of
+///    truth for the truncation arithmetic and `file+` carve-out.
+pub fn dep_path_to_filename(dep_path: &str, max_length_without_hash: usize) -> String {
+    let mut filename = dep_path_to_filename_unescaped(dep_path);
+    filename = filename.replace(['\\', '/', ':', '*', '?', '"', '<', '>', '|', '#'], "+");
+    if filename.contains('(') {
+        if filename.ends_with(')') {
+            filename.pop();
+        }
+        filename = filename.replace(")(", "_").replace(['(', ')'], "_");
+    }
+    shorten_virtual_store_name(filename, max_length_without_hash)
+}
+
+/// Pre-escape pass: rewrite `file:` to `file+`, strip a single leading
+/// `/`, and re-join `@version`. Mirrors pnpm's private
+/// [`depPathToFilenameUnescaped`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L182-L192).
+fn dep_path_to_filename_unescaped(dep_path: &str) -> String {
+    if dep_path.starts_with("file:") {
+        return dep_path.replacen(':', "+", 1);
+    }
+    let trimmed = dep_path.strip_prefix('/').unwrap_or(dep_path);
+    // Find the `@` separator after position 1 (upstream's
+    // `depPath.indexOf('@', 1)` — position 1 skips a scope marker
+    // `@scope/...`).
+    let after_first = &trimmed.as_bytes()[1..];
+    let Some(rel) = after_first.iter().position(|&b| b == b'@') else {
+        return trimmed.to_string();
+    };
+    let split = rel + 1;
+    let (name, rest) = trimmed.split_at(split);
+    // Upstream rebuilds as `${name}@${rest.slice(1)}` — i.e. it consumes
+    // the `@` and re-emits one. The transformation is a no-op for any
+    // input whose `name` slot does not already end in `@`; matches the
+    // upstream form byte-for-byte.
+    let rest = rest.strip_prefix('@').unwrap_or(rest);
+    format!("{name}@{rest}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dep_path_to_filename;
+
+    #[test]
+    fn plain_name_at_version_round_trips() {
+        assert_eq!(dep_path_to_filename("foo@1.0.0", 120), "foo@1.0.0");
+    }
+
+    #[test]
+    fn scoped_name_keeps_at_replaces_slash_with_plus() {
+        assert_eq!(dep_path_to_filename("@scope/foo@1.0.0", 120), "@scope+foo@1.0.0");
+    }
+
+    #[test]
+    fn peer_suffix_is_flattened_with_underscores() {
+        assert_eq!(
+            dep_path_to_filename("foo@1.0.0(bar@2.0.0)(baz@3.0.0)", 120),
+            "foo@1.0.0_bar@2.0.0_baz@3.0.0",
+        );
+    }
+
+    #[test]
+    fn file_scheme_keeps_path_separators_via_plus_escape() {
+        assert_eq!(dep_path_to_filename("file:packages/foo", 120), "file+packages+foo",);
+    }
+
+    #[test]
+    fn exceeding_length_replaces_with_hash_suffix() {
+        let very_long_input = format!("foo@1.0.0{}", "(bar@2.0.0)".repeat(40));
+        let got = dep_path_to_filename(&very_long_input, 60);
+        assert_eq!(got.len(), 60);
+        assert!(got.contains('_'));
+        // The hash suffix is `_` + 32 hex chars at the end.
+        let hash_part = &got[got.len() - 32..];
+        assert!(hash_part.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn uppercase_outside_file_scheme_forces_hash_suffix() {
+        let got = dep_path_to_filename("FOO@1.0.0", 120);
+        assert!(got.starts_with("FOO@1.0.0_"));
+        assert_eq!(got.len(), "FOO@1.0.0_".len() + 32);
+    }
+
+    #[test]
+    fn uppercase_in_file_scheme_is_preserved_untouched() {
+        // `file+...` is excluded from the case-mismatch branch — the
+        // filesystem casing of `file:` paths is part of the install
+        // address, so hashing it would split the cache.
+        assert_eq!(dep_path_to_filename("file:Pkg", 120), "file+Pkg");
+    }
+}

--- a/pacquet/crates/deps-path/src/dep_path_to_filename.rs
+++ b/pacquet/crates/deps-path/src/dep_path_to_filename.rs
@@ -42,9 +42,15 @@ fn dep_path_to_filename_unescaped(dep_path: &str) -> String {
         return dep_path.replacen(':', "+", 1);
     }
     let trimmed = dep_path.strip_prefix('/').unwrap_or(dep_path);
-    // Find the `@` separator after position 1 (upstream's
-    // `depPath.indexOf('@', 1)` — position 1 skips a scope marker
-    // `@scope/...`).
+    // Upstream's `depPath.indexOf('@', 1)` skips position 0 so a leading
+    // `@` on a scoped name (`@scope/foo`) doesn't get treated as the
+    // version separator. The `len() < 2` guard mirrors that
+    // out-of-range scan returning -1: nothing to rebuild, return the
+    // string as-is. Without it the `[1..]` slice panics on empty /
+    // single-byte input.
+    if trimmed.len() < 2 {
+        return trimmed.to_string();
+    }
     let after_first = &trimmed.as_bytes()[1..];
     let Some(rel) = after_first.iter().position(|&b| b == b'@') else {
         return trimmed.to_string();
@@ -110,5 +116,16 @@ mod tests {
         // filesystem casing of `file:` paths is part of the install
         // address, so hashing it would split the cache.
         assert_eq!(dep_path_to_filename("file:Pkg", 120), "file+Pkg");
+    }
+
+    #[test]
+    fn empty_input_does_not_panic() {
+        assert_eq!(dep_path_to_filename("", 120), "");
+    }
+
+    #[test]
+    fn single_byte_input_does_not_panic() {
+        assert_eq!(dep_path_to_filename("/", 120), "");
+        assert_eq!(dep_path_to_filename("a", 120), "a");
     }
 }

--- a/pacquet/crates/deps-path/src/lib.rs
+++ b/pacquet/crates/deps-path/src/lib.rs
@@ -13,11 +13,13 @@
 //! to locate the peer-suffix / `(patch_hash=…)` boundary.
 
 mod create_peer_dep_graph_hash;
+mod dep_path;
 mod dep_path_to_filename;
 mod peer_id;
 mod suffix_index;
 
 pub use create_peer_dep_graph_hash::create_peer_dep_graph_hash;
+pub use dep_path::DepPath;
 pub use dep_path_to_filename::dep_path_to_filename;
 pub use peer_id::PeerId;
 pub use suffix_index::{

--- a/pacquet/crates/deps-path/src/lib.rs
+++ b/pacquet/crates/deps-path/src/lib.rs
@@ -1,0 +1,23 @@
+//! Pacquet port of pnpm's
+//! [`@pnpm/deps.path`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts).
+//!
+//! String manipulation over depPaths (`name@version(peer1@v)(peer2@v)`).
+//! Pacquet already carries typed parsers for the simple shapes
+//! ([`pacquet_lockfile::PkgNameVerPeer`] et al.), but the peer-resolution
+//! stage needs a handful of pure string helpers that operate on the
+//! pre-typed surface: build a peer suffix from a list of peer IDs, turn
+//! a depPath into a filesystem-safe directory name (with the length cap
+//! that the typed `to_virtual_store_name` shortcut skips), and walk
+//! balanced parens to locate the peer-suffix / `(patch_hash=…)` boundary.
+
+mod create_peer_dep_graph_hash;
+mod dep_path_to_filename;
+mod peer_id;
+mod suffix_index;
+
+pub use create_peer_dep_graph_hash::create_peer_dep_graph_hash;
+pub use dep_path_to_filename::dep_path_to_filename;
+pub use peer_id::PeerId;
+pub use suffix_index::{
+    DepPathSuffixIndex, get_pkg_id_with_patch_hash, index_of_dep_path_suffix, remove_suffix,
+};

--- a/pacquet/crates/deps-path/src/lib.rs
+++ b/pacquet/crates/deps-path/src/lib.rs
@@ -3,12 +3,14 @@
 //!
 //! String manipulation over depPaths (`name@version(peer1@v)(peer2@v)`).
 //! Pacquet already carries typed parsers for the simple shapes
-//! ([`pacquet_lockfile::PkgNameVerPeer`] et al.), but the peer-resolution
-//! stage needs a handful of pure string helpers that operate on the
-//! pre-typed surface: build a peer suffix from a list of peer IDs, turn
-//! a depPath into a filesystem-safe directory name (with the length cap
-//! that the typed `to_virtual_store_name` shortcut skips), and walk
-//! balanced parens to locate the peer-suffix / `(patch_hash=…)` boundary.
+//! (`pacquet_lockfile::PkgNameVerPeer` et al. — referenced as plain
+//! text because this crate deliberately doesn't depend on
+//! `pacquet-lockfile`), but the peer-resolution stage needs a handful
+//! of pure string helpers that operate on the pre-typed surface: build
+//! a peer suffix from a list of peer IDs, turn a depPath into a
+//! filesystem-safe directory name (with the length cap that the typed
+//! `to_virtual_store_name` shortcut skips), and walk balanced parens
+//! to locate the peer-suffix / `(patch_hash=…)` boundary.
 
 mod create_peer_dep_graph_hash;
 mod dep_path_to_filename;

--- a/pacquet/crates/deps-path/src/peer_id.rs
+++ b/pacquet/crates/deps-path/src/peer_id.rs
@@ -1,7 +1,9 @@
+use crate::dep_path::DepPath;
+
 /// One peer entry fed to [`fn@crate::create_peer_dep_graph_hash`]. Mirrors
 /// pnpm's
 /// [`PeerId`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L195)
-/// union: either `{ name, version }` or a pre-rendered depPath string.
+/// union: either `{ name, version }` or a pre-rendered depPath.
 ///
 /// `Pair` is used when the peer resolver wants to identify a peer by its
 /// `name@version` (the common path, and what `dedupePeers` emits).
@@ -10,20 +12,20 @@
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PeerId {
     Pair { name: String, version: String },
-    DepPath(String),
+    DepPath(DepPath),
 }
 
 impl PeerId {
     /// String form used inside the joined peer suffix. Pair entries are
-    /// `name@version`; depPath strings are passed through with a single
+    /// `name@version`; depPaths are passed through with a single
     /// leading `/` stripped (mirrors upstream's `peerId[0] === '/'`
     /// fast path for the absolute / relative depPath distinction).
     pub fn as_segment(&self) -> String {
         match self {
             PeerId::Pair { name, version } => format!("{name}@{version}"),
-            PeerId::DepPath(s) => match s.strip_prefix('/') {
+            PeerId::DepPath(dep_path) => match dep_path.as_str().strip_prefix('/') {
                 Some(rest) => rest.to_string(),
-                None => s.clone(),
+                None => dep_path.as_str().to_string(),
             },
         }
     }

--- a/pacquet/crates/deps-path/src/peer_id.rs
+++ b/pacquet/crates/deps-path/src/peer_id.rs
@@ -1,4 +1,4 @@
-/// One peer entry fed to [`crate::create_peer_dep_graph_hash`]. Mirrors
+/// One peer entry fed to [`fn@crate::create_peer_dep_graph_hash`]. Mirrors
 /// pnpm's
 /// [`PeerId`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L195)
 /// union: either `{ name, version }` or a pre-rendered depPath string.

--- a/pacquet/crates/deps-path/src/peer_id.rs
+++ b/pacquet/crates/deps-path/src/peer_id.rs
@@ -1,0 +1,30 @@
+/// One peer entry fed to [`crate::create_peer_dep_graph_hash`]. Mirrors
+/// pnpm's
+/// [`PeerId`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L195)
+/// union: either `{ name, version }` or a pre-rendered depPath string.
+///
+/// `Pair` is used when the peer resolver wants to identify a peer by its
+/// `name@version` (the common path, and what `dedupePeers` emits).
+/// `DepPath` carries an already-built depPath — for transitive peers
+/// that have their own peers, the suffix is recursive.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PeerId {
+    Pair { name: String, version: String },
+    DepPath(String),
+}
+
+impl PeerId {
+    /// String form used inside the joined peer suffix. Pair entries are
+    /// `name@version`; depPath strings are passed through with a single
+    /// leading `/` stripped (mirrors upstream's `peerId[0] === '/'`
+    /// fast path for the absolute / relative depPath distinction).
+    pub fn as_segment(&self) -> String {
+        match self {
+            PeerId::Pair { name, version } => format!("{name}@{version}"),
+            PeerId::DepPath(s) => match s.strip_prefix('/') {
+                Some(rest) => rest.to_string(),
+                None => s.clone(),
+            },
+        }
+    }
+}

--- a/pacquet/crates/deps-path/src/suffix_index.rs
+++ b/pacquet/crates/deps-path/src/suffix_index.rs
@@ -30,8 +30,8 @@ pub fn index_of_dep_path_suffix(dep_path: &str) -> DepPathSuffixIndex {
     // starts at `length - 2` and stops at `>= 0`; we mirror it byte-for-
     // byte (depPath is ASCII outside of the package-name slot, and pnpm
     // doesn't permit non-ASCII there either).
-    let mut i = bytes.len().checked_sub(2);
-    while let Some(idx) = i {
+    let mut cursor = bytes.len().checked_sub(2);
+    while let Some(idx) = cursor {
         match bytes[idx] {
             b'(' => open -= 1,
             b')' => open += 1,
@@ -50,7 +50,7 @@ pub fn index_of_dep_path_suffix(dep_path: &str) -> DepPathSuffixIndex {
             }
             _ => {}
         }
-        i = idx.checked_sub(1);
+        cursor = idx.checked_sub(1);
     }
     absent
 }

--- a/pacquet/crates/deps-path/src/suffix_index.rs
+++ b/pacquet/crates/deps-path/src/suffix_index.rs
@@ -1,0 +1,135 @@
+/// Index pair returned by [`index_of_dep_path_suffix`]. Both fields are
+/// byte offsets into the original depPath, or `None` when the suffix is
+/// absent. Mirrors pnpm's
+/// [`indexOfDepPathSuffix`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L9-L31)
+/// `{ peersIndex, patchHashIndex }` return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DepPathSuffixIndex {
+    pub peers_index: Option<usize>,
+    pub patch_hash_index: Option<usize>,
+}
+
+/// Walk `dep_path` from right to left, balancing parentheses, and find
+/// the boundary of the peer-suffix and (optional) `(patch_hash=…)`
+/// segments. Mirrors pnpm's
+/// [`indexOfDepPathSuffix`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L9-L31).
+///
+/// Returns `(None, None)` when the path has no trailing `)` to anchor
+/// the scan from — the depPath has neither a peer suffix nor a patch
+/// hash, and the whole string is the `pkgIdWithPatchHash` (without a
+/// patch hash, that's just the bare `name@version` id).
+pub fn index_of_dep_path_suffix(dep_path: &str) -> DepPathSuffixIndex {
+    let bytes = dep_path.as_bytes();
+    let absent = DepPathSuffixIndex { peers_index: None, patch_hash_index: None };
+    if !dep_path.ends_with(')') {
+        return absent;
+    }
+
+    let mut open: i32 = 1;
+    // Scan from second-to-last byte down to byte 0. Upstream's loop
+    // starts at `length - 2` and stops at `>= 0`; we mirror it byte-for-
+    // byte (depPath is ASCII outside of the package-name slot, and pnpm
+    // doesn't permit non-ASCII there either).
+    let mut i = bytes.len().checked_sub(2);
+    while let Some(idx) = i {
+        match bytes[idx] {
+            b'(' => open -= 1,
+            b')' => open += 1,
+            _ if open == 0 => {
+                // Position `idx + 1` is the start of a balanced
+                // top-level segment. Upstream checks if that segment
+                // starts with `(patch_hash=` — if so, the patch-hash
+                // segment lives here and the peers segment (if any)
+                // starts at the next `(` after `idx + 2`.
+                let start = idx + 1;
+                if dep_path[start..].starts_with("(patch_hash=") {
+                    let peers_index = dep_path[start + 2..].find('(').map(|off| start + 2 + off);
+                    return DepPathSuffixIndex { peers_index, patch_hash_index: Some(start) };
+                }
+                return DepPathSuffixIndex { peers_index: Some(start), patch_hash_index: None };
+            }
+            _ => {}
+        }
+        i = idx.checked_sub(1);
+    }
+    absent
+}
+
+/// Strip the peer-suffix and `(patch_hash=…)` segments from `dep_path`,
+/// returning just the `pkgId` (no patch hash) prefix. Mirrors pnpm's
+/// [`removeSuffix`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L52-L61).
+pub fn remove_suffix(dep_path: &str) -> &str {
+    let DepPathSuffixIndex { peers_index, patch_hash_index } = index_of_dep_path_suffix(dep_path);
+    if let Some(idx) = patch_hash_index {
+        return &dep_path[..idx];
+    }
+    if let Some(idx) = peers_index {
+        return &dep_path[..idx];
+    }
+    dep_path
+}
+
+/// Strip just the peer-suffix from `dep_path`, keeping the
+/// `(patch_hash=…)` segment if present. Mirrors pnpm's
+/// [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/097983fbca/deps/path/src/index.ts#L63-L70).
+pub fn get_pkg_id_with_patch_hash(dep_path: &str) -> &str {
+    let DepPathSuffixIndex { peers_index, .. } = index_of_dep_path_suffix(dep_path);
+    match peers_index {
+        Some(idx) => &dep_path[..idx],
+        None => dep_path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DepPathSuffixIndex, get_pkg_id_with_patch_hash, index_of_dep_path_suffix, remove_suffix,
+    };
+
+    #[test]
+    fn no_trailing_paren_means_no_suffix() {
+        assert_eq!(
+            index_of_dep_path_suffix("foo@1.0.0"),
+            DepPathSuffixIndex { peers_index: None, patch_hash_index: None },
+        );
+    }
+
+    #[test]
+    fn locates_a_peer_suffix() {
+        let dep_path = "foo@1.0.0(bar@2.0.0)";
+        let got = index_of_dep_path_suffix(dep_path);
+        assert_eq!(got.peers_index, Some("foo@1.0.0".len()));
+        assert_eq!(got.patch_hash_index, None);
+        assert_eq!(remove_suffix(dep_path), "foo@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "foo@1.0.0");
+    }
+
+    #[test]
+    fn locates_a_patch_hash_suffix_without_peers() {
+        let dep_path = "foo@1.0.0(patch_hash=abc)";
+        let got = index_of_dep_path_suffix(dep_path);
+        assert_eq!(got.patch_hash_index, Some("foo@1.0.0".len()));
+        assert_eq!(got.peers_index, None);
+        assert_eq!(remove_suffix(dep_path), "foo@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "foo@1.0.0(patch_hash=abc)");
+    }
+
+    #[test]
+    fn locates_both_patch_hash_and_peers() {
+        let dep_path = "foo@1.0.0(patch_hash=abc)(bar@2.0.0)";
+        let got = index_of_dep_path_suffix(dep_path);
+        assert_eq!(got.patch_hash_index, Some("foo@1.0.0".len()));
+        assert_eq!(got.peers_index, Some("foo@1.0.0(patch_hash=abc)".len()));
+        assert_eq!(remove_suffix(dep_path), "foo@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "foo@1.0.0(patch_hash=abc)");
+    }
+
+    #[test]
+    fn handles_nested_parens_in_peer_segment() {
+        // A transitive peer can itself carry a peer suffix —
+        // `(bar@2.0.0(baz@3.0.0))` is one balanced segment.
+        let dep_path = "foo@1.0.0(bar@2.0.0(baz@3.0.0))";
+        let got = index_of_dep_path_suffix(dep_path);
+        assert_eq!(got.peers_index, Some("foo@1.0.0".len()));
+    }
+}

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -29,6 +29,7 @@ pacquet-patching                = { workspace = true }
 pacquet-real-hoist              = { workspace = true }
 pacquet-registry                = { workspace = true }
 pacquet-reporter                = { workspace = true }
+pacquet-deps-path               = { workspace = true }
 pacquet-resolving-deps-resolver = { workspace = true }
 pacquet-resolving-npm-resolver  = { workspace = true }
 pacquet-resolving-resolver-base = { workspace = true }

--- a/pacquet/crates/package-manager/src/install_without_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_without_lockfile.rs
@@ -9,13 +9,12 @@ use futures_util::future;
 use miette::Diagnostic;
 use pacquet_cmd_shim::{Host, LinkBinsError, link_bins};
 use pacquet_config::Config;
-use pacquet_crypto_hash::shorten_virtual_store_name;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_resolving_deps_resolver::{
-    DirectDep, ResolveDependencyTreeError, ResolveDependencyTreeOptions, ResolvedTree,
-    resolve_dependency_tree,
+    DepPath, DependenciesGraph, ResolveDependencyTreeError, ResolveDependencyTreeOptions,
+    ResolvePeersOptions, resolve_dependency_tree, resolve_peers,
 };
 use pacquet_resolving_npm_resolver::{InMemoryPackageMetaCache, NpmResolver};
 use pacquet_resolving_resolver_base::ResolveOptions;
@@ -248,11 +247,31 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
         // for any later package referencing the same blob.
         let verified_files_cache = SharedVerifiedFilesCache::default();
 
+        // Peer-resolution pass. Walks the per-occurrence tree built
+        // above, matches each visited package's `peerDependencies`
+        // against its parent chain, and emits a depPath-keyed graph
+        // the install pass consumes. Peer issues collected here are
+        // not fatal — they are reported (TODO: wire into the reporter
+        // once the issue renderer is ported) and the install proceeds
+        // with whichever candidate was reachable.
+        let peers_result =
+            resolve_peers(&tree, ResolvePeersOptions { peers_suffix_max_length: 1000 });
+        if !peers_result.peer_dependency_issues.missing.is_empty()
+            || !peers_result.peer_dependency_issues.bad.is_empty()
+        {
+            tracing::warn!(
+                target: "pacquet::install",
+                missing = peers_result.peer_dependency_issues.missing.len(),
+                bad = peers_result.peer_dependency_issues.bad.len(),
+                "Peer dependency issues detected (issue renderer not ported yet)",
+            );
+        }
+
         let install_ctx = InstallCtx {
             tarball_mem_cache,
             http_client,
             config,
-            tree: &tree,
+            graph: &peers_result.graph,
             store_index: store_index_ref,
             store_index_writer: store_index_writer_ref,
             verified_files_cache: &verified_files_cache,
@@ -261,9 +280,12 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             requester,
         };
 
-        tree.direct
+        peers_result
+            .direct_dependencies_by_alias
             .iter()
-            .map(|dep| install_subtree::<Reporter>(&install_ctx, dep, &config.modules_dir))
+            .map(|(alias, dep_path)| {
+                install_subtree::<Reporter>(&install_ctx, alias, dep_path, &config.modules_dir)
+            })
             .pipe(future::try_join_all)
             .await?;
 
@@ -344,12 +366,12 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
 
 /// Per-install state threaded into [`install_subtree`]. Holds every
 /// shared handle the per-package installer needs plus a borrowed view
-/// of the resolved tree the resolve pass produced.
+/// of the depPath-keyed graph the peer-resolution pass produced.
 struct InstallCtx<'a> {
     tarball_mem_cache: &'a MemCache,
     http_client: &'a ThrottledClient,
     config: &'static Config,
-    tree: &'a ResolvedTree,
+    graph: &'a DependenciesGraph,
     store_index: Option<&'a pacquet_store_dir::SharedReadonlyStoreIndex>,
     store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     verified_files_cache: &'a SharedVerifiedFilesCache,
@@ -358,30 +380,37 @@ struct InstallCtx<'a> {
     requester: &'a str,
 }
 
-/// Install the package referenced by `dep` plus its transitive
+/// Install the package referenced by `dep_path` plus its transitive
 /// children. Recurses into each child's `node_modules/.pacquet/<vsn>/
 /// node_modules/` so transitive symlinks land in their parent's slot.
+///
+/// `dep_path` is the depPath key produced by [`resolve_peers`] —
+/// `pkgIdWithPatchHash` for pure packages, `pkgId(peer1@v)(peer2@v)`
+/// when peer-suffix variation applies. The virtual-store slot name is
+/// derived via [`pacquet_deps_path::dep_path_to_filename`] so it stays
+/// stable across peer variants of the same package.
 #[async_recursion]
 async fn install_subtree<'ctx, Reporter>(
     ctx: &InstallCtx<'ctx>,
-    dep: &DirectDep,
+    alias: &str,
+    dep_path: &DepPath,
     node_modules_dir: &Path,
 ) -> Result<(), InstallWithoutLockfileError>
 where
     Reporter: self::Reporter,
 {
-    let package = ctx
-        .tree
-        .packages
-        .get(&dep.id)
-        .expect("resolve_dependency_tree must populate every referenced id");
+    let node =
+        ctx.graph.get(dep_path).expect("resolve_peers must populate every referenced depPath");
 
-    let virtual_store_name = shorten_virtual_store_name(
-        format!(
-            "{}@{}",
-            package.result.id.name.to_string().replace('/', "+"),
-            package.result.id.suffix,
-        ),
+    // Slot name = the depPath flattened to a filesystem-safe form.
+    // Mirrors upstream's `depPathToFilename(depPath, virtualStoreDirMaxLength)`.
+    // `dep_path_to_filename` already applies the same trailing length /
+    // case shortening that `pacquet_crypto_hash::shorten_virtual_store_name`
+    // exposes for the flat-name call sites; consume the configured cap
+    // from `ctx.config.virtual_store_dir_max_length` so users can override
+    // via `pnpm-workspace.yaml` / env.
+    let virtual_store_name = pacquet_deps_path::dep_path_to_filename(
+        dep_path.as_str(),
         ctx.config.virtual_store_dir_max_length as usize,
     );
 
@@ -423,8 +452,8 @@ where
         logged_methods: ctx.logged_methods,
         requester: ctx.requester,
         node_modules_dir,
-        alias: &dep.alias,
-        resolution: &package.result,
+        alias,
+        resolution: &node.resolve_result,
         first_visit,
     }
     .run::<Reporter>()
@@ -460,10 +489,13 @@ where
     let child_node_modules =
         ctx.config.virtual_store_dir.join(&virtual_store_name).join("node_modules");
 
-    package
-        .children
+    let child_node_modules_ref = &child_node_modules;
+    node.children
         .iter()
-        .map(|child| install_subtree::<Reporter>(ctx, child, &child_node_modules))
+        .map(|(child_alias, child_dep_path)| async move {
+            install_subtree::<Reporter>(ctx, child_alias, child_dep_path, child_node_modules_ref)
+                .await
+        })
         .pipe(future::try_join_all)
         .await?;
 

--- a/pacquet/crates/resolving-deps-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-deps-resolver/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-deps-path               = { workspace = true }
 pacquet-package-manifest        = { workspace = true }
 pacquet-resolving-resolver-base = { workspace = true }
 
@@ -18,6 +19,7 @@ async-recursion = { workspace = true }
 derive_more     = { workspace = true }
 futures-util    = { workspace = true }
 miette          = { workspace = true }
+node-semver     = { workspace = true }
 pipe-trait      = { workspace = true }
 serde_json      = { workspace = true }
 tokio           = { workspace = true, features = ["sync"] }

--- a/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -1,0 +1,114 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use pacquet_resolving_resolver_base::ResolveResult;
+
+use crate::resolved_tree::PeerDep;
+
+/// Branded depPath string. Mirrors pnpm's
+/// [`DepPath`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/misc.ts).
+/// Today this is a plain wrapper; future tightening could enforce the
+/// `name@version(peer)*` shape at the parser boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DepPath(pub String);
+
+impl DepPath {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for DepPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for DepPath {
+    fn from(s: String) -> DepPath {
+        DepPath(s)
+    }
+}
+
+/// Post-peer-resolution graph keyed by depPath. Mirrors upstream's
+/// [`GenericDependenciesGraphWithResolvedChildren`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L66-L68).
+///
+/// Two snapshots of the same package can coexist here with different
+/// keys (e.g. `react-dom@18.0.0(react@18.0.0)` and
+/// `react-dom@18.0.0(react@17.0.0)`) — exactly the case the peer-
+/// resolution stage exists to handle.
+pub type DependenciesGraph = HashMap<DepPath, DependenciesGraphNode>;
+
+/// One node in the [`DependenciesGraph`]. Mirrors upstream's
+/// [`GenericDependenciesGraphNodeWithResolvedChildren`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L50-L53).
+#[derive(Debug, Clone)]
+pub struct DependenciesGraphNode {
+    pub dep_path: DepPath,
+    /// The shared envelope, looked up via `ResolvedTree::packages`. Held
+    /// by reference value (cloned) so consumers don't need a separate
+    /// map lookup.
+    pub resolved_package_id: String,
+    pub resolve_result: ResolveResult,
+    /// `alias → DepPath` edges to children + resolved peers. Children
+    /// inherited from the per-occurrence tree node, peers added during
+    /// peer resolution.
+    pub children: BTreeMap<String, DepPath>,
+    pub peer_dependencies: BTreeMap<String, PeerDep>,
+    /// Names of peers resolved from outside this node's own peer-deps —
+    /// i.e. peers it inherited from its parents' context.
+    pub transitive_peer_dependencies: HashSet<String>,
+    /// Names of peers actually resolved (parents present in the chain).
+    pub resolved_peer_names: HashSet<String>,
+    pub depth: i32,
+    pub installable: bool,
+    /// `true` when this snapshot has zero unresolved + missing peers,
+    /// i.e. its depPath equals its `pkgIdWithPatchHash`. Mirrors
+    /// upstream's `isPure` flag.
+    pub is_pure: bool,
+}
+
+/// One issue collected during peer resolution. Mirrors upstream's per-
+/// project
+/// [`PeerDependencyIssues`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/peerDependencyIssues.ts)
+/// shape, simplified to the surface pacquet exposes today.
+#[derive(Debug, Default, Clone)]
+pub struct PeerDependencyIssues {
+    /// `peerName → entries` where each entry describes a parent that
+    /// requires the peer but a satisfying version isn't reachable.
+    pub missing: HashMap<String, Vec<MissingPeer>>,
+    /// `peerName → entries` where each entry describes a parent that
+    /// requires the peer and a candidate exists but doesn't satisfy
+    /// the range.
+    pub bad: HashMap<String, Vec<PeerDependencyIssue>>,
+}
+
+/// One missing-peer entry. Mirrors upstream's `missing[peerName]` item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingPeer {
+    pub wanted_range: String,
+    pub optional: bool,
+    /// Chain of `(name, version)` from the root importer down to the
+    /// parent that declared the peer requirement. Mirrors upstream's
+    /// `parents: ParentPackages`.
+    pub parents: Vec<ParentPackageRef>,
+}
+
+/// One bad-peer entry. Mirrors upstream's `bad[peerName]` item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerDependencyIssue {
+    pub wanted_range: String,
+    pub found_version: String,
+    pub optional: bool,
+    pub parents: Vec<ParentPackageRef>,
+    /// Chain that brought the bad candidate into scope — `parents`
+    /// describes who requires the peer; this describes where the bad
+    /// version was found.
+    pub resolved_from: Vec<ParentPackageRef>,
+}
+
+/// One `(name, version)` link in the chain returned with each peer
+/// issue. Mirrors upstream's `ParentPackages` element.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentPackageRef {
+    pub name: String,
+    pub version: String,
+}

--- a/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -8,7 +8,7 @@ use crate::resolved_tree::PeerDep;
 /// [`DepPath`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/misc.ts).
 /// Today this is a plain wrapper; future tightening could enforce the
 /// `name@version(peer)*` shape at the parser boundary.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DepPath(pub String);
 
 impl DepPath {
@@ -24,8 +24,8 @@ impl std::fmt::Display for DepPath {
 }
 
 impl From<String> for DepPath {
-    fn from(s: String) -> DepPath {
-        DepPath(s)
+    fn from(value: String) -> DepPath {
+        DepPath(value)
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -1,33 +1,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use pacquet_deps_path::DepPath;
 use pacquet_resolving_resolver_base::ResolveResult;
 
 use crate::resolved_tree::PeerDep;
-
-/// Branded depPath string. Mirrors pnpm's
-/// [`DepPath`](https://github.com/pnpm/pnpm/blob/097983fbca/packages/types/src/misc.ts).
-/// Today this is a plain wrapper; future tightening could enforce the
-/// `name@version(peer)*` shape at the parser boundary.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DepPath(pub String);
-
-impl DepPath {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for DepPath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl From<String> for DepPath {
-    fn from(value: String) -> DepPath {
-        DepPath(value)
-    }
-}
 
 /// Post-peer-resolution graph keyed by depPath. Mirrors upstream's
 /// [`GenericDependenciesGraphWithResolvedChildren`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L66-L68).

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! Two passes live here:
 //!
-//! 1. **Tree pass** ([`resolve_dependency_tree`]). Walks a project
+//! 1. **Tree pass** ([`fn@resolve_dependency_tree`]). Walks a project
 //!    manifest's direct dependencies through a
 //!    [`Resolver`](pacquet_resolving_resolver_base::Resolver) chain
 //!    and recurses on every resolved package's own manifest
@@ -21,7 +21,7 @@
 //!    tree pass. They are recorded on [`ResolvedPackage::peer_dependencies`]
 //!    and consumed by the peer pass.
 //!
-//! 2. **Peer pass** ([`resolve_peers`]). Walks the tree, matches each
+//! 2. **Peer pass** ([`fn@resolve_peers`]). Walks the tree, matches each
 //!    package's peer requirements against the parent chain, and
 //!    produces [`DependenciesGraph`] — keyed by `DepPath` (one entry per
 //!    `(pkgIdWithPatchHash, peer-suffix)` combination) and the entry
@@ -54,7 +54,9 @@ pub use resolve_dependency_tree::{
     ResolveDependencyTreeError, ResolveDependencyTreeOptions, resolve_dependency_tree,
 };
 pub use resolve_peers::{ResolvePeersOptions, resolve_peers};
-pub use resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree};
+pub use resolved_tree::{
+    DependenciesTree, DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree,
+};
 
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -46,9 +46,10 @@ mod resolve_peers;
 mod resolved_tree;
 
 pub use dependencies_graph::{
-    DepPath, DependenciesGraph, DependenciesGraphNode, MissingPeer, PeerDependencyIssue,
+    DependenciesGraph, DependenciesGraphNode, MissingPeer, PeerDependencyIssue,
     PeerDependencyIssues,
 };
+pub use pacquet_deps_path::DepPath;
 pub use node_id::NodeId;
 pub use resolve_dependency_tree::{
     ResolveDependencyTreeError, ResolveDependencyTreeOptions, resolve_dependency_tree,

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -1,35 +1,60 @@
-//! Minimum-slice port of pnpm's
-//! [`resolveDependencyTree`](https://github.com/pnpm/pnpm/blob/f657b5cb44/installing/deps-resolver/src/resolveDependencyTree.ts).
+//! Port of pnpm's
+//! [`@pnpm/installing.deps-resolver`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/index.ts).
 //!
-//! Walks a project manifest's direct dependencies through a
-//! [`Resolver`](pacquet_resolving_resolver_base::Resolver) chain,
-//! then recurses on every resolved package's own manifest
-//! dependencies, producing a flat package map and a tree of parent-
-//! child edges. Pacquet's install layer uses this as the resolve
-//! pass before the tarball-fetch + install pass.
+//! Two passes live here:
+//!
+//! 1. **Tree pass** ([`resolve_dependency_tree`]). Walks a project
+//!    manifest's direct dependencies through a
+//!    [`Resolver`](pacquet_resolving_resolver_base::Resolver) chain
+//!    and recurses on every resolved package's own manifest
+//!    dependencies. Produces:
+//!
+//!    - [`ResolvedTree::packages`] — flat dedup map keyed by
+//!      `pkgIdWithPatchHash`, mirroring upstream's `resolvedPkgsById`.
+//!    - [`ResolvedTree::dependencies_tree`] — per-occurrence tree
+//!      keyed by [`NodeId`], mirroring upstream's `dependenciesTree`.
+//!    - [`ResolvedTree::all_peer_dep_names`] — names every visited
+//!      package declares as a peer, used by the peer pass as the
+//!      `parentPkgs` filter.
+//!
+//!    Peer dependencies are **not** walked as regular edges during the
+//!    tree pass. They are recorded on [`ResolvedPackage::peer_dependencies`]
+//!    and consumed by the peer pass.
+//!
+//! 2. **Peer pass** ([`resolve_peers`]). Walks the tree, matches each
+//!    package's peer requirements against the parent chain, and
+//!    produces [`DependenciesGraph`] — keyed by `DepPath` (one entry per
+//!    `(pkgIdWithPatchHash, peer-suffix)` combination) and the entry
+//!    point for the install layer.
 //!
 //! This is intentionally a thin slice of upstream:
 //!
 //! - **Single importer.** Pacquet's install doesn't expose workspaces
 //!   to the resolver yet; the entry point takes one manifest at a
-//!   time. The flat-map shape ports cleanly when multi-importer
-//!   lands.
-//! - **No peers resolution.** Upstream's
-//!   [`resolveRootDependencies`](https://github.com/pnpm/pnpm/blob/f657b5cb44/installing/deps-resolver/src/resolveDependencies.ts#L327)
-//!   walks peer dependencies as a postponed phase; this port relies
-//!   on `auto_install_peers` to fold peer-deps into the regular
-//!   dependency walk.
+//!   time.
+//! - **No `autoInstallPeers` hoisting.** Upstream's
+//!   [`hoistPeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/hoistPeers.ts)
+//!   pre-pass that folds peer deps into the importer's direct deps is
+//!   a separate concern, scheduled after this slice lands.
 //! - **No catalog / hook / lockfile-pinned-version bias.** The
-//!   resolver is fed each child's manifest range verbatim. Lockfile-
-//!   driven `preferred_versions` is a follow-up.
+//!   resolver is fed each child's manifest range verbatim.
 
+mod dependencies_graph;
+mod node_id;
 mod resolve_dependency_tree;
+mod resolve_peers;
 mod resolved_tree;
 
+pub use dependencies_graph::{
+    DepPath, DependenciesGraph, DependenciesGraphNode, MissingPeer, PeerDependencyIssue,
+    PeerDependencyIssues,
+};
+pub use node_id::NodeId;
 pub use resolve_dependency_tree::{
     ResolveDependencyTreeError, ResolveDependencyTreeOptions, resolve_dependency_tree,
 };
-pub use resolved_tree::{DirectDep, ResolvedPackage, ResolvedTree};
+pub use resolve_peers::{ResolvePeersOptions, resolve_peers};
+pub use resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree};
 
 #[cfg(test)]
 mod tests;

--- a/pacquet/crates/resolving-deps-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/lib.rs
@@ -49,8 +49,8 @@ pub use dependencies_graph::{
     DependenciesGraph, DependenciesGraphNode, MissingPeer, PeerDependencyIssue,
     PeerDependencyIssues,
 };
-pub use pacquet_deps_path::DepPath;
 pub use node_id::NodeId;
+pub use pacquet_deps_path::DepPath;
 pub use resolve_dependency_tree::{
     ResolveDependencyTreeError, ResolveDependencyTreeOptions, resolve_dependency_tree,
 };

--- a/pacquet/crates/resolving-deps-resolver/src/node_id.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/node_id.rs
@@ -1,0 +1,29 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Per-occurrence identifier for a node in the [`DependenciesTree`].
+/// Mirrors pnpm's [`NodeId`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/nextNodeId.ts).
+///
+/// Pnpm's `NodeId` is a branded `string | number` union: numbers come
+/// from a monotonic counter; strings are `link:<rel-path>` for linked
+/// local workspace packages. Pacquet stays in the numeric arm —
+/// workspace-link resolution hasn't been ported yet, and the peer
+/// resolver only needs equality / hashing of opaque ids.
+///
+/// [`DependenciesTree`]: super::DependenciesTree
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeId(u64);
+
+impl NodeId {
+    /// Allocate a fresh `NodeId`. Mirrors pnpm's
+    /// [`nextNodeId`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/nextNodeId.ts).
+    pub fn next() -> NodeId {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        NodeId(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/pacquet/crates/resolving-deps-resolver/src/node_id.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/node_id.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// resolver only needs equality / hashing of opaque ids.
 ///
 /// [`DependenciesTree`]: super::resolved_tree::DependenciesTree
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NodeId(u64);
 
 impl NodeId {

--- a/pacquet/crates/resolving-deps-resolver/src/node_id.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/node_id.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// workspace-link resolution hasn't been ported yet, and the peer
 /// resolver only needs equality / hashing of opaque ids.
 ///
-/// [`DependenciesTree`]: super::DependenciesTree
+/// [`DependenciesTree`]: super::resolved_tree::DependenciesTree
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct NodeId(u64);
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -15,7 +15,7 @@ use crate::{
     resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree},
 };
 
-/// Options threaded into [`resolve_dependency_tree`].
+/// Options threaded into [`fn@resolve_dependency_tree`].
 ///
 /// Mirrors upstream's per-importer options; pacquet's slice is single-
 /// importer so the bag is smaller. `base_opts` is the [`ResolveOptions`]
@@ -29,7 +29,7 @@ pub struct ResolveDependencyTreeOptions {
     /// upstream's
     /// [`hoistPeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/hoistPeers.ts)
     /// pre-pass until that full algorithm lands. Independent of
-    /// peer-suffix construction in [`crate::resolve_peers`] — that
+    /// peer-suffix construction in [`fn@crate::resolve_peers`] — that
     /// stage runs regardless and produces the same depPath shape
     /// whether peers were installed automatically or supplied by the
     /// user.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
 use async_recursion::async_recursion;
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -8,17 +10,29 @@ use pipe_trait::Pipe;
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use crate::resolved_tree::{DirectDep, ResolvedPackage, ResolvedTree};
+use crate::{
+    node_id::NodeId,
+    resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree},
+};
 
 /// Options threaded into [`resolve_dependency_tree`].
 ///
 /// Mirrors upstream's per-importer options; pacquet's slice is single-
 /// importer so the bag is smaller. `base_opts` is the [`ResolveOptions`]
 /// every per-package `resolve()` call sees; the tree walker doesn't
-/// mutate it. `auto_install_peers` controls whether a parent's
-/// `peerDependencies` are folded into its child set during the walk.
+/// mutate it.
 #[derive(Debug)]
 pub struct ResolveDependencyTreeOptions {
+    /// When `true`, fold each visited package's `peerDependencies`
+    /// into the regular dependency walk so peer packages get
+    /// installed alongside their hosts. Pacquet's stand-in for
+    /// upstream's
+    /// [`hoistPeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/hoistPeers.ts)
+    /// pre-pass until that full algorithm lands. Independent of
+    /// peer-suffix construction in [`crate::resolve_peers`] — that
+    /// stage runs regardless and produces the same depPath shape
+    /// whether peers were installed automatically or supplied by the
+    /// user.
     pub auto_install_peers: bool,
     pub base_opts: ResolveOptions,
 }
@@ -32,11 +46,7 @@ pub enum ResolveDependencyTreeError {
     Resolve(#[error(not(source))] String),
 
     /// No resolver in the chain claimed the spec. Mirrors pnpm's
-    /// [`SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER`](https://github.com/pnpm/pnpm/blob/3687b0e180/resolving/default-resolver/src/index.ts#L148-L156)
-    /// — the chain returning `None` is a contract violation outside
-    /// `DefaultResolver`'s `??` fall-through, so the tree walker
-    /// surfaces it instead of silently dropping the edge (which
-    /// would leave installs missing transitive deps).
+    /// [`SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER`](https://github.com/pnpm/pnpm/blob/097983fbca/resolving/default-resolver/src/index.ts#L148-L156).
     #[display("\"{specifier}\" isn't supported by any available resolver.")]
     #[diagnostic(code(SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER))]
     SpecNotSupported {
@@ -47,19 +57,21 @@ pub enum ResolveDependencyTreeError {
 
 /// Walk `manifest` plus the entries in `dependency_groups`, dispatch
 /// each direct dep through `resolver`, recurse on each picked
-/// package's own `dependencies` / `peerDependencies`, and return a
-/// flat tree keyed by `name@version`.
+/// package's own `dependencies`, and return a [`ResolvedTree`] that
+/// carries both the flat dedup map (`packages`) and the per-occurrence
+/// tree (`dependencies_tree`).
 ///
 /// Mirrors upstream's
-/// [`resolveDependencyTree`](https://github.com/pnpm/pnpm/blob/f657b5cb44/installing/deps-resolver/src/resolveDependencyTree.ts#L172-L357)
+/// [`resolveDependencyTree`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencyTree.ts#L172-L357)
 /// for the npm-shaped slice pacquet currently exposes.
 ///
 /// Resolves siblings in parallel via `try_join_all` at every level.
 /// The per-package dedupe gate is a shared `HashMap` behind a
-/// [`tokio::sync::Mutex`]: a sibling that's already resolving an id
-/// `X` makes a later visitor see the placeholder, attach the
-/// outstanding `DirectDep { id: X }`, and skip the recursion the
-/// in-flight task is already running.
+/// [`tokio::sync::Mutex`]: a sibling already resolving an id `X` makes
+/// later visitors skip the recursion the in-flight task is running and
+/// reuse the eventually-populated `ResolvedPackage`. Per-occurrence
+/// tree nodes are still allocated for each visit — only the
+/// `ResolvedPackage` envelope is shared.
 pub async fn resolve_dependency_tree<DependencyGroupList, Chain>(
     resolver: &Chain,
     manifest: &PackageManifest,
@@ -73,7 +85,9 @@ where
     let ctx = Ctx {
         auto_install_peers: opts.auto_install_peers,
         base_opts: opts.base_opts,
-        packages: Mutex::new(std::collections::HashMap::new()),
+        packages: Mutex::new(HashMap::new()),
+        dependencies_tree: Mutex::new(HashMap::new()),
+        all_peer_dep_names: Mutex::new(HashSet::new()),
         policy_violations: Mutex::new(Vec::new()),
     };
 
@@ -82,11 +96,7 @@ where
         .map(|(name, range)| (name.to_string(), range.to_string()))
         .collect();
 
-    // Capture `&ctx` and `resolver` by reference into each async
-    // block. The borrow lives for the duration of the `try_join_all`
-    // await below, so we don't need an `Arc` and the post-await
-    // `into_inner()` doesn't have to dance around a refcount.
-    let direct = direct_specs
+    let direct_results = direct_specs
         .into_iter()
         .map(|(name, range)| async {
             let wanted = WantedDependency {
@@ -94,14 +104,20 @@ where
                 bare_specifier: Some(range),
                 ..WantedDependency::default()
             };
-            resolve_node(&ctx, resolver, wanted).await
+            resolve_node(&ctx, resolver, wanted, &[], 0).await
         })
         .pipe(future::try_join_all)
         .await?;
+    // Top-level cycles can't occur (the importer can't appear in its
+    // own ancestor chain), but `resolve_node` may still return `None`
+    // for any spec the cycle break gated out. Filter at the join.
+    let direct: Vec<DirectDep> = direct_results.into_iter().flatten().collect();
 
     Ok(ResolvedTree {
         direct,
         packages: ctx.packages.into_inner(),
+        dependencies_tree: ctx.dependencies_tree.into_inner(),
+        all_peer_dep_names: ctx.all_peer_dep_names.into_inner(),
         policy_violations: ctx.policy_violations.into_inner(),
     })
 }
@@ -109,16 +125,34 @@ where
 struct Ctx {
     auto_install_peers: bool,
     base_opts: ResolveOptions,
-    packages: Mutex<std::collections::HashMap<String, ResolvedPackage>>,
+    packages: Mutex<HashMap<String, ResolvedPackage>>,
+    dependencies_tree: Mutex<HashMap<NodeId, DependenciesTreeNode>>,
+    all_peer_dep_names: Mutex<HashSet<String>>,
     policy_violations: Mutex<Vec<pacquet_resolving_resolver_base::ResolutionPolicyViolation>>,
 }
 
+/// Resolve one `(alias, range)` edge, register the resolved package in
+/// the dedup map if absent, allocate a fresh [`NodeId`] for this
+/// occurrence, and recurse into children.
+///
+/// `ancestor_ids` is the chain of `pkgIdWithPatchHash` values from the
+/// root importer down to the current node's parent. Mirrors upstream's
+/// `parentIds` / `parentDepPathsChain`. When the resolved id appears
+/// in the chain, this call is a cycle re-entry: pacquet drops the
+/// edge entirely (returns `Ok(None)`) so the parent's `children` map
+/// omits the cycled child — same shape as upstream's
+/// [`parentIdsContainSequence`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencyTree.ts#L378)
+/// gate in `buildTree`. Without this, two nodes for the same id race
+/// each other into `graph.insert`, and an empty-children entry for the
+/// cycled occurrence can overwrite the real one.
 #[async_recursion]
 async fn resolve_node<Chain>(
     ctx: &Ctx,
     resolver: &Chain,
     wanted: WantedDependency,
-) -> Result<DirectDep, ResolveDependencyTreeError>
+    ancestor_ids: &[String],
+    depth: i32,
+) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
 {
@@ -126,11 +160,6 @@ where
         .resolve(&wanted, &ctx.base_opts)
         .await
         .map_err(|err: ResolveError| ResolveDependencyTreeError::Resolve(err.to_string()))?;
-    // The resolver returning `None` means the chain declined the
-    // spec. Outside `DefaultResolver`'s internal `??` fall-through,
-    // that is a contract violation — surface as
-    // `SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` instead of dropping the
-    // edge, which would leave installs missing dependencies.
     let Some(result) = result else {
         return Err(ResolveDependencyTreeError::SpecNotSupported {
             specifier: render_specifier(&wanted),
@@ -142,41 +171,75 @@ where
     }
 
     let id = result.id.to_string();
+
+    // Cycle break — see the doc comment above.
+    if ancestor_ids.iter().any(|prev| prev == &id) {
+        return Ok(None);
+    }
+
     let alias =
         result.alias.clone().or(wanted.alias.clone()).unwrap_or_else(|| result.id.name.to_string());
 
-    // Insert a placeholder under the global lock so concurrent
-    // resolves for the same id collapse to one walker. The first to
-    // get past the gate populates the children; later visitors return
-    // a `DirectDep` referencing the (eventually fully populated) id.
+    // Build (or look up) the ResolvedPackage envelope. The first
+    // visitor populates it; later visitors collapse onto it.
     {
         let mut packages = ctx.packages.lock().await;
-        if packages.contains_key(&id) {
-            return Ok(DirectDep { alias, id });
+        if !packages.contains_key(&id) {
+            let peer_dependencies = extract_peer_dependencies(&result);
+            // Collect peer names for the peer-resolution stage's
+            // `parentPkgs` filter (only peers count as parents).
+            {
+                let mut all_peers = ctx.all_peer_dep_names.lock().await;
+                for name in peer_dependencies.keys() {
+                    all_peers.insert(name.clone());
+                }
+            }
+            packages.insert(
+                id.clone(),
+                ResolvedPackage { id: id.clone(), result: result.clone(), peer_dependencies },
+            );
         }
-        packages.insert(
-            id.clone(),
-            ResolvedPackage { id: id.clone(), result: result.clone(), children: Vec::new() },
-        );
     }
 
+    // Allocate a fresh NodeId for this occurrence. Two parents sharing
+    // the same `pkgIdWithPatchHash` get different `NodeId`s so the peer
+    // resolver can attach different peer suffixes per call site.
+    let node_id = NodeId::next();
+
+    let next_ancestors: Vec<String> =
+        ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
+
     let child_specs = extract_children(&result, ctx.auto_install_peers);
-    let children: Vec<DirectDep> = child_specs
-        .into_iter()
-        .map(|(child_name, child_range)| {
-            let child_wanted = WantedDependency {
-                alias: Some(child_name),
-                bare_specifier: Some(child_range),
-                ..WantedDependency::default()
-            };
-            resolve_node(ctx, resolver, child_wanted)
-        })
-        .pipe(future::try_join_all)
-        .await?;
+    let child_results =
+        child_specs
+            .into_iter()
+            .map(|(child_name, child_range)| {
+                let child_wanted = WantedDependency {
+                    alias: Some(child_name),
+                    bare_specifier: Some(child_range),
+                    ..WantedDependency::default()
+                };
+                let next_ancestors = next_ancestors.clone();
+                async move {
+                    resolve_node(ctx, resolver, child_wanted, &next_ancestors, depth + 1).await
+                }
+            })
+            .pipe(future::try_join_all)
+            .await?;
+    let children: BTreeMap<String, NodeId> =
+        child_results.into_iter().flatten().map(|dep| (dep.alias, dep.node_id)).collect();
 
-    ctx.packages.lock().await.get_mut(&id).expect("placeholder inserted above").children = children;
+    ctx.dependencies_tree.lock().await.insert(
+        node_id,
+        DependenciesTreeNode {
+            resolved_package_id: id.clone(),
+            children,
+            depth,
+            installable: true,
+        },
+    );
 
-    Ok(DirectDep { alias, id })
+    Ok(Some(DirectDep { alias, node_id, id }))
 }
 
 /// Render `{alias}@{bare}` (either half dropped when absent) for the
@@ -193,17 +256,19 @@ fn render_specifier(wanted: &WantedDependency) -> String {
     }
 }
 
-/// Extract `(name, version_range)` pairs from a resolved package's
-/// manifest fragment, filtered by `auto_install_peers` to optionally
-/// fold `peerDependencies` into the child set.
+/// Extract regular `dependencies` from a resolved package's manifest,
+/// optionally folding in `peerDependencies` when `auto_install_peers`
+/// is on. Peers are still recorded on
+/// [`ResolvedPackage::peer_dependencies`] regardless so the peer-
+/// resolution stage can compute the correct depPath suffix.
 fn extract_children(
     result: &pacquet_resolving_resolver_base::ResolveResult,
-    with_peers: bool,
+    auto_install_peers: bool,
 ) -> Vec<(String, String)> {
     let Some(manifest) = result.manifest.as_ref() else { return Vec::new() };
     let mut out = Vec::new();
     collect_deps(manifest, "dependencies", &mut out);
-    if with_peers {
+    if auto_install_peers {
         collect_deps(manifest, "peerDependencies", &mut out);
     }
     out
@@ -216,4 +281,61 @@ fn collect_deps(manifest: &Value, key: &str, out: &mut Vec<(String, String)>) {
             out.push((name.clone(), range_str.to_string()));
         }
     }
+}
+
+/// Extract `peerDependencies` from a resolved package's manifest, with
+/// `peerDependenciesMeta[name].optional` folded onto each entry.
+/// Mirrors upstream's
+/// [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1791-L1815):
+/// names also present in `dependencies` or `optionalDependencies` are
+/// skipped because those edges already supply the same package
+/// directly.
+fn extract_peer_dependencies(
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+) -> BTreeMap<String, PeerDep> {
+    let Some(manifest) = result.manifest.as_ref() else { return BTreeMap::new() };
+    let mut peers: BTreeMap<String, PeerDep> = BTreeMap::new();
+
+    let own_deps: HashSet<String> = ["dependencies", "optionalDependencies"]
+        .iter()
+        .flat_map(|key| {
+            manifest
+                .get(*key)
+                .and_then(Value::as_object)
+                .into_iter()
+                .flat_map(|map| map.keys().cloned())
+        })
+        .collect();
+
+    if let Some(map) = manifest.get("peerDependencies").and_then(Value::as_object) {
+        for (name, range) in map {
+            if own_deps.contains(name) {
+                continue;
+            }
+            if let Some(range_str) = range.as_str() {
+                peers.insert(
+                    name.clone(),
+                    PeerDep { version: range_str.to_string(), optional: false },
+                );
+            }
+        }
+    }
+
+    if let Some(meta) = manifest.get("peerDependenciesMeta").and_then(Value::as_object) {
+        for (name, info) in meta {
+            if own_deps.contains(name) {
+                continue;
+            }
+            let optional = info.get("optional").and_then(Value::as_bool).unwrap_or(false);
+            // peerDependenciesMeta can declare a peer without a
+            // matching peerDependencies entry — upstream treats those
+            // as version "*". Mirror that shape.
+            peers
+                .entry(name.clone())
+                .and_modify(|entry| entry.optional = entry.optional || optional)
+                .or_insert(PeerDep { version: "*".to_string(), optional });
+        }
+    }
+
+    peers
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -256,11 +256,18 @@ fn render_specifier(wanted: &WantedDependency) -> String {
     }
 }
 
-/// Extract regular `dependencies` from a resolved package's manifest,
-/// optionally folding in `peerDependencies` when `auto_install_peers`
-/// is on. Peers are still recorded on
-/// [`ResolvedPackage::peer_dependencies`] regardless so the peer-
-/// resolution stage can compute the correct depPath suffix.
+/// Extract regular `dependencies` + `optionalDependencies` from a
+/// resolved package's manifest, optionally folding in `peerDependencies`
+/// when `auto_install_peers` is on. Peers that name an existing own dep
+/// are skipped here because the regular edge already supplies the same
+/// package — `BTreeMap` collection of the result by alias would
+/// otherwise silently drop the optional edge. Mirrors the filter
+/// upstream's [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1791-L1815)
+/// applies on the peer side.
+///
+/// Peers are still recorded on [`ResolvedPackage::peer_dependencies`]
+/// (via [`extract_peer_dependencies`]) regardless of this flag so the
+/// peer-resolution stage can compute the correct depPath suffix.
 fn extract_children(
     result: &pacquet_resolving_resolver_base::ResolveResult,
     auto_install_peers: bool,
@@ -268,8 +275,20 @@ fn extract_children(
     let Some(manifest) = result.manifest.as_ref() else { return Vec::new() };
     let mut out = Vec::new();
     collect_deps(manifest, "dependencies", &mut out);
+    collect_deps(manifest, "optionalDependencies", &mut out);
     if auto_install_peers {
-        collect_deps(manifest, "peerDependencies", &mut out);
+        let own_deps: HashSet<String> = out.iter().map(|(name, _)| name.clone()).collect();
+        let Some(map) = manifest.get("peerDependencies").and_then(Value::as_object) else {
+            return out;
+        };
+        for (name, range) in map {
+            if own_deps.contains(name) {
+                continue;
+            }
+            if let Some(range_str) = range.as_str() {
+                out.push((name.clone(), range_str.to_string()));
+            }
+        }
     }
     out
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -33,11 +33,11 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use node_semver::{Range, Version};
-use pacquet_deps_path::{PeerId, create_peer_dep_graph_hash};
+use pacquet_deps_path::{DepPath, PeerId, create_peer_dep_graph_hash};
 
 use crate::{
     dependencies_graph::{
-        DepPath, DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentPackageRef,
+        DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentPackageRef,
         PeerDependencyIssue, PeerDependencyIssues,
     },
     node_id::NodeId,
@@ -79,6 +79,7 @@ pub fn resolve_peers(tree: &ResolvedTree, opts: ResolvePeersOptions) -> ResolveP
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
         in_progress: HashSet::new(),
+        pending_peer_edges: Vec::new(),
     };
     walker.walk()
 }
@@ -136,6 +137,24 @@ struct Walker<'tree> {
     /// is a cycle — the recursion bottoms out with a `name@version`
     /// peer-id and the original visit drives the actual graph insert.
     in_progress: HashSet<NodeId>,
+    /// Peer edges whose target `NodeId` had no `DepPath` yet at the
+    /// time we built the parent's `graph_children` map — typically
+    /// because the peer is a later sibling direct dep that the walker
+    /// hasn't reached yet. `walk()` drains this list once every direct
+    /// dep is walked and patches the recorded entries with the now-
+    /// known peer `DepPath`. Without this post-pass the install layer
+    /// would walk the parent's `children` map and find no symlink edge
+    /// for the peer, leaving the package without the peer in its slot.
+    pending_peer_edges: Vec<PendingPeerEdge>,
+}
+
+/// One `parent → peer` edge whose peer target wasn't walked yet at the
+/// time the parent's `graph_children` was built. Patched up by
+/// [`Walker::patch_pending_peer_edges`] after the main walk completes.
+struct PendingPeerEdge {
+    parent_dep_path: DepPath,
+    peer_alias: String,
+    peer_node_id: NodeId,
 }
 
 /// Sentinel for "this node's subtree is still missing peer `X`". The
@@ -173,10 +192,34 @@ impl<'tree> Walker<'tree> {
                 self.resolve_node(direct.node_id, &importer_parents, &parent_chain_names, 0);
             direct_by_alias.insert(direct.alias.clone(), output.dep_path);
         }
+        self.patch_pending_peer_edges();
         ResolvePeersResult {
             graph: self.graph,
             direct_dependencies_by_alias: direct_by_alias,
             peer_dependency_issues: self.issues,
+        }
+    }
+
+    /// Fill in `graph_children` edges that were skipped during the main
+    /// walk because the peer target's `DepPath` hadn't been computed
+    /// yet. Each direct dep's subtree is fully walked by the time
+    /// `walk()` drains this list, so every peer that was reachable
+    /// from an ancestor's `ParentRefs` has a `DepPath` now. Peers that
+    /// still don't resolve here came from a `parent_chain` outside the
+    /// walked set — there's nothing to patch, and the absence already
+    /// surfaced via [`PeerDependencyIssues::missing`].
+    fn patch_pending_peer_edges(&mut self) {
+        for edge in std::mem::take(&mut self.pending_peer_edges) {
+            let Some(peer_dep_path) = self.node_dep_paths.get(&edge.peer_node_id).cloned() else {
+                continue;
+            };
+            if let Some(node) = self.graph.get_mut(&edge.parent_dep_path) {
+                // `entry().or_insert` rather than unconditional insert:
+                // if a later walk of the same `dep_path` already
+                // populated the edge (e.g. via the cycle path), we
+                // don't want to overwrite a more specific entry.
+                node.children.entry(edge.peer_alias).or_insert(peer_dep_path);
+            }
         }
     }
 
@@ -296,9 +339,15 @@ impl<'tree> Walker<'tree> {
             );
             child_dep_paths.insert(alias.clone(), child_output.dep_path);
             for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
-                if tree_node.children.contains_key(&peer_alias) {
+                if tree_node.children.values().any(|id| *id == peer_node_id) {
                     // Resolved against one of *this node's* children —
                     // not external from this node's perspective.
+                    // Compare by NodeId (not alias) because `children`
+                    // is keyed by install alias while `peer_alias` can
+                    // be the resolved package's real name (the
+                    // [`ParentRefs`] map indexes parents under both
+                    // alias and real name when they differ). An
+                    // alias-only check misses npm-aliased children.
                     continue;
                 }
                 external_from_children.insert(peer_alias, peer_node_id);
@@ -369,11 +418,22 @@ impl<'tree> Walker<'tree> {
         self.node_missing_peers.insert(node_id, all_missing_peers.clone());
 
         // The children's depPath edges become this node's graph children.
-        // Resolved peers become extra edges, aliased by peer name.
+        // Resolved peers become extra edges, aliased by peer name. If a
+        // peer's depPath isn't known yet — typically a later sibling
+        // direct dep — defer the edge to the post-walk patch pass; the
+        // install layer drives off `graph_children`, so skipping the
+        // edge entirely would leave the peer un-symlinked in the
+        // parent's slot.
         let mut graph_children = child_dep_paths.clone();
         for (peer_alias, peer_node_id) in &all_resolved_peers {
             if let Some(peer_dep_path) = self.node_dep_paths.get(peer_node_id) {
                 graph_children.insert(peer_alias.clone(), peer_dep_path.clone());
+            } else {
+                self.pending_peer_edges.push(PendingPeerEdge {
+                    parent_dep_path: dep_path.clone(),
+                    peer_alias: peer_alias.clone(),
+                    peer_node_id: *peer_node_id,
+                });
             }
         }
 
@@ -421,10 +481,15 @@ impl<'tree> Walker<'tree> {
 
         // External resolved peers reported up: this node's collected
         // peers minus any that map to this node's own children
-        // (already covered by the children's depPaths).
+        // (already covered by the children's depPaths). Filter by
+        // NodeId rather than alias for the same reason as the
+        // `external_from_children` filter above — `children` is keyed
+        // by install alias while peers may be keyed by the resolved
+        // package's real name.
+        let own_child_ids: HashSet<NodeId> = tree_node.children.values().copied().collect();
         let external_to_report: HashMap<String, NodeId> = all_resolved_peers
             .into_iter()
-            .filter(|(alias, _)| !tree_node.children.contains_key(alias))
+            .filter(|(_, peer_node_id)| !own_child_ids.contains(peer_node_id))
             .collect();
 
         NodeOutput {
@@ -489,7 +554,7 @@ impl<'tree> Walker<'tree> {
     /// `name@version` from the resolved package.
     fn build_peer_id(&self, peer_node_id: NodeId) -> PeerId {
         if let Some(dep_path) = self.node_dep_paths.get(&peer_node_id) {
-            return PeerId::DepPath(dep_path.as_str().to_string());
+            return PeerId::DepPath(dep_path.clone());
         }
         let tree_node = &self.tree.dependencies_tree[&peer_node_id];
         let pkg = &self.tree.packages[&tree_node.resolved_package_id];
@@ -552,6 +617,18 @@ fn parents_from_chain(chain_names: &[String], _pkg_name: &str) -> Vec<ParentPack
 /// match. Mirrors upstream's
 /// [`semverUtils.satisfiesWithPrereleases`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L922)
 /// call site.
+///
+/// **Prerelease tolerance.** `node-semver`'s [`Range::satisfies`]
+/// rejects prerelease versions against non-prerelease comparators —
+/// `18.0.0-rc.1` against `^18.0.0` returns `false`. Yarn's
+/// `satisfiesWithPrereleases` (which pnpm imports here) explicitly
+/// allows that pairing. We approximate it by retrying with the
+/// prerelease tag stripped: if `version` is a prerelease and the
+/// straight check fails, see whether the base `MAJOR.MINOR.PATCH`
+/// satisfies the range. That covers the cases pnpm cares about for
+/// peer-range matching (a candidate with a `-rc.N` / `-alpha.N` suffix
+/// satisfying a regular `^X.Y` peer requirement) without pulling in
+/// Yarn's full per-comparator algorithm.
 fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
     if range == "*" {
         return true;
@@ -562,7 +639,20 @@ fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
     let Ok(parsed_range) = Range::parse(range) else {
         return version == range;
     };
-    parsed_version.satisfies(&parsed_range)
+    if parsed_version.satisfies(&parsed_range) {
+        return true;
+    }
+    if !parsed_version.is_prerelease() {
+        return false;
+    }
+    let base = Version {
+        major: parsed_version.major,
+        minor: parsed_version.minor,
+        patch: parsed_version.patch,
+        pre_release: Vec::new(),
+        build: Vec::new(),
+    };
+    base.satisfies(&parsed_range)
 }
 
 #[cfg(test)]
@@ -580,5 +670,17 @@ mod tests {
     fn satisfies_falls_back_to_equality_for_unparsable_ranges() {
         assert!(satisfies_with_prereleases("workspace:^1.0.0", "workspace:^1.0.0"));
         assert!(!satisfies_with_prereleases("1.0.0", "workspace:^1.0.0"));
+    }
+
+    #[test]
+    fn satisfies_accepts_prerelease_against_non_prerelease_range() {
+        // Mirrors Yarn's `satisfiesWithPrereleases` carve-out: a peer
+        // candidate at `18.0.0-rc.1` should satisfy a `^18.0.0` peer
+        // requirement. node-semver's default `satisfies` rejects this
+        // pairing, so the prerelease-strip retry has to catch it.
+        assert!(satisfies_with_prereleases("18.0.0-rc.1", "^18.0.0"));
+        assert!(satisfies_with_prereleases("1.2.3-beta.0", "^1.2.0"));
+        // Out-of-range prereleases still fail.
+        assert!(!satisfies_with_prereleases("19.0.0-rc.1", "^18.0.0"));
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -44,7 +44,7 @@ use crate::{
     resolved_tree::{PeerDep, ResolvedPackage, ResolvedTree},
 };
 
-/// Options threaded into [`resolve_peers`].
+/// Options threaded into [`fn@resolve_peers`].
 #[derive(Debug, Clone, Copy)]
 pub struct ResolvePeersOptions {
     /// Cap on the rendered peer-suffix length before pacquet swaps the
@@ -59,7 +59,7 @@ impl Default for ResolvePeersOptions {
     }
 }
 
-/// Output bag of [`resolve_peers`]. Mirrors upstream's
+/// Output bag of [`fn@resolve_peers`]. Mirrors upstream's
 /// [`resolvePeers` return shape](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L101-L102).
 #[derive(Debug, Default)]
 pub struct ResolvePeersResult {
@@ -577,7 +577,7 @@ mod tests {
     }
 
     #[test]
-    fn satisfies_falls_back_to_equality_for_unparseable_ranges() {
+    fn satisfies_falls_back_to_equality_for_unparsable_ranges() {
         assert!(satisfies_with_prereleases("workspace:^1.0.0", "workspace:^1.0.0"));
         assert!(!satisfies_with_prereleases("1.0.0", "workspace:^1.0.0"));
     }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -1,0 +1,584 @@
+//! Pacquet port of pnpm's
+//! [`resolvePeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts).
+//!
+//! Walks the per-occurrence [`crate::ResolvedTree::dependencies_tree`]
+//! depth-first, propagating a [`ParentRefs`] map of available parents
+//! down the chain, and matches each visited package's
+//! [`crate::ResolvedPackage::peer_dependencies`] against that map.
+//! Produces a [`DependenciesGraph`] keyed by depPath plus the
+//! `direct → DepPath` map the install layer consumes.
+//!
+//! **Scope of this port.** The slice landing here covers the
+//! correctness surface — peer matching, depPath construction with
+//! per-occurrence variation, missing / bad peer issue collection,
+//! transitive-peer propagation, and the basic cycle break. Upstream
+//! also runs three optimisations on top of the algorithm that pacquet
+//! does **not** port yet:
+//!
+//! - **`peersCache`** — caches resolved peer combinations keyed by
+//!   `pkgIdWithPatchHash` so a repeat visit short-circuits the walk.
+//!   Pacquet always recomputes; correctness is unaffected.
+//! - **`purePkgs` fast path** — a pure package (no resolved / missing
+//!   peers) gets its depPath equal to its `pkgIdWithPatchHash` without
+//!   recursing. The general path produces the same answer, just one
+//!   walk later.
+//! - **`graph-cycles`-driven async deferment** — upstream's
+//!   `pathsByNodeIdPromises` lets a cyclic peer pick a `name@version`
+//!   peer-id once `analyzeGraph` confirms the cycle. Pacquet performs
+//!   a synchronous post-order traversal with an `in_progress` set; a
+//!   re-entry on the same `NodeId` falls back to `name@version` as
+//!   the peer-id, which is what upstream's cycle resolution converges
+//!   on anyway.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use node_semver::{Range, Version};
+use pacquet_deps_path::{PeerId, create_peer_dep_graph_hash};
+
+use crate::{
+    dependencies_graph::{
+        DepPath, DependenciesGraph, DependenciesGraphNode, MissingPeer, ParentPackageRef,
+        PeerDependencyIssue, PeerDependencyIssues,
+    },
+    node_id::NodeId,
+    resolved_tree::{PeerDep, ResolvedPackage, ResolvedTree},
+};
+
+/// Options threaded into [`resolve_peers`].
+#[derive(Debug, Clone, Copy)]
+pub struct ResolvePeersOptions {
+    /// Cap on the rendered peer-suffix length before pacquet swaps the
+    /// suffix for its short hash. Mirrors upstream's
+    /// `peersSuffixMaxLength` (default 1000).
+    pub peers_suffix_max_length: usize,
+}
+
+impl Default for ResolvePeersOptions {
+    fn default() -> Self {
+        ResolvePeersOptions { peers_suffix_max_length: 1000 }
+    }
+}
+
+/// Output bag of [`resolve_peers`]. Mirrors upstream's
+/// [`resolvePeers` return shape](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L101-L102).
+#[derive(Debug, Default)]
+pub struct ResolvePeersResult {
+    pub graph: DependenciesGraph,
+    pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
+    pub peer_dependency_issues: PeerDependencyIssues,
+}
+
+/// Resolve peer dependencies for `tree` and emit a depPath-keyed graph.
+pub fn resolve_peers(tree: &ResolvedTree, opts: ResolvePeersOptions) -> ResolvePeersResult {
+    let walker = Walker {
+        tree,
+        opts,
+        graph: DependenciesGraph::new(),
+        issues: PeerDependencyIssues::default(),
+        node_dep_paths: HashMap::new(),
+        node_external_peers: HashMap::new(),
+        node_missing_peers: HashMap::new(),
+        in_progress: HashSet::new(),
+    };
+    walker.walk()
+}
+
+/// Per-name entry in the propagating `ParentRefs` map. Mirrors upstream's
+/// [`ParentRef`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L998-L1006).
+///
+/// Pacquet's port flattens upstream's `occurrence` / `parentNodeIds`
+/// fields — those feed the `peersCache` and `parentPackagesMatch`
+/// validation, neither of which is ported in this slice.
+#[derive(Debug, Clone)]
+struct ParentRef {
+    version: String,
+    /// `None` for top-level deps that were already installed (upstream
+    /// fills these from `topParents`). Pacquet doesn't surface those
+    /// yet — `None` only appears on the importer-level cycle-break
+    /// fallback, where the `name@version` form of the peer-id is the
+    /// only useful representation.
+    node_id: Option<NodeId>,
+    /// Local install name in `node_modules`. May differ from the
+    /// package's real name for npm-alias entries.
+    ///
+    /// Recorded for upstream parity but not read in this slice. Used by
+    /// `parentPkgsMatch` (cache validation), ported in a later slice.
+    #[allow(dead_code, reason = "future peersCache validation")]
+    alias: Option<String>,
+}
+
+/// `name → ParentRef` map propagated down the walk. Entries are indexed
+/// by both the package's real name and its alias when the two differ —
+/// `react-dom@npm:next` resolves a `peerDependencies.react-dom`
+/// requirement against the alias and `peerDependencies.next` against
+/// the real name.
+type ParentRefs = HashMap<String, ParentRef>;
+
+struct Walker<'tree> {
+    tree: &'tree ResolvedTree,
+    opts: ResolvePeersOptions,
+    graph: DependenciesGraph,
+    issues: PeerDependencyIssues,
+    /// `NodeId → DepPath` once a node has been walked. Mirrors
+    /// upstream's `pathsByNodeId` map. Lets repeated visits (an
+    /// importer-direct dep that's also reached transitively) reuse the
+    /// already-computed depPath.
+    node_dep_paths: HashMap<NodeId, DepPath>,
+    /// Peers each node and its subtree resolved against ancestors —
+    /// the "unknown resolved peers" upstream propagates up so a parent
+    /// can fold its descendants' peer dependencies into its own peer
+    /// suffix. Indexed by `NodeId`; value's keys are peer aliases.
+    node_external_peers: HashMap<NodeId, HashMap<String, NodeId>>,
+    /// Peers each node and its subtree declared but couldn't find.
+    /// Indexed by `NodeId`; value's keys are peer aliases.
+    node_missing_peers: HashMap<NodeId, HashMap<String, MissingPeerInfo>>,
+    /// Stack of nodes currently being walked. Re-entry on a node here
+    /// is a cycle — the recursion bottoms out with a `name@version`
+    /// peer-id and the original visit drives the actual graph insert.
+    in_progress: HashSet<NodeId>,
+}
+
+/// Sentinel for "this node's subtree is still missing peer `X`". The
+/// `range` + `optional` payload mirrors upstream's `MissingPeers` map
+/// value; pacquet records them for upstream parity (and for the
+/// `peersCache` lookup ported in a later slice) but the
+/// issue-collection path uses [`PeerDependencyIssues::missing`]
+/// directly, so neither field is read after construction yet.
+#[derive(Debug, Clone)]
+struct MissingPeerInfo {
+    #[allow(dead_code, reason = "future peersCache validation")]
+    range: String,
+    #[allow(dead_code, reason = "future peersCache validation")]
+    optional: bool,
+}
+
+/// Output of [`Walker::resolve_node`] — the per-node result the parent
+/// folds into its own state.
+struct NodeOutput {
+    dep_path: DepPath,
+    /// Peers that this node + its subtree resolved against ancestors.
+    /// Excludes peers resolved against this node's own children (those
+    /// are absorbed into the children's depPaths).
+    external_resolved_peers: HashMap<String, NodeId>,
+    missing_peers: HashMap<String, MissingPeerInfo>,
+}
+
+impl<'tree> Walker<'tree> {
+    fn walk(mut self) -> ResolvePeersResult {
+        let importer_parents = self.build_importer_parents();
+        let parent_chain_names: Vec<String> = Vec::new();
+        let mut direct_by_alias = BTreeMap::new();
+        for direct in &self.tree.direct {
+            let output =
+                self.resolve_node(direct.node_id, &importer_parents, &parent_chain_names, 0);
+            direct_by_alias.insert(direct.alias.clone(), output.dep_path);
+        }
+        ResolvePeersResult {
+            graph: self.graph,
+            direct_dependencies_by_alias: direct_by_alias,
+            peer_dependency_issues: self.issues,
+        }
+    }
+
+    /// Build the seed [`ParentRefs`] from the importer's direct deps so
+    /// a direct dep's peer requirements can be satisfied by a sibling
+    /// direct dep. Mirrors upstream's `pkgsByName` initialisation at
+    /// the entry of `resolvePeers`.
+    fn build_importer_parents(&self) -> ParentRefs {
+        let mut refs = ParentRefs::new();
+        for direct in &self.tree.direct {
+            let Some(tree_node) = self.tree.dependencies_tree.get(&direct.node_id) else {
+                continue;
+            };
+            let Some(pkg) = self.tree.packages.get(&tree_node.resolved_package_id) else {
+                continue;
+            };
+            insert_parent_ref(&mut refs, direct, pkg, self.tree);
+        }
+        refs
+    }
+
+    #[allow(
+        clippy::only_used_in_recursion,
+        reason = "`depth` is kept for upstream parity with `currentDepth`"
+    )]
+    fn resolve_node(
+        &mut self,
+        node_id: NodeId,
+        parent_parent_refs: &ParentRefs,
+        parent_chain_names: &[String],
+        depth: i32,
+    ) -> NodeOutput {
+        if let Some(existing) = self.node_dep_paths.get(&node_id).cloned() {
+            return NodeOutput {
+                dep_path: existing,
+                external_resolved_peers: self
+                    .node_external_peers
+                    .get(&node_id)
+                    .cloned()
+                    .unwrap_or_default(),
+                missing_peers: self.node_missing_peers.get(&node_id).cloned().unwrap_or_default(),
+            };
+        }
+
+        if self.in_progress.contains(&node_id) {
+            // Cycle: bottom out with the bare `pkgIdWithPatchHash` as
+            // the depPath. The original visit (still on the stack) will
+            // compute the real depPath and insert it into
+            // `node_dep_paths`. Returning the bare id here ensures the
+            // current ancestor's peer-suffix construction can use a
+            // `name@version` PeerId — see [`build_peer_id`] for the
+            // cycle handling.
+            let tree_node = &self.tree.dependencies_tree[&node_id];
+            let pkg = &self.tree.packages[&tree_node.resolved_package_id];
+            return NodeOutput {
+                dep_path: DepPath::from(pkg.id.clone()),
+                external_resolved_peers: HashMap::new(),
+                missing_peers: HashMap::new(),
+            };
+        }
+        self.in_progress.insert(node_id);
+
+        let tree_node = self.tree.dependencies_tree[&node_id].clone();
+        let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
+        let pkg_name = pkg.result.id.name.to_string();
+
+        // Build the ParentRefs map that descendants of this node see:
+        // parent's view + this node's own children, restricted to
+        // names that are declared as peers somewhere in the install.
+        let mut child_parent_refs = parent_parent_refs.clone();
+        for (alias, child_node_id) in &tree_node.children {
+            let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
+            let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
+                continue;
+            };
+            let child_real_name = child_pkg.result.id.name.to_string();
+            // Only peer-relevant aliases need to land in `parentRefs`.
+            // Pnpm filters with `allPeerDepNames` to keep the propagated
+            // map small.
+            let alias_relevant = self.tree.all_peer_dep_names.contains(alias);
+            let real_relevant = self.tree.all_peer_dep_names.contains(&child_real_name);
+            if !alias_relevant && !real_relevant {
+                continue;
+            }
+            let child_version = child_pkg.result.id.suffix.to_string();
+            let parent_ref = ParentRef {
+                version: child_version,
+                node_id: Some(*child_node_id),
+                alias: if alias != &child_real_name { Some(alias.clone()) } else { None },
+            };
+            if alias_relevant {
+                child_parent_refs.insert(alias.clone(), parent_ref.clone());
+            }
+            if real_relevant && alias != &child_real_name {
+                child_parent_refs.insert(child_real_name.clone(), parent_ref);
+            }
+        }
+
+        let mut child_chain_names: Vec<String> = parent_chain_names.to_vec();
+        child_chain_names.push(pkg_name.clone());
+
+        // Recurse into children first (post-order). Collect each child's
+        // depPath and the external peers / missing peers they propagate
+        // up. Children's external peers may overlap with this node's
+        // own children (e.g. a child resolved a peer to a sibling of
+        // its parent — i.e., this node's child). Those are not external
+        // *to this node* — they're internal here — so filter them out.
+        let mut external_from_children: HashMap<String, NodeId> = HashMap::new();
+        let mut missing_from_children: HashMap<String, MissingPeerInfo> = HashMap::new();
+        let mut child_dep_paths: BTreeMap<String, DepPath> = BTreeMap::new();
+        for (alias, child_node_id) in &tree_node.children {
+            let child_output = self.resolve_node(
+                *child_node_id,
+                &child_parent_refs,
+                &child_chain_names,
+                depth + 1,
+            );
+            child_dep_paths.insert(alias.clone(), child_output.dep_path);
+            for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
+                if tree_node.children.contains_key(&peer_alias) {
+                    // Resolved against one of *this node's* children —
+                    // not external from this node's perspective.
+                    continue;
+                }
+                external_from_children.insert(peer_alias, peer_node_id);
+            }
+            for (peer_alias, info) in child_output.missing_peers {
+                missing_from_children.insert(peer_alias, info);
+            }
+        }
+
+        // Resolve this node's own peer requirements against the
+        // ParentRefs visible at this node — that is, the ones its
+        // parent passed in, *not* the augmented child view (a node
+        // does not satisfy its own peers from its own children).
+        let mut own_resolved_peers: HashMap<String, NodeId> = HashMap::new();
+        let mut own_missing_peers: HashMap<String, MissingPeerInfo> = HashMap::new();
+        for (peer_name, peer_dep) in &pkg.peer_dependencies {
+            self.resolve_one_peer(
+                &pkg_name,
+                peer_name,
+                peer_dep,
+                parent_parent_refs,
+                &child_chain_names,
+                &mut own_resolved_peers,
+                &mut own_missing_peers,
+            );
+        }
+
+        // Combine all resolved peers (this node's own + descendants').
+        // Filter out the node's own name (a package doesn't peer-depend
+        // on itself).
+        let mut all_resolved_peers = external_from_children;
+        for (peer_alias, peer_node_id) in &own_resolved_peers {
+            all_resolved_peers.insert(peer_alias.clone(), *peer_node_id);
+        }
+        all_resolved_peers.remove(&pkg_name);
+
+        // Same for missing peers (children + own).
+        let mut all_missing_peers = missing_from_children;
+        for (peer_alias, info) in &own_missing_peers {
+            all_missing_peers.insert(peer_alias.clone(), info.clone());
+        }
+
+        // Construct the depPath. Empty resolved-peers ⇒ pure node:
+        // depPath = pkgIdWithPatchHash.
+        let dep_path = if all_resolved_peers.is_empty() {
+            DepPath::from(pkg.id.clone())
+        } else {
+            let mut peer_ids: Vec<PeerId> = all_resolved_peers
+                .values()
+                .map(|peer_node_id| self.build_peer_id(*peer_node_id))
+                .collect();
+            // Sorting happens inside `create_peer_dep_graph_hash`, but
+            // we deduplicate by stringified form here to mirror
+            // upstream's `Map<alias, NodeId>` semantics (each peer
+            // contributes at most once).
+            peer_ids.sort_by_key(PeerId::as_segment);
+            peer_ids.dedup_by_key(|p| p.as_segment());
+            let suffix = create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
+            DepPath::from(format!("{}{}", pkg.id, suffix))
+        };
+
+        // Register the depPath ↔ NodeId mapping and per-node
+        // propagated state before inserting into the graph (so any
+        // cycle the graph insert hits via `child_dep_paths` can find
+        // this node's depPath).
+        self.node_dep_paths.insert(node_id, dep_path.clone());
+        self.node_external_peers.insert(node_id, all_resolved_peers.clone());
+        self.node_missing_peers.insert(node_id, all_missing_peers.clone());
+
+        // The children's depPath edges become this node's graph children.
+        // Resolved peers become extra edges, aliased by peer name.
+        let mut graph_children = child_dep_paths.clone();
+        for (peer_alias, peer_node_id) in &all_resolved_peers {
+            if let Some(peer_dep_path) = self.node_dep_paths.get(peer_node_id) {
+                graph_children.insert(peer_alias.clone(), peer_dep_path.clone());
+            }
+        }
+
+        // Compute transitive peer set: peers visible in this subtree
+        // that are NOT declared in this package's own peerDependencies.
+        let mut transitive_peer_dependencies: HashSet<String> = HashSet::new();
+        for peer_alias in all_resolved_peers.keys() {
+            if !pkg.peer_dependencies.contains_key(peer_alias) {
+                transitive_peer_dependencies.insert(peer_alias.clone());
+            }
+        }
+        for peer_alias in all_missing_peers.keys() {
+            if !pkg.peer_dependencies.contains_key(peer_alias) {
+                transitive_peer_dependencies.insert(peer_alias.clone());
+            }
+        }
+
+        let is_pure = all_resolved_peers.is_empty() && all_missing_peers.is_empty();
+
+        // Multiple visits with the same depPath collapse onto the same
+        // graph entry. Upstream takes the entry with the smallest
+        // `depth` when there's a conflict; pacquet ports the same
+        // tie-break so install order matches.
+        self.graph
+            .entry(dep_path.clone())
+            .and_modify(|node| {
+                if node.depth > tree_node.depth {
+                    node.depth = tree_node.depth;
+                }
+            })
+            .or_insert(DependenciesGraphNode {
+                dep_path: dep_path.clone(),
+                resolved_package_id: pkg.id.clone(),
+                resolve_result: pkg.result.clone(),
+                children: graph_children,
+                peer_dependencies: pkg.peer_dependencies.clone(),
+                transitive_peer_dependencies,
+                resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
+                depth: tree_node.depth,
+                installable: tree_node.installable,
+                is_pure,
+            });
+
+        self.in_progress.remove(&node_id);
+
+        // External resolved peers reported up: this node's collected
+        // peers minus any that map to this node's own children
+        // (already covered by the children's depPaths).
+        let external_to_report: HashMap<String, NodeId> = all_resolved_peers
+            .into_iter()
+            .filter(|(alias, _)| !tree_node.children.contains_key(alias))
+            .collect();
+
+        NodeOutput {
+            dep_path,
+            external_resolved_peers: external_to_report,
+            missing_peers: all_missing_peers,
+        }
+    }
+
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "splitting these into a struct would only obscure the call site"
+    )]
+    fn resolve_one_peer(
+        &mut self,
+        pkg_name: &str,
+        peer_name: &str,
+        peer_dep: &PeerDep,
+        parent_refs: &ParentRefs,
+        chain: &[String],
+        resolved: &mut HashMap<String, NodeId>,
+        missing: &mut HashMap<String, MissingPeerInfo>,
+    ) {
+        let raw_range = peer_dep.version.as_str();
+        let range_for_match = raw_range.strip_prefix("workspace:").unwrap_or(raw_range);
+        let optional = peer_dep.optional;
+
+        match parent_refs.get(peer_name) {
+            None => {
+                missing.insert(
+                    peer_name.to_string(),
+                    MissingPeerInfo { range: range_for_match.to_string(), optional },
+                );
+                self.issues.missing.entry(peer_name.to_string()).or_default().push(MissingPeer {
+                    wanted_range: range_for_match.to_string(),
+                    optional,
+                    parents: parents_from_chain(chain, pkg_name),
+                });
+            }
+            Some(parent) => {
+                if !satisfies_with_prereleases(&parent.version, range_for_match) {
+                    self.issues.bad.entry(peer_name.to_string()).or_default().push(
+                        PeerDependencyIssue {
+                            wanted_range: range_for_match.to_string(),
+                            found_version: parent.version.clone(),
+                            optional,
+                            parents: parents_from_chain(chain, pkg_name),
+                            resolved_from: Vec::new(),
+                        },
+                    );
+                }
+                if let Some(parent_node_id) = parent.node_id {
+                    resolved.insert(peer_name.to_string(), parent_node_id);
+                }
+            }
+        }
+    }
+
+    /// Build the [`PeerId`] contribution for one resolved peer. If the
+    /// peer's depPath is already in `node_dep_paths`, use it (the
+    /// `DepPath` form). Otherwise (the cycle path), fall back to
+    /// `name@version` from the resolved package.
+    fn build_peer_id(&self, peer_node_id: NodeId) -> PeerId {
+        if let Some(dep_path) = self.node_dep_paths.get(&peer_node_id) {
+            return PeerId::DepPath(dep_path.as_str().to_string());
+        }
+        let tree_node = &self.tree.dependencies_tree[&peer_node_id];
+        let pkg = &self.tree.packages[&tree_node.resolved_package_id];
+        PeerId::Pair {
+            name: pkg.result.id.name.to_string(),
+            version: pkg.result.id.suffix.to_string(),
+        }
+    }
+}
+
+/// Reproduce upstream's `Map<NodeId, ParentRef>` dual-keying: each
+/// parent is recorded by its install alias *and* its real name when
+/// the two differ. Mirrors
+/// [`updateParentRefs`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L1035-L1044).
+fn insert_parent_ref(
+    refs: &mut ParentRefs,
+    direct: &crate::resolved_tree::DirectDep,
+    pkg: &ResolvedPackage,
+    tree: &ResolvedTree,
+) {
+    let real_name = pkg.result.id.name.to_string();
+    let version = pkg.result.id.suffix.to_string();
+    let alias_relevant = tree.all_peer_dep_names.contains(&direct.alias);
+    let real_relevant = tree.all_peer_dep_names.contains(&real_name);
+    if !alias_relevant && !real_relevant {
+        return;
+    }
+    let parent_ref = ParentRef {
+        version: version.clone(),
+        node_id: Some(direct.node_id),
+        alias: if direct.alias != real_name { Some(direct.alias.clone()) } else { None },
+    };
+    if alias_relevant {
+        refs.insert(direct.alias.clone(), parent_ref.clone());
+    }
+    if real_relevant && direct.alias != real_name {
+        refs.insert(real_name, parent_ref);
+    }
+}
+
+/// Build the `parents` chain attached to a peer issue. Upstream uses
+/// the `ResolvedPackage` of each parent; pacquet's slice records just
+/// `name` and `version`, which is what the renderer downstream
+/// consumes.
+fn parents_from_chain(chain_names: &[String], _pkg_name: &str) -> Vec<ParentPackageRef> {
+    // The chain pacquet tracks today is name-only — populating
+    // `version` would need a parallel `Vec<String>` of versions or a
+    // re-lookup against the tree. The issue-renderer consumes the
+    // names primarily; expanding to versions is a follow-up.
+    chain_names
+        .iter()
+        .map(|name| ParentPackageRef { name: name.clone(), version: String::new() })
+        .collect()
+}
+
+/// Range-satisfaction check that tolerates prereleases the way pnpm's
+/// `@yarnpkg/core/semverUtils.satisfiesWithPrereleases` does — falls
+/// back to a literal-equality check when the range can't be parsed,
+/// which lets non-semver peer ranges (`*`, git refs, etc.) still
+/// match. Mirrors upstream's
+/// [`semverUtils.satisfiesWithPrereleases`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts#L922)
+/// call site.
+fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
+    if range == "*" {
+        return true;
+    }
+    let Ok(parsed_version) = Version::parse(version) else {
+        return version == range;
+    };
+    let Ok(parsed_range) = Range::parse(range) else {
+        return version == range;
+    };
+    parsed_version.satisfies(&parsed_range)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::satisfies_with_prereleases;
+
+    #[test]
+    fn satisfies_handles_basic_ranges() {
+        assert!(satisfies_with_prereleases("1.2.3", "^1.0.0"));
+        assert!(!satisfies_with_prereleases("2.0.0", "^1.0.0"));
+        assert!(satisfies_with_prereleases("18.0.0", "*"));
+    }
+
+    #[test]
+    fn satisfies_falls_back_to_equality_for_unparseable_ranges() {
+        assert!(satisfies_with_prereleases("workspace:^1.0.0", "workspace:^1.0.0"));
+        assert!(!satisfies_with_prereleases("1.0.0", "workspace:^1.0.0"));
+    }
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -1,27 +1,41 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use pacquet_resolving_resolver_base::{ResolutionPolicyViolation, ResolveResult};
 
-/// Output of [`super::resolve_dependency_tree()`]. A flat package map
-/// keyed by `name@version` plus the importer's direct entries, so the
-/// install pass can traverse the graph without re-resolving and skip
-/// duplicates by ID.
+use crate::node_id::NodeId;
+
+/// Output of [`crate::resolve_dependency_tree`].
 ///
 /// Mirrors upstream's
-/// [`ResolveDependencyTreeResult`](https://github.com/pnpm/pnpm/blob/f657b5cb44/installing/deps-resolver/src/resolveDependencyTree.ts#L151-L170)
-/// shape — `direct` carries the project's manifest-level entries, the
-/// flat map carries every transitively-resolved package.
+/// [`ResolveDependencyTreeResult`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencyTree.ts#L151-L170)
+/// for the npm-shaped slice pacquet currently exposes.
+///
+/// The shape carries two indices into the same set of resolved
+/// packages:
+///
+/// - [`packages`](Self::packages) is the **flat dedup map**, keyed by
+///   `pkgIdWithPatchHash` (today `name@version`). One entry per
+///   resolved package, no per-occurrence repetition. Upstream calls
+///   the equivalent index `resolvedPkgsById`.
+/// - [`dependencies_tree`](Self::dependencies_tree) is the **per-
+///   occurrence tree**, keyed by [`NodeId`]. Every parent → child edge
+///   has a fresh child `NodeId`, even when two parents share the same
+///   `pkgIdWithPatchHash`, because the peer-resolution stage needs
+///   per-occurrence state (a shared package under two parents can
+///   compute different peer suffixes).
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedTree {
     pub direct: Vec<DirectDep>,
     pub packages: HashMap<String, ResolvedPackage>,
+    pub dependencies_tree: HashMap<NodeId, DependenciesTreeNode>,
+    pub all_peer_dep_names: HashSet<String>,
     pub policy_violations: Vec<ResolutionPolicyViolation>,
 }
 
 /// One edge in the resolved tree: the local install name (`alias`) and
-/// the resolved package's ID (`name@version`). Same shape for top-
-/// level (project manifest) entries and for transitive (parent
-/// package) entries.
+/// the resolved node's [`NodeId`]. Mirrors upstream's edge shape on
+/// `directNodeIdsByAlias` plus the `pkgId` field carried on
+/// `ResolvedDirectDependency`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectDep {
     /// Local install name in `node_modules`. For an npm-alias entry
@@ -29,16 +43,76 @@ pub struct DirectDep {
     /// package's real name is recoverable from
     /// [`ResolvedPackage::result`].
     pub alias: String,
-    /// `name@version` key into [`ResolvedTree::packages`].
+    /// Per-occurrence node identifier. Use this to look up the
+    /// corresponding [`DependenciesTreeNode`] in
+    /// [`ResolvedTree::dependencies_tree`].
+    pub node_id: NodeId,
+    /// `pkgIdWithPatchHash` of the resolved package — same value as
+    /// `dependencies_tree[node_id].resolved_package_id`. Carried at
+    /// the edge for callers that only need the dedup key and want to
+    /// avoid the tree lookup.
     pub id: String,
 }
 
-/// A single resolved package and its outgoing edges. Mirrors upstream's
-/// [`ResolvedPackage`](https://github.com/pnpm/pnpm/blob/f657b5cb44/installing/deps-resolver/src/resolveDependencies.ts#L168-L189)
-/// envelope as far as the npm-shaped install path cares.
+/// One resolved package, deduped by `pkgIdWithPatchHash`. Mirrors
+/// upstream's
+/// [`ResolvedPackage`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L248-L279)
+/// for the npm-shaped slice pacquet currently exposes.
+///
+/// **Children live on [`DependenciesTreeNode`], not here.** Two parents
+/// that share a resolved package each get their own per-occurrence
+/// tree node with its own children edges — a `ResolvedPackage` is the
+/// dedup-shared *envelope*, not a tree node.
 #[derive(Debug, Clone)]
 pub struct ResolvedPackage {
     pub id: String,
     pub result: ResolveResult,
-    pub children: Vec<DirectDep>,
+    /// `peerDependencies` from the package's manifest, with names that
+    /// also appear in the package's own `dependencies` /
+    /// `optionalDependencies` filtered out (mirrors upstream's
+    /// [`peerDependenciesWithoutOwn`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1791-L1815)).
+    /// `BTreeMap` keeps iteration order stable so peer-suffix
+    /// construction is deterministic.
+    pub peer_dependencies: BTreeMap<String, PeerDep>,
+}
+
+/// One peer-dependency entry on a [`ResolvedPackage`]. Mirrors upstream's
+/// [`PeerDependency`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L246-L247)
+/// shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerDep {
+    /// Semver range from the upstream manifest. May carry a
+    /// `workspace:` prefix that the peer matcher strips before
+    /// checking.
+    pub version: String,
+    /// `true` when the manifest's `peerDependenciesMeta[name].optional`
+    /// is set — a missing peer with `optional` true is recorded as an
+    /// issue but does not block resolution.
+    pub optional: bool,
+}
+
+/// One per-occurrence node in the dependencies tree. Mirrors upstream's
+/// [`DependenciesTreeNode`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L92-L103).
+///
+/// Children resolution is eager in pacquet — upstream supports a lazy
+/// `children: () => ChildrenMap` arm so cycles can be broken inside
+/// `buildTree`. Pacquet's port detects cycles by tracking the chain of
+/// `pkgIdWithPatchHash` ancestors directly inside
+/// [`crate::resolve_dependency_tree`], so children are always materialised.
+#[derive(Debug, Clone)]
+pub struct DependenciesTreeNode {
+    /// Key into [`ResolvedTree::packages`].
+    pub resolved_package_id: String,
+    /// `alias → child NodeId` edges. `BTreeMap` keeps iteration order
+    /// stable so downstream peer-suffix construction is deterministic.
+    pub children: BTreeMap<String, NodeId>,
+    /// Distance from the root importer (root = 0). Upstream uses
+    /// `depth = -1` to mark linked / pruned nodes; pacquet doesn't
+    /// emit `-1` today because workspace-link resolution hasn't been
+    /// ported.
+    pub depth: i32,
+    /// Whether the package may be skipped when an optional dep fails
+    /// for its host platform. Always `true` for the npm-shaped slice
+    /// pacquet currently exposes.
+    pub installable: bool,
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -4,7 +4,13 @@ use pacquet_resolving_resolver_base::{ResolutionPolicyViolation, ResolveResult};
 
 use crate::node_id::NodeId;
 
-/// Output of [`crate::resolve_dependency_tree`].
+/// Per-occurrence tree carried by [`ResolvedTree::dependencies_tree`].
+/// Mirrors upstream's
+/// [`DependenciesTree`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L103-L109)
+/// type alias.
+pub type DependenciesTree = HashMap<NodeId, DependenciesTreeNode>;
+
+/// Output of [`fn@crate::resolve_dependency_tree`].
 ///
 /// Mirrors upstream's
 /// [`ResolveDependencyTreeResult`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencyTree.ts#L151-L170)
@@ -27,7 +33,7 @@ use crate::node_id::NodeId;
 pub struct ResolvedTree {
     pub direct: Vec<DirectDep>,
     pub packages: HashMap<String, ResolvedPackage>,
-    pub dependencies_tree: HashMap<NodeId, DependenciesTreeNode>,
+    pub dependencies_tree: DependenciesTree,
     pub all_peer_dep_names: HashSet<String>,
     pub policy_violations: Vec<ResolutionPolicyViolation>,
 }
@@ -98,7 +104,7 @@ pub struct PeerDep {
 /// `children: () => ChildrenMap` arm so cycles can be broken inside
 /// `buildTree`. Pacquet's port detects cycles by tracking the chain of
 /// `pkgIdWithPatchHash` ancestors directly inside
-/// [`crate::resolve_dependency_tree`], so children are always materialised.
+/// [`fn@crate::resolve_dependency_tree`], so children are always materialised.
 #[derive(Debug, Clone)]
 pub struct DependenciesTreeNode {
     /// Key into [`ResolvedTree::packages`].

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -233,9 +233,9 @@ mod peers {
     use pretty_assertions::assert_eq;
 
     use super::{StubResolver, fake_manifest, fake_result};
-    use pacquet_deps_path::DepPath;
     use crate::resolve_dependency_tree::{ResolveDependencyTreeOptions, resolve_dependency_tree};
     use crate::resolve_peers::{ResolvePeersOptions, resolve_peers};
+    use pacquet_deps_path::DepPath;
 
     /// A pure leaf — no peer dependencies — should land in the graph
     /// with its depPath equal to its pkgIdWithPatchHash.
@@ -454,9 +454,8 @@ mod peers {
         );
         let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
         // Manifest order puts react-dom first.
-        let (_tmp, manifest) = fake_manifest(
-            serde_json::json!({ "react-dom": "18.0.0", "react": "18.0.0" }),
-        );
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "react-dom": "18.0.0", "react": "18.0.0" }));
         let tree = resolve_dependency_tree(
             &resolver,
             &manifest,
@@ -479,9 +478,6 @@ mod peers {
         // Without the post-pass, this edge would be missing because
         // `node_dep_paths` doesn't yet contain react when react-dom is
         // being walked.
-        assert_eq!(
-            node.children.get("react"),
-            Some(&DepPath::from("react@18.0.0".to_string())),
-        );
+        assert_eq!(node.children.get("react"), Some(&DepPath::from("react@18.0.0".to_string())),);
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -478,6 +478,6 @@ mod peers {
         // Without the post-pass, this edge would be missing because
         // `node_dep_paths` doesn't yet contain react when react-dom is
         // being walked.
-        assert_eq!(node.children.get("react"), Some(&DepPath::from("react@18.0.0".to_string())),);
+        assert_eq!(node.children.get("react"), Some(&DepPath::from("react@18.0.0".to_string())));
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -124,9 +124,13 @@ async fn walks_dependencies_and_builds_flat_tree() {
     assert_eq!(tree.direct[0].alias, "foo");
     assert_eq!(tree.direct[0].id, "foo@1.2.0");
     assert_eq!(tree.packages.len(), 2);
-    let foo = tree.packages.get("foo@1.2.0").unwrap();
-    assert_eq!(foo.children.len(), 1);
-    assert_eq!(foo.children[0].id, "bar@2.3.0");
+    assert!(tree.packages.contains_key("foo@1.2.0"));
+    let foo_node_id = tree.direct[0].node_id;
+    let foo_tree_node = tree.dependencies_tree.get(&foo_node_id).unwrap();
+    assert_eq!(foo_tree_node.children.len(), 1);
+    let bar_node_id = foo_tree_node.children.get("bar").unwrap();
+    let bar_tree_node = tree.dependencies_tree.get(bar_node_id).unwrap();
+    assert_eq!(bar_tree_node.resolved_package_id, "bar@2.3.0");
     assert!(tree.policy_violations.is_empty());
 }
 
@@ -217,5 +221,205 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
             assert_eq!(specifier, "foo@git+ssh://example.com");
         }
         other => panic!("expected SpecNotSupported, got {other:?}"),
+    }
+}
+
+mod peers {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use pacquet_package_manifest::DependencyGroup;
+    use pacquet_resolving_resolver_base::ResolveOptions;
+    use pretty_assertions::assert_eq;
+
+    use super::{StubResolver, fake_manifest, fake_result};
+    use crate::dependencies_graph::DepPath;
+    use crate::resolve_dependency_tree::{ResolveDependencyTreeOptions, resolve_dependency_tree};
+    use crate::resolve_peers::{ResolvePeersOptions, resolve_peers};
+
+    /// A pure leaf — no peer dependencies — should land in the graph
+    /// with its depPath equal to its pkgIdWithPatchHash.
+    #[tokio::test]
+    async fn pure_package_has_dep_path_equal_to_pkg_id() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("foo".to_string(), "^1.0.0".to_string()),
+            fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" })),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                auto_install_peers: false,
+                base_opts: ResolveOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_peers(&tree, ResolvePeersOptions::default());
+        assert_eq!(
+            result.direct_dependencies_by_alias.get("foo"),
+            Some(&DepPath::from("foo@1.0.0".to_string())),
+        );
+        assert!(result.peer_dependency_issues.missing.is_empty());
+        assert!(result.peer_dependency_issues.bad.is_empty());
+    }
+
+    /// `parent → child` where `child` declares `react` as a peer and
+    /// `parent` also depends on `react`: the peer resolves against the
+    /// sibling, and `child`'s depPath gains a `(react@…)` suffix.
+    #[tokio::test]
+    async fn peer_resolved_against_sibling_at_parent_level() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("react".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react",
+                "18.0.0",
+                serde_json::json!({ "name": "react", "version": "18.0.0" }),
+            ),
+        );
+        table.insert(
+            ("react-dom".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react-dom",
+                "18.0.0",
+                serde_json::json!({
+                    "name": "react-dom",
+                    "version": "18.0.0",
+                    "peerDependencies": { "react": "^18.0.0" }
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "react": "18.0.0", "react-dom": "18.0.0" }));
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                auto_install_peers: false,
+                base_opts: ResolveOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(tree.all_peer_dep_names.contains("react"));
+
+        let result = resolve_peers(&tree, ResolvePeersOptions::default());
+        let react_dom_dep_path = result
+            .direct_dependencies_by_alias
+            .get("react-dom")
+            .cloned()
+            .expect("react-dom is a direct dep");
+        assert_eq!(react_dom_dep_path, DepPath::from("react-dom@18.0.0(react@18.0.0)".to_string()));
+        // react itself stays pure.
+        assert_eq!(
+            result.direct_dependencies_by_alias.get("react"),
+            Some(&DepPath::from("react@18.0.0".to_string())),
+        );
+        assert!(result.peer_dependency_issues.missing.is_empty());
+        assert!(result.peer_dependency_issues.bad.is_empty());
+    }
+
+    /// Missing peer: `react-dom` requires `react` but the importer
+    /// doesn't include it. We expect an issue + no resolved peer.
+    #[tokio::test]
+    async fn missing_peer_is_reported() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("react-dom".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react-dom",
+                "18.0.0",
+                serde_json::json!({
+                    "name": "react-dom",
+                    "version": "18.0.0",
+                    "peerDependencies": { "react": "^18.0.0" }
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "react-dom": "18.0.0" }));
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                auto_install_peers: false,
+                base_opts: ResolveOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_peers(&tree, ResolvePeersOptions::default());
+        assert!(result.peer_dependency_issues.missing.contains_key("react"));
+        // No resolved peer ⇒ react-dom stays pure.
+        assert_eq!(
+            result.direct_dependencies_by_alias.get("react-dom"),
+            Some(&DepPath::from("react-dom@18.0.0".to_string())),
+        );
+    }
+
+    /// Bad peer: the importer carries `react@17` but `react-dom@18`
+    /// requires `react@^18`. An issue surfaces; the peer is still
+    /// recorded as resolved (the pick is intentional, the warning is
+    /// informational).
+    #[tokio::test]
+    async fn bad_peer_version_is_reported() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("react".to_string(), "17.0.0".to_string()),
+            fake_result(
+                "react",
+                "17.0.0",
+                serde_json::json!({ "name": "react", "version": "17.0.0" }),
+            ),
+        );
+        table.insert(
+            ("react-dom".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react-dom",
+                "18.0.0",
+                serde_json::json!({
+                    "name": "react-dom",
+                    "version": "18.0.0",
+                    "peerDependencies": { "react": "^18.0.0" }
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "react": "17.0.0", "react-dom": "18.0.0" }));
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                auto_install_peers: false,
+                base_opts: ResolveOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_peers(&tree, ResolvePeersOptions::default());
+        assert!(result.peer_dependency_issues.bad.contains_key("react"));
+        let bad = &result.peer_dependency_issues.bad["react"];
+        assert_eq!(bad.len(), 1);
+        assert_eq!(bad[0].found_version, "17.0.0");
+        assert_eq!(bad[0].wanted_range, "^18.0.0");
+        // Peer-suffix uses the resolved (17.0.0) version — the install
+        // proceeds with the picked candidate.
+        assert_eq!(
+            result.direct_dependencies_by_alias.get("react-dom"),
+            Some(&DepPath::from("react-dom@18.0.0(react@17.0.0)".to_string())),
+        );
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -233,7 +233,7 @@ mod peers {
     use pretty_assertions::assert_eq;
 
     use super::{StubResolver, fake_manifest, fake_result};
-    use crate::dependencies_graph::DepPath;
+    use pacquet_deps_path::DepPath;
     use crate::resolve_dependency_tree::{ResolveDependencyTreeOptions, resolve_dependency_tree};
     use crate::resolve_peers::{ResolvePeersOptions, resolve_peers};
 
@@ -420,6 +420,68 @@ mod peers {
         assert_eq!(
             result.direct_dependencies_by_alias.get("react-dom"),
             Some(&DepPath::from("react-dom@18.0.0(react@17.0.0)".to_string())),
+        );
+    }
+
+    /// Regression test for the post-walk peer-edge patch. With manifest
+    /// order `{ react-dom: …, react: … }`, react-dom is walked before
+    /// react and the peer's depPath isn't known yet at the time
+    /// `graph_children` is built. The post-pass has to patch the edge
+    /// in so the install layer's recursion finds react when descending
+    /// into react-dom's slot.
+    #[tokio::test]
+    async fn peer_edge_is_patched_when_peer_walked_after_consumer() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("react-dom".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react-dom",
+                "18.0.0",
+                serde_json::json!({
+                    "name": "react-dom",
+                    "version": "18.0.0",
+                    "peerDependencies": { "react": "^18.0.0" }
+                }),
+            ),
+        );
+        table.insert(
+            ("react".to_string(), "18.0.0".to_string()),
+            fake_result(
+                "react",
+                "18.0.0",
+                serde_json::json!({ "name": "react", "version": "18.0.0" }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        // Manifest order puts react-dom first.
+        let (_tmp, manifest) = fake_manifest(
+            serde_json::json!({ "react-dom": "18.0.0", "react": "18.0.0" }),
+        );
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                auto_install_peers: false,
+                base_opts: ResolveOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_peers(&tree, ResolvePeersOptions::default());
+        let react_dom_dep_path = result
+            .direct_dependencies_by_alias
+            .get("react-dom")
+            .cloned()
+            .expect("react-dom is a direct dep");
+        let node = result.graph.get(&react_dom_dep_path).expect("graph entry for react-dom");
+        // Without the post-pass, this edge would be missing because
+        // `node_dep_paths` doesn't yet contain react when react-dom is
+        // being walked.
+        assert_eq!(
+            node.children.get("react"),
+            Some(&DepPath::from("react@18.0.0".to_string())),
         );
     }
 }


### PR DESCRIPTION
## Summary

Ports pnpm's [`resolvePeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolvePeers.ts) algorithm to pacquet's `resolving-deps-resolver` crate and wires it into `install_without_lockfile`. The depPath-keyed `DependenciesGraph` produced by the new stage replaces the flat `(name, version)` keying the install pass used to derive virtual-store slot names from, so two parents sharing the same package can now get different peer suffixes.

### What's new

- **`pacquet-deps-path` crate** — ports `@pnpm/deps.path` helpers: `create_peer_dep_graph_hash`, `dep_path_to_filename`, balanced-paren suffix scan (`index_of_dep_path_suffix` / `remove_suffix` / `get_pkg_id_with_patch_hash`), and the `PeerId` union (`Pair { name, version }` | `DepPath(String)`).

- **`resolving-deps-resolver` data-shape refactor**:
  - New `NodeId` newtype (monotonic counter) for per-occurrence tree identity, mirroring upstream's `nextNodeId`.
  - `ResolvedTree` now carries both the flat dedup map (`packages` keyed by `pkgIdWithPatchHash`) and the per-occurrence tree (`dependencies_tree` keyed by `NodeId`), plus `all_peer_dep_names`.
  - `ResolvedPackage` records `peer_dependencies` extracted with `peerDependenciesMeta` folding and `peerDependenciesWithoutOwn` filtering.
  - Cycles in the tree pass break by skipping the cycled edge entirely (`Ok(None)` from `resolve_node`), matching upstream's [`parentIdsContainSequence`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencyTree.ts#L378) gate in `buildTree`.

- **`resolve_peers` algorithm**:
  - `DependenciesGraph` keyed by `DepPath`, with children, transitive peer set, depth, and `is_pure`.
  - `ParentRefs` propagation — descend with parent + own-children view; resolve own peers against the parent view only.
  - Per-peer semver matching via `node-semver`, with `workspace:` prefix stripping, `*` shortcut, and a literal-equality fallback for unparseable ranges.
  - Missing / bad peer issue collection.
  - Transitive peer propagation — children's external peers fold into ancestors' peer suffixes.
  - Cycle handling via `in_progress` set + `name@version` fallback peer-id (synchronous analog of upstream's `analyzeGraph`-driven async deferment).

- **`install_without_lockfile` rewiring**: runs `resolve_dependency_tree → resolve_peers` and walks the `DependenciesGraph` by `DepPath`. Virtual-store slot names flow through `dep_path_to_filename`.

### Scope limits (explicit follow-ups)

- **`autoInstallPeers` keeps its existing fold behavior.** Upstream's [`hoistPeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/hoistPeers.ts) pre-pass is **not** ported in this PR — peer resolution itself runs regardless, but auto-installed peers don't get hoisted to the importer level yet, so their peer-suffix construction is limited until that lands.
- **Three correctness-preserving optimisations are skipped**, called out at the top of `resolve_peers.rs`:
  - `peersCache` (always recomputes)
  - `purePkgs` fast path (general path produces same answer)
  - `graph-cycles`-driven async deferment (replaced by sync `in_progress` set + name@version fallback)
- **Peer-issue rendering** — issues are logged via `tracing::warn!` for now; porting the issue renderer is its own slice.

## Test plan

- [x] `cargo nextest run --workspace` — **1608 passed, 3 skipped, 0 failed**
- [x] `cargo clippy --workspace --all-targets -- --deny warnings`
- [x] `cargo fmt --check`
- [x] `cargo check --workspace --all-targets`
- [x] `should_install_circular_dependencies` (cycle-break regression) passes
- [x] 18 new unit tests in `pacquet-deps-path` (helpers + balanced-paren scan)
- [x] 4 new tests in `resolving-deps-resolver::tests::peers`: pure package → depPath equals pkgId; peer resolved against sibling at parent level; missing peer is reported + node stays pure; bad peer version is reported + install still proceeds with picked candidate.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installs are now peer-aware, automatically resolving peers and driving installation.
  * Virtual store slot names are now stable and derived from dependency-paths for more reproducible installs.
  * New dependency-path utilities generate filesystem-safe names and compact peer-suffix hashes.
  * Improved detection and reporting of peer dependency issues with clearer diagnostics.

* **Tests**
  * Added unit and integration tests for peer resolution, dep-path formatting, naming, and truncation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->