### PR TITLE
fix(installing.commands): forward `pnpm install` flags to pacquet

### DIFF
--- a/.changeset/fix-pacquet-outdated-lockfile-on-update.md
+++ b/.changeset/fix-pacquet-outdated-lockfile-on-update.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed `pnpm up` (and `pnpm add` / `pnpm remove`) failing with `pacquet_package_manager::outdated_lockfile` when pacquet is declared in `configDependencies`. pnpm now passes `--ignore-manifest-check` to pacquet so its `--frozen-lockfile` check doesn't fire against the (pre-mutation) `package.json` pnpm hasn't written yet [#11797](https://github.com/pnpm/pnpm/issues/11797). Requires a pacquet release that supports the flag — bump `PACQUET_VERSION` in the e2e tests once it ships.

--- a/.changeset/forward-install-flags-to-pacquet.md
+++ b/.changeset/forward-install-flags-to-pacquet.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+When the install engine is delegated to pacquet via `configDependencies`, the user's CLI flags passed to `pnpm install` (e.g. `--no-runtime`, `--prod`, `--dev`, `--no-optional`, `--node-linker`, `--cpu`/`--os`/`--libc`, `--offline`, `--prefer-offline`) are now forwarded to pacquet's `install` subcommand verbatim. Previously pacquet was invoked with a fixed argument list, so flags like `--no-runtime` were silently dropped. Flag forwarding is gated on the command being `install`/`i`; `add`, `update`, and `dedupe` still don't forward (their flag surface doesn't line up with pacquet's `install`).

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -350,9 +350,9 @@ export type InstallCommandOptions = Pick<Config,
 | 'selectedProjectsGraph'
 > & CreateStoreControllerOptions & Partial<Pick<Config, 'globalPkgDir'>> & {
   argv: {
-    cooked: string[]
+    cooked?: string[]
     original: string[]
-    remain: string[]
+    remain?: string[]
   }
   fixLockfile?: boolean
   frozenLockfileIfExists?: boolean

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -350,7 +350,9 @@ export type InstallCommandOptions = Pick<Config,
 | 'selectedProjectsGraph'
 > & CreateStoreControllerOptions & Partial<Pick<Config, 'globalPkgDir'>> & {
   argv: {
+    cooked: string[]
     original: string[]
+    remain: string[]
   }
   fixLockfile?: boolean
   frozenLockfileIfExists?: boolean

--- a/installing/commands/src/install.ts
+++ b/installing/commands/src/install.ts
@@ -388,6 +388,7 @@ export async function handler (opts: InstallCommandOptions & { _calledFromLink?:
     include,
     includeDirect: include,
     fetchFullMetadata: getFetchFullMetadata(opts),
+    isInstallCommand: true,
   }
   if (opts.resolutionOnly) {
     installDepsOptions.lockfileOnly = true

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -160,6 +160,13 @@ export type InstallDepsOptions = Pick<Config,
   rebuildHandler?: CommandHandler
   pnpmfile: string[]
   packageVulnerabilityAudit?: PackageVulnerabilityAudit
+  /**
+   * `true` when this call originated from `pnpm install` (or `pnpm i`),
+   * `false`/`undefined` for `add`, `update`, `dedupe`, etc. Used to gate
+   * which pnpm CLI flags are safe to forward to pacquet's `install`
+   * subcommand — see `runPacquet.ts`'s `noRuntime` opt.
+   */
+  isInstallCommand?: boolean
 } & Partial<Pick<Config, 'pnpmHomeDir' | 'strictDepBuilds'>>
 
 export async function installDeps (
@@ -217,6 +224,7 @@ export async function installDeps (
       lockfileDir: opts.lockfileDir ?? opts.dir,
       packageName: pacquetConfigDepName,
       argv: opts.argv.original,
+      isInstallCommand: opts.isInstallCommand === true,
     })
     : undefined
   const includeDirect = opts.includeDirect ?? {

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -127,9 +127,9 @@ export type InstallDepsOptions = Pick<Config,
 > & Partial<Pick<Config, 'ci'>>
 & CreateStoreControllerOptions & {
   argv: {
-    cooked: string[]
+    cooked?: string[]
     original: string[]
-    remain: string[]
+    remain?: string[]
   }
   allowNew?: boolean
   forceFullResolution?: boolean
@@ -225,7 +225,7 @@ export async function installDeps (
     ? makeRunPacquet({
       lockfileDir: opts.lockfileDir ?? opts.dir,
       packageName: pacquetConfigDepName,
-      argv: opts.argv,
+      argv: { original: opts.argv.original, remain: opts.argv.remain ?? [] },
       isInstallCommand: opts.isInstallCommand === true,
     })
     : undefined

--- a/installing/commands/src/installDeps.ts
+++ b/installing/commands/src/installDeps.ts
@@ -127,7 +127,9 @@ export type InstallDepsOptions = Pick<Config,
 > & Partial<Pick<Config, 'ci'>>
 & CreateStoreControllerOptions & {
   argv: {
+    cooked: string[]
     original: string[]
+    remain: string[]
   }
   allowNew?: boolean
   forceFullResolution?: boolean
@@ -223,7 +225,7 @@ export async function installDeps (
     ? makeRunPacquet({
       lockfileDir: opts.lockfileDir ?? opts.dir,
       packageName: pacquetConfigDepName,
-      argv: opts.argv.original,
+      argv: opts.argv,
       isInstallCommand: opts.isInstallCommand === true,
     })
     : undefined

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -27,27 +27,37 @@ export interface MakeRunPacquetOpts {
    */
   packageName: 'pacquet' | '@pnpm/pacquet'
   /**
-   * The user's original `pnpm` argv (`process.argv.slice(2)`). Not
-   * forwarded to pacquet — we only inspect it to warn about flags
-   * pacquet won't see.
+   * The user's original `pnpm` argv (`process.argv.slice(2)`). When
+   * `isInstallCommand` is true the flags (everything after the
+   * `install`/`i` token) ride along to pacquet's own `install`
+   * subcommand verbatim; otherwise we only inspect it to warn about
+   * flags pacquet won't see.
    */
   argv: string[]
+  /**
+   * `true` when the user invoked `pnpm install` (or `pnpm i`). Gates
+   * flag forwarding: pacquet's `install` subcommand mirrors pnpm's
+   * surface closely enough that the user's flags are safe to pass
+   * along on that command, but not from `add`/`update`/`dedupe` (whose
+   * own flag surface doesn't line up with pacquet's `install`).
+   */
+  isInstallCommand: boolean
 }
 
 /**
  * Build the install-engine callback `mutateModules` invokes when
- * `configDependencies` declares pacquet. Returns `undefined` when no
- * pacquet binary is on disk — the caller falls back to the JS path in
- * that case.
+ * `configDependencies` declares pacquet.
  *
  * The callback spawns the pacquet binary installed under
- * `node_modules/.pnpm-config/pacquet` and forwards the user's own
- * pnpm CLI flags. Pacquet's NDJSON stderr is parsed line-by-line and
- * the valid JSON records are re-emitted on pnpm's global
- * `streamParser` so `@pnpm/cli.default-reporter` renders pacquet's
- * events the same way it renders pnpm's own. Non-JSON stderr lines
- * (panic backtraces, unexpected diagnostics) are forwarded to the
- * real stderr verbatim so they reach the user.
+ * `node_modules/.pnpm-config/pacquet`. From `pnpm install`/`pnpm i` it
+ * forwards the user's own pnpm CLI flags to pacquet's `install`
+ * subcommand; from `add`/`update`/`dedupe` it doesn't forward (warning
+ * instead). Pacquet's NDJSON stderr is parsed line-by-line and the
+ * valid JSON records are re-emitted on pnpm's global `streamParser` so
+ * `@pnpm/cli.default-reporter` renders pacquet's events the same way it
+ * renders pnpm's own. Non-JSON stderr lines (panic backtraces,
+ * unexpected diagnostics) are forwarded to the real stderr verbatim so
+ * they reach the user.
  */
 /** Args the deps-installer passes per pacquet invocation. */
 export interface RunPacquetCallOpts {
@@ -67,15 +77,18 @@ export interface RunPacquetCallOpts {
 export function makeRunPacquet (opts: MakeRunPacquetOpts): (callOpts?: RunPacquetCallOpts) => Promise<void> {
   return async (callOpts) => {
     const pacquetBin = resolvePacquetBin(opts.lockfileDir, opts.packageName)
-    // Always the same fixed args. We don't forward pnpm's CLI flags
-    // even though pacquet's `install` subcommand mirrors most of them:
-    // pnpm has commands like `add` and `update` that carry flags
-    // pacquet's `install` doesn't recognize (e.g., `--save-dev`,
-    // `--save-peer`), and clap would reject them. The settings users
-    // care about live in `pnpm-workspace.yaml` / `.npmrc`, which
-    // pacquet reads on its own.
-    const args = ['--reporter=ndjson', 'install', '--frozen-lockfile']
-    const droppedFlags = collectDroppedFlags(opts.argv)
+    // From `pnpm install`/`pnpm i` we forward the user's flags through to
+    // pacquet's own `install` subcommand verbatim — pacquet mirrors pnpm's
+    // surface closely enough on that command that they're safe to pass
+    // along. From `add`/`update`/`dedupe` we don't forward anything: those
+    // commands carry flags pacquet's `install` doesn't recognize
+    // (`--save-dev`, `--save-peer`, etc.) which clap would reject. Either
+    // way pacquet picks up the settings users care about from
+    // `pnpm-workspace.yaml` / `.npmrc` on its own, so a non-install
+    // delegation isn't broken by the omission.
+    const forwardedFlags = opts.isInstallCommand ? collectForwardedFlags(opts.argv) : []
+    const args = ['--reporter=ndjson', 'install', '--frozen-lockfile', ...forwardedFlags]
+    const droppedFlags = opts.isInstallCommand ? [] : collectDroppedFlags(opts.argv)
     if (droppedFlags.length > 0) {
       logger.warn({
         message: `The following CLI flags are not forwarded to pacquet and may not be honored: ${droppedFlags.join(' ')}. Move the equivalent settings into pnpm-workspace.yaml (or .npmrc for auth/registry) if pacquet needs them.`,
@@ -154,12 +167,33 @@ function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm
 }
 
 /**
- * Pull the CLI flags out of pnpm's argv so we can warn about them
- * before pacquet runs. We don't forward any of them — pacquet always
- * gets `install --frozen-lockfile --reporter=ndjson` — but most are
- * handled by pnpm itself before delegation (`--save-dev` rewrites
- * `package.json`, `--filter` selects projects, etc.) so listing them
- * to the user makes the "not forwarded" surface concrete.
+ * From `pnpm install`/`pnpm i`, return everything in argv that should
+ * ride along to pacquet's own `install` subcommand. That's every entry
+ * after the leading command-name token (`install` / `i` / nothing) —
+ * pacquet's clap parser walks the same `--prod`, `--dev`, `--no-optional`,
+ * `--no-runtime`, `--node-linker`, `--offline`, `--prefer-offline`,
+ * `--cpu`, `--os`, `--libc`, `--frozen-lockfile` surface pnpm itself
+ * accepts on `install`, so we don't reshape them.
+ *
+ * `--reporter=ndjson` is dropped if the user passed it explicitly: we
+ * always emit our own copy at the head of the args, and clap's
+ * "last-value-wins" parse for options-with-value would otherwise let a
+ * user-supplied `--reporter=...` override the one we depend on for
+ * NDJSON-to-streamParser plumbing.
+ */
+function collectForwardedFlags (argv: string[]): string[] {
+  const first = argv[0]
+  const flags = first === 'install' || first === 'i' ? argv.slice(1) : argv
+  return flags.filter((arg) => arg !== '--reporter=ndjson')
+}
+
+/**
+ * From a non-install command (`add`, `update`, `dedupe`, ...), pull the
+ * CLI flags out of pnpm's argv so we can warn that pacquet won't see
+ * them. They're still handled by pnpm itself before delegation
+ * (`--save-dev` rewrites `package.json`, `--filter` selects projects,
+ * etc.) so listing them to the user makes the "not forwarded" surface
+ * concrete.
  *
  * Flags we explicitly emit ourselves (`--frozen-lockfile`,
  * `--reporter=ndjson`) are filtered out: they're honored, so warning

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -193,20 +193,33 @@ function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm
  * surface pnpm itself accepts on `install`, so the flags don't need
  * reshaping.
  *
- * Flags we always inject ourselves (`--reporter=ndjson`,
- * `--frozen-lockfile`, `--ignore-manifest-check`) are dropped from
- * the forwarded set: clap rejects most of those as "used multiple
- * times", and even where it doesn't, a user-supplied
- * `--reporter=other` would override the one we depend on for
- * NDJSON-to-streamParser plumbing.
+ * Flags we always inject ourselves (`--frozen-lockfile`,
+ * `--ignore-manifest-check`) are dropped — clap rejects them as
+ * "used multiple times" otherwise. `--reporter` is stripped in any
+ * form (`--reporter=foo`, `--reporter foo`): pacquet's `reporter`
+ * is a clap value option with last-value-wins semantics, so a
+ * user-supplied value would override our `--reporter=ndjson` and
+ * break the NDJSON-to-streamParser plumbing the default reporter
+ * relies on.
  */
 function collectForwardedFlags (argv: { original: string[], remain: string[] }): string[] {
   const positionals = new Set(argv.remain)
-  return argv.original.filter((arg) => !positionals.has(arg) && !ALWAYS_INJECTED.has(arg))
+  const result: string[] = []
+  for (let i = 0; i < argv.original.length; i++) {
+    const arg = argv.original[i]
+    if (positionals.has(arg) || ALWAYS_INJECTED.has(arg)) continue
+    if (arg.startsWith('--reporter=')) continue
+    if (arg === '--reporter') {
+      // Consume the next token as the reporter value (`--reporter foo`).
+      i++
+      continue
+    }
+    result.push(arg)
+  }
+  return result
 }
 
 const ALWAYS_INJECTED = new Set([
-  '--reporter=ndjson',
   '--frozen-lockfile',
   '--ignore-manifest-check',
 ])

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -211,11 +211,18 @@ function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm
  * NDJSON-to-streamParser plumbing the default reporter relies on.
  */
 function collectForwardedFlags (argv: { original: string[], remain: string[] }): string[] {
-  const positionals = new Set(argv.remain)
   const result: string[] = []
+  // `argv.remain` is the ordered subsequence of positionals nopt
+  // extracted from `original`. Match by index rather than by value so
+  // an option's value that happens to equal a positional (e.g.
+  // `--node-linker install`) isn't mistaken for the positional itself.
+  let positionalIdx = 0
   for (let i = 0; i < argv.original.length; i++) {
     const arg = argv.original[i]
-    if (positionals.has(arg)) continue
+    if (positionalIdx < argv.remain.length && arg === argv.remain[positionalIdx]) {
+      positionalIdx++
+      continue
+    }
     if (isAlwaysInjected(arg)) continue
     if (arg.startsWith('--reporter=')) continue
     if (arg === '--reporter') {
@@ -246,17 +253,26 @@ function isAlwaysInjected (arg: string): boolean {
  * etc.) so listing them to the user makes the "not forwarded" surface
  * concrete.
  *
- * Flags we explicitly emit ourselves (`--frozen-lockfile`,
- * `--reporter=ndjson`) are filtered out: they're honored, so warning
- * about them would be misleading. `--config.*` is filtered too —
- * those configure pnpm's runtime and aren't intended for the install
- * engine.
+ * Flags pnpm itself honors before delegation are filtered out —
+ * warning about them would be misleading: `--frozen-lockfile` and
+ * `--ignore-manifest-check` in every shape (positive / negated /
+ * `=value`); `--reporter` in every shape (`--reporter=foo`,
+ * `--reporter foo`); and `--config.*` (configures pnpm's runtime,
+ * not the install engine).
  */
 function collectDroppedFlags (argv: { original: string[] }): string[] {
-  return argv.original.filter((arg) => {
-    if (!arg.startsWith('-')) return false
-    if (arg === '--frozen-lockfile' || arg === '--reporter=ndjson') return false
-    if (arg.startsWith('--config.')) return false
-    return true
-  })
+  const result: string[] = []
+  for (let i = 0; i < argv.original.length; i++) {
+    const arg = argv.original[i]
+    if (!arg.startsWith('-')) continue
+    if (isAlwaysInjected(arg)) continue
+    if (arg.startsWith('--config.')) continue
+    if (arg.startsWith('--reporter=')) continue
+    if (arg === '--reporter') {
+      i++
+      continue
+    }
+    result.push(arg)
+  }
+  return result
 }

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -87,7 +87,16 @@ export function makeRunPacquet (opts: MakeRunPacquetOpts): (callOpts?: RunPacque
     // `pnpm-workspace.yaml` / `.npmrc` on its own, so a non-install
     // delegation isn't broken by the omission.
     const forwardedFlags = opts.isInstallCommand ? collectForwardedFlags(opts.argv) : []
-    const args = ['--reporter=ndjson', 'install', '--frozen-lockfile', ...forwardedFlags]
+    // `--ignore-manifest-check` tells pacquet to skip its per-importer
+    // `package.json` ↔ `pnpm-lock.yaml` freshness gate. pnpm just
+    // resolved and wrote the lockfile itself; on `pnpm up` / `add` /
+    // `remove` the manifest on disk is still the pre-mutation copy
+    // (pnpm writes it after `mutateModules` returns), so pacquet's own
+    // check would always fire here. See
+    // https://github.com/pnpm/pnpm/issues/11797. The flag is narrow
+    // (only the manifest check); settings drift like `overrides` is
+    // still enforced and was already re-validated by pnpm.
+    const args = ['--reporter=ndjson', 'install', '--frozen-lockfile', '--ignore-manifest-check', ...forwardedFlags]
     const droppedFlags = opts.isInstallCommand ? [] : collectDroppedFlags(opts.argv)
     if (droppedFlags.length > 0) {
       logger.warn({

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -194,20 +194,29 @@ function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm
  * reshaping.
  *
  * Flags we always inject ourselves (`--frozen-lockfile`,
- * `--ignore-manifest-check`) are dropped — clap rejects them as
- * "used multiple times" otherwise. `--reporter` is stripped in any
- * form (`--reporter=foo`, `--reporter foo`): pacquet's `reporter`
- * is a clap value option with last-value-wins semantics, so a
- * user-supplied value would override our `--reporter=ndjson` and
- * break the NDJSON-to-streamParser plumbing the default reporter
- * relies on.
+ * `--ignore-manifest-check`) are dropped in every form the user can
+ * type them — positive (`--frozen-lockfile`), negated
+ * (`--no-frozen-lockfile`), and any `=value` form. Pacquet's clap
+ * defines these as plain `#[clap(long)] bool` flags, so a duplicate
+ * `--frozen-lockfile` or a conflicting `--no-frozen-lockfile`
+ * crashes the parser with "used multiple times" / "unexpected
+ * argument". The user's `--no-frozen-lockfile` intent is already
+ * honored upstream (pnpm did a fresh resolve before delegating);
+ * pacquet's role here is just lockfile-driven materialization.
+ *
+ * `--reporter` is stripped in any form (`--reporter=foo`,
+ * `--reporter foo`): pacquet's `reporter` is a clap value option
+ * with last-value-wins semantics, so a user-supplied value would
+ * override our `--reporter=ndjson` and break the
+ * NDJSON-to-streamParser plumbing the default reporter relies on.
  */
 function collectForwardedFlags (argv: { original: string[], remain: string[] }): string[] {
   const positionals = new Set(argv.remain)
   const result: string[] = []
   for (let i = 0; i < argv.original.length; i++) {
     const arg = argv.original[i]
-    if (positionals.has(arg) || ALWAYS_INJECTED.has(arg)) continue
+    if (positionals.has(arg)) continue
+    if (isAlwaysInjected(arg)) continue
     if (arg.startsWith('--reporter=')) continue
     if (arg === '--reporter') {
       // Consume the next token as the reporter value (`--reporter foo`).
@@ -219,10 +228,15 @@ function collectForwardedFlags (argv: { original: string[], remain: string[] }):
   return result
 }
 
-const ALWAYS_INJECTED = new Set([
-  '--frozen-lockfile',
-  '--ignore-manifest-check',
-])
+const ALWAYS_INJECTED_FLAGS = ['frozen-lockfile', 'ignore-manifest-check'] as const
+
+function isAlwaysInjected (arg: string): boolean {
+  for (const name of ALWAYS_INJECTED_FLAGS) {
+    if (arg === `--${name}` || arg === `--no-${name}`) return true
+    if (arg.startsWith(`--${name}=`) || arg.startsWith(`--no-${name}=`)) return true
+  }
+  return false
+}
 
 /**
  * From a non-install command (`add`, `update`, `dedupe`, ...), pull the

--- a/installing/commands/src/runPacquet.ts
+++ b/installing/commands/src/runPacquet.ts
@@ -27,13 +27,19 @@ export interface MakeRunPacquetOpts {
    */
   packageName: 'pacquet' | '@pnpm/pacquet'
   /**
-   * The user's original `pnpm` argv (`process.argv.slice(2)`). When
-   * `isInstallCommand` is true the flags (everything after the
-   * `install`/`i` token) ride along to pacquet's own `install`
-   * subcommand verbatim; otherwise we only inspect it to warn about
-   * flags pacquet won't see.
+   * The parsed pnpm argv from `@pnpm/cli.parse-cli-args` — `original`
+   * preserves the user's exact tokens (so `--key=value` stays joined,
+   * which pacquet's `--config.<key>=<value>` parser requires), and
+   * `remain` lists the positionals (the `install`/`i` command token
+   * among them). When `isInstallCommand` is true we forward
+   * `original` minus positionals to pacquet's own `install`
+   * subcommand; otherwise we only inspect it to warn about flags
+   * pacquet won't see.
    */
-  argv: string[]
+  argv: {
+    original: string[]
+    remain: string[]
+  }
   /**
    * `true` when the user invoked `pnpm install` (or `pnpm i`). Gates
    * flag forwarding: pacquet's `install` subcommand mirrors pnpm's
@@ -177,24 +183,33 @@ function resolvePacquetBin (lockfileDir: string, packageName: 'pacquet' | '@pnpm
 
 /**
  * From `pnpm install`/`pnpm i`, return everything in argv that should
- * ride along to pacquet's own `install` subcommand. That's every entry
- * after the leading command-name token (`install` / `i` / nothing) —
- * pacquet's clap parser walks the same `--prod`, `--dev`, `--no-optional`,
- * `--no-runtime`, `--node-linker`, `--offline`, `--prefer-offline`,
- * `--cpu`, `--os`, `--libc`, `--frozen-lockfile` surface pnpm itself
- * accepts on `install`, so we don't reshape them.
+ * ride along to pacquet's own `install` subcommand. Drops the
+ * positionals nopt classified (`install` / `i`, plus anything users
+ * typed positionally) since pacquet's `install` doesn't accept any —
+ * leaving them in produces `error: unexpected argument 'install'
+ * found`. Pacquet's clap parser walks the same `--prod`, `--dev`,
+ * `--no-optional`, `--no-runtime`, `--node-linker`, `--offline`,
+ * `--prefer-offline`, `--cpu`, `--os`, `--libc`, `--frozen-lockfile`
+ * surface pnpm itself accepts on `install`, so the flags don't need
+ * reshaping.
  *
- * `--reporter=ndjson` is dropped if the user passed it explicitly: we
- * always emit our own copy at the head of the args, and clap's
- * "last-value-wins" parse for options-with-value would otherwise let a
- * user-supplied `--reporter=...` override the one we depend on for
+ * Flags we always inject ourselves (`--reporter=ndjson`,
+ * `--frozen-lockfile`, `--ignore-manifest-check`) are dropped from
+ * the forwarded set: clap rejects most of those as "used multiple
+ * times", and even where it doesn't, a user-supplied
+ * `--reporter=other` would override the one we depend on for
  * NDJSON-to-streamParser plumbing.
  */
-function collectForwardedFlags (argv: string[]): string[] {
-  const first = argv[0]
-  const flags = first === 'install' || first === 'i' ? argv.slice(1) : argv
-  return flags.filter((arg) => arg !== '--reporter=ndjson')
+function collectForwardedFlags (argv: { original: string[], remain: string[] }): string[] {
+  const positionals = new Set(argv.remain)
+  return argv.original.filter((arg) => !positionals.has(arg) && !ALWAYS_INJECTED.has(arg))
 }
+
+const ALWAYS_INJECTED = new Set([
+  '--reporter=ndjson',
+  '--frozen-lockfile',
+  '--ignore-manifest-check',
+])
 
 /**
  * From a non-install command (`add`, `update`, `dedupe`, ...), pull the
@@ -210,8 +225,8 @@ function collectForwardedFlags (argv: string[]): string[] {
  * those configure pnpm's runtime and aren't intended for the install
  * engine.
  */
-function collectDroppedFlags (argv: string[]): string[] {
-  return argv.filter((arg) => {
+function collectDroppedFlags (argv: { original: string[] }): string[] {
+  return argv.original.filter((arg) => {
     if (!arg.startsWith('-')) return false
     if (arg === '--frozen-lockfile' || arg === '--reporter=ndjson') return false
     if (arg.startsWith('--config.')) return false

--- a/pnpm/test/install/pacquet.ts
+++ b/pnpm/test/install/pacquet.ts
@@ -11,7 +11,7 @@ import { execPnpm, execPnpmSync } from '../utils/index.js'
 // version known to ship the `configDependencies` integration surface this
 // PR depends on; tests are gated on the public registry being reachable.
 const PUBLIC_REGISTRY = '--config.registry=https://registry.npmjs.org/'
-const PACQUET_VERSION = '0.2.2-9'
+const PACQUET_VERSION = '0.2.2'
 
 // Each test runs two or three installs against the public registry; raise
 // the per-test timeout above jest's 5s default to allow for cold caches.

--- a/pnpm/test/install/pacquet.ts
+++ b/pnpm/test/install/pacquet.ts
@@ -126,9 +126,9 @@ test.skip('`pnpm update <pkg>` resolves a new version with pnpm and materializes
 
 // Skipped until pacquet ships a release built with the updated
 // `generate-packages.mjs` (this PR's change) so the `@pnpm/pacquet`
-// scoped alias actually exists on npm. The pinned `0.2.2-9` doesn't
-// publish that mirror yet. Re-enable when the next pacquet release
-// ships under both names.
+// scoped alias actually exists on npm. The pinned PACQUET_VERSION
+// above doesn't publish that mirror yet. Re-enable when the next
+// pacquet release ships under both names.
 test.skip('the `@pnpm/pacquet` scoped alias is recognized in configDependencies', async () => {
   await prepareWithPacquet({
     manifest: { dependencies: { 'is-positive': '3.1.0' } },


### PR DESCRIPTION
## Summary

When the install engine is delegated to pacquet via `configDependencies`, pnpm was hard-coding the args to `install --frozen-lockfile --reporter=ndjson` and silently dropping every other CLI flag. As a result, `pnpm install --no-runtime` still installed the workspace's runtime devDependency.

This surfaced as the `Verify Node version` failure on the `use-pacquet-config-dep` CI job for #11765: setup-pnpm provisions Node 24.0.0, then `pnpm install --no-runtime` runs through pacquet, pacquet doesn't see `--no-runtime`, and node 24.6.0 from devDependencies clobbers the runtime on `PATH`. See [the failing run](https://github.com/pnpm/pnpm/actions/runs/26171121477/job/76989744603?pr=11765).

Pacquet's `install` subcommand already mirrors pnpm's surface for the common flags (`--no-runtime`, `--prod`, `--dev`, `--no-optional`, `--node-linker`, `--offline`, `--prefer-offline`, `--cpu`/`--os`/`--libc`, `--frozen-lockfile`). Forward the user's argv verbatim when the command is `install`/`i`; `add`/`update`/`dedupe` still don't forward — their flag surfaces don't line up with pacquet's `install`.

## Changes

- `installing/commands/src/runPacquet.ts` — new `isInstallCommand` opt on `MakeRunPacquetOpts`. When true, `collectForwardedFlags()` strips the leading `install`/`i` token from argv and appends the rest to pacquet's args (dropping a user-supplied `--reporter=ndjson` so our own copy wins). The dropped-flags warning only fires on non-install commands.
- `installing/commands/src/installDeps.ts` — `isInstallCommand?: boolean` on `InstallDepsOptions`, threaded into `makeRunPacquet`.
- `installing/commands/src/install.ts` — handler sets `isInstallCommand: true`.

## Test plan

- [ ] Once this lands, rebase #11765 on top — the `ubuntu-latest / Node.js 24 / Test` job's `Verify Node version` step should pass (the warning `The following CLI flags are not forwarded to pacquet and may not be honored: --no-runtime` should disappear, and the workspace's `node 24.6.0` devDependency should no longer overwrite the setup-pnpm runtime).
- [ ] Existing `pnpm/test/install/pacquet.ts` suite still passes (no behavior change when no flags are passed).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures of pnpm up/add/remove when using pacquet so updates no longer error.

* **New Features**
  * pnpm install/i now forwards user install flags to pacquet, preserving selection, linker, platform and offline options.

* **Tests**
  * Updated pinned pacquet version in integration tests to align with the new install behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->