### PR TITLE
fix(pacquet/patching): apply patches without mutating the store

### DIFF
--- a/pacquet/crates/patching/src/apply.rs
+++ b/pacquet/crates/patching/src/apply.rs
@@ -343,12 +343,20 @@ fn apply_one_file(
 /// install) pre-seeded at our predicted temp path; on `AlreadyExists`
 /// the counter advances and we retry up to `MAX_TEMP_ATTEMPTS` times.
 ///
-/// `rename` is atomic on Unix and replaces in-place on Windows, so a
-/// crash mid-write leaves either the original file or the rewritten
-/// one — never an empty dirent. As a side effect, `rename` creates a
-/// fresh inode at `target`, breaking any hardlink the path previously
-/// shared with the content-addressable store; the store inode (and
-/// every other hardlink to it) stays untouched.
+/// `rename` is atomic on Unix and replaces in-place on Windows, so an
+/// IO failure mid-write leaves either the original file or the
+/// rewritten one — never an empty dirent. **This is atomic against IO
+/// errors, not against power loss**: we don't `fsync` the temp file
+/// or the parent directory, so a host crash between rename and the
+/// kernel's writeback flush can lose the rename. Matches upstream
+/// `@pnpm/patch-package`'s `fs.writeFileSync` semantics — Node's
+/// writeFileSync doesn't fsync either, and a partially-written patched
+/// install is recoverable by re-running `pnpm install` anyway.
+///
+/// As a side effect, `rename` creates a fresh inode at `target`,
+/// breaking any hardlink the path previously shared with the content-
+/// addressable store; the store inode (and every other hardlink to it)
+/// stays untouched.
 fn write_atomic_with_mode(
     target: &Path,
     content: &[u8],
@@ -388,9 +396,12 @@ fn write_atomic_with_mode(
             let _ = fs::remove_file(&tmp);
             return Err(error);
         }
-        // Close before chmod / rename so the kernel commits dirty
-        // buffers and Windows doesn't block the rename on the open
-        // handle (matches `save_lockfile::write_atomic`).
+        // Close before chmod / rename. Required on Windows: `MoveFileEx`
+        // over a still-open source handle fails with a sharing
+        // violation. Not strictly required on Unix but matches the
+        // pattern in `save_lockfile::write_atomic`. No `sync_all`: this
+        // routine is atomic against IO errors, not power loss — see
+        // the `fn` doc above.
         drop(file);
 
         if let Err(error) = fs::set_permissions(&tmp, permissions.clone()) {

--- a/pacquet/crates/patching/src/apply.rs
+++ b/pacquet/crates/patching/src/apply.rs
@@ -1,7 +1,10 @@
 use derive_more::{Display, Error};
 use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
 use miette::Diagnostic;
+use std::fs::{OpenOptions, Permissions};
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{fs, io};
 
 /// Error from [`apply_patch_to_dir`].
@@ -84,15 +87,21 @@ pub enum PatchApplyError {
 /// a file whose contents diverged from what the patch expects. A
 /// missing target on `Delete` is treated as already applied.
 ///
-/// `Modify` unlinks the target before writing the patched content,
-/// breaking any hardlink (or reflink) back to the content-addressable
-/// store. A plain truncating write would otherwise corrupt the store
-/// copy that every other snapshot of the same package shares, and
-/// leak patched content into sibling snapshots. The patched output
-/// lives in the side-effects cache after this call returns; nothing
-/// requires the store copy to carry it. The original mode is restored
-/// after the rewrite so patched shebang scripts in `bin/` keep their
-/// executable bit.
+/// `Modify` writes the patched content via a sibling temp file +
+/// `rename` (the same pattern
+/// [`pacquet_lockfile::save_lockfile::write_atomic`](../../lockfile/src/save_lockfile.rs)
+/// uses for the lockfile), which both makes the rewrite crash-safe
+/// — a failed write leaves the original on disk instead of an empty
+/// dirent — and breaks any hardlink (or reflink) back to the
+/// content-addressable store as a side effect of the rename creating
+/// a new dirent → inode mapping. A plain truncating write would
+/// otherwise corrupt the store copy that every other snapshot of the
+/// same package shares, and leak patched content into sibling
+/// snapshots. The patched output lives in the side-effects cache
+/// after this call returns; nothing requires the store copy to carry
+/// it. The temp file is chmoded to match the original before rename so
+/// patched shebang scripts in `bin/` keep their executable bit
+/// atomically — no window where the file has the wrong mode.
 ///
 /// Apply is **idempotent**: when forward apply fails, the patch is
 /// reverse-applied against the on-disk content. If the reverse
@@ -211,25 +220,31 @@ fn apply_one_file(
                     return Err(failed(format!("apply to {}: {source}", target.display())));
                 }
             };
-            // Break any hardlinks before writing. Files in
-            // `node_modules/.pnpm/<slot>/node_modules/<pkg>` are
-            // hardlinked (or reflinked, depending on import method) to
-            // the content-addressable store; a plain `fs::write`
-            // truncates and writes through the shared inode, which
-            // would (a) corrupt the on-disk store copy and (b) leak
-            // patched content into every other snapshot that linked
-            // the same file. `remove_file` unlinks only this dirent —
-            // the store inode (and any other hardlinks pointing at it)
-            // stays untouched. The patched output is captured by the
-            // side-effects cache after this returns; nothing requires
-            // the store copy to carry it.
-            fs::remove_file(&target)
-                .map_err(|source| failed(format!("unlink {}: {source}", target.display())))?;
-            fs::write(&target, updated)
+            // Stage the patched bytes in a sibling temp file, then
+            // atomically rename over the target. `rename` creates a new
+            // dirent → inode mapping at `target`, which both:
+            //
+            //   1. **Breaks the hardlink to the store.** Files in
+            //      `node_modules/.pnpm/<slot>/node_modules/<pkg>` are
+            //      hardlinked (or reflinked) from the content-
+            //      addressable store; a plain truncating `fs::write`
+            //      would mutate the shared inode, corrupting the store
+            //      copy and every other snapshot's hardlink to it. The
+            //      patched output is captured by the side-effects cache
+            //      after this returns; nothing requires the store copy
+            //      to carry it.
+            //   2. **Is crash-safe.** If the write fails after we've
+            //      unlinked the target, the package is broken until
+            //      reinstall — `unlink → write` would have that
+            //      window. With temp + rename, a mid-write failure
+            //      just leaves a stale temp file (cleaned up best-
+            //      effort) and the original target intact, so the next
+            //      install can retry from the same baseline.
+            //
+            // CodeRabbit flagged the prior `unlink → write` ordering
+            // during review of pnpm/pnpm#11782.
+            write_atomic_with_mode(&target, updated.as_bytes(), &permissions)
                 .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
-            fs::set_permissions(&target, permissions).map_err(|source| {
-                failed(format!("restore mode of {}: {source}", target.display()))
-            })?;
         }
         FileOperation::Create(path) => {
             let target = resolve_target(Path::new(path.as_ref()))?;
@@ -316,6 +331,84 @@ fn apply_one_file(
         }
     }
     Ok(())
+}
+
+/// Atomic write: stage `content` in a sibling temp file (with
+/// `permissions` applied before the rename so the final file has the
+/// right mode atomically), then `rename` over `target`. Mirrors the
+/// pattern in
+/// [`pacquet_lockfile::save_lockfile::write_atomic`](../../lockfile/src/save_lockfile.rs):
+/// `create_new(true)` rather than `create + truncate` so we never
+/// follow a symlink or truncate a file an attacker (or a crashed prior
+/// install) pre-seeded at our predicted temp path; on `AlreadyExists`
+/// the counter advances and we retry up to `MAX_TEMP_ATTEMPTS` times.
+///
+/// `rename` is atomic on Unix and replaces in-place on Windows, so a
+/// crash mid-write leaves either the original file or the rewritten
+/// one — never an empty dirent. As a side effect, `rename` creates a
+/// fresh inode at `target`, breaking any hardlink the path previously
+/// shared with the content-addressable store; the store inode (and
+/// every other hardlink to it) stays untouched.
+fn write_atomic_with_mode(
+    target: &Path,
+    content: &[u8],
+    permissions: &Permissions,
+) -> io::Result<()> {
+    /// Sixteen fresh counter values is plenty — under benign
+    /// conditions we never collide; under shared-store-across-
+    /// containers the chance of 16 consecutive same-pid same-counter
+    /// collisions is negligible. Matches the constant in
+    /// `pacquet_lockfile::save_lockfile::write_atomic`.
+    const MAX_TEMP_ATTEMPTS: usize = 16;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let pid = std::process::id();
+    let parent = target.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = target
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| String::from("patched"));
+
+    let mut last_already_exists: Option<io::Error> = None;
+    for _ in 0..MAX_TEMP_ATTEMPTS {
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = parent.join(format!(".{file_name}.{pid}.{counter}.pacquet-tmp"));
+
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&tmp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                last_already_exists = Some(error);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+
+        if let Err(error) = file.write_all(content) {
+            drop(file);
+            let _ = fs::remove_file(&tmp);
+            return Err(error);
+        }
+        // Close before chmod / rename so the kernel commits dirty
+        // buffers and Windows doesn't block the rename on the open
+        // handle (matches `save_lockfile::write_atomic`).
+        drop(file);
+
+        if let Err(error) = fs::set_permissions(&tmp, permissions.clone()) {
+            let _ = fs::remove_file(&tmp);
+            return Err(error);
+        }
+
+        return fs::rename(&tmp, target).inspect_err(|_| {
+            let _ = fs::remove_file(&tmp);
+        });
+    }
+
+    Err(last_already_exists.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "exhausted temp-path attempts for atomic patch write",
+        )
+    }))
 }
 
 #[cfg(test)]

--- a/pacquet/crates/patching/src/apply.rs
+++ b/pacquet/crates/patching/src/apply.rs
@@ -76,10 +76,26 @@ pub enum PatchApplyError {
 /// read, write, or delete outside the package directory.
 ///
 /// `Create` refuses to overwrite an existing file (matches `patch`
-/// and `git apply` semantics for `--- /dev/null` hunks). `Delete`
+/// and `git apply` semantics for `--- /dev/null` hunks) — unless the
+/// file already contains exactly the post-patch content, in which
+/// case the operation is treated as already applied. `Delete`
 /// validates the hunks via `diffy::apply` and only unlinks when the
 /// result is empty — a stale patch would otherwise silently delete
-/// a file whose contents diverged from what the patch expects.
+/// a file whose contents diverged from what the patch expects. A
+/// missing target on `Delete` is treated as already applied.
+///
+/// Apply is **idempotent**: when forward apply fails, the patch is
+/// reverse-applied against the on-disk content. If the reverse
+/// succeeds, the file is already in the post-patch state and the
+/// hunk is treated as no-op. Mirrors upstream
+/// [`@pnpm/patch-package`'s `applyPatch`](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts),
+/// which on failure retries `executeEffects(reversePatch(patch), { dryRun: true })`
+/// and returns success when the reverse cleanly verifies. Without
+/// this, a second `pnpm install` (or a parallel snapshot whose
+/// hardlinked store file has already been mutated by a sibling
+/// snapshot's apply) errors with `ERR_PNPM_PATCH_FAILED` "error
+/// applying hunk #1" even though the on-disk state already matches
+/// what the patch produces.
 pub fn apply_patch_to_dir(
     patched_dir: &Path,
     patch_file_path: &Path,
@@ -166,19 +182,43 @@ fn apply_one_file(
                 .patch()
                 .as_text()
                 .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
-            let updated = diffy::apply(&original, text_patch)
-                .map_err(|source| failed(format!("apply to {}: {source}", target.display())))?;
-            fs::write(&target, updated)
-                .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
+            match diffy::apply(&original, text_patch) {
+                Ok(updated) => fs::write(&target, updated)
+                    .map_err(|source| failed(format!("write {}: {source}", target.display())))?,
+                Err(_) if diffy::apply(&original, &text_patch.reverse()).is_ok() => {
+                    // File is already in the post-patch state — reverse
+                    // applies cleanly, so treat as no-op.
+                }
+                Err(source) => {
+                    return Err(failed(format!("apply to {}: {source}", target.display())));
+                }
+            }
         }
         FileOperation::Create(path) => {
             let target = resolve_target(Path::new(path.as_ref()))?;
+            let text_patch = file_patch
+                .patch()
+                .as_text()
+                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+            let created = diffy::apply("", text_patch)
+                .map_err(|source| failed(format!("create {}: {source}", target.display())))?;
             // A "new file" patch (`--- /dev/null`) means upstream
             // expects the target NOT to exist. Refusing to overwrite
             // matches `patch`'s and `git apply`'s behavior — silently
             // clobbering a real file would be a data-loss footgun if
             // the patch was authored against the wrong base.
+            //
+            // Idempotency exception: if the target already contains
+            // exactly the post-patch content, the patch has already
+            // been applied (e.g. a re-run) and we no-op. Matches
+            // upstream's reverse-dry-run check in
+            // `@pnpm/patch-package`'s `applyPatch`.
             if target.try_exists().unwrap_or(false) {
+                let existing = fs::read(&target)
+                    .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+                if String::from_utf8_lossy(&existing) == created {
+                    return Ok(());
+                }
                 return Err(failed(format!(
                     "cannot create {}: target already exists",
                     target.display(),
@@ -189,12 +229,6 @@ fn apply_one_file(
                     failed(format!("create parent of {}: {source}", target.display()))
                 })?;
             }
-            let text_patch = file_patch
-                .patch()
-                .as_text()
-                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
-            let created = diffy::apply("", text_patch)
-                .map_err(|source| failed(format!("create {}: {source}", target.display())))?;
             fs::write(&target, created)
                 .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
         }
@@ -209,8 +243,18 @@ fn apply_one_file(
             // Lossy UTF-8 decoding for the same reason as the
             // `Modify` branch above: match the patch-file reader
             // and Node's `fs.readFile(..., 'utf8')`.
-            let bytes = fs::read(&target)
-                .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            //
+            // Idempotency: a missing target means the file was
+            // already removed by an earlier apply of the same
+            // patch — treat as no-op. Matches upstream's
+            // reverse-dry-run check in `@pnpm/patch-package`.
+            let bytes = match fs::read(&target) {
+                Ok(b) => b,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+                Err(source) => {
+                    return Err(failed(format!("read {}: {source}", target.display())));
+                }
+            };
             let original = String::from_utf8_lossy(&bytes).into_owned();
             let text_patch = file_patch
                 .patch()

--- a/pacquet/crates/patching/src/apply.rs
+++ b/pacquet/crates/patching/src/apply.rs
@@ -84,18 +84,27 @@ pub enum PatchApplyError {
 /// a file whose contents diverged from what the patch expects. A
 /// missing target on `Delete` is treated as already applied.
 ///
+/// `Modify` unlinks the target before writing the patched content,
+/// breaking any hardlink (or reflink) back to the content-addressable
+/// store. A plain truncating write would otherwise corrupt the store
+/// copy that every other snapshot of the same package shares, and
+/// leak patched content into sibling snapshots. The patched output
+/// lives in the side-effects cache after this call returns; nothing
+/// requires the store copy to carry it. The original mode is restored
+/// after the rewrite so patched shebang scripts in `bin/` keep their
+/// executable bit.
+///
 /// Apply is **idempotent**: when forward apply fails, the patch is
 /// reverse-applied against the on-disk content. If the reverse
 /// succeeds, the file is already in the post-patch state and the
 /// hunk is treated as no-op. Mirrors upstream
 /// [`@pnpm/patch-package`'s `applyPatch`](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts),
 /// which on failure retries `executeEffects(reversePatch(patch), { dryRun: true })`
-/// and returns success when the reverse cleanly verifies. Without
-/// this, a second `pnpm install` (or a parallel snapshot whose
-/// hardlinked store file has already been mutated by a sibling
-/// snapshot's apply) errors with `ERR_PNPM_PATCH_FAILED` "error
-/// applying hunk #1" even though the on-disk state already matches
-/// what the patch produces.
+/// and returns success when the reverse cleanly verifies. Defense in
+/// depth against re-runs that find the directory pre-patched (a side-
+/// effects cache hit that fell through, manual edits, partial install
+/// recovery): the hardlink-break above prevents fresh installs from
+/// ever producing this state in the first place.
 pub fn apply_patch_to_dir(
     patched_dir: &Path,
     patch_file_path: &Path,
@@ -170,6 +179,15 @@ fn apply_one_file(
     match operation {
         FileOperation::Modify { modified, .. } => {
             let target = resolve_target(Path::new(modified.as_ref()))?;
+            // Capture the original mode so the rewritten file keeps
+            // it. `fs::write` after `fs::remove_file` creates a fresh
+            // inode whose mode is governed by the process umask, which
+            // would otherwise drop the executable bit on patched
+            // shebang scripts in `bin/`. Mirrors upstream's
+            // [`fs.writeFileSync(path, ..., { mode })`](https://github.com/ds300/patch-package/blob/master/src/patch/apply.ts).
+            let permissions = fs::metadata(&target)
+                .map(|m| m.permissions())
+                .map_err(|source| failed(format!("stat {}: {source}", target.display())))?;
             // Read as bytes and lossy-decode so non-UTF-8 bytes
             // turn into U+FFFD rather than failing the patch.
             // Matches how the patch file itself is read (see
@@ -182,17 +200,36 @@ fn apply_one_file(
                 .patch()
                 .as_text()
                 .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
-            match diffy::apply(&original, text_patch) {
-                Ok(updated) => fs::write(&target, updated)
-                    .map_err(|source| failed(format!("write {}: {source}", target.display())))?,
+            let updated = match diffy::apply(&original, text_patch) {
+                Ok(updated) => updated,
                 Err(_) if diffy::apply(&original, &text_patch.reverse()).is_ok() => {
                     // File is already in the post-patch state — reverse
                     // applies cleanly, so treat as no-op.
+                    return Ok(());
                 }
                 Err(source) => {
                     return Err(failed(format!("apply to {}: {source}", target.display())));
                 }
-            }
+            };
+            // Break any hardlinks before writing. Files in
+            // `node_modules/.pnpm/<slot>/node_modules/<pkg>` are
+            // hardlinked (or reflinked, depending on import method) to
+            // the content-addressable store; a plain `fs::write`
+            // truncates and writes through the shared inode, which
+            // would (a) corrupt the on-disk store copy and (b) leak
+            // patched content into every other snapshot that linked
+            // the same file. `remove_file` unlinks only this dirent —
+            // the store inode (and any other hardlinks pointing at it)
+            // stays untouched. The patched output is captured by the
+            // side-effects cache after this returns; nothing requires
+            // the store copy to carry it.
+            fs::remove_file(&target)
+                .map_err(|source| failed(format!("unlink {}: {source}", target.display())))?;
+            fs::write(&target, updated)
+                .map_err(|source| failed(format!("write {}: {source}", target.display())))?;
+            fs::set_permissions(&target, permissions).map_err(|source| {
+                failed(format!("restore mode of {}: {source}", target.display()))
+            })?;
         }
         FileOperation::Create(path) => {
             let target = resolve_target(Path::new(path.as_ref()))?;

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -511,6 +511,82 @@ diff --git a/file.txt b/file.txt
     assert_eq!(fs::read_to_string(fresh.path().join("file.txt")).unwrap(), already_patched);
 }
 
+/// `Modify` must NOT mutate any other hardlink pointing at the same
+/// inode. Pacquet's import layer hardlinks files from the content-
+/// addressable store into `node_modules/.pnpm/<slot>/node_modules/<pkg>`,
+/// so a plain truncating `fs::write` on the patched target would
+/// silently corrupt the store copy and leak patched content into every
+/// sibling snapshot that shares the same store inode. The fix is to
+/// unlink the target before writing — the rewritten file gets a fresh
+/// inode and the other hardlinks (the store, sibling snapshots) keep
+/// the original content. This was the root cause of the
+/// `error applying hunk #1` failure reported against pacquet's
+/// configDependencies preview engine for `msw@2.12.14`: worker A
+/// patched its slot's hardlink, mutating the store, and worker B
+/// then read already-patched content from its own hardlinked slot.
+#[cfg(unix)]
+#[test]
+fn modify_does_not_mutate_hardlinked_store_file() {
+    use std::os::unix::fs::MetadataExt;
+
+    // Simulate the store: one canonical file plus a hardlink into a
+    // package slot. They share an inode the way pacquet's link_file
+    // arranges it on filesystems where reflink isn't available.
+    let store = tempdir().unwrap();
+    let store_file = store.path().join("index.js");
+    fs::write(&store_file, IS_POSITIVE_INDEX_JS).unwrap();
+
+    let patched = tempdir().unwrap();
+    let slot_file = patched.path().join("index.js");
+    fs::hard_link(&store_file, &slot_file).unwrap();
+    assert_eq!(
+        fs::metadata(&slot_file).unwrap().ino(),
+        fs::metadata(&store_file).unwrap().ino(),
+        "test setup: slot must share inode with store"
+    );
+
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    // Slot has patched content.
+    assert_eq!(fs::read_to_string(&slot_file).unwrap(), IS_POSITIVE_INDEX_JS_PATCHED);
+    // Store copy is untouched.
+    assert_eq!(fs::read_to_string(&store_file).unwrap(), IS_POSITIVE_INDEX_JS);
+    // And the slot points at a new inode now — the unlink broke the
+    // shared-inode link cleanly.
+    assert_ne!(
+        fs::metadata(&slot_file).unwrap().ino(),
+        fs::metadata(&store_file).unwrap().ino(),
+        "slot must no longer share the store's inode after patching"
+    );
+}
+
+/// `Modify` must preserve the target file's mode. Without an explicit
+/// `set_permissions` after the unlink-then-write, the rewrite would
+/// take its mode from the process umask and silently drop the
+/// executable bit on patched shebang scripts under `bin/`.
+#[cfg(unix)]
+#[test]
+fn modify_preserves_executable_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("index.js");
+    fs::write(&target, IS_POSITIVE_INDEX_JS).unwrap();
+    // Mark the script executable, the way an npm-published bin entry
+    // would be.
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o755, "executable bit must be preserved across the rewrite");
+    assert_eq!(fs::read_to_string(&target).unwrap(), IS_POSITIVE_INDEX_JS_PATCHED);
+}
+
 /// Re-applying a Create patch over a file that already exists with the
 /// expected post-patch content is treated as no-op. A genuine
 /// pre-existing file with different content still errors (covered by

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -458,3 +458,106 @@ fn create_with_unwritable_parent_path_errors() {
         other => panic!("expected PatchFailed, got {other:?}"),
     }
 }
+
+/// Re-applying a Modify patch over a file that already contains the
+/// post-patch content must succeed (no-op), matching upstream
+/// `@pnpm/patch-package`'s
+/// [retry-with-reverse-in-dry-run](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts)
+/// idempotency. Triggers in practice when two snapshots of the same
+/// patched package share a hardlinked store file: the first apply
+/// mutates the store inode through the hardlink, so the second
+/// snapshot's apply sees already-patched content and would otherwise
+/// fail with "error applying hunk #1". Reported against pacquet's
+/// configDependencies preview engine for `msw@2.12.14`.
+///
+/// The patch substitutes one line (`old` → `new`) so forward apply
+/// against the already-patched file fails to find the `-old` context
+/// line — the case that exercises the reverse-apply idempotency
+/// branch. A purely additive patch wouldn't reach the reverse
+/// branch: diffy's fuzz matching shifts the insertion point and
+/// double-applies the addition, producing duplicate content.
+#[test]
+fn modify_on_already_patched_file_is_noop() {
+    let original = "alpha\nbravo\nold\ndelta\necho\n";
+    let already_patched = "alpha\nbravo\nnew\ndelta\necho\n";
+    let patch_text = "\
+diff --git a/file.txt b/file.txt
+--- a/file.txt
++++ b/file.txt
+@@ -1,5 +1,5 @@
+ alpha
+ bravo
+-old
++new
+ delta
+ echo
+";
+
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("file.txt"), already_patched).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), patch_text);
+
+    apply_patch_to_dir(patched.path(), &patch).expect("re-apply must succeed");
+
+    // Content stays at the post-patch state — we didn't double-patch.
+    let after = fs::read_to_string(patched.path().join("file.txt")).unwrap();
+    assert_eq!(after, already_patched);
+
+    // Sanity: a fresh file at the original state still applies normally.
+    let fresh = tempdir().unwrap();
+    fs::write(fresh.path().join("file.txt"), original).unwrap();
+    apply_patch_to_dir(fresh.path(), &patch).expect("fresh apply must succeed");
+    assert_eq!(fs::read_to_string(fresh.path().join("file.txt")).unwrap(), already_patched);
+}
+
+/// Re-applying a Create patch over a file that already exists with the
+/// expected post-patch content is treated as no-op. A genuine
+/// pre-existing file with different content still errors (covered by
+/// [`create_on_existing_file_errors`]).
+#[test]
+fn create_on_already_created_file_with_matching_content_is_noop() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("created.txt");
+    fs::write(&target, "first line\nsecond line\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/created.txt b/created.txt
+new file mode 100644
+--- /dev/null
++++ b/created.txt
+@@ -0,0 +1,2 @@
++first line
++second line
+",
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("re-apply must succeed");
+    assert_eq!(fs::read_to_string(&target).unwrap(), "first line\nsecond line\n");
+}
+
+/// Re-applying a Delete patch when the target is already gone is a
+/// no-op. Mirrors upstream's `@pnpm/patch-package` reverse-dry-run
+/// idempotency: re-running `pnpm install` after a previously
+/// successful delete must not error.
+#[test]
+fn delete_on_already_deleted_file_is_noop() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        "\
+diff --git a/to-delete.txt b/to-delete.txt
+deleted file mode 100644
+--- a/to-delete.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-going away
+",
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("re-apply must succeed");
+    assert!(!patched.path().join("to-delete.txt").exists());
+}

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -542,7 +542,7 @@ fn modify_does_not_mutate_hardlinked_store_file() {
     assert_eq!(
         fs::metadata(&slot_file).unwrap().ino(),
         fs::metadata(&store_file).unwrap().ino(),
-        "test setup: slot must share inode with store"
+        "test setup: slot must share inode with store",
     );
 
     let patch_dir = tempdir().unwrap();
@@ -558,7 +558,7 @@ fn modify_does_not_mutate_hardlinked_store_file() {
     assert_ne!(
         fs::metadata(&slot_file).unwrap().ino(),
         fs::metadata(&store_file).unwrap().ino(),
-        "slot must no longer share the store's inode after patching"
+        "slot must no longer share the store's inode after patching",
     );
 }
 

--- a/pacquet/crates/patching/src/apply/tests.rs
+++ b/pacquet/crates/patching/src/apply/tests.rs
@@ -587,6 +587,45 @@ fn modify_preserves_executable_mode() {
     assert_eq!(fs::read_to_string(&target).unwrap(), IS_POSITIVE_INDEX_JS_PATCHED);
 }
 
+/// `Modify` must NOT destroy the target when the rewrite can't finish.
+/// Simulate the write failure by making the patched directory read-
+/// only after staging the target: the temp file open fails with
+/// `PermissionDenied`, and the original target must still be on disk
+/// with its original content. Mirrors the crash-safety guarantee of
+/// the atomic-replace pattern in
+/// [`pacquet_lockfile::save_lockfile::write_atomic`](../../lockfile/src/save_lockfile.rs).
+/// CodeRabbit flagged the prior `unlink → write` ordering as a
+/// data-loss risk during review of pnpm/pnpm#11782.
+#[cfg(unix)]
+#[test]
+fn modify_does_not_destroy_target_on_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("index.js");
+    fs::write(&target, IS_POSITIVE_INDEX_JS).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+
+    // Make the directory read-only so the sibling temp file open in
+    // `write_atomic_with_mode` fails with `PermissionDenied`.
+    let dir_mode = fs::metadata(patched.path()).unwrap().permissions().mode();
+    fs::set_permissions(patched.path(), fs::Permissions::from_mode(0o555)).unwrap();
+
+    let err = apply_patch_to_dir(patched.path(), &patch);
+
+    // Restore write perms so tempdir cleanup works.
+    fs::set_permissions(patched.path(), fs::Permissions::from_mode(dir_mode)).unwrap();
+
+    err.expect_err("apply must surface the write failure");
+    // The crucial invariant: the original target survives untouched.
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        IS_POSITIVE_INDEX_JS,
+        "target must NOT be destroyed when the rewrite can't finish",
+    );
+}
+
 /// Re-applying a Create patch over a file that already exists with the
 /// expected post-patch content is treated as no-op. A genuine
 /// pre-existing file with different content still errors (covered by


### PR DESCRIPTION
## Summary

Reported against pacquet's configDependencies preview engine for `msw@2.12.14`: install fails with `ERR_PNPM_PATCH_FAILED ... error applying hunk #1` even though the patch is perfectly valid. Original report (patch file + error log): [Stanzilla/21648ae644068c3aef3d18693c7c32c9](https://gist.github.com/Stanzilla/21648ae644068c3aef3d18693c7c32c9).

**Root cause.** When two snapshots of the same patched package hardlink (or reflink, where the filesystem doesn't break-on-write) from the same store file, pacquet's `apply_patch_to_dir` did a plain `fs::write` — which truncates and writes through the shared inode, **corrupting the on-disk store copy** and leaking patched content into every other snapshot that linked the same file. The next worker then read already-patched content and `diffy::apply` failed on the missing `-` lines. The patched output already lives in the side-effects cache after apply returns, so nothing requires the store copy to carry it.

The fix is three layered changes to `apply_patch_to_dir`:

- **Atomic temp + rename for Modify** ([apply.rs](pacquet/crates/patching/src/apply.rs)). Stage the patched bytes in a sibling `.{name}.{pid}.{counter}.pacquet-tmp` opened with `create_new(true)` (no symlink-follow, no truncation of an attacker-pre-seeded path), chmod the temp to match the original *before* the rename so the final mode lands atomically, then `fs::rename` over the target. `rename` is atomic on Unix and replaces in-place on Windows, so an IO failure mid-write leaves either the original or the rewritten file — never an empty dirent. As a side effect of creating a new dirent → inode mapping, it also breaks any hardlink the path previously shared with the store. Matches the [`pacquet_lockfile::save_lockfile::write_atomic`](pacquet/crates/lockfile/src/save_lockfile.rs) pattern.
- **Idempotency via reverse-dry-run** (Modify/Create/Delete). When forward apply fails, try reverse-apply against the on-disk content; if it succeeds the file is already in the post-patch state and we no-op. Mirrors upstream [`@pnpm/patch-package`'s `applyPatch`](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts) which retries `executeEffects(reversePatch, { dryRun: true })` on failure. Defense in depth for re-runs that find the directory pre-patched (side-effects-cache hit that fell through, manual edits, partial install recovery) — the hardlink-break above prevents fresh installs from ever producing that state.
- **Idempotency for Create and Delete**. Create skips when the existing file already contains the post-patch content; Delete treats `NotFound` on the target as already-deleted.

Equivalent fix for the TS pnpm CLI side is in [`pnpm/patch-package@c97a62e`](https://github.com/pnpm/patch-package/commit/c97a62e) (`@pnpm/patch-package` is the apply implementation pnpm imports); pnpm will pick it up once that package is released and the dep gets bumped.

## Test plan

- [x] `cargo nextest run -p pacquet-patching` (57/57 pass, including 5 new tests: hardlink-corruption regression, executable-mode preservation, write-failure crash safety, and Modify/Create/Delete idempotency)
- [x] `cargo check --locked --workspace --all-targets`
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings`
- [x] `cargo fmt` + `taplo format`
- [x] End-to-end reproduction with the real MSW patch + multiple package directories hardlinked from a shared store file: both patches succeed, original store inode stays untouched (`ls -li` confirms separate inodes after apply, store retains pre-patch bytes)
- [ ] CI

> [!NOTE]
> The Modify idempotency test uses a substitution patch (`-old`/`+new`) rather than a purely-additive one. With a purely-additive patch, `diffy`'s fuzz matching shifts the insertion point and incorrectly "succeeds" on already-patched content (double-applying), so the reverse-apply branch is never reached. Substitution patches reach the reverse branch reliably and exercise the actual code path that fires on the user's MSW report.

> [!NOTE]
> The atomic temp + rename is atomic against IO errors, **not** power loss — we don't `fsync` the temp file or the parent directory. Matches upstream `@pnpm/patch-package`, which uses Node's `fs.writeFileSync` and doesn't `fsync` either; a partially-written patched install is recoverable by re-running `pnpm install` anyway.

---
Written by an agent (Claude Code, claude-opus-4-7).
