### PR TITLE
fix(pacquet/lockfile): accept non-semver version slots (URLs, git refs)

### DIFF
--- a/pacquet/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/load_lockfile/tests.rs
@@ -1,4 +1,6 @@
-use crate::{DirectoryResolution, Lockfile, LockfileResolution, PackageKey};
+use crate::{
+    DirectoryResolution, ImporterDepVersion, Lockfile, LockfileResolution, PackageKey, PkgName,
+};
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 use text_block_macros::text_block;
@@ -155,4 +157,61 @@ fn reconstructs_dropped_directory_resolution_for_pruned_file_peer_variant() {
             "tarball `{tarball_key}` must not get a synthesized directory resolution",
         );
     }
+}
+
+/// Regression for [pnpm/pnpm#11776](https://github.com/pnpm/pnpm/issues/11776):
+/// a lockfile whose importer dependency version is a GitHub codeload
+/// tarball URL used to crash the loader with `Failed to parse the
+/// version part: Failed to parse version`. The URL is the upstream
+/// `nonSemverVersion` shape and must round-trip through the loader as
+/// an `ImporterDepVersion::Regular` with a non-semver version slot,
+/// plus parse as a `packages:` / `snapshots:` key under the same URL.
+#[test]
+fn loads_importer_dep_with_codeload_tarball_url_version() {
+    let url = "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/0848bc83347720c322c5087f3bd0d6cd086ffa4b";
+    let yaml = format!(
+        "\
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      libsignal:
+        specifier: {url}
+        version: {url}
+
+packages:
+
+  libsignal@{url}:
+    resolution: {{tarball: {url}}}
+    version: 2.0.1
+
+snapshots:
+
+  libsignal@{url}: {{}}
+"
+    );
+    let tmp = write_lockfile(&yaml);
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+    let lockfile = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("load codeload-url lockfile")
+        .expect("codeload-url lockfile should be present");
+
+    let importer = lockfile.root_project().expect("root importer present");
+    let deps = importer.dependencies.as_ref().expect("importer has dependencies");
+    let libsignal_name: PkgName = "libsignal".parse().expect("parse libsignal name");
+    let spec = deps.get(&libsignal_name).expect("libsignal dep present");
+    assert_eq!(spec.specifier, url);
+    let regular = match &spec.version {
+        ImporterDepVersion::Regular(ver_peer) => ver_peer,
+        other => panic!("expected Regular, got {other:?}"),
+    };
+    assert_eq!(regular.to_string(), url);
+
+    let key: PackageKey = format!("libsignal@{url}").parse().expect("parse package key");
+    let packages = lockfile.packages.as_ref().expect("packages present");
+    assert!(packages.contains_key(&key));
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots present");
+    assert!(snapshots.contains_key(&key));
 }

--- a/pacquet/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pacquet/crates/lockfile/src/load_lockfile/tests.rs
@@ -190,7 +190,7 @@ packages:
 snapshots:
 
   libsignal@{url}: {{}}
-"
+",
     );
     let tmp = write_lockfile(&yaml);
     let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -57,7 +57,7 @@ impl PkgNameVerPeer {
         let bare_input = format!("{}{}", prefix, self.suffix.version());
         let bare = bare_input
             .parse::<PkgVerPeer>()
-            .expect("a prefix + bare semver version is always a valid PkgVerPeer");
+            .expect("a prefix + the displayed version is always a valid PkgVerPeer");
         PkgNameVerPeer::new(self.name.clone(), bare)
     }
 }

--- a/pacquet/crates/lockfile/src/pkg_ver_peer.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer.rs
@@ -3,14 +3,23 @@ use node_semver::{SemverError, Version};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt, str::FromStr};
 
-/// Version slot of a [`PkgVerPeer`]: either a semver, or the raw
-/// path of an injected workspace `file:<path>` dep. Mirrors pnpm's
+/// Version slot of a [`PkgVerPeer`]: a semver, the raw path of an
+/// injected workspace `file:<path>` dep, or an opaque non-semver
+/// reference (typically a tarball or git URL). Mirrors pnpm's
 /// `parseDepPath` `nonSemverVersion` arm in `packages/deps.path/src`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum VersionPart {
     Semver(Version),
     /// Path portion of a `file:<path>` dep, scheme stripped.
     File(String),
+    /// Non-semver reference preserved verbatim. Pnpm writes the raw
+    /// reference (e.g. a `https://codeload.github.com/...` tarball URL,
+    /// a `git+...` URL, or a custom resolution id) into the version
+    /// slot of importer entries and `packages:` / `snapshots:` keys
+    /// when no semver applies. Pacquet preserves the string so the
+    /// lockfile round-trips byte-for-byte and downstream resolvers
+    /// can inspect it.
+    NonSemver(String),
 }
 
 impl fmt::Display for VersionPart {
@@ -18,6 +27,7 @@ impl fmt::Display for VersionPart {
         match self {
             VersionPart::Semver(version) => version.fmt(f),
             VersionPart::File(path) => write!(f, "file:{path}"),
+            VersionPart::NonSemver(raw) => f.write_str(raw),
         }
     }
 }
@@ -100,7 +110,7 @@ impl PkgVerPeer {
     pub fn version_semver(&self) -> Option<&'_ Version> {
         match &self.version {
             VersionPart::Semver(version) => Some(version),
-            VersionPart::File(_) => None,
+            VersionPart::File(_) | VersionPart::NonSemver(_) => None,
         }
     }
 
@@ -145,10 +155,16 @@ fn parse_version_part(input: &str) -> Result<VersionPart, ParsePkgVerPeerError> 
         }
         return Ok(VersionPart::File(path.to_string()));
     }
-    input
-        .parse::<Version>()
-        .map(VersionPart::Semver)
-        .map_err(ParsePkgVerPeerError::ParseVersionFailure)
+    // Upstream's `parse` in `deps/path/src/index.ts` (pnpm@1819226b51)
+    // falls back to `nonSemverVersion` whenever `semver.valid` rejects
+    // the version, so tarball / git URLs and other custom resolution
+    // ids in the version slot still parse. Mirror that here — only an
+    // empty body is a hard error.
+    match input.parse::<Version>() {
+        Ok(version) => Ok(VersionPart::Semver(version)),
+        Err(err) if input.is_empty() => Err(ParsePkgVerPeerError::ParseVersionFailure(err)),
+        Err(_) => Ok(VersionPart::NonSemver(input.to_string())),
+    }
 }
 
 impl FromStr for PkgVerPeer {

--- a/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -65,7 +65,6 @@ fn parse_err() {
     case!("1.21.3(@types/react@17.0.49)(react-dom@17.0.2)(react@17.0.2" => "Mismatch parenthesis", ParsePkgVerPeerError::MismatchParenthesis);
     case!("1.21.3(" => "Mismatch parenthesis", ParsePkgVerPeerError::MismatchParenthesis);
     case!("1.21.3)" => "Mismatch parenthesis", ParsePkgVerPeerError::MismatchParenthesis);
-    case!("a.b.c" => "Failed to parse the version part: Failed to parse version.", ParsePkgVerPeerError::ParseVersionFailure(_));
     case!("file:" => "Empty path after `file:` scheme", ParsePkgVerPeerError::EmptyFilePath);
     case!("runtime:file:packages/pkg" => "`runtime:` and `file:` schemes are mutually exclusive", ParsePkgVerPeerError::ConflictingSchemes);
 }
@@ -221,4 +220,47 @@ fn serde_round_trip_file_prefix() {
     assert_eq!(parsed.version(), &VersionPart::File("packages/pkg".to_string()));
     let serialized = serde_saphyr::to_string(&parsed).expect("serialize").trim().to_string();
     assert_eq!(serialized, "file:packages/pkg(peer@1.0.0)");
+}
+
+/// Pnpm writes a GitHub codeload tarball URL into the version slot of
+/// an importer entry when the dependency was specified by URL (the
+/// reproduction shape in pnpm/pnpm#11776). The URL has no parentheses
+/// and isn't a valid semver, so it falls through to the non-semver
+/// branch and round-trips verbatim.
+#[test]
+fn parse_codeload_tarball_url_round_trips() {
+    let url = "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/0848bc83347720c322c5087f3bd0d6cd086ffa4b";
+    let parsed: PkgVerPeer = url.parse().expect("parse codeload tarball url");
+    assert_eq!(parsed.prefix(), Prefix::None);
+    assert_eq!(parsed.version(), &VersionPart::NonSemver(url.to_string()));
+    assert_eq!(parsed.version_semver(), None);
+    assert_eq!(parsed.peer(), "");
+    assert_eq!(parsed.to_string(), url);
+}
+
+/// A non-semver version slot composes with the parenthesised peer
+/// suffix the same way `file:` and `runtime:` shapes do — the version
+/// is everything before the first `(`, the suffix is everything from
+/// the first `(` to the trailing `)`.
+#[test]
+fn parse_non_semver_with_peer_suffix() {
+    let parsed: PkgVerPeer =
+        "https://example.com/foo.tgz(peer@1.0.0)".parse().expect("parse non-semver with peer");
+    assert_eq!(parsed.prefix(), Prefix::None);
+    assert_eq!(
+        parsed.version(),
+        &VersionPart::NonSemver("https://example.com/foo.tgz".to_string())
+    );
+    assert_eq!(parsed.peer(), "(peer@1.0.0)");
+    assert_eq!(parsed.to_string(), "https://example.com/foo.tgz(peer@1.0.0)");
+}
+
+#[test]
+fn serde_round_trip_non_semver() {
+    let url = "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/0848bc83347720c322c5087f3bd0d6cd086ffa4b";
+    let parsed: PkgVerPeer = serde_saphyr::from_str(url).expect("deserialize non-semver");
+    assert_eq!(parsed.version(), &VersionPart::NonSemver(url.to_string()));
+    let serialized = serde_saphyr::to_string(&parsed).expect("serialize");
+    let round_trip: PkgVerPeer = serde_saphyr::from_str(&serialized).expect("deserialize back");
+    assert_eq!(round_trip, parsed);
 }

--- a/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -249,7 +249,7 @@ fn parse_non_semver_with_peer_suffix() {
     assert_eq!(parsed.prefix(), Prefix::None);
     assert_eq!(
         parsed.version(),
-        &VersionPart::NonSemver("https://example.com/foo.tgz".to_string())
+        &VersionPart::NonSemver("https://example.com/foo.tgz".to_string()),
     );
     assert_eq!(parsed.peer(), "(peer@1.0.0)");
     assert_eq!(parsed.to_string(), "https://example.com/foo.tgz(peer@1.0.0)");

--- a/pacquet/crates/lockfile/src/resolved_dependency/tests.rs
+++ b/pacquet/crates/lockfile/src/resolved_dependency/tests.rs
@@ -161,16 +161,31 @@ fn ver_peer_returns_snapshot_version_for_each_variant() {
     assert!(link.ver_peer().is_none());
 }
 
-/// Garbage input that is not `link:`, not an alias shape, and not
-/// a valid semver-with-peer surfaces as the bare-parse variant of
-/// the error. The wrapped error keeps the original value for
-/// diagnostics.
+/// A bare version that doesn't parse as semver but is otherwise
+/// well-formed (no mismatched parens) is accepted as a non-semver
+/// reference, mirroring upstream's `nonSemverVersion` fallback. The
+/// reproduction case from pnpm/pnpm#11776 is a `https://codeload...`
+/// tarball URL.
 #[test]
-fn parse_errors_on_invalid_bare_version() {
-    let err = "not a version".parse::<ImporterDepVersion>().unwrap_err();
+fn parses_non_semver_url_version() {
+    let url = "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/0848bc83347720c322c5087f3bd0d6cd086ffa4b";
+    let parsed: ImporterDepVersion = url.parse().unwrap();
+    let regular = parsed.as_regular().expect("regular variant");
+    assert_eq!(regular.to_string(), url);
+    let serialized: String = parsed.into();
+    assert_eq!(serialized, url);
+}
+
+/// A bare version with mismatched parentheses still surfaces as the
+/// `Parse` variant of the error so the lockfile reader rejects
+/// structurally broken values rather than silently treating them as
+/// non-semver references.
+#[test]
+fn parse_errors_on_mismatched_parens() {
+    let err = "1.21.3(".parse::<ImporterDepVersion>().unwrap_err();
     match err {
         ParseImporterDepVersionError::Parse { value, .. } => {
-            assert_eq!(value, "not a version");
+            assert_eq!(value, "1.21.3(");
         }
         other => panic!("expected Parse variant, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

- pacquet's `PkgVerPeer` parser used to error on any version slot that wasn't a semver or a `file:` path, so a lockfile whose importer (or `packages:` / `snapshots:` key) recorded a tarball URL — e.g. `https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/<sha>` — failed to load with `Failed to parse importer dependency version "https://codeload...": Failed to parse the version part: Failed to parse version.`
- Upstream pnpm's [`parse` in `deps/path/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/deps/path/src/index.ts#L120-L167) routes anything `semver.valid` rejects to a `nonSemverVersion` branch. This PR mirrors that fallback: a new `VersionPart::NonSemver(String)` variant preserves the raw string, the parser falls through to it only on a non-empty semver-parse failure, and `Display` / `serde` round-trip byte-stable.
- Adds unit tests for the new branch and a loader-level regression that mirrors the issue's lockfile shape (codeload URL in both the importer's `version:` and the package/snapshot key).

Closes #11776.

## Out of scope

The reproduction install still fails after this PR at a separate, downstream check: pacquet's `MissingTarballIntegrity` error refuses tarball resolutions without an `integrity` field, but pnpm omits `integrity` for git-hosted tarballs and computes it post-download in [`gitHostedTarballFetcher.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/fetching/tarball-fetcher/src/gitHostedTarballFetcher.ts#L14-L48). Worth its own bug + fix; flagging here so reviewers don't expect `--frozen-lockfile install` to succeed end-to-end on the reproduction repo yet.

## Test plan

- [x] `cargo nextest run -p pacquet-lockfile` (145 tests pass; includes 4 new ones)
- [x] `cargo nextest run --workspace` (1722 tests pass)
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo dylint --all -- -p pacquet-lockfile`
- [x] Built `target/release/pacquet` and ran `pacquet install --frozen-lockfile` against the [reproduction repo](https://github.com/schickling-repros/2026-05-pnpm-pacquet-github-tarball); the parse error is gone (next failure is the unrelated `MissingTarballIntegrity` noted above).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lockfiles now accept and preserve non-semantic dependency versions (e.g., tarball/git URL forms) alongside semver.
* **Bug Fixes**
  * Non-semver dependency strings round-trip exactly and are treated distinctly from semver.
  * Improved parsing to avoid misclassifying file/non-semver versions.
* **Tests**
  * Added regression and unit tests covering non-semver parsing, serialization, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->