### PR TITLE
feat(pacquet): port blockExoticSubdeps to reject exotic subdeps

### DIFF
--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -144,6 +144,7 @@ impl WorkspaceSettings {
         json_field!(dedupe_peer_dependents, "DEDUPE_PEER_DEPENDENTS");
         json_field!(strict_peer_dependencies, "STRICT_PEER_DEPENDENCIES");
         json_field!(resolve_peers_from_workspace_root, "RESOLVE_PEERS_FROM_WORKSPACE_ROOT");
+        json_field!(block_exotic_subdeps, "BLOCK_EXOTIC_SUBDEPS");
         json_field!(verify_store_integrity, "VERIFY_STORE_INTEGRITY");
         json_field!(side_effects_cache, "SIDE_EFFECTS_CACHE");
         json_field!(side_effects_cache_readonly, "SIDE_EFFECTS_CACHE_READONLY");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -492,6 +492,15 @@ pub struct Config {
     #[default = true]
     pub resolve_peers_from_workspace_root: bool,
 
+    /// When `true`, reject exotic (git, tarball, file, …) dependencies
+    /// reached transitively from the importer. Direct deps remain
+    /// allowed. Mirrors pnpm's
+    /// [`blockExoticSubdeps`](https://github.com/pnpm/pnpm/blob/df990fdb51/config/reader/src/Config.ts#L222).
+    /// Default `true` to match pnpm v11's
+    /// [`block-exotic-subdeps`](https://github.com/pnpm/pnpm/blob/df990fdb51/config/reader/src/index.ts#L187).
+    #[default = true]
+    pub block_exotic_subdeps: bool,
+
     /// Whether to verify each CAFS file's on-disk integrity before reusing it
     /// for an install. When `true` (pnpm's default), the store-index cache
     /// lookup stats each referenced file and re-hashes any whose mtime has

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -148,6 +148,7 @@ pub struct WorkspaceSettings {
     pub dedupe_peer_dependents: Option<bool>,
     pub strict_peer_dependencies: Option<bool>,
     pub resolve_peers_from_workspace_root: Option<bool>,
+    pub block_exotic_subdeps: Option<bool>,
     pub verify_store_integrity: Option<bool>,
     pub side_effects_cache: Option<bool>,
     pub side_effects_cache_readonly: Option<bool>,
@@ -356,6 +357,7 @@ impl WorkspaceSettings {
         self.dedupe_peer_dependents = None;
         self.strict_peer_dependencies = None;
         self.resolve_peers_from_workspace_root = None;
+        self.block_exotic_subdeps = None;
         self.hoisting_limits = None;
         self.external_dependencies = None;
         self.patched_dependencies = None;
@@ -445,6 +447,7 @@ impl WorkspaceSettings {
             hoisting_limits, external_dependencies,
             dedupe_peer_dependents, strict_peer_dependencies,
             resolve_peers_from_workspace_root, verify_store_integrity,
+            block_exotic_subdeps,
             side_effects_cache, side_effects_cache_readonly,
             fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -48,6 +48,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         dedupe_peer_dependents: false,
         strict_peer_dependencies: false,
         resolve_peers_from_workspace_root: false,
+        block_exotic_subdeps: false,
         verify_store_integrity: true,
         side_effects_cache: true,
         side_effects_cache_readonly: false,

--- a/pacquet/crates/package-manager/src/install_without_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_without_lockfile.rs
@@ -361,6 +361,7 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
                 project_dir,
                 lockfile_dir: lockfile_dir.to_path_buf(),
                 workspace_packages,
+                block_exotic_subdeps: config.block_exotic_subdeps,
                 ..ResolveOptions::default()
             },
             catalogs,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -78,6 +78,20 @@ pub enum ResolveDependencyTreeError {
     #[display("{_0}")]
     #[diagnostic(transparent)]
     PatchKeyConflict(#[error(source)] PatchKeyConflictError),
+
+    /// A transitive dependency was resolved through an exotic
+    /// protocol (git, tarball, file, …) while `block_exotic_subdeps`
+    /// is on. Mirrors pnpm's
+    /// [`EXOTIC_SUBDEP`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts#L1420-L1434).
+    #[display(
+        "Exotic dependency \"{specifier}\" (resolved via {resolved_via}) is not allowed in subdependencies when blockExoticSubdeps is enabled"
+    )]
+    #[diagnostic(code(EXOTIC_SUBDEP))]
+    ExoticSubdep {
+        #[error(not(source))]
+        specifier: String,
+        resolved_via: String,
+    },
 }
 
 impl From<PatchKeyConflictError> for ResolveDependencyTreeError {
@@ -289,6 +303,16 @@ where
 
     if let Some(violation) = result.policy_violation.clone() {
         ctx.policy_violations.lock().await.push(violation);
+    }
+
+    if ctx.base_opts.block_exotic_subdeps
+        && depth > 0
+        && is_exotic_resolved_via(&result.resolved_via)
+    {
+        return Err(ResolveDependencyTreeError::ExoticSubdep {
+            specifier: wanted.alias.clone().or(wanted.bare_specifier.clone()).unwrap_or_default(),
+            resolved_via: result.resolved_via.clone(),
+        });
     }
 
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
@@ -541,4 +565,23 @@ fn extract_peer_dependencies(
     }
 
     peers
+}
+
+/// Provenance tags that count as non-exotic for `blockExoticSubdeps`.
+/// Mirrors upstream's
+/// [`NON_EXOTIC_RESOLVED_VIA`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts#L1831-L1841).
+const NON_EXOTIC_RESOLVED_VIA: &[&str] = &[
+    "custom-resolver",
+    "github.com/denoland/deno",
+    "github.com/oven-sh/bun",
+    "jsr-registry",
+    "local-filesystem",
+    "named-registry",
+    "nodejs.org",
+    "npm-registry",
+    "workspace",
+];
+
+fn is_exotic_resolved_via(resolved_via: &str) -> bool {
+    !NON_EXOTIC_RESOLVED_VIA.contains(&resolved_via)
 }

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -225,6 +225,199 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
     }
 }
 
+mod block_exotic_subdeps {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use pacquet_package_manifest::DependencyGroup;
+    use pacquet_resolving_resolver_base::ResolveOptions;
+
+    use super::{StubResolver, fake_manifest, fake_result};
+    use crate::resolve_dependency_tree::{
+        ResolveDependencyTreeError, ResolveDependencyTreeOptions, resolve_dependency_tree,
+    };
+
+    fn git_result(
+        name: &str,
+        version: &str,
+        manifest: serde_json::Value,
+    ) -> pacquet_resolving_resolver_base::ResolveResult {
+        let mut result = fake_result(name, version, manifest);
+        result.resolved_via = "git-repository".to_string();
+        result
+    }
+
+    /// A transitive dep resolved via an exotic protocol fails the
+    /// install when `block_exotic_subdeps` is on. Mirrors upstream's
+    /// `EXOTIC_SUBDEP` error.
+    #[tokio::test]
+    async fn rejects_exotic_transitive_dep() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("foo".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "foo",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "dependencies": { "say-hi": "github:zkochan/hi" }
+                }),
+            ),
+        );
+        table.insert(
+            ("say-hi".to_string(), "github:zkochan/hi".to_string()),
+            git_result(
+                "say-hi",
+                "1.0.0",
+                serde_json::json!({ "name": "say-hi", "version": "1.0.0" }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
+
+        let err = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions {
+                    block_exotic_subdeps: true,
+                    ..ResolveOptions::default()
+                },
+                patched_dependencies: None,
+            },
+        )
+        .await
+        .expect_err("exotic subdep must error");
+        match err {
+            ResolveDependencyTreeError::ExoticSubdep { specifier, resolved_via } => {
+                assert_eq!(specifier, "say-hi");
+                assert_eq!(resolved_via, "git-repository");
+            }
+            other => panic!("expected ExoticSubdep, got {other:?}"),
+        }
+    }
+
+    /// An exotic *direct* dep still resolves — the gate only fires
+    /// past the importer.
+    #[tokio::test]
+    async fn allows_exotic_direct_dep() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("is-negative".to_string(), "kevva/is-negative#1.0.0".to_string()),
+            git_result(
+                "is-negative",
+                "1.0.0",
+                serde_json::json!({ "name": "is-negative", "version": "1.0.0" }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "is-negative": "kevva/is-negative#1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions {
+                    block_exotic_subdeps: true,
+                    ..ResolveOptions::default()
+                },
+                patched_dependencies: None,
+            },
+        )
+        .await
+        .expect("direct exotic dep should resolve");
+        assert_eq!(tree.direct.len(), 1);
+        assert_eq!(tree.direct[0].alias, "is-negative");
+    }
+
+    /// A registry subdep is fine when the gate is on.
+    #[tokio::test]
+    async fn allows_registry_subdep() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("foo".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "foo",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "dependencies": { "bar": "^2.0.0" }
+                }),
+            ),
+        );
+        table.insert(
+            ("bar".to_string(), "^2.0.0".to_string()),
+            fake_result("bar", "2.0.0", serde_json::json!({ "name": "bar", "version": "2.0.0" })),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
+
+        resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions {
+                    block_exotic_subdeps: true,
+                    ..ResolveOptions::default()
+                },
+                patched_dependencies: None,
+            },
+        )
+        .await
+        .expect("registry subdep must pass");
+    }
+
+    /// With the gate off, an exotic subdep walks like any other.
+    #[tokio::test]
+    async fn allows_exotic_subdep_when_disabled() {
+        let mut table = HashMap::new();
+        table.insert(
+            ("foo".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "foo",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "foo",
+                    "version": "1.0.0",
+                    "dependencies": { "say-hi": "github:zkochan/hi" }
+                }),
+            ),
+        );
+        table.insert(
+            ("say-hi".to_string(), "github:zkochan/hi".to_string()),
+            git_result(
+                "say-hi",
+                "1.0.0",
+                serde_json::json!({ "name": "say-hi", "version": "1.0.0" }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions {
+                    block_exotic_subdeps: false,
+                    ..ResolveOptions::default()
+                },
+                patched_dependencies: None,
+            },
+        )
+        .await
+        .expect("exotic subdep must pass when disabled");
+        assert!(tree.packages.contains_key("say-hi@1.0.0"));
+    }
+}
+
 mod peers {
     use std::collections::HashMap;
     use std::sync::Mutex;

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -215,6 +215,13 @@ pub struct ResolveOptions {
     /// resolution. Mirrors upstream's `dryRun` flag at the resolver
     /// boundary.
     pub dry_run: bool,
+    /// When `true`, reject exotic (git, tarball, file, …) dependencies
+    /// appearing anywhere below the importer. Direct dependencies are
+    /// still allowed; only transitive deps are gated. The check
+    /// consults [`ResolveResult::resolved_via`] against the closed set
+    /// of non-exotic provenance tags. Mirrors pnpm's
+    /// [`blockExoticSubdeps`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts#L1420-L1434).
+    pub block_exotic_subdeps: bool,
 }
 
 /// In-memory manifest shape a resolver may attach to its


### PR DESCRIPTION
## Summary

Ports pnpm's `blockExoticSubdeps` setting to pacquet. When on, transitive dependencies resolved via an exotic protocol (git, tarball, file, …) fail the install with `ERR_PNPM_EXOTIC_SUBDEP`. Direct dependencies remain allowed. Mirrors upstream's gate at [`installing/deps-resolver/src/resolveDependencies.ts:1420-1434`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts#L1420-L1434) and the closed [`NON_EXOTIC_RESOLVED_VIA`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts#L1831-L1841) set.

- `ResolveOptions.block_exotic_subdeps` and the per-node check inside `resolve_dependency_tree`'s walker.
- `Config.block_exotic_subdeps` (default `true`, matching v11's [`config/reader/src/index.ts:187`](https://github.com/pnpm/pnpm/blob/df990fdb51/config/reader/src/index.ts#L187)), wired through `pnpm-workspace.yaml` and the `BLOCK_EXOTIC_SUBDEPS` env-overlay key.
- Threaded into `install_without_lockfile`'s `ResolveOptions`.

## Test plan

- [x] Unit tests in `resolving-deps-resolver/src/tests.rs` covering the four upstream scenarios (rejects exotic transitive, allows exotic direct, allows registry transitive, gate-off lets exotic through).
- [x] `cargo nextest run -p pacquet-resolving-deps-resolver -p pacquet-config -p pacquet-resolving-resolver-base -p pacquet-package-manager` — 516 / 516 pass.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` clean.
- [x] `cargo fmt --check` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to block exotic (git/tarball/file) transitive dependencies while allowing direct ones; settable via config, workspace, or environment.
* **Behavior**
  * Install/resolution now honor this option and fail with a clear error when an exotic transitive dependency is blocked.
* **Tests**
  * Added tests for blocking, allowing, and disabled scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->