### PR TITLE
feat(pacquet/resolving-npm-resolver): port abbreviated metadata fast path

### DIFF
--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -99,6 +99,7 @@ async fn resolve_via_mock(
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: true,
+        full_metadata: false,
     };
     let wanted = WantedDependency {
         alias: Some(alias.to_string()),

--- a/pacquet/crates/package-manager/src/install_without_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_without_lockfile.rs
@@ -216,6 +216,14 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             offline: config.offline,
             prefer_offline: config.prefer_offline,
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
+            // Default to abbreviated metadata at resolve time and let
+            // [`pick_package`] upgrade per-call when `published_by` or
+            // `optional` demand it. Mirrors upstream's
+            // [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175)
+            // default. Pacquet's `Config` doesn't surface a
+            // `fullMetadata` knob; if one lands later, thread it
+            // here.
+            full_metadata: false,
         });
         let git_resolver = GitResolver::new(
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
@@ -247,6 +255,8 @@ impl<'a, DependencyGroupList> InstallWithoutLockfile<'a, DependencyGroupList> {
             offline: config.offline,
             prefer_offline: config.prefer_offline,
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
+            // Same rationale as `NpmResolver.full_metadata` above.
+            full_metadata: false,
         };
         // Order mirrors upstream's chain at
         // <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L128-L147>:

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -546,6 +546,9 @@ impl NpmResolutionVerifier {
             http_client: &self.http_client,
             auth_headers: &self.auth_headers,
             cache_dir: self.cache_dir.as_deref(),
+            // The verifier reads `time` and trust evidence per-version,
+            // both of which the abbreviated form drops. Always full.
+            full_metadata: true,
         };
         fetch_full_metadata_cached(&name.to_string(), &opts).await.map_err(|err| err.to_string())
     }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -267,7 +267,7 @@ async fn min_age_pass_when_published_before_cutoff() {
         .await;
     let _full_mock = server
         .mock("GET", "/acme")
-        .match_header("accept", "application/json")
+        .match_header("accept", "application/json; q=1.0, */*")
         .with_status(200)
         .with_body(min_age_packument_json("acme", "1.0.0", "2024-01-01T00:00:00.000Z").to_string())
         .expect(1)

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -1,41 +1,58 @@
-//! No-cache full-metadata fetcher.
+//! No-cache metadata fetcher.
 //!
-//! Issues a GET against `<registry>/<package>` with the *full*
-//! metadata `Accept` header (`application/json; q=1.0`) — distinct
-//! from the abbreviated `application/vnd.npm.install-v1+json`
-//! endpoint that pnpm's resolver uses for fast picks. The verifier
-//! needs the full document because the abbreviated form omits the
-//! `time` map, `_npmUser`, and `dist.attestations` — the three
-//! fields the `minimumReleaseAge` and `trustPolicy='no-downgrade'`
-//! checks read.
+//! Issues a GET against `<registry>/<package>`. The `full_metadata`
+//! flag picks between the **full** packument
+//! (`Accept: application/json; q=1.0, */*`) and the **abbreviated**
+//! install-v1 form
+//! (`Accept: application/vnd.npm.install-v1+json; q=1.0,
+//! application/json; q=0.8, */*`). The two forms are byte-different:
+//! the abbreviated document drops the per-version `time` map,
+//! `_npmUser`, and `dist.attestations`, which are exactly the fields
+//! the `minimumReleaseAge` and `trustPolicy='no-downgrade'` checks
+//! read.
 //!
-//! Caching (conditional GETs + on-disk mirror) lands in a follow-up
-//! phase. This module is the no-cache baseline that
-//! [`crate::create_npm_resolution_verifier()`] consumes today; the
-//! cached variant wraps it without changing the call site.
+//! Callers that need maturity / trust evidence (the verifier and the
+//! resolver's upgrade-on-recent-modified path) must request full
+//! metadata. The resolver's default install path requests
+//! abbreviated and upgrades to full only when the maturity check
+//! demands it — mirroring upstream's pickPackage logic.
 //!
-//! Ports the no-cache half of upstream's
-//! [`fetchFullMetadataCached.ts`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts).
+//! Ports the request half of upstream's
+//! [`fetchMetadataFromFromRegistry`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L118-L204).
 
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_registry::Package;
 
 use crate::{FetchMetadataError, registry_url::to_registry_url};
 
+/// Accept header for the full packument. Matches upstream's
+/// [`ACCEPT_FULL_DOC`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/network/fetch/src/fetchFromRegistry.ts#L12).
+pub(crate) const ACCEPT_FULL_DOC: &str = "application/json; q=1.0, */*";
+
+/// Accept header for the abbreviated `install-v1` packument. Matches
+/// upstream's
+/// [`ACCEPT_ABBREVIATED_DOC`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/network/fetch/src/fetchFromRegistry.ts#L15).
+pub(crate) const ACCEPT_ABBREVIATED_DOC: &str =
+    "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+
 /// Options bundle for [`fetch_full_metadata`]. Mirrors upstream's
-/// `FetchFullMetadataCachedOptions` minus the cache fields, which the
-/// cached variant (Phase 5) will layer on.
+/// `FetchFullMetadataCachedOptions` minus the cache fields; the
+/// cached variant layers them on.
 #[derive(Debug, Clone)]
 pub struct FetchFullMetadataOptions<'a> {
     pub registry: &'a str,
     pub http_client: &'a ThrottledClient,
     pub auth_headers: &'a AuthHeaders,
+    /// `true` requests the full packument (with `time`, `_npmUser`,
+    /// and `dist.attestations`); `false` requests the abbreviated
+    /// `install-v1` form. Mirrors upstream's
+    /// [`opts.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L113).
+    pub full_metadata: bool,
 }
 
-/// Fetch the **full** registry metadata document for `pkg_name`.
-/// The full document carries `time`, per-version `_npmUser`, and
-/// `dist.attestations` — the abbreviated install-v1 endpoint pnpm's
-/// resolver normally uses omits all three.
+/// Fetch the registry metadata document for `pkg_name`. The
+/// `full_metadata` flag on [`FetchFullMetadataOptions`] picks
+/// between the full and abbreviated packument forms.
 pub async fn fetch_full_metadata(
     pkg_name: &str,
     opts: &FetchFullMetadataOptions<'_>,
@@ -47,8 +64,9 @@ pub async fn fetch_full_metadata(
     // so the registry routes the request to the package as a single
     // path segment, not two.
     let url = to_registry_url(opts.registry, pkg_name);
+    let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let mut request =
-        opts.http_client.acquire_for_url(&url).await.get(&url).header("accept", "application/json");
+        opts.http_client.acquire_for_url(&url).await.get(&url).header("accept", accept);
     if let Some(value) = opts.auth_headers.for_url(&url) {
         request = request.header("authorization", value);
     }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -37,7 +37,7 @@ async fn fetch_full_metadata_targets_full_endpoint_with_auth() {
     }"#;
     let mock = server
         .mock("GET", "/acme")
-        .match_header("accept", "application/json")
+        .match_header("accept", "application/json; q=1.0, */*")
         .match_header("authorization", "Bearer top-secret")
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -56,6 +56,7 @@ async fn fetch_full_metadata_targets_full_endpoint_with_auth() {
         registry: &registry,
         http_client: &http_client,
         auth_headers: &auth_headers,
+        full_metadata: true,
     };
 
     let pkg = fetch_full_metadata("acme", &opts).await.expect("server returns 200");
@@ -84,6 +85,7 @@ async fn fetch_full_metadata_surfaces_5xx_as_network_error() {
         registry: &registry,
         http_client: &http_client,
         auth_headers: &auth_headers,
+        full_metadata: true,
     };
 
     let err = fetch_full_metadata("acme", &opts).await.expect_err("503 must surface");
@@ -136,6 +138,7 @@ async fn fetch_full_metadata_encodes_scoped_name() {
         registry: &registry,
         http_client: &http_client,
         auth_headers: &auth_headers,
+        full_metadata: true,
     };
 
     let pkg =
@@ -167,6 +170,7 @@ async fn fetch_full_metadata_surfaces_decode_failure_distinctly() {
         registry: &registry,
         http_client: &http_client,
         auth_headers: &auth_headers,
+        full_metadata: true,
     };
 
     let err = fetch_full_metadata("acme", &opts).await.expect_err("malformed JSON must surface");

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -1,15 +1,16 @@
-//! Cache-aware full-metadata fetcher.
+//! Cache-aware metadata fetcher.
 //!
 //! Ports pnpm's
 //! [`fetchFullMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts).
 //!
 //! When a cache directory is configured, the fetcher consults a
-//! shared mirror at `<cache_dir>/v11/metadata-full/<registry>/<pkg>.jsonl`,
-//! issues a conditional GET against the upstream registry, and either
-//! reads the cached body (304) or writes the new body back (2xx).
-//! Without a cache directory it falls through to a plain GET — the
-//! same behavior callers got before Phase 5 from
-//! [`crate::fetch_full_metadata()`].
+//! shared mirror under `<cache_dir>/v11/metadata-full/` (full) or
+//! `<cache_dir>/v11/metadata/` (abbreviated), keyed by
+//! `full_metadata`. It issues a conditional GET against the upstream
+//! registry, and either reads the cached body (304) or writes the
+//! new body back (2xx). Without a cache directory it falls through
+//! to a plain GET — the same behavior callers got before Phase 5
+//! from [`crate::fetch_full_metadata()`].
 //!
 //! The cache layout matches pnpm's so a pnpm-populated mirror is
 //! usable from pacquet (and vice versa). The two-line NDJSON shape
@@ -24,9 +25,10 @@ use reqwest::{StatusCode, header};
 
 use crate::{
     FetchMetadataError,
+    fetch_full_metadata::{ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC},
     mirror::{
-        FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers, prepare_json_for_disk,
-        save_meta,
+        ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers,
+        prepare_json_for_disk, save_meta,
     },
     registry_url::to_registry_url,
 };
@@ -40,10 +42,20 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     pub registry: &'a str,
     pub http_client: &'a ThrottledClient,
     pub auth_headers: &'a AuthHeaders,
-    /// When `Some`, the fetcher consults the on-disk mirror at
-    /// `<cache_dir>/v11/metadata-full/...`. When `None`, the fetcher
-    /// short-circuits to an unconditional GET.
+    /// When `Some`, the fetcher consults the on-disk mirror under
+    /// the matching `<cache_dir>/v11/metadata...` subdirectory.
+    /// When `None`, the fetcher short-circuits to an unconditional
+    /// GET.
     pub cache_dir: Option<&'a Path>,
+    /// `true` requests the full packument and caches it under
+    /// [`FULL_META_DIR`]; `false` requests the abbreviated form
+    /// and caches it under [`ABBREVIATED_META_DIR`]. Mirrors
+    /// upstream's
+    /// [`fetchFullMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts#L30-L36)
+    /// vs.
+    /// [`fetchAbbreviatedMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts#L47-L53)
+    /// dispatch.
+    pub full_metadata: bool,
 }
 
 /// Fetch the full registry metadata document for `pkg_name`, reusing
@@ -82,12 +94,13 @@ pub async fn fetch_full_metadata_cached(
     pkg_name: &str,
     opts: &FetchFullMetadataCachedOptions<'_>,
 ) -> Result<Package, FetchMetadataError> {
+    let meta_dir = if opts.full_metadata { FULL_META_DIR } else { ABBREVIATED_META_DIR };
     // Encoding the mirror path can fail only on a malformed registry
     // URL (no host, unparsable). Either case is a config bug; we
     // log and proceed without a cache so the user still gets metadata
     // on this install instead of a hard error.
     let mirror_path = match opts.cache_dir {
-        Some(dir) => match get_pkg_mirror_path(dir, FULL_META_DIR, opts.registry, pkg_name) {
+        Some(dir) => match get_pkg_mirror_path(dir, meta_dir, opts.registry, pkg_name) {
             Ok(path) => Some(path),
             Err(error) => {
                 tracing::debug!(
@@ -95,6 +108,7 @@ pub async fn fetch_full_metadata_cached(
                     ?error,
                     registry = opts.registry,
                     pkg_name,
+                    full_metadata = opts.full_metadata,
                     "could not encode mirror path; bypassing cache for this call",
                 );
                 None
@@ -105,12 +119,9 @@ pub async fn fetch_full_metadata_cached(
     let cache_headers = mirror_path.as_deref().and_then(load_meta_headers);
 
     let url = to_registry_url(opts.registry, pkg_name);
-    let mut request = opts
-        .http_client
-        .acquire_for_url(&url)
-        .await
-        .get(&url)
-        .header(header::ACCEPT, "application/json");
+    let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
+    let mut request =
+        opts.http_client.acquire_for_url(&url).await.get(&url).header(header::ACCEPT, accept);
     if let Some(value) = opts.auth_headers.for_url(&url) {
         request = request.header(header::AUTHORIZATION, value);
     }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -29,7 +29,7 @@ async fn cold_cache_writes_mirror_on_200() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", "/acme")
-        .match_header("accept", "application/json")
+        .match_header("accept", "application/json; q=1.0, */*")
         .with_status(200)
         .with_header("etag", r#"W/"fresh""#)
         .with_body(PACKAGE_BODY)
@@ -46,6 +46,7 @@ async fn cold_cache_writes_mirror_on_200() {
         http_client: &http_client,
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
+        full_metadata: true,
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 → ok");
@@ -67,7 +68,7 @@ async fn warm_cache_serves_from_mirror_on_304() {
     // First call: 200, mirror written.
     let first = server
         .mock("GET", "/acme")
-        .match_header("accept", "application/json")
+        .match_header("accept", "application/json; q=1.0, */*")
         .with_status(200)
         .with_header("etag", r#"W/"v1""#)
         .with_body(PACKAGE_BODY)
@@ -92,6 +93,7 @@ async fn warm_cache_serves_from_mirror_on_304() {
         http_client: &http_client,
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
+        full_metadata: true,
     };
 
     let _first_pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 populates cache");
@@ -137,6 +139,7 @@ async fn stale_cache_refreshes_mirror_on_200() {
         http_client: &http_client,
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
+        full_metadata: true,
     };
 
     let _ = fetch_full_metadata_cached("acme", &opts).await.expect("populate");
@@ -158,7 +161,7 @@ async fn no_cache_dir_skips_mirror_io() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", "/acme")
-        .match_header("accept", "application/json")
+        .match_header("accept", "application/json; q=1.0, */*")
         .with_status(200)
         .with_body(PACKAGE_BODY)
         .expect(1)
@@ -173,6 +176,7 @@ async fn no_cache_dir_skips_mirror_io() {
         http_client: &http_client,
         auth_headers: &auth_headers,
         cache_dir: None,
+        full_metadata: true,
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 → ok");
@@ -210,6 +214,7 @@ async fn read_only_cache_dir_does_not_fail_the_call() {
         http_client: &http_client,
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
+        full_metadata: true,
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("read-only must not fail");

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -73,6 +73,10 @@ pub struct NamedRegistryResolver<Cache: PackageMetaCache> {
     pub offline: bool,
     pub prefer_offline: bool,
     pub ignore_missing_time_field: bool,
+    /// Install-wide bias toward full metadata. Threaded through to
+    /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
+    /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
+    pub full_metadata: bool,
 }
 
 impl<Cache: PackageMetaCache + 'static> Resolver for NamedRegistryResolver<Cache> {
@@ -123,7 +127,8 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             return Ok(None);
         };
 
-        let picked = match self.pick_from_registry(registry, &spec, opts).await? {
+        let optional = wanted_dependency.optional.unwrap_or(false);
+        let picked = match self.pick_from_registry(registry, &spec, opts, optional).await? {
             Some(picked) => picked,
             None => return Ok(None),
         };
@@ -178,6 +183,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
         registry: &str,
         spec: &RegistryPackageSpec,
         opts: &ResolveOptions,
+        optional: bool,
     ) -> Result<Option<PickedFromRegistry>, ResolveError> {
         let pick_opts = PickPackageOptions {
             registry,
@@ -187,6 +193,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             pick_lowest_version: opts.pick_lowest_version,
             include_latest_tag: opts.update == UpdateBehavior::Latest,
             dry_run: opts.dry_run,
+            optional,
         };
 
         let ctx = PickPackageContext {
@@ -197,6 +204,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             offline: self.offline,
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
+            full_metadata: self.full_metadata,
         };
 
         let pick_result = pick_package(&ctx, spec, &pick_opts)

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
@@ -72,6 +72,7 @@ fn build_resolver(
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
     (resolver, cache_dir)
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -94,6 +94,10 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     pub offline: bool,
     pub prefer_offline: bool,
     pub ignore_missing_time_field: bool,
+    /// Install-wide bias toward full metadata. Threaded through to
+    /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
+    /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
+    pub full_metadata: bool,
 }
 
 impl<Cache: PackageMetaCache + 'static> Resolver for NpmResolver<Cache> {
@@ -172,7 +176,8 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             },
         };
 
-        let picked = match self.pick_from_registry(&registry, &spec, opts).await? {
+        let optional = wanted_dependency.optional.unwrap_or(false);
+        let picked = match self.pick_from_registry(&registry, &spec, opts, optional).await? {
             Some(picked) => picked,
             None => return Ok(None),
         };
@@ -216,7 +221,9 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         let registry =
             self.registries.get("@jsr").map(String::as_str).unwrap_or(DEFAULT_JSR_REGISTRY);
 
-        let picked = match self.pick_from_registry(registry, &jsr_spec.spec, opts).await? {
+        let optional = wanted_dependency.optional.unwrap_or(false);
+        let picked = match self.pick_from_registry(registry, &jsr_spec.spec, opts, optional).await?
+        {
             Some(picked) => picked,
             None => return Ok(None),
         };
@@ -243,6 +250,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         registry: &str,
         spec: &RegistryPackageSpec,
         opts: &ResolveOptions,
+        optional: bool,
     ) -> Result<Option<PickedFromRegistry>, ResolveError> {
         let pick_opts = PickPackageOptions {
             registry,
@@ -252,6 +260,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             pick_lowest_version: opts.pick_lowest_version,
             include_latest_tag: opts.update == UpdateBehavior::Latest,
             dry_run: opts.dry_run,
+            optional,
         };
 
         let ctx = PickPackageContext {
@@ -262,6 +271,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             offline: self.offline,
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
+            full_metadata: self.full_metadata,
         };
 
         let pick_result = pick_package(&ctx, spec, &pick_opts)

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -64,6 +64,7 @@ fn build_resolver_with_registries(
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
     (resolver, cache_dir)
 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -16,14 +16,19 @@
 //! 4. Handing the resolved packument to [`pick_package_from_meta`]
 //!    for the actual version pick.
 //!
-//! Compared to upstream this port simplifies one axis: pacquet's
-//! metadata fetcher always returns *full* metadata (the verifier
-//! needs it for `time` and trust evidence). The upstream code paths
-//! that upgrade an abbreviated cache entry to full mid-pick are
-//! therefore dead in pacquet today — the picker still goes through
-//! the same shape so adding an abbreviated fetcher later is a
-//! drop-in. Notes on the abbreviated paths are inline at the
-//! sites they would activate.
+//! Full vs. abbreviated metadata is selected per call from
+//! `opts.optional || ctx.full_metadata`, matching upstream's
+//! [`fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201)
+//! derivation. The orchestrator wires the choice through to the
+//! mirror directory ([`ABBREVIATED_META_DIR`] vs. [`FULL_META_DIR`]),
+//! the in-memory cache key (`:full` suffix when full), and the
+//! `Accept` header on the registry request. When `published_by` is
+//! active and the picker ends up with abbreviated metadata that
+//! lacks the per-version `time` map, the orchestrator transparently
+//! upgrades to full metadata via a follow-up fetch so the
+//! `minimumReleaseAge` check runs against real timestamps instead of
+//! silently degrading to its warn-and-skip fallback. Ports upstream's
+//! [`maybeUpgradeAbbreviatedMetaForReleaseAge`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L450-L501).
 //!
 //! Concurrency: upstream uses `p-limit(1)` keyed on the mirror path
 //! to serialize disk operations. Pacquet relies on the atomic
@@ -48,8 +53,12 @@ use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::VersionSelectors;
 
 use crate::{
-    FetchFullMetadataCachedOptions, FetchMetadataError, fetch_full_metadata_cached,
-    mirror::{FULL_META_DIR, get_pkg_mirror_path, load_meta, prepare_json_for_disk, save_meta},
+    FetchFullMetadataCachedOptions, FetchFullMetadataOptions, FetchMetadataError,
+    fetch_full_metadata, fetch_full_metadata_cached,
+    mirror::{
+        ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta, prepare_json_for_disk,
+        save_meta,
+    },
     pick_package_from_meta::{
         PickPackageFromMetaError, PickPackageFromMetaOptions, RegistryPackageSpec,
         RegistryPackageSpecType, pick_lowest_version_by_version_range, pick_package_from_meta,
@@ -125,12 +134,19 @@ pub struct PickPackageContext<'a, Cache: PackageMetaCache> {
     /// falls back to picking without the maturity filter. Mirrors
     /// upstream's `ctx.ignoreMissingTimeField`.
     ///
-    /// Pacquet's full-metadata fetcher always returns `time` when
-    /// the registry exposes it, so the missing-time path here is
-    /// only reachable when the registry itself stripped the field —
-    /// rare, but the opt-in stays for parity with the resolver
-    /// option flag.
+    /// Reachable when the registry-served packument omits `time`
+    /// even after a full-metadata fetch (rare; the official npm
+    /// registry always populates `time` for full responses) — the
+    /// opt-in stays for parity with the resolver option flag.
     pub ignore_missing_time_field: bool,
+    /// Install-wide bias toward full metadata, mirroring upstream's
+    /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
+    /// `true` forces every pick to use the full packument; `false`
+    /// defers to the per-call `opts.optional` flag, defaulting to
+    /// abbreviated metadata. The resolver typically leaves this
+    /// `false`; the verifier-time fetcher sets it `true` because
+    /// it needs `time` and trust evidence for every entry.
+    pub full_metadata: bool,
 }
 
 /// Per-call options the orchestrator threads to the picker. Mirrors
@@ -163,6 +179,16 @@ pub struct PickPackageOptions<'a> {
     /// Matches the upstream flag — used when the install is a
     /// pure dry-run (`--lockfile-only`, frozen lockfile, etc.).
     pub dry_run: bool,
+    /// `true` forces this pick to use the full packument because
+    /// the dependency carries `optionalDependencies`-specific
+    /// fields (`libc`, `cpu`, `os`) the abbreviated form drops
+    /// some of. Mirrors upstream's
+    /// [`opts.optional`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L72)
+    /// — see [pnpm/pnpm#9950](https://github.com/pnpm/pnpm/issues/9950).
+    /// Combined with [`PickPackageContext::full_metadata`] via OR:
+    /// either knob set to `true` makes the pick request full
+    /// metadata.
+    pub optional: bool,
 }
 
 /// Outcome of a successful [`pick_package`] call. Mirrors
@@ -262,9 +288,19 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         ignore_missing_time_field: ctx.ignore_missing_time_field,
     };
 
+    // Per upstream's
+    // [`pickPackage`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201):
+    // `opts.optional` is a per-call escape hatch (needed for
+    // `libc`/`cpu`/`os` filtering on optional deps —
+    // <https://github.com/pnpm/pnpm/issues/9950>); `ctx.full_metadata`
+    // is the install-wide bias. Either being `true` forces the full
+    // packument.
+    let full_metadata = opts.optional || ctx.full_metadata;
+    let meta_dir = if full_metadata { FULL_META_DIR } else { ABBREVIATED_META_DIR };
+
     let pkg_mirror = ctx
         .cache_dir
-        .and_then(|dir| get_pkg_mirror_path(dir, FULL_META_DIR, opts.registry, &spec.name).ok());
+        .and_then(|dir| get_pkg_mirror_path(dir, meta_dir, opts.registry, &spec.name).ok());
 
     // Scope the in-memory cache key by registry so the same package
     // name in two different registries (private + public, scoped
@@ -273,12 +309,36 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     // `PackageMetaCache` per resolver instance per registry; pacquet
     // shares one cache across all `pick_package` calls, so the key
     // has to do the scoping itself.
-    let cache_key = format!("{}\x00{}", opts.registry, spec.name);
+    //
+    // The `:full` suffix mirrors upstream's
+    // [cache-key shape](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L206):
+    // a later call with `opts.optional = true` must not satisfy
+    // itself with the abbreviated cache entry an earlier call
+    // populated (the abbreviated form drops `libc`/`cpu`/`os` from
+    // some shapes).
+    let cache_key = if full_metadata {
+        format!("{}\x00{}:full", opts.registry, spec.name)
+    } else {
+        format!("{}\x00{}", opts.registry, spec.name)
+    };
 
     // 1. In-memory cache.
     if let Some(cached) = ctx.meta_cache.get(&cache_key) {
-        let picked = pick_matching_version_final(&picker_opts, spec, &cached)?;
-        return Ok(PickPackageResult { meta: cached, picked_package: picked });
+        let upgrade =
+            maybe_upgrade_abbreviated_meta_for_release_age(ctx, spec, opts, full_metadata, cached)
+                .await?;
+        let meta = upgrade.meta;
+        if upgrade.upgraded && !opts.dry_run {
+            // Persist so a fresh process doesn't re-trigger the
+            // upgrade fetch on its next install. Matches upstream's
+            // [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
+            if let Some(path) = pkg_mirror.as_deref() {
+                persist_upgraded_to_mirror(path, &meta);
+            }
+            ctx.meta_cache.set(cache_key.clone(), meta.clone());
+        }
+        let picked = pick_matching_version_final(&picker_opts, spec, &meta)?;
+        return Ok(PickPackageResult { meta, picked_package: picked });
     }
 
     let mut meta_cached_in_store: Option<Package> = None;
@@ -299,14 +359,31 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             });
         }
 
-        if let Some(ref meta) = meta_cached_in_store {
-            let picked = pick_matching_version_final(&picker_opts, spec, meta)?;
+        if let Some(meta) = meta_cached_in_store.take() {
+            let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
+                ctx,
+                spec,
+                opts,
+                full_metadata,
+                meta,
+            )
+            .await?;
+            let meta = upgrade.meta;
+            if upgrade.upgraded && !opts.dry_run {
+                if let Some(path) = pkg_mirror.as_deref() {
+                    persist_upgraded_to_mirror(path, &meta);
+                }
+                ctx.meta_cache.set(cache_key.clone(), meta.clone());
+            }
+            let picked = pick_matching_version_final(&picker_opts, spec, &meta)?;
             if picked.is_some() {
-                return Ok(PickPackageResult { meta: meta.clone(), picked_package: picked });
+                return Ok(PickPackageResult { meta, picked_package: picked });
             }
             // Fall through to fetch when disk had the meta but no
             // version satisfied the spec — the disk copy may be
-            // stale.
+            // stale. Restore the (possibly upgraded) meta for later
+            // paths that reuse the in-store load.
+            meta_cached_in_store = Some(meta);
         }
     }
 
@@ -357,6 +434,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         http_client: ctx.http_client,
         auth_headers: ctx.auth_headers,
         cache_dir: ctx.cache_dir,
+        full_metadata,
     };
 
     let fetch_result = fetch_full_metadata_cached(&spec.name, &fetch_opts).await;
@@ -382,6 +460,25 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             return Err(error.into());
         }
     };
+
+    // After a fresh fetch we may still need an upgrade: a 304 reused
+    // an abbreviated mirror body, or a 200 returned abbreviated data
+    // for a recently-modified package. Either way, if
+    // `published_by` is active and `meta.time` is missing, re-fetch
+    // full so the maturity check runs on real timestamps. Mirrors
+    // upstream's
+    // [post-304 upgrade](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L333-L347)
+    // and inline upgrade at lines 364-400.
+    let upgrade =
+        maybe_upgrade_abbreviated_meta_for_release_age(ctx, spec, opts, full_metadata, meta)
+            .await?;
+    let meta = upgrade.meta;
+    if upgrade.upgraded
+        && !opts.dry_run
+        && let Some(path) = pkg_mirror.as_deref()
+    {
+        persist_upgraded_to_mirror(path, &meta);
+    }
 
     // Divergence from upstream worth flagging: pnpm's pickPackage
     // gates the on-disk save behind `!opts.dryRun`. Pacquet's
@@ -628,18 +725,22 @@ fn warn_missing_time_once(pkg_name: &str) {
 }
 
 /// Convenience writer: persist `meta` to the on-disk mirror under
-/// `<cache_dir>/<FULL_META_DIR>/<registry>/<encoded-pkg>.jsonl`.
-/// Errors are logged at debug — a cache-write failure should never
+/// `<cache_dir>/<meta_dir>/<registry>/<encoded-pkg>.jsonl`. Pass
+/// [`FULL_META_DIR`] when seeding the full-metadata cache (verifier
+/// tests, integrated benchmark) and [`ABBREVIATED_META_DIR`] when
+/// seeding the abbreviated cache (resolver tests). Errors are logged
+/// at debug by the install path — a cache-write failure should never
 /// fail an install. Kept public so the rare caller that
 /// constructs a `Package` outside the fetcher (test fixtures, the
 /// integrated benchmark's pre-warmer) can seed the mirror without
 /// reaching into `crate::mirror`.
 pub fn persist_meta_to_mirror(
     cache_dir: &Path,
+    meta_dir: &str,
     registry: &str,
     meta: &Package,
 ) -> Result<(), MirrorPersistError> {
-    let path = get_pkg_mirror_path(cache_dir, FULL_META_DIR, registry, &meta.name)
+    let path = get_pkg_mirror_path(cache_dir, meta_dir, registry, &meta.name)
         .map_err(|error| MirrorPersistError::EncodePath { error: error.to_string() })?;
     let json = prepare_json_for_disk(meta, meta.etag.as_deref(), None)
         .map_err(|error| MirrorPersistError::Serialize { error: error.to_string() })?;
@@ -678,6 +779,122 @@ pub enum MirrorPersistError {
 /// `pick_package` call.
 pub fn shared_in_memory_cache() -> Arc<InMemoryPackageMetaCache> {
     Arc::new(InMemoryPackageMetaCache::default())
+}
+
+/// Outcome of [`maybe_upgrade_abbreviated_meta_for_release_age`].
+struct UpgradeOutcome {
+    /// The packument the orchestrator should pick from. Either the
+    /// original meta (when no upgrade was needed) or the freshly
+    /// fetched full meta.
+    meta: Package,
+    /// `true` when the orchestrator should persist `meta` to the
+    /// abbreviated mirror and write it back to the in-memory cache.
+    /// Matches upstream's `upgradedFrom != null` branch.
+    upgraded: bool,
+}
+
+/// Port of upstream's
+/// [`maybeUpgradeAbbreviatedMetaForReleaseAge`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L450-L501).
+///
+/// When the resolver default-fetched abbreviated metadata but
+/// `published_by` is active, the per-version `time` map is missing
+/// so the maturity check would silently degrade to the warn-and-skip
+/// fallback. This function detects that and re-fetches full metadata
+/// when the package's top-level `modified` field shows it was
+/// touched after the maturity cutoff. Returns the original meta
+/// untouched in every other case.
+///
+/// The early returns are guard rails that mirror upstream verbatim:
+///
+/// - `ctx.offline`: no network allowed. Stick with what we have.
+/// - `opts.published_by.is_none()`: maturity check disabled.
+/// - `meta.time.is_some()`: already full metadata (or an
+///   abbreviated response that happens to carry `time`). Nothing
+///   to upgrade.
+/// - `opts.published_by_exclude` matches the package: caller has
+///   opted this package out of the policy.
+/// - `meta.modified.is_some()` and parses as a date `<= cutoff`:
+///   every version in the packument was published at or before the
+///   cutoff, so the abbreviated form is enough. Inclusive at the
+///   boundary on purpose, matching the per-version `<=` filter in
+///   [`filter_pkg_metadata_by_publish_date`](crate::filter_pkg_metadata_by_publish_date).
+///
+/// On upgrade the call uses the network-only [`fetch_full_metadata`]
+/// (not the cached variant) so the response writes back to the
+/// abbreviated mirror via [`persist_upgraded_to_mirror`] — same
+/// shape as upstream's `persistUpgradedMeta`, which intentionally
+/// updates the *abbreviated* cache file with full data so the next
+/// install sees `time` populated and skips the upgrade fetch.
+async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>(
+    ctx: &PickPackageContext<'_, Cache>,
+    spec: &RegistryPackageSpec,
+    opts: &PickPackageOptions<'_>,
+    full_metadata: bool,
+    meta: Package,
+) -> Result<UpgradeOutcome, PickPackageError> {
+    if ctx.offline || full_metadata {
+        return Ok(UpgradeOutcome { meta, upgraded: false });
+    }
+    let Some(cutoff) = opts.published_by else {
+        return Ok(UpgradeOutcome { meta, upgraded: false });
+    };
+    if meta.time.is_some() {
+        return Ok(UpgradeOutcome { meta, upgraded: false });
+    }
+    if let Some(policy) = opts.published_by_exclude {
+        use pacquet_config::version_policy::PolicyMatch;
+        if matches!(policy.matches(&spec.name), PolicyMatch::AnyVersion) {
+            return Ok(UpgradeOutcome { meta, upgraded: false });
+        }
+    }
+    // Inclusive `<=` at the boundary: matches the per-version
+    // `<=` filter in `filter_pkg_metadata_by_publish_date`. When
+    // `modified` is missing or unparsable we fall through to the
+    // upgrade — better to spend one extra fetch than to silently
+    // bypass the maturity check.
+    if let Some(modified_str) = meta.modified.as_deref()
+        && let Ok(modified) = chrono::DateTime::parse_from_rfc3339(modified_str)
+        && modified.with_timezone(&Utc) <= cutoff
+    {
+        return Ok(UpgradeOutcome { meta, upgraded: false });
+    }
+    let fetch_opts = FetchFullMetadataOptions {
+        registry: opts.registry,
+        http_client: ctx.http_client,
+        auth_headers: ctx.auth_headers,
+        full_metadata: true,
+    };
+    let upgraded = fetch_full_metadata(&spec.name, &fetch_opts).await?;
+    Ok(UpgradeOutcome { meta: upgraded, upgraded: true })
+}
+
+/// Write the upgraded full metadata back to `pkg_mirror` (which
+/// points at the abbreviated cache because the picker is in
+/// abbreviated mode). Fire-and-forget: a write failure logs at debug
+/// and the install proceeds — the next install simply re-triggers
+/// the upgrade fetch. Mirrors upstream's
+/// [`persistUpgradedMeta`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L507-L524).
+fn persist_upgraded_to_mirror(pkg_mirror: &Path, meta: &Package) {
+    let json = match prepare_json_for_disk(meta, meta.etag.as_deref(), None) {
+        Ok(json) => json,
+        Err(error) => {
+            tracing::debug!(
+                target: "pacquet_resolving_npm_resolver::pick_package",
+                ?error,
+                path = %pkg_mirror.display(),
+                "could not serialize upgraded meta; skipping persist",
+            );
+            return;
+        }
+    };
+    if let Err(error) = save_meta(pkg_mirror, &json) {
+        tracing::debug!(
+            target: "pacquet_resolving_npm_resolver::pick_package",
+            ?error,
+            path = %pkg_mirror.display(),
+            "could not write upgraded meta to mirror; skipping persist",
+        );
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -819,7 +819,7 @@ struct UpgradeOutcome {
 ///   boundary on purpose, matching the per-version `<=` filter in
 ///   [`filter_pkg_metadata_by_publish_date`](crate::filter_pkg_metadata_by_publish_date).
 ///
-/// On upgrade the call uses the network-only [`fetch_full_metadata`]
+/// On upgrade the call uses the network-only [`fetch_full_metadata()`]
 /// (not the cached variant) so the response writes back to the
 /// abbreviated mirror via [`persist_upgraded_to_mirror`] — same
 /// shape as upstream's `persistUpgradedMeta`, which intentionally

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -2,11 +2,16 @@ use pacquet_network::{AuthHeaders, ThrottledClient};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
+use chrono::{DateTime, Utc};
+
 use super::{
     InMemoryPackageMetaCache, PackageMetaCache, PickPackageContext, PickPackageError,
     PickPackageOptions, persist_meta_to_mirror, pick_package,
 };
-use crate::pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType};
+use crate::{
+    mirror::{ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta},
+    pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
+};
 
 const PACKAGE_BODY: &str = r#"{
     "name": "acme",
@@ -65,6 +70,7 @@ fn default_opts<'a>(registry: &'a str) -> PickPackageOptions<'a> {
         pick_lowest_version: false,
         include_latest_tag: false,
         dry_run: false,
+        optional: false,
     }
 }
 
@@ -95,6 +101,7 @@ async fn cold_pick_fetches_and_picks_max_in_range() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -140,6 +147,7 @@ async fn warm_in_memory_cache_skips_network() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -160,7 +168,8 @@ async fn offline_with_mirror_picks_from_disk() {
     let registry = format!("{}/", server.url());
     let preloaded: pacquet_registry::Package =
         serde_json::from_str(PACKAGE_BODY).expect("parse packument");
-    persist_meta_to_mirror(cache_dir.path(), &registry, &preloaded).expect("warm mirror");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
 
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
@@ -173,6 +182,7 @@ async fn offline_with_mirror_picks_from_disk() {
         offline: true,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -200,6 +210,7 @@ async fn offline_without_mirror_errors() {
         offline: true,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let err = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -219,7 +230,8 @@ async fn version_spec_with_mirror_takes_fast_path() {
     let registry = format!("{}/", server.url());
     let preloaded: pacquet_registry::Package =
         serde_json::from_str(PACKAGE_BODY).expect("parse packument");
-    persist_meta_to_mirror(cache_dir.path(), &registry, &preloaded).expect("warm mirror");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
 
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
@@ -232,6 +244,7 @@ async fn version_spec_with_mirror_takes_fast_path() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let result = pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
@@ -279,7 +292,8 @@ async fn version_spec_missing_in_mirror_fetches() {
     }"#;
     let preloaded: pacquet_registry::Package =
         serde_json::from_str(older_body).expect("parse old packument");
-    persist_meta_to_mirror(cache_dir.path(), &registry, &preloaded).expect("warm mirror");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
 
     let http_client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
@@ -292,6 +306,7 @@ async fn version_spec_missing_in_mirror_fetches() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let result = pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
@@ -329,6 +344,7 @@ async fn dry_run_skips_in_memory_cache() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let mut opts = default_opts(&registry);
@@ -364,6 +380,7 @@ async fn pick_lowest_version_picks_min() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let mut opts = default_opts(&registry);
@@ -444,6 +461,7 @@ async fn in_memory_cache_does_not_leak_across_registries() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let pick_a = pick_package(&ctx, &range_spec("acme", "*"), &default_opts(&registry_a))
@@ -483,10 +501,307 @@ async fn invalid_package_name_errors_synchronously() {
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     };
 
     let err = pick_package(&ctx, &range_spec("foo/bar", "*"), &default_opts(&registry))
         .await
         .expect_err("invalid name");
     assert!(matches!(err, PickPackageError::InvalidPackageName { .. }), "got {err:?}");
+}
+
+/// Abbreviated metadata body, mirroring what a real npm registry
+/// returns under `Accept: application/vnd.npm.install-v1+json`.
+/// Missing per-version `time`, no `_npmUser`, no `dist.attestations`
+/// — just the picker-relevant shape.
+const ABBREVIATED_BODY: &str = r#"{
+    "name": "acme",
+    "dist-tags": { "latest": "1.0.0" },
+    "modified": "2024-12-01T00:00:00.000Z",
+    "versions": {
+        "1.0.0": {
+            "name": "acme",
+            "version": "1.0.0",
+            "dist": {
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.0.tgz"
+            }
+        }
+    }
+}"#;
+
+fn parse_cutoff(rfc3339: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(rfc3339).expect("parse cutoff").with_timezone(&Utc)
+}
+
+/// Default-mode pick (full_metadata=false, no opts.optional) hits
+/// the abbreviated install-v1 endpoint and caches under
+/// `ABBREVIATED_META_DIR`. The full mirror stays untouched.
+#[tokio::test]
+async fn default_pick_targets_abbreviated_endpoint_and_mirror() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+    };
+
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.0.0");
+    mock.assert_async().await;
+
+    let abbrev_path =
+        get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+            .expect("path");
+    assert!(abbrev_path.exists(), "abbreviated mirror written");
+    let full_path =
+        get_pkg_mirror_path(cache_dir.path(), FULL_META_DIR, &registry, "acme").expect("path");
+    assert!(!full_path.exists(), "full mirror left untouched on default pick");
+}
+
+/// `opts.optional = true` forces full metadata even when
+/// `ctx.full_metadata` is off. Mirrors upstream's
+/// `fullMetadata = opts.optional || ctx.fullMetadata` derivation
+/// (pnpm/pnpm#9950).
+#[tokio::test]
+async fn optional_opt_forces_full_metadata_endpoint() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+    };
+
+    let mut opts = default_opts(&registry);
+    opts.optional = true;
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("ok");
+    mock.assert_async().await;
+
+    let full_path =
+        get_pkg_mirror_path(cache_dir.path(), FULL_META_DIR, &registry, "acme").expect("path");
+    assert!(full_path.exists(), "full mirror written when optional=true");
+}
+
+/// Two pick calls with different full-mode flags must not share an
+/// in-memory cache slot — the abbreviated entry is missing fields
+/// that a full-mode caller (optional dep) depends on. Mirrors
+/// upstream's `cacheKey = fullMetadata ? '${name}:full' : name`
+/// scoping.
+#[tokio::test]
+async fn cache_key_separates_abbreviated_from_full() {
+    let mut server = mockito::Server::new_async().await;
+    let abbrev_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    let full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+    };
+
+    // First call: default (abbreviated).
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("first");
+    // Second call: optional=true (full). Cache key has `:full`
+    // suffix so it must NOT hit the abbreviated slot — the
+    // network mock for full must fire.
+    let mut opts = default_opts(&registry);
+    opts.optional = true;
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("second");
+
+    abbrev_mock.assert_async().await;
+    full_mock.assert_async().await;
+}
+
+/// `published_by` active + abbreviated cache lacking `time` +
+/// `modified` after the cutoff → re-fetch full metadata so the
+/// maturity check runs on real timestamps. Persisting the upgrade
+/// to the abbreviated mirror means the next call sees `time`
+/// populated and skips the upgrade fetch entirely. Ports the spirit
+/// of upstream's
+/// [`upgrades cached abbreviated metadata to full when 304 Not Modified and publishedBy is set`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/test/publishedBy.test.ts#L450-L511).
+#[tokio::test]
+async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
+    let mut server = mockito::Server::new_async().await;
+    // First fetch: abbreviated response (no `time`), recent
+    // `modified` so the upgrade trigger fires.
+    let abbrev_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    // Second fetch: the upgrade-to-full request. The body carries
+    // a `time` map so the picker can run the maturity check.
+    let full_mock = server
+        .mock("GET", "/acme")
+        .match_header("accept", "application/json; q=1.0, */*")
+        .with_status(200)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+    };
+
+    let mut opts = default_opts(&registry);
+    // Cutoff sits before `modified=2024-12-01` AND before every
+    // version's publish date in PACKAGE_BODY, so every version is
+    // immature; the picker still returns a fall-back pick so the
+    // call doesn't error.
+    opts.published_by = Some(parse_cutoff("2023-01-01T00:00:00Z"));
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("ok");
+
+    abbrev_mock.assert_async().await;
+    full_mock.assert_async().await;
+
+    // The upgraded full meta is written back to the abbreviated
+    // mirror so the next install sees `time` populated and skips
+    // the upgrade fetch — matches upstream's `persistUpgradedMeta`.
+    let abbrev_path =
+        get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+            .expect("path");
+    let persisted = load_meta(&abbrev_path).expect("abbreviated mirror readable");
+    assert!(
+        persisted.time.is_some(),
+        "abbreviated mirror should now carry time so the next install skips the upgrade",
+    );
+}
+
+/// Boundary case: `modified == cutoff`. `modified` is an upper
+/// bound on every version's publish time, so when it equals the
+/// cutoff every version passes the per-version `<=` filter and
+/// the upgrade fetch is unnecessary. Mirrors upstream's strict
+/// inclusive boundary in
+/// [`maybeUpgradeAbbreviatedMetaForReleaseAge`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L474).
+#[tokio::test]
+async fn published_by_skips_upgrade_when_modified_equals_cutoff() {
+    let mut server = mockito::Server::new_async().await;
+    let abbrev_mock = server
+        .mock("GET", "/acme")
+        .match_header(
+            "accept",
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        )
+        .with_status(200)
+        .with_body(ABBREVIATED_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+    // No second mock — the registry must NOT see a full-metadata
+    // request. If the upgrade trigger fires by mistake, the test
+    // panics on an unmatched request from `mockito`.
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: true,
+        full_metadata: false,
+    };
+
+    let mut opts = default_opts(&registry);
+    opts.published_by = Some(parse_cutoff("2024-12-01T00:00:00Z"));
+    let _ = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &opts).await.expect("ok");
+
+    abbrev_mock.assert_async().await;
 }

--- a/pacquet/crates/resolving-npm-resolver/tests/chain.rs
+++ b/pacquet/crates/resolving-npm-resolver/tests/chain.rs
@@ -44,6 +44,7 @@ fn named_registry_resolver(
         offline: false,
         prefer_offline: false,
         ignore_missing_time_field: false,
+        full_metadata: false,
     }
 }
 


### PR DESCRIPTION
## Summary

Default the resolver-time fetch to the abbreviated install-v1 packument (`application/vnd.npm.install-v1+json`) and only request full metadata when the call explicitly needs it — mirrors pnpm's `fullMetadata = opts.optional || ctx.fullMetadata` derivation in [pickPackage.ts L201](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201).

Pacquet previously always requested full metadata; the picker module documented this as a known simplification. After this PR pacquet matches pnpm's two-tier metadata flow.

## What changed

- **Fetchers (`fetch_full_metadata.rs`, `fetch_full_metadata_cached.rs`):** added a `full_metadata: bool` field. Selects between `Accept: application/json; q=1.0, */*` (full) and `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*` (abbreviated). The cached variant also routes the on-disk mirror to `FULL_META_DIR` vs `ABBREVIATED_META_DIR`.
- **`PickPackageContext.full_metadata`** is the install-wide bias; **`PickPackageOptions.optional`** is the per-call override that forces full (needed for `libc`/`cpu`/`os` fields on optional deps — [pnpm/pnpm#9950](https://github.com/pnpm/pnpm/issues/9950)). In-memory cache key gains a `:full` suffix when full, so the two modes can coexist without contamination.
- **`maybe_upgrade_abbreviated_meta_for_release_age`** ports pnpm's [`maybeUpgradeAbbreviatedMetaForReleaseAge`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L450-L501). When `published_by` is active, the picker has abbreviated metadata that lacks per-version `time`, and the package's top-level `modified` falls past the cutoff, the orchestrator re-fetches full metadata so the `minimumReleaseAge` check runs on real timestamps instead of degrading to the warn-and-skip fallback. The upgraded full meta is persisted back to the abbreviated mirror so the next install skips the upgrade fetch — matches upstream's `persistUpgradedMeta`.
- **Resolver wiring:** `NpmResolver` and `NamedRegistryResolver` gain `full_metadata` (defaulted to `false`) and plumb `wanted_dependency.optional` into the picker. The verifier sets `full_metadata: true` explicitly.
- **`persist_meta_to_mirror`** takes a `meta_dir` parameter so tests can seed either cache.

## Test plan

- [x] 5 new tests in `pick_package/tests.rs`: abbreviated default, optional override forces full, cache-key separation between modes, upgrade triggers when `modified > cutoff`, upgrade skipped when `modified == cutoff` (boundary).
- [x] All 1836 workspace tests pass (`cargo nextest run --workspace`).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy --workspace --all-targets -- --deny warnings` clean.
- [x] Existing fetcher / pick_package / resolver tests updated for the new struct fields and the q-value Accept headers.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved package metadata resolution with optimized abbreviated metadata format by default, reducing resolution time.
  * Enhanced support for optional dependencies with intelligent full metadata fetching when required.
  * Separate cache management for different metadata types to optimize storage and retrieval.
  * Trust verification now requests appropriate metadata depth based on security requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->