### PR TITLE
fix(pacquet/config): pick the store on the project's volume

### DIFF
--- a/pacquet/crates/config/src/api.rs
+++ b/pacquet/crates/config/src/api.rs
@@ -15,7 +15,11 @@
 //! [Dependency injection for tests](../../../CODE_STYLE_GUIDE.md#dependency-injection-for-tests)
 //! section of the style guide for the full convention.
 
-use std::{ffi::OsString, io, path::PathBuf};
+use std::{
+    ffi::OsString,
+    io,
+    path::{Path, PathBuf},
+};
 
 /// Capability: read a process environment variable as a UTF-8 string.
 ///
@@ -75,6 +79,34 @@ pub trait GetCurrentDir {
     fn current_dir() -> io::Result<PathBuf>;
 }
 
+/// Capability: probe whether a file dropped into `from_dir` could be
+/// hardlinked into a subdirectory of `to_dir`.
+///
+/// Port of pnpm's
+/// [`canLinkToSubdir`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L80-L92),
+/// abstracted as a single yes/no question so the production impl owns
+/// all filesystem effects (creating the source file, the destination
+/// temp dir, the link attempt, and cleanup) and tests can answer
+/// without touching disk. Lets pacquet's port of
+/// [`storePathRelativeToHome`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L45-L78)
+/// drive its branches deterministically.
+///
+/// "Linkable" means
+/// [`std::fs::hard_link`] returns `Ok(())`; everything else (EXDEV,
+/// EACCES, EPERM, ENOSPC, missing parent dir, …) is treated as "not
+/// linkable" and the caller falls through to the next branch.
+/// Mirrors pnpm's
+/// [`canLink`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L3-L18)
+/// catch-all: any failure means "this volume is not a candidate," not
+/// "the install should abort."
+pub trait LinkProbe {
+    /// Return `true` when a hardlink can be created from a file in
+    /// `from_dir` into a subdirectory of `to_dir`, `false` otherwise.
+    /// Implementations must clean up any temp file or directory they
+    /// create — no filesystem effects survive the call.
+    fn can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool;
+}
+
 /// Production provider for the capability traits in this crate.
 /// Production code threads `Host` through generic call sites with an
 /// explicit turbofish:
@@ -108,5 +140,11 @@ impl GetHomeDir for Host {
 impl GetCurrentDir for Host {
     fn current_dir() -> io::Result<PathBuf> {
         std::env::current_dir()
+    }
+}
+
+impl LinkProbe for Host {
+    fn can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool {
+        crate::store_path::host_can_link_between_dirs(from_dir, to_dir)
     }
 }

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -77,6 +77,19 @@ fn default_store_dir_windows(home_dir: &Path, current_dir: &Path) -> PathBuf {
 /// `home::home_dir` and `env::current_dir` through the
 /// capability impls — see the `SmartDefault` expression on
 /// [`crate::Config::store_dir`].
+///
+/// On non-Windows hosts, this is only the **initial** default. After
+/// [`crate::Config::current`] has applied global config, workspace
+/// yaml, and `PNPM_CONFIG_*` env vars, the store is re-resolved
+/// against the project's volume via
+/// [`crate::store_path::resolve_store_dir`] when none of those
+/// sources pinned `storeDir` — mirroring pnpm's
+/// [`getStorePath`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L14-L43),
+/// which falls back to `<mountpoint>/.pnpm-store` when the home
+/// volume can't be hardlinked from the project. Without that
+/// re-resolution a workspace on a separate case-sensitive volume
+/// would land in the case-insensitive home store, breaking tools
+/// that compare canonicalised file paths (typescript-eslint, for one).
 pub fn default_store_dir<Sys>() -> StoreDir
 where
     Sys: EnvVar + GetHomeDir + GetCurrentDir,

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -4,10 +4,11 @@ mod env_overlay;
 mod env_replace;
 pub mod matcher;
 mod npmrc_auth;
+mod store_path;
 pub mod version_policy;
 mod workspace_yaml;
 
-pub use crate::api::{EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host};
+pub use crate::api::{EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe};
 
 use indexmap::IndexMap;
 use pacquet_patching::{PatchGroupRecord, ResolvePatchedDependenciesError, resolve_and_group};
@@ -966,7 +967,7 @@ impl Config {
         start_dir: &std::path::Path,
     ) -> Result<Self, LoadWorkspaceYamlError>
     where
-        Sys: EnvVar + EnvVarOs + GetHomeDir,
+        Sys: EnvVar + EnvVarOs + GetHomeDir + LinkProbe,
     {
         // Re-anchor the path-valued defaults (`modules_dir`,
         // `virtual_store_dir`) onto the caller-supplied starting directory.
@@ -1035,12 +1036,22 @@ impl Config {
         // doesn't leak.
         let mut virtual_store_dir_explicit = false;
         let mut global_virtual_store_dir_explicit = false;
+        // `store_dir_explicit` carries the "did the user set `storeDir`
+        // anywhere?" signal through the cascade. Tracked separately
+        // from `virtual_store_dir_explicit` because the downstream
+        // consumer is different — store_dir's late-stage cross-volume
+        // resolution (port of pnpm's
+        // [`storePathRelativeToHome`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L45-L78))
+        // must fire only when the user has *not* pinned a path. See
+        // [`crate::store_path::resolve_store_dir`].
+        let mut store_dir_explicit = false;
         let global_config_dir = default_config_dir::<Sys>();
         let global_settings =
             global_config_dir.as_deref().map(WorkspaceSettings::load_global).transpose()?.flatten();
         if let Some(mut global_settings) = global_settings {
             virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
             global_virtual_store_dir_explicit |= global_settings.global_virtual_store_dir.is_some();
+            store_dir_explicit |= global_settings.store_dir.is_some();
             global_settings.substitute_env::<Sys>();
             let saved_workspace_dir = self.workspace_dir.take();
             global_settings.apply_to(&mut self, start_dir);
@@ -1138,6 +1149,7 @@ impl Config {
                 // leaves it unset.
                 virtual_store_dir_explicit |= settings.virtual_store_dir.is_some();
                 global_virtual_store_dir_explicit |= settings.global_virtual_store_dir.is_some();
+                store_dir_explicit |= settings.store_dir.is_some();
                 settings.substitute_env::<Sys>();
                 settings.apply_to(&mut self, &base_dir);
             }
@@ -1161,6 +1173,7 @@ impl Config {
         let mut env_settings = WorkspaceSettings::from_pnpm_config_env::<Sys>();
         virtual_store_dir_explicit |= env_settings.virtual_store_dir.is_some();
         global_virtual_store_dir_explicit |= env_settings.global_virtual_store_dir.is_some();
+        store_dir_explicit |= env_settings.store_dir.is_some();
         env_settings.substitute_env::<Sys>();
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.apply_to(&mut self, start_dir);
@@ -1171,6 +1184,32 @@ impl Config {
         // header lookup so default-registry creds key at the final
         // URL.
         npmrc_auth.build_auth_headers(&mut self);
+
+        // Re-resolve `store_dir` against the project's volume when no
+        // explicit source (global config.yaml, pnpm-workspace.yaml,
+        // `PNPM_CONFIG_STORE_DIR`) set it. The SmartDefault picks
+        // `<pnpm_home>/store` unconditionally; pnpm's
+        // [`getStorePath`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L14-L43)
+        // probes whether `pkg_root` can hardlink into the home volume
+        // and falls back to `<mountpoint>/.pnpm-store` when it can't,
+        // so a workspace on a separate (case-sensitive) volume gets a
+        // store on that same volume rather than the home volume.
+        // Without this, typescript-eslint's case-folded path cache
+        // diverges from TypeScript's case-sensitive program when the
+        // workspace is case-sensitive and the home is not.
+        if !store_dir_explicit && let Some(home_dir) = Sys::home_dir() {
+            // The "pnpm home dir" pnpm probes against is the parent of
+            // the home store (`~/Library/pnpm` for `~/Library/pnpm/store`).
+            // Fall back to the user's actual home if no parent is
+            // available — same-volume linkability is what we're after,
+            // and the home dir is on the same volume as any of its
+            // children.
+            let store_root = self.store_dir.root().to_path_buf();
+            let pnpm_home_dir = store_root.parent().unwrap_or(&home_dir).to_path_buf();
+            let resolved =
+                store_path::resolve_store_dir::<Sys>(store_root, &pnpm_home_dir, start_dir);
+            self.store_dir = StoreDir::from(resolved);
+        }
 
         // Derive `global_virtual_store_dir` last so it sees the final
         // `store_dir` / `virtual_store_dir` after yaml has been
@@ -1208,12 +1247,34 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, NodeLinker, PackageImportMethod,
-        fs,
+        Config, EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProbe, NodeLinker,
+        PackageImportMethod, fs,
     };
     use crate::defaults::default_store_dir;
     use pacquet_store_dir::StoreDir;
     use pacquet_testing_utils::env_guard::EnvGuard;
+    use std::path::Path;
+
+    /// `Config::current` requires `Sys: LinkProbe` so the late-stage
+    /// `store_dir` resolver (port of pnpm's `storePathRelativeToHome`)
+    /// can probe linkability between project and home. Tests in this
+    /// module pin specific config-cascade behaviours, none of which
+    /// turn on cross-volume detection, so the test fakes return
+    /// `false` for every probe. The probe failing collapses to the
+    /// pre-existing SmartDefault `store_dir` value, which is what the
+    /// pre-port assertions already assume.
+    ///
+    /// `inert_link_probe!(Name)` wires the impl onto a local test
+    /// fake without polluting each test fn with the boilerplate.
+    macro_rules! inert_link_probe {
+        ($($t:ty),+ $(,)?) => {$(
+            impl LinkProbe for $t {
+                fn can_link_between_dirs(_: &Path, _: &Path) -> bool {
+                    false
+                }
+            }
+        )+};
+    }
 
     fn display_store_dir(store_dir: &StoreDir) -> String {
         store_dir.display().to_string().replace('\\', "/")
@@ -1270,6 +1331,7 @@ mod tests {
             None
         }
     }
+    inert_link_probe!(HostNoHome);
 
     #[test]
     pub fn have_default_values() {
@@ -1457,6 +1519,7 @@ mod tests {
                 HOME_PATH.get().cloned()
             }
         }
+        inert_link_probe!(HostWithHome);
         let config = Config::new()
             .current::<HostWithHome>(current_dir.path())
             .expect("workspace yaml absent => no error");
@@ -1515,6 +1578,7 @@ mod tests {
                 HOME_PATH.get().cloned()
             }
         }
+        inert_link_probe!(HostWithHome);
         let config = Config { symlink: false, ..Config::new() }
             .current::<HostWithHome>(current_dir.path())
             .expect("workspace yaml absent => no error");
@@ -1779,6 +1843,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithEnvWorkspaceDir);
 
         let config =
             Config::new().current::<HostWithEnvWorkspaceDir>(cwd_dir.path()).expect("config loads");
@@ -1822,6 +1887,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithEmptyEnvWorkspaceDir);
         let tmp = tempdir().unwrap();
         let config = Config::new()
             .current::<HostWithEmptyEnvWorkspaceDir>(tmp.path())
@@ -1881,6 +1947,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithXdgConfigHome);
 
         let tmp = tempdir().unwrap();
         let config =
@@ -1932,6 +1999,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithXdgConfigHome);
 
         let config =
             Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
@@ -1993,6 +2061,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithXdgConfigHome);
 
         let config =
             Config::new().current::<HostWithXdgConfigHome>(project.path()).expect("config loads");
@@ -2048,6 +2117,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithXdgConfigHome);
 
         let tmp = tempdir().unwrap();
         let defaults = Config::new();
@@ -2088,6 +2158,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithPnpmConfigEnv);
 
         let tmp = tempdir().unwrap();
         let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
@@ -2119,6 +2190,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithLowercaseEnv);
 
         let tmp = tempdir().unwrap();
         let config = Config::new().current::<HostWithLowercaseEnv>(tmp.path()).expect("loads");
@@ -2155,6 +2227,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithPnpmConfigEnv);
 
         let config = Config::new().current::<HostWithPnpmConfigEnv>(tmp.path()).expect("loads");
         assert!(
@@ -2192,6 +2265,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithHoistEnv);
 
         let tmp = tempdir().unwrap();
         let config = Config::new().current::<HostWithHoistEnv>(tmp.path()).expect("loads");
@@ -2255,6 +2329,7 @@ mod tests {
                 None
             }
         }
+        inert_link_probe!(HostWithEnvOverride);
 
         let config = Config::new().current::<HostWithEnvOverride>(tmp.path()).expect("loads");
         assert_eq!(

--- a/pacquet/crates/config/src/store_path.rs
+++ b/pacquet/crates/config/src/store_path.rs
@@ -28,17 +28,18 @@
 //! "TSConfig does not include this file" error on every project file.
 //!
 //! The hardlink attempt itself is threaded through the
-//! [`LinkProbe`][crate::api::LinkProbe] capability so tests can
-//! answer the linkability question without touching disk. The
-//! production [`Host`][crate::api::Host] impl performs the real link
-//! attempts via [`host_can_link_between_dirs`].
+//! [`LinkProbe`] capability so tests can answer the linkability
+//! question without touching disk. The production [`Host`] impl
+//! performs the real link attempts via [`host_can_link_between_dirs`].
 //!
-//! `STORE_VERSION` ("v11") is intentionally *not* appended here: pacquet's
-//! [`StoreDir`] stores the root one level above v11 and appends it at
-//! access time via
-//! [`StoreDir::v11`](pacquet_store_dir::StoreDir::v11), where pnpm's
-//! `getStorePath` returns the v11-suffixed path directly. Both
-//! implementations land on identical on-disk paths.
+//! `STORE_VERSION` ("v11") is intentionally *not* appended here:
+//! pacquet's [`pacquet_store_dir::StoreDir`] stores the root one
+//! level above v11 and appends it at access time via
+//! [`pacquet_store_dir::StoreDir::v11`], where pnpm's `getStorePath`
+//! returns the v11-suffixed path directly. Both implementations land
+//! on identical on-disk paths.
+//!
+//! [`Host`]: crate::api::Host
 
 use crate::api::LinkProbe;
 use std::{

--- a/pacquet/crates/config/src/store_path.rs
+++ b/pacquet/crates/config/src/store_path.rs
@@ -1,0 +1,199 @@
+//! Port of pnpm's
+//! [`getStorePath` / `storePathRelativeToHome`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L14-L78).
+//!
+//! When the user has not pinned `storeDir`, pnpm places the store on
+//! the same volume as the project so the on-disk layout can use
+//! hardlinks instead of cross-volume copies. The choice is:
+//!
+//! 1. If a file in the project root can be hardlinked into the
+//!    user's pnpm home directory, use `<pnpm_home>/store` (the home
+//!    store).
+//! 2. Otherwise walk from the filesystem root toward the project,
+//!    find the first directory that *does* accept the hardlink (the
+//!    mount point), prefer that mount point's parent if it is also
+//!    linkable, and return `<mount_point>/.pnpm-store`. If only the
+//!    project folder itself is linkable, fall back to the home store
+//!    — that's what pnpm does at
+//!    [`index.ts:67-68`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L67-L68).
+//!
+//! Without this detection a developer with a separate
+//! case-sensitive workspace volume (for example
+//! `/Volumes/src/` on macOS) would have pacquet install into the
+//! case-*insensitive* home volume (`~/Library/pnpm/store`).
+//! Downstream tools that compare canonical paths get confused by the
+//! mismatch — typescript-eslint, for instance, canonicalises its
+//! parser cache against the home store and then can't find the same
+//! source files in the case-sensitive TypeScript program loaded from
+//! the workspace volume, so `eslint --fix` fails with a
+//! "TSConfig does not include this file" error on every project file.
+//!
+//! The hardlink attempt itself is threaded through the
+//! [`LinkProbe`][crate::api::LinkProbe] capability so tests can
+//! answer the linkability question without touching disk. The
+//! production [`Host`][crate::api::Host] impl performs the real link
+//! attempts via [`host_can_link_between_dirs`].
+//!
+//! `STORE_VERSION` ("v11") is intentionally *not* appended here: pacquet's
+//! [`StoreDir`] stores the root one level above v11 and appends it at
+//! access time via
+//! [`StoreDir::v11`](pacquet_store_dir::StoreDir::v11), where pnpm's
+//! `getStorePath` returns the v11-suffixed path directly. Both
+//! implementations land on identical on-disk paths.
+
+use crate::api::LinkProbe;
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Resolve where to place the default pnpm store given the SmartDefault
+/// home-based path and the project root.
+///
+/// Returns `home_default` unchanged when the project's volume can be
+/// reached via hardlink from `pnpm_home_dir`. Otherwise returns
+/// `<mountpoint>/.pnpm-store` where `<mountpoint>` is the first
+/// ancestor of `pkg_root` that accepts the hardlink (the volume mount
+/// point), preferring the mountpoint's parent when it too is linkable.
+/// Falls back to `home_default` whenever the algorithm cannot complete
+/// — pnpm's
+/// [`storePathRelativeToHome`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L45-L78)
+/// makes the same conservative choice on any error in its `try` /
+/// `catch`.
+pub fn resolve_store_dir<Sys: LinkProbe>(
+    home_default: PathBuf,
+    pnpm_home_dir: &Path,
+    pkg_root: &Path,
+) -> PathBuf {
+    let Ok(pkg_root) = fs::canonicalize(pkg_root) else {
+        return home_default;
+    };
+
+    if Sys::can_link_between_dirs(&pkg_root, pnpm_home_dir) {
+        return home_default;
+    }
+
+    let Some(mountpoint) = root_link_target::<Sys>(&pkg_root) else {
+        return home_default;
+    };
+
+    // Walk one level up if that parent is also linkable. Mirrors
+    // [`index.ts:60-64`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L60-L64):
+    // some mounts expose a writable parent (e.g. `/Volumes` on macOS
+    // is writable even though the actual mount is `/Volumes/src`).
+    let mountpoint = match mountpoint.parent() {
+        Some(parent) if parent != mountpoint && Sys::can_link_between_dirs(&pkg_root, parent) => {
+            parent.to_path_buf()
+        }
+        _ => mountpoint,
+    };
+
+    // pnpm's [`index.ts:67-68`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L67-L68):
+    // when linkability is confined to the project folder itself, the
+    // mount-point fallback would put the store *inside* the project
+    // — instead, defer to the home store.
+    if mountpoint == pkg_root {
+        return home_default;
+    }
+
+    mountpoint.join(".pnpm-store")
+}
+
+/// Find the volume mount point for the directory containing `existing`,
+/// using `can_link_between_dirs` to test each ancestor. Port of pnpm's
+/// [`rootLinkTarget`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L6-L21).
+///
+/// Returns `None` if no ancestor accepts the hardlink (no usable
+/// mount point) — the caller falls back to the home store.
+fn root_link_target<Sys: LinkProbe>(pkg_root: &Path) -> Option<PathBuf> {
+    let mut dir = filesystem_root(pkg_root);
+    loop {
+        if Sys::can_link_between_dirs(pkg_root, &dir) {
+            return Some(dir);
+        }
+        if dir == pkg_root {
+            return None;
+        }
+        dir = next_path(&dir, pkg_root);
+    }
+}
+
+/// Extract the absolute-path prefix that anchors `path` (the root
+/// `/` on Unix; the disk-prefix `C:\` on Windows; etc.). When `path`
+/// has no absolute root component the function returns the path
+/// unchanged — that branch should be unreachable here because
+/// `pkg_root` is canonicalised before [`root_link_target`] is called.
+fn filesystem_root(path: &Path) -> PathBuf {
+    let mut root = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => root.push(component.as_os_str()),
+            _ => break,
+        }
+    }
+    if root.as_os_str().is_empty() { path.to_path_buf() } else { root }
+}
+
+/// Given `from` (an ancestor of `to`), return `from` with one more
+/// path segment appended along the way to `to`. Port of npm's
+/// [`next-path`](https://github.com/zkochan/packages/blob/main/next-path/index.js):
+/// `nextPath('/', '/Volumes/src/proj')` → `'/Volumes'`,
+/// `nextPath('/Volumes', '/Volumes/src/proj')` → `'/Volumes/src'`.
+/// Returns `from` unchanged when `from` is not a prefix of `to`.
+fn next_path(from: &Path, to: &Path) -> PathBuf {
+    let from_components: Vec<_> = from.components().collect();
+    let to_components: Vec<_> = to.components().collect();
+    if to_components.len() <= from_components.len() {
+        return from.to_path_buf();
+    }
+    for (i, c) in from_components.iter().enumerate() {
+        if to_components.get(i) != Some(c) {
+            return from.to_path_buf();
+        }
+    }
+    let mut result = from.to_path_buf();
+    if let Some(next) = to_components.get(from_components.len()) {
+        result.push(next.as_os_str());
+    }
+    result
+}
+
+/// Real-filesystem implementation of [`LinkProbe::can_link_between_dirs`]
+/// used by the production [`Host`][crate::api::Host] impl. Mirrors
+/// pnpm's
+/// [`canLinkToSubdir`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L80-L92):
+/// create a temp file in `from_dir`, create a temp subdirectory in
+/// `to_dir`, attempt the hardlink, then clean up. Failure for any
+/// reason (parent missing, EACCES, EXDEV, …) collapses to `false`.
+pub(crate) fn host_can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool {
+    let src = path_temp_in(from_dir);
+    if fs::File::create(&src).is_err() {
+        return false;
+    }
+    let tmp_dir = path_temp_in(to_dir);
+    if fs::create_dir_all(&tmp_dir).is_err() {
+        let _ = fs::remove_file(&src);
+        return false;
+    }
+    let dst = path_temp_in(&tmp_dir);
+    let success = fs::hard_link(&src, &dst).is_ok();
+    let _ = fs::remove_file(&dst);
+    let _ = fs::remove_dir(&tmp_dir);
+    let _ = fs::remove_file(&src);
+    success
+}
+
+/// Generate a unique temp-path inside `folder`. Mirrors
+/// [`pathTemp`](https://github.com/zkochan/packages/blob/main/path-temp/index.js):
+/// `<folder>/_tmp_<pid>_<random>`. Collisions across racing pacquet
+/// processes are avoided by encoding both the pid and a nanosecond
+/// reading, which is sufficient because each callsite uses the path
+/// once and removes it.
+fn path_temp_in(folder: &Path) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.subsec_nanos()).unwrap_or(0);
+    folder.join(format!("_tmp_{pid}_{nanos:08x}"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/config/src/store_path/tests.rs
+++ b/pacquet/crates/config/src/store_path/tests.rs
@@ -89,22 +89,36 @@ fn resolve_store_dir_same_volume_uses_home_default() {
 /// the mountpoint deterministically without needing two real
 /// volumes.
 ///
-/// The state lives in a `Mutex<Vec<PathBuf>>` keyed by an explicit
-/// test-supplied label, swapped before each scenario via
-/// `PrefixProbe::set_allow`. We re-use the same fake struct across
-/// scenarios in this file by serializing access with the mutex.
+/// The allowlist lives in `ALLOW_PREFIXES`. To keep two
+/// concurrently-running scenarios from clobbering each other's
+/// allowlist between `set_allow` and the subsequent `resolve_store_dir`
+/// call (nextest runs tests in parallel by default), every scenario
+/// goes through [`PrefixProbe::with_allow`], which holds
+/// [`PREFIX_PROBE_SCENARIO_LOCK`] across the entire set-and-probe.
+/// Per CodeRabbit review on pnpm/pnpm#11804.
 #[cfg(unix)]
 static ALLOW_PREFIXES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+#[cfg(unix)]
+static PREFIX_PROBE_SCENARIO_LOCK: Mutex<()> = Mutex::new(());
 
 #[cfg(unix)]
 struct PrefixProbe;
 
 #[cfg(unix)]
 impl PrefixProbe {
-    fn set_allow(prefixes: &[&Path]) {
+    /// Install `prefixes` as the allowlist, run `body`, then drop
+    /// the scenario lock. Serialises every `PrefixProbe`-driven
+    /// scenario so parallel test execution can't race the allowlist
+    /// out from under a `resolve_store_dir` call.
+    fn with_allow<R>(prefixes: &[&Path], body: impl FnOnce() -> R) -> R {
+        let _scenario =
+            PREFIX_PROBE_SCENARIO_LOCK.lock().expect("PREFIX_PROBE_SCENARIO_LOCK not poisoned");
         let mut slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");
         slot.clear();
         slot.extend(prefixes.iter().map(|p| p.to_path_buf()));
+        drop(slot);
+        body()
     }
 }
 
@@ -139,8 +153,9 @@ fn resolve_store_dir_cross_volume_walks_to_mountpoint() {
 
     // Only the mount and its descendants are linkable — anything
     // higher (the tempdir root, `/`, the home dir) fails the probe.
-    PrefixProbe::set_allow(&[&mount_canon]);
-    let resolved = resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon);
+    let resolved = PrefixProbe::with_allow(&[&mount_canon], || {
+        resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon)
+    });
     assert_eq!(resolved, mount_canon.join(".pnpm-store"));
 }
 
@@ -166,8 +181,9 @@ fn resolve_store_dir_prefers_parent_when_parent_is_also_linkable() {
 
     // Both the mount and its parent accept the link → algorithm
     // prefers the parent.
-    PrefixProbe::set_allow(&[&parent_canon]);
-    let resolved = resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon);
+    let resolved = PrefixProbe::with_allow(&[&parent_canon], || {
+        resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon)
+    });
     assert_eq!(resolved, parent_canon.join(".pnpm-store"));
 }
 
@@ -186,9 +202,9 @@ fn resolve_store_dir_falls_back_when_only_pkg_root_is_linkable() {
     let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
     let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
 
-    PrefixProbe::set_allow(&[&pkg_root_canon]);
-    let resolved =
-        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon);
+    let resolved = PrefixProbe::with_allow(&[&pkg_root_canon], || {
+        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon)
+    });
     assert_eq!(resolved, home_default);
 }
 
@@ -209,9 +225,9 @@ fn resolve_store_dir_falls_back_when_no_mountpoint_is_linkable() {
     let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
 
     // Empty allowlist — every probe returns false.
-    PrefixProbe::set_allow(&[]);
-    let resolved =
-        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon);
+    let resolved = PrefixProbe::with_allow(&[], || {
+        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon)
+    });
     assert_eq!(resolved, home_default);
 }
 

--- a/pacquet/crates/config/src/store_path/tests.rs
+++ b/pacquet/crates/config/src/store_path/tests.rs
@@ -1,12 +1,20 @@
 use super::{filesystem_root, host_can_link_between_dirs, next_path, resolve_store_dir};
-use crate::api::LinkProbe;
 use pretty_assertions::assert_eq;
 use std::{
     fs,
     path::{Path, PathBuf},
-    sync::Mutex,
 };
 use tempfile::tempdir;
+
+// The `PrefixProbe` machinery below is only used by tests gated on
+// `cfg(unix)` (the cross-volume scenarios construct absolute Unix paths
+// like `/Volumes/src/...`). On Windows, every consumer is excluded, so
+// gate the fake itself to keep clippy's `dead_code` lint happy under
+// `-D warnings`.
+#[cfg(unix)]
+use crate::api::LinkProbe;
+#[cfg(unix)]
+use std::sync::Mutex;
 
 /// `next_path` walks one path segment at a time from `from` toward
 /// `to`. Mirrors the upstream
@@ -83,12 +91,15 @@ fn resolve_store_dir_same_volume_uses_home_default() {
 ///
 /// The state lives in a `Mutex<Vec<PathBuf>>` keyed by an explicit
 /// test-supplied label, swapped before each scenario via
-/// [`PrefixProbe::set_allow`]. We re-use the same fake struct across
+/// `PrefixProbe::set_allow`. We re-use the same fake struct across
 /// scenarios in this file by serializing access with the mutex.
+#[cfg(unix)]
 static ALLOW_PREFIXES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
+#[cfg(unix)]
 struct PrefixProbe;
 
+#[cfg(unix)]
 impl PrefixProbe {
     fn set_allow(prefixes: &[&Path]) {
         let mut slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");
@@ -97,6 +108,7 @@ impl PrefixProbe {
     }
 }
 
+#[cfg(unix)]
 impl LinkProbe for PrefixProbe {
     fn can_link_between_dirs(_from_dir: &Path, to_dir: &Path) -> bool {
         let slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");

--- a/pacquet/crates/config/src/store_path/tests.rs
+++ b/pacquet/crates/config/src/store_path/tests.rs
@@ -111,7 +111,7 @@ impl PrefixProbe {
     /// the scenario lock. Serialises every `PrefixProbe`-driven
     /// scenario so parallel test execution can't race the allowlist
     /// out from under a `resolve_store_dir` call.
-    fn with_allow<R>(prefixes: &[&Path], body: impl FnOnce() -> R) -> R {
+    fn with_allow<Output>(prefixes: &[&Path], body: impl FnOnce() -> Output) -> Output {
         let _scenario =
             PREFIX_PROBE_SCENARIO_LOCK.lock().expect("PREFIX_PROBE_SCENARIO_LOCK not poisoned");
         let mut slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");

--- a/pacquet/crates/config/src/store_path/tests.rs
+++ b/pacquet/crates/config/src/store_path/tests.rs
@@ -1,0 +1,250 @@
+use super::{filesystem_root, host_can_link_between_dirs, next_path, resolve_store_dir};
+use crate::api::LinkProbe;
+use pretty_assertions::assert_eq;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+use tempfile::tempdir;
+
+/// `next_path` walks one path segment at a time from `from` toward
+/// `to`. Mirrors the upstream
+/// [`next-path` tests](https://github.com/zkochan/packages/blob/main/next-path/test.js)
+/// without depending on the npm package.
+#[test]
+fn next_path_walks_one_segment_toward_target() {
+    assert_eq!(
+        next_path(Path::new("/"), Path::new("/Volumes/src/proj")),
+        PathBuf::from("/Volumes"),
+    );
+    assert_eq!(
+        next_path(Path::new("/Volumes"), Path::new("/Volumes/src/proj")),
+        PathBuf::from("/Volumes/src"),
+    );
+    assert_eq!(
+        next_path(Path::new("/Volumes/src"), Path::new("/Volumes/src/proj")),
+        PathBuf::from("/Volumes/src/proj"),
+    );
+}
+
+/// `next_path` returns `from` unchanged when `from` is not actually an
+/// ancestor of `to` — keeps the loop in `root_link_target` from
+/// looping forever on malformed inputs.
+#[test]
+fn next_path_returns_from_when_not_an_ancestor() {
+    assert_eq!(
+        next_path(Path::new("/Volumes/src"), Path::new("/Users/zoltan")),
+        PathBuf::from("/Volumes/src"),
+    );
+}
+
+/// `filesystem_root` extracts the root prefix of an absolute path —
+/// `/` on Unix; the windows-prefix test is gated separately.
+#[test]
+#[cfg(unix)]
+fn filesystem_root_unix_is_slash() {
+    assert_eq!(filesystem_root(Path::new("/Volumes/src/proj")), PathBuf::from("/"));
+    assert_eq!(filesystem_root(Path::new("/")), PathBuf::from("/"));
+}
+
+#[test]
+#[cfg(windows)]
+fn filesystem_root_windows_keeps_drive_prefix() {
+    assert_eq!(filesystem_root(Path::new(r"C:\Users\proj")), PathBuf::from(r"C:\"));
+}
+
+/// Real-fixture happy path: project and home are on the same volume
+/// (both inside the same `tempdir`), so the Host impl observes a
+/// successful hardlink and `resolve_store_dir` returns the
+/// home_default unchanged. This is the dominant branch on a single-
+/// volume developer setup and the one the SmartDefault used to
+/// short-circuit to without checking.
+#[test]
+fn resolve_store_dir_same_volume_uses_home_default() {
+    use crate::api::Host;
+
+    let tmp = tempdir().expect("create tempdir");
+    let pkg_root = tmp.path().join("project");
+    let pnpm_home = tmp.path().join("home/pnpm");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    fs::create_dir_all(&pnpm_home).expect("create home dir");
+    let home_default = pnpm_home.join("store");
+
+    let resolved = resolve_store_dir::<Host>(home_default.clone(), &pnpm_home, &pkg_root);
+    assert_eq!(resolved, home_default);
+}
+
+/// Fake [`LinkProbe`] driven by a path-allowlist for the
+/// `to_dir`: only directories whose canonical path starts with one
+/// of the recorded prefixes accept the hardlink. Lets a test pin
+/// the mountpoint deterministically without needing two real
+/// volumes.
+///
+/// The state lives in a `Mutex<Vec<PathBuf>>` keyed by an explicit
+/// test-supplied label, swapped before each scenario via
+/// [`PrefixProbe::set_allow`]. We re-use the same fake struct across
+/// scenarios in this file by serializing access with the mutex.
+static ALLOW_PREFIXES: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+
+struct PrefixProbe;
+
+impl PrefixProbe {
+    fn set_allow(prefixes: &[&Path]) {
+        let mut slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");
+        slot.clear();
+        slot.extend(prefixes.iter().map(|p| p.to_path_buf()));
+    }
+}
+
+impl LinkProbe for PrefixProbe {
+    fn can_link_between_dirs(_from_dir: &Path, to_dir: &Path) -> bool {
+        let slot = ALLOW_PREFIXES.lock().expect("ALLOW_PREFIXES not poisoned");
+        slot.iter().any(|allowed| to_dir.starts_with(allowed))
+    }
+}
+
+/// Cross-volume scenario: home volume is unreachable, so the
+/// algorithm walks from `/` toward `pkg_root` until it hits the
+/// project's mount point (here a fake `/Volumes/src`), then returns
+/// `<mountpoint>/.pnpm-store`. Mirrors pnpm's
+/// [`'a link can be created to the a subdir in the root of the
+/// drive'`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/test/index.ts#L84-L88)
+/// test.
+#[test]
+#[cfg(unix)]
+fn resolve_store_dir_cross_volume_walks_to_mountpoint() {
+    let tmp = tempdir().expect("create tempdir");
+    let mount = tmp.path().join("Volumes/src");
+    let pkg_root = mount.join("project");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    // pkg_root must canonicalize, so symlinks (`/var` → `/private/var`
+    // on macOS) don't surprise the prefix match.
+    let pkg_root_canon = fs::canonicalize(&pkg_root).expect("canonicalize pkg_root");
+    let mount_canon = pkg_root_canon.parent().expect("project has parent").to_path_buf();
+    let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
+    let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
+
+    // Only the mount and its descendants are linkable — anything
+    // higher (the tempdir root, `/`, the home dir) fails the probe.
+    PrefixProbe::set_allow(&[&mount_canon]);
+    let resolved = resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon);
+    assert_eq!(resolved, mount_canon.join(".pnpm-store"));
+}
+
+/// When the algorithm walks toward `pkg_root` and the *parent* of the
+/// first linkable directory is also linkable, prefer the parent.
+/// Mirrors pnpm's `mountpointParent` short-walk at
+/// [`index.ts:60-64`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L60-L64)
+/// — the macOS case where `/Volumes` is writable even though the
+/// volume mount is `/Volumes/src`.
+#[test]
+#[cfg(unix)]
+fn resolve_store_dir_prefers_parent_when_parent_is_also_linkable() {
+    let tmp = tempdir().expect("create tempdir");
+    let parent_mount = tmp.path().join("VolumesGroup");
+    let mount = parent_mount.join("src");
+    let pkg_root = mount.join("project");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    let pkg_root_canon = fs::canonicalize(&pkg_root).expect("canonicalize pkg_root");
+    let mount_canon = pkg_root_canon.parent().expect("project has parent").to_path_buf();
+    let parent_canon = mount_canon.parent().expect("mount has parent").to_path_buf();
+    let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
+    let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
+
+    // Both the mount and its parent accept the link → algorithm
+    // prefers the parent.
+    PrefixProbe::set_allow(&[&parent_canon]);
+    let resolved = resolve_store_dir::<PrefixProbe>(home_default, &pnpm_home, &pkg_root_canon);
+    assert_eq!(resolved, parent_canon.join(".pnpm-store"));
+}
+
+/// When the only directory that accepts the hardlink is `pkg_root`
+/// itself (i.e. linkability is confined to the project folder), the
+/// algorithm falls back to the home default — putting the store
+/// *inside* the project would be wrong. Pnpm makes the same call at
+/// [`index.ts:67-68`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L67-L68).
+#[test]
+#[cfg(unix)]
+fn resolve_store_dir_falls_back_when_only_pkg_root_is_linkable() {
+    let tmp = tempdir().expect("create tempdir");
+    let pkg_root = tmp.path().join("project");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    let pkg_root_canon = fs::canonicalize(&pkg_root).expect("canonicalize pkg_root");
+    let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
+    let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
+
+    PrefixProbe::set_allow(&[&pkg_root_canon]);
+    let resolved =
+        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon);
+    assert_eq!(resolved, home_default);
+}
+
+/// When *nothing* on the way from filesystem root to `pkg_root` is
+/// linkable (e.g. the volume holding `pkg_root` rejects every probe),
+/// the algorithm cannot identify a mount point and falls back to
+/// home. Matches pnpm's outer `try`/`catch` at
+/// [`index.ts:56-77`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L56-L77):
+/// any algorithm failure collapses to `storeInHomeDir`.
+#[test]
+#[cfg(unix)]
+fn resolve_store_dir_falls_back_when_no_mountpoint_is_linkable() {
+    let tmp = tempdir().expect("create tempdir");
+    let pkg_root = tmp.path().join("project");
+    fs::create_dir_all(&pkg_root).expect("create project dir");
+    let pkg_root_canon = fs::canonicalize(&pkg_root).expect("canonicalize pkg_root");
+    let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
+    let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
+
+    // Empty allowlist — every probe returns false.
+    PrefixProbe::set_allow(&[]);
+    let resolved =
+        resolve_store_dir::<PrefixProbe>(home_default.clone(), &pnpm_home, &pkg_root_canon);
+    assert_eq!(resolved, home_default);
+}
+
+/// `pkg_root` that doesn't exist on disk (e.g. CLI run before
+/// `mkdir -p`) cannot be canonicalized, so the algorithm falls
+/// back to home. The store creation code downstream will create the
+/// directory itself, so a missing `pkg_root` is not an error here.
+#[test]
+fn resolve_store_dir_falls_back_when_pkg_root_does_not_exist() {
+    use crate::api::Host;
+
+    let home_default = PathBuf::from("/home/test-user/Library/pnpm/store");
+    let pnpm_home = PathBuf::from("/home/test-user/Library/pnpm");
+    let missing = PathBuf::from("/this/path/should/not/exist/anywhere");
+    let resolved = resolve_store_dir::<Host>(home_default.clone(), &pnpm_home, &missing);
+    assert_eq!(resolved, home_default);
+}
+
+/// `host_can_link_between_dirs` returns `true` between two directories
+/// on the same tempdir-volume (the common case). This is the
+/// production primitive [`Host`][crate::api::Host] threads through the
+/// [`LinkProbe`] trait; same-volume happiness is exercised here so a
+/// future refactor that broke the linker would be caught directly.
+#[test]
+fn host_can_link_between_dirs_same_volume_is_true() {
+    let tmp = tempdir().expect("create tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    fs::create_dir_all(&from).expect("create from");
+    fs::create_dir_all(&to).expect("create to");
+    assert!(host_can_link_between_dirs(&from, &to));
+}
+
+/// `host_can_link_between_dirs` collapses every failure mode to
+/// `false`, including the case where `from_dir` does not exist
+/// (so the temp source file can't be created). Mirrors pnpm's
+/// `canLink` returning `false` on `EACCES` / `EPERM` / `EXDEV` /
+/// anything else — pacquet's probe widens that to "any error means
+/// not linkable" so the algorithm degrades to home_default rather
+/// than aborting the install.
+#[test]
+fn host_can_link_between_dirs_missing_from_dir_is_false() {
+    let tmp = tempdir().expect("create tempdir");
+    let missing_from = tmp.path().join("does/not/exist");
+    let to = tmp.path().join("to");
+    fs::create_dir_all(&to).expect("create to");
+    assert!(!host_can_link_between_dirs(&missing_from, &to));
+}


### PR DESCRIPTION
## Summary

- Port pnpm's [`getStorePath` / `storePathRelativeToHome`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L14-L78) cross-volume detection to pacquet's `default_store_dir`.
- When no `storeDir` is explicitly set, `Config::current` now probes whether the project root can be hardlinked into the user's pnpm home dir and falls back to `<mountpoint>/.pnpm-store` when it can't.
- New `LinkProbe` capability in `pacquet-config::api` so tests can answer the linkability question deterministically; production `Host` impl performs the real link attempts.

## Why

Before this fix, a workspace on a separate volume (e.g. `/Volumes/src/` on macOS) installed into the home-volume store (`~/Library/pnpm/store`). When the home volume is case-insensitive and the workspace volume is case-sensitive, **typescript-eslint's** path cache canonicalises against the home store and then can't locate the same files in TypeScript's case-sensitive program loaded from the workspace, so `eslint --fix` fails with `Parsing error: ESLint was configured to run on <file> using parserOptions.project: tsconfig.lint.json — TSConfig does not include this file` on every project file.

Concrete repro: on the `use-pacquet-config-dep` branch (which delegates installs to pacquet via `configDependencies['@pnpm/pacquet']`), `pn -w compile` fails its `eslint --fix` step with ~50 of those errors. After this fix pacquet picks `/Volumes/src/.pnpm-store/v11` — the same store pnpm 11 picks via `getStorePath` — and the lint succeeds.

## What landed

- `pacquet/crates/config/src/store_path.rs` — port of `getStorePath` / `storePathRelativeToHome` / `rootLinkTarget` / `canLinkToSubdir` / `nextPath`. Algorithm is generic over `LinkProbe`; the `Host` impl performs the real link attempts via `host_can_link_between_dirs`.
- `pacquet/crates/config/src/store_path/tests.rs` — 11 unit tests: `next_path` walks, `filesystem_root` extraction, same-volume happy path (real fixture), cross-volume to mountpoint (DI probe), mountpoint-parent preference, `pkg_root`-only fallback, no-mountpoint fallback, missing-`pkg_root` fallback, and the `Host` primitive itself. Each cites the upstream `index.ts` lines it mirrors.
- `pacquet/crates/config/src/api.rs` — new `LinkProbe` capability trait + `Host` impl.
- `pacquet/crates/config/src/lib.rs` — added `store_dir_explicit` tracking through the cascade (global config.yaml → pnpm-workspace.yaml → `PNPM_CONFIG_*` env vars), and a late-stage `resolve_store_dir::<Sys>` call when the user didn't pin `storeDir`. `Config::current`'s `Sys` bound gained `+ LinkProbe`; an `inert_link_probe!` macro in the test module wires the bound onto every existing test fake.
- `pacquet/crates/config/src/defaults.rs` — doc-comment update on `default_store_dir` pointing at the new re-resolution step.

## Test plan

- [x] `cargo nextest run --workspace` — 1947/1947 pass, 3 skipped.
- [x] `cargo nextest run -p pacquet-config -E 'test(store_path)'` — 11/11 pass.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` clean.
- [x] `just dylint` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] End-to-end: `pacquet install --frozen-lockfile` in `/Volumes/src/tmp/pacquet-store-test` (workspace on case-sensitive volume) now links `node_modules/is-positive` → `/Volumes/src/.pnpm-store/v11/links/...`, matching what `pnpm install` picks at the same directory.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter store-directory resolution that picks an appropriate store location across volumes/mounts and avoids cross-volume linking issues when possible.
  * Configuration now detects whether the store directory was explicitly set and only re-resolves the default when appropriate.

* **Documentation**
  * Clarified the non-Windows default store-dir behavior: initial default may be re-resolved later unless explicitly pinned.

* **Tests**
  * Added comprehensive tests covering store resolution and linkability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->