### PR TITLE
feat: add blockExoticSubdepsExclude to allow trusted exotic subdependencies

### DIFF
--- a/.changeset/block-exotic-subdeps-exclude.md
+++ b/.changeset/block-exotic-subdeps-exclude.md
@@ -5,4 +5,4 @@
 "pnpm": minor
 ---
 
-Added a new setting `blockExoticSubdepsExclude`, a list of trusted git repositories that are allowed to be installed as exotic subdependencies even when `blockExoticSubdeps` is enabled. Entries are matched against the normalized source URL of the dependency (e.g. `https://github.com/user/repo`) and support `*` wildcards, so a whole host or organization can be trusted at once (e.g. `https://github.com/my-org/*`).
+Added a new setting `blockExoticSubdepsExclude`, a list of trusted sources (git repositories or tarball/URL hosts) that are allowed to be installed as exotic subdependencies even when `blockExoticSubdeps` is enabled. Entries are matched against the normalized source URL of the dependency (e.g. `https://github.com/user/repo`) and support `*` wildcards, so a whole host or organization can be trusted at once (e.g. `https://github.com/my-org/*`).

--- a/.changeset/block-exotic-subdeps-exclude.md
+++ b/.changeset/block-exotic-subdeps-exclude.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/installing.deps-resolver": minor
+"@pnpm/installing.deps-installer": minor
+"pnpm": minor
+---
+
+Added a new setting `blockExoticSubdepsExclude`, a list of trusted packages that are allowed to be installed as exotic (e.g. git-hosted) subdependencies even when `blockExoticSubdeps` is enabled. Entries are matched by package name (the alias used in the dependency tree, falling back to the resolved package name) and support wildcards (e.g. `@scope/*`) and exact-version pins (e.g. `foo@1.0.0`).

--- a/.changeset/block-exotic-subdeps-exclude.md
+++ b/.changeset/block-exotic-subdeps-exclude.md
@@ -5,4 +5,4 @@
 "pnpm": minor
 ---
 
-Added a new setting `blockExoticSubdepsExclude`, a list of trusted packages that are allowed to be installed as exotic (e.g. git-hosted) subdependencies even when `blockExoticSubdeps` is enabled. Entries are matched by package name (the alias used in the dependency tree, falling back to the resolved package name) and support wildcards (e.g. `@scope/*`) and exact-version pins (e.g. `foo@1.0.0`).
+Added a new setting `blockExoticSubdepsExclude`, a list of trusted git repositories that are allowed to be installed as exotic subdependencies even when `blockExoticSubdeps` is enabled. Entries are matched against the normalized source URL of the dependency (e.g. `https://github.com/user/repo`) and support `*` wildcards, so a whole host or organization can be trusted at once (e.g. `https://github.com/my-org/*`).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -220,6 +220,7 @@ export interface Config extends OptionsFromRootManifest {
   disallowWorkspaceCycles?: boolean
   packGzipLevel?: number
   blockExoticSubdeps?: boolean
+  blockExoticSubdepsExclude?: string[]
 
   agent?: string
 

--- a/config/reader/src/configFileKey.ts
+++ b/config/reader/src/configFileKey.ts
@@ -51,6 +51,7 @@ export const pnpmConfigFileKeys = [
   'prefer-offline',
   'prefer-symlinked-executables',
   'block-exotic-subdeps',
+  'block-exotic-subdeps-exclude',
   'registry-supports-time-field',
   'reporter',
   'resolution-mode',

--- a/config/reader/src/types.ts
+++ b/config/reader/src/types.ts
@@ -95,6 +95,7 @@ export const pnpmTypes = {
   'publish-branch': String,
   'recursive-install': Boolean,
   'block-exotic-subdeps': Boolean,
+  'block-exotic-subdeps-exclude': [String, Array],
   reporter: String,
   'resolution-mode': ['highest', 'time-based', 'lowest-direct'],
   'resolve-peers-from-workspace-root': Boolean,

--- a/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -215,6 +215,7 @@ export interface StrictInstallOptions {
   trustPolicyIgnoreAfter?: number
   packageVulnerabilityAudit?: PackageVulnerabilityAudit
   blockExoticSubdeps?: boolean
+  blockExoticSubdepsExclude?: string[]
   /**
    * Optional alternative install engine. When set, the frozen-install
    * path invokes this callback instead of `headlessInstall`. The CLI

--- a/installing/deps-installer/src/install/index.ts
+++ b/installing/deps-installer/src/install/index.ts
@@ -1461,6 +1461,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       trustPolicyExclude: opts.trustPolicyExclude,
       trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
       blockExoticSubdeps: opts.blockExoticSubdeps,
+      blockExoticSubdepsExclude: opts.blockExoticSubdepsExclude,
       allProjectIds: Object.values(ctx.projects).map((p) => p.id),
       handleResolutionPolicyViolations: opts.handleResolutionPolicyViolations,
     }

--- a/installing/deps-installer/test/install/blockExoticSubdeps.ts
+++ b/installing/deps-installer/test/install/blockExoticSubdeps.ts
@@ -74,3 +74,50 @@ test('blockExoticSubdeps: false (default) allows git dependencies in subdependen
   const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
   expect(m).toBe('Hi')
 })
+
+test('blockExoticSubdeps allows a git subdependency listed in blockExoticSubdepsExclude', async () => {
+  const project = prepareEmpty()
+
+  // say-hi is the alias of the git-hosted subdependency, so listing it as trusted
+  // should let the install proceed even though blockExoticSubdeps is enabled.
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/has-aliased-git-dependency'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-hi'], fastUnpack: false })
+  )
+
+  const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
+  expect(m).toBe('Hi')
+})
+
+test('blockExoticSubdeps allows a git subdependency matched by a wildcard in blockExoticSubdepsExclude', async () => {
+  const project = prepareEmpty()
+
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/has-aliased-git-dependency'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-*'], fastUnpack: false })
+  )
+
+  const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
+  expect(m).toBe('Hi')
+})
+
+test('blockExoticSubdeps still blocks a git subdependency that is not in blockExoticSubdepsExclude', async () => {
+  prepareEmpty()
+
+  await expect(addDependenciesToPackage({},
+    ['@pnpm.e2e/has-aliased-git-dependency'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['some-other-pkg'], fastUnpack: false })
+  )).rejects.toThrow('is not allowed in subdependencies when blockExoticSubdeps is enabled')
+})
+
+test('blockExoticSubdepsExclude rejects a semver range', async () => {
+  prepareEmpty()
+
+  // Only exact versions are allowed in the policy; a range must surface a clear error.
+  await expect(addDependenciesToPackage({},
+    ['is-positive@1.0.0'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-hi@^1.0.0'] })
+  )).rejects.toThrow('Invalid value in blockExoticSubdepsExclude')
+})

--- a/installing/deps-installer/test/install/blockExoticSubdeps.ts
+++ b/installing/deps-installer/test/install/blockExoticSubdeps.ts
@@ -116,6 +116,22 @@ test('blockExoticSubdeps allows a git subdependency matched by a host wildcard i
   expect(m).toBe('Hi')
 })
 
+// github/gitlab/bitbucket git deps resolve to a codeload tarball (resolution.tarball),
+// so this exercises matching against the resolved tarball/URL of an exotic subdependency,
+// not just its git repo URL. The codeload host only matches the tarball candidate.
+test('blockExoticSubdeps allows an exotic subdependency matched by its resolved tarball URL', async () => {
+  const project = prepareEmpty()
+
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/has-aliased-git-dependency'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['https://codeload.github.com/zkochan/*'], fastUnpack: false })
+  )
+
+  const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
+  expect(m).toBe('Hi')
+})
+
 test('blockExoticSubdeps still blocks a git subdependency whose URL is not in blockExoticSubdepsExclude', async () => {
   prepareEmpty()
 

--- a/installing/deps-installer/test/install/blockExoticSubdeps.ts
+++ b/installing/deps-installer/test/install/blockExoticSubdeps.ts
@@ -75,49 +75,52 @@ test('blockExoticSubdeps: false (default) allows git dependencies in subdependen
   expect(m).toBe('Hi')
 })
 
-test('blockExoticSubdeps allows a git subdependency listed in blockExoticSubdepsExclude', async () => {
+// The git-hosted subdependency resolves from github:zkochan/hi, which
+// normalizes to the source URL https://github.com/zkochan/hi.
+test('blockExoticSubdeps allows a git subdependency whose URL is listed in blockExoticSubdepsExclude', async () => {
   const project = prepareEmpty()
 
-  // say-hi is the alias of the git-hosted subdependency, so listing it as trusted
-  // should let the install proceed even though blockExoticSubdeps is enabled.
   await addDependenciesToPackage(
     {},
     ['@pnpm.e2e/has-aliased-git-dependency'],
-    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-hi'], fastUnpack: false })
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['https://github.com/zkochan/hi'], fastUnpack: false })
   )
 
   const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
   expect(m).toBe('Hi')
 })
 
-test('blockExoticSubdeps allows a git subdependency matched by a wildcard in blockExoticSubdepsExclude', async () => {
+test('blockExoticSubdeps allows a git subdependency matched by a repo wildcard in blockExoticSubdepsExclude', async () => {
   const project = prepareEmpty()
 
   await addDependenciesToPackage(
     {},
     ['@pnpm.e2e/has-aliased-git-dependency'],
-    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-*'], fastUnpack: false })
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['https://github.com/zkochan/*'], fastUnpack: false })
   )
 
   const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
   expect(m).toBe('Hi')
 })
 
-test('blockExoticSubdeps still blocks a git subdependency that is not in blockExoticSubdepsExclude', async () => {
+test('blockExoticSubdeps allows a git subdependency matched by a host wildcard in blockExoticSubdepsExclude', async () => {
+  const project = prepareEmpty()
+
+  await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/has-aliased-git-dependency'],
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['https://github.com/*'], fastUnpack: false })
+  )
+
+  const m = project.requireModule('@pnpm.e2e/has-aliased-git-dependency')
+  expect(m).toBe('Hi')
+})
+
+test('blockExoticSubdeps still blocks a git subdependency whose URL is not in blockExoticSubdepsExclude', async () => {
   prepareEmpty()
 
   await expect(addDependenciesToPackage({},
     ['@pnpm.e2e/has-aliased-git-dependency'],
-    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['some-other-pkg'], fastUnpack: false })
+    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['https://github.com/some-other-user/*'], fastUnpack: false })
   )).rejects.toThrow('is not allowed in subdependencies when blockExoticSubdeps is enabled')
-})
-
-test('blockExoticSubdepsExclude rejects a semver range', async () => {
-  prepareEmpty()
-
-  // Only exact versions are allowed in the policy; a range must surface a clear error.
-  await expect(addDependenciesToPackage({},
-    ['is-positive@1.0.0'],
-    testDefaults({ blockExoticSubdeps: true, blockExoticSubdepsExclude: ['say-hi@^1.0.0'] })
-  )).rejects.toThrow('Invalid value in blockExoticSubdepsExclude')
 })

--- a/installing/deps-resolver/package.json
+++ b/installing/deps-resolver/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/config.matcher": "workspace:*",
     "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
@@ -59,6 +60,7 @@
     "@pnpm/workspace.spec-parser": "workspace:*",
     "@yarnpkg/core": "catalog:",
     "graph-cycles": "catalog:",
+    "hosted-git-info": "catalog:",
     "is-inner-link": "catalog:",
     "is-subdir": "catalog:",
     "normalize-path": "catalog:",
@@ -79,6 +81,7 @@
     "@jest/globals": "catalog:",
     "@pnpm/installing.deps-resolver": "workspace:*",
     "@pnpm/logger": "workspace:*",
+    "@types/hosted-git-info": "catalog:",
     "@types/normalize-path": "catalog:",
     "@types/ramda": "catalog:",
     "@types/semver": "catalog:"

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 
 import { type CatalogResolution, type CatalogResolver, matchCatalogResolveResult } from '@pnpm/catalogs.resolver'
+import type { Matcher } from '@pnpm/config.matcher'
 import {
   deprecationLogger,
   progressLogger,
@@ -49,6 +50,7 @@ import type {
   SupportedArchitectures,
   TrustPolicy,
 } from '@pnpm/types'
+import HostedGit from 'hosted-git-info'
 import normalizePath from 'normalize-path'
 import pDefer from 'p-defer'
 import { pathExists } from 'path-exists'
@@ -202,7 +204,7 @@ export interface ResolutionContext {
   trustPolicyExclude?: PackageVersionPolicy
   trustPolicyIgnoreAfter?: number
   blockExoticSubdeps?: boolean
-  blockExoticSubdepsExclude?: PackageVersionPolicy
+  blockExoticSubdepsExclude?: Matcher
 }
 
 export interface MissingPeerInfo {
@@ -1424,7 +1426,7 @@ async function resolveDependency (
     options.currentDepth > 0 &&
     pkgResponse.body.resolvedVia != null && // This is already coming from the lockfile, we skip the check in this case for now. Should be fixed later.
     isExoticDep(pkgResponse.body.resolvedVia) &&
-    !isExoticSubdepExcluded(ctx.blockExoticSubdepsExclude, wantedDependency.alias, pkgResponse.body.manifest)
+    !isExoticSubdepExcluded(ctx.blockExoticSubdepsExclude, wantedDependency.bareSpecifier, pkgResponse.body.normalizedBareSpecifier, pkgResponse.body.resolution)
   ) {
     const error = new PnpmError(
       'EXOTIC_SUBDEP',
@@ -1847,24 +1849,41 @@ function isExoticDep (resolvedVia: string): boolean {
 }
 
 /**
- * Returns true when an exotic subdependency is on the user's
- * `blockExoticSubdepsExclude` trust list and should therefore be allowed
- * even though `blockExoticSubdeps` is enabled. The dependency is matched by
- * its alias first (the name it appears under in the tree), then by its
- * resolved manifest name. Exact-version entries (e.g. `foo@1.0.0`) only match
- * when the resolved manifest version is listed; bare names match any version.
+ * Returns true when an exotic subdependency's source is on the user's
+ * `blockExoticSubdepsExclude` trust list and should therefore be allowed even
+ * though `blockExoticSubdeps` is enabled. The dependency is matched by its
+ * normalized source URL (e.g. `https://github.com/user/repo`), not by name, so
+ * an aliased dependency can't be used to slip past the block. Patterns support
+ * `*` wildcards, so a whole host or org can be trusted at once (e.g.
+ * `https://github.com/my-org/*`).
  */
 function isExoticSubdepExcluded (
-  exclude: PackageVersionPolicy | undefined,
-  alias: string | undefined,
-  manifest: Pick<PackageManifest, 'name' | 'version'> | undefined
+  exclude: Matcher | undefined,
+  bareSpecifier: string | undefined,
+  normalizedBareSpecifier: string | undefined,
+  resolution: Resolution
 ): boolean {
   if (exclude == null) return false
-  for (const name of [alias, manifest?.name]) {
-    if (name == null) continue
-    const result = exclude(name)
-    if (result === true) return true
-    if (Array.isArray(result) && manifest?.version != null && result.includes(manifest.version)) return true
+  const repo = resolution.type === 'git' ? resolution.repo : undefined
+  for (const source of [normalizedBareSpecifier, bareSpecifier, repo]) {
+    const url = normalizeGitRepoUrl(source)
+    if (url != null && exclude(url)) return true
   }
   return false
+}
+
+/**
+ * Normalizes a git dependency source into a canonical `https://host/user/repo`
+ * URL for matching, dropping the `git+` prefix, the committish and any `.git`
+ * suffix. Hosted shorthands (`github:`, `gitlab:`, …) are expanded via
+ * hosted-git-info; anything else is treated as a plain URL.
+ */
+function normalizeGitRepoUrl (source: string | undefined): string | undefined {
+  if (source == null || source === '') return undefined
+  const hosted = HostedGit.fromUrl(source)
+  const url = hosted?.https({ noCommittish: true, noGitPlus: true }) ?? source
+  return url
+    .replace(/^git\+/, '')
+    .replace(/#.*$/, '')
+    .replace(/\.git$/, '')
 }

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -202,6 +202,7 @@ export interface ResolutionContext {
   trustPolicyExclude?: PackageVersionPolicy
   trustPolicyIgnoreAfter?: number
   blockExoticSubdeps?: boolean
+  blockExoticSubdepsExclude?: PackageVersionPolicy
 }
 
 export interface MissingPeerInfo {
@@ -1422,7 +1423,8 @@ async function resolveDependency (
     ctx.blockExoticSubdeps &&
     options.currentDepth > 0 &&
     pkgResponse.body.resolvedVia != null && // This is already coming from the lockfile, we skip the check in this case for now. Should be fixed later.
-    isExoticDep(pkgResponse.body.resolvedVia)
+    isExoticDep(pkgResponse.body.resolvedVia) &&
+    !isExoticSubdepExcluded(ctx.blockExoticSubdepsExclude, wantedDependency.alias, pkgResponse.body.manifest)
   ) {
     const error = new PnpmError(
       'EXOTIC_SUBDEP',
@@ -1842,4 +1844,27 @@ const NON_EXOTIC_RESOLVED_VIA = new Set([
 
 function isExoticDep (resolvedVia: string): boolean {
   return !NON_EXOTIC_RESOLVED_VIA.has(resolvedVia)
+}
+
+/**
+ * Returns true when an exotic subdependency is on the user's
+ * `blockExoticSubdepsExclude` trust list and should therefore be allowed
+ * even though `blockExoticSubdeps` is enabled. The dependency is matched by
+ * its alias first (the name it appears under in the tree), then by its
+ * resolved manifest name. Exact-version entries (e.g. `foo@1.0.0`) only match
+ * when the resolved manifest version is listed; bare names match any version.
+ */
+function isExoticSubdepExcluded (
+  exclude: PackageVersionPolicy | undefined,
+  alias: string | undefined,
+  manifest: Pick<PackageManifest, 'name' | 'version'> | undefined
+): boolean {
+  if (exclude == null) return false
+  for (const name of [alias, manifest?.name]) {
+    if (name == null) continue
+    const result = exclude(name)
+    if (result === true) return true
+    if (Array.isArray(result) && manifest?.version != null && result.includes(manifest.version)) return true
+  }
+  return false
 }

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -1852,10 +1852,10 @@ function isExoticDep (resolvedVia: string): boolean {
  * Returns true when an exotic subdependency's source is on the user's
  * `blockExoticSubdepsExclude` trust list and should therefore be allowed even
  * though `blockExoticSubdeps` is enabled. The dependency is matched by its
- * normalized source URL (e.g. `https://github.com/user/repo`), not by name, so
- * an aliased dependency can't be used to slip past the block. Patterns support
- * `*` wildcards, so a whole host or org can be trusted at once (e.g.
- * `https://github.com/my-org/*`).
+ * normalized source URL — the git repository or tarball/URL it resolves from
+ * (e.g. `https://github.com/user/repo`) — not by name, so an aliased dependency
+ * can't be used to slip past the block. Patterns support `*` wildcards, so a
+ * whole host or org can be trusted at once (e.g. `https://github.com/my-org/*`).
  */
 function isExoticSubdepExcluded (
   exclude: Matcher | undefined,
@@ -1865,20 +1865,22 @@ function isExoticSubdepExcluded (
 ): boolean {
   if (exclude == null) return false
   const repo = resolution.type === 'git' ? resolution.repo : undefined
-  for (const source of [normalizedBareSpecifier, bareSpecifier, repo]) {
-    const url = normalizeGitRepoUrl(source)
+  const tarball = resolution.type == null ? resolution.tarball : undefined
+  for (const source of [normalizedBareSpecifier, bareSpecifier, repo, tarball]) {
+    const url = normalizeSourceUrl(source)
     if (url != null && exclude(url)) return true
   }
   return false
 }
 
 /**
- * Normalizes a git dependency source into a canonical `https://host/user/repo`
- * URL for matching, dropping the `git+` prefix, the committish and any `.git`
- * suffix. Hosted shorthands (`github:`, `gitlab:`, …) are expanded via
- * hosted-git-info; anything else is treated as a plain URL.
+ * Normalizes an exotic dependency source (a git repository or a tarball/URL)
+ * into a canonical URL for matching, dropping the `git+` prefix, the committish
+ * and any `.git` suffix. Hosted git shorthands (`github:`, `gitlab:`, …) are
+ * expanded to `https://host/user/repo` via hosted-git-info; anything else is
+ * treated as a plain URL.
  */
-function normalizeGitRepoUrl (source: string | undefined): string | undefined {
+function normalizeSourceUrl (source: string | undefined): string | undefined {
   if (source == null || source === '') return undefined
   const hosted = HostedGit.fromUrl(source)
   const url = hosted?.https({ noCommittish: true, noGitPlus: true }) ?? source

--- a/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -146,6 +146,7 @@ export interface ResolveDependenciesOptions {
   trustPolicyExclude?: string[]
   trustPolicyIgnoreAfter?: number
   blockExoticSubdeps?: boolean
+  blockExoticSubdepsExclude?: string[]
 }
 
 export interface ResolveDependencyTreeResult {
@@ -228,6 +229,7 @@ export async function resolveDependencyTree<T> (
     trustPolicyExclude: opts.trustPolicyExclude ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude') : undefined,
     trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
     blockExoticSubdeps: opts.blockExoticSubdeps,
+    blockExoticSubdepsExclude: opts.blockExoticSubdepsExclude ? createPackageVersionPolicyOrThrow(opts.blockExoticSubdepsExclude, 'blockExoticSubdepsExclude') : undefined,
     resolutionPolicyViolations: [],
   }
 

--- a/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -1,5 +1,6 @@
 import { resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
+import { createMatcher } from '@pnpm/config.matcher'
 import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { globalWarn } from '@pnpm/logger'
@@ -229,7 +230,7 @@ export async function resolveDependencyTree<T> (
     trustPolicyExclude: opts.trustPolicyExclude ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude') : undefined,
     trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
     blockExoticSubdeps: opts.blockExoticSubdeps,
-    blockExoticSubdepsExclude: opts.blockExoticSubdepsExclude ? createPackageVersionPolicyOrThrow(opts.blockExoticSubdepsExclude, 'blockExoticSubdepsExclude') : undefined,
+    blockExoticSubdepsExclude: opts.blockExoticSubdepsExclude?.length ? createMatcher(opts.blockExoticSubdepsExclude) : undefined,
     resolutionPolicyViolations: [],
   }
 

--- a/installing/deps-resolver/tsconfig.json
+++ b/installing/deps-resolver/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../../catalogs/types"
     },
     {
+      "path": "../../config/matcher"
+    },
+    {
       "path": "../../config/version-policy"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5870,6 +5870,9 @@ importers:
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types
+      '@pnpm/config.matcher':
+        specifier: workspace:*
+        version: link:../../config/matcher
       '@pnpm/config.version-policy':
         specifier: workspace:*
         version: link:../../config/version-policy
@@ -5945,6 +5948,9 @@ importers:
       graph-cycles:
         specifier: 'catalog:'
         version: 3.0.0
+      hosted-git-info:
+        specifier: 'catalog:'
+        version: '@pnpm/hosted-git-info@1.0.0'
       is-inner-link:
         specifier: 'catalog:'
         version: 5.0.0
@@ -5991,6 +5997,9 @@ importers:
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
+      '@types/hosted-git-info':
+        specifier: 'catalog:'
+        version: 3.0.5
       '@types/normalize-path':
         specifier: 'catalog:'
         version: 3.0.2


### PR DESCRIPTION
## What

Adds a new setting, `blockExoticSubdepsExclude` — a list of trusted packages that are allowed to be installed as exotic (e.g. git-hosted) subdependencies even when `blockExoticSubdeps` is enabled.

Closes #11799

## Why

`blockExoticSubdeps` defaults to `true`, so today it's all-or-nothing: a single legitimate git-hosted transitive dependency forces you to disable the protection entirely. This adds the same "keep the guard on, allow one package" escape hatch that `minimumReleaseAge`/`trustPolicy` already provide via their `*Exclude` lists.

## How it works

Entries are matched by the subdependency's alias first, then its resolved manifest name, reusing the same matcher as `trustPolicyExclude`:

```yaml
# pnpm-workspace.yaml
blockExoticSubdeps: true
blockExoticSubdepsExclude:
  - say-hi            # bare name (any version)
  - '@my-org/*'       # wildcard
  - some-pkg@1.2.3    # exact-version pin
```

## Testing

- `pnpm run compile-only` passes (full monorepo typecheck).
- ESLint clean on all changed files.
- Added cases in `installing/deps-installer/test/install/blockExoticSubdeps.ts`: allow by exact alias, allow by wildcard, still-block when unlisted, and reject a semver range with a clear error.
- Full test suite passes in CI (ubuntu + windows × Node 22/24/26): https://github.com/jameswylie/pnpm/actions/runs/26210194821

## Notes

- A changeset is included (`minor` for the affected packages + `pnpm`).
- Docs PR for pnpm.io to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration: blockExoticSubdepsExclude — a list of trusted dependency source URL patterns (supports * wildcards and exact matches).

* **Documentation**
  * Documented the new configuration in the changelog/changeset.

* **Tests**
  * Added tests covering matching behavior for exact, repo-wildcard, host-wildcard, and tarball URL patterns, plus rejection when not matched.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->