### PR TITLE
feat(pacquet/cli): accept `--config.<key>=<value>` overrides

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -4,7 +4,7 @@ pub mod run;
 pub mod store;
 pub mod supported_architectures;
 
-use crate::State;
+use crate::{State, config_overrides::ConfigOverrides};
 use add::AddArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use install::InstallArgs;
@@ -72,8 +72,12 @@ pub enum CliCommand {
 }
 
 impl CliArgs {
-    /// Execute the command
-    pub async fn run(self) -> miette::Result<()> {
+    /// Execute the command. `config_overrides` carries `--config.<key>=<value>`
+    /// tokens already stripped from argv by [`ConfigOverrides::extract`];
+    /// they're layered on top of `.npmrc` / `pnpm-workspace.yaml` whenever
+    /// `Config` is loaded, mirroring pnpm 11's
+    /// "CLI > yaml > .npmrc > defaults" precedence.
+    pub async fn run(self, config_overrides: &ConfigOverrides) -> miette::Result<()> {
         let CliArgs { command, dir, reporter } = self;
         // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
         // the reporter is the same absolute, symlink-resolved path that
@@ -101,7 +105,10 @@ impl CliArgs {
         let config = || -> miette::Result<&'static mut Config> {
             Config::default()
                 .current::<Host>(&dir)
-                .map(Config::leak)
+                .map(|mut cfg| {
+                    config_overrides.apply(&mut cfg);
+                    Config::leak(cfg)
+                })
                 .map_err(miette::Report::new)
                 .wrap_err("load configuration")
         };

--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -1,0 +1,151 @@
+use pacquet_config::Config;
+use std::ffi::{OsStr, OsString};
+
+/// CLI overrides parsed from pnpm's `--config.<key>=<value>` dotted-key
+/// syntax. Upstream pnpm uses [`npm-conf`](https://github.com/npm/npm-conf)
+/// to translate each `--config.<key>=<value>` token into a runtime config
+/// assignment that wins over `.npmrc` and `pnpm-workspace.yaml`; pacquet
+/// mirrors that by stripping the same tokens out of argv before clap sees
+/// them and re-applying them onto [`Config`] after the file-based layers
+/// have run.
+///
+/// Unknown keys are accepted silently: pnpm exposes a long tail of config
+/// keys, and erroring on an unrecognized one would break the moment pnpm
+/// adds a new key that pacquet hasn't ported yet. The token has already
+/// been honored by pnpm itself before delegation, so dropping it on
+/// pacquet's side just means the pacquet leg falls back to the yaml/npmrc
+/// value — never an incorrect override.
+#[derive(Debug, Default)]
+pub struct ConfigOverrides {
+    registry: Option<String>,
+}
+
+impl ConfigOverrides {
+    /// Pull `--config.<key>=<value>` tokens out of `argv` and collect
+    /// them. Returns the parsed overrides together with the remaining
+    /// argv tokens (in their original order) for clap to parse.
+    ///
+    /// Malformed tokens — `--config.foo` with no `=`, or `--config.=value`
+    /// with an empty key — are dropped: clap would reject `--config.*` as
+    /// unknown anyway, and the dropped tokens carry no usable signal.
+    pub fn extract<Argv>(argv: Argv) -> (Self, Vec<OsString>)
+    where
+        Argv: IntoIterator<Item = OsString>,
+    {
+        let mut overrides = Self::default();
+        let mut remaining = Vec::new();
+        for arg in argv {
+            match classify(&arg) {
+                ConfigToken::WellFormed { key, value } => overrides.set(key, value),
+                ConfigToken::Malformed => {}
+                ConfigToken::NotOurs => remaining.push(arg),
+            }
+        }
+        (overrides, remaining)
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        if key == "registry" {
+            self.registry = Some(value.to_owned());
+        }
+    }
+
+    /// Layer the CLI overrides on top of a [`Config`] that has already
+    /// been built from defaults, `.npmrc`, and `pnpm-workspace.yaml`.
+    /// Mirrors pnpm 11's "CLI > yaml > .npmrc > defaults" precedence.
+    pub fn apply(&self, config: &mut Config) {
+        if let Some(registry) = &self.registry {
+            config.registry = registry.clone();
+        }
+    }
+}
+
+enum ConfigToken<'a> {
+    WellFormed { key: &'a str, value: &'a str },
+    Malformed,
+    NotOurs,
+}
+
+/// Decide whether an argv token belongs to the `--config.<key>=<value>`
+/// family. Everything with a `--config.` prefix is claimed, so a typo
+/// like `--config.foo` never escapes into clap's "unexpected argument"
+/// path; non-prefixed tokens are returned untouched.
+fn classify(arg: &OsStr) -> ConfigToken<'_> {
+    let Some(rest) = arg.to_str().and_then(|arg| arg.strip_prefix("--config.")) else {
+        return ConfigToken::NotOurs;
+    };
+    let Some((key, value)) = rest.split_once('=') else {
+        return ConfigToken::Malformed;
+    };
+    if key.is_empty() {
+        return ConfigToken::Malformed;
+    }
+    ConfigToken::WellFormed { key, value }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConfigOverrides;
+    use pacquet_config::Config;
+    use pretty_assertions::assert_eq;
+    use std::ffi::OsString;
+
+    fn argv<Items: IntoIterator<Item = &'static str>>(items: Items) -> Vec<OsString> {
+        items.into_iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn extract_separates_config_tokens_from_argv() {
+        let (overrides, remaining) = ConfigOverrides::extract(argv([
+            "pacquet",
+            "--config.registry=https://example.test/",
+            "install",
+            "--frozen-lockfile",
+        ]));
+        assert_eq!(remaining, argv(["pacquet", "install", "--frozen-lockfile"]));
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert_eq!(config.registry, "https://example.test/");
+    }
+
+    #[test]
+    fn unknown_keys_are_dropped_silently() {
+        let (overrides, remaining) =
+            ConfigOverrides::extract(argv(["pacquet", "--config.unknown-key=whatever", "install"]));
+        assert_eq!(remaining, argv(["pacquet", "install"]));
+        let default_registry = Config::default().registry;
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert_eq!(config.registry, default_registry, "no known key set ⇒ registry untouched");
+    }
+
+    #[test]
+    fn malformed_tokens_are_dropped() {
+        let (_, remaining) = ConfigOverrides::extract(argv([
+            "--config.registry",
+            "--config.=missing-key",
+            "install",
+        ]));
+        assert_eq!(remaining, argv(["install"]));
+    }
+
+    #[test]
+    fn last_value_wins_for_repeated_keys() {
+        let (overrides, _) = ConfigOverrides::extract(argv([
+            "--config.registry=https://first.test/",
+            "--config.registry=https://second.test/",
+        ]));
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert_eq!(config.registry, "https://second.test/");
+    }
+
+    #[test]
+    fn apply_is_a_noop_when_no_overrides_set() {
+        let (overrides, _) = ConfigOverrides::extract(argv(["pacquet", "install"]));
+        let default_registry = Config::default().registry;
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert_eq!(config.registry, default_registry);
+    }
+}

--- a/pacquet/crates/cli/src/lib.rs
+++ b/pacquet/crates/cli/src/lib.rs
@@ -1,8 +1,10 @@
 mod cli_args;
+mod config_overrides;
 mod state;
 
 use clap::Parser;
 use cli_args::CliArgs;
+use config_overrides::ConfigOverrides;
 use miette::set_panic_hook;
 use pacquet_diagnostics::enable_tracing_by_env;
 use state::State;
@@ -10,14 +12,20 @@ use state::State;
 pub async fn main() -> miette::Result<()> {
     enable_tracing_by_env();
     set_panic_hook();
+    // Extract pnpm's `--config.<key>=<value>` tokens before clap sees
+    // argv. Clap can't parse a dotted-key flag whose right-hand name is
+    // arbitrary, so a `--config.registry=...` from pnpm's forwarded flags
+    // would otherwise error out as "unexpected argument". Each extracted
+    // token is layered onto `Config` after `.npmrc` / yaml run.
+    let (config_overrides, argv) = ConfigOverrides::extract(std::env::args_os());
     // Run argument parsing *before* sizing the rayon pool so
     // `pacquet --help` / `--version` (and any clap parse error) exit
     // without spinning up worker threads. `clap::Parser::parse` calls
     // `std::process::exit` on those paths, so we never reach
     // `configure_rayon_pool` for them (Copilot review on #292).
-    let args = CliArgs::parse();
+    let args = CliArgs::parse_from(argv);
     configure_rayon_pool();
-    args.run().await
+    args.run(&config_overrides).await
 }
 
 /// Size rayon's global pool at `2 × available_parallelism`. The link


### PR DESCRIPTION
## Summary

- Strips pnpm's `--config.<key>=<value>` tokens out of argv before clap parses, and layers the values onto `Config` after `.npmrc`/`pnpm-workspace.yaml` have been applied — matching pnpm 11's `CLI > yaml > .npmrc > defaults` precedence.
- Only `registry` is wired in for now; unknown keys are accepted silently (forward-compat with future pnpm keys); malformed tokens (`--config.foo`, `--config.=value`) are dropped so clap never sees them.
- New `ConfigOverrides` lives in `pacquet/crates/cli/src/config_overrides.rs` with 5 unit tests covering the happy path, unknown-key tolerance, malformed-token dropping, last-value-wins, and the no-op case.

## Context

When pnpm delegates `install` to pacquet (via `configDependencies`) it forwards the user's `pnpm install` flags verbatim, including pnpm's `--config.<key>=<value>` universal syntax (npm-conf upstream). Pacquet's clap parser previously rejected those with `error: unexpected argument '--config.registry' found`, which broke the e2e `pnpm install --config.registry=…` path on the JS side (the failing case being added in #11774 — `pnpm/test/install/pacquet.ts`).

A companion change on the JS side (filed separately) tightens `runPacquet.ts`'s command-token detection so that a leading `--config.*` doesn't cause `install` to be re-forwarded as a positional. Both changes are needed for the JS test to flip green end-to-end; this PR is the pacquet half.

## Test plan

- [x] `cargo nextest run -p pacquet-cli` (92 tests pass, including 5 new `config_overrides` tests)
- [x] `cargo clippy -p pacquet-cli --all-targets --locked -- --deny warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [ ] Verify the matching JS-side change lands so the `pnpm install --config.registry=…` e2e test in `pnpm/test/install/pacquet.ts` goes green end-to-end.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CLI configuration overrides via `--config.<key>=<value>` arguments, enabling users to customize configuration values directly from the command line without modifying config files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->