### PR TITLE
fix(pacquet/cli): patch --version literal during release build

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -72,6 +72,28 @@ jobs:
       - name: Add Rust Target
         run: rustup target add ${{ matrix.target }}
 
+      - name: Validate version input
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version: '$VERSION' (expected semver like 0.2.3 or 0.2.3-rc.1)"
+            exit 1
+          fi
+
+      - name: Inject version into pacquet/crates/cli/src/cli_args.rs
+        # The version reported by `pacquet --version` is a hardcoded clap
+        # attribute. Patch it here so the binary built for the matrix leg
+        # reports the version we're about to publish.
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          file=pacquet/crates/cli/src/cli_args.rs
+          perl -i -pe 's/#\[clap\(version = "[^"]*"\)\]/#[clap(version = "'"$VERSION"'")]/' "$file"
+          grep -F "version = \"$VERSION\"" "$file"
+
       - name: Build with cross
         run: cross build -p pacquet-cli --bin pacquet --release --target=${{ matrix.target }}
 

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -21,7 +21,7 @@ use store::StoreCommand;
 #[derive(Debug, Parser)]
 #[clap(name = "pacquet")]
 #[clap(bin_name = "pacquet")]
-#[clap(version = "0.2.1")]
+#[clap(version = "0.2.2")]
 #[clap(about = "Experimental package manager for node.js")]
 pub struct CliArgs {
     #[clap(subcommand)]


### PR DESCRIPTION
## Summary

- `pacquet --version` reports a hardcoded clap attribute literal in `pacquet/crates/cli/src/cli_args.rs`. It wasn't bumped for the 0.2.2 release, so the published 0.2.2 binary still reports 0.2.1. Bump the literal to `0.2.2`.
- Add a step to the release workflow (`.github/workflows/pacquet-release-to-npm.yml`) that rewrites the attribute from `inputs.version` before `cross build`, so future releases stay correct without anyone having to remember.

The substitution is a portable `perl -i -pe` (matching macOS / Linux / Windows-bash matrix legs); a trailing `grep -F` fails the job loudly if the regex stops matching after a future refactor of the attribute. The same `inputs.version` semver check that already gates the publish job now also runs at the top of the matched build step, so an invalid version fails early instead of after six parallel builds.

## Test plan

- [ ] Manually verify the perl substitution by running it locally against `cli_args.rs` with a `0.2.3-rc.1`-style value (done; substitution lands and `grep -F` succeeds).
- [ ] Next release dispatch: confirm the build matrix log shows the injected version and that the published `pacquet --version` matches `inputs.version`.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI version to 0.2.2
  * Enhanced release automation for version management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->