### PR TITLE
chore(release): 11.2.2

### DIFF
--- a/.changeset-released/release-11-2-2.txt
+++ b/.changeset-released/release-11-2-2.txt
@@ -1,0 +1,2 @@
+fix-pacquet-outdated-lockfile-on-update
+forward-install-flags-to-pacquet

--- a/.changeset/fix-pacquet-outdated-lockfile-on-update.md
+++ b/.changeset/fix-pacquet-outdated-lockfile-on-update.md
@@ -1,5 +1,0 @@
----
-"pnpm": patch
----
-
-Fixed `pnpm up` (and `pnpm add` / `pnpm remove`) failing with `pacquet_package_manager::outdated_lockfile` when pacquet is declared in `configDependencies`. pnpm now passes `--ignore-manifest-check` to pacquet so its `--frozen-lockfile` check doesn't fire against the (pre-mutation) `package.json` pnpm hasn't written yet [#11797](https://github.com/pnpm/pnpm/issues/11797). Requires a pacquet release that supports the flag — bump `PACQUET_VERSION` in the e2e tests once it ships.

--- a/.changeset/forward-install-flags-to-pacquet.md
+++ b/.changeset/forward-install-flags-to-pacquet.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.commands": patch
-"pnpm": patch
----
-
-When the install engine is delegated to pacquet via `configDependencies`, the user's CLI flags passed to `pnpm install` (e.g. `--no-runtime`, `--prod`, `--dev`, `--no-optional`, `--node-linker`, `--cpu`/`--os`/`--libc`, `--offline`, `--prefer-offline`) are now forwarded to pacquet's `install` subcommand verbatim. Previously pacquet was invoked with a fixed argument list, so flags like `--no-runtime` were silently dropped. Flag forwarding is gated on the command being `install`/`i`; `add`, `update`, and `dedupe` still don't forward (their flag surface doesn't line up with pacquet's `install`).

--- a/building/commands/CHANGELOG.md
+++ b/building/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/building.commands
 
+## 1100.0.21
+
+### Patch Changes
+
+- Updated dependencies [881a865]
+  - @pnpm/installing.commands@1100.4.2
+
 ## 1100.0.20
 
 ### Patch Changes

--- a/building/commands/package.json
+++ b/building/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.commands",
-  "version": "1100.0.20",
+  "version": "1100.0.21",
   "description": "Commands for rebuilding and managing dependency builds",
   "keywords": [
     "pnpm",

--- a/deps/compliance/commands/CHANGELOG.md
+++ b/deps/compliance/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/deps.compliance.commands
 
+## 1101.2.6
+
+### Patch Changes
+
+- Updated dependencies [881a865]
+  - @pnpm/installing.commands@1100.4.2
+
 ## 1101.2.5
 
 ### Patch Changes

--- a/deps/compliance/commands/package.json
+++ b/deps/compliance/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.commands",
-  "version": "1101.2.5",
+  "version": "1101.2.6",
   "description": "pnpm commands for audit, licenses, and sbom",
   "keywords": [
     "pnpm",

--- a/exec/commands/CHANGELOG.md
+++ b/exec/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/plugin-commands-script-runners
 
+## 1100.1.11
+
+### Patch Changes
+
+- Updated dependencies [881a865]
+  - @pnpm/installing.commands@1100.4.2
+  - @pnpm/building.commands@1100.0.21
+
 ## 1100.1.10
 
 ### Patch Changes

--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.commands",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Commands for running scripts",
   "keywords": [
     "pnpm",

--- a/installing/commands/CHANGELOG.md
+++ b/installing/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/plugin-commands-installation
 
+## 1100.4.2
+
+### Patch Changes
+
+- 881a865: When the install engine is delegated to pacquet via `configDependencies`, the user's CLI flags passed to `pnpm install` (e.g. `--no-runtime`, `--prod`, `--dev`, `--no-optional`, `--node-linker`, `--cpu`/`--os`/`--libc`, `--offline`, `--prefer-offline`) are now forwarded to pacquet's `install` subcommand verbatim. Previously pacquet was invoked with a fixed argument list, so flags like `--no-runtime` were silently dropped. Flag forwarding is gated on the command being `install`/`i`; `add`, `update`, and `dedupe` still don't forward (their flag surface doesn't line up with pacquet's `install`).
+
 ## 1100.4.1
 
 ### Patch Changes

--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.commands",
-  "version": "1100.4.1",
+  "version": "1100.4.2",
   "description": "Commands for installation",
   "keywords": [
     "pnpm",

--- a/patching/commands/CHANGELOG.md
+++ b/patching/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/plugin-commands-patching
 
+## 1100.0.21
+
+### Patch Changes
+
+- Updated dependencies [881a865]
+  - @pnpm/installing.commands@1100.4.2
+
 ## 1100.0.20
 
 ### Patch Changes

--- a/patching/commands/package.json
+++ b/patching/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.commands",
-  "version": "1100.0.20",
+  "version": "1100.0.21",
   "description": "Commands for creating patches",
   "keywords": [
     "pnpm",

--- a/pnpm/CHANGELOG.md
+++ b/pnpm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pnpm
 
+## 11.2.2
+
+### Patch Changes
+
+- When the install engine is delegated to pacquet via `configDependencies`, the user's CLI flags passed to `pnpm install` (e.g. `--no-runtime`, `--prod`, `--dev`, `--no-optional`, `--node-linker`, `--cpu`/`--os`/`--libc`, `--offline`, `--prefer-offline`) are now forwarded to pacquet's `install` subcommand verbatim. Previously pacquet was invoked with a fixed argument list, so flags like `--no-runtime` were silently dropped. Flag forwarding is gated on the command being `install`/`i`; `add`, `update`, and `dedupe` still don't forward (their flag surface doesn't line up with pacquet's `install`).
+- Fixed `pnpm up` (and `pnpm add` / `pnpm remove`) failing with `pacquet_package_manager::outdated_lockfile` when pacquet is declared in `configDependencies`. pnpm now passes `--ignore-manifest-check` to pacquet so its `--frozen-lockfile` check doesn't fire against the (pre-mutation) `package.json` pnpm hasn't written yet [#11797](https://github.com/pnpm/pnpm/issues/11797). Requires a pacquet release that supports the flag — bump `PACQUET_VERSION` in the e2e tests once it ships.
+
 ## 11.2.1
 
 ### Patch Changes

--- a/pnpm/artifacts/darwin-arm64/package.json
+++ b/pnpm/artifacts/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/macos-arm64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exe",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm/artifacts/linux-arm64-musl/package.json
+++ b/pnpm/artifacts/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-arm64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-arm64/package.json
+++ b/pnpm/artifacts/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-arm64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-x64-musl/package.json
+++ b/pnpm/artifacts/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-x64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-x64/package.json
+++ b/pnpm/artifacts/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-x64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/win32-arm64/package.json
+++ b/pnpm/artifacts/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-arm64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/win32-x64/package.json
+++ b/pnpm/artifacts/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-x64",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "11.2.1",
+  "version": "11.2.2",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/releasing/commands/CHANGELOG.md
+++ b/releasing/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/releasing.commands
 
+## 1100.2.18
+
+### Patch Changes
+
+- Updated dependencies [881a865]
+  - @pnpm/installing.commands@1100.4.2
+
 ## 1100.2.17
 
 ### Patch Changes

--- a/releasing/commands/package.json
+++ b/releasing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.commands",
-  "version": "1100.2.17",
+  "version": "1100.2.18",
   "description": "Commands for deploy, pack, and publish",
   "keywords": [
     "pnpm",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm up`, `pnpm add`, and `pnpm remove` failing when pacquet is configured as the install engine.

* **New Features**
  * CLI flags passed to `pnpm install` are now forwarded to pacquet, enabling direct control over the installation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->