### PR TITLE
fix(pacquet): resolve catalog: in pnpm.overrides before freshness check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,8 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "miette 7.6.0",
+ "pacquet-catalogs-resolver",
+ "pacquet-catalogs-types",
  "pacquet-resolving-parse-wanted-dependency",
 ]
 

--- a/pacquet/crates/config-parse-overrides/Cargo.toml
+++ b/pacquet/crates/config-parse-overrides/Cargo.toml
@@ -13,6 +13,8 @@ repository.workspace  = true
 [dependencies]
 derive_more                               = { workspace = true }
 miette                                    = { workspace = true }
+pacquet-catalogs-resolver                 = { workspace = true }
+pacquet-catalogs-types                    = { workspace = true }
 pacquet-resolving-parse-wanted-dependency = { workspace = true }
 
 [lints]

--- a/pacquet/crates/config-parse-overrides/src/lib.rs
+++ b/pacquet/crates/config-parse-overrides/src/lib.rs
@@ -19,16 +19,20 @@
 //! `3 || >=2` are not mistaken for a parent>child split.
 //!
 //! Catalog protocol: when the override value uses the `catalog:` form
-//! pnpm resolves it against the workspace's named catalogs. Pacquet
-//! does not have catalog support yet, so a `catalog:` override here
+//! it is resolved against the workspace's named catalogs before being
+//! stored on the parsed entry, matching pnpm's
+//! `parseOverrides(overrides, catalogs)` signature. A `catalog:` value
+//! that misses (no entry, recursive, or uses a forbidden inner protocol)
 //! surfaces as [`ParseOverridesError::CatalogInOverrides`] (matching
-//! upstream's `ERR_PNPM_CATALOG_IN_OVERRIDES`). When catalogs land in
-//! pacquet, this function gains the catalog table parameter upstream
-//! threads through, and the error fires only on genuine
-//! misconfiguration.
+//! upstream's `ERR_PNPM_CATALOG_IN_OVERRIDES`). Pass an empty
+//! [`Catalogs`] map when the caller has no catalogs configured — any
+//! `catalog:` value will then fall through to the missing-entry branch,
+//! same as upstream.
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pacquet_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_from_catalog};
+use pacquet_catalogs_types::Catalogs;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use std::collections::HashMap;
 
@@ -48,9 +52,10 @@ pub struct VersionOverride {
     /// The dependency the override targets.
     pub target_pkg: PackageSelector,
 
-    /// The replacement spec (or `-` to delete, or a `link:`/`file:`/
-    /// `catalog:` reference). Catalog references are resolved against
-    /// the workspace's catalogs before this is stored.
+    /// The replacement spec (or `-` to delete, or a `link:`/`file:`
+    /// reference). `catalog:` references are resolved against the
+    /// workspace's catalogs before this is stored, so downstream
+    /// consumers never see the `catalog:` form here.
     pub new_bare_specifier: String,
 }
 
@@ -80,9 +85,9 @@ pub enum ParseOverridesError {
         selector: String,
     },
 
-    /// The override value uses the `catalog:` protocol but no catalog
-    /// table can resolve it (or, in pacquet today, catalogs aren't
-    /// wired up at all). Mirrors upstream's
+    /// The override value uses the `catalog:` protocol but the
+    /// configured catalogs can't resolve it (missing entry, recursive
+    /// definition, or forbidden inner protocol). Mirrors upstream's
     /// `ERR_PNPM_CATALOG_IN_OVERRIDES` at
     /// <https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L35>.
     #[display("Could not resolve a catalog in the overrides: {message}")]
@@ -102,29 +107,12 @@ pub enum ParseOverridesError {
 /// [`parse_overrides_iter`] with an ordered map (e.g. `IndexMap`)
 /// or pre-sort by key. The functional behavior of each entry —
 /// selector splitting via [`parse_pkg_and_parent_selector`] and
-/// catalog-protocol detection — is independent of order.
+/// `catalog:` resolution — is independent of order.
 pub fn parse_overrides(
     overrides: &HashMap<String, String>,
+    catalogs: &Catalogs,
 ) -> Result<Vec<VersionOverride>, ParseOverridesError> {
-    let mut out = Vec::with_capacity(overrides.len());
-    for (selector, new_bare_specifier) in overrides {
-        let (parent_pkg, target_pkg) = parse_pkg_and_parent_selector(selector)?;
-        if let Some(catalog_name) = parse_catalog_protocol(new_bare_specifier) {
-            return Err(ParseOverridesError::CatalogInOverrides {
-                message: format!(
-                    "No catalog entry '{}' was found for catalog '{}'.",
-                    target_pkg.name, catalog_name,
-                ),
-            });
-        }
-        out.push(VersionOverride {
-            selector: selector.clone(),
-            parent_pkg,
-            target_pkg,
-            new_bare_specifier: new_bare_specifier.clone(),
-        });
-    }
-    Ok(out)
+    parse_overrides_iter(overrides.iter(), catalogs)
 }
 
 /// Stable-ordered variant of [`parse_overrides`] for callers that
@@ -133,6 +121,7 @@ pub fn parse_overrides(
 /// to [`parse_overrides`]; only the input iterator differs.
 pub fn parse_overrides_iter<'a, Iter>(
     overrides: Iter,
+    catalogs: &Catalogs,
 ) -> Result<Vec<VersionOverride>, ParseOverridesError>
 where
     Iter: IntoIterator<Item = (&'a String, &'a String)>,
@@ -142,22 +131,31 @@ where
     let mut out = Vec::with_capacity(lower_bound);
     for (selector, new_bare_specifier) in iter {
         let (parent_pkg, target_pkg) = parse_pkg_and_parent_selector(selector)?;
-        if let Some(catalog_name) = parse_catalog_protocol(new_bare_specifier) {
-            return Err(ParseOverridesError::CatalogInOverrides {
-                message: format!(
-                    "No catalog entry '{}' was found for catalog '{}'.",
-                    target_pkg.name, catalog_name,
-                ),
-            });
-        }
+        let resolved_specifier =
+            resolve_catalog_in_value(catalogs, &target_pkg.name, new_bare_specifier)?;
         out.push(VersionOverride {
             selector: selector.clone(),
             parent_pkg,
             target_pkg,
-            new_bare_specifier: new_bare_specifier.clone(),
+            new_bare_specifier: resolved_specifier,
         });
     }
     Ok(out)
+}
+
+/// Flatten parsed overrides back into the `selector → newBareSpecifier`
+/// map shape used by lockfile freshness checks. Mirrors upstream's
+/// [`createOverridesMapFromParsed`](https://github.com/pnpm/pnpm/blob/4a36b9a110/lockfile/settings-checker/src/createOverridesMapFromParsed.ts).
+/// The resulting map's values are post-catalog-resolution, so it
+/// compares apples-to-apples against `lockfile.overrides`, which pnpm
+/// writes out with `catalog:` already expanded.
+pub fn create_overrides_map_from_parsed(
+    parsed_overrides: &[VersionOverride],
+) -> HashMap<String, String> {
+    parsed_overrides
+        .iter()
+        .map(|entry| (entry.selector.clone(), entry.new_bare_specifier.clone()))
+        .collect()
 }
 
 /// Split a raw selector key into its (optional) parent half and its
@@ -201,16 +199,32 @@ fn parse_pkg_selector(selector: &str) -> Result<PackageSelector, ParseOverridesE
     Ok(PackageSelector { name, bare_specifier: wanted.bare_specifier })
 }
 
-/// Mirrors pnpm's
-/// [`parseCatalogProtocol`](https://github.com/pnpm/pnpm/blob/4a36b9a110/catalogs/protocol-parser/src/parseCatalogProtocol.ts).
-/// Returns `Some("default")` for a bare `"catalog:"`, `Some(name)` for
-/// `"catalog:name"`, and `None` when the spec is not a catalog
-/// reference. The bare `"catalog:"` shorthand normalizes to
-/// `"default"` to match upstream.
-fn parse_catalog_protocol(bare_specifier: &str) -> Option<&str> {
-    const CATALOG_PROTOCOL: &str = "catalog:";
-    let raw = bare_specifier.strip_prefix(CATALOG_PROTOCOL)?.trim();
-    Some(if raw.is_empty() { "default" } else { raw })
+/// Run the override value through the catalog resolver. Mirrors
+/// upstream's `matchCatalogResolveResult` arm at
+/// <https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L28-L41>:
+/// `found` returns the resolved specifier, `unused` (non-`catalog:`)
+/// returns the value verbatim, and `misconfiguration` (missing entry
+/// or recursive / forbidden inner protocol) raises
+/// [`ParseOverridesError::CatalogInOverrides`] with the resolver's
+/// error message.
+fn resolve_catalog_in_value(
+    catalogs: &Catalogs,
+    target_name: &str,
+    new_bare_specifier: &str,
+) -> Result<String, ParseOverridesError> {
+    let wanted = WantedDependency {
+        alias: target_name.to_string(),
+        bare_specifier: new_bare_specifier.to_string(),
+    };
+    match resolve_from_catalog(catalogs, &wanted) {
+        CatalogResolutionResult::Found(found) => Ok(found.resolution.specifier),
+        CatalogResolutionResult::Unused => Ok(new_bare_specifier.to_string()),
+        CatalogResolutionResult::Misconfiguration(misconfiguration) => {
+            Err(ParseOverridesError::CatalogInOverrides {
+                message: misconfiguration.error.to_string(),
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/config-parse-overrides/src/tests.rs
+++ b/pacquet/crates/config-parse-overrides/src/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
-    PackageSelector, ParseOverridesError, VersionOverride, parse_overrides,
-    parse_pkg_and_parent_selector,
+    PackageSelector, ParseOverridesError, VersionOverride, create_overrides_map_from_parsed,
+    parse_overrides, parse_pkg_and_parent_selector,
 };
+use pacquet_catalogs_types::{Catalog, Catalogs};
 use std::collections::HashMap;
 
 fn vo(
@@ -32,14 +33,14 @@ fn sorted(mut overrides: Vec<VersionOverride>) -> Vec<VersionOverride> {
 #[test]
 fn parses_bare_name_override() {
     let input = HashMap::from([("foo".to_string(), "1".to_string())]);
-    let out = parse_overrides(&input).unwrap();
+    let out = parse_overrides(&input, &Catalogs::new()).unwrap();
     assert_eq!(out, vec![vo("foo", "1", None, sel("foo", None))]);
 }
 
 #[test]
 fn parses_name_at_version_override() {
     let input = HashMap::from([("foo@2".to_string(), "1".to_string())]);
-    let out = parse_overrides(&input).unwrap();
+    let out = parse_overrides(&input, &Catalogs::new()).unwrap();
     assert_eq!(out, vec![vo("foo@2", "1", None, sel("foo", Some("2")))]);
 }
 
@@ -49,7 +50,7 @@ fn parses_range_operators_in_target() {
         ("foo@>2".to_string(), "1".to_string()),
         ("foo@3 || >=2".to_string(), "1".to_string()),
     ]);
-    let out = sorted(parse_overrides(&input).unwrap());
+    let out = sorted(parse_overrides(&input, &Catalogs::new()).unwrap());
     assert_eq!(
         out,
         sorted(vec![
@@ -67,7 +68,7 @@ fn parses_parent_child_selectors() {
         ("bar>foo@1".to_string(), "2".to_string()),
         ("bar@1>foo@1".to_string(), "2".to_string()),
     ]);
-    let out = sorted(parse_overrides(&input).unwrap());
+    let out = sorted(parse_overrides(&input, &Catalogs::new()).unwrap());
     assert_eq!(
         out,
         sorted(vec![
@@ -88,7 +89,7 @@ fn range_operator_on_parent_does_not_split() {
         ("foo@>2>bar@>2".to_string(), "1".to_string()),
         ("foo@3 || >=2>bar@3 || >=2".to_string(), "1".to_string()),
     ]);
-    let out = sorted(parse_overrides(&input).unwrap());
+    let out = sorted(parse_overrides(&input, &Catalogs::new()).unwrap());
     assert_eq!(
         out,
         sorted(vec![
@@ -107,7 +108,7 @@ fn range_operator_on_parent_does_not_split() {
 fn rejects_invalid_selector() {
     let input = HashMap::from([("%".to_string(), "2".to_string())]);
     assert_eq!(
-        parse_overrides(&input).unwrap_err(),
+        parse_overrides(&input, &Catalogs::new()).unwrap_err(),
         ParseOverridesError::InvalidSelector { selector: "%".to_string() },
     );
 }
@@ -120,7 +121,7 @@ fn rejects_invalid_selector_with_whitespace() {
     // because `parse_wanted_dependency` doesn't validate the alias.
     let input = HashMap::from([("foo > bar".to_string(), "2".to_string())]);
     assert_eq!(
-        parse_overrides(&input).unwrap_err(),
+        parse_overrides(&input, &Catalogs::new()).unwrap_err(),
         ParseOverridesError::InvalidSelector { selector: "foo > bar".to_string() },
     );
 }
@@ -139,12 +140,12 @@ fn parse_pkg_and_parent_selector_parent_child() {
 }
 
 #[test]
-fn catalog_protocol_in_override_value_errors() {
-    // Pacquet doesn't support catalogs yet; a `catalog:` value in an
-    // override surfaces as `CatalogInOverrides`, matching upstream's
-    // behavior on an empty catalog table.
+fn catalog_protocol_with_missing_entry_errors() {
+    // An empty catalog table can never resolve a `catalog:` value;
+    // upstream surfaces this as `ERR_PNPM_CATALOG_IN_OVERRIDES` with
+    // the underlying "No catalog entry" message.
     let input = HashMap::from([("foo".to_string(), "catalog:default".to_string())]);
-    let err = parse_overrides(&input).unwrap_err();
+    let err = parse_overrides(&input, &Catalogs::new()).unwrap_err();
     let ParseOverridesError::CatalogInOverrides { message } = err else {
         panic!("expected CatalogInOverrides, got {err:?}");
     };
@@ -152,4 +153,56 @@ fn catalog_protocol_in_override_value_errors() {
         message.contains("foo") && message.contains("default"),
         "message should mention target and catalog name, got: {message}",
     );
+}
+
+/// `catalog:` resolves to the catalog's specifier when the entry exists.
+/// Matches upstream's
+/// [`parseOverrides`](https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L28-L41)
+/// behavior where `matchCatalogResolveResult.found` returns the
+/// resolved specifier and the entry's `newBareSpecifier` is rewritten
+/// to it.
+#[test]
+fn catalog_protocol_resolves_to_catalog_specifier() {
+    let mut catalogs = Catalogs::new();
+    let mut default = Catalog::new();
+    default.insert("foo".to_string(), "^1.2.3".to_string());
+    catalogs.insert("default".to_string(), default);
+
+    let input = HashMap::from([("foo".to_string(), "catalog:".to_string())]);
+    let out = parse_overrides(&input, &catalogs).unwrap();
+    assert_eq!(out, vec![vo("foo", "^1.2.3", None, sel("foo", None))]);
+}
+
+/// `catalog:name` looks up the named catalog by name.
+#[test]
+fn catalog_protocol_with_named_catalog_resolves() {
+    let mut catalogs = Catalogs::new();
+    let mut shared = Catalog::new();
+    shared.insert("bar".to_string(), "2.0.0".to_string());
+    catalogs.insert("shared".to_string(), shared);
+
+    let input = HashMap::from([("bar".to_string(), "catalog:shared".to_string())]);
+    let out = parse_overrides(&input, &catalogs).unwrap();
+    assert_eq!(out, vec![vo("bar", "2.0.0", None, sel("bar", None))]);
+}
+
+/// `create_overrides_map_from_parsed` flattens the parsed entries back
+/// into the `selector → newBareSpecifier` map shape — with catalog
+/// resolution already applied. Mirrors upstream's
+/// [`createOverridesMapFromParsed`](https://github.com/pnpm/pnpm/blob/4a36b9a110/lockfile/settings-checker/src/createOverridesMapFromParsed.ts).
+#[test]
+fn create_overrides_map_returns_resolved_specifiers() {
+    let mut catalogs = Catalogs::new();
+    let mut default = Catalog::new();
+    default.insert("foo".to_string(), "^1.2.3".to_string());
+    catalogs.insert("default".to_string(), default);
+
+    let input = HashMap::from([
+        ("foo".to_string(), "catalog:".to_string()),
+        ("bar".to_string(), "2.0.0".to_string()),
+    ]);
+    let parsed = parse_overrides(&input, &catalogs).unwrap();
+    let map = create_overrides_map_from_parsed(&parsed);
+    assert_eq!(map.get("foo").map(String::as_str), Some("^1.2.3"));
+    assert_eq!(map.get("bar").map(String::as_str), Some("2.0.0"));
 }

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -445,16 +445,37 @@ where
             // Upstream flips `needsFullResolution` and re-runs the
             // resolver; pacquet has no resolver, so the matching
             // action is to abort with `OutdatedLockfile`.
-            // `Config::overrides` is an `IndexMap` so user-supplied
-            // order survives all the way to diagnostics; the
-            // freshness check is order-insensitive (it normalizes to
-            // `BTreeMap` internally to match upstream's
-            // `equals(lockfile.overrides ?? {}, overrides ?? {})`),
-            // so a flat clone into `HashMap` here is fine.
-            let overrides_map: Option<std::collections::HashMap<String, String>> = config
-                .overrides
-                .as_ref()
-                .map(|map| map.iter().map(|(key, value)| (key.clone(), value.clone())).collect());
+            //
+            // `pnpm.overrides` values can use the `catalog:` protocol,
+            // which pnpm resolves against the workspace's catalogs
+            // *before* writing them to `pnpm-lock.yaml#overrides`. We
+            // mirror that here: parse the raw map through
+            // `parse_overrides_iter` with the current catalogs to get
+            // the resolved specifiers, then flatten to a plain map for
+            // the freshness comparison. Without this step, an override
+            // declared as `"foo": "catalog:"` would compare unequal to
+            // the lockfile's already-resolved `"foo": "<concrete>"` on
+            // every install. Mirrors upstream's
+            // `parseOverrides(overrides, catalogs)` →
+            // `createOverridesMapFromParsed(...)` pipeline at
+            // <https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L20-L44>
+            // and
+            // <https://github.com/pnpm/pnpm/blob/4a36b9a110/lockfile/settings-checker/src/createOverridesMapFromParsed.ts>.
+            // Parsing the same overrides twice (once for the freshness
+            // check, once for the `VersionsOverrider` apply below)
+            // would double-walk the map and double-resolve `catalog:`
+            // values, so we parse once and share.
+            let parsed_overrides_opt = match config.overrides.as_ref() {
+                Some(map) if !map.is_empty() => Some(
+                    pacquet_config_parse_overrides::parse_overrides_iter(map.iter(), &catalogs)
+                        .map_err(InstallError::InvalidOverrides)?,
+                ),
+                _ => None,
+            };
+            let overrides_map: Option<std::collections::HashMap<String, String>> =
+                parsed_overrides_opt
+                    .as_deref()
+                    .map(pacquet_config_parse_overrides::create_overrides_map_from_parsed);
             pacquet_lockfile::check_lockfile_settings(
                 lockfile,
                 overrides_map.as_ref(),
@@ -472,29 +493,20 @@ where
             // upstream's read-package-hook conceptually returns a
             // new manifest from the perspective of every consumer
             // downstream of the resolver.
-            //
-            // Parsing today is infallible *barring* catalog refs —
-            // pacquet has no catalogs yet, so a `catalog:` value
-            // surfaces as `INVALID_OVERRIDES` here. When catalogs
-            // land, the parse call gains the catalog table.
             let overrider_manifest_holder;
-            let manifest_for_freshness: &PackageManifest = if let Some(map) =
-                config.overrides.as_ref()
-                && !map.is_empty()
-            {
-                let parsed = pacquet_config_parse_overrides::parse_overrides_iter(map.iter())
-                    .map_err(InstallError::InvalidOverrides)?;
-                let root_dir = manifest.path().parent().unwrap_or_else(|| Path::new("."));
-                let overrider = crate::VersionsOverrider::new(&parsed, root_dir);
-                overrider_manifest_holder = {
-                    let mut cloned: PackageManifest = (*manifest).clone();
-                    overrider.apply(&mut cloned, Some(root_dir));
-                    cloned
+            let manifest_for_freshness: &PackageManifest =
+                if let Some(parsed) = parsed_overrides_opt.as_deref() {
+                    let root_dir = manifest.path().parent().unwrap_or_else(|| Path::new("."));
+                    let overrider = crate::VersionsOverrider::new(parsed, root_dir);
+                    overrider_manifest_holder = {
+                        let mut cloned: PackageManifest = (*manifest).clone();
+                        overrider.apply(&mut cloned, Some(root_dir));
+                        cloned
+                    };
+                    &overrider_manifest_holder
+                } else {
+                    manifest
                 };
-                &overrider_manifest_holder
-            } else {
-                manifest
-            };
             // Build the `ignoredOptionalDependencies` filter set.
             // Mirrors upstream's
             // [`createOptionalDependenciesRemover`](https://github.com/pnpm/pnpm/blob/94240bc046/hooks/read-package-hook/src/createOptionalDependenciesRemover.ts):

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1652,6 +1652,110 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
     drop(dir);
 }
 
+/// `pnpm.overrides` values can reference a workspace catalog via the
+/// `catalog:` protocol; pnpm resolves them against `catalogs:` in
+/// `pnpm-workspace.yaml` and writes the *resolved* specifier to
+/// `pnpm-lock.yaml#overrides`. The freshness check must therefore
+/// resolve `catalog:` on the config side too before comparing — a
+/// raw string compare would treat `catalog:` ≠ `<concrete>` on every
+/// install. Mirrors pnpm's
+/// [`parseOverrides(overrides, catalogs)`](https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L20-L44)
+/// →
+/// [`createOverridesMapFromParsed`](https://github.com/pnpm/pnpm/blob/4a36b9a110/lockfile/settings-checker/src/createOverridesMapFromParsed.ts)
+/// pipeline. Regression test for the case the user hit on a workspace
+/// whose `pnpm.overrides` declared catalog-backed entries.
+#[tokio::test]
+async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness_check() {
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+    seed_placeholder_virtual_store_slot(&virtual_store_dir);
+
+    // The catalog lives in `pnpm-workspace.yaml` next to the manifest;
+    // `Install::run` walks up from the manifest dir to find it.
+    std::fs::write(
+        project_root.join("pnpm-workspace.yaml"),
+        text_block! {
+            "catalogs:"
+            "  default:"
+            "    placeholder: 1.0.0"
+        },
+    )
+    .unwrap();
+
+    let manifest_path = project_root.join("package.json");
+    std::fs::write(
+        &manifest_path,
+        r#"{"name":"my-app","version":"1.0.0","dependencies":{"placeholder":"^9"}}"#,
+    )
+    .unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    // Override value is `catalog:`, which must resolve to the
+    // catalog's `placeholder: 1.0.0` entry before the freshness
+    // comparison. The lockfile records the *resolved* `1.0.0`, so a
+    // raw compare would fail on every install.
+    let mut overrides = indexmap::IndexMap::new();
+    overrides.insert("placeholder".to_string(), "catalog:".to_string());
+    config.overrides = Some(overrides);
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "overrides:"
+        "  placeholder: 1.0.0"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      placeholder:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "packages:"
+        "  placeholder@1.0.0:"
+        "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, tarball: 'http://invalid.local/placeholder.tgz'}"
+        "snapshots:"
+        "  placeholder@1.0.0: {}"
+    })
+    .expect("parse fixture lockfile with overrides");
+
+    let result = Install {
+        tarball_mem_cache: &Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        resolved_packages: &Default::default(),
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+    }
+    .run::<SilentReporter>()
+    .await;
+
+    // The freshness check must accept the install; before the fix
+    // pacquet would surface `OutdatedLockfile::OverridesChanged`
+    // because `catalog:` ≠ `1.0.0` as raw strings. (The install may
+    // still fail later for unrelated reasons in this minimal fixture,
+    // but the overrides gate must pass.)
+    if let Err(InstallError::OutdatedLockfile { reason }) = &result {
+        panic!("unexpected OutdatedLockfile after catalog resolution: {reason:?}");
+    }
+
+    drop(dir);
+}
+
 /// Negative-case: lockfile loads successfully but has no
 /// `importers["."]` entry for the project being installed. Distinct
 /// from `NoLockfile` (file missing entirely) — here the file is

--- a/pacquet/crates/package-manager/src/overrides/tests.rs
+++ b/pacquet/crates/package-manager/src/overrides/tests.rs
@@ -1,4 +1,5 @@
 use super::VersionsOverrider;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config_parse_overrides::parse_overrides;
 use pacquet_package_manifest::PackageManifest;
 use serde_json::{Value, json};
@@ -10,7 +11,7 @@ use std::{
 fn parsed(map: &[(&str, &str)]) -> Vec<pacquet_config_parse_overrides::VersionOverride> {
     let owned: HashMap<String, String> =
         map.iter().map(|(k, v)| ((*k).to_string(), (*v).to_string())).collect();
-    parse_overrides(&owned).expect("parse_overrides fixture")
+    parse_overrides(&owned, &Catalogs::new()).expect("parse_overrides fixture")
 }
 
 /// Build an in-memory `PackageManifest` from a JSON value. The path


### PR DESCRIPTION
## Summary

The frozen-lockfile freshness check compared the lockfile's `overrides` map (where pnpm has already expanded `catalog:` to a concrete specifier) against the raw config map (still holding the literal `catalog:` strings). Every catalog-backed override therefore surfaced as `ERR_PNPM_OUTDATED_LOCKFILE` on every install, with output like:

```
`overrides` in the lockfile ({"hosted-git-info@1": "npm:@pnpm/hosted-git-info@1.0.0", ...})
  doesn't match the current config ({"hosted-git-info@1": "catalog:", ...})
```

## Fix

Mirror pnpm's [`parseOverrides(overrides, catalogs)`](https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts#L20-L44) → [`createOverridesMapFromParsed`](https://github.com/pnpm/pnpm/blob/4a36b9a110/lockfile/settings-checker/src/createOverridesMapFromParsed.ts) pipeline:

- `pacquet-config-parse-overrides::parse_overrides[_iter]` now takes `&Catalogs` and runs each value through `resolve_from_catalog` — `Found` swaps in the resolved specifier, `Unused` keeps the original value, `Misconfiguration` surfaces as `ERR_PNPM_CATALOG_IN_OVERRIDES` with the resolver's own error message (closer to upstream than the old hardcoded message).
- Added `create_overrides_map_from_parsed` helper mirroring upstream.
- The frozen-lockfile branch of `Install::run` parses `config.overrides` once with the workspace catalogs *before* the freshness check, hands the resolved map to `check_lockfile_settings`, and reuses the same parsed slice for `VersionsOverrider` (no double parsing).

## Test plan

- [x] Added `frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness_check`: workspace catalog defines `placeholder: 1.0.0`, manifest declares `placeholder: ^9`, `pnpm.overrides` is `placeholder: catalog:`, lockfile records the resolved `overrides.placeholder: 1.0.0`. Install must accept the lockfile.
- [x] Verified the test catches the regression: temporarily reverted the fix and the test failed with the exact error users see — `OverridesChanged { lockfile: {"placeholder": "1.0.0"}, config: {"placeholder": "catalog:"} }`.
- [x] Existing `parse_overrides` and `VersionsOverrider` tests updated to pass an empty catalogs map; two new tests cover `catalog:` and `catalog:<name>` resolution.
- [x] `cargo nextest run -p pacquet-config-parse-overrides -p pacquet-package-manager --lib` → 293/293 pass.
- [x] `cargo clippy -p pacquet-config-parse-overrides -p pacquet-package-manager --all-targets -- --deny warnings` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package overrides configuration now fully supports catalog protocol resolution, with `catalog:` and `catalog:<name>` references being automatically resolved from workspace catalogs.
  * Frozen lockfile freshness checks now properly account for and resolve catalog references in overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->