### PR TITLE
fix: validate devEngines runtime onFail

### DIFF
--- a/.changeset/strong-buckets-hear.md
+++ b/.changeset/strong-buckets-hear.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Validate `devEngines.runtime` `onFail` settings against the current Node.js version.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7677,6 +7677,9 @@ importers:
       '@pnpm/engine.runtime.commands':
         specifier: workspace:*
         version: link:../engine/runtime/commands
+      '@pnpm/engine.runtime.system-node-version':
+        specifier: workspace:*
+        version: link:../engine/runtime/system-node-version
       '@pnpm/error':
         specifier: workspace:*
         version: link:../core/error

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -100,6 +100,7 @@
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/engine.pm.commands": "workspace:*",
     "@pnpm/engine.runtime.commands": "workspace:*",
+    "@pnpm/engine.runtime.system-node-version": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.commands": "workspace:*",
     "@pnpm/hooks.pnpmfile": "workspace:*",

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -12,9 +12,10 @@ import { stripVTControlCharacters as stripAnsi } from 'node:util'
 import { isExecutedByCorepack, packageManager } from '@pnpm/cli.meta'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { executionTimeLogger, scopeLogger } from '@pnpm/core-loggers'
+import { getSystemNodeVersion } from '@pnpm/engine.runtime.system-node-version'
 import { PnpmError } from '@pnpm/error'
 import { globalWarn, logger } from '@pnpm/logger'
-import type { EngineDependency } from '@pnpm/types'
+import type { EngineDependency, ProjectManifest } from '@pnpm/types'
 import { finishWorkers } from '@pnpm/worker'
 import { safeReadProjectManifestOnly } from '@pnpm/workspace.project-manifest-reader'
 import { filterProjectsFromDir } from '@pnpm/workspace.projects-filter'
@@ -124,6 +125,9 @@ export async function main (inputArgv: string[]): Promise<void> {
           await syncEnvLockfile(config, context)
         }
       }
+    }
+    if (cmd !== 'setup' && context.rootProjectManifest != null && !cliOptions.global) {
+      checkRuntime(context.rootProjectManifest)
     }
     // `pnpm set` / `pnpm get` are separate top-level commands whose handlers
     // delegate to the `config` command internally. They are not rewritten to
@@ -442,4 +446,31 @@ function checkPackageManager (pm: EngineDependency, opts: { underCorepack: boole
       }
     }
   }
+}
+
+function checkRuntime (manifest: ProjectManifest): void {
+  const runtime = getNodeRuntime(manifest)
+  if (!runtime?.name || !runtime.version) return
+  if (runtime.onFail !== 'error' && runtime.onFail !== 'warn') return
+  const currentNodeVersion = getSystemNodeVersion() ?? process.version
+  if (semver.satisfies(currentNodeVersion, runtime.version, { includePrerelease: true })) return
+
+  const msg = `This project is configured to use ${runtime.version} of Node.js. Your current Node.js is ${currentNodeVersion}`
+  if (runtime.onFail === 'error') {
+    throw new PnpmError('BAD_NODE_VERSION', msg, {
+      hint: 'If you want to bypass this version check, set devEngines.runtime.onFail to "warn" or "ignore", or set the "runtimeOnFail" configuration to "warn" or "ignore"',
+    })
+  }
+  globalWarn(msg)
+}
+
+function getNodeRuntime (manifest: ProjectManifest): EngineDependency | undefined {
+  for (const enginesFieldName of ['devEngines', 'engines'] as const) {
+    const enginesRuntime = manifest[enginesFieldName]?.runtime
+    if (enginesRuntime == null) continue
+    const runtimes: EngineDependency[] = Array.isArray(enginesRuntime) ? enginesRuntime : [enginesRuntime]
+    const nodeRuntime = runtimes.find((runtime) => runtime.name === 'node')
+    if (nodeRuntime) return nodeRuntime
+  }
+  return undefined
 }

--- a/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm/test/packageManagerCheck.test.ts
@@ -143,6 +143,40 @@ test('devEngines.packageManager with onFail=ignore should not check version', as
   expect(stderr.toString()).not.toContain('0.0.1')
 })
 
+test('devEngines.runtime with onFail=error should fail on Node.js version mismatch', async () => {
+  prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '11111.0.0',
+        onFail: 'error',
+      },
+    },
+  })
+
+  const { status, stderr } = execPnpmSync(['exec', 'node', '--version'])
+
+  expect(status).toBe(1)
+  expect(stderr.toString()).toContain('This project is configured to use 11111.0.0 of Node.js')
+})
+
+test('devEngines.runtime with onFail=warn should warn on Node.js version mismatch', async () => {
+  prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '11111.0.0',
+        onFail: 'warn',
+      },
+    },
+  })
+
+  const { status, stdout } = execPnpmSync(['exec', 'node', '--version'])
+
+  expect(status).toBe(0)
+  expect(stdout.toString()).toContain('This project is configured to use 11111.0.0 of Node.js')
+})
+
 test('devEngines.packageManager defaults to onFail=download (#11676)', async () => {
   prepare({
     devEngines: {


### PR DESCRIPTION
Closed as duplicate of #11822.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Node.js runtime version validation to enforce configured engine requirements during execution
  * Supports configurable failure modes: emit warnings or error when the current Node.js version doesn't match requirements
  * Validation applies based on project manifest engine specifications

* **Tests**
  * Added test coverage for Node.js version validation with both error and warning failure modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->