### PR TITLE
test(pacquet/fs): port upstream multi-process CAS stress tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,6 +2231,7 @@ dependencies = [
  "junction",
  "miette 7.6.0",
  "pathdiff",
+ "sha2",
  "tempfile",
 ]
 

--- a/pacquet/crates/fs/Cargo.toml
+++ b/pacquet/crates/fs/Cargo.toml
@@ -17,6 +17,7 @@ miette      = { workspace = true }
 pathdiff    = { workspace = true }
 
 [dev-dependencies]
+sha2     = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/pacquet/crates/fs/src/bin/cafs_stress_worker.rs
+++ b/pacquet/crates/fs/src/bin/cafs_stress_worker.rs
@@ -1,0 +1,50 @@
+//! Test-only worker invoked by the CAFS multi-process stress tests in
+//! `tests/ensure_file_stress.rs`.
+//!
+//! Reads the content payload from `argv[1]` and the target CAS path
+//! from `argv[2]`, then calls [`pacquet_fs::ensure_file`] exactly once.
+//! Exits `0` on success, `1` on error (with the error printed to
+//! stderr).
+//!
+//! Mirrors the per-worker JS script the upstream
+//! [`writeBufferToCafs.test.ts`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts)
+//! spawns to exercise cross-process behaviour. Pacquet's `cas_write_lock`
+//! is process-local just like upstream's `locker: Map<string, number>`,
+//! so the OS-level mutex tests need real subprocesses to exercise the
+//! `O_CREAT | O_EXCL` + `verify_or_rewrite` recovery path that holds the
+//! store together when N processes race on the same blob.
+
+use pacquet_fs::ensure_file;
+use std::{fs, path::PathBuf, process::ExitCode};
+
+fn main() -> ExitCode {
+    let mut args = std::env::args().skip(1);
+    let Some(content_path) = args.next().map(PathBuf::from) else {
+        eprintln!("usage: cafs_stress_worker <content-file> <target-file>");
+        return ExitCode::from(2);
+    };
+    let Some(target_path) = args.next().map(PathBuf::from) else {
+        eprintln!("usage: cafs_stress_worker <content-file> <target-file>");
+        return ExitCode::from(2);
+    };
+
+    let content = match fs::read(&content_path) {
+        Ok(content) => content,
+        Err(error) => {
+            eprintln!("failed to read content from {content_path:?}: {error}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // `mode: None` matches the upstream test's `420` (octal `0o644`)
+    // after the umask is applied — pacquet's `ensure_file` on `None`
+    // takes the kernel default, which is the same set of bits a
+    // `0o644` request would survive after a typical umask. The test
+    // only inspects content, not mode, so the simplification is safe.
+    if let Err(error) = ensure_file(&target_path, &content, None) {
+        eprintln!("ensure_file failed: {error}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::SUCCESS
+}

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -1,0 +1,192 @@
+//! Cross-process stress tests for [`pacquet_fs::ensure_file`].
+//!
+//! Ports the three multi-process scenarios upstream pnpm covers in
+//! [`store/cafs/test/writeBufferToCafs.test.ts`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts):
+//!
+//! 1. Concurrent writes of the same content from many processes all
+//!    succeed and converge on a byte-identical CAS file.
+//! 2. The same scenario after a previous (crashed) writer has left
+//!    a corrupt blob at the target path — recovery via
+//!    `verify_or_rewrite` + `write_atomic` rewrites the blob and
+//!    every concurrent writer still returns success.
+//! 3. The same scenario after a previous (crashed) writer has left
+//!    a truncated prefix of the correct content — the size-mismatch
+//!    fast path inside `verify_or_rewrite` kicks in and the
+//!    overwrite-via-rename heals the store.
+//!
+//! Pacquet's [`cas_write_lock`](pacquet_fs::ensure_file) is
+//! process-local (a `OnceLock<DashMap<PathBuf, Arc<Mutex<()>>>>`),
+//! just like upstream's `locker: Map<string, number>`. The
+//! cross-process safety contract therefore lives entirely in the
+//! kernel-level `O_CREAT | O_EXCL` + atomic-rename primitives. The
+//! existing intra-process 32-thread test in `ensure_file::tests`
+//! ([`concurrent_writers_of_same_path_do_not_swap_the_inode`])
+//! exercises the lock; this suite exercises the unprotected
+//! filesystem-only path.
+
+use sha2::{Digest, Sha512};
+use std::{fs, path::Path, process::Command, sync::Arc, thread};
+use tempfile::tempdir;
+
+/// Number of worker processes per test. Eight matches upstream's
+/// `numWorkers = 8` default.
+const WORKER_COUNT: usize = 8;
+
+/// 256 KiB matches upstream's `crypto.randomBytes(256 * 1024)`.
+/// Big enough to make a partial write detectable as a size mismatch
+/// without being so big it dominates the test runtime.
+const CONTENT_SIZE: usize = 256 * 1024;
+
+/// Path to the test-only worker binary that `cargo build` produced
+/// alongside this integration test. The env var is set by Cargo at
+/// test compile time so the worker stays reachable without anyone
+/// having to run `cargo build --bin` first.
+const WORKER_BIN: &str = env!("CARGO_BIN_EXE_cafs_stress_worker");
+
+/// Run [`WORKER_COUNT`] worker subprocesses in parallel, each calling
+/// `ensure_file(target, content, None)`. Returns the exit codes; the
+/// caller asserts every one is `0`.
+fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::ExitStatus> {
+    let content_path: Arc<Path> = Arc::from(content_path.to_path_buf());
+    let target_path: Arc<Path> = Arc::from(target_path.to_path_buf());
+
+    let handles: Vec<_> = (0..WORKER_COUNT)
+        .map(|_| {
+            let content_path = Arc::clone(&content_path);
+            let target_path = Arc::clone(&target_path);
+            thread::spawn(move || {
+                Command::new(WORKER_BIN)
+                    .arg(&*content_path)
+                    .arg(&*target_path)
+                    .status()
+                    .expect("spawn cafs_stress_worker")
+            })
+        })
+        .collect();
+
+    handles.into_iter().map(|handle| handle.join().expect("worker thread")).collect()
+}
+
+/// Sha-512-hex the byte slice, the same digest format
+/// [`pacquet_fs::ensure_file`] would use for CAS naming.
+fn sha512_hex(content: &[u8]) -> String {
+    let digest = Sha512::digest(content);
+    format!("{digest:x}")
+}
+
+/// Concurrent writes of the same buffer from many processes all
+/// succeed and converge on a byte-identical CAS file. Mirrors
+/// upstream's [`should handle concurrent writes from multiple
+/// processes without corruption`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts#L60).
+#[test]
+fn multi_process_concurrent_writes_converge_on_correct_content() {
+    let tmp = tempdir().expect("tempdir");
+    let content_path = tmp.path().join("content.bin");
+    let target_path = tmp.path().join("target.bin");
+
+    let content: Vec<u8> = (0..CONTENT_SIZE).map(|i| (i % 256) as u8).collect();
+    fs::write(&content_path, &content).expect("write content fixture");
+    let expected_digest = sha512_hex(&content);
+
+    let statuses = run_workers(&content_path, &target_path);
+
+    for (idx, status) in statuses.iter().enumerate() {
+        assert!(status.success(), "worker {idx} failed: {status:?}");
+    }
+
+    let final_content = fs::read(&target_path).expect("read target");
+    assert_eq!(final_content.len(), content.len(), "size mismatch after concurrent writes");
+    assert_eq!(
+        sha512_hex(&final_content),
+        expected_digest,
+        "content mismatch after concurrent writes",
+    );
+}
+
+/// A pre-seeded corrupt blob at the target path doesn't wedge the
+/// store: every concurrent writer still returns success, and the
+/// final on-disk content matches the buffer the workers were trying
+/// to write. Mirrors upstream's [`should recover from a corrupt file
+/// when multiple processes write
+/// concurrently`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts#L85).
+#[test]
+fn multi_process_recovery_from_pre_seeded_corrupt_file() {
+    let tmp = tempdir().expect("tempdir");
+    let content_path = tmp.path().join("content.bin");
+    let target_path = tmp.path().join("target.bin");
+
+    let content: Vec<u8> = (0..CONTENT_SIZE).map(|i| ((i * 7) % 256) as u8).collect();
+    fs::write(&content_path, &content).expect("write content fixture");
+    let expected_digest = sha512_hex(&content);
+
+    // Pre-seed a corrupt file at the target path. Same byte count
+    // as the real content (so the size short-circuit doesn't fire)
+    // but every byte inverted, so the byte-comparison in
+    // `verify_or_rewrite` rejects it and `write_atomic` rewrites
+    // the blob. `0xAA` is the bit-inverse of nothing in particular —
+    // just a non-zero pattern that won't accidentally match the real
+    // content even for trivial inputs.
+    let corrupt = vec![0xAA_u8; CONTENT_SIZE];
+    fs::write(&target_path, &corrupt).expect("pre-seed corrupt blob");
+
+    let statuses = run_workers(&content_path, &target_path);
+
+    for (idx, status) in statuses.iter().enumerate() {
+        assert!(status.success(), "worker {idx} failed: {status:?}");
+    }
+
+    let final_content = fs::read(&target_path).expect("read target");
+    assert_eq!(
+        final_content.len(),
+        content.len(),
+        "size mismatch after recovery from pre-seeded corrupt file",
+    );
+    assert_eq!(
+        sha512_hex(&final_content),
+        expected_digest,
+        "content mismatch after recovery from pre-seeded corrupt file",
+    );
+}
+
+/// A pre-seeded truncated prefix of the correct content (simulating
+/// a writer that crashed mid-`write_all`) also recovers: the size
+/// mismatch short-circuits the byte comparison and `write_atomic`
+/// renames a fresh blob over the partial one. Mirrors upstream's
+/// [`should recover from a truncated file (simulating crash
+/// mid-write)`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts#L111).
+#[test]
+fn multi_process_recovery_from_pre_seeded_truncated_file() {
+    let tmp = tempdir().expect("tempdir");
+    let content_path = tmp.path().join("content.bin");
+    let target_path = tmp.path().join("target.bin");
+
+    let content: Vec<u8> = (0..CONTENT_SIZE).map(|i| ((i * 13) % 256) as u8).collect();
+    fs::write(&content_path, &content).expect("write content fixture");
+    let expected_digest = sha512_hex(&content);
+
+    // Pre-seed the first 1 KiB of the correct content. Same as
+    // upstream's `content.subarray(0, 1024)`: matches the prefix
+    // of what the workers will write, so a naive content-matching
+    // path that compared only the first chunk would erroneously
+    // claim a hit. The size-mismatch guard inside
+    // `verify_or_rewrite` is what makes recovery work.
+    fs::write(&target_path, &content[..1024]).expect("pre-seed truncated blob");
+
+    let statuses = run_workers(&content_path, &target_path);
+
+    for (idx, status) in statuses.iter().enumerate() {
+        assert!(status.success(), "worker {idx} failed: {status:?}");
+    }
+
+    let final_content = fs::read(&target_path).expect("read target");
+    assert_eq!(
+        final_content.len(),
+        content.len(),
+        "size mismatch after recovery from pre-seeded truncated file",
+    );
+    assert_eq!(
+        sha512_hex(&final_content),
+        expected_digest,
+        "content mismatch after recovery from pre-seeded truncated file",
+    );
+}


### PR DESCRIPTION
## Summary

Ports the three cross-process CAFS stress scenarios from upstream [`store/cafs/test/writeBufferToCafs.test.ts`](https://github.com/pnpm/pnpm/blob/8695496f58/store/cafs/test/writeBufferToCafs.test.ts). Pacquet had the intra-process variant (one 32-thread test in `ensure_file::tests`) but no multi-process coverage. The new suite exercises the kernel-level safety contract (`O_CREAT | O_EXCL` + atomic-rename) that's the only thing protecting the store when N processes race on the same blob — pacquet's `cas_write_lock` is process-local just like upstream's `locker: Map<string, number>`.

Three scenarios, all spawning 8 worker processes per test:
1. **Clean target.** Concurrent writes of the same buffer all succeed; final content matches.
2. **Pre-seeded corrupt blob.** Same byte count but different bytes, simulating a previous crashed write. `verify_or_rewrite` + `write_atomic` heal it; every worker still returns success.
3. **Pre-seeded truncated prefix.** First 1 KiB of correct content. Size-mismatch short-circuits the byte comparison; rename rebuilds the full file.

## Approach

- New `[[bin]]` `cafs_stress_worker` under `pacquet-fs/src/bin/`. Reads a content fixture from `argv[1]` and a target path from `argv[2]`, calls `ensure_file`, exits 0/1. Tiny and test-only — `pacquet-fs` is `publish = false` so an extra bin target is free.
- New integration test `pacquet-fs/tests/ensure_file_stress.rs`. Uses `env!(\"CARGO_BIN_EXE_cafs_stress_worker\")` to find the bin Cargo builds alongside the test, then spawns 8 instances per scenario via `std::process::Command`.
- Each scenario asserts every worker exited 0 and the final on-disk content sha-512-matches the expected payload.

## Verified

Each recovery test was verified to catch a regression by temporarily bypassing `verify_or_rewrite` — both recovery tests flipped red, the clean-target test stayed green (it doesn't pre-seed anything so the recovery branch isn't on its critical path). Matches upstream's coverage shape.

## Test plan

- [x] `cargo nextest run -p pacquet-fs` — 28 tests pass (incl. the 3 new ones)
- [x] `cargo fmt --all -- --check`, `just lint`, `just dylint`
- [x] Break-and-restore on `verify_or_rewrite` confirms recovery tests catch regressions

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive stress testing suite for concurrent file operations
  * Implemented integration tests validating file system reliability under multi-process load, including corruption recovery scenarios

* **Chores**
  * Updated development dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->