### PR TITLE
fix(pacquet/store-dir): close writer×verifier race in verify_file

### DIFF
--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -205,7 +205,16 @@ pub fn ensure_file(
 /// released — otherwise a recursive lookup on the same shard could
 /// deadlock. The map is never pruned: entries are one per unique
 /// CAS path the install wrote, bounded by the working set.
-fn cas_write_lock(file_path: &Path) -> Arc<Mutex<()>> {
+///
+/// Made `pub` so verifiers (`check_pkg_files_integrity`) can acquire
+/// the same lock before stat-then-maybe-`rimraf`'ing a CAS path.
+/// Without that, a verifier can `unlink` a file while a writer's
+/// `write_all` is still running — leaving the writer's `cas_paths`
+/// pointing at a now-orphaned inode whose dirent is gone, which
+/// surfaces later as ENOENT inside `link_file`. The lock is the
+/// only primitive that already coordinates per-blob writers, so it
+/// is the right gate to extend to readers that delete.
+pub fn cas_write_lock(file_path: &Path) -> Arc<Mutex<()>> {
     static LOCKS: OnceLock<DashMap<PathBuf, Arc<Mutex<()>>>> = OnceLock::new();
     let locks = LOCKS.get_or_init(DashMap::new);
     Arc::clone(

--- a/pacquet/crates/store-dir/Cargo.toml
+++ b/pacquet/crates/store-dir/Cargo.toml
@@ -42,6 +42,7 @@ sha2 = { workspace = true, features = ["asm"] }
 [dev-dependencies]
 pipe-trait        = { workspace = true }
 pretty_assertions = { workspace = true }
+sha2              = { workspace = true }
 tempfile          = { workspace = true }
 
 [lints]

--- a/pacquet/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pacquet/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -269,8 +269,27 @@ fn build_side_effects_maps(
 /// doesn't affect behaviour, only the `debug!` log when verification
 /// fails, so operators can see *which* package file invalidated the
 /// store-index row in the log.
+///
+/// **Locking discipline.** The fast path (`is_modified == false`, i.e.
+/// the file's mtime is within 100 ms of the recorded `checked_at`)
+/// runs lock-free — it never touches the file's bytes and never
+/// considers a delete, so it cannot race with an in-flight writer.
+/// The slow path (where verification could lead to a
+/// `remove_stale_cafs_entry` call) acquires
+/// [`pacquet_fs::cas_write_lock`] for `path` before re-stating the
+/// file. This is the same per-path mutex
+/// [`pacquet_fs::ensure_file`] holds across `O_CREAT|O_EXCL` +
+/// `write_all`, so a concurrent writer's full sequence completes
+/// before the verifier evaluates the file. Without this gate, the
+/// verifier observes the writer's intermediate (partial) state,
+/// `unlink`s the file out from under the writer's open fd, and the
+/// install ends up with `cas_paths` referencing a path whose dirent
+/// has been removed — which surfaces later as ENOENT in
+/// `link_file`.
 fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> bool {
-    let Some((is_modified, size)) = check_file(path, info.checked_at) else {
+    // Lock-free fast path. `check_file` is read-only and only touches
+    // the file's metadata; no risk of clobbering a writer's state.
+    let Some((is_modified, _)) = check_file(path, info.checked_at) else {
         tracing::debug!(
             target: "pacquet::store_index",
             ?filename,
@@ -280,6 +299,37 @@ fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> 
         return false;
     };
     if !is_modified {
+        return true;
+    }
+
+    // Slow path: the file's mtime indicates a recent change. Acquire
+    // the per-path lock and re-check so a concurrent writer's
+    // `write_all` lands before we decide whether to delete. The
+    // common case (unmodified file from a prior install) never gets
+    // here — the lock cost only applies to files actually being
+    // re-verified, which is rare.
+    let lock = pacquet_fs::cas_write_lock(path);
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-stat under the lock. The writer (if any) has finished by
+    // now, so the size + mtime reflect the committed state. A file
+    // that vanished between the fast-path check and lock acquisition
+    // (concurrent prune or a sibling verifier that beat us in)
+    // surfaces as ENOENT here and we propagate the cache miss
+    // without trying to delete a path that's already gone.
+    let Some((is_modified, size)) = check_file(path, info.checked_at) else {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?filename,
+            ?path,
+            "CAFS file disappeared between fast-path stat and lock acquisition; re-fetching",
+        );
+        return false;
+    };
+    if !is_modified {
+        // Writer completed and the result happens to match
+        // `checked_at` (uncommon but possible if `checked_at` was
+        // updated very recently). Trust the cache, no further work.
         return true;
     }
     if size != info.size {

--- a/pacquet/crates/store-dir/tests/verify_writer_race.rs
+++ b/pacquet/crates/store-dir/tests/verify_writer_race.rs
@@ -1,0 +1,220 @@
+//! Reproducer for the writer × verifier race that surfaces in CI as
+//! `failed to import "<store>/v11/files/…": No such file or directory (os error 2)`.
+//!
+//! Scenario:
+//!
+//! 1. A writer thread is inside [`pacquet_fs::ensure_file`] for path
+//!    `F`, holding the per-path `cas_write_lock`. Between
+//!    `O_CREAT|O_EXCL` and `write_all` completion, `F` exists on
+//!    disk with a partial body.
+//! 2. A verifier thread runs [`pacquet_store_dir::check_pkg_files_integrity`]
+//!    for an index row that references `F` (different package, same
+//!    content hash — common for shared boilerplate like `LICENSE`
+//!    files across sibling packages).
+//! 3. Verifier `stat`s `F` (no lock), sees a size that doesn't
+//!    match the index, and calls `remove_stale_cafs_entry(F)` to
+//!    scrub the "torn" blob.
+//! 4. The writer's `write_all` continues — but `F`'s dirent is now
+//!    gone. The kernel keeps the inode alive while the fd is open;
+//!    once the writer drops the fd, the inode is freed. The
+//!    writer's `ensure_file` returns `Ok(())` and the install
+//!    proceeds with `cas_paths` pointing at a path that no longer
+//!    exists.
+//! 5. Downstream `link_file` hits `ENOENT` and the install fails.
+//!
+//! Option C fix: extend `cas_write_lock` to `verify_file` so the
+//! verifier waits for the writer to finish before deciding whether
+//! the file is stale. With the fix, the verifier always observes
+//! the writer's final state — either fully-written and valid (skip
+//! the delete) or genuinely stale (delete safely).
+//!
+//! The race is timing-dependent in production because the
+//! writer's `write_all` is fast (milliseconds for a small file).
+//! To make the reproducer deterministic, the test holds
+//! `cas_write_lock` from the main thread for the entire critical
+//! window — this is exactly what an in-flight `ensure_file` would
+//! do, just on a wall-clock the test controls. The verifier runs
+//! in the background while the lock is held; without the fix it
+//! unlinks the file unconditionally, with the fix it blocks on
+//! the lock until the simulated writer releases it.
+
+use std::{
+    fs,
+    sync::{Arc, Mutex, mpsc},
+    thread,
+    time::Duration,
+};
+
+use pacquet_store_dir::{
+    CafsFileInfo, PackageFilesIndex, StoreDir, VerifiedFilesCache, check_pkg_files_integrity,
+};
+use sha2::{Digest, Sha512};
+use tempfile::tempdir;
+
+const CONTENT_SIZE: usize = 64 * 1024;
+
+fn sha512_hex(content: &[u8]) -> String {
+    let digest = Sha512::digest(content);
+    format!("{digest:x}")
+}
+
+/// Place a `CafsFileInfo` row that the verifier will check against,
+/// with `checked_at` pinned to the Unix epoch so the file's current
+/// mtime is always > 100 ms past the recorded check time — the
+/// condition that makes `verify_file` enter its destructive branch.
+fn make_index(filename: &str, content: &[u8]) -> PackageFilesIndex {
+    let mut files = std::collections::HashMap::new();
+    files.insert(
+        filename.to_string(),
+        CafsFileInfo {
+            digest: sha512_hex(content),
+            mode: 0o644,
+            size: content.len() as u64,
+            checked_at: Some(0),
+        },
+    );
+    PackageFilesIndex {
+        manifest: None,
+        requires_build: None,
+        algo: "sha512".to_string(),
+        files,
+        side_effects: None,
+    }
+}
+
+/// Compute the CAS path the writer + verifier agree on for a given
+/// content hash. Mirrors `StoreDir::cas_file_path_by_mode` for
+/// `mode = 0o644` (no `-exec` suffix).
+fn cas_path_for(store: &StoreDir, content: &[u8]) -> std::path::PathBuf {
+    store
+        .cas_file_path_by_mode(&sha512_hex(content), 0o644)
+        .expect("sha512 hex is always a valid CAFS path")
+}
+
+/// The reproducer.
+///
+/// Pre-Option-C: the verifier deletes the file while the simulated
+/// writer "holds the lock", because verify_file doesn't acquire the
+/// lock at all.
+///
+/// Post-Option-C: the verifier acquires `cas_write_lock(path)`
+/// before deciding whether to delete. While the test holds the
+/// lock, the verifier blocks; we observe the file is still on disk.
+/// Then the test releases the lock, the verifier finishes, and we
+/// observe the file is still there (because the verifier now sees
+/// the final committed state).
+#[test]
+fn verify_does_not_unlink_file_while_writer_holds_cas_lock() {
+    let tmp = tempdir().expect("tempdir");
+    let store = StoreDir::new(tmp.path().to_path_buf());
+
+    let expected_content: Vec<u8> = (0..CONTENT_SIZE).map(|i| (i % 256) as u8).collect();
+    let target = cas_path_for(&store, &expected_content);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).expect("create shard dir");
+    }
+
+    // Simulate "writer is mid-`write_all`": F exists on disk with a
+    // partial prefix of the expected content. Size mismatch — exactly
+    // the condition that drives `verify_file` into the
+    // `remove_stale_cafs_entry` branch.
+    fs::write(&target, &expected_content[..1024]).expect("pre-seed partial blob");
+
+    // The main thread "becomes" the writer: acquire the per-path
+    // `cas_write_lock` and hold it across the verifier's run. The
+    // lock is the only primitive `ensure_file` uses to gate concurrent
+    // writers; with Option C, `verify_file` acquires the same lock
+    // before considering a delete.
+    let lock = pacquet_fs::cas_write_lock(&target);
+    let guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+
+    // Use a channel to synchronize lock-release with the verifier so
+    // we can assert the file's state at a known point.
+    let (verifier_started_tx, verifier_started_rx) = mpsc::channel::<()>();
+    let result_slot: Arc<Mutex<Option<bool>>> = Arc::new(Mutex::new(None));
+
+    let verify_store = StoreDir::new(tmp.path().to_path_buf());
+    let verify_content = expected_content.clone();
+    let result_slot_writer = Arc::clone(&result_slot);
+    let target_for_verifier = target.clone();
+    let verifier = thread::spawn(move || {
+        verifier_started_tx.send(()).expect("send start");
+        let pkg_index = make_index("LICENSE", &verify_content);
+        let cache = VerifiedFilesCache::new();
+        let result = check_pkg_files_integrity(&verify_store, pkg_index, &cache);
+        // Record whether the file survived the verifier's run.
+        *result_slot_writer.lock().expect("result mutex") =
+            Some((target_for_verifier.exists(), result.passed).0);
+    });
+
+    // Wait until the verifier thread has actually started.
+    verifier_started_rx.recv().expect("verifier started");
+
+    // Sleep to give the verifier time to either:
+    //   - (pre-fix) charge ahead, stat the partial file, unlink it
+    //     before we can react, OR
+    //   - (post-fix) block on `cas_write_lock` and make no progress.
+    // 200 ms is far more than enough for either outcome on any
+    // realistic runner.
+    thread::sleep(Duration::from_millis(200));
+
+    // Snapshot the on-disk state while we still hold the simulated
+    // writer's lock. This is the assertion that distinguishes the
+    // two implementations.
+    let file_exists_under_lock = target.exists();
+
+    // Simulate the writer "finishing" by replacing the partial blob
+    // with the full content — what `ensure_file`'s `write_all` +
+    // close would have produced. Drop the lock guard so the verifier
+    // (if it's blocked) can wake up and observe the final state.
+    fs::write(&target, &expected_content).expect("commit full content");
+    drop(guard);
+
+    verifier.join().expect("verifier thread should not panic");
+    let file_exists_after_verify = target.exists();
+
+    // The killer assertion. Without Option C the verifier doesn't
+    // wait — it sees the partial file under the lock and unlinks it,
+    // which means `file_exists_under_lock` is `false`. With Option
+    // C, the verifier waits on the lock and never makes a decision
+    // until we release it, so `file_exists_under_lock` is `true`.
+    assert!(
+        file_exists_under_lock,
+        "Verifier unlinked the CAS file while a writer was still holding cas_write_lock. \
+         This is the writer-vs-verifier race that surfaces as ENOENT inside link_file at \
+         install time. Option C (extending cas_write_lock to verify_file) is what closes it.",
+    );
+
+    // Also assert the file is still present after the verifier finished:
+    // with the fix, once the lock releases the verifier sees the full
+    // content (we wrote it under the lock) and either skips the delete
+    // (matching hash) or deletes safely with no writer racing it.
+    // Without the fix this would already be false from the unlink above,
+    // so the earlier assert catches it first; we keep this as a final
+    // contract check.
+    assert!(
+        file_exists_after_verify,
+        "After the simulated writer released its lock, the verifier should observe \
+         the final (correct) content and not delete it",
+    );
+
+    drop(tmp);
+}
+
+/// Sanity check: the lock acquired by [`pacquet_fs::cas_write_lock`]
+/// keys on the absolute path. Two callers asking for the same path
+/// receive an `Arc` to the same `Mutex` — the property the Option-C
+/// fix relies on for the verifier to wait on the writer.
+#[test]
+fn cas_write_lock_returns_same_mutex_for_same_path() {
+    let tmp = tempdir().expect("tempdir");
+    let path = tmp.path().join("shared-blob");
+
+    let lock_a = pacquet_fs::cas_write_lock(&path);
+    let lock_b = pacquet_fs::cas_write_lock(&path);
+
+    assert!(
+        Arc::ptr_eq(&lock_a, &lock_b),
+        "cas_write_lock must hand out the same Arc<Mutex<()>> for the same path",
+    );
+}


### PR DESCRIPTION
## Summary

Closes the writer×verifier race that surfaces in CI as `failed to import "<store>/v11/files/…": No such file or directory (os error 2)`. While `ensure_file` was holding the per-path `cas_write_lock` and partway through `write_all`, a sibling snapshot's `check_pkg_files_integrity` would stat the same CAS path (no lock), see a partial size, and `remove_stale_cafs_entry` it. The writer's `write_all` then carried on against an orphan inode; once the fd closed, the inode was freed and the install's `cas_paths` was pointing at a now-missing dirent.

## The fix

Acquire `cas_write_lock(path)` in `verify_file` before any branch that could call `remove_stale_cafs_entry`. The lock is the same per-path mutex `ensure_file` already holds, so a concurrent writer's `write_all` always lands before the verifier evaluates.

Implementation:
- `verify_file`'s fast path stays lock-free. When the file's mtime is within the 100 ms `checked_at` slack (the common case — file untouched since a prior install), no lock is acquired and no fs operations beyond the original stat.
- The slow path (where the verifier could end up calling `remove_stale_cafs_entry`) acquires the lock, re-stats under the lock, and only then decides. A file that vanished between the fast-path stat and lock acquisition surfaces as a graceful "cache miss / re-fetch" instead of a panic.
- `pacquet_fs::cas_write_lock` was promoted from `fn` to `pub fn` so the store-dir crate can reach it.

## Performance

- Fast path: zero overhead.
- Slow path: one uncontended Mutex acquire per file, sub-microsecond.
- Contention: only fires when a writer + verifier hit the same blob simultaneously. Wait is bounded by one `write_all` (milliseconds), trading a millisecond-scale wait for avoiding the network re-fetch the install would otherwise have to do.

## Reproducer test

`pacquet/crates/store-dir/tests/verify_writer_race.rs` — deterministic, fails pre-fix, passes post-fix.

The test holds `cas_write_lock` from the test thread (standing in for an in-flight writer) and pre-seeds a partial CAS file at the matching path. A background thread runs `check_pkg_files_integrity` for a row that references the same path. The assertion checks whether the file still exists while the "writer" holds the lock:

- Pre-Option-C: verifier doesn't acquire the lock, sees partial file, unlinks. Assertion fails.
- Post-Option-C: verifier acquires the lock and blocks. Assertion holds.

I verified the test flips green only because of the fix:

```
$ git stash    # un-apply the fix
$ cargo nextest run -p pacquet-store-dir --test verify_writer_race
…FAIL [   0.327s] (2/2) pacquet-store-dir::verify_writer_race verify_does_not_unlink_file_while_writer_holds_cas_lock

$ git stash pop   # re-apply
$ cargo nextest run -p pacquet-store-dir --test verify_writer_race
…PASS [   0.478s] (2/2) pacquet-store-dir::verify_writer_race verify_does_not_unlink_file_while_writer_holds_cas_lock
```

## Test plan

- [x] `cargo nextest run -p pacquet-store-dir` — 105 tests pass (incl. 2 new)
- [x] `cargo nextest run -p pacquet-fs` — 28 tests pass
- [x] `cargo fmt --all -- --check`, `just lint`, `just dylint` — clean

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package file integrity verification with enhanced concurrency handling. File verification now properly synchronizes with concurrent write operations to prevent race conditions where verification processes could interfere with active writers or cause files to be prematurely deleted. This ensures more reliable integrity validation during simultaneous package operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->