### PR TITLE
fix(pacquet/registry): tolerate non-string entries in dependency maps

### DIFF
--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -349,6 +349,64 @@ fn package_deserializes_without_time_field() {
     assert!(pkg.published_at("1.0.0").is_none(), "no per-version lookup possible");
 }
 
+/// Some historical npm packages (e.g. `deep-diff@0.1.0`) ship
+/// `devDependencies` whose values are objects rather than the
+/// declared `Record<string, string>` shape. The full packument is
+/// fetched by the verifier and includes every version's per-version
+/// manifest, so a single malformed historical entry would otherwise
+/// fail the whole deserialization and surface as
+/// `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` for an unrelated
+/// version pinned in the lockfile (issue #11829). Non-string entries
+/// must be silently dropped, matching pnpm's JS-side tolerance.
+#[test]
+fn package_tolerates_object_valued_dependency_entries() {
+    let body = r#"{
+        "name": "deep-diff",
+        "dist-tags": { "latest": "0.3.8" },
+        "versions": {
+            "0.1.0": {
+                "name": "deep-diff",
+                "version": "0.1.0",
+                "devDependencies": {
+                    "vows": {
+                        "version": "0.6.4",
+                        "dependencies": {
+                            "diff": { "version": "1.0.4" },
+                            "eyes": { "version": "0.1.8" }
+                        }
+                    },
+                    "should": "1.2.1"
+                },
+                "dist": {
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/deep-diff-0.1.0.tgz"
+                }
+            },
+            "0.3.8": {
+                "name": "deep-diff",
+                "version": "0.3.8",
+                "dependencies": {},
+                "devDependencies": { "mocha": "^2.0.0" },
+                "dist": {
+                    "shasum": "1111111111111111111111111111111111111111",
+                    "tarball": "https://registry/deep-diff-0.3.8.tgz"
+                }
+            }
+        }
+    }"#;
+    let pkg: Package = serde_json::from_str(body)
+        .expect("deserialize packument with object-valued devDependencies entries");
+
+    let old = pkg.versions.get("0.1.0").expect("0.1.0 deserialized");
+    let old_dev = old.dev_dependencies.as_ref().expect("devDependencies present");
+    assert_eq!(old_dev.get("should").map(String::as_str), Some("1.2.1"));
+    assert!(!old_dev.contains_key("vows"), "object-valued entries are dropped");
+
+    let current = pkg.versions.get("0.3.8").expect("0.3.8 deserialized");
+    let current_dev = current.dev_dependencies.as_ref().expect("devDependencies present");
+    assert_eq!(current_dev.get("mocha").map(String::as_str), Some("^2.0.0"));
+}
+
 /// The reserved `time.unpublished` key carries an object value
 /// (not a string). [`Package::published_at`] must ignore it
 /// instead of returning the object's serialized form. Mirrors the

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -12,8 +12,23 @@ pub struct PackageVersion {
     pub name: String,
     pub version: node_semver::Version,
     pub dist: PackageDistribution,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_dependency_map",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dependencies: Option<HashMap<String, String>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_dependency_map",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub dev_dependencies: Option<HashMap<String, String>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_dependency_map",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub peer_dependencies: Option<HashMap<String, String>>,
 
     /// npm registry's per-version publisher metadata. When
@@ -59,6 +74,56 @@ pub struct PackageVersion {
         skip_serializing_if = "Option::is_none"
     )]
     pub deprecated: Option<String>,
+}
+
+/// Deserialize a `Record<string, string>`-shaped dependency map while
+/// tolerating historical npm registry entries whose values are objects
+/// or other non-string shapes. Non-string entries are silently dropped,
+/// matching pnpm's JavaScript path which never validates the value
+/// shape and relies on later `typeof spec === 'string'` checks to
+/// ignore the bad rows (e.g. `deep-diff@0.1.0`'s nested
+/// `devDependencies`). Missing field and JSON `null` both decode to
+/// `None`; a present map (even one whose entries are all dropped)
+/// decodes to `Some`.
+fn deserialize_dependency_map<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<HashMap<String, String>>, Deser::Error>
+where
+    Deser: serde::Deserializer<'de>,
+{
+    use serde::de::{self, MapAccess, Visitor};
+    use std::fmt;
+
+    struct DependencyMapVisitor;
+    impl<'de> Visitor<'de> for DependencyMapVisitor {
+        type Value = Option<HashMap<String, String>>;
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a map of dependency name to version-spec string, or null")
+        }
+        fn visit_none<Err: de::Error>(self) -> Result<Self::Value, Err> {
+            Ok(None)
+        }
+        fn visit_unit<Err: de::Error>(self) -> Result<Self::Value, Err> {
+            Ok(None)
+        }
+        fn visit_some<Nested: serde::Deserializer<'de>>(
+            self,
+            deserializer: Nested,
+        ) -> Result<Self::Value, Nested::Error> {
+            deserializer.deserialize_any(DependencyMapVisitor)
+        }
+        fn visit_map<Map: MapAccess<'de>>(self, mut map: Map) -> Result<Self::Value, Map::Error> {
+            let mut out = HashMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                let value = map.next_value::<serde_json::Value>()?;
+                if let serde_json::Value::String(spec) = value {
+                    out.insert(key, spec);
+                }
+            }
+            Ok(Some(out))
+        }
+    }
+    deserializer.deserialize_any(DependencyMapVisitor)
 }
 
 /// Accept either a string or a boolean for the `deprecated` field.


### PR DESCRIPTION
## Summary

Fixes #11829.

When the lockfile-verifier fetches the full packument for a package
whose history includes pre-spec entries, pacquet's strict serde fails
the whole document with `invalid type: map, expected a string`. The
malformed historical version surfaces as a spurious
`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` for an unrelated, validly
pinned version in the lockfile.

The reported case is `deep-diff@0.3.8`: the response carries
`deep-diff@0.1.0` whose `devDependencies` is
`{ "vows": { "version": "0.6.4", "dependencies": {...} } }` — an object
value where the schema declares `Record<string, string>`. pnpm's JS path
silently tolerates this because later access goes through
`typeof spec === 'string'` checks; pacquet's Rust deserializer is
strict.

A custom serde deserializer on `dependencies`, `devDependencies`, and
`peerDependencies` now drops non-string entries while keeping the
string-valued ones, matching pnpm's JavaScript tolerance.

## Test plan

- [x] `package_tolerates_object_valued_dependency_entries` reproduces the
  exact failing shape from `deep-diff@0.1.0` and asserts that
  string-valued entries survive deserialization while object-valued
  ones are dropped. Verified the test fails with the original
  `invalid type: map, expected a string` error when the fix is reverted.
- [x] `cargo nextest run -p pacquet-registry` — 16 passed (existing
  `deprecated` / `_npmUser` / `attestations` / `time` deserialization
  coverage all still green).
- [x] `just check` — workspace builds clean.
- [x] `just lint` — `cargo clippy --locked --workspace --all-targets --
  --deny warnings` clean.
- [x] `just fmt` — no diff (already formatted).

`just typos` and the wider `just ready` recipe surface preexisting
CHANGELOG typos on `main` (git short hashes flagged as misspellings),
unrelated to this change.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of legacy npm packages with malformed dependency entries that may contain object values
* Invalid dependency data is automatically filtered during import, preventing processing failures with historical npm registry anomalies
* Added test coverage for dependency deserialization edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->