### PR TITLE
chore(pacquet/lint): more clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 # see "Cloning `Arc` and `Rc`" in `pacquet/CODE_STYLE_GUIDE.md`. It replaces
 # perfectionist's `arc_rc_clone`, which is disabled in `dylint.toml`.
 [workspace.lints.clippy]
-clone_on_ref_ptr           = "warn"
-if_then_some_else_none     = "warn"
+clone_on_ref_ptr             = "warn"
+if_then_some_else_none       = "warn"
 unnecessary_lazy_evaluations = "warn"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,6 @@ allow_branch = "main"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfectionist"))'] }
 
-# `clone_on_ref_ptr` requires `Arc::clone(&x)` / `Rc::clone(&x)` over
-# `x.clone()` so the O(1) refcount bump stays visible at the call site —
-# see "Cloning `Arc` and `Rc`" in `pacquet/CODE_STYLE_GUIDE.md`.
 [workspace.lints.clippy]
 clone_on_ref_ptr             = "warn"
 if_then_some_else_none       = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 
 # `clone_on_ref_ptr` requires `Arc::clone(&x)` / `Rc::clone(&x)` over
 # `x.clone()` so the O(1) refcount bump stays visible at the call site —
-# see "Cloning `Arc` and `Rc`" in `pacquet/CODE_STYLE_GUIDE.md`. It replaces
-# perfectionist's `arc_rc_clone`, which is disabled in `dylint.toml`.
+# see "Cloning `Arc` and `Rc`" in `pacquet/CODE_STYLE_GUIDE.md`.
 [workspace.lints.clippy]
 clone_on_ref_ptr             = "warn"
 if_then_some_else_none       = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,15 @@ allow_branch = "main"
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfectionist"))'] }
 
+# `clone_on_ref_ptr` requires `Arc::clone(&x)` / `Rc::clone(&x)` over
+# `x.clone()` so the O(1) refcount bump stays visible at the call site —
+# see "Cloning `Arc` and `Rc`" in `pacquet/CODE_STYLE_GUIDE.md`. It replaces
+# perfectionist's `arc_rc_clone`, which is disabled in `dylint.toml`.
+[workspace.lints.clippy]
+clone_on_ref_ptr           = "warn"
+if_then_some_else_none     = "warn"
+unnecessary_lazy_evaluations = "warn"
+
 [profile.release]
 opt-level     = 3
 lto           = "fat"

--- a/dylint.toml
+++ b/dylint.toml
@@ -40,23 +40,11 @@ ignore = [
     "params",
 ]
 
-# Enforce a single canonical ordering inside every `#[derive(...)]`
-# attribute. The codebase has ~270 derive sites in 79 distinct
-# orderings before this rule; the prefix below encodes the
-# conventions that already dominate (Debug first, error-chain
-# `Display→Error→Diagnostic` together, supertraits before subtraits,
-# serde at the end) and alphabetises everything past the long tail.
-# Trait matching is on the final path segment, so `derive_more::Display`
-# / `miette::Diagnostic` / `clap::Parser` match `Display` / `Diagnostic`
-# / `Parser` respectively.
 [perfectionist]
 enable = ["derive_ordering"]
-# `arc_rc_clone` is enforced by `clippy::clone_on_ref_ptr` instead — see
-# `[workspace.lints.clippy]` in the root `Cargo.toml`. Consolidating on the
-# clippy rule keeps the requirement visible to anyone running `cargo clippy`
-# without the Dylint job, and drops the perfectionist tag from the linter
-# matrix for this particular finding.
-disable = ["arc_rc_clone"]
+disable = [
+  { name = "arc_rc_clone", reason = "`arc_rc_clone` is enforced by `clippy::clone_on_ref_ptr` instead" },
+]
 
 ["perfectionist::derive_ordering"]
 style = "prefix_then_alphabetical"

--- a/dylint.toml
+++ b/dylint.toml
@@ -51,6 +51,12 @@ ignore = [
 # / `Parser` respectively.
 [perfectionist]
 enable = ["derive_ordering"]
+# `arc_rc_clone` is enforced by `clippy::clone_on_ref_ptr` instead — see
+# `[workspace.lints.clippy]` in the root `Cargo.toml`. Consolidating on the
+# clippy rule keeps the requirement visible to anyone running `cargo clippy`
+# without the Dylint job, and drops the perfectionist tag from the linter
+# matrix for this particular finding.
+disable = ["arc_rc_clone"]
 
 ["perfectionist::derive_ordering"]
 style = "prefix_then_alphabetical"

--- a/pacquet/CODE_STYLE_GUIDE.md
+++ b/pacquet/CODE_STYLE_GUIDE.md
@@ -502,7 +502,7 @@ Do not flatten the tests into a sibling file such as `src/foo_tests.rs`, and do 
 
 ### Cloning `Arc` and `Rc`
 
-Prefer `Arc::clone(&x)` / `Rc::clone(&x)` over `x.clone()` for reference-counted types. The qualified form makes the O(1) refcount bump visible at the call site and fails to compile if a refactor changes the binding's type to something whose `Clone` is an arbitrarily expensive deep copy. Enforced by [`clippy::clone_on_ref_ptr`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr), wired into `[workspace.lints.clippy]` in the root `Cargo.toml`. The corresponding `perfectionist::arc_rc_clone` rule is intentionally disabled in `dylint.toml` so the requirement lives in one place.
+Prefer `Arc::clone(&x)` / `Rc::clone(&x)` over `x.clone()` for reference-counted types. The qualified form makes the O(1) refcount bump visible at the call site and fails to compile if a refactor changes the binding's type to something whose `Clone` is an arbitrarily expensive deep copy. Enforced by [`clippy::clone_on_ref_ptr`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr), wired into `[workspace.lints.clippy]` in the root `Cargo.toml`.
 
 ### Reading process state
 

--- a/pacquet/CODE_STYLE_GUIDE.md
+++ b/pacquet/CODE_STYLE_GUIDE.md
@@ -502,7 +502,7 @@ Do not flatten the tests into a sibling file such as `src/foo_tests.rs`, and do 
 
 ### Cloning `Arc` and `Rc`
 
-Prefer `Arc::clone(&x)` / `Rc::clone(&x)` over `x.clone()` for reference-counted types. The qualified form makes the O(1) refcount bump visible at the call site and fails to compile if a refactor changes the binding's type to something whose `Clone` is an arbitrarily expensive deep copy. Enforced by [`perfectionist::arc_rc_clone`](https://github.com/KSXGitHub/perfectionist/blob/0.0.0-rc.15/rules/arc_rc_clone.md).
+Prefer `Arc::clone(&x)` / `Rc::clone(&x)` over `x.clone()` for reference-counted types. The qualified form makes the O(1) refcount bump visible at the call site and fails to compile if a refactor changes the binding's type to something whose `Clone` is an arbitrarily expensive deep copy. Enforced by [`clippy::clone_on_ref_ptr`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr), wired into `[workspace.lints.clippy]` in the root `Cargo.toml`. The corresponding `perfectionist::arc_rc_clone` rule is intentionally disabled in `dylint.toml` so the requirement lives in one place.
 
 ### Reading process state
 

--- a/pacquet/crates/cmd-shim/src/link_bins.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins.rs
@@ -453,15 +453,13 @@ where
     // themselves still get computed inside the `cfg!(windows)` branch
     // below — moving the `generate_*` calls there keeps Unix builds
     // off the `relative_target_windows` allocation path entirely.
-    let windows_shims = if cfg!(windows) {
+    let windows_shims = cfg!(windows).then(|| {
         let cmd_path = with_extension_appended(shim_path, "cmd");
         let ps1_path = with_extension_appended(shim_path, "ps1");
         let cmd_body = generate_cmd_shim(target_path, &cmd_path, runtime.as_ref());
         let ps1_body = generate_pwsh_shim(target_path, &ps1_path, runtime.as_ref());
-        Some((cmd_path, cmd_body, ps1_path, ps1_body))
-    } else {
-        None
-    };
+        (cmd_path, cmd_body, ps1_path, ps1_body)
+    });
 
     // Idempotent skip fires only when every flavor that *should* be
     // present is present and pointing at the right target. The `.sh`

--- a/pacquet/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pacquet/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -294,11 +294,7 @@ async fn read_node_assets_from_mirror(
                 error: Arc::new(error),
             }) as ResolveError
         })?;
-        let prefix = if matches!(archive, BinaryArchive::Zip) {
-            Some(address.basename.clone())
-        } else {
-            None
-        };
+        let prefix = matches!(archive, BinaryArchive::Zip).then(|| address.basename.clone());
         let binary = BinaryResolution {
             url,
             integrity,

--- a/pacquet/crates/executor/src/lifecycle.rs
+++ b/pacquet/crates/executor/src/lifecycle.rs
@@ -164,11 +164,8 @@ pub fn run_postinstall_hooks<Reporter: self::Reporter>(
     }
 
     let install_script = get_script("install").map(String::from).or_else(|| {
-        if get_script("preinstall").is_none() && opts.pkg_root.join("binding.gyp").exists() {
-            Some("node-gyp rebuild".to_string())
-        } else {
-            None
-        }
+        (get_script("preinstall").is_none() && opts.pkg_root.join("binding.gyp").exists())
+            .then(|| "node-gyp rebuild".to_string())
     });
     if let Some(script) = &install_script
         && script != "npx only-allow pnpm"

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -624,16 +624,14 @@ impl<'a> CreateVirtualStore<'a> {
         // need to reason across the two branches. Cold-batch
         // entries are appended at the bottom of the function once
         // the cold-batch fetch finishes.
-        let mut cas_paths_by_pkg_id: Option<CasPathsByPkgId> = if is_hoisted {
+        let mut cas_paths_by_pkg_id: Option<CasPathsByPkgId> = is_hoisted.then(|| {
             let mut map = CasPathsByPkgId::with_capacity(warm.len());
             for (snapshot_key, _snapshot, cas_paths) in &warm {
                 let pkg_id = PkgIdWithPatchHash::from(snapshot_key.to_string());
                 map.entry(pkg_id).or_insert_with(|| (***cas_paths).clone());
             }
-            Some(map)
-        } else {
-            None
-        };
+            map
+        });
 
         let import_method = config.package_import_method;
         if !is_hoisted {

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -521,11 +521,9 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // way.
         let allow_build_policy = AllowBuildPolicy::from_config(config)
             .map_err(InstallWithFreshLockfileError::AllowBuildsPolicy)?;
-        let layout_lockfile = if config.enable_global_virtual_store {
-            Some(build_fresh_lockfile(config, manifest, &importer_result))
-        } else {
-            None
-        };
+        let layout_lockfile = config
+            .enable_global_virtual_store
+            .then(|| build_fresh_lockfile(config, manifest, &importer_result));
         let engine_name: Option<String> = if config.enable_global_virtual_store {
             tokio::task::spawn_blocking(|| {
                 pacquet_graph_hasher::detect_node_major()

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -152,7 +152,7 @@ where
             Ok(Some(value))
         }
         fn visit_bool<Err: de::Error>(self, value: bool) -> Result<Self::Value, Err> {
-            Ok(if value { Some(String::new()) } else { None })
+            Ok(value.then(String::new))
         }
         fn visit_none<Err: de::Error>(self) -> Result<Self::Value, Err> {
             Ok(None)

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -330,7 +330,7 @@ impl<'tree> Walker<'tree> {
             let parent_ref = ParentRef {
                 version: child_version,
                 node_id: Some(*child_node_id),
-                alias: if alias != &child_real_name { Some(alias.clone()) } else { None },
+                alias: (alias != &child_real_name).then(|| alias.clone()),
             };
             if alias_relevant {
                 child_parent_refs.insert(alias.clone(), parent_ref.clone());
@@ -605,7 +605,7 @@ fn insert_parent_ref(
     let parent_ref = ParentRef {
         version: version.clone(),
         node_id: Some(direct.node_id),
-        alias: if direct.alias != real_name { Some(direct.alias.clone()) } else { None },
+        alias: (direct.alias != real_name).then(|| direct.alias.clone()),
     };
     if alias_relevant {
         refs.insert(direct.alias.clone(), parent_ref.clone());

--- a/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
@@ -221,11 +221,7 @@ fn pick_matching_local_version_or_null(
             resolve_workspace_range("*", &raw)
         }
         RegistryPackageSpecType::Version => {
-            if versions.contains_key(&spec.fetch_spec) {
-                Some(spec.fetch_spec.clone())
-            } else {
-                None
-            }
+            versions.contains_key(&spec.fetch_spec).then(|| spec.fetch_spec.clone())
         }
         RegistryPackageSpecType::Range => {
             let raw: Vec<String> = versions.keys().cloned().collect();


### PR DESCRIPTION
Enable three clippy restriction lints workspace-wide via `[workspace.lints.clippy]` in the root `Cargo.toml`:

- **`clone_on_ref_ptr`** — makes `Arc::clone(&x)` / `Rc::clone(&x)` mandatory at the call site. Same requirement `perfectionist::arc_rc_clone` was already enforcing via Dylint, so disable the perfectionist rule in `dylint.toml` and consolidate on clippy. The requirement now shows up under any `cargo clippy` run, not just the Dylint job. The "Cloning `Arc` and `Rc`" section of `CODE_STYLE_GUIDE.md` is updated to point at the clippy lint.
- **`if_then_some_else_none`** — prefer `x.then(|| ...)` over `if x { Some(...) } else { None }`.
- **`unnecessary_lazy_evaluations`** — pair with the above; use `.then_some(...)` / `.then(fn_ref)` when the value is trivial.

Turning on `if_then_some_else_none` surfaced seven pre-existing patterns across the workspace (`cmd-shim`, `engine-runtime-node-resolver`, `executor`, `package-manager` ×2, `registry`, `resolving-deps-resolver` ×2, `resolving-npm-resolver`). Each is rewritten to the lint-compliant form; all rewrites are pure desugarings, behavior unchanged.

Verified locally: `cargo clippy --locked --workspace --all-targets -- --deny warnings`, `cargo fmt --check`, `taplo format --check`, and `cargo check --locked --workspace --all-targets` all pass.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced code quality standards through workspace-wide Clippy lints.
  * Updated code style guidelines and linting configuration for consistency.
  * Refactored conditional patterns across the codebase for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->