### PR TITLE
perf(pacquet): collapse leaf-package occurrences in the dependencies tree

### DIFF
--- a/pacquet/crates/resolving-deps-resolver/src/node_id.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/node_id.rs
@@ -1,29 +1,50 @@
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Per-occurrence identifier for a node in the [`DependenciesTree`].
 /// Mirrors pnpm's [`NodeId`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/nextNodeId.ts).
 ///
 /// Pnpm's `NodeId` is a branded `string | number` union: numbers come
-/// from a monotonic counter; strings are `link:<rel-path>` for linked
-/// local workspace packages. Pacquet stays in the numeric arm —
-/// workspace-link resolution hasn't been ported yet, and the peer
-/// resolver only needs equality / hashing of opaque ids.
+/// from a monotonic counter; strings are reused for leaf packages (no
+/// children, no peers) and for `link:<rel-path>` linked local
+/// workspace packages. Pacquet ports the counter and leaf arms;
+/// workspace-link resolution hasn't been ported yet.
+///
+/// Leaves share a single tree node across every parent that references
+/// them — see [`resolveDependencies.ts:1580`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1580)
+/// for the upstream gate.
 ///
 /// [`DependenciesTree`]: super::resolved_tree::DependenciesTree
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NodeId(u64);
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum NodeId {
+    /// Fresh per-occurrence counter value. Allocated by [`NodeId::next`].
+    Counter(u64),
+    /// Leaf package id reused across every occurrence of the same
+    /// package. Allocated by [`NodeId::leaf`].
+    Leaf(Arc<str>),
+}
 
 impl NodeId {
-    /// Allocate a fresh `NodeId`. Mirrors pnpm's
+    /// Allocate a fresh per-occurrence `NodeId`. Mirrors pnpm's
     /// [`nextNodeId`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/nextNodeId.ts).
     pub fn next() -> NodeId {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
-        NodeId(COUNTER.fetch_add(1, Ordering::Relaxed))
+        NodeId::Counter(COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+
+    /// Build a leaf `NodeId` from a package id. Every occurrence of a
+    /// leaf shares the same `NodeId`, so the tree carries one node
+    /// instead of one per parent edge.
+    pub fn leaf(id: &str) -> NodeId {
+        NodeId::Leaf(Arc::from(id))
     }
 }
 
 impl std::fmt::Display for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            NodeId::Counter(n) => write!(f, "{n}"),
+            NodeId::Leaf(id) => f.write_str(id),
+        }
     }
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -417,10 +417,14 @@ where
         }
     }
 
-    // Allocate a fresh NodeId for this occurrence. Two parents sharing
-    // the same `pkgIdWithPatchHash` get different `NodeId`s so the peer
-    // resolver can attach different peer suffixes per call site.
-    let node_id = NodeId::next();
+    // Leaves (no deps / optional deps / peers / peerDependenciesMeta)
+    // reuse the package id as their `NodeId`, collapsing every parent
+    // edge onto one tree node. Non-leaves still get a fresh per-
+    // occurrence id so the peer resolver can attach different peer
+    // suffixes per call site. Mirrors upstream's
+    // [`resolveDependencies.ts:1580`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1580).
+    let is_leaf = pkg_is_leaf(&result);
+    let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
@@ -453,15 +457,26 @@ where
     let children: BTreeMap<String, NodeId> =
         child_results.into_iter().flatten().map(|dep| (dep.alias, dep.node_id)).collect();
 
-    lock_recoverable(&ctx.dependencies_tree).insert(
-        node_id,
-        DependenciesTreeNode {
+    // Repeat-visit leaves collapse onto one tree node; keep the
+    // shallowest depth seen so downstream consumers that read
+    // `tree_node.depth` (the peer pass folds it onto the graph node's
+    // `depth`) match upstream's
+    // [`Math.min(...)` arm](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1636-L1637).
+    // Per-occurrence counter ids are unique by construction, so the
+    // `and_modify` arm is dead for non-leaves.
+    lock_recoverable(&ctx.dependencies_tree)
+        .entry(node_id.clone())
+        .and_modify(|node| {
+            if node.depth > depth {
+                node.depth = depth;
+            }
+        })
+        .or_insert_with(|| DependenciesTreeNode {
             resolved_package_id: id.clone(),
             children,
             depth,
             installable: true,
-        },
-    );
+        });
 
     Ok(Some(DirectDep { alias, node_id, id }))
 }
@@ -653,6 +668,25 @@ fn extract_peer_dependencies(
     }
 
     peers
+}
+
+/// `true` when the package has no `dependencies`, `optionalDependencies`,
+/// `peerDependencies`, or `peerDependenciesMeta`. Mirrors upstream's
+/// [`pkgIsLeaf`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1735-L1742).
+///
+/// Conservatively returns `false` when the manifest is missing — a
+/// future visit may reveal children, and collapsing onto a leaf
+/// `NodeId` would lose that information.
+fn pkg_is_leaf(result: &pacquet_resolving_resolver_base::ResolveResult) -> bool {
+    let Some(manifest) = result.manifest.as_ref() else { return false };
+    is_empty_or_absent(manifest.get("dependencies"))
+        && is_empty_or_absent(manifest.get("optionalDependencies"))
+        && is_empty_or_absent(manifest.get("peerDependencies"))
+        && is_empty_or_absent(manifest.get("peerDependenciesMeta"))
+}
+
+fn is_empty_or_absent(value: Option<&Value>) -> bool {
+    value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
 }
 
 /// Provenance tags that count as non-exotic for `blockExoticSubdeps`.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -212,8 +212,12 @@ impl<'tree> Walker<'tree> {
         let parent_chain_names: Vec<String> = Vec::new();
         let mut direct_by_alias = BTreeMap::new();
         for direct in &self.tree.direct {
-            let output =
-                self.resolve_node(direct.node_id, &importer_parents, &parent_chain_names, 0);
+            let output = self.resolve_node(
+                direct.node_id.clone(),
+                &importer_parents,
+                &parent_chain_names,
+                0,
+            );
             direct_by_alias.insert(direct.alias.clone(), output.dep_path);
         }
         self.patch_pending_peer_edges();
@@ -304,7 +308,7 @@ impl<'tree> Walker<'tree> {
                 missing_peers: HashMap::new(),
             };
         }
-        self.in_progress.insert(node_id);
+        self.in_progress.insert(node_id.clone());
 
         let tree_node = self.tree.dependencies_tree[&node_id].clone();
         let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
@@ -330,7 +334,7 @@ impl<'tree> Walker<'tree> {
             }
             let parent_ref = ParentRef {
                 version: child_version,
-                node_id: Some(*child_node_id),
+                node_id: Some(child_node_id.clone()),
                 alias: if alias != &child_real_name { Some(alias.clone()) } else { None },
             };
             if alias_relevant {
@@ -355,14 +359,14 @@ impl<'tree> Walker<'tree> {
         let mut child_dep_paths: BTreeMap<String, DepPath> = BTreeMap::new();
         for (alias, child_node_id) in &tree_node.children {
             let child_output = self.resolve_node(
-                *child_node_id,
+                child_node_id.clone(),
                 &child_parent_refs,
                 &child_chain_names,
                 depth + 1,
             );
             child_dep_paths.insert(alias.clone(), child_output.dep_path);
             for (peer_alias, peer_node_id) in child_output.external_resolved_peers {
-                if tree_node.children.values().any(|id| *id == peer_node_id) {
+                if tree_node.children.values().any(|id| id == &peer_node_id) {
                     // Resolved against one of *this node's* children —
                     // not external from this node's perspective.
                     // Compare by NodeId (not alias) because `children`
@@ -403,7 +407,7 @@ impl<'tree> Walker<'tree> {
         // on itself).
         let mut all_resolved_peers = external_from_children;
         for (peer_alias, peer_node_id) in &own_resolved_peers {
-            all_resolved_peers.insert(peer_alias.clone(), *peer_node_id);
+            all_resolved_peers.insert(peer_alias.clone(), peer_node_id.clone());
         }
         all_resolved_peers.remove(&pkg_name);
 
@@ -420,7 +424,7 @@ impl<'tree> Walker<'tree> {
         } else {
             let mut peer_ids: Vec<PeerId> = all_resolved_peers
                 .values()
-                .map(|peer_node_id| self.build_peer_id(*peer_node_id))
+                .map(|peer_node_id| self.build_peer_id(peer_node_id))
                 .collect();
             // Sorting happens inside `create_peer_dep_graph_hash`, but
             // we deduplicate by stringified form here to mirror
@@ -436,9 +440,9 @@ impl<'tree> Walker<'tree> {
         // propagated state before inserting into the graph (so any
         // cycle the graph insert hits via `child_dep_paths` can find
         // this node's depPath).
-        self.node_dep_paths.insert(node_id, dep_path.clone());
-        self.node_external_peers.insert(node_id, all_resolved_peers.clone());
-        self.node_missing_peers.insert(node_id, all_missing_peers.clone());
+        self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+        self.node_external_peers.insert(node_id.clone(), all_resolved_peers.clone());
+        self.node_missing_peers.insert(node_id.clone(), all_missing_peers.clone());
 
         // The children's depPath edges become this node's graph children.
         // Resolved peers become extra edges, aliased by peer name. If a
@@ -455,7 +459,7 @@ impl<'tree> Walker<'tree> {
                 self.pending_peer_edges.push(PendingPeerEdge {
                     parent_dep_path: dep_path.clone(),
                     peer_alias: peer_alias.clone(),
-                    peer_node_id: *peer_node_id,
+                    peer_node_id: peer_node_id.clone(),
                 });
             }
         }
@@ -510,7 +514,7 @@ impl<'tree> Walker<'tree> {
         // `external_from_children` filter above — `children` is keyed
         // by install alias while peers may be keyed by the resolved
         // package's real name.
-        let own_child_ids: HashSet<NodeId> = tree_node.children.values().copied().collect();
+        let own_child_ids: HashSet<&NodeId> = tree_node.children.values().collect();
         let external_to_report: HashMap<String, NodeId> = all_resolved_peers
             .into_iter()
             .filter(|(_, peer_node_id)| !own_child_ids.contains(peer_node_id))
@@ -565,8 +569,8 @@ impl<'tree> Walker<'tree> {
                         },
                     );
                 }
-                if let Some(parent_node_id) = parent.node_id {
-                    resolved.insert(peer_name.to_string(), parent_node_id);
+                if let Some(parent_node_id) = parent.node_id.as_ref() {
+                    resolved.insert(peer_name.to_string(), parent_node_id.clone());
                 }
             }
         }
@@ -576,11 +580,11 @@ impl<'tree> Walker<'tree> {
     /// peer's depPath is already in `node_dep_paths`, use it (the
     /// `DepPath` form). Otherwise (the cycle path), fall back to
     /// `name@version` from the resolved package.
-    fn build_peer_id(&self, peer_node_id: NodeId) -> PeerId {
-        if let Some(dep_path) = self.node_dep_paths.get(&peer_node_id) {
+    fn build_peer_id(&self, peer_node_id: &NodeId) -> PeerId {
+        if let Some(dep_path) = self.node_dep_paths.get(peer_node_id) {
             return PeerId::DepPath(dep_path.clone());
         }
-        let tree_node = &self.tree.dependencies_tree[&peer_node_id];
+        let tree_node = &self.tree.dependencies_tree[peer_node_id];
         let pkg = &self.tree.packages[&tree_node.resolved_package_id];
         let (name, version) = pkg_name_version(&pkg.result);
         PeerId::Pair { name, version }
@@ -605,7 +609,7 @@ fn insert_parent_ref(
     }
     let parent_ref = ParentRef {
         version: version.clone(),
-        node_id: Some(direct.node_id),
+        node_id: Some(direct.node_id.clone()),
         alias: if direct.alias != real_name { Some(direct.alias.clone()) } else { None },
     };
     if alias_relevant {

--- a/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -24,11 +24,15 @@ pub type DependenciesTree = HashMap<NodeId, DependenciesTreeNode>;
 ///   resolved package, no per-occurrence repetition. Upstream calls
 ///   the equivalent index `resolvedPkgsById`.
 /// - [`dependencies_tree`](Self::dependencies_tree) is the **per-
-///   occurrence tree**, keyed by [`NodeId`]. Every parent → child edge
-///   has a fresh child `NodeId`, even when two parents share the same
-///   `pkgIdWithPatchHash`, because the peer-resolution stage needs
-///   per-occurrence state (a shared package under two parents can
-///   compute different peer suffixes).
+///   occurrence tree**, keyed by [`NodeId`]. Non-leaf nodes get a fresh
+///   child `NodeId` per parent occurrence so the peer-resolution stage
+///   can compute different peer suffixes per call site. Leaves (no
+///   `dependencies`, `optionalDependencies`, `peerDependencies`, or
+///   `peerDependenciesMeta`) collapse onto one shared `NodeId`,
+///   mirroring upstream's
+///   [`pkgIsLeaf` reuse](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1580):
+///   a leaf has no per-occurrence state worth distinguishing, so every
+///   parent that references it points at the same tree node.
 #[derive(Debug, Default, Clone)]
 pub struct ResolvedTree {
     pub direct: Vec<DirectDep>,
@@ -74,9 +78,10 @@ pub struct DirectDep {
 /// for the npm-shaped slice pacquet currently exposes.
 ///
 /// **Children live on [`DependenciesTreeNode`], not here.** Two parents
-/// that share a resolved package each get their own per-occurrence
-/// tree node with its own children edges — a `ResolvedPackage` is the
-/// dedup-shared *envelope*, not a tree node.
+/// that share a non-leaf resolved package each get their own per-
+/// occurrence tree node with its own children edges; leaves collapse
+/// onto one shared tree node (see [`DependenciesTree`]). Either way,
+/// `ResolvedPackage` is the dedup-shared *envelope*, not a tree node.
 #[derive(Debug, Clone)]
 pub struct ResolvedPackage {
     pub id: String,

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -126,8 +126,8 @@ async fn walks_dependencies_and_builds_flat_tree() {
     assert_eq!(tree.direct[0].id, "foo@1.2.0");
     assert_eq!(tree.packages.len(), 2);
     assert!(tree.packages.contains_key("foo@1.2.0"));
-    let foo_node_id = tree.direct[0].node_id;
-    let foo_tree_node = tree.dependencies_tree.get(&foo_node_id).unwrap();
+    let foo_node_id = &tree.direct[0].node_id;
+    let foo_tree_node = tree.dependencies_tree.get(foo_node_id).unwrap();
     assert_eq!(foo_tree_node.children.len(), 1);
     let bar_node_id = foo_tree_node.children.get("bar").unwrap();
     let bar_tree_node = tree.dependencies_tree.get(bar_node_id).unwrap();
@@ -192,6 +192,19 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
     assert!(tree.packages.contains_key("a@1.0.0"));
     assert!(tree.packages.contains_key("b@1.0.0"));
     assert!(tree.packages.contains_key("shared@1.0.0"));
+
+    // `shared` is a leaf (no deps / peers); both `a` and `b` must
+    // point at the same `NodeId` and the tree must carry exactly one
+    // `shared` entry. Mirrors upstream's
+    // [`pkgIsLeaf` reuse](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1580).
+    let a_tree = tree.dependencies_tree.get(&tree.direct[0].node_id).unwrap();
+    let b_tree = tree.dependencies_tree.get(&tree.direct[1].node_id).unwrap();
+    let shared_via_a = a_tree.children.get("shared").unwrap();
+    let shared_via_b = b_tree.children.get("shared").unwrap();
+    assert_eq!(shared_via_a, shared_via_b);
+    let shared_occurrences =
+        tree.dependencies_tree.values().filter(|n| n.resolved_package_id == "shared@1.0.0").count();
+    assert_eq!(shared_occurrences, 1);
 }
 
 /// A chain that declines every spec (every `resolve()` returns


### PR DESCRIPTION
## Summary

Mirrors pnpm's [`pkgIsLeaf` reuse](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1580): a package with no \`dependencies\`, \`optionalDependencies\`, \`peerDependencies\`, or \`peerDependenciesMeta\` collapses every parent reference onto one tree node keyed by the package id, instead of allocating a fresh \`NodeId\` per occurrence. Peer resolution and every downstream \`HashMap<NodeId, _>\` see the reduced node set.

\`NodeId\` becomes an enum:

\`\`\`rust
pub enum NodeId {
    Counter(u64),    // per-occurrence (existing path, non-leaves)
    Leaf(Arc<str>),  // shared across every leaf occurrence
}
\`\`\`

The tree insert switches to \`entry().and_modify(min depth).or_insert_with(...)\` so collapsed-leaf depth still folds to the shallowest occurrence, matching pnpm's [\`Math.min\` arm](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1636-L1637).

Two conservative deviations from the issue:

- \`pkg_is_leaf\` returns \`false\` when \`result.manifest\` is \`None\` — resolvers that defer manifest reading can't be wrongly collapsed.
- Kept upstream's per-visit depth-fold for collapsed leaves; the peer pass reads \`tree_node.depth\` on every node, so we still need the min.

Closes #11844.

## Test plan

- [x] \`cargo check --workspace --all-targets\` clean
- [x] \`cargo clippy --locked --workspace --all-targets -- --deny warnings\` clean
- [x] \`cargo nextest run -p pacquet-resolving-deps-resolver -p pacquet-package-manager -p pacquet-cli\` — 440/440 pass
- [x] \`dedupes_when_the_same_package_appears_in_two_subtrees\` extended to assert \`a\` and \`b\` point at the same shared NodeId and the tree carries exactly one \`shared\` entry

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of leaf dependencies (packages with no sub-dependencies) during tree resolution.
  * Enhanced deduplication accuracy for shared packages appearing across multiple dependency subtrees.

* **Tests**
  * Strengthened test assertions for dependency deduplication validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->