### PR TITLE
chore(lint): more clippy rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 clone_on_ref_ptr             = "warn"
 if_then_some_else_none       = "warn"
 unnecessary_lazy_evaluations = "warn"
+redundant_clone              = "warn"
 
 [profile.release]
 opt-level     = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ if_then_some_else_none       = "warn"
 unnecessary_lazy_evaluations = "warn"
 redundant_clone              = "warn"
 needless_collect             = "warn"
+or_fun_call                  = "warn"
 
 [profile.release]
 opt-level     = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ clone_on_ref_ptr             = "warn"
 if_then_some_else_none       = "warn"
 unnecessary_lazy_evaluations = "warn"
 redundant_clone              = "warn"
+needless_collect             = "warn"
 
 [profile.release]
 opt-level     = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,10 +149,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 [workspace.lints.clippy]
 clone_on_ref_ptr             = "warn"
 if_then_some_else_none       = "warn"
-unnecessary_lazy_evaluations = "warn"
-redundant_clone              = "warn"
 needless_collect             = "warn"
 or_fun_call                  = "warn"
+redundant_clone              = "warn"
+unnecessary_lazy_evaluations = "warn"
 
 [profile.release]
 opt-level     = 3

--- a/pacquet/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins/tests.rs
@@ -994,8 +994,7 @@ fn direct_origin_wins_over_hoisted_regardless_of_lexical() {
         &[
             PackageBinSource::new(hoisted, Arc::new(manifest_hoisted))
                 .with_origin(BinOrigin::Hoisted),
-            PackageBinSource::new(direct, Arc::new(manifest_direct))
-                .with_origin(BinOrigin::Direct),
+            PackageBinSource::new(direct, Arc::new(manifest_direct)).with_origin(BinOrigin::Direct),
         ],
         &bins,
     )
@@ -1045,8 +1044,7 @@ fn hoisted_origin_loses_to_existing_direct() {
     // candidate is processed second.
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(direct, Arc::new(manifest_direct))
-                .with_origin(BinOrigin::Direct),
+            PackageBinSource::new(direct, Arc::new(manifest_direct)).with_origin(BinOrigin::Direct),
             PackageBinSource::new(hoisted, Arc::new(manifest_hoisted))
                 .with_origin(BinOrigin::Hoisted),
         ],

--- a/pacquet/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins/tests.rs
@@ -1225,7 +1225,7 @@ fn link_node_bin_hardlinks_node_exe_on_windows() {
     let manifest: Value =
         serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &[PackageBinSource::new(node_dir, Arc::new(manifest))],
         &bin_target,
     )
     .unwrap();
@@ -1268,7 +1268,7 @@ fn link_node_bin_falls_through_to_cmd_shim_when_source_is_not_exe() {
     let manifest: Value =
         serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &[PackageBinSource::new(node_dir, Arc::new(manifest))],
         &bin_target,
     )
     .unwrap();

--- a/pacquet/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pacquet/crates/cmd-shim/src/link_bins/tests.rs
@@ -49,7 +49,7 @@ fn writes_shim_flavors_matching_host_platform() {
     let manifest_value: Value =
         serde_json::from_slice(&read_file(pkg_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(pkg_dir.clone(), Arc::new(manifest_value))],
+        &[PackageBinSource::new(pkg_dir, Arc::new(manifest_value))],
         &bins_dir,
     )
     .unwrap();
@@ -216,8 +216,8 @@ fn lexical_compare_breaks_tie_when_neither_owns() {
     // discovery order.
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(beta.clone(), Arc::new(manifest_beta)),
-            PackageBinSource::new(alpha.clone(), Arc::new(manifest_alpha)),
+            PackageBinSource::new(beta, Arc::new(manifest_beta)),
+            PackageBinSource::new(alpha, Arc::new(manifest_alpha)),
         ],
         &bins,
     )
@@ -832,8 +832,8 @@ fn ownership_breaks_bin_conflicts_when_existing_owns() {
     let bins = tmp.path().join(".bin");
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(npm.clone(), Arc::new(manifest_npm)),
-            PackageBinSource::new(aaa_other.clone(), Arc::new(manifest_other)),
+            PackageBinSource::new(npm, Arc::new(manifest_npm)),
+            PackageBinSource::new(aaa_other, Arc::new(manifest_other)),
         ],
         &bins,
     )
@@ -938,7 +938,7 @@ fn ownership_breaks_bin_conflicts() {
     let bins = tmp.path().join(".bin");
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(aaa_other.clone(), Arc::new(manifest_other)),
+            PackageBinSource::new(aaa_other, Arc::new(manifest_other)),
             PackageBinSource::new(npm.clone(), Arc::new(manifest_npm)),
         ],
         &bins,
@@ -992,9 +992,9 @@ fn direct_origin_wins_over_hoisted_regardless_of_lexical() {
     let bins = tmp.path().join(".bin");
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(hoisted.clone(), Arc::new(manifest_hoisted))
+            PackageBinSource::new(hoisted, Arc::new(manifest_hoisted))
                 .with_origin(BinOrigin::Hoisted),
-            PackageBinSource::new(direct.clone(), Arc::new(manifest_direct))
+            PackageBinSource::new(direct, Arc::new(manifest_direct))
                 .with_origin(BinOrigin::Direct),
         ],
         &bins,
@@ -1045,9 +1045,9 @@ fn hoisted_origin_loses_to_existing_direct() {
     // candidate is processed second.
     link_bins_of_packages::<Host>(
         &[
-            PackageBinSource::new(direct.clone(), Arc::new(manifest_direct))
+            PackageBinSource::new(direct, Arc::new(manifest_direct))
                 .with_origin(BinOrigin::Direct),
-            PackageBinSource::new(hoisted.clone(), Arc::new(manifest_hoisted))
+            PackageBinSource::new(hoisted, Arc::new(manifest_hoisted))
                 .with_origin(BinOrigin::Hoisted),
         ],
         &bins,
@@ -1086,7 +1086,7 @@ fn link_node_bin_symlinks_directly_instead_of_writing_shim() {
     let manifest: Value =
         serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &[PackageBinSource::new(node_dir, Arc::new(manifest))],
         &bin_target,
     )
     .unwrap();
@@ -1141,7 +1141,7 @@ fn link_node_bin_replaces_dangling_symlink() {
     let manifest: Value =
         serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &[PackageBinSource::new(node_dir, Arc::new(manifest))],
         &bin_target,
     )
     .unwrap();
@@ -1189,7 +1189,7 @@ fn link_node_bin_does_not_corrupt_hardlinked_target() {
     let manifest: Value =
         serde_json::from_slice(&read_file(node_dir.join("package.json")).unwrap()).unwrap();
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(node_dir.clone(), Arc::new(manifest))],
+        &[PackageBinSource::new(node_dir, Arc::new(manifest))],
         &bin_target,
     )
     .unwrap();

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -588,7 +588,7 @@ supportedArchitectures:
   os: [darwin]
 "#;
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
-    let raw = settings.supported_architectures.clone().expect("field present");
+    let raw = settings.supported_architectures.expect("field present");
     assert_eq!(raw.os.as_deref(), Some(&["darwin".to_string()][..]));
     assert!(raw.cpu.is_none());
     assert!(raw.libc.is_none());

--- a/pacquet/crates/fs/src/ensure_file/tests.rs
+++ b/pacquet/crates/fs/src/ensure_file/tests.rs
@@ -276,7 +276,7 @@ fn file_equals_bytes_handles_multi_chunk_files() {
 
     assert!(file_equals_bytes(&path, &content).unwrap());
 
-    let mut perturbed = content.clone();
+    let mut perturbed = content;
     *perturbed.last_mut().unwrap() ^= 0xff;
     assert!(!file_equals_bytes(&path, &perturbed).unwrap());
 }

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -50,7 +50,8 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
     let content_path: Arc<Path> = Arc::from(content_path.to_path_buf());
     let target_path: Arc<Path> = Arc::from(target_path.to_path_buf());
 
-    (0..WORKER_COUNT)
+    #[allow(clippy::needless_collect, reason = "For spawns all worker subprocesses in parallel")]
+    let handles: Vec<_> = (0..WORKER_COUNT)
         .map(|_| {
             let content_path = Arc::clone(&content_path);
             let target_path = Arc::clone(&target_path);
@@ -62,8 +63,8 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
                     .expect("spawn cafs_stress_worker")
             })
         })
-        .map(|handle| handle.join().expect("worker thread"))
-        .collect()
+        .collect();
+    handles.into_iter().map(|handle| handle.join().expect("worker thread")).collect()
 }
 
 /// Sha-512-hex the byte slice, the same digest format

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -50,7 +50,7 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
     let content_path: Arc<Path> = Arc::from(content_path.to_path_buf());
     let target_path: Arc<Path> = Arc::from(target_path.to_path_buf());
 
-    #[allow(
+    #[expect(
         clippy::needless_collect,
         reason = "Collecting the handles is needed to spawn all worker subprocesses before joining them"
     )]

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -52,7 +52,7 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
 
     #[allow(
         clippy::needless_collect,
-        reason = "Collecting the handles is needed to spawn all worker subprocesses before joining them",
+        reason = "Collecting the handles is needed to spawn all worker subprocesses before joining them"
     )]
     let handles: Vec<_> = (0..WORKER_COUNT)
         .map(|_| {

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -50,7 +50,7 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
     let content_path: Arc<Path> = Arc::from(content_path.to_path_buf());
     let target_path: Arc<Path> = Arc::from(target_path.to_path_buf());
 
-    let handles: Vec<_> = (0..WORKER_COUNT)
+    (0..WORKER_COUNT)
         .map(|_| {
             let content_path = Arc::clone(&content_path);
             let target_path = Arc::clone(&target_path);
@@ -62,9 +62,8 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
                     .expect("spawn cafs_stress_worker")
             })
         })
-        .collect();
-
-    handles.into_iter().map(|handle| handle.join().expect("worker thread")).collect()
+        .map(|handle| handle.join().expect("worker thread"))
+        .collect()
 }
 
 /// Sha-512-hex the byte slice, the same digest format

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -50,7 +50,10 @@ fn run_workers(content_path: &Path, target_path: &Path) -> Vec<std::process::Exi
     let content_path: Arc<Path> = Arc::from(content_path.to_path_buf());
     let target_path: Arc<Path> = Arc::from(target_path.to_path_buf());
 
-    #[allow(clippy::needless_collect, reason = "For spawns all worker subprocesses in parallel")]
+    #[allow(
+        clippy::needless_collect,
+        reason = "Collecting the handles is needed to spawn all worker subprocesses before joining them",
+    )]
     let handles: Vec<_> = (0..WORKER_COUNT)
         .map(|_| {
             let content_path = Arc::clone(&content_path);

--- a/pacquet/crates/git-fetcher/src/fetcher.rs
+++ b/pacquet/crates/git-fetcher/src/fetcher.rs
@@ -109,7 +109,7 @@ impl<'a> GitFetcher<'a> {
         let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
         let temp_location = temp.path();
 
-        let git_bin = self.git_bin.unwrap_or(Path::new("git"));
+        let git_bin = self.git_bin.unwrap_or_else(|| Path::new("git"));
         if should_use_shallow(self.repo, self.git_shallow_hosts) {
             exec_git_with(git_bin, &["init"], Some(temp_location))?;
             exec_git_with(git_bin, &["remote", "add", "origin", self.repo], Some(temp_location))?;

--- a/pacquet/crates/graph-hasher/src/dep_state.rs
+++ b/pacquet/crates/graph-hasher/src/dep_state.rs
@@ -127,7 +127,7 @@ where
         "id": node.full_pkg_id.clone(),
         "deps": Value::Object(deps_obj),
     }));
-    cache.insert(dep_path.clone(), hashed.clone());
+    cache.insert(dep_path.clone(), hashed);
     cache.get(dep_path).expect("just inserted").clone()
 }
 

--- a/pacquet/crates/lockfile-verification/src/cache/tests.rs
+++ b/pacquet/crates/lockfile-verification/src/cache/tests.rs
@@ -217,8 +217,7 @@ fn append_only_log_records_each_call() {
         );
     }
     let contents = fs::read_to_string(dir.path().join(CACHE_FILE_NAME)).expect("read cache");
-    let lines: Vec<&str> = contents.lines().filter(|line| !line.is_empty()).collect();
-    assert_eq!(lines.len(), 3);
+    assert_eq!(contents.lines().filter(|line| !line.is_empty()).count(), 3);
 }
 
 /// Compaction kicks in past the byte threshold: a poisoned log full

--- a/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pacquet/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -224,7 +224,7 @@ fn collect_candidates(lockfile: &Lockfile) -> Vec<Candidate> {
         let resolution_json = serde_json::to_string(&metadata.resolution)
             .expect("LockfileResolution must serialize for candidate dedupe");
         let key = format!("{name}@{version}@{resolution_json}");
-        deduped.entry(key).or_insert(Candidate {
+        deduped.entry(key).or_insert_with(|| Candidate {
             name,
             version,
             resolution: metadata.resolution.clone(),

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -713,8 +713,8 @@ fn build_one_snapshot<Reporter: self::Reporter>(
                             details: Some(err.to_string()),
                             package: SkippedOptionalPackage::Installed {
                                 id: pkg_dir.to_string_lossy().into_owned(),
-                                name: name.clone(),
-                                version: version.clone(),
+                                name,
+                                version,
                             },
                             prefix: lockfile_dir.to_string_lossy().into_owned(),
                             reason: SkippedOptionalReason::BuildFailure,

--- a/pacquet/crates/package-manager/src/build_modules.rs
+++ b/pacquet/crates/package-manager/src/build_modules.rs
@@ -855,7 +855,7 @@ fn bin_dirs_in_all_parent_dirs(pkg_root: &Path, lockfile_dir: &Path) -> Vec<Path
     let mut bin_dirs: Vec<PathBuf> = Vec::new();
     let mut dir: PathBuf = pkg_root.to_path_buf();
     loop {
-        let parent = dir.parent().unwrap_or(Path::new(""));
+        let parent = dir.parent().unwrap_or_else(|| Path::new(""));
         let parent_starts_with_at =
             parent.to_str().and_then(|text| text.chars().next()).is_some_and(|ch| ch == '@');
         if !parent_starts_with_at {

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -704,7 +704,7 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
     let mut overlay = std::collections::HashMap::new();
     overlay.insert("any-key".to_string(), std::collections::HashMap::new());
     let mut side_effects_maps = std::collections::HashMap::new();
-    side_effects_maps.insert(pkg_key.clone(), std::sync::Arc::new(overlay));
+    side_effects_maps.insert(pkg_key, std::sync::Arc::new(overlay));
 
     let err = BuildModules {
         layout: &VirtualStoreLayout::legacy(

--- a/pacquet/crates/package-manager/src/build_sequence/tests.rs
+++ b/pacquet/crates/package-manager/src/build_sequence/tests.rs
@@ -252,7 +252,7 @@ fn skipped_patched_snapshot_does_not_enter_build_queue() {
         },
     )]);
 
-    let skipped = SkippedSnapshots::from_set(HashSet::from([a_key.clone()]));
+    let skipped = SkippedSnapshots::from_set(HashSet::from([a_key]));
 
     let chunks = build_sequence(&requires_build, Some(&patches), &snapshots, &importers, &skipped);
 
@@ -286,7 +286,7 @@ fn skipped_parent_does_not_drag_descendants_into_build_queue() {
         (c_key.clone(), snap(&[])),
     ]);
     let requires_build =
-        requires([(root_key.clone(), false), (s_key.clone(), false), (c_key.clone(), true)]);
+        requires([(root_key, false), (s_key.clone(), false), (c_key, true)]);
     let importers = root_importers(&[("root", "1.0.0")]);
 
     let skipped = SkippedSnapshots::from_set(HashSet::from([s_key]));

--- a/pacquet/crates/package-manager/src/build_sequence/tests.rs
+++ b/pacquet/crates/package-manager/src/build_sequence/tests.rs
@@ -285,8 +285,7 @@ fn skipped_parent_does_not_drag_descendants_into_build_queue() {
         (s_key.clone(), snap(&[("c", "1.0.0")])),
         (c_key.clone(), snap(&[])),
     ]);
-    let requires_build =
-        requires([(root_key, false), (s_key.clone(), false), (c_key, true)]);
+    let requires_build = requires([(root_key, false), (s_key.clone(), false), (c_key, true)]);
     let importers = root_importers(&[("root", "1.0.0")]);
 
     let skipped = SkippedSnapshots::from_set(HashSet::from([s_key]));

--- a/pacquet/crates/package-manager/src/create_symlink_layout/tests.rs
+++ b/pacquet/crates/package-manager/src/create_symlink_layout/tests.rs
@@ -47,7 +47,7 @@ fn links_matching_optional_sibling_alongside_regular_deps() {
     let tmp = tempdir().expect("tempdir");
     let virtual_store_dir = tmp.path().to_path_buf();
     let layout = VirtualStoreLayout::legacy(
-        virtual_store_dir.clone(),
+        virtual_store_dir,
         pacquet_config::default_virtual_store_dir_max_length() as usize,
     );
 

--- a/pacquet/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
@@ -61,7 +61,7 @@ async fn run_emits_imported_event_after_import_indexed_dir() {
     // `.run()` directly here. The function itself is sync — only
     // the caller's runtime flavor matters.
     let layout = crate::VirtualStoreLayout::legacy(
-        virtual_store_dir.clone(),
+        virtual_store_dir,
         pacquet_config::default_virtual_store_dir_max_length() as usize,
     );
     let skipped = crate::SkippedSnapshots::default();

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -357,7 +357,7 @@ impl<'a> CreateVirtualStore<'a> {
         // the legacy path is empty, so the skip gate would
         // incorrectly mark every warm slot as "broken" and emit
         // `BrokenModules` for the wrong path.
-        let survivors: Vec<(&PackageKey, &SnapshotEntry)> = snapshots
+        let survivors = snapshots
             .iter()
             // Reason 1: installability skip. Drop entirely.
             .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
@@ -409,9 +409,7 @@ impl<'a> CreateVirtualStore<'a> {
                     }));
                     true
                 }
-            })
-            .collect();
-
+            });
         // Validate every surviving snapshot upfront so a malformed
         // lockfile (missing metadata, missing tarball integrity,
         // currently-unsupported directory / git resolution) errors
@@ -437,7 +435,6 @@ impl<'a> CreateVirtualStore<'a> {
         //   warm-reinstall path).
         type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
         let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = survivors
-            .into_iter()
             .map(|(snapshot_key, snapshot)| {
                 snapshot_cache_key(snapshot_key, packages).map(|key| (snapshot_key, snapshot, key))
             })
@@ -461,7 +458,7 @@ impl<'a> CreateVirtualStore<'a> {
             // `skipped_entries` too — they were never installed, so
             // there's no store-index row to keep warm for the
             // build-cache lookup. Only the current-lockfile-skip
-            // path (`survivors` filtered above) should contribute
+            // path (`snapshot_entries` filtered above) should contribute
             // here.
             .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
             .map(|(snapshot_key, snapshot)| {

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -72,7 +72,7 @@ fn make_node_with_optional(
 ) -> DependenciesGraphNode {
     let dep_path = DepPath::from(format!("{name}@{version}"));
     DependenciesGraphNode {
-        dep_path: dep_path.clone(),
+        dep_path,
         resolved_package_id: format!("{name}@{version}"),
         resolve_result: std::sync::Arc::new(make_resolve_result(name, version, manifest)),
         children,

--- a/pacquet/crates/package-manager/src/deps_graph/tests.rs
+++ b/pacquet/crates/package-manager/src/deps_graph/tests.rs
@@ -112,10 +112,8 @@ fn optional_dependencies_fold_into_children() {
         ),
         (opt_key.clone(), SnapshotEntry::default()),
     ]);
-    let packages = HashMap::from([
-        (parent_key.clone(), registry_metadata()),
-        (opt_key, registry_metadata()),
-    ]);
+    let packages =
+        HashMap::from([(parent_key.clone(), registry_metadata()), (opt_key, registry_metadata())]);
 
     let graph = build_deps_graph(&snapshots, &packages);
     let parent_node = graph.get(&parent_key).expect("parent node");

--- a/pacquet/crates/package-manager/src/deps_graph/tests.rs
+++ b/pacquet/crates/package-manager/src/deps_graph/tests.rs
@@ -114,7 +114,7 @@ fn optional_dependencies_fold_into_children() {
     ]);
     let packages = HashMap::from([
         (parent_key.clone(), registry_metadata()),
-        (opt_key.clone(), registry_metadata()),
+        (opt_key, registry_metadata()),
     ]);
 
     let graph = build_deps_graph(&snapshots, &packages);
@@ -129,7 +129,7 @@ fn optional_dependencies_fold_into_children() {
 #[test]
 fn snapshot_without_metadata_is_skipped() {
     let pkg = key("orphan", "1.0.0");
-    let snapshots = HashMap::from([(pkg.clone(), SnapshotEntry::default())]);
+    let snapshots = HashMap::from([(pkg, SnapshotEntry::default())]);
     let packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
 
     let graph = build_deps_graph(&snapshots, &packages);

--- a/pacquet/crates/package-manager/src/graph_sequencer/tests.rs
+++ b/pacquet/crates/package-manager/src/graph_sequencer/tests.rs
@@ -92,7 +92,7 @@ fn cycle_marks_unsafe_and_groups_cycle_nodes() {
     assert!(!r.cycles.is_empty(), "cycle list must record the cycle: {r:?}");
     // Both nodes still appear in some chunk.
     let flat: Vec<String> = r.chunks.into_iter().flatten().collect();
-    let mut sorted = flat.clone();
+    let mut sorted = flat;
     sorted.sort();
     assert_eq!(sorted, vec!["a".to_string(), "b".to_string()]);
 }

--- a/pacquet/crates/package-manager/src/hoist/tests.rs
+++ b/pacquet/crates/package-manager/src/hoist/tests.rs
@@ -405,7 +405,7 @@ fn symlink_skips_dropped_nodes() {
     std::fs::create_dir_all(layout.slot_dir(&kept_key).join("node_modules/kept")).unwrap();
 
     let mut skipped: HashSet<PackageKey> = HashSet::new();
-    skipped.insert(dropped_key.clone());
+    skipped.insert(dropped_key);
 
     super::symlink_hoisted_dependencies(
         &hoisted,

--- a/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
@@ -1847,7 +1847,7 @@ mod tests {
         );
         let lockfile_dir = PathBuf::from("/repo");
         let opts = LockfileToHoistedDepGraphOptions {
-            lockfile_dir: lockfile_dir.clone(),
+            lockfile_dir,
             ..LockfileToHoistedDepGraphOptions::default()
         };
         let result =
@@ -1886,7 +1886,7 @@ mod tests {
         let mut externals = BTreeSet::new();
         externals.insert("a".to_string());
         let opts = LockfileToHoistedDepGraphOptions {
-            lockfile_dir: lockfile_dir.clone(),
+            lockfile_dir,
             external_dependencies: externals,
             ..LockfileToHoistedDepGraphOptions::default()
         };

--- a/pacquet/crates/package-manager/src/installability/tests.rs
+++ b/pacquet/crates/package-manager/src/installability/tests.rs
@@ -355,11 +355,11 @@ fn duplicate_metadata_dedupes_reporter_events() {
 
     // ...but the reporter only sees one event for the metadata row.
     let events = take_events();
-    let skipped_events: Vec<_> = events
+    let skipped_events_count = events
         .iter()
         .filter(|event| matches!(event, LogEvent::SkippedOptionalDependency(_)))
-        .collect();
-    assert_eq!(skipped_events.len(), 1, "must dedup per metadata row");
+        .count();
+    assert_eq!(skipped_events_count, 1, "must dedup per metadata row");
 }
 
 /// `supportedArchitectures` widens the host triple so an optional
@@ -557,8 +557,7 @@ fn disjoint_subsets_preserve_len_and_iter() {
     // higher-precedence subset wins — `len` and `iter` see exactly
     // one entry, matching `contains`.
     assert_eq!(skipped.len(), 1);
-    let collected: Vec<&PackageKey> = skipped.iter().collect();
-    assert_eq!(collected.len(), 1);
+    assert_eq!(skipped.iter().count(), 1);
     assert!(skipped.contains(&key));
 
     // `add_fetch_failed` against the same key is similarly a no-op

--- a/pacquet/crates/package-manager/src/installability/tests.rs
+++ b/pacquet/crates/package-manager/src/installability/tests.rs
@@ -382,7 +382,7 @@ fn supported_architectures_widens_accept_set_so_optional_stays() {
     let mut snapshots = HashMap::new();
     snapshots.insert(key.clone(), SnapshotEntry { optional: true, ..Default::default() });
     let mut packages = HashMap::new();
-    packages.insert(key.clone(), synthetic_metadata(None, None, Some(&["darwin"]), None));
+    packages.insert(key, synthetic_metadata(None, None, Some(&["darwin"]), None));
 
     let mut host = host("20.10.0", "linux", "x64");
     host.supported_architectures = Some(pacquet_package_is_installable::SupportedArchitectures {
@@ -563,7 +563,7 @@ fn disjoint_subsets_preserve_len_and_iter() {
 
     // `add_fetch_failed` against the same key is similarly a no-op
     // — installability has highest precedence.
-    skipped.add_fetch_failed(key.clone());
+    skipped.add_fetch_failed(key);
     assert_eq!(skipped.len(), 1);
 }
 

--- a/pacquet/crates/package-manager/src/link_bins.rs
+++ b/pacquet/crates/package-manager/src/link_bins.rs
@@ -486,7 +486,7 @@ where
         // fallback is the same `read_package` used elsewhere.
         if self_has_bin {
             if let Some(manifest) = package_manifests.get(&self_metadata_key) {
-                bin_sources.push(PackageBinSource::new(self_pkg_dir.clone(), Arc::clone(manifest)));
+                bin_sources.push(PackageBinSource::new(self_pkg_dir, Arc::clone(manifest)));
             } else {
                 match read_package::<Sys>(&self_pkg_dir) {
                     Ok(Some(pkg)) => bin_sources.push(pkg),

--- a/pacquet/crates/package-manager/src/link_bins/tests.rs
+++ b/pacquet/crates/package-manager/src/link_bins/tests.rs
@@ -50,7 +50,7 @@ fn writes_child_bins_into_slot_own_package_node_modules() {
 
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -121,7 +121,7 @@ fn skips_slot_own_package_when_walking_children() {
 
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -149,7 +149,7 @@ fn link_virtual_store_bins_no_op_when_dir_missing() {
     let nonexistent = tmp.path().join("does-not-exist");
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            nonexistent.clone(),
+            nonexistent,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -190,7 +190,7 @@ fn link_virtual_store_bins_handles_scoped_slot_name() {
 
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -244,7 +244,7 @@ fn link_virtual_store_bins_handles_peer_resolved_slot_name() {
 
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -297,7 +297,7 @@ fn link_virtual_store_bins_handles_unscoped_name_with_plus() {
 
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -325,7 +325,7 @@ fn link_virtual_store_bins_skips_slot_without_node_modules() {
     create_dir_all(virtual_dir.join("incomplete@1.0.0")).unwrap();
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,
@@ -355,7 +355,7 @@ fn link_virtual_store_bins_skips_slot_without_own_package_dir() {
     create_dir_all(virtual_dir.join("foo@1.0.0/node_modules")).unwrap();
     LinkVirtualStoreBins {
         layout: &VirtualStoreLayout::legacy(
-            virtual_dir.clone(),
+            virtual_dir,
             pacquet_config::default_virtual_store_dir_max_length() as usize,
         ),
         snapshots: None,

--- a/pacquet/crates/package-manager/src/link_hoisted_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/link_hoisted_modules/tests.rs
@@ -258,7 +258,7 @@ fn missing_cas_for_required_dep_errors() {
     graph.insert(dir.clone(), make_node("a", "a@1.0.0", "a@1.0.0", dir.clone()));
 
     let mut hierarchy_children = BTreeMap::new();
-    hierarchy_children.insert(dir.clone(), DepHierarchy::default());
+    hierarchy_children.insert(dir, DepHierarchy::default());
     let mut hierarchy = BTreeMap::new();
     hierarchy.insert(lockfile_dir.clone(), DepHierarchy(hierarchy_children));
 
@@ -369,7 +369,7 @@ fn orphan_already_removed_is_tolerated() {
     let mut prev_graph = DependenciesGraph::new();
     prev_graph.insert(
         phantom_orphan.clone(),
-        make_node("phantom", "phantom@1.0.0", "phantom@1.0.0", phantom_orphan.clone()),
+        make_node("phantom", "phantom@1.0.0", "phantom@1.0.0", phantom_orphan),
     );
 
     let (graph, hierarchy, cas_paths) = flat_layout(

--- a/pacquet/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/pacquet/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -170,7 +170,7 @@ fn duplicate_dep_across_groups_collapses_to_one_entry() {
 
     let mut config = Config::new();
     config.store_dir = dir.path().join("pacquet-store").into();
-    config.modules_dir = modules_dir.clone();
+    config.modules_dir = modules_dir;
     config.virtual_store_dir = virtual_store_dir.clone();
     let config = config.leak();
 

--- a/pacquet/crates/package-manager/src/virtual_store_layout.rs
+++ b/pacquet/crates/package-manager/src/virtual_store_layout.rs
@@ -717,8 +717,8 @@ mod tests {
         let mut snapshots = HashMap::new();
         snapshots.insert(pins_22.clone(), pins_22_snapshot);
         snapshots.insert(pins_20.clone(), pins_20_snapshot);
-        snapshots.insert(node22_key.clone(), SnapshotEntry::default());
-        snapshots.insert(node20_key.clone(), SnapshotEntry::default());
+        snapshots.insert(node22_key, SnapshotEntry::default());
+        snapshots.insert(node20_key, SnapshotEntry::default());
 
         // Both siblings are approved builders so the engine portion
         // of the hash isn't dropped by the engine-agnostic gating.

--- a/pacquet/crates/package-manifest/src/tests.rs
+++ b/pacquet/crates/package-manifest/src/tests.rs
@@ -368,7 +368,7 @@ fn from_path_applies_convert_engines_runtime() {
 fn from_path_errors_no_importer_when_missing() {
     let dir = tempdir().unwrap();
     let missing = dir.path().join("does-not-exist").join("package.json");
-    let result = PackageManifest::from_path(missing.clone());
+    let result = PackageManifest::from_path(missing);
     let err = match result {
         Err(err) => err,
         Ok(_) => panic!("missing package.json should not parse"),

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -363,7 +363,11 @@ where
         && is_exotic_resolved_via(&result.resolved_via)
     {
         return Err(ResolveDependencyTreeError::ExoticSubdep {
-            specifier: wanted.alias.clone().or(wanted.bare_specifier.clone()).unwrap_or_default(),
+            specifier: wanted
+                .alias
+                .clone()
+                .or_else(|| wanted.bare_specifier.clone())
+                .unwrap_or_default(),
             resolved_via: result.resolved_via.clone(),
         });
     }
@@ -378,7 +382,7 @@ where
     let alias = result
         .alias
         .clone()
-        .or(wanted.alias.clone())
+        .or_else(|| wanted.alias.clone())
         .or_else(|| result.name_ver.as_ref().map(|nv| nv.name.to_string()))
         .unwrap_or_else(|| id.clone());
 
@@ -663,7 +667,7 @@ fn extract_peer_dependencies(
             peers
                 .entry(name.clone())
                 .and_modify(|entry| entry.optional = entry.optional || optional)
-                .or_insert(PeerDep { version: "*".to_string(), optional });
+                .or_insert_with(|| PeerDep { version: "*".to_string(), optional });
         }
     }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -166,7 +166,7 @@ async fn does_not_hoist_when_disabled() {
             .direct_dependencies_by_alias
             .keys()
             .map(String::as_str)
-            .any(|name| name == "react")
+            .any(|name| name == "react"),
     );
     assert!(result.peers_result.peer_dependency_issues.missing.contains_key("react"));
 }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -160,9 +160,14 @@ async fn does_not_hoist_when_disabled() {
     let result =
         resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
 
-    let direct: Vec<&str> =
-        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
-    assert!(!direct.contains(&"react"));
+    assert!(
+        !result
+            .peers_result
+            .direct_dependencies_by_alias
+            .keys()
+            .map(String::as_str)
+            .any(|name| name == "react")
+    );
     assert!(result.peers_result.peer_dependency_issues.missing.contains_key("react"));
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -160,14 +160,13 @@ async fn does_not_hoist_when_disabled() {
     let result =
         resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
 
-    assert!(
-        !result
-            .peers_result
-            .direct_dependencies_by_alias
-            .keys()
-            .map(String::as_str)
-            .any(|name| name == "react"),
-    );
+    #[expect(
+        clippy::needless_collect,
+        reason = "Collecting into a Vec keeps the assertion readable; `.any(...)` on the iterator would be denser without saving meaningful work."
+    )]
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert!(!direct.contains(&"react"));
     assert!(result.peers_result.peer_dependency_issues.missing.contains_key("react"));
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -608,7 +608,7 @@ fn insert_parent_ref(
         return;
     }
     let parent_ref = ParentRef {
-        version: version.clone(),
+        version,
         node_id: Some(direct.node_id.clone()),
         alias: (direct.alias != real_name).then(|| direct.alias.clone()),
     };

--- a/pacquet/crates/resolving-git-resolver/src/resolve_ref.rs
+++ b/pacquet/crates/resolving-git-resolver/src/resolve_ref.rs
@@ -203,7 +203,7 @@ fn resolve_ref_from_refs(
             .strip_prefix("refs/tags/")
             .expect("guard above ensures the prefix")
             .strip_suffix("^{}")
-            .unwrap_or(key.strip_prefix("refs/tags/").expect("guarded"));
+            .unwrap_or_else(|| key.strip_prefix("refs/tags/").expect("guarded"));
         if Version::parse(cleaned).is_ok() || Version::parse(strip_v(cleaned)).is_ok() {
             v_tags.insert(cleaned.to_string());
         }

--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -187,8 +187,8 @@ pub fn find_workspace_projects_no_check(
     // sort below to make the contract visible.
     let mut sorted: Vec<PathBuf> = manifest_paths.into_iter().collect();
     sorted.sort_by(|left, right| {
-        let dir_left = left.parent().unwrap_or(Path::new(""));
-        let dir_right = right.parent().unwrap_or(Path::new(""));
+        let dir_left = left.parent().unwrap_or_else(|| Path::new(""));
+        let dir_right = right.parent().unwrap_or_else(|| Path::new(""));
         dir_left.cmp(dir_right)
     });
 

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -63,7 +63,7 @@ impl WorkEnv {
     /// pacquet repo when the caller didn't override it — useful when
     /// the same monorepo checkout contains both code bases.
     fn pnpm_repository(&self) -> &'_ Path {
-        self.pnpm_repository.as_deref().unwrap_or(self.repository())
+        self.pnpm_repository.as_deref().unwrap_or_else(|| self.repository())
     }
 
     fn bench_dir(&self, id: BenchId) -> PathBuf {


### PR DESCRIPTION
- **chore(lint): more clippy rules**
- **fix: address clippy needless_collect warnings**
- **fix: silence clippy or_fun_call warnings**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary cloning, adopted lazy evaluation and iterator flows to lower memory churn and improve efficiency.
* **Chores**
  * Workspace linting updated to enable three additional Clippy warnings.
* **Tests**
  * Test code updated to pass ownership directly, avoid extra collects, and silence a Clippy lint; test behavior and assertions unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->