### PR TITLE
perf(pacquet): trim install-phase syscalls and allocations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ Defaults:
 -   **Do not write a comment** that restates what the code already says. If renaming a variable, splitting a helper, or moving a check to a more obvious place would carry the information, do that instead.
 -   **Do not repeat documentation** at call sites that already lives on the callee. If the function has a JSDoc, the call site shouldn't re-explain what calling it does. Update the JSDoc once; let every call site benefit.
 -   **JSDoc is for the function's contract** — preconditions, postconditions, edge cases, why the function exists. Not for re-narrating the body.
+-   **Do not record past implementation shape, refactor history, or "the previous code did X" framing.** That's what `git log` and `git blame` are for. Describe the current contract — what the code is and what it guarantees — not what it replaced. Phrasings like "used to", "previously", "the original X", or a parenthetical naming a removed type belong in the commit message, not in the source.
 
 Write a comment only when:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,6 @@ dependencies = [
 name = "pacquet-fs"
 version = "0.0.1"
 dependencies = [
- "dashmap",
  "derive_more",
  "dunce",
  "junction",

--- a/pacquet/crates/fs/Cargo.toml
+++ b/pacquet/crates/fs/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace    = true
 repository.workspace = true
 
 [dependencies]
-dashmap     = { workspace = true }
 derive_more = { workspace = true }
 miette      = { workspace = true }
 pathdiff    = { workspace = true }

--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -200,35 +200,29 @@ pub fn ensure_file(
 
 /// Borrow the process-local write mutex for `file_path`.
 ///
-/// Striped: hashes the path into one of `NUM_CAS_LOCK_STRIPES` static
-/// mutexes. Mirrors the per-path serialization the previous
-/// `DashMap<PathBuf, Arc<Mutex<()>>>` shape gave but without the per-call
-/// `PathBuf::to_path_buf` allocation, the `DashMap` shard write lock, or
-/// the `Arc<Mutex<()>>` slot allocation — each install pays one path
-/// hash + one uncontended mutex acquire per CAFS file written
-/// (~170k on the alotta-files fixture) instead.
-///
-/// **Correctness with striping.** The original map was per-*path*: a
-/// concurrent writer and verifier of the same path always met on the
-/// same mutex. Striping by hash relaxes that to "writers of paths
-/// hashing into the same stripe wait on each other" — which is a
-/// superset of the original blocking relation, so every safety
-/// invariant the per-path lock provided still holds. The extra
-/// false-sharing between unrelated paths is bounded: with 256 stripes
-/// and ~10 rayon workers, collision probability per pair is ~4 %, and
-/// the body the lock guards (`O_CREAT|O_EXCL` open + `write_all` of a
-/// single tar entry) is microseconds long. Pnpm's own
+/// The hot path costs one path hash + one uncontended mutex acquire
+/// per CAFS file written (~170k on the alotta-files fixture), with no
+/// allocations: the path is hashed into one of `NUM_CAS_LOCK_STRIPES`
+/// statically-allocated mutexes. Pnpm's own
 /// [`writeFile`](https://github.com/pnpm/pnpm/blob/4750fd370c/store/cafs/src/writeFile.ts)
-/// uses a refcount `Map<string, number>` for the same coordination —
-/// striping is the Rust analogue with the same upper bound on
-/// blocking.
+/// uses a refcount `Map<string, number>` for the equivalent
+/// coordination — this is the Rust analogue.
+///
+/// **Coordination contract.** Callers handing in the same `&Path`
+/// always receive the same `Mutex<()>`. The hasher is initialised
+/// once per process (`OnceLock<RandomState>`) so the path-to-stripe
+/// mapping stays stable for the lifetime of the process; writers
+/// (`ensure_file`) and verifiers (`check_pkg_files_integrity`) of the
+/// same path are guaranteed to meet on the same lock and serialise.
+/// Stripe-hash collisions between unrelated paths block each other
+/// too — that false-sharing is bounded by `NUM_CAS_LOCK_STRIPES` and
+/// the guarded section (a single `O_CREAT|O_EXCL` open + `write_all`)
+/// is microseconds long.
 ///
 /// Made `pub` so verifiers (`check_pkg_files_integrity`) can acquire
 /// the same lock before stat-then-maybe-`rimraf`'ing a CAS path —
 /// otherwise the verifier can `unlink` a file while a writer's
-/// `write_all` is still running. The verifier and writer pass the
-/// same `&Path` and the hasher is process-deterministic, so both land
-/// on the same stripe.
+/// `write_all` is still running.
 pub fn cas_write_lock(file_path: &Path) -> &'static Mutex<()> {
     use std::collections::hash_map::RandomState;
     static BUILDER: std::sync::OnceLock<RandomState> = std::sync::OnceLock::new();

--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -245,6 +245,11 @@ pub fn cas_write_lock(file_path: &Path) -> &'static Mutex<()> {
 /// file install that's ~660 writes per stripe, all on different paths
 /// — uncontended pairings dominate.
 const NUM_CAS_LOCK_STRIPES: usize = 256;
+const _: () = assert!(
+    NUM_CAS_LOCK_STRIPES.is_power_of_two(),
+    "cas_write_lock uses `& (NUM_CAS_LOCK_STRIPES - 1)` as the stripe selector, which only \
+     distributes uniformly when the count is a power of two",
+);
 
 static CAS_LOCK_STRIPES: [Mutex<()>; NUM_CAS_LOCK_STRIPES] =
     [const { Mutex::new(()) }; NUM_CAS_LOCK_STRIPES];

--- a/pacquet/crates/fs/src/ensure_file.rs
+++ b/pacquet/crates/fs/src/ensure_file.rs
@@ -1,12 +1,12 @@
-use dashmap::DashMap;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::{
     fs::{self, File, OpenOptions},
+    hash::{BuildHasher, Hasher},
     io::{self, Write},
     path::{Path, PathBuf},
     sync::{
-        Arc, Mutex, OnceLock,
+        Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -200,27 +200,54 @@ pub fn ensure_file(
 
 /// Borrow the process-local write mutex for `file_path`.
 ///
-/// Returning `Arc<Mutex<()>>` (rather than a `Ref` into the map) so
-/// the caller `.lock()`s after the shard guard from `entry()` is
-/// released — otherwise a recursive lookup on the same shard could
-/// deadlock. The map is never pruned: entries are one per unique
-/// CAS path the install wrote, bounded by the working set.
+/// Striped: hashes the path into one of `NUM_CAS_LOCK_STRIPES` static
+/// mutexes. Mirrors the per-path serialization the previous
+/// `DashMap<PathBuf, Arc<Mutex<()>>>` shape gave but without the per-call
+/// `PathBuf::to_path_buf` allocation, the `DashMap` shard write lock, or
+/// the `Arc<Mutex<()>>` slot allocation — each install pays one path
+/// hash + one uncontended mutex acquire per CAFS file written
+/// (~170k on the alotta-files fixture) instead.
+///
+/// **Correctness with striping.** The original map was per-*path*: a
+/// concurrent writer and verifier of the same path always met on the
+/// same mutex. Striping by hash relaxes that to "writers of paths
+/// hashing into the same stripe wait on each other" — which is a
+/// superset of the original blocking relation, so every safety
+/// invariant the per-path lock provided still holds. The extra
+/// false-sharing between unrelated paths is bounded: with 256 stripes
+/// and ~10 rayon workers, collision probability per pair is ~4 %, and
+/// the body the lock guards (`O_CREAT|O_EXCL` open + `write_all` of a
+/// single tar entry) is microseconds long. Pnpm's own
+/// [`writeFile`](https://github.com/pnpm/pnpm/blob/4750fd370c/store/cafs/src/writeFile.ts)
+/// uses a refcount `Map<string, number>` for the same coordination —
+/// striping is the Rust analogue with the same upper bound on
+/// blocking.
 ///
 /// Made `pub` so verifiers (`check_pkg_files_integrity`) can acquire
-/// the same lock before stat-then-maybe-`rimraf`'ing a CAS path.
-/// Without that, a verifier can `unlink` a file while a writer's
-/// `write_all` is still running — leaving the writer's `cas_paths`
-/// pointing at a now-orphaned inode whose dirent is gone, which
-/// surfaces later as ENOENT inside `link_file`. The lock is the
-/// only primitive that already coordinates per-blob writers, so it
-/// is the right gate to extend to readers that delete.
-pub fn cas_write_lock(file_path: &Path) -> Arc<Mutex<()>> {
-    static LOCKS: OnceLock<DashMap<PathBuf, Arc<Mutex<()>>>> = OnceLock::new();
-    let locks = LOCKS.get_or_init(DashMap::new);
-    Arc::clone(
-        locks.entry(file_path.to_path_buf()).or_insert_with(|| Arc::new(Mutex::new(()))).value(),
-    )
+/// the same lock before stat-then-maybe-`rimraf`'ing a CAS path —
+/// otherwise the verifier can `unlink` a file while a writer's
+/// `write_all` is still running. The verifier and writer pass the
+/// same `&Path` and the hasher is process-deterministic, so both land
+/// on the same stripe.
+pub fn cas_write_lock(file_path: &Path) -> &'static Mutex<()> {
+    use std::collections::hash_map::RandomState;
+    static BUILDER: std::sync::OnceLock<RandomState> = std::sync::OnceLock::new();
+    let builder = BUILDER.get_or_init(RandomState::new);
+    let mut hasher = builder.build_hasher();
+    std::hash::Hash::hash(file_path, &mut hasher);
+    let stripe = (hasher.finish() as usize) & (NUM_CAS_LOCK_STRIPES - 1);
+    &CAS_LOCK_STRIPES[stripe]
 }
+
+/// Number of static mutex stripes used by [`cas_write_lock`]. Power of
+/// two so the modulo collapses to a mask. 256 picked so each stripe
+/// sees on average `total_files / 256` writes per install; for a 170k-
+/// file install that's ~660 writes per stripe, all on different paths
+/// — uncontended pairings dominate.
+const NUM_CAS_LOCK_STRIPES: usize = 256;
+
+static CAS_LOCK_STRIPES: [Mutex<()>; NUM_CAS_LOCK_STRIPES] =
+    [const { Mutex::new(()) }; NUM_CAS_LOCK_STRIPES];
 
 /// Re-read an already-present CAS file and byte-compare with `content`.
 /// If they match we're done; if not, recover the torn blob by writing a

--- a/pacquet/crates/fs/tests/ensure_file_stress.rs
+++ b/pacquet/crates/fs/tests/ensure_file_stress.rs
@@ -15,11 +15,12 @@
 //!    overwrite-via-rename heals the store.
 //!
 //! Pacquet's [`cas_write_lock`](pacquet_fs::ensure_file) is
-//! process-local (a `OnceLock<DashMap<PathBuf, Arc<Mutex<()>>>>`),
-//! just like upstream's `locker: Map<string, number>`. The
-//! cross-process safety contract therefore lives entirely in the
-//! kernel-level `O_CREAT | O_EXCL` + atomic-rename primitives. The
-//! existing intra-process 32-thread test in `ensure_file::tests`
+//! process-local (a static array of [`std::sync::Mutex<()>`] stripes
+//! keyed by hashed path), just like upstream's
+//! `locker: Map<string, number>`. The cross-process safety contract
+//! therefore lives entirely in the kernel-level `O_CREAT | O_EXCL` +
+//! atomic-rename primitives. The existing intra-process 32-thread
+//! test in `ensure_file::tests`
 //! ([`concurrent_writers_of_same_path_do_not_swap_the_inode`])
 //! exercises the lock; this suite exercises the unprotected
 //! filesystem-only path.

--- a/pacquet/crates/package-manager/src/import_indexed_dir.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir.rs
@@ -95,8 +95,8 @@ pub enum ImportIndexedDirError {
 ///
 /// * **Default opts (isolated linker).** If `dir_path` already exists,
 ///   short-circuit; otherwise mkdir parents and link each file in
-///   parallel via `link_file()`. Matches pnpm's `importIndexedPackage`
-///   when called without `force`.
+///   parallel via `import_into_fresh_target()`. Matches pnpm's
+///   `importIndexedPackage` when called without `force`.
 /// * **`opts.force` (hoisted linker).** Re-import even when `dir_path`
 ///   exists. The new contents are staged in a sibling directory so the
 ///   final rename stays on one filesystem, the old directory is
@@ -111,11 +111,14 @@ pub enum ImportIndexedDirError {
 ///   deps. Required by the hoisted linker's interleaved orphan-removal
 ///   and insert passes.
 ///
-/// Files in `cas_paths` are materialized by `link_file()` using
-/// `import_method`'s preference order
+/// Files in `cas_paths` are materialized by `import_into_fresh_target()`
+/// using `import_method`'s preference order
 /// (hardlink → reflink → copy, etc.), and the per-method
 /// `pnpm:package-import-method` log is emitted via `logged_methods`
-/// the first time each tier is used in this install.
+/// the first time each tier is used in this install. The pre-flight
+/// `fs::metadata` short-circuit lives on `link_file()` for callers
+/// without a freshness guarantee — `populate_dir` already gates on
+/// the directory being fresh, so it skips that stat.
 pub fn import_indexed_dir<Reporter: self::Reporter>(
     logged_methods: &AtomicU8,
     import_method: PackageImportMethod,
@@ -163,7 +166,7 @@ pub fn import_indexed_dir<Reporter: self::Reporter>(
 }
 
 /// Fresh-target path: make the parent dir set, then run the parallel
-/// `link_file` over `cas_paths`. Mirrors pnpm v11's
+/// `import_into_fresh_target` over `cas_paths`. Mirrors pnpm v11's
 /// `tryImportIndexedDir`: collect the unique relative parent dirs,
 /// sort shortest-first, mkdir each sequentially, then dispatch the
 /// file imports in parallel. Sorting by length means the recursive

--- a/pacquet/crates/package-manager/src/import_indexed_dir.rs
+++ b/pacquet/crates/package-manager/src/import_indexed_dir.rs
@@ -1,4 +1,4 @@
-use crate::{LinkFileError, link_file};
+use crate::{LinkFileError, import_into_fresh_target};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::PackageImportMethod;
@@ -95,7 +95,7 @@ pub enum ImportIndexedDirError {
 ///
 /// * **Default opts (isolated linker).** If `dir_path` already exists,
 ///   short-circuit; otherwise mkdir parents and link each file in
-///   parallel via [`link_file()`]. Matches pnpm's `importIndexedPackage`
+///   parallel via `link_file()`. Matches pnpm's `importIndexedPackage`
 ///   when called without `force`.
 /// * **`opts.force` (hoisted linker).** Re-import even when `dir_path`
 ///   exists. The new contents are staged in a sibling directory so the
@@ -111,7 +111,7 @@ pub enum ImportIndexedDirError {
 ///   deps. Required by the hoisted linker's interleaved orphan-removal
 ///   and insert passes.
 ///
-/// Files in `cas_paths` are materialized by [`link_file()`] using
+/// Files in `cas_paths` are materialized by `link_file()` using
 /// `import_method`'s preference order
 /// (hardlink → reflink → copy, etc.), and the per-method
 /// `pnpm:package-import-method` log is emitted via `logged_methods`
@@ -205,7 +205,15 @@ fn populate_dir<Reporter: self::Reporter>(
     cas_paths
         .par_iter()
         .try_for_each(|(cleaned_entry, store_path)| {
-            link_file::<Reporter>(
+            // Targets are guaranteed fresh: `populate_dir` only runs
+            // against a freshly-mkdir'd `dir_path` (the caller in
+            // `import_indexed_dir` gates on the directory not existing,
+            // or staged it as a new sibling). Skipping the pre-flight
+            // `fs::metadata` saves one `stat` syscall per file — ~170k
+            // on the alotta-files fixture — without losing the
+            // no-op-on-existing-target contract that `link_file` exposes
+            // to other callers.
+            import_into_fresh_target::<Reporter>(
                 logged_methods,
                 import_method,
                 store_path,

--- a/pacquet/crates/package-manager/src/link_file.rs
+++ b/pacquet/crates/package-manager/src/link_file.rs
@@ -137,6 +137,35 @@ pub fn link_file<Reporter: self::Reporter>(
         return Ok(());
     }
 
+    import_into_fresh_target::<Reporter>(logged, method, source_file, target_link)
+}
+
+/// Same as [`link_file`] but without the pre-flight `fs::metadata`
+/// stat. Caller guarantees `target_link` is fresh (does not currently
+/// exist) — the import syscall is invoked directly.
+///
+/// On the alotta-files fixture this saves ~170k `stat` syscalls per
+/// clean install. The pre-flight stat in [`link_file`] only matters
+/// to preserve the no-op-on-existing-target contract for the
+/// `Copy` / downgraded `Auto`→`Copy` / `CloneOrCopy`→`Copy` paths,
+/// where `fs::copy` would otherwise silently overwrite. When the
+/// caller knows the target is fresh — as is the case for
+/// `crate::import_indexed_dir::populate_dir`, which only ever
+/// runs against a directory it just created — that protection is
+/// unneeded.
+///
+/// EEXIST from the import syscall is still treated as a no-op:
+/// concurrent installs (or a sibling rayon worker writing the same
+/// CAFS path) can occasionally race past the freshness guarantee,
+/// and the kernel's atomic-create error is the right way to detect
+/// the contention. The content is content-addressed so the existing
+/// dirent is equivalent.
+pub fn import_into_fresh_target<Reporter: self::Reporter>(
+    logged: &AtomicU8,
+    method: PackageImportMethod,
+    source_file: &Path,
+    target_link: &Path,
+) -> Result<(), LinkFileError> {
     // Hardlinking a file from the store into `node_modules` means any
     // package that edits its own files at runtime (postinstall scripts
     // are the usual offender) ends up mutating the shared store copy.
@@ -146,15 +175,9 @@ pub fn link_file<Reporter: self::Reporter>(
     match try_import::<Reporter>(method, logged, source_file, target_link) {
         Ok(()) => Ok(()),
         // Mirrors pnpm's `linkOrCopy`: on EEXIST, return without
-        // touching disk. The pre-flight `fs::metadata` short-circuit
-        // above covers the live-target case for the `Copy` /
-        // `Auto`→copy path (where the import syscall would silently
-        // overwrite rather than surface EEXIST); when execution
-        // reaches here the import syscall *did* surface EEXIST,
-        // which can only happen if a concurrent writer raced ahead
-        // between the stat and the syscall. No additional stat is
-        // needed — the dirent exists, the contents are
-        // content-addressed, so the no-op contract holds.
+        // touching disk. A concurrent writer beat us to the target;
+        // contents are content-addressed so leaving theirs in place
+        // is equivalent.
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(()),
         Err(error) => Err(LinkFileError::Import {
             from: source_file.to_path_buf(),

--- a/pacquet/crates/store-dir/src/cas_file.rs
+++ b/pacquet/crates/store-dir/src/cas_file.rs
@@ -11,9 +11,23 @@ use std::path::PathBuf;
 impl StoreDir {
     /// Path to a file in the store directory.
     pub fn cas_file_path(&self, hash: FileHash, executable: bool) -> PathBuf {
-        let hex = format!("{hash:x}");
+        // Sha-512 → 64 bytes → 128 hex chars. Render into a stack
+        // buffer so the per-file path build doesn't pay a String
+        // allocation just for the digest. `write!` of `{:02x}` is
+        // identical on the wire to `format!("{hash:x}")` for the
+        // `digest::Output<Sha512>` value (a fixed-size byte array
+        // whose `LowerHex` impl emits each byte as `%02x`).
+        use std::io::Write as _;
+        let mut hex_buf = [0u8; 128];
+        let mut writer = &mut hex_buf[..];
+        for byte in hash.iter() {
+            // `write!` on `&mut [u8]` never errors when the buffer is
+            // large enough — 128 bytes is exactly the digest length.
+            write!(writer, "{byte:02x}").expect("hex buffer sized for full sha-512 digest");
+        }
+        let hex = std::str::from_utf8(&hex_buf).expect("LowerHex of byte digest is ASCII");
         let suffix = if executable { "-exec" } else { "" };
-        self.file_path_by_hex_str(&hex, suffix)
+        self.file_path_by_hex_str(hex, suffix)
     }
 
     /// Path to a content-addressed file given its pre-computed hex digest

--- a/pacquet/crates/store-dir/src/store_dir.rs
+++ b/pacquet/crates/store-dir/src/store_dir.rs
@@ -1,7 +1,10 @@
 use dashmap::DashSet;
 use serde::{Deserialize, Serialize};
 use sha2::{Sha512, digest};
-use std::path::{self, PathBuf};
+use std::{
+    path::{self, PathBuf},
+    sync::OnceLock,
+};
 
 /// Content hash of a file.
 pub type FileHash = digest::Output<Sha512>;
@@ -56,6 +59,14 @@ pub struct StoreDir {
     /// through `PathBuf`, so the cache is regenerated empty on every
     /// deserialise.
     ensured_shards: DashSet<u8>,
+
+    /// Memoised `<root>/files` directory. Resolved lazily on the first
+    /// CAS path lookup and reused across every subsequent file write
+    /// — saves one `Path::join` allocation per file on the hot path,
+    /// ~170k on the alotta-files clean install. `OnceLock` so
+    /// initialization across rayon threads stays race-free.
+    #[serde(skip, default)]
+    cached_files_dir: OnceLock<PathBuf>,
 }
 
 impl From<StoreDir> for PathBuf {
@@ -87,7 +98,7 @@ impl From<PathBuf> for StoreDir {
         } else {
             root.join(STORE_VERSION)
         };
-        StoreDir { root, ensured_shards: DashSet::new() }
+        StoreDir { root, ensured_shards: DashSet::new(), cached_files_dir: OnceLock::new() }
     }
 }
 
@@ -118,7 +129,15 @@ impl StoreDir {
 
     /// The directory that contains all content-addressed files.
     fn files(&self) -> PathBuf {
-        self.root.join("files")
+        self.files_dir().to_path_buf()
+    }
+
+    /// Borrow the memoised `<root>/files` path. The CAS write hot
+    /// path calls this per CAFS file written, so caching the joined
+    /// path saves one `PathBuf` allocation per call (~170k on the
+    /// alotta-files clean install).
+    fn files_dir(&self) -> &PathBuf {
+        self.cached_files_dir.get_or_init(|| self.root.join("files"))
     }
 
     /// Path to a file in the store directory.
@@ -127,7 +146,7 @@ impl StoreDir {
     /// * `head` is the first 2 hexadecimal digit of the file address.
     /// * `tail` is the rest of the address and an optional suffix.
     fn file_path_by_head_tail(&self, head: &str, tail: &str) -> PathBuf {
-        self.files().join(head).join(tail)
+        self.files_dir().join(head).join(tail)
     }
 
     /// Path to a content-addressed file. The hex digest is split into a

--- a/pacquet/crates/store-dir/tests/verify_writer_race.rs
+++ b/pacquet/crates/store-dir/tests/verify_writer_race.rs
@@ -203,7 +203,7 @@ fn verify_does_not_unlink_file_while_writer_holds_cas_lock() {
 
 /// Sanity check: the lock acquired by [`pacquet_fs::cas_write_lock`]
 /// keys on the absolute path. Two callers asking for the same path
-/// receive an `Arc` to the same `Mutex` — the property the Option-C
+/// receive a reference to the same `Mutex` — the property the Option-C
 /// fix relies on for the verifier to wait on the writer.
 #[test]
 fn cas_write_lock_returns_same_mutex_for_same_path() {
@@ -214,7 +214,7 @@ fn cas_write_lock_returns_same_mutex_for_same_path() {
     let lock_b = pacquet_fs::cas_write_lock(&path);
 
     assert!(
-        Arc::ptr_eq(&lock_a, &lock_b),
-        "cas_write_lock must hand out the same Arc<Mutex<()>> for the same path",
+        std::ptr::eq(lock_a, lock_b),
+        "cas_write_lock must hand out the same Mutex<()> for the same path",
     );
 }


### PR DESCRIPTION
## Summary

Continues the perf work from #11856 / [#11857](https://github.com/pnpm/pnpm/issues/11857). Three install-phase wins on the clean-install path, none user-visible.

- **Striped CAS write lock.** `pacquet_fs::cas_write_lock` used to lazily insert per-path `Arc<Mutex<()>>` entries into a process-global `DashMap<PathBuf, Arc<Mutex<()>>>`. Every CAFS write paid a `PathBuf::to_path_buf` clone + a `DashMap` shard write lock + an `Arc<Mutex<()>>` slot allocation, even though the lock is virtually never contended. Replaced with 256 static `Mutex<()>` stripes keyed by hashed path. Same writer/verifier coordination invariant the per-path mutex provided (writers and verifiers of the same `&Path` hash to the same stripe), no allocations on the hot path.

- **Skip the pre-flight `fs::metadata` stat on fresh-target imports.** `link_file` does a `fs::metadata(target_link)` first so the no-op-on-existing-target contract holds for the `Copy` method (`fs::copy` would otherwise silently overwrite). `populate_dir` only ever runs against a directory it just `mkdir`'d, so the protection is wasted there — every call goes `NotFound`. Added a new `import_into_fresh_target` entry point that skips the stat and lets the import syscall's EEXIST handle the rare collision case. Saves ~170k `stat` syscalls per clean install on the `alotta-files` fixture. `link_file` keeps its full semantics for any caller that genuinely doesn't know whether the target is fresh.

- **Trim per-CAS-file allocations.** `cas_file_path` formats the sha-512 hex into a 128-byte stack buffer instead of a heap `String`, and `<root>/v11/files` is memoised on `StoreDir` behind a `OnceLock` so `file_path_by_head_tail` borrows it instead of rebuilding the `PathBuf` per call.

## Bench

5-run `hyperfine` against the verdaccio mock on the 3343-package `alotta-files` fixture, 10-core M-series Mac:

| | wall | user | sys |
|---|---:|---:|---:|
| baseline (976504fd04) | ~27.8 s | 6.0 s | 34.4 s |
| this PR | 25.5 s ± 1.9 | 6.05 s | 32.5 s |
| pnpm v11.2.1 | 20.9 s ± 1.7 | 7.4 s | 18.5 s |

Best pacquet run dropped from ~28 s to 23.2 s, ~10 % improvement on the median.

This **doesn't** close the gap to pnpm. The remaining ~20 % is dominated by sys-time in `clonefileat` — pacquet issues roughly twice the kernel time per file as pnpm does, plausibly because pacquet has ~20 concurrent threads contending for the APFS metadata journal where pnpm's libuv pool is bounded to 4. The rayon-pool-size knob discussed in #11851 helps on bigger hosts but regresses 23.95 s → 27.67 s on this 10-core machine, so I left the default alone; the `RAYON_NUM_THREADS` escape hatch still lets users on bigger hosts tune it.

## Test plan

- [x] \`cargo nextest run -p pacquet-fs -p pacquet-store-dir -p pacquet-tarball\` (382 tests pass)
- [x] \`cargo nextest run -p pacquet-package-manager\` (298 tests pass)
- [x] \`cargo clippy --locked --workspace --all-targets -- --deny warnings\` clean
- [x] Manual clean-install run against verdaccio mock on the bench fixture
- [ ] CI: \`just ready\` (delegated to CI)

---

Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * More efficient file locking for better concurrency (striped static locks)
  * Reduced memory allocations when constructing file hashes/paths
  * Cached file-store directory path for faster lookups

* **Bug Fixes**
  * Improved atomic import/creation path to handle races without failures

* **Documentation**
  * Clarified contributor guideline and updated comments to reflect current contracts

* **Tests**
  * Updated tests to align with new locking behavior

* **Chores**
  * Updated workspace dependency list (one dependency replaced)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->