### PR TITLE
fix(workspace.projects-reader): point resolutions warning at pnpm-workspace.yaml overrides

### DIFF
--- a/.changeset/fix-resolutions-warning-message.md
+++ b/.changeset/fix-resolutions-warning-message.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.projects-reader": patch
+pnpm: patch
+---
+
+The warning shown when a non-root workspace package contains a `"resolutions"` field now directs users to the correct fix for pnpm v11: the `"overrides"` field in `pnpm-workspace.yaml` at the workspace root. The previous message told users to "configure `resolutions` at the root of the workspace", which is no longer how pnpm wires version overrides. Fixes [#11757](https://github.com/pnpm/pnpm/issues/11757).

--- a/workspace/projects-reader/src/index.ts
+++ b/workspace/projects-reader/src/index.ts
@@ -59,20 +59,17 @@ export async function findWorkspaceProjectsNoCheck (workspaceRoot: string, opts?
   return projects
 }
 
-const uselessNonRootManifestFields: Array<keyof ProjectManifest> = ['resolutions']
+const uselessNonRootManifestFields = {
+  resolutions: 'Use the "overrides" field in pnpm-workspace.yaml at the root of the workspace instead.',
+} satisfies Partial<Record<keyof ProjectManifest, string>>
 
 function checkNonRootProjectManifest ({ manifest, rootDir }: Project): void {
-  const warn = printNonRootFieldWarning.bind(null, rootDir)
-  for (const field of uselessNonRootManifestFields) {
+  for (const [field, suggestion] of Object.entries(uselessNonRootManifestFields)) {
     if (field in manifest) {
-      warn(field)
+      logger.warn({
+        message: `The field "${field}" was found in ${rootDir}/package.json. This will not take effect. ${suggestion}`,
+        prefix: rootDir,
+      })
     }
   }
-}
-
-function printNonRootFieldWarning (prefix: string, propertyPath: string): void {
-  logger.warn({
-    message: `The field "${propertyPath}" was found in ${prefix}/package.json. This will not take effect. You should configure "${propertyPath}" at the root of the workspace instead.`,
-    prefix,
-  })
 }

--- a/workspace/projects-reader/test/index.ts
+++ b/workspace/projects-reader/test/index.ts
@@ -49,6 +49,6 @@ test('findWorkspaceProjects() outputs warnings for non-root workspace project', 
     jest.mocked(logger.warn).mock.calls
       .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
   ).toStrictEqual([
-    [{ prefix: barPath, message: `The field "resolutions" was found in ${barPath}/package.json. This will not take effect. You should configure "resolutions" at the root of the workspace instead.` }],
+    [{ prefix: barPath, message: `The field "resolutions" was found in ${barPath}/package.json. This will not take effect. Use the "overrides" field in pnpm-workspace.yaml at the root of the workspace instead.` }],
   ])
 })


### PR DESCRIPTION
## Summary

#11757 reports that the warning shown when a non-root workspace package contains a `"resolutions"` field is misleading on pnpm v11. The current message says:

> The field "resolutions" was found in <path>/package.json. This will not take effect. You should configure "resolutions" at the root of the workspace instead.

But pnpm v11 doesn't read `resolutions` at the workspace root either — version overrides are wired through the `"overrides"` field in `pnpm-workspace.yaml`. Following the warning's advice doesn't fix anything; users still have to discover the real mechanism on their own.

The maintainer ([@zkochan in #11757](https://github.com/pnpm/pnpm/issues/11757#issuecomment-3559430175)) confirmed: "pnpm uses the 'overrides' field in 'pnpm-workspace.yaml'."

## What changed

- `workspace/projects-reader/src/index.ts`
  - Convert `uselessNonRootManifestFields` from `Array<keyof ProjectManifest>` to a map of field → fix suggestion, so each useless field can carry its own correction instead of the warning template guessing one fix for all fields. Type-guarded with `satisfies Partial<Record<keyof ProjectManifest, string>>` so the keys are still checked against `ProjectManifest`.
  - Inline `printNonRootFieldWarning` — the helper was only called from one place and the new map shape gives the suggestion directly, so the extra indirection no longer pays for itself.
- `workspace/projects-reader/test/index.ts` — update the expected warning string to match.
- Changeset added (`patch` to `@pnpm/workspace.projects-reader` and `pnpm`).

## Test plan

- `pnpm exec tsgo --build` (in `workspace/projects-reader`) — clean
- `pnpm run lint` — clean
- Verified the emitted `lib/index.js` contains the new wording

Local Jest run on this machine has a pre-existing baseline failure ("module is already linked") that reproduces on stock `main` with no changes, so I haven't been able to confirm the updated assertion executes in-tree — but the expected string in `test/index.ts` matches the source string exactly, so CI should pick it up cleanly.

Fixes #11757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the warning message displayed when non-root workspace packages include a `resolutions` field. The warning now provides corrected guidance to use the `overrides` field in the workspace root `pnpm-workspace.yaml` configuration file for pnpm v11 compatibility.

* **Tests**
  * Updated test assertions to reflect the revised warning message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->