### PR TITLE
perf(pacquet): cache per-wanted resolves in resolve_dependency_tree

### DIFF
--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -177,8 +177,8 @@ pub(crate) fn importer_optional_dependency_names(manifest: &PackageManifest) -> 
 /// dep across revisits.
 ///
 /// `optional` is part of the key because the npm resolver's
-/// [`pick_package`] toggles between the abbreviated and full packument
-/// based on `wanted.optional` ([`pick_package.rs:391`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201)) —
+/// `pick_package` toggles between the abbreviated and full packument
+/// based on `wanted.optional` ([`pickPackage.ts:391`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201)) —
 /// caching by `(alias, bare_specifier)` alone would let an optional
 /// caller satisfy itself with a non-optional caller's abbreviated
 /// result, losing the `libc`/`cpu`/`os` filter inputs that mode
@@ -221,7 +221,7 @@ pub struct TreeCtx {
     /// re-enters the resolver chain. pacquet shortcuts at the layer
     /// above that (the wanted-dep edge) because a `(name, range)`
     /// pair that's already been resolved doesn't need
-    /// [`pick_package`]'s in-memory packument lookup, cache-key
+    /// `pick_package`'s in-memory packument lookup, cache-key
     /// formatting, or semver matching repeated. On the `alotta-files`
     /// fixture this collapses the ~3 redundant `resolver.resolve()`
     /// calls per package the tree walk used to drive into one.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -166,6 +166,31 @@ pub(crate) fn importer_optional_dependency_names(manifest: &PackageManifest) -> 
     manifest.dependencies([DependencyGroup::Optional]).map(|(name, _)| name.to_string()).collect()
 }
 
+/// Cache key for [`TreeCtx::resolved_by_wanted`].
+///
+/// The npm-shaped slice pacquet exposes today calls
+/// [`Resolver::resolve`] with only three [`WantedDependency`] fields
+/// populated — `alias`, `bare_specifier`, and `optional` (see the
+/// `WantedDependency` literals in [`extend_tree`] and the recursive
+/// arm of [`fn@resolve_node`]). Anything else stays at `Default::default()`,
+/// so a tuple over those three fields uniquely identifies a wanted
+/// dep across revisits.
+///
+/// `optional` is part of the key because the npm resolver's
+/// [`pick_package`] toggles between the abbreviated and full packument
+/// based on `wanted.optional` ([`pick_package.rs:391`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201)) —
+/// caching by `(alias, bare_specifier)` alone would let an optional
+/// caller satisfy itself with a non-optional caller's abbreviated
+/// result, losing the `libc`/`cpu`/`os` filter inputs that mode
+/// supplies.
+type WantedKey = (Option<String>, Option<String>, Option<bool>);
+
+/// One entry in [`TreeCtx::children_specs_by_id`] —
+/// `(child_alias, child_range, child_optional)` triples extracted from
+/// a resolved package's manifest's `dependencies` plus
+/// `optionalDependencies` sections.
+type ChildSpec = (String, String, bool);
+
 /// Mutable workspace for an in-flight tree walk. The orchestrator
 /// (`resolve_importer`) holds one of these across hoist iterations and
 /// extends it via [`extend_tree`] so newly-hoisted peer dependencies
@@ -185,6 +210,30 @@ pub struct TreeCtx {
     /// matched against at least one resolved package. Mirrors upstream's
     /// `ctx.appliedPatches`.
     applied_patches: Mutex<HashSet<String>>,
+    /// Memoised [`Resolver::resolve`] results keyed by the parts of
+    /// [`WantedDependency`] the npm slice actually populates (see
+    /// [`WantedKey`]).
+    ///
+    /// pnpm's `resolveDependencies` carries the equivalent skip via the
+    /// [`isNew` gate](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1584) —
+    /// the second time a `pkgIdWithPatchHash` is reached, the walker
+    /// reuses the existing `resolvedPkgsById` envelope and never
+    /// re-enters the resolver chain. pacquet shortcuts at the layer
+    /// above that (the wanted-dep edge) because a `(name, range)`
+    /// pair that's already been resolved doesn't need
+    /// [`pick_package`]'s in-memory packument lookup, cache-key
+    /// formatting, or semver matching repeated. On the `alotta-files`
+    /// fixture this collapses the ~3 redundant `resolver.resolve()`
+    /// calls per package the tree walk used to drive into one.
+    resolved_by_wanted:
+        Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
+    /// Cached `extract_children` output keyed by `pkgIdWithPatchHash`.
+    /// First visit walks the manifest's `dependencies` /
+    /// `optionalDependencies`; subsequent visits clone the `Arc` and
+    /// skip the JSON traversal. Paired with [`Self::resolved_by_wanted`]
+    /// so a revisit's per-call CPU is two HashMap lookups and an
+    /// `Arc::clone`.
+    children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
 }
 
 impl TreeCtx {
@@ -199,6 +248,8 @@ impl TreeCtx {
             policy_violations: Mutex::new(Vec::new()),
             patched_dependencies: None,
             applied_patches: Mutex::new(HashSet::new()),
+            resolved_by_wanted: Mutex::new(HashMap::new()),
+            children_specs_by_id: Mutex::new(HashMap::new()),
         }
     }
 
@@ -339,20 +390,44 @@ where
 {
     let current_is_optional = wanted.optional.unwrap_or(false) || parent_optional;
 
-    let result = resolver
-        .resolve(&wanted, &ctx.base_opts)
-        .await
-        .map_err(|err: ResolveError| ResolveDependencyTreeError::Resolve(err.to_string()))?;
-    let Some(result) = result else {
-        return Err(ResolveDependencyTreeError::SpecNotSupported {
-            specifier: render_specifier(&wanted),
-        });
+    // Memoise the per-wanted resolve. The first caller for a given
+    // `(alias, bare_specifier, optional)` runs the resolver chain and
+    // stores the `Arc<ResolveResult>` on `ctx.resolved_by_wanted`;
+    // every later caller for the same wanted dep clones the `Arc` and
+    // skips the chain entirely. Concurrent first-callers can both miss
+    // the cache and run `resolver.resolve` in parallel — the resolver's
+    // own per-cache-key semaphore (`pick_package::fetch_locker`)
+    // already coalesces those into a single network fetch, so the
+    // doubled work is bounded to in-memory packument lookups + semver
+    // matching, and the second to finish loses the `insert` race
+    // harmlessly (the entry holds an `Arc` to an equivalent
+    // `ResolveResult`).
+    let cache_key: WantedKey =
+        (wanted.alias.clone(), wanted.bare_specifier.clone(), wanted.optional);
+    let cached = lock_recoverable(&ctx.resolved_by_wanted).get(&cache_key).map(Arc::clone);
+    let result = match cached {
+        Some(result) => result,
+        None => {
+            let result =
+                resolver.resolve(&wanted, &ctx.base_opts).await.map_err(|err: ResolveError| {
+                    ResolveDependencyTreeError::Resolve(err.to_string())
+                })?;
+            let Some(result) = result else {
+                return Err(ResolveDependencyTreeError::SpecNotSupported {
+                    specifier: render_specifier(&wanted),
+                });
+            };
+            // Wrap in `Arc` once so the cache, the per-id
+            // `ResolvedPackage` envelope, and the later peer-resolved
+            // graph node share one heap-allocated `ResolveResult`
+            // instead of cloning every `String` field per occurrence.
+            let result = Arc::new(result);
+            lock_recoverable(&ctx.resolved_by_wanted)
+                .entry(cache_key)
+                .or_insert_with(|| Arc::clone(&result));
+            result
+        }
     };
-    // Wrap in `Arc` once so the two store sites below (the per-id
-    // `ResolvedPackage` envelope and the later peer-resolved graph
-    // node) share one heap-allocated `ResolveResult` instead of
-    // cloning every `String` field per occurrence.
-    let result = Arc::new(result);
 
     if let Some(violation) = result.policy_violation.clone() {
         lock_recoverable(&ctx.policy_violations).push(violation);
@@ -429,14 +504,30 @@ where
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
 
-    let child_specs = extract_children(&result);
+    // Look up cached children specs first; only walk the manifest on
+    // a miss. The cache value is held by `Arc` so revisits clone the
+    // refcount instead of the inner `Vec<(String, String, bool)>`.
+    let child_specs = {
+        let cache = lock_recoverable(&ctx.children_specs_by_id);
+        cache.get(&id).map(Arc::clone)
+    };
+    let child_specs = match child_specs {
+        Some(specs) => specs,
+        None => {
+            let specs = Arc::new(extract_children(&result));
+            lock_recoverable(&ctx.children_specs_by_id)
+                .entry(id.clone())
+                .or_insert_with(|| Arc::clone(&specs));
+            specs
+        }
+    };
     let child_results = child_specs
-        .into_iter()
+        .iter()
         .map(|(child_name, child_range, child_optional)| {
             let child_wanted = WantedDependency {
-                alias: Some(child_name),
-                bare_specifier: Some(child_range),
-                optional: Some(child_optional),
+                alias: Some(child_name.clone()),
+                bare_specifier: Some(child_range.clone()),
+                optional: Some(*child_optional),
                 ..WantedDependency::default()
             };
             let next_ancestors = next_ancestors.clone();
@@ -589,9 +680,7 @@ fn render_specifier(wanted: &WantedDependency) -> String {
 /// `optionalDependencies`. The walker propagates this through
 /// `current_is_optional` so [`ResolvedPackage::optional`] reflects
 /// whether every path to the node went through an optional edge.
-fn extract_children(
-    result: &pacquet_resolving_resolver_base::ResolveResult,
-) -> Vec<(String, String, bool)> {
+fn extract_children(result: &pacquet_resolving_resolver_base::ResolveResult) -> Vec<ChildSpec> {
     let Some(manifest) = result.manifest.as_ref() else { return Vec::new() };
     let mut out = Vec::new();
     collect_deps(manifest, "dependencies", false, &mut out);
@@ -599,12 +688,7 @@ fn extract_children(
     out
 }
 
-fn collect_deps(
-    manifest: &Value,
-    key: &str,
-    optional: bool,
-    out: &mut Vec<(String, String, bool)>,
-) {
+fn collect_deps(manifest: &Value, key: &str, optional: bool, out: &mut Vec<ChildSpec>) {
     let Some(map) = manifest.get(key).and_then(Value::as_object) else { return };
     for (name, range) in map {
         if let Some(range_str) = range.as_str() {


### PR DESCRIPTION
Closes #11869.

## Summary

`resolve_node` in `resolve_dependency_tree.rs` re-entered the resolver chain for every parent edge that reached a given package — on a typical npm graph (~1 300 unique packages with avg ~3 incoming paths), that's ~3× more `pick_package` calls than necessary. This PR memoises the two per-edge bits of work that don't depend on the visitor's ancestor chain:

- **`resolved_by_wanted: Mutex<HashMap<(alias, bare_specifier, optional), Arc<ResolveResult>>>`** — first caller for a given wanted dep runs the resolver chain; later callers clone the `Arc` and skip `pick_package`'s cache-key formatting, `HashMap` probing, and per-call semver matching. `optional` is part of the key because the npm resolver toggles between abbreviated and full packument based on `wanted.optional` ([`pickPackage.ts:201`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L201)), so a non-optional caller's abbreviated entry can't satisfy an optional one.
- **`children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>`** — first visit walks the manifest for `dependencies` + `optionalDependencies` triples; later visits clone the `Arc` and skip the JSON traversal.

Per-occurrence `NodeId`s and the cycle-break gate are unchanged, so peer-suffix variants for non-leaf packages stay intact. The change mirrors pnpm's `resolveDependencies.ts` [`isNew` gate](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1584) at the wanted-dep edge — the layer pacquet's eager (non-lazy) tree builder can short-circuit without restructuring.

## Local benchmark numbers (macOS, virtual registry, alotta-files fixture)

`integrated-benchmark --scenario=clean-install --runs=8 --warmup=1`:

| target | mean | min | max |
|---|---:|---:|---:|
| `pacquet@HEAD~1` (#11867) | 12.397 s ± 1.883 s | 10.803 s | 15.880 s |
| `pacquet@HEAD` | **9.382 s ± 0.612 s** | 8.799 s | 10.816 s |

→ `pacquet@HEAD` is **1.32 × faster** (~24 % wall-time reduction).

`integrated-benchmark --scenario=full-resolution --runs=6 --warmup=1` (warm cache, isolates the resolve phase):

| target | wall | user CPU |
|---|---:|---:|
| `pacquet@HEAD~1` | 9.729 s ± 0.318 s | 4.479 s |
| `pacquet@HEAD` | **8.152 s ± 0.367 s** | **2.557 s** |

→ **1.19 × faster wall** (~16 %), but the headline is **−43 % user CPU** — confirms the redundant resolver-chain work is what disappeared.

These are macOS-local numbers and noisier than CI; the issue's 40–60 % resolve-wall estimate referred to the ubuntu-latest profile. CI's integrated-benchmark workflow will produce the comparable numbers against `main`.

## Why the conservative slice of the issue's proposal

[#11869](https://github.com/pnpm/pnpm/issues/11869) sketched two caches: `resolved_subtree_node_id` (collapses non-leaf `NodeId`s across occurrences) and `children_by_parent_id` (caches the resolved child list). The issue itself flagged the `NodeId` collapse as risky because pacquet's peer resolver memoises by `NodeId` and would lose per-occurrence peer-suffix variation if non-leaves collapsed — and pointed at the children-only cache as the fallback, "the win is still substantial because the recursive subtree walk is the dominant cost." This PR is that fallback shape, with `resolved_by_wanted` covering the resolver-chain reentry side (analogous to pnpm's `resolvedPkgsById` short-circuit at the same call site) and `children_specs_by_id` covering the children-extraction side. The `NodeId` collapse remains an open follow-up if profiling on CI shows it's needed.

## Test plan

- [x] `cargo nextest run -p pacquet-resolving-deps-resolver` — 50 tests pass (diamond, cycle, peer-variant, patched, optional-propagation scenarios all green)
- [x] `cargo nextest run -p pacquet-package-manager` — 298 tests pass
- [x] `cargo clippy -p pacquet-resolving-deps-resolver --all-targets -- --deny warnings` — clean
- [x] `just fmt` — clean
- [x] Integrated-benchmark locally on `clean-install` and `full-resolution` scenarios — numbers above
- [ ] CI integrated-benchmark workflow against `main` — will post when CI publishes

---

Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dependency-resolution performance by adding memoization to reuse resolver results and extracted child-dependency lists, reducing redundant work during dependency-tree traversal and lowering repeated manifest processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->