### PR TITLE
ci(bencher): record benchmark results to Bencher

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -123,7 +123,7 @@ jobs:
           --file "$BENCH_DIR/bencher-results.json"
           --github-actions "$GITHUB_TOKEN"
         )
-        if [ "$EVENT_NAME" = "push" ]; then
+        if [ "$EVENT_NAME" = "push" ] || [ "$REF_NAME" = "main" ]; then
           args+=(--branch main)
         elif [ -n "$INPUT_PR_NUMBER" ]; then
           args+=(--branch "pr/$INPUT_PR_NUMBER" --start-point main --start-point-reset)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,12 @@ on:
         required: false
         default: '1'
         type: string
+  push:
+    # Build Bencher's continuous baseline for the `pnpm` testbed.
+    # Every merge to main re-runs the bench so PR comparisons have
+    # an up-to-date reference; cancel-in-progress stays off below
+    # so we never throw away a partial run.
+    branches: [main]
 
 permissions:
   contents: read
@@ -79,6 +85,52 @@ jobs:
       env:
         RUNS: ${{ inputs.runs }}
         WARMUP: ${{ inputs.warmup }}
+
+    - name: Install Bencher CLI
+      if: steps.bench.outputs.bench_dir != ''
+      uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
+
+    - name: Upload results to Bencher
+      if: steps.bench.outputs.bench_dir != ''
+      env:
+        BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+        BENCH_DIR: ${{ steps.bench.outputs.bench_dir }}
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        REF_NAME: ${{ github.ref_name }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ -z "${BENCHER_API_TOKEN:-}" ]; then
+          echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
+          exit 0
+        fi
+        if [ ! -f "$BENCH_DIR/bencher-results.json" ]; then
+          echo "::warning::bencher-results.json not found, skipping upload"
+          exit 0
+        fi
+
+        # `bencher run --file` takes hyperfine JSON via the
+        # shell_hyperfine adapter. Branch policy:
+        # - push to main → record into the `main` branch (baseline)
+        # - workflow_dispatch with pr_number → record into `pr/<n>`,
+        #   forked from main at the latest baseline
+        # - workflow_dispatch without pr_number → record into the
+        #   ref's branch name (e.g. a feature branch), forked from main
+        args=(
+          --project pnpm
+          --testbed pnpm
+          --adapter shell_hyperfine
+          --file "$BENCH_DIR/bencher-results.json"
+          --github-actions "$GITHUB_TOKEN"
+        )
+        if [ "$EVENT_NAME" = "push" ]; then
+          args+=(--branch main)
+        elif [ -n "$INPUT_PR_NUMBER" ]; then
+          args+=(--branch "pr/$INPUT_PR_NUMBER" --start-point main --start-point-reset)
+        else
+          args+=(--branch "$REF_NAME" --start-point main --start-point-reset)
+        fi
+        bencher run "${args[@]}"
 
     - name: Comment on PR
       if: steps.bench.outputs.bench_dir != ''

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -131,3 +131,36 @@ jobs:
           edit-mode: replace
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body-file: benchmark-artifact/SUMMARY.md
+
+      - name: Install Bencher CLI
+        if: hashFiles('benchmark-artifact/bencher-results.json') != ''
+        uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
+
+      - name: Upload PR results to Bencher
+        # workflow_run runs in the base-repo privilege context, so
+        # BENCHER_API_TOKEN is available even for fork PRs. PR number
+        # comes from the trusted workflow_run payload (resolved in
+        # `meta` above), never from the artifact body. `--ci-number`
+        # is required here because Bencher can't infer the PR from a
+        # workflow_run event the way it does on pull_request.
+        if: hashFiles('benchmark-artifact/bencher-results.json') != ''
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+        shell: bash
+        run: |
+          if [ -z "${BENCHER_API_TOKEN:-}" ]; then
+            echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
+            exit 0
+          fi
+          bencher run \
+            --project pnpm \
+            --testbed pacquet \
+            --branch "pr/$PR_NUMBER" \
+            --start-point main \
+            --start-point-reset \
+            --adapter shell_hyperfine \
+            --file benchmark-artifact/bencher-results.json \
+            --ci-number "$PR_NUMBER" \
+            --github-actions "$GITHUB_TOKEN"

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -310,28 +310,35 @@ jobs:
           retention-days: 14
 
       - name: Install Bencher CLI
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
 
-      - name: Upload main baseline to Bencher
-        # Only runs on push to main — secrets are available in that
-        # context. PR runs (including from forks) upload via the
-        # workflow_run comment workflow, which executes in the base
-        # repo's privilege context.
-        if: github.event_name == 'push'
+      - name: Upload results to Bencher
+        # Runs on push and workflow_dispatch — both execute in the
+        # base-repo privilege context where secrets are available.
+        # PR runs (including from forks) skip this step and upload
+        # via the workflow_run comment workflow instead.
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         shell: bash
         run: |
           if [ -z "${BENCHER_API_TOKEN:-}" ]; then
             echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
             exit 0
           fi
-          bencher run \
-            --project pnpm \
-            --testbed pacquet \
-            --branch main \
-            --adapter shell_hyperfine \
-            --file bench-work-env/bencher-results.json \
+          args=(
+            --project pnpm
+            --testbed pacquet
+            --adapter shell_hyperfine
+            --file bench-work-env/bencher-results.json
             --github-actions "$GITHUB_TOKEN"
+          )
+          if [ "$REF_NAME" = "main" ]; then
+            args+=(--branch main)
+          else
+            args+=(--branch "$REF_NAME" --start-point main --start-point-reset)
+          fi
+          bencher run "${args[@]}"

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -156,7 +156,7 @@ jobs:
         timeout-minutes: 15
         run: just integrated-benchmark --build-only pacquet@HEAD pacquet@main
 
-      - name: 'Benchmark: Frozen Lockfile'
+      - name: 'Benchmark: Fresh restore, cold cache + cold store, isolated linker'
         shell: bash
         # Hyperfine has no per-command timeout, so a single hanging
         # install takes the whole step down with the GHA default job
@@ -164,47 +164,45 @@ jobs:
         # headroom, and a failure surfaces fast enough to iterate on.
         timeout-minutes: 10
         run: |
-          just integrated-benchmark --scenario=frozen-lockfile --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
+          just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.json
 
-      - name: 'Benchmark: Frozen Lockfile (Hot Cache)'
+      - name: 'Benchmark: Fresh restore, hot cache + hot store, isolated linker'
         shell: bash
-        # Same timeout rationale as the cold-cache step above.
-        # Mirrors pnpm's "Headless install (frozen lockfile, warm
-        # store+cache)" benchmark: each timed run wipes only
-        # `node_modules`, the per-revision store survives, and
-        # hyperfine's warmup run is what populates it on the first
+        # Same timeout rationale as the cold-cache step above. Each
+        # timed run wipes only `node_modules`; the per-revision store
+        # survives, and hyperfine's warmup populates it on the first
         # iteration so timed runs all see a hot store.
         timeout-minutes: 10
         run: |
-          just integrated-benchmark --scenario=frozen-lockfile-hot-cache --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
+          just integrated-benchmark --scenario=fresh-restore-hot-cache-hot-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.json
 
-      - name: 'Benchmark: Clean Install'
+      - name: 'Benchmark: Fresh install, cold cache + cold store, isolated linker'
         shell: bash
         # No-lockfile scenario: pacquet does fresh resolution against
         # the registry, ~3-5x slower than pnpm on `alotta-files`
         # (pnpm/pnpm#11832), so a single iteration runs longer than
-        # the frozen-lockfile steps. 20 min leaves headroom for the
-        # default hyperfine 1 warmup + 10 timed runs across all three
+        # the restore steps. 20 min leaves headroom for the default
+        # hyperfine 1 warmup + 10 timed runs across all three
         # benchmark targets without losing the per-command timeout
         # safety net the other steps document.
         timeout-minutes: 20
         run: |
-          just integrated-benchmark --scenario=clean-install --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.json
+          just integrated-benchmark --scenario=fresh-install-cold-cache-cold-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.json
 
-      - name: 'Benchmark: Full Resolution'
+      - name: 'Benchmark: Fresh install, hot cache + hot store, isolated linker'
         shell: bash
-        # Same timeout rationale as the clean-install step above.
+        # Same timeout rationale as the cold-cache install step above.
         timeout-minutes: 20
         run: |
-          just integrated-benchmark --scenario=full-resolution --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FULL_RESOLUTION.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FULL_RESOLUTION.json
+          just integrated-benchmark --scenario=fresh-install-hot-cache-hot-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.json
 
       - name: Generate summary
         shell: bash
@@ -212,50 +210,50 @@ jobs:
           (
             echo '## Integrated-Benchmark Report (${{ runner.os }})'
             echo
-            echo '### Scenario: Frozen Lockfile'
+            echo '### Scenario: Fresh restore, cold cache + cold store, isolated linker'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.md
+            cat bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Frozen Lockfile (Hot Cache)'
+            echo '### Scenario: Fresh restore, hot cache + hot store, isolated linker'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.md
+            cat bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FROZEN_LOCKFILE_HOT_CACHE.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Clean Install'
+            echo '### Scenario: Fresh install, cold cache + cold store, isolated linker'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.md
+            cat bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_CLEAN_INSTALL.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Full Resolution'
+            echo '### Scenario: Fresh install, hot cache + hot store, isolated linker'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FULL_RESOLUTION.md
+            cat bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FULL_RESOLUTION.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.json
             echo '```'
             echo
             echo '</details>'
@@ -270,10 +268,10 @@ jobs:
         shell: bash
         run: |
           scenarios=(
-            'FROZEN_LOCKFILE:frozen-lockfile'
-            'FROZEN_LOCKFILE_HOT_CACHE:frozen-lockfile-hot-cache'
-            'CLEAN_INSTALL:clean-install'
-            'FULL_RESOLUTION:full-resolution'
+            'FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED:fresh-restore-cold-cache-cold-store-isolated'
+            'FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED:fresh-restore-hot-cache-hot-store-isolated'
+            'FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED:fresh-install-cold-cache-cold-store-isolated'
+            'FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED:fresh-install-hot-cache-hot-store-isolated'
           )
           inputs=()
           for entry in "${scenarios[@]}"; do

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -156,7 +156,7 @@ jobs:
         timeout-minutes: 15
         run: just integrated-benchmark --build-only pacquet@HEAD pacquet@main
 
-      - name: 'Benchmark: Fresh restore, cold cache + cold store, isolated linker'
+      - name: 'Benchmark: Isolated linker: fresh restore, cold cache + cold store'
         shell: bash
         # Hyperfine has no per-command timeout, so a single hanging
         # install takes the whole step down with the GHA default job
@@ -164,11 +164,11 @@ jobs:
         # headroom, and a failure surfaces fast enough to iterate on.
         timeout-minutes: 10
         run: |
-          just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.json
+          just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
 
-      - name: 'Benchmark: Fresh restore, hot cache + hot store, isolated linker'
+      - name: 'Benchmark: Isolated linker: fresh restore, hot cache + hot store'
         shell: bash
         # Same timeout rationale as the cold-cache step above. Each
         # timed run wipes only `node_modules`; the per-revision store
@@ -176,11 +176,11 @@ jobs:
         # iteration so timed runs all see a hot store.
         timeout-minutes: 10
         run: |
-          just integrated-benchmark --scenario=fresh-restore-hot-cache-hot-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.json
+          just integrated-benchmark --scenario=isolated-linker.fresh-restore.hot-cache.hot-store --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
 
-      - name: 'Benchmark: Fresh install, cold cache + cold store, isolated linker'
+      - name: 'Benchmark: Isolated linker: fresh install, cold cache + cold store'
         shell: bash
         # No-lockfile scenario: pacquet does fresh resolution against
         # the registry, ~3-5x slower than pnpm on `alotta-files`
@@ -191,18 +191,18 @@ jobs:
         # safety net the other steps document.
         timeout-minutes: 20
         run: |
-          just integrated-benchmark --scenario=fresh-install-cold-cache-cold-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.json
+          just integrated-benchmark --scenario=isolated-linker.fresh-install.cold-cache.cold-store --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
 
-      - name: 'Benchmark: Fresh install, hot cache + hot store, isolated linker'
+      - name: 'Benchmark: Isolated linker: fresh install, hot cache + hot store'
         shell: bash
         # Same timeout rationale as the cold-cache install step above.
         timeout-minutes: 20
         run: |
-          just integrated-benchmark --scenario=fresh-install-hot-cache-hot-store-isolated --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
-          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.md
-          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.json
+          just integrated-benchmark --scenario=isolated-linker.fresh-install.hot-cache.hot-store --registry=verdaccio --with-pnpm pacquet@HEAD pacquet@main
+          cp bench-work-env/BENCHMARK_REPORT.md bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.md
+          cp bench-work-env/BENCHMARK_REPORT.json bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
 
       - name: Generate summary
         shell: bash
@@ -210,50 +210,50 @@ jobs:
           (
             echo '## Integrated-Benchmark Report (${{ runner.os }})'
             echo
-            echo '### Scenario: Fresh restore, cold cache + cold store, isolated linker'
+            echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.md
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Fresh restore, hot cache + hot store, isolated linker'
+            echo '### Scenario: Isolated linker: fresh restore, hot cache + hot store'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.md
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Fresh install, cold cache + cold store, isolated linker'
+            echo '### Scenario: Isolated linker: fresh install, cold cache + cold store'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.md
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE.json
             echo '```'
             echo
             echo '</details>'
             echo
-            echo '### Scenario: Fresh install, hot cache + hot store, isolated linker'
+            echo '### Scenario: Isolated linker: fresh install, hot cache + hot store'
             echo
-            cat bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.md
+            cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.md
             echo
             echo '<details><summary>BENCHMARK_REPORT.json</summary>'
             echo
             echo '```json'
-            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED.json
+            jq 'del(.results[].exit_codes)' bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE.json
             echo '```'
             echo
             echo '</details>'
@@ -268,10 +268,10 @@ jobs:
         shell: bash
         run: |
           scenarios=(
-            'FRESH_RESTORE_COLD_CACHE_COLD_STORE_ISOLATED:fresh-restore-cold-cache-cold-store-isolated'
-            'FRESH_RESTORE_HOT_CACHE_HOT_STORE_ISOLATED:fresh-restore-hot-cache-hot-store-isolated'
-            'FRESH_INSTALL_COLD_CACHE_COLD_STORE_ISOLATED:fresh-install-cold-cache-cold-store-isolated'
-            'FRESH_INSTALL_HOT_CACHE_HOT_STORE_ISOLATED:fresh-install-hot-cache-hot-store-isolated'
+            'ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE:isolated-linker.fresh-restore.cold-cache.cold-store'
+            'ISOLATED_FRESH_RESTORE_HOT_CACHE_HOT_STORE:isolated-linker.fresh-restore.hot-cache.hot-store'
+            'ISOLATED_FRESH_INSTALL_COLD_CACHE_COLD_STORE:isolated-linker.fresh-install.cold-cache.cold-store'
+            'ISOLATED_FRESH_INSTALL_HOT_CACHE_HOT_STORE:isolated-linker.fresh-install.hot-cache.hot-store'
           )
           inputs=()
           for entry in "${scenarios[@]}"; do

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -2,6 +2,25 @@ name: Pacquet Integrated-Benchmark
 
 on:
   workflow_dispatch:
+  push:
+    # Update Bencher's baseline for the `pacquet` testbed whenever
+    # something that could move pacquet's install perf lands on main.
+    # Paths mirror the pull_request filter below.
+    branches: [main]
+    paths:
+      - 'pacquet/**/*.rs'
+      - 'pacquet/**/Cargo.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'justfile'
+      - 'pacquet/tasks/registry-mock/package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'pacquet/tasks/integrated-benchmark/src/fixtures/**'
+      - '.github/actions/rustup/**'
+      - '.github/actions/binstall/**'
+      - '.github/workflows/pacquet-integrated-benchmark.yml'
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -242,15 +261,45 @@ jobs:
             echo '</details>'
           ) > bench-work-env/SUMMARY.md
 
+      - name: Build Bencher-shaped report
+        # Combine the four scenario JSONs into one hyperfine-shaped
+        # file that Bencher's shell_hyperfine adapter accepts. We
+        # keep only the @HEAD result from each scenario and rename
+        # `.command` to the scenario name, so Bencher names the
+        # benchmark after the scenario instead of `pacquet@HEAD`.
+        shell: bash
+        run: |
+          scenarios=(
+            'FROZEN_LOCKFILE:frozen-lockfile'
+            'FROZEN_LOCKFILE_HOT_CACHE:frozen-lockfile-hot-cache'
+            'CLEAN_INSTALL:clean-install'
+            'FULL_RESOLUTION:full-resolution'
+          )
+          inputs=()
+          for entry in "${scenarios[@]}"; do
+            file_tag="${entry%%:*}"
+            name="${entry#*:}"
+            src="bench-work-env/BENCHMARK_REPORT_${file_tag}.json"
+            dst="bench-work-env/${name}-bencher.json"
+            jq --arg s "$name" \
+              '.results |= [.[] | select(.command == "pacquet@HEAD") | .command = $s]' \
+              "$src" > "$dst"
+            inputs+=("$dst")
+          done
+          jq -s '{results: map(.results) | add}' \
+            "${inputs[@]}" > bench-work-env/bencher-results.json
+
       - name: Stage artifact contents
-        # The artifact carries only the rendered report. The PR number
-        # and runner OS are derived from the trusted workflow_run
-        # event payload in the comment-posting workflow, not from
-        # fork-controlled artifact contents.
+        # The artifact carries the rendered report plus the
+        # Bencher-shaped JSON consumed by the comment-posting
+        # workflow. The PR number and runner OS are derived from the
+        # trusted workflow_run event payload in that workflow, not
+        # from fork-controlled artifact contents.
         shell: bash
         run: |
           mkdir -p benchmark-artifact
           cp bench-work-env/SUMMARY.md benchmark-artifact/SUMMARY.md
+          cp bench-work-env/bencher-results.json benchmark-artifact/bencher-results.json
 
       - name: Upload benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -259,3 +308,30 @@ jobs:
           path: benchmark-artifact/
           if-no-files-found: error
           retention-days: 14
+
+      - name: Install Bencher CLI
+        if: github.event_name == 'push'
+        uses: bencherdev/bencher@50fb1e138651a46d2fb704fab1adab38c181552e # v0.6.6
+
+      - name: Upload main baseline to Bencher
+        # Only runs on push to main — secrets are available in that
+        # context. PR runs (including from forks) upload via the
+        # workflow_run comment workflow, which executes in the base
+        # repo's privilege context.
+        if: github.event_name == 'push'
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "${BENCHER_API_TOKEN:-}" ]; then
+            echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
+            exit 0
+          fi
+          bencher run \
+            --project pnpm \
+            --testbed pacquet \
+            --branch main \
+            --adapter shell_hyperfine \
+            --file bench-work-env/bencher-results.json \
+            --github-actions "$GITHUB_TOKEN"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,19 +41,23 @@ The script:
 
 ## Scenarios
 
-Every scenario starts with `node_modules` wiped — "Fresh" names that
-target state. The `nodeLinker` mode is `isolated` in all six; future
-scenarios will introduce `hoisted` / `pnp` variants and counterparts
-that begin with a populated `node_modules`.
+Slugs follow `<linker>.<action>.<cache state>.<store state>` so the
+leading segment groups runs by linker mode. Today there are two
+groups (`isolated-linker.*` and `gvs-linker.*`); future scenarios
+will add `hoisted-linker.*` and `pnp-linker.*`.
+
+Every current scenario starts with `node_modules` wiped — "fresh"
+names that target state; future variants that begin with a populated
+`node_modules` will use a different action prefix.
 
 | # | Slug | Lockfile | Cache | Store | Description |
 |---|---|---|---|---|---|
-| 1 | `fresh-restore-hot-cache-hot-store-isolated` | ✔ frozen | hot | hot | Restore from lockfile with both directories warm (repeat-headless shape) |
-| 2 | `fresh-add-dep-hot-cache-hot-store-isolated` | ✔ + add dep | hot | hot | `pnpm add <dep>` against an existing lockfile |
-| 3 | `fresh-install-hot-cache-hot-store-isolated` | ✗ | hot | hot | Resolve from scratch with both directories warm |
-| 4 | `fresh-restore-cold-cache-cold-store-isolated` | ✔ frozen | cold | cold | Restore from lockfile with cold disks (typical CI shape) |
-| 5 | `fresh-install-cold-cache-cold-store-isolated` | ✗ | cold | cold | True cold start — no lockfile, nothing cached |
-| 6 | `fresh-restore-hot-cache-hot-store-isolated-gvs` | ✔ frozen | hot | hot + GVS | Frozen-lockfile restore with `enableGlobalVirtualStore: true`, pre-warmed GVS |
+| 1 | `isolated-linker.fresh-restore.hot-cache.hot-store` | ✔ frozen | hot | hot | Restore from lockfile with both directories hot (repeat-headless shape) |
+| 2 | `isolated-linker.fresh-add-dep.hot-cache.hot-store` | ✔ + add dep | hot | hot | `pnpm add <dep>` against an existing lockfile |
+| 3 | `isolated-linker.fresh-install.hot-cache.hot-store` | ✗ | hot | hot | Resolve from scratch with both directories hot |
+| 4 | `isolated-linker.fresh-restore.cold-cache.cold-store` | ✔ frozen | cold | cold | Restore from lockfile with cold disks (typical CI shape) |
+| 5 | `isolated-linker.fresh-install.cold-cache.cold-store` | ✗ | cold | cold | True cold start — no lockfile, nothing cached |
+| 6 | `gvs-linker.fresh-restore.hot-cache.hot-store` | ✔ frozen | hot | hot + GVS | Frozen-lockfile restore with `enableGlobalVirtualStore: true`, pre-warmed GVS |
 
 All scenarios use `--ignore-scripts` and isolated store/cache directories per revision.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,6 +34,10 @@ The script:
 4. Writes a per-scenario `BENCHMARK_REPORT.md` / `.json` and a
    consolidated `results.md` into the temp work-env. The path is printed
    at the end of the run.
+5. Emits `bencher-results.json` — a hyperfine-shaped file with one
+   result per scenario (the `@HEAD` revision only, `command` renamed to
+   the scenario name) that the `Benchmarks` GitHub Actions workflow
+   uploads to [Bencher](https://bencher.dev) for continuous tracking.
 
 ## Scenarios
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,14 +41,19 @@ The script:
 
 ## Scenarios
 
-| # | Name (orchestrator) | Lockfile | Store + Cache | Description |
-|---|---|---|---|---|
-| 1 | `frozen-lockfile-hot-cache` | ✔ frozen | warm | Headless install (repeat install with warm store) |
-| 2 | `peek` | ✔ + add dep | warm | Re-resolution: add a new dep to an existing lockfile |
-| 3 | `full-resolution` | ✗ | warm | Resolve everything from scratch with warm cache |
-| 4 | `frozen-lockfile` | ✔ frozen | cold | Typical CI install — fetch all packages with lockfile |
-| 5 | `clean-install` | ✗ | cold | True cold start — nothing cached |
-| 6 | `gvs-warm` | ✔ frozen | warm + GVS | GVS warm reinstall (frozen lockfile, warm global virtual store) |
+Every scenario starts with `node_modules` wiped — "Fresh" names that
+target state. The `nodeLinker` mode is `isolated` in all six; future
+scenarios will introduce `hoisted` / `pnp` variants and counterparts
+that begin with a populated `node_modules`.
+
+| # | Slug | Lockfile | Cache | Store | Description |
+|---|---|---|---|---|---|
+| 1 | `fresh-restore-hot-cache-hot-store-isolated` | ✔ frozen | hot | hot | Restore from lockfile with both directories warm (repeat-headless shape) |
+| 2 | `fresh-add-dep-hot-cache-hot-store-isolated` | ✔ + add dep | hot | hot | `pnpm add <dep>` against an existing lockfile |
+| 3 | `fresh-install-hot-cache-hot-store-isolated` | ✗ | hot | hot | Resolve from scratch with both directories warm |
+| 4 | `fresh-restore-cold-cache-cold-store-isolated` | ✔ frozen | cold | cold | Restore from lockfile with cold disks (typical CI shape) |
+| 5 | `fresh-install-cold-cache-cold-store-isolated` | ✗ | cold | cold | True cold start — no lockfile, nothing cached |
+| 6 | `fresh-restore-hot-cache-hot-store-isolated-gvs` | ✔ frozen | hot | hot + GVS | Frozen-lockfile restore with `enableGlobalVirtualStore: true`, pre-warmed GVS |
 
 All scenarios use `--ignore-scripts` and isolated store/cache directories per revision.
 

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -121,6 +121,23 @@ for entry in "${SCENARIOS[@]}"; do
   i=$((i + 1))
 done
 
+# Combine the per-scenario hyperfine JSONs into one Bencher-shaped
+# report. Keep only the @HEAD result from each scenario and rename
+# `.command` to the scenario name so Bencher's shell_hyperfine adapter
+# names the benchmark after the scenario instead of `pnpm@HEAD`.
+if command -v jq >/dev/null; then
+  bencher_inputs=()
+  for entry in "${SCENARIOS[@]}"; do
+    scenario="${entry%%:*}"
+    jq --arg s "$scenario" \
+      '.results |= [.[] | select(.command == "pnpm@HEAD") | .command = $s]' \
+      "$BENCH_DIR/${scenario}.json" > "$BENCH_DIR/${scenario}-bencher.json"
+    bencher_inputs+=("$BENCH_DIR/${scenario}-bencher.json")
+  done
+  jq -s '{results: map(.results) | add}' \
+    "${bencher_inputs[@]}" > "$BENCH_DIR/bencher-results.json"
+fi
+
 echo
 echo "━━━ Results ━━━"
 cat "$results_md"

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -49,12 +49,12 @@ fi
 # `nodeLinker` mode; alternatives (`hoisted`, `pnp`) and populated-
 # node_modules counterparts are reserved for future scenarios.
 SCENARIOS=(
-  "fresh-restore-hot-cache-hot-store-isolated:Fresh restore, hot cache + hot store, isolated linker"
-  "fresh-add-dep-hot-cache-hot-store-isolated:Fresh add new dep, hot cache + hot store, isolated linker"
-  "fresh-install-hot-cache-hot-store-isolated:Fresh install, hot cache + hot store, isolated linker"
-  "fresh-restore-cold-cache-cold-store-isolated:Fresh restore, cold cache + cold store, isolated linker"
-  "fresh-install-cold-cache-cold-store-isolated:Fresh install, cold cache + cold store, isolated linker"
-  "fresh-restore-hot-cache-hot-store-isolated-gvs:Fresh restore, hot cache + hot store + GVS, isolated linker"
+  "isolated-linker.fresh-restore.hot-cache.hot-store:Isolated linker: fresh restore, hot cache + hot store"
+  "isolated-linker.fresh-add-dep.hot-cache.hot-store:Isolated linker: fresh add new dep, hot cache + hot store"
+  "isolated-linker.fresh-install.hot-cache.hot-store:Isolated linker: fresh install, hot cache + hot store"
+  "isolated-linker.fresh-restore.cold-cache.cold-store:Isolated linker: fresh restore, cold cache + cold store"
+  "isolated-linker.fresh-install.cold-cache.cold-store:Isolated linker: fresh install, cold cache + cold store"
+  "gvs-linker.fresh-restore.hot-cache.hot-store:GVS linker: fresh restore, hot cache + hot store"
 )
 
 # Pre-build both revisions once. Subsequent scenario invocations still

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -42,15 +42,19 @@ if ! git -C "$REPO_ROOT" rev-parse --verify --quiet refs/heads/main >/dev/null; 
   git -C "$REPO_ROOT" fetch --no-tags origin main:main
 fi
 
-# Scenario list mirrors bench.sh's original six. Order = the order they
-# were measured before; `generate-results.js` used this same order.
+# Scenario list: `slug:Display label`. The slug matches the
+# orchestrator's `--scenario` value (the clap-derived kebab-case name
+# from `BenchmarkScenario`). All six start with `node_modules` wiped
+# — "Fresh" names that target state. "Isolated linker" names the
+# `nodeLinker` mode; alternatives (`hoisted`, `pnp`) and populated-
+# node_modules counterparts are reserved for future scenarios.
 SCENARIOS=(
-  "frozen-lockfile-hot-cache:Headless (warm store+cache)"
-  "peek:Re-resolution (add dep, warm)"
-  "full-resolution:Full resolution (warm, no lockfile)"
-  "frozen-lockfile:Headless (cold store+cache)"
-  "clean-install:Cold install (nothing warm)"
-  "gvs-warm:GVS warm reinstall (warm global store)"
+  "fresh-restore-hot-cache-hot-store-isolated:Fresh restore, hot cache + hot store, isolated linker"
+  "fresh-add-dep-hot-cache-hot-store-isolated:Fresh add new dep, hot cache + hot store, isolated linker"
+  "fresh-install-hot-cache-hot-store-isolated:Fresh install, hot cache + hot store, isolated linker"
+  "fresh-restore-cold-cache-cold-store-isolated:Fresh restore, cold cache + cold store, isolated linker"
+  "fresh-install-cold-cache-cold-store-isolated:Fresh install, cold cache + cold store, isolated linker"
+  "fresh-restore-hot-cache-hot-store-isolated-gvs:Fresh restore, hot cache + hot store + GVS, isolated linker"
 )
 
 # Pre-build both revisions once. Subsequent scenario invocations still

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -136,6 +136,8 @@ if command -v jq >/dev/null; then
   done
   jq -s '{results: map(.results) | add}' \
     "${bencher_inputs[@]}" > "$BENCH_DIR/bencher-results.json"
+else
+  echo "warning: jq not on PATH; skipping bencher-results.json generation" >&2
 fi
 
 echo

--- a/pacquet/CONTRIBUTING.md
+++ b/pacquet/CONTRIBUTING.md
@@ -140,22 +140,22 @@ Then use the `integrated-benchmark` task to run benchmarks. For example:
 
 ```sh
 # Compare the branch you are working on against main
-just integrated-benchmark --scenario=frozen-lockfile pacquet@my-branch pacquet@main
+just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated pacquet@my-branch pacquet@main
 ```
 
 ```sh
 # Compare the current commit against the previous commit
-just integrated-benchmark --scenario=frozen-lockfile pacquet@HEAD pacquet@HEAD~
+just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated pacquet@HEAD pacquet@HEAD~
 ```
 
 ```sh
 # Compare pacquet of the current commit against pnpm
-just integrated-benchmark --scenario=frozen-lockfile --with-pnpm pacquet@HEAD
+just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --with-pnpm pacquet@HEAD
 ```
 
 ```sh
 # Compare pacquet of the current commit, pacquet of main, and pnpm against each other
-just integrated-benchmark --scenario=frozen-lockfile --with-pnpm pacquet@HEAD pacquet@main
+just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --with-pnpm pacquet@HEAD pacquet@main
 ```
 
 ```sh

--- a/pacquet/CONTRIBUTING.md
+++ b/pacquet/CONTRIBUTING.md
@@ -140,22 +140,22 @@ Then use the `integrated-benchmark` task to run benchmarks. For example:
 
 ```sh
 # Compare the branch you are working on against main
-just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated pacquet@my-branch pacquet@main
+just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store pacquet@my-branch pacquet@main
 ```
 
 ```sh
 # Compare the current commit against the previous commit
-just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated pacquet@HEAD pacquet@HEAD~
+just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store pacquet@HEAD pacquet@HEAD~
 ```
 
 ```sh
 # Compare pacquet of the current commit against pnpm
-just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --with-pnpm pacquet@HEAD
+just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --with-pnpm pacquet@HEAD
 ```
 
 ```sh
 # Compare pacquet of the current commit, pacquet of main, and pnpm against each other
-just integrated-benchmark --scenario=fresh-restore-cold-cache-cold-store-isolated --with-pnpm pacquet@HEAD pacquet@main
+just integrated-benchmark --scenario=isolated-linker.fresh-restore.cold-cache.cold-store --with-pnpm pacquet@HEAD pacquet@main
 ```
 
 ```sh

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -98,20 +98,32 @@ pub enum RegistryMode {
     Virtual,
 }
 
+/// Every variant starts with `node_modules` wiped — "fresh" describes
+/// that target state. Future scenarios that begin with a populated
+/// `node_modules` will drop the prefix (or pick a different one).
+/// "Isolated" names the `nodeLinker` mode; alternatives like `hoisted`
+/// or `pnp` will land as separate variants.
+//
+// `enum_variant_names` triggers because every variant currently shares
+// the `Fresh` prefix. That prefix is the load-bearing differentiator
+// against the future `Filled*` / `Resynced*` variants whose
+// `node_modules` is populated at start; the lint will stop firing once
+// those land.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum BenchmarkScenario {
-    /// Clean install: no lockfile, cold cache.
-    CleanInstall,
-    /// Frozen lockfile, cold cache.
-    FrozenLockfile,
-    /// Frozen lockfile, warm cache.
-    FrozenLockfileHotCache,
-    /// Re-resolution: add a dep to an existing lockfile, warm cache.
-    Peek,
-    /// Full resolution without a lockfile, warm cache.
-    FullResolution,
-    /// GVS warm reinstall: frozen lockfile, warm GVS.
-    GvsWarm,
+    /// No lockfile, cold cache. Mirrors `pnpm install` with nothing on disk.
+    FreshInstallColdCacheColdStoreIsolated,
+    /// No lockfile, warm cache. Resolves everything against an already-populated store.
+    FreshInstallHotCacheHotStoreIsolated,
+    /// Frozen lockfile, cold cache. The typical CI shape.
+    FreshRestoreColdCacheColdStoreIsolated,
+    /// Frozen lockfile, warm cache. The repeat-headless-install shape.
+    FreshRestoreHotCacheHotStoreIsolated,
+    /// `pnpm add <dep>` against an existing lockfile, warm cache.
+    FreshAddDepHotCacheHotStoreIsolated,
+    /// Frozen lockfile, warm cache, `enableGlobalVirtualStore: true` with a pre-warmed GVS.
+    FreshRestoreHotCacheHotStoreIsolatedGvs,
 }
 
 /// Per-iteration cleanup applied by hyperfine's `--prepare`.
@@ -128,11 +140,12 @@ impl BenchmarkScenario {
     /// element (`install` or `add`), followed by any flags.
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
-            BenchmarkScenario::CleanInstall | BenchmarkScenario::FullResolution => &["install"],
-            BenchmarkScenario::FrozenLockfile
-            | BenchmarkScenario::FrozenLockfileHotCache
-            | BenchmarkScenario::GvsWarm => &["install", "--frozen-lockfile"],
-            BenchmarkScenario::Peek => &["add", "is-odd"],
+            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated
+            | BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => &["install"],
+            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated
+            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated
+            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => &["install", "--frozen-lockfile"],
+            BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated => &["add", "is-odd"],
         }
     }
 
@@ -146,18 +159,18 @@ impl BenchmarkScenario {
     /// value up regardless of which config source it prefers.
     pub fn lockfile_enabled(self) -> bool {
         match self {
-            BenchmarkScenario::CleanInstall | BenchmarkScenario::FullResolution => false,
-            BenchmarkScenario::FrozenLockfile
-            | BenchmarkScenario::FrozenLockfileHotCache
-            | BenchmarkScenario::Peek
-            | BenchmarkScenario::GvsWarm => true,
+            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated
+            | BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => false,
+            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated
+            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated
+            | BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated
+            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => true,
         }
     }
 
     /// Whether to seed a `pnpm-lock.yaml` into the bench dir during
-    /// init. Scenarios that start without a lockfile (`CleanInstall`,
-    /// `FullResolution`) skip this; scenarios that consume a lockfile
-    /// or mutate one (`Peek`, the frozen variants, `GvsWarm`) need it.
+    /// init. The two install variants skip this; the restore, add-dep,
+    /// and GVS variants need it.
     pub fn lockfile<Text, LoadLockfile>(self, load_lockfile: LoadLockfile) -> Option<String>
     where
         Text: Into<String>,
@@ -172,25 +185,25 @@ impl BenchmarkScenario {
         const SAVED_LOCKFILE: (&str, &str) = ("pnpm-lock.yaml", ".saved-pnpm-lock.yaml");
         const SAVED_PACKAGE_JSON: (&str, &str) = ("package.json", ".saved-package.json");
         match self {
-            BenchmarkScenario::CleanInstall => Cleanup {
+            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated => Cleanup {
                 remove: &["node_modules", "pnpm-lock.yaml", "store-dir"],
                 restore: &[SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::FrozenLockfile => {
+            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated => {
                 Cleanup { remove: &["node_modules", "store-dir"], restore: &[SAVED_LOCKFILE] }
             }
-            BenchmarkScenario::FrozenLockfileHotCache => {
+            BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
-            BenchmarkScenario::Peek => Cleanup {
+            BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated => Cleanup {
                 remove: &["node_modules"],
                 restore: &[SAVED_LOCKFILE, SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::FullResolution => Cleanup {
+            BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => Cleanup {
                 remove: &["node_modules", "pnpm-lock.yaml"],
                 restore: &[SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::GvsWarm => {
+            BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
         }
@@ -200,7 +213,7 @@ impl BenchmarkScenario {
     /// in the workspace manifest, and a pre-warm pass that primes the
     /// store before hyperfine's warmup runs.
     pub fn enables_gvs(self) -> bool {
-        matches!(self, BenchmarkScenario::GvsWarm)
+        matches!(self, BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs)
     }
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -98,32 +98,40 @@ pub enum RegistryMode {
     Virtual,
 }
 
-/// Every variant starts with `node_modules` wiped — "fresh" describes
-/// that target state. Future scenarios that begin with a populated
-/// `node_modules` will drop the prefix (or pick a different one).
-/// "Isolated" names the `nodeLinker` mode; alternatives like `hoisted`
-/// or `pnp` will land as separate variants.
+/// Slug shape: `<linker>.<action>.<cache state>.<store state>`. Dots
+/// separate the four axes that the bench varies, so charts and
+/// dashboards can group by leading segment (`isolated-linker.*`,
+/// `gvs-linker.*`, future `hoisted-linker.*` / `pnp-linker.*`).
+///
+/// Every current variant starts with `node_modules` wiped — "fresh"
+/// names that target state; future variants that begin with a
+/// populated `node_modules` will use a different action prefix.
 //
-// `enum_variant_names` triggers because every variant currently shares
-// the `Fresh` prefix. That prefix is the load-bearing differentiator
-// against the future `Filled*` / `Resynced*` variants whose
-// `node_modules` is populated at start; the lint will stop firing once
-// those land.
+// Five of six variants share the `Isolated` prefix today; the lint
+// will stop firing once the `Hoisted*` and `Pnp*` linker buckets land.
+// Keeping the prefix is intentional — it mirrors the slug's leading
+// segment and makes the linker grouping legible in code.
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum BenchmarkScenario {
-    /// No lockfile, cold cache. Mirrors `pnpm install` with nothing on disk.
-    FreshInstallColdCacheColdStoreIsolated,
-    /// No lockfile, warm cache. Resolves everything against an already-populated store.
-    FreshInstallHotCacheHotStoreIsolated,
-    /// Frozen lockfile, cold cache. The typical CI shape.
-    FreshRestoreColdCacheColdStoreIsolated,
-    /// Frozen lockfile, warm cache. The repeat-headless-install shape.
-    FreshRestoreHotCacheHotStoreIsolated,
-    /// `pnpm add <dep>` against an existing lockfile, warm cache.
-    FreshAddDepHotCacheHotStoreIsolated,
-    /// Frozen lockfile, warm cache, `enableGlobalVirtualStore: true` with a pre-warmed GVS.
-    FreshRestoreHotCacheHotStoreIsolatedGvs,
+    /// No lockfile, cold cache + cold store. Mirrors `pnpm install` with nothing on disk.
+    #[value(name = "isolated-linker.fresh-install.cold-cache.cold-store")]
+    IsolatedFreshInstallColdCacheColdStore,
+    /// No lockfile, hot cache + hot store. Resolves everything against an already-populated store.
+    #[value(name = "isolated-linker.fresh-install.hot-cache.hot-store")]
+    IsolatedFreshInstallHotCacheHotStore,
+    /// Frozen lockfile, cold cache + cold store. The typical CI shape.
+    #[value(name = "isolated-linker.fresh-restore.cold-cache.cold-store")]
+    IsolatedFreshRestoreColdCacheColdStore,
+    /// Frozen lockfile, hot cache + hot store. The repeat-headless-install shape.
+    #[value(name = "isolated-linker.fresh-restore.hot-cache.hot-store")]
+    IsolatedFreshRestoreHotCacheHotStore,
+    /// `pnpm add <dep>` against an existing lockfile, hot cache + hot store.
+    #[value(name = "isolated-linker.fresh-add-dep.hot-cache.hot-store")]
+    IsolatedFreshAddDepHotCacheHotStore,
+    /// Frozen lockfile, hot cache + hot store, `enableGlobalVirtualStore: true` with a pre-warmed GVS.
+    #[value(name = "gvs-linker.fresh-restore.hot-cache.hot-store")]
+    GvsFreshRestoreHotCacheHotStore,
 }
 
 /// Per-iteration cleanup applied by hyperfine's `--prepare`.
@@ -140,12 +148,12 @@ impl BenchmarkScenario {
     /// element (`install` or `add`), followed by any flags.
     pub fn install_args(self) -> &'static [&'static str] {
         match self {
-            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated
-            | BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => &["install"],
-            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated
-            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated
-            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => &["install", "--frozen-lockfile"],
-            BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated => &["add", "is-odd"],
+            BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore => &["install"],
+            BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
+            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => &["install", "--frozen-lockfile"],
+            BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => &["add", "is-odd"],
         }
     }
 
@@ -159,12 +167,12 @@ impl BenchmarkScenario {
     /// value up regardless of which config source it prefers.
     pub fn lockfile_enabled(self) -> bool {
         match self {
-            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated
-            | BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => false,
-            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated
-            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated
-            | BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated
-            | BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => true,
+            BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore => false,
+            BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
+            | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
+            | BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore
+            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => true,
         }
     }
 
@@ -185,25 +193,25 @@ impl BenchmarkScenario {
         const SAVED_LOCKFILE: (&str, &str) = ("pnpm-lock.yaml", ".saved-pnpm-lock.yaml");
         const SAVED_PACKAGE_JSON: (&str, &str) = ("package.json", ".saved-package.json");
         match self {
-            BenchmarkScenario::FreshInstallColdCacheColdStoreIsolated => Cleanup {
+            BenchmarkScenario::IsolatedFreshInstallColdCacheColdStore => Cleanup {
                 remove: &["node_modules", "pnpm-lock.yaml", "store-dir"],
                 restore: &[SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::FreshRestoreColdCacheColdStoreIsolated => {
+            BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore => {
                 Cleanup { remove: &["node_modules", "store-dir"], restore: &[SAVED_LOCKFILE] }
             }
-            BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolated => {
+            BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
-            BenchmarkScenario::FreshAddDepHotCacheHotStoreIsolated => Cleanup {
+            BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => Cleanup {
                 remove: &["node_modules"],
                 restore: &[SAVED_LOCKFILE, SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::FreshInstallHotCacheHotStoreIsolated => Cleanup {
+            BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore => Cleanup {
                 remove: &["node_modules", "pnpm-lock.yaml"],
                 restore: &[SAVED_PACKAGE_JSON],
             },
-            BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs => {
+            BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => {
                 Cleanup { remove: &["node_modules"], restore: &[SAVED_LOCKFILE] }
             }
         }
@@ -213,7 +221,7 @@ impl BenchmarkScenario {
     /// in the workspace manifest, and a pre-warm pass that primes the
     /// store before hyperfine's warmup runs.
     pub fn enables_gvs(self) -> bool {
-        matches!(self, BenchmarkScenario::FreshRestoreHotCacheHotStoreIsolatedGvs)
+        matches!(self, BenchmarkScenario::GvsFreshRestoreHotCacheHotStore)
     }
 }
 

--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -152,7 +152,9 @@ impl BenchmarkScenario {
             | BenchmarkScenario::IsolatedFreshInstallHotCacheHotStore => &["install"],
             BenchmarkScenario::IsolatedFreshRestoreColdCacheColdStore
             | BenchmarkScenario::IsolatedFreshRestoreHotCacheHotStore
-            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => &["install", "--frozen-lockfile"],
+            | BenchmarkScenario::GvsFreshRestoreHotCacheHotStore => {
+                &["install", "--frozen-lockfile"]
+            }
             BenchmarkScenario::IsolatedFreshAddDepHotCacheHotStore => &["add", "is-odd"],
         }
     }

--- a/pacquet/tasks/integrated-benchmark/src/work_env.rs
+++ b/pacquet/tasks/integrated-benchmark/src/work_env.rs
@@ -297,9 +297,9 @@ impl WorkEnv {
         // scenarios wipe `node_modules` and `store-dir`, hot-cache wipes
         // only `node_modules` so the warmup-populated store survives
         // into the timed runs. Scenarios that mutate `package.json` or
-        // the lockfile (peek, full-resolution, clean-install) restore
-        // a pristine copy saved during `init()` so the next iteration
-        // sees the same starting state.
+        // the lockfile (the add-dep variant and the no-lockfile install
+        // variants) restore a pristine copy saved during `init()` so the
+        // next iteration sees the same starting state.
         let cleanup = scenario.cleanup();
         let cleanup_command =
             build_cleanup_command(&cleanup, self.benchmarked_ids(), |id| self.bench_dir(id));


### PR DESCRIPTION
## Summary

Wires both benchmark workflows to [Bencher](https://bencher.dev) so install-perf history is tracked continuously instead of only being visible in per-PR comments. Both stacks live in one Bencher project (slug: `pnpm`) under separate testbeds (`pnpm`, `pacquet`) so the scenario charts are directly comparable.

- `benchmarks/bench.sh` emits a hyperfine-shaped `bencher-results.json` that combines the six pnpm scenarios — `@HEAD` result only, `command` renamed to the scenario name so Bencher uses the scenario as the benchmark identifier.
- `.github/workflows/benchmark.yml` (pnpm TS bench): adds `push: branches: [main]` so each merge updates the `pnpm` baseline, then uploads via `bencher run --testbed pnpm`. Branch policy: `main` on push, `pr/<n>` on manual PR dispatch, `ref_name` otherwise (all forked from main).
- `.github/workflows/pacquet-integrated-benchmark.yml`: adds the same main-push baseline for the `pacquet` testbed, builds the Bencher report from the four scenario JSONs, and stages it into the existing artifact. Inline `bencher run` only fires on `push` to `main` (where secrets are available).
- `.github/workflows/pacquet-integrated-benchmark-comment.yml`: after the existing summary comment, downloads `bencher-results.json` from the artifact and runs `bencher run --branch pr/<n> --start-point main --start-point-reset --ci-number <n>`. Runs in the trusted `workflow_run` privilege context, so fork PRs are covered too.

The existing hand-rolled PR comments are kept alongside Bencher's auto-comment during rollout; we can drop them once thresholds are tuned.

## Required out-of-band setup

1. Create a Bencher project with slug `pnpm` at bencher.dev. Testbeds (`pnpm`, `pacquet`), the `main` branch, and scenario benchmarks will auto-create on the first push.
2. Add `BENCHER_API_TOKEN` to repo secrets (Actions). Without it, the new steps no-op with a `::notice::` — so this PR is safe to merge before the token lands, but Bencher won't actually record anything until both are in place.

## Out of scope

- `pacquet-micro-benchmark.yml` is unchanged. It uses criterion, not hyperfine, and would need Bencher's `rust_criterion` adapter. Easy follow-up if useful.
- No changeset added — these are CI/script changes, no published package is touched.

## Test plan

- [ ] Merge → first main push runs `benchmark.yml` and `pacquet-integrated-benchmark.yml`; both should attempt their Bencher upload steps. With the token unset they should emit `::notice::BENCHER_API_TOKEN not set` and exit 0.
- [ ] After creating the Bencher project and adding the secret, re-run `benchmark.yml` manually with a recent PR number and verify Bencher comments on the PR.
- [ ] Trigger the pacquet benchmark on a PR (changes under `pacquet/**`) and confirm both the existing summary comment and Bencher's comment appear.
- [ ] Confirm fork PRs flow correctly — the inline upload step is gated to `github.event_name == 'push'`, so fork PRs skip it and rely entirely on the comment workflow.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now can install a Bencher client and automatically upload consolidated Bencher-compatible benchmark results for PRs and main-branch pushes when configured; uploads are skipped if credentials or results are absent.
  * Bench runner produces a single bencher-results.json and CI stages/uploads it; local tooling can optionally generate this report when JSON tooling is present.

* **Documentation**
  * Docs and contributor guidance updated with revised scenario names, new scenario descriptions, and updated example benchmark commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->