### PR TITLE
fix(pacquet): drop synthetic transitive-peer entries from the importer lockfile

### DIFF
--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -318,6 +318,15 @@ fn install_resolves_env_var_in_npmrc_registry() {
 /// pnpm), all three peers should appear in `node_modules/.pnpm/`.
 /// Without the orchestrator's hoist loop they'd be missing, and the
 /// peer-resolution issue list would carry three entries.
+///
+/// Transitive auto-installed peers are NOT also linked at
+/// `node_modules/<alias>` — pnpm's `addDirectDependenciesToLockfile`
+/// iterates only `getAllDependenciesFromManifest(manifest)`, so
+/// transitive peers live in `snapshots:` / `packages:` only and
+/// consumers reach them through their parent's slot's `node_modules`.
+/// Hoisting them at the importer would require listing them in
+/// `importer.dependencies`, which breaks `satisfiesPackageManifest`
+/// and pushes every later install onto the fresh-resolve path.
 #[test]
 fn auto_install_peers_hoists_missing_peers_at_importer() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -350,15 +359,6 @@ fn auto_install_peers_hoists_missing_peers_at_importer() {
         assert!(
             entries.iter().any(|name| name.starts_with(&prefix) && !name.contains('_')),
             "expected {peer} to be auto-installed; .pnpm/ entries: {entries:?}",
-        );
-    }
-    // The top-level alias symlink should also point at the auto-installed
-    // peer — pacquet hoists peers all the way to the importer's node_modules.
-    for peer in ["peer-a", "peer-b", "peer-c"] {
-        let symlink_path = workspace.join(format!("node_modules/@pnpm.e2e/{peer}"));
-        assert!(
-            is_symlink_or_junction(&symlink_path).unwrap_or(false),
-            "expected node_modules/@pnpm.e2e/{peer} to be a symlink to the hoisted peer",
         );
     }
 

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -116,36 +116,20 @@ fn build_root_importer(
     for (alias, dep_path) in direct {
         let Some(node) = graph.get(dep_path) else { continue };
         let Ok(name_for_key) = PkgName::parse(alias.as_str()) else { continue };
-        let manifest_specifier = read_manifest_specifier(manifest, alias);
+        // Skip aliases the manifest doesn't declare. The resolver's
+        // `direct_dependencies_by_alias` includes auto-installed peers
+        // hoisted to the importer when `autoInstallPeers: true` is on,
+        // but pnpm's `addDirectDependenciesToLockfile` iterates only
+        // over `getAllDependenciesFromManifest(manifest)` — transitive
+        // auto-installed peers never enter `importer.dependencies` /
+        // `importer.specifiers`, only the snapshots graph below. Writing
+        // them here would carry specifiers the manifest can't satisfy
+        // through `satisfies_package_manifest` and force every later
+        // install onto the fresh-resolve path.
+        let Some(specifier) = read_manifest_specifier(manifest, alias) else { continue };
         let version = importer_dep_version(alias, node);
-        // Auto-installed peers (added by the resolver under
-        // `autoInstallPeers: true`) don't appear in the manifest, so
-        // `read_manifest_specifier` returns `None` for them. Pnpm
-        // records them in the lockfile under `dependencies` with a
-        // synthetic specifier so a downstream install knows they're
-        // hoisted at the importer level. Mirror that here: fall back
-        // to the resolved version string when the manifest has no
-        // specifier. The `specifiers:` map only carries
-        // user-authored values, so it skips the synthetic entry.
-        let synthetic_specifier;
-        let (specifier_for_spec, record_specifier) = match manifest_specifier {
-            Some(spec) => {
-                let owned = spec.clone();
-                (spec, Some(owned))
-            }
-            None => {
-                synthetic_specifier = match &version {
-                    ImporterDepVersion::Regular(ver) => ver.version().to_string(),
-                    ImporterDepVersion::Alias(name_ver) => name_ver.suffix.version().to_string(),
-                    ImporterDepVersion::Link(target) => format!("link:{target}"),
-                };
-                (synthetic_specifier.clone(), None)
-            }
-        };
-        let spec = ResolvedDependencySpec { specifier: specifier_for_spec, version };
-        if let Some(value) = record_specifier {
-            specifiers.insert(alias.clone(), value);
-        }
+        let spec = ResolvedDependencySpec { specifier: specifier.clone(), version };
+        specifiers.insert(alias.clone(), specifier);
         let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
         match group {
             DependencyGroup::Dev => {

--- a/pacquet/crates/package-manager/src/install/snapshots/pacquet_package_manager__install__tests__should_install_dependencies.snap
+++ b/pacquet/crates/package-manager/src/install/snapshots/pacquet_package_manager__install__tests__should_install_dependencies.snap
@@ -33,10 +33,7 @@ expression: get_all_folders(&project_root)
     "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules",
     "node_modules/.pacquet/@pnpm.e2e+hello-world-js-bin@1.0.0/node_modules/@pnpm.e2e/hello-world-js-bin/node_modules/.bin",
     "node_modules/@pnpm",
-    "node_modules/@pnpm/x",
     "node_modules/@pnpm/xyz",
-    "node_modules/@pnpm/y",
-    "node_modules/@pnpm/z",
     "node_modules/@pnpm.e2e",
     "node_modules/@pnpm.e2e/hello-world-js-bin",
 ]


### PR DESCRIPTION
## Summary

- Aligns `dependencies_graph_to_lockfile` with pnpm's `addDirectDependenciesToLockfile`: transitive auto-installed peers no longer get written into `importers["."].dependencies` / `specifiers`. They stay in `snapshots:` / `packages:` only, matching what `pnpm install` itself produces (verified locally with `pnpm install react-dom@18.2.0`).
- Restores the auto-frozen fast path (`preferFrozenLockfile: true`) for installs whose lockfile is up-to-date — `withWarmCacheAndLockfile` / `withWarmModulesAndLockfile` / `repeatInstall` were ~5–25× slower in pacquet@0.2.5 than in 0.2.4 because the synthetic entries failed `satisfies_package_manifest` and pushed every install onto the full fresh-resolve pipeline.

## Why

#11867 routed the fresh-lockfile install through `CreateVirtualStore` + `SymlinkDirectDependencies`, which both read from `importer.dependencies`. To keep the top-level `node_modules/<peer>` symlinks the old recursive walker happened to produce, the PR also taught `build_root_importer` to write synthetic entries for auto-installed peers — using the resolved version as their specifier.

Those entries then landed in `pnpm-lock.yaml` (17 of them against the alotta-files fixture: `@babel/core`, `typescript`, `@types/node`, …). On the next install:

1. `satisfies_package_manifest` flagged them as "removed" specifiers
2. `preferFrozenLockfile` saw `Stale` and fell through to the fresh-resolve path
3. `pacquet install --frozen-lockfile` failed outright with `ERR_PNPM_OUTDATED_LOCKFILE` listing all 17

This is visible on the published benchmark page: 0.2.4 `withWarmCacheAndLockfile` was ~720 ms, 0.2.5 jumped to ~4500 ms; `withWarmModulesAndLockfile` went from ~220 ms to ~5000 ms.

Pnpm itself doesn't put transitive auto-installed peers in `importer.dependencies` — `addDirectDependenciesToLockfile` iterates only over `getAllDependenciesFromManifest(manifest)`. Confirmed by inspecting a real `pnpm install react-dom@18.2.0` lockfile: only `react-dom` in `importers["."].dependencies`, no top-level `react` symlink.

Per the cardinal rule (pnpm is the source of truth, pacquet ports from it), pacquet should match. This PR restores the `continue` for aliases the manifest doesn't declare and updates the two tests that were asserting the divergent top-level-symlink behavior.

## Local verification on the alotta-files fixture

| | before fix | after fix |
| --- | ---: | ---: |
| `importer.dependencies` entry count | 126 | 109 (= manifest deps) |
| `pacquet install --frozen-lockfile` | fails: "17 dependencies were removed" | succeeds |
| repeat `pacquet install` | ~22 s | ~0.5 s |

## Test plan

- [x] `cargo nextest run --release -p pacquet-package-manager` — 298/298 pass
- [x] `cargo nextest run --release -p pacquet-cli --test install` — 10/10 pass (including the updated `auto_install_peers_hoists_missing_peers_at_importer`)
- [x] `cargo nextest run --release -p pacquet-lockfile` — 154/154 pass
- [x] `cargo clippy --release --locked --all-targets -- -D warnings` clean on the affected crates
- [x] `cargo fmt --check` clean
- [x] Manual: `pacquet install` on the alotta-files fixture — lockfile clean, second install fast, `--frozen-lockfile` no longer errors

Refs #11867.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of auto-installed peer dependencies. Transitive peers are no longer unnecessarily linked in `node_modules`, and missing peer specifiers are now properly handled during the installation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->