### PR TITLE
fix(pacquet): accept string `libc` in `PackageMetadata`

### DIFF
--- a/pacquet/crates/lockfile/src/package_metadata.rs
+++ b/pacquet/crates/lockfile/src/package_metadata.rs
@@ -1,5 +1,5 @@
 use crate::LockfileResolution;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 
 /// Metadata for one resolved package version, as stored in the v9
@@ -19,7 +19,11 @@ pub struct PackageMetadata {
     pub cpu: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_string_or_vec"
+    )]
     pub libc: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
@@ -36,7 +40,34 @@ pub struct PackageMetadata {
     pub peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>,
 }
 
+// Some packages declare `libc` as a plain string in `package.json`; pnpm writes
+// that string as-is into the lockfile. Accepts both string and array forms,
+// normalizing to `Vec<Value>`.
+fn deserialize_string_or_vec<'de, Value, Deser>(
+    deserializer: Deser,
+) -> Result<Option<Vec<Value>>, Deser::Error>
+where
+    Value: Deserialize<'de>,
+    Deser: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec<Value> {
+        String(Value),
+        Vec(Vec<Value>),
+    }
+
+    let opt = Option::<StringOrVec<Value>>::deserialize(deserializer)?;
+    Ok(opt.map(|value| match value {
+        StringOrVec::String(item) => vec![item],
+        StringOrVec::Vec(items) => items,
+    }))
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PeerDependencyMeta {
     pub optional: bool,
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/lockfile/src/package_metadata/tests.rs
+++ b/pacquet/crates/lockfile/src/package_metadata/tests.rs
@@ -1,0 +1,44 @@
+use super::PackageMetadata;
+use crate::serialize_yaml;
+use text_block_macros::text_block;
+
+fn make_metadata(libc_yaml: &str) -> String {
+    let base = text_block! {
+        "resolution:"
+        "  integrity: sha512-abc123"
+        "  tarball: https://registry.npmjs.org/foo/-/foo-1.0.0.tgz"
+        "cpu: [arm64]"
+        "os: [linux]"
+    };
+    format!("{base}\n{libc_yaml}")
+}
+
+#[test]
+fn libc_as_string() {
+    let yaml = make_metadata("libc: glibc\n");
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(metadata.libc, Some(vec!["glibc".to_string()]));
+}
+
+#[test]
+fn libc_as_array() {
+    let yaml = make_metadata("libc: [glibc]\n");
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(metadata.libc, Some(vec!["glibc".to_string()]));
+}
+
+#[test]
+fn libc_absent() {
+    let yaml = make_metadata("");
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(metadata.libc, None);
+}
+
+#[test]
+fn libc_string_roundtrip() {
+    let yaml = make_metadata("libc: glibc\n");
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    let serialized = serialize_yaml::to_string(&metadata).unwrap();
+    let reparsed: PackageMetadata = serde_saphyr::from_str(&serialized).unwrap();
+    assert_eq!(metadata.libc, reparsed.libc);
+}


### PR DESCRIPTION
## Summary

Fixes #11879.

`sass-embedded-linux-*` packages declare `libc` as a plain string in `package.json`:

```json
{ "libc": "glibc" }
```

pnpm writes this string as-is into the lockfile (`libc: glibc`). pacquet's `PackageMetadata` deserialised `libc` as `Vec<String>` and crashed on the string value.

I added a custom `deserialize_string_or_vec` that accepts both a string and an array, normalising to `Vec<Value>`. The helper is generic, following the pattern already established by `deserialize_double_option` in `crates/config`. `serde_with` was not used — the existing comment in `workspace_yaml.rs` notes it is not in the workspace deps and the body is short enough not to justify adding it.

`cpu` and `os` share the same field shape, so they may need the same treatment. Limiting the scope of this PR to `libc` to keep the change small and focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced lockfile parser to accept both single string and array formats for package metadata fields, improving flexibility when reading lockfiles.

* **Tests**
  * Added comprehensive test suite for lockfile YAML parsing and serialization, covering various input formats and round-trip scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->