### PR TITLE
ci(bencher): enforce PR thresholds and grant checks: write

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 # Don't cancel-in-progress — killing a bench mid-run wastes a long
 # CI job and produces no usable data.
@@ -123,12 +124,28 @@ jobs:
           --file "$BENCH_DIR/bencher-results.json"
           --github-actions "$GITHUB_TOKEN"
         )
+        # `--start-point-clone-thresholds` so the forked branch inherits
+        # the threshold configured on main; `--err` so the workflow fails
+        # when a sample breaches the upper boundary. Main pushes skip
+        # both — by then the regression has already landed.
         if [ "$EVENT_NAME" = "push" ] || [ "$REF_NAME" = "main" ]; then
           args+=(--branch main)
         elif [ -n "$INPUT_PR_NUMBER" ]; then
-          args+=(--branch "pr/$INPUT_PR_NUMBER" --start-point main --start-point-reset)
+          args+=(
+            --branch "pr/$INPUT_PR_NUMBER"
+            --start-point main
+            --start-point-reset
+            --start-point-clone-thresholds
+            --err
+          )
         else
-          args+=(--branch "$REF_NAME" --start-point main --start-point-reset)
+          args+=(
+            --branch "$REF_NAME"
+            --start-point main
+            --start-point-reset
+            --start-point-clone-thresholds
+            --err
+          )
         fi
         bencher run "${args[@]}"
 

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -26,6 +26,7 @@ permissions:
   actions: read
   issues: write
   pull-requests: write
+  checks: write
 
 jobs:
   comment:
@@ -154,12 +155,17 @@ jobs:
             echo "::notice::BENCHER_API_TOKEN not set, skipping Bencher upload"
             exit 0
           fi
+          # `--start-point-clone-thresholds` so the PR branch inherits the
+          # threshold configured on main; `--err` so the action surfaces
+          # a regression on the PR check.
           bencher run \
             --project pnpm \
             --testbed pacquet \
             --branch "pr/$PR_NUMBER" \
             --start-point main \
             --start-point-reset \
+            --start-point-clone-thresholds \
+            --err \
             --adapter shell_hyperfine \
             --file benchmark-artifact/bencher-results.json \
             --ci-number "$PR_NUMBER" \

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -48,6 +48,7 @@ concurrency:
 # the base-repo privilege context via `workflow_run`.
 permissions:
   contents: read
+  checks: write
 
 jobs:
   benchmark:
@@ -334,9 +335,19 @@ jobs:
             --file bench-work-env/bencher-results.json
             --github-actions "$GITHUB_TOKEN"
           )
+          # `--start-point-clone-thresholds` so the forked branch inherits
+          # the threshold configured on main; `--err` so the workflow fails
+          # when a sample breaches the upper boundary. Main pushes skip
+          # both — by then the regression has already landed.
           if [ "$REF_NAME" = "main" ]; then
             args+=(--branch main)
           else
-            args+=(--branch "$REF_NAME" --start-point main --start-point-reset)
+            args+=(
+              --branch "$REF_NAME"
+              --start-point main
+              --start-point-reset
+              --start-point-clone-thresholds
+              --err
+            )
           fi
           bencher run "${args[@]}"


### PR DESCRIPTION
## Summary

- Add `--start-point-clone-thresholds` to the non-main upload arms in `benchmark.yml`, `pacquet-integrated-benchmark.yml`, and `pacquet-integrated-benchmark-comment.yml`, so PR / feature-branch records inherit thresholds configured on `main` in the Bencher UI. Pair it with `--err` so the workflow fails when a sample breaches the upper boundary — without this, a regression is recorded but the GitHub check stays green.
- Add `checks: write` to all three workflows. On `push: main` (no `--ci-number`, not a `pull_request` event) Bencher falls back to creating a GitHub Check on the commit; without the permission the upload step exits 1 with `Failed to create GitHub Check`, which is what's currently happening on main.

Main-branch uploads still skip the threshold/`--err` flags on purpose: by the time main fails, the regression has already landed.

This branch was forked from `main` so its own benchmark runs against the threshold can be compared against the `main` baseline once the workflows run.

## Test plan

- [ ] Configure `Percentage` thresholds in Bencher UI for `main/pnpm/Latency` and `main/pacquet/Latency` (upper boundary `0.20`, min samples `10`, max samples `30`).
- [ ] After merge (or via `workflow_dispatch` from this branch): confirm the next `push: main` run completes without the `Failed to create GitHub Check` error and shows a Check on the commit.
- [ ] Dispatch `Benchmarks` and `Pacquet integrated benchmark` against this branch (or open a follow-up PR with an intentional perf regression) and confirm Bencher reports the upper-boundary breach and the job exits non-zero.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Improved benchmark regression reporting: workflow now surfaces regressions as errors for better visibility during pull request reviews
  - Enhanced threshold management: pull requests automatically inherit benchmark thresholds from the main branch for consistent comparison
  - Upgraded GitHub integration: benchmark results now fully integrate with GitHub's check system for improved workflow visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->