### PR TITLE
fix(exec.commands): fall back to alias as bin name when dlx slot lacks package.json

### DIFF
--- a/.changeset/dlx-fall-back-to-alias-when-manifest-missing.md
+++ b/.changeset/dlx-fall-back-to-alias-when-manifest-missing.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+pnpm: patch
+---
+
+Fixed `pnpm dlx` failing with `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` when the installed package's CAS slot is missing its `package.json`. Observed in the wild for `pnpm dlx node@runtime:<version>` when the GVS slot was populated without the synthesized manifest runtime archives need (they don't ship a `package.json` of their own, so the synthesized one is the only way it gets there; an existing slot from an earlier code path that skipped the synthesis stays incomplete). The bin link itself is wired up from the resolution and remains valid, so `dlx` now falls back to the scopeless package name when the slot's manifest is unreadable — for single-bin packages (the dlx common case, including every `runtime:` spec) this matches what `manifest.bin` would have named. Multi-bin packages already require `--package=<spec> <bin>` to disambiguate and don't enter this code path.

--- a/exec/commands/src/dlx.ts
+++ b/exec/commands/src/dlx.ts
@@ -256,7 +256,26 @@ async function getPkgName (pkgDir: string): Promise<string> {
 async function getBinName (cachedDir: string, opts: Pick<DlxCommandOptions, 'engineStrict'>): Promise<string> {
   const pkgName = await getPkgName(cachedDir)
   const pkgDir = path.join(cachedDir, 'node_modules', pkgName)
-  const manifest = await readProjectManifestOnly(pkgDir, opts) as PackageManifest
+  let manifest: PackageManifest
+  try {
+    manifest = await readProjectManifestOnly(pkgDir, opts) as PackageManifest
+  } catch (err: unknown) {
+    // The installed package's `package.json` is unreadable. Observed in the
+    // wild for `node@runtime:<version>` whose CAS slot was materialized by
+    // a code path that didn't run pnpm's `appendManifest` (or pacquet's
+    // equivalent runtime-manifest synthesis), leaving the slot without
+    // the `package.json` runtime archives don't ship themselves. Fall back
+    // to the scopeless package name — for single-bin packages (the dlx
+    // common case) it matches what `manifest.bin` would have named, and
+    // the `node_modules/.bin/<name>` symlink the install already wired up
+    // from the resolution's bin info is what `execa` resolves against.
+    // Multi-bin packages require `--package=<spec> <bin>` to disambiguate,
+    // which short-circuits `getBinName` upstream and never enters this path.
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND') {
+      return scopeless(pkgName)
+    }
+    throw err
+  }
   const bins = await getBinsFromPackageManifest(manifest, pkgDir)
   if (bins.length === 0) {
     throw new PnpmError('DLX_NO_BIN', `No binaries found in ${pkgName}`)


### PR DESCRIPTION
## Summary

`pnpm dlx` infers the binary name by reading the installed package's `package.json` out of the GVS slot (`exec/commands/src/dlx.ts:256-276`). On CI that read has been failing intermittently for `node@runtime:24.6.0`:

```
[ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json was found in
"/home/runner/.cache/pnpm/dlx/.../node_modules/node"
```

The dlx install reports `added 1, done`, the `node_modules/<pkg>` symlink is wired up, and the `node_modules/.bin/<bin>` shim works — pnpm builds the bin link from the resolution's `bin` info, not from the slot's manifest, so that side is fine. The only casualty is `getBinName`, which throws when the slot it inspects has no `package.json`.

Example failed bench run: https://github.com/pnpm/pnpm/actions/runs/26339269440/job/77538272988. The workflow's `continue-on-error` on the bench step turns the failure into a green job whose Bencher upload steps are silently skipped, so this has been easy to miss.

### Why the manifest can be missing

Runtime archives (`node`, `bun`, `deno` tarballs) don't ship a `package.json`. pnpm's worker (`worker/src/start.ts:332-337`) writes the synthesized one via `appendManifest`, and falls back to a placeholder when neither a real nor an appended manifest is available — so any fresh fetch through pnpm leaves a `package.json` in the slot. Pacquet's equivalent for runtime archives (`pacquet/crates/package-manager/src/install_package_by_snapshot.rs:726-750`) likewise inserts the synthesized manifest into `cas_paths` unconditionally.

The hole is on the reuse path. Both pnpm and pacquet short-circuit `importIndexedDir` / `import_indexed_dir` when the slot already exists (`pacquet/crates/package-manager/src/import_indexed_dir.rs:144`), trusting that the previous import populated it correctly. If anything *else* in the runner's history materialized that slot — an older pnpm/pacquet version without the synthesis, a partial install that wrote files but didn't commit the manifest, `pnpm/setup`'s store-cache layer being restored from an older run — the short-circuit leaves it half-populated, and a follow-up `pnpm dlx` reuses the broken slot.

### The fix

Catch `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` in `getBinName` and fall back to the scopeless package name. The bin link is already valid; the package name is what `manifest.bin` would have named anyway for single-bin packages (the dlx common case, including every `runtime:` spec). Multi-bin packages require `--package=<spec> <bin>` to disambiguate and short-circuit `getBinName` upstream, so they don't enter this branch.

This keeps dlx working when the slot is in the half-populated state described above without papering over real "binary doesn't exist" failures — those still surface from `execa`.

## Test plan

- [x] `pnpm --filter @pnpm/exec.commands run compile` — clean.
- [ ] CI runs the suite. The existing `test/dlx.ts` Jest+ESM mocks fail to load locally (`module is already linked`) so I couldn't exercise the unit suite here.
- [ ] Re-trigger the `Benchmarks` workflow_dispatch on this branch and confirm the run completes through the Bencher upload step.

---
Written by an agent (Claude Code, claude-opus-4-7).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm dlx` command failing with "ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND" when an installed package's manifest is missing or unreadable. The command now gracefully falls back to the package name instead of failing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->