### PR TITLE
ci: fix zizmor ref-version-mismatch on action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         # `gh release create` could replace this, but the release pipeline is
         # sensitive and softprops/action-gh-release is widely battle-tested.
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2.5.0 # zizmor: ignore[superfluous-actions]
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
           files: dist/*


### PR DESCRIPTION
## Summary

- Fix the lone zizmor `ref-version-mismatch` finding flagged on recent CI runs (e.g. [this run](https://github.com/pnpm/pnpm/actions/runs/26342913981/job/77547943697?pr=11512)).
- Dependabot bumped \`softprops/action-gh-release\` from v2.5.0 to v3.0.0 in #11642, updating the pinned commit hash but leaving the trailing \`# v2.5.0\` comment. zizmor's ref-version-mismatch audit caught the inconsistency.

## Test plan

- [ ] zizmor passes on the next CI run for this branch.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation dependencies to maintain compatibility and security standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->