### PR TITLE
fix(deps-resolver): restore index-based wantedDep pairing so git/tarball deps aren't dropped from manifest update

### DIFF
--- a/.changeset/fix-unaliased-deps-dropped-from-manifest.md
+++ b/.changeset/fix-unaliased-deps-dropped-from-manifest.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed a regression introduced by [#11711](https://github.com/pnpm/pnpm/pull/11711) where `pnpm add <github-shorthand>` (and any other wanted-dependency whose alias can't be parsed from the user-supplied spec, e.g. tarball URLs or `pnpm/test-git-fetch#sha`) was silently dropped from the manifest update and from `pendingBuilds`. The alias-keyed lookup added in that PR couldn't find a `wantedDependency` whose `alias` was `undefined` at parse time but resolved to a package name only after fetching, so the entry never made it into `specsToUpsert`. Restored the original index-based pairing between `directDependencies` and `wantedDependencies`; the catalog-protocol preservation that PR was originally fixing is unaffected because it's driven by `rdd.catalogLookup.userSpecifiedBareSpecifier`, not by the lookup. Fixes the three `rebuilds dependencies` / `rebuilds specific dependencies` / `rebuild with pending option` failures in `building/commands/test/build/index.ts`.

--- a/installing/deps-resolver/src/index.ts
+++ b/installing/deps-resolver/src/index.ts
@@ -345,16 +345,10 @@ export async function resolveDependencies (
   for (const project of projectsToResolve) {
     if (!project.updatePackageManifest) continue
     const resolvedImporter = resolvedImporters[project.id]
-    // Build a map from alias to wantedDependency for O(1) lookup, since
-    // directDependencies and wantedDependencies are not aligned by index
-    // (linked deps like workspace:* are excluded from directDependencies).
-    const wantedDepsByAlias = new Map(
-      project.wantedDependencies.map((wd) => [wd.alias, wd] as const)
-    )
-    for (const dep of resolvedImporter.directDependencies) {
-      const wantedDep = wantedDepsByAlias.get(dep.alias)
-      const updateSpec = wantedDep?.updateSpec ?? false
+    for (let i = 0; i < resolvedImporter.directDependencies.length; i++) {
+      const updateSpec = project.wantedDependencies[i]?.updateSpec ?? false
       if (!updateSpec) continue
+      const dep = resolvedImporter.directDependencies[i]
       if (dep.catalogLookup == null) continue
       // If normalizedBareSpecifier isn't defined, this catalog entry was resolved from cache.
       // Avoid updating the updatedCatalogs map since it is likely unchanged.

--- a/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/installing/deps-resolver/src/updateProjectManifest.ts
@@ -18,16 +18,10 @@ export async function updateProjectManifest (
   if (!importer.manifest) {
     throw new Error('Cannot save because no package.json found')
   }
-  // directDependencies and wantedDependencies are not aligned by index
-  // (linked deps like workspace:* are excluded from directDependencies),
-  // so match by alias instead.
-  const wantedDepsByAlias = new Map(
-    importer.wantedDependencies.map((wd) => [wd.alias, wd] as const)
-  )
   const specsToUpsert: PackageSpecObject[] = opts.directDependencies
-    .filter((rdd) => wantedDepsByAlias.get(rdd.alias)?.updateSpec)
-    .map((rdd) => {
-      const wantedDep = wantedDepsByAlias.get(rdd.alias)!
+    .filter((rdd, index) => importer.wantedDependencies[index]?.updateSpec)
+    .map((rdd, index) => {
+      const wantedDep = importer.wantedDependencies[index]!
       return {
         alias: rdd.alias,
         peer: importer.peer,


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by #11711: `pnpm add <github-shorthand>` (and any unaliased wanted-dependency — tarball URLs, `pnpm/foo#sha`, etc.) was silently dropped from `specsToUpsert`, never written to the manifest, and missing from `pendingBuilds`.
- The root cause is in `installing/deps-resolver/src/updateProjectManifest.ts` (and a parallel pattern in `index.ts`): #11711 switched a parallel-array index pairing between `directDependencies` and `wantedDependencies` to a `Map` keyed by `wantedDep.alias`. But `parseWantedDependency('pnpm/foo#abc')` returns `{ alias: undefined, bareSpecifier }` — alias is only known after fetching the package. All such entries collide under the `undefined` Map key, then the lookup of the resolved dep (which has its real alias `foo`) misses, the filter drops the dep, and it disappears from `specsToUpsert`.
- Catalog: preservation isn't affected by this revert. It's driven by `rdd.catalogLookup.userSpecifiedBareSpecifier` in the spec-object construction (line 34), not by how the `wantedDep` is looked up.
- The premise in the removed comment ("linked deps like workspace:\* are excluded from directDependencies") was also incorrect — linked deps stay in `directDependencies` with `isLinkedDependency: true` (see `resolveDependencyTree.ts:323`).

## Test plan

Locally on Node 26 (matches `devEngines.runtime` after #11889):

- [x] `installing/deps-installer/test/catalogs.ts` — 44/44 pass (confirms catalog: preservation still works)
- [x] `installing/deps-resolver` unit tests — 60/60 across 9 suites
- [x] `building/commands/test/build/index.ts` — 8/8 pass, including the three that were failing on `main` after #11711 was merged:
  - `rebuilds dependencies`
  - `rebuilds specific dependencies`
  - `rebuild with pending option`

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed a regression where certain dependency specifications (GitHub shorthand syntax, tarball URLs, and similar unparseable formats) could be silently dropped from package manifest updates when using `pnpm add`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->