### PR TITLE
fix(env-installer): prune env lockfile when updating a config dep

### DIFF
--- a/.changeset/prune-env-lockfile-on-config-dep-update.md
+++ b/.changeset/prune-env-lockfile-on-config-dep-update.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.env-installer": patch
+"pnpm": patch
+---
+
+Fixed `pnpm add --config` leaving orphan entries in `pnpm-lock.env.yaml` (the optional subdependencies of the previously resolved version of the updated config dependency).

--- a/installing/env-installer/src/resolveConfigDeps.ts
+++ b/installing/env-installer/src/resolveConfigDeps.ts
@@ -15,6 +15,7 @@ import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import type { ConfigDependencies, ConfigDependencySpecifiers, RegistryConfig } from '@pnpm/types'
 
 import { installConfigDeps, type InstallConfigDepsOpts } from './installConfigDeps.js'
+import { pruneEnvLockfile } from './pruneEnvLockfile.js'
 import { resolveOptionalSubdeps } from './resolveOptionalSubdeps.js'
 
 export type ResolveConfigDepsOpts = CreateFetchFromRegistryOptions & ResolverFactoryOptions & InstallConfigDepsOpts & {
@@ -77,6 +78,8 @@ export async function resolveConfigDeps (configDeps: string[], opts: ResolveConf
     })
     envLockfile.snapshots[pkgKey] = optionalSubdeps ? { optionalDependencies: optionalSubdeps } : {}
   }))
+
+  pruneEnvLockfile(envLockfile)
 
   await Promise.all([
     writeSettings({

--- a/installing/env-installer/test/resolveConfigDeps.test.ts
+++ b/installing/env-installer/test/resolveConfigDeps.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { resolveConfigDeps } from '@pnpm/installing.env-installer'
-import { readEnvLockfile } from '@pnpm/lockfile.fs'
+import { readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { prepareEmpty } from '@pnpm/prepare'
 import { getIntegrity, REGISTRY_MOCK_PORT } from '@pnpm/registry-mock'
 import { createTempStore } from '@pnpm/testing.temp-store'
@@ -138,6 +138,46 @@ test('rejects an optionalDependency declared with a non-exact version', async ()
     store: storeController,
     storeDir,
   })).rejects.toThrow(/only exact versions are supported/)
+})
+
+test('orphan optional subdeps from a previous resolution are pruned', async () => {
+  prepareEmpty()
+  const { storeController, storeDir } = createTempStore()
+
+  // Simulate a prior resolution that left optional subdeps for a now-removed
+  // version of a config dependency. The stale `foo@99.0.0` and its optional
+  // subdep `bar@1.0.0` are not referenced from any current configDependency.
+  await writeEnvLockfile(process.cwd(), {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': { configDependencies: {} },
+    },
+    packages: {
+      '@pnpm.e2e/foo@99.0.0': { resolution: { integrity: 'sha512-stale==' } },
+      '@pnpm.e2e/bar@1.0.0': { resolution: { integrity: 'sha512-stale==' } },
+    },
+    snapshots: {
+      '@pnpm.e2e/foo@99.0.0': { optionalDependencies: { '@pnpm.e2e/bar': '1.0.0' } },
+      '@pnpm.e2e/bar@1.0.0': { optional: true },
+    },
+  })
+
+  await resolveConfigDeps(['@pnpm.e2e/foo@100.0.0'], {
+    registries: {
+      default: registry,
+    },
+    rootDir: process.cwd(),
+    cacheDir: path.resolve('cache'),
+    store: storeController,
+    storeDir,
+  })
+
+  const envLockfile = await readEnvLockfile(process.cwd())
+  expect(envLockfile!.packages['@pnpm.e2e/foo@99.0.0']).toBeUndefined()
+  expect(envLockfile!.packages['@pnpm.e2e/bar@1.0.0']).toBeUndefined()
+  expect(envLockfile!.snapshots['@pnpm.e2e/foo@99.0.0']).toBeUndefined()
+  expect(envLockfile!.snapshots['@pnpm.e2e/bar@1.0.0']).toBeUndefined()
+  expect(envLockfile!.packages['@pnpm.e2e/foo@100.0.0']).toBeDefined()
 })
 
 test('fails with frozenLockfile', async () => {


### PR DESCRIPTION
## Summary

When updating a config dependency via `pnpm add --config <pkg>`, the optional subdependencies of the previously resolved version were left as orphan entries in `pnpm-lock.env.yaml`. The sibling `resolveAndInstallConfigDeps` path already prunes; this PR adds the same `pruneEnvLockfile` call to `resolveConfigDeps` before the write.

## Test plan

- [x] New regression test in `installing/env-installer/test/resolveConfigDeps.test.ts` (`orphan optional subdeps from a previous resolution are pruned`) — pre-populates the env lockfile with an unreferenced parent + optional subdep, runs `resolveConfigDeps`, asserts the orphans are gone. Verified the test fails on `main` and passes with the fix.
- [x] All 6 tests in `resolveConfigDeps.test.ts` pass.

## Pacquet parity

If pacquet has ported the config-deps install flow, this same pruning needs to land on the Rust side too — flagging for a maintainer to check before merge.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `pnpm add --config` left orphan entries in `pnpm-lock.env.yaml` for outdated configuration dependencies. The package manager now properly cleans up stale optional subdependencies when config dependencies are updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->