### PR TITLE
fix(deploy): skip configDependencies in the nested install

### DIFF
--- a/.changeset/deploy-skip-config-dependencies.md
+++ b/.changeset/deploy-skip-config-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fix `pnpm deploy` crashing with `ENOENT: ... lstat '<deployDir>/node_modules'` when `configDependencies` declares pacquet (`pacquet` or `@pnpm/pacquet`). The deploy directory never installs config dependencies, so the install engine they designate isn't on disk to invoke; the nested install now skips them.

--- a/pnpm/test/deploy.ts
+++ b/pnpm/test/deploy.ts
@@ -89,8 +89,9 @@ test.skip('legacy deploy creates only necessary directories when the root manife
 })
 
 // `pacquet` is fetched from the real npm registry — registry-mock doesn't
-// carry it (or its platform-specific binary sub-packages). Tests are
-// gated on the public registry being reachable.
+// carry it (or its platform-specific binary sub-packages), so this test
+// requires the public registry to be reachable. Matches the pattern in
+// `pnpm/test/install/pacquet.ts`.
 const PUBLIC_REGISTRY = '--config.registry=https://registry.npmjs.org/'
 const PACQUET_VERSION = '0.2.2'
 

--- a/pnpm/test/deploy.ts
+++ b/pnpm/test/deploy.ts
@@ -87,3 +87,40 @@ test.skip('legacy deploy creates only necessary directories when the root manife
   expect(fs.readdirSync('services/foo/pnpm.out').sort()).toStrictEqual(['node_modules', 'package.json'])
   expect(loadJsonFileSync('services/foo/pnpm.out/package.json')).toStrictEqual(loadJsonFileSync('services/foo/package.json'))
 })
+
+// `pacquet` is fetched from the real npm registry — registry-mock doesn't
+// carry it (or its platform-specific binary sub-packages). Tests are
+// gated on the public registry being reachable.
+const PUBLIC_REGISTRY = '--config.registry=https://registry.npmjs.org/'
+const PACQUET_VERSION = '0.2.2'
+
+// Two installs against the public registry plus a deploy; raise the per-test
+// timeout above jest's 5s default to allow for cold caches.
+const PUBLIC_REGISTRY_TIMEOUT = 5 * 60 * 1000
+
+test('deploy with a shared lockfile succeeds when pacquet is declared in configDependencies', async () => {
+  preparePackages([
+    { location: '.', package: { name: 'root', version: '0.0.0' } },
+    {
+      location: 'services/foo',
+      package: {
+        name: 'foo',
+        version: '0.0.0',
+        dependencies: { 'is-positive': '3.1.0' },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['services/*'],
+    configDependencies: { pacquet: PACQUET_VERSION },
+    injectWorkspacePackages: true,
+  })
+
+  await execPnpm([PUBLIC_REGISTRY, 'install'])
+
+  const deployDir = path.resolve('services/foo/pnpm.out')
+  await execPnpm([PUBLIC_REGISTRY, '--filter=foo', 'deploy', deployDir])
+
+  expect(fs.existsSync(path.join(deployDir, 'node_modules/is-positive/package.json'))).toBe(true)
+}, PUBLIC_REGISTRY_TIMEOUT)

--- a/releasing/commands/src/deploy/deploy.ts
+++ b/releasing/commands/src/deploy/deploy.ts
@@ -281,6 +281,7 @@ async function deployFromSharedLockfile (
       injectWorkspacePackages: undefined, // the effects of injecting workspace packages should already be part of the package snapshots
       overrides: undefined, // the effects of the overrides should already be part of the package snapshots
       packageExtensions: undefined, // the effects of the package extensions should already be part of the package snapshots
+      configDependencies: undefined, // configDependencies (e.g. pacquet) are not installed into the deploy dir, so the install engine they designate isn't on disk to invoke
       hooks: {
         ...opts.hooks,
         readPackage: [


### PR DESCRIPTION
## Summary

`pnpm deploy` (the shared-lockfile path) crashes with `ENOENT: ... lstat '<deployDir>/node_modules'` when the workspace declares pacquet under `configDependencies`.

`deployFromSharedLockfile` (in `releasing/commands/src/deploy/deploy.ts`) spreads `...opts` into the nested `install.handler` call and explicitly overrides things that shouldn't apply to the deploy target (`overrides`, `packageExtensions`, `injectWorkspacePackages`, `enableGlobalVirtualStore`, hooks, etc.) — but not `configDependencies`. The nested install therefore sees `configDependencies['@pnpm/pacquet']`, builds a `runPacquet` callback with `lockfileDir: deployDir`, and `resolvePacquetBin` blows up on `realpathSync(path.join(deployDir, 'node_modules/.pnpm-config/@pnpm/pacquet/package.json'))` against the freshly created, empty deploy directory.

This is what broke the [11.3.0 publish job](https://github.com/pnpm/pnpm/actions/runs/26347431083/job/77559577350) (called from `pnpm/bundle-deps.ts` while building `@pnpm/exe`).

The fix is one line: `configDependencies: undefined` next to the other "already part of the package snapshots" overrides.

## Test plan

- [x] `pnpm --filter @pnpm/releasing.commands run compile` passes
- [ ] Watch the next publish job; the deploy step should no longer hit `ENOENT` on the empty `node_modules`

Note: this only helps **future** publishes — the currently-failing job runs against the already-published `@pnpm/exe@11.2.2`, which still carries the bug. To unblock the current release, either add `forceLegacyDeploy: true` to `pnpm-workspace.yaml` (the workaround the failure printed) or temporarily drop the `@pnpm/pacquet` entry from `configDependencies` and put it back after.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deploy from crashing with an ENOENT lstat error when certain config-defined dependencies are present; deploy now skips those config dependencies so deployment succeeds.

* **Tests**
  * Added a test verifying deploy succeeds when configDependencies are declared and that expected packages appear in the deployed node_modules.

* **Documentation**
  * Added a changeset documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->