### PR TITLE
fix(pacquet/modules-yaml): write GVS-aware virtualStoreDir to match pnpm

### DIFF
--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -19,7 +19,7 @@ use smart_default::SmartDefault;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 pub use crate::defaults::{
@@ -950,6 +950,35 @@ impl Config {
             } else {
                 self.store_dir.links()
             };
+    }
+
+    /// Return the `virtualStoreDir` value pnpm exposes externally — the
+    /// path written into `.modules.yaml` and emitted in the `pnpm:context`
+    /// NDJSON event.
+    ///
+    /// Upstream pnpm mutates `virtualStoreDir` in place inside
+    /// [`extendInstallOptions.ts:419-422`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/deps-installer/src/install/extendInstallOptions.ts#L419-L422)
+    /// when `enableGlobalVirtualStore` is on and the user hasn't pinned
+    /// `virtualStoreDir`, so every consumer that reads `ctx.virtualStoreDir`
+    /// — including [`writeModulesManifest`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/modules-yaml/src/index.ts#L111-L138)
+    /// and the [`pnpm:context` debug log](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/context/src/index.ts#L196-L201)
+    /// — sees the GVS-derived path.
+    ///
+    /// Pacquet deliberately keeps [`Self::virtual_store_dir`] at its
+    /// project-local value (see [`Self::apply_global_virtual_store_derivation`]
+    /// for the why), so consumers that need the externally-observable
+    /// value must route through this helper instead of reading the field
+    /// directly. Otherwise the `.modules.yaml` round-trip mismatches
+    /// pnpm's, and the next `pnpm install` trips
+    /// `ERR_PNPM_UNEXPECTED_VIRTUAL_STORE_DIR` → forces a
+    /// "modules directories will be reinstalled from scratch" prompt
+    /// on every install.
+    pub fn effective_virtual_store_dir(&self) -> &Path {
+        if self.enable_global_virtual_store {
+            &self.global_virtual_store_dir
+        } else {
+            &self.virtual_store_dir
+        }
     }
 
     pub fn resolved_patched_dependencies(

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -443,7 +443,7 @@ where
             level: LogLevel::Debug,
             current_lockfile_exists: current_lockfile.is_some(),
             store_dir: config.store_dir.display().to_string(),
-            virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
+            virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         }));
 
         Reporter::emit(&LogEvent::Stage(StageLog {
@@ -1068,7 +1068,7 @@ fn build_modules_manifest(
         // <https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-builder/src/lockfileToDepGraph.ts#L294-L298>.
         skipped: skipped.iter_installability().map(ToString::to_string).collect(),
         store_dir: config.store_dir.display().to_string(),
-        virtual_store_dir: config.virtual_store_dir.to_string_lossy().into_owned(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
         ..Default::default()
     }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1920,6 +1920,148 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
     drop(dir);
 }
 
+/// Under GVS, the `virtualStoreDir` value pacquet persists in
+/// `.modules.yaml` must equal the path upstream pnpm writes — i.e.
+/// `<storeDir>/v11/links` — not the project-local `node_modules/.pnpm`
+/// path pacquet keeps internally in [`Config::virtual_store_dir`]. If
+/// they diverge, the next `pnpm install` reads the manifest, recomputes
+/// `ctx.virtualStoreDir` from the GVS-on path, and trips upstream's
+/// [`checkCompatibility`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/deps-installer/src/install/checkCompatibility/index.ts#L37-L43)
+/// with `ERR_PNPM_UNEXPECTED_VIRTUAL_STORE_DIR` for every project,
+/// forcing the "modules directories will be reinstalled from scratch"
+/// prompt on every invocation. The same value is also emitted on the
+/// `pnpm:context` channel that `@pnpm/cli.default-reporter` parses, so
+/// the same parity rule applies there.
+#[tokio::test]
+async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    // GVS on — the whole point of the test.
+    config.enable_global_virtual_store = true;
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    // Keep `virtual_store_dir` at the project-local path. Pacquet's
+    // internal layout consumers still read this field; the parity
+    // requirement is only that the externally-observed value (the one
+    // pnpm sees in `.modules.yaml` / `pnpm:context`) routes through
+    // `global_virtual_store_dir` via `effective_virtual_store_dir`.
+    config.virtual_store_dir = virtual_store_dir.clone();
+    // Source the GVS root from `store_dir.links()` so the assertion
+    // below targets the same v11-suffixed path the
+    // [`From<PathBuf> for StoreDir`] impl produces in production. Hard-
+    // coding `store_dir.join("links")` here would drop the `v11`
+    // segment and turn the test into a tautology.
+    config.global_virtual_store_dir = config.store_dir.links();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies: {}"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile");
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        resolved_packages: &Default::default(),
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("frozen-lockfile install under GVS should succeed");
+
+    // The path pnpm would have written. `StoreDir::from` appends the
+    // [`STORE_VERSION`] suffix to the configured root, so the live
+    // value is `<store_dir>/v11/links` even though the test handed
+    // `Config::store_dir` the un-suffixed root.
+    let expected_resolved = store_dir.join(STORE_VERSION).join("links");
+
+    // Ensure the GVS root exists on disk so `dunce::canonicalize` can
+    // resolve it. An empty-lockfile install doesn't link anything into
+    // `<store_dir>/v11/links/`, so the dir would otherwise be absent.
+    std::fs::create_dir_all(&expected_resolved).expect("create GVS links dir for canonicalize");
+    let expected_canonical =
+        dunce::canonicalize(&expected_resolved).expect("canonicalize GVS links dir");
+
+    // `.modules.yaml` is what `pnpm install` reads on the *next*
+    // invocation; this is the round-trip pnpm's `checkCompatibility`
+    // sees. `read_modules_manifest` normalises the stored relative
+    // path back to absolute against `modules_dir`, so a successful
+    // assertion proves both halves: pacquet wrote the GVS path, and
+    // the relative form on disk re-resolves to it. Canonicalize the
+    // result because `read_modules_manifest`'s
+    // `modules_dir.join(relative)` keeps `..` segments verbatim, while
+    // pnpm's `path.relative(modules.virtualStoreDir, opts.virtualStoreDir)`
+    // check at
+    // [`checkCompatibility/index.ts:37-43`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/deps-installer/src/install/checkCompatibility/index.ts#L37-L43)
+    // reduces them before comparing.
+    let read_back =
+        read_modules_manifest::<Host>(&modules_dir).expect("read .modules.yaml").expect("present");
+    assert_eq!(
+        dunce::canonicalize(&read_back.virtual_store_dir)
+            .expect("canonicalize read-back virtualStoreDir"),
+        expected_canonical,
+        "modules.yaml virtualStoreDir must round-trip to <storeDir>/{STORE_VERSION}/links under GVS",
+    );
+
+    // The `pnpm:context` event the default reporter prints in the
+    // install header. Same parity rule, different channel — pnpm
+    // emits `ctx.virtualStoreDir` (the GVS-mutated value); pacquet
+    // must too.
+    let captured = EVENTS.lock().unwrap();
+    let context_log = captured
+        .iter()
+        .find_map(|event| match event {
+            LogEvent::Context(log) => Some(log),
+            _ => None,
+        })
+        .expect("install emits exactly one pnpm:context event");
+    assert_eq!(
+        dunce::canonicalize(&context_log.virtual_store_dir)
+            .expect("canonicalize context virtualStoreDir"),
+        expected_canonical,
+        "pnpm:context virtualStoreDir must report the GVS path, matching pnpm's default reporter",
+    );
+
+    drop(dir);
+}
+
 /// GVS-off frozen-lockfile install. The dispatch path is the same,
 /// but `Install::run` skips the project-registry write entirely.
 /// Pins that turning off `enable_global_virtual_store` makes the

--- a/pacquet/crates/store-dir/src/store_dir/tests.rs
+++ b/pacquet/crates/store-dir/src/store_dir/tests.rs
@@ -45,11 +45,20 @@ fn from_pathbuf_does_not_double_append_when_already_suffixed() {
 /// from the user's home and demands an exact match against the
 /// recorded value. The constant test makes the bug
 /// `ERR_PNPM_UNEXPECTED_STORE` triggered legible for future readers.
+///
+/// Build the expected value through `Path::join` rather than a
+/// hardcoded `/v11` so the assertion stays valid on Windows: pnpm
+/// uses Node's [`path.join`](https://nodejs.org/api/path.html#pathjoinpaths)
+/// (and [`getStorePath`](https://github.com/pnpm/pnpm/blob/29a42efc3b/store/path/src/index.ts#L39-L42)
+/// goes through it too), which emits `\v11` on Windows; pacquet's
+/// [`From<PathBuf> for StoreDir`] mirrors that with `PathBuf::join`.
+/// Hardcoding `/` here would compare a backslash-joined left against
+/// a slash-joined right and panic on Windows only.
 #[test]
 fn modules_yaml_serialized_store_dir_carries_store_version() {
     let store = StoreDir::new("/tmp/.pnpm-store");
     let recorded = store.display().to_string();
-    let pnpm_would_emit = format!("/tmp/.pnpm-store/{STORE_VERSION}");
+    let pnpm_would_emit = Path::new("/tmp/.pnpm-store").join(STORE_VERSION).display().to_string();
     assert_eq!(recorded, pnpm_would_emit);
 }
 


### PR DESCRIPTION
## Summary

Under \`enableGlobalVirtualStore: true\`, upstream pnpm mutates \`virtualStoreDir\` in place at [\`extendInstallOptions.ts:419-422\`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/deps-installer/src/install/extendInstallOptions.ts#L419-L422) so every consumer that reads \`ctx.virtualStoreDir\` — including [\`writeModulesManifest\`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/modules-yaml/src/index.ts#L111-L138) and the [\`pnpm:context\` debug log](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/context/src/index.ts#L196-L201) — sees the GVS-derived \`<storeDir>/v11/links\` path.

Pacquet kept \`Config::virtual_store_dir\` at its project-local value (deliberately, see \`apply_global_virtual_store_derivation\`'s rationale) and wrote that field straight into \`.modules.yaml\` and the context log. With \`pnpm install\` delegating to pacquet via \`configDependencies: @pnpm/pacquet\`, every run came back through pnpm's [\`checkCompatibility\`](https://github.com/pnpm/pnpm/blob/f2a4d2caef/installing/deps-installer/src/install/checkCompatibility/index.ts#L37-L43), the recorded project-local \`virtualStoreDir\` didn't match the GVS-mutated value pnpm computed, and per-importer purges fired the *"modules directories will be reinstalled from scratch"* prompt on **every** install.

This was reproducible in this repo: \`pnpm-workspace.yaml\` declares both \`enableGlobalVirtualStore: true\` and \`configDependencies: '@pnpm/pacquet': 0.2.7\`. Aborting the prompt (e.g. in CI without a TTY) failed with \`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY\`.

## Fix

Route both externally-visible consumers — \`build_modules_manifest\` and the \`pnpm:context\` emission — through a new \`Config::effective_virtual_store_dir\` helper that returns \`global_virtual_store_dir\` when GVS is on (which already encodes "user pinned or fall back to \`<storeDir>/links\`" via \`apply_global_virtual_store_derivation\`) and the project-local \`virtual_store_dir\` otherwise.

Pacquet's internal layout consumers still read the field directly — the deliberate divergence the helper documents lives only at the parity boundary.

## Test plan

- [x] New \`gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log\` pins both halves: \`.modules.yaml\` round-trips to \`<storeDir>/v11/links\` under GVS, and the \`pnpm:context\` event reports the same path.
- [x] Verified the test fails when either consumer is reverted to the buggy form (the assertion fires on each leg in turn).
- [x] \`cargo nextest run -p pacquet-package-manager\` — 2007/2007 pass.
- [x] \`just check\` / \`cargo fmt --check\` / \`just lint\` clean.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtual store directory reporting so installs now record the effective virtual store path consistently in .modules.yaml and context logs when global virtual store mode is enabled.

* **Tests**
  * Added/updated integration tests to verify the effective virtual store path is persisted and canonicalized consistently across manifests and emitted logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->