### PR TITLE
perf(pacquet): prefetch packuments during fresh-resolve tree walk

### DIFF
--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -451,7 +451,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // download's `pnpm:progress` emits route through the same
         // reporter the install pass uses. See
         // `prefetching_resolver.rs` for the full design rationale.
-        let resolver: Box<dyn Resolver> = Box::new(PrefetchingResolver::<Reporter>::new(
+        let resolver: Arc<dyn Resolver> = Arc::new(PrefetchingResolver::<Reporter>::new(
             inner_resolver,
             PrefetchContext {
                 http_client: &http_client_arc,
@@ -541,7 +541,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
 
         let phase_start = std::time::Instant::now();
         let importer_result = resolve_importer(
-            &*resolver,
+            Arc::clone(&resolver),
             manifest,
             dependency_groups.iter().copied(),
             importer_opts,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -375,13 +375,13 @@ pub async fn extend_tree(
 ///
 /// Each spec is dispatched through the resolver chain on its own
 /// [`tokio::spawn`] task; the result is discarded. The npm resolver's
-/// per-`(registry, name)` packument fetch semaphore (see
-/// [`pacquet_resolving_npm_resolver::shared_packument_fetch_locker`])
-/// coalesces this prefetch with the later real `resolve()` call from
-/// the tree walker so the recursion hits the in-memory packument
-/// cache and the per-version manifest cache instead of paying for a
-/// fresh network round-trip plus a fresh JSON parse + serde re-roundtrip
-/// per call site.
+/// per-`(registry, name)` packument fetch semaphore (the
+/// `shared_packument_fetch_locker` exposed by the `pacquet-resolving-
+/// npm-resolver` crate) coalesces this prefetch with the later real
+/// `resolve()` call from the tree walker so the recursion hits the
+/// in-memory packument cache and the per-version manifest cache
+/// instead of paying for a fresh network round-trip plus a fresh JSON
+/// parse + serde re-roundtrip per call site.
 ///
 /// Detached spawns matter because the tree walker resolves siblings via
 /// `try_join_all`: those futures cooperate on the current task, so a

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -131,17 +131,17 @@ impl From<PatchKeyConflictError> for ResolveDependencyTreeError {
 /// `await` inside, so a sync mutex is the right tool — tokio's async
 /// mutex adds per-acquire overhead that the resolve hot path was
 /// paying once per visit per ctx field.
-pub async fn resolve_dependency_tree<DependencyGroupList, Chain>(
-    resolver: &Chain,
+pub async fn resolve_dependency_tree<DependencyGroupList>(
+    resolver: Arc<dyn Resolver>,
     manifest: &PackageManifest,
     dependency_groups: DependencyGroupList,
     opts: ResolveDependencyTreeOptions,
 ) -> Result<ResolvedTree, ResolveDependencyTreeError>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
-    Chain: Resolver + ?Sized,
 {
-    let ctx = TreeCtx::new(opts.base_opts).with_patched_dependencies(opts.patched_dependencies);
+    let ctx =
+        TreeCtx::new(resolver, opts.base_opts).with_patched_dependencies(opts.patched_dependencies);
     let optional_names = importer_optional_dependency_names(manifest);
     let wanted: Vec<(String, String, bool)> = manifest
         .dependencies(dependency_groups)
@@ -150,7 +150,7 @@ where
             (name.to_string(), range.to_string(), optional)
         })
         .collect();
-    let direct = extend_tree(&ctx, resolver, wanted).await?;
+    let direct = extend_tree(&ctx, wanted).await?;
     Ok(ctx.into_resolved_tree(direct))
 }
 
@@ -196,7 +196,18 @@ type ChildSpec = (String, String, bool);
 /// extends it via [`extend_tree`] so newly-hoisted peer dependencies
 /// reuse the existing per-id dedup map instead of restarting the walk.
 pub struct TreeCtx {
-    base_opts: ResolveOptions,
+    /// Resolver chain shared with every per-package
+    /// [`Resolver::resolve`] call. Held as `Arc<dyn Resolver>` so the
+    /// per-level packument prefetch (see [`prefetch_packuments`]) can
+    /// clone it into [`tokio::spawn`]ed tasks — the spawned future
+    /// must own `'static`, which a borrowed `&dyn Resolver` can't
+    /// provide.
+    resolver: Arc<dyn Resolver>,
+    /// Arc-wrapped resolve options shared by every per-package
+    /// `resolve()` call. Arc'd (rather than cloned per call) so the
+    /// prefetch fan-out only bumps a refcount instead of re-cloning
+    /// `PreferredVersions` and `PackageVersionPolicy` per task.
+    base_opts: Arc<ResolveOptions>,
     packages: Mutex<HashMap<String, ResolvedPackage>>,
     dependencies_tree: Mutex<HashMap<NodeId, DependenciesTreeNode>>,
     all_peer_dep_names: Mutex<HashSet<String>>,
@@ -239,9 +250,10 @@ pub struct TreeCtx {
 impl TreeCtx {
     /// Construct an empty context. Calls to [`extend_tree`] populate
     /// `packages` / `dependencies_tree` / `all_peer_dep_names`.
-    pub fn new(base_opts: ResolveOptions) -> Self {
+    pub fn new(resolver: Arc<dyn Resolver>, base_opts: ResolveOptions) -> Self {
         TreeCtx {
-            base_opts,
+            resolver,
+            base_opts: Arc::new(base_opts),
             packages: Mutex::new(HashMap::new()),
             dependencies_tree: Mutex::new(HashMap::new()),
             all_peer_dep_names: Mutex::new(HashSet::new()),
@@ -338,14 +350,11 @@ impl TreeCtx {
 /// importer can't appear in its own ancestor chain), but the walker
 /// may still return `None` for any spec the cycle break gated out;
 /// those are filtered here.
-pub async fn extend_tree<Chain>(
+pub async fn extend_tree(
     ctx: &TreeCtx,
-    resolver: &Chain,
     wanted: Vec<(String, String, bool)>,
-) -> Result<Vec<DirectDep>, ResolveDependencyTreeError>
-where
-    Chain: Resolver + ?Sized,
-{
+) -> Result<Vec<DirectDep>, ResolveDependencyTreeError> {
+    prefetch_packuments(&ctx.resolver, &ctx.base_opts, &wanted);
     let results = wanted
         .into_iter()
         .map(|(name, range, optional)| async move {
@@ -355,11 +364,62 @@ where
                 optional: Some(optional),
                 ..WantedDependency::default()
             };
-            resolve_node(ctx, resolver, wanted, &[], 0, false).await
+            resolve_node(ctx, wanted, &[], 0, false).await
         })
         .pipe(future::try_join_all)
         .await?;
     Ok(results.into_iter().flatten().collect())
+}
+
+/// Fire-and-forget packument prefetch for a batch of child specs.
+///
+/// Each spec is dispatched through the resolver chain on its own
+/// [`tokio::spawn`] task; the result is discarded. The npm resolver's
+/// per-`(registry, name)` packument fetch semaphore (see
+/// [`pacquet_resolving_npm_resolver::shared_packument_fetch_locker`])
+/// coalesces this prefetch with the later real `resolve()` call from
+/// the tree walker so the recursion hits the in-memory packument
+/// cache and the per-version manifest cache instead of paying for a
+/// fresh network round-trip plus a fresh JSON parse + serde re-roundtrip
+/// per call site.
+///
+/// Detached spawns matter because the tree walker resolves siblings via
+/// `try_join_all`: those futures cooperate on the current task, so a
+/// CPU-heavy step inside one resolve (JSON parse, semver pick, manifest
+/// serde) blocks the others until it yields. The packument fetch tasks
+/// run on the multi-thread executor instead, so the I/O and the
+/// duplicate-work-after-cache-hit can land on whichever worker is free.
+///
+/// Mirrors upstream pnpm's
+/// [`resolveDependencies` BFS-batched fan-out](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L690-L697)
+/// where every sibling's `pickPackage` runs concurrently via
+/// `Promise.all` before the deferred `postponedResolution` queue
+/// recurses into the next level. Called twice — once at
+/// [`extend_tree`] for the importer's direct deps, and once inside
+/// [`resolve_node`] as soon as a parent's manifest reveals its
+/// children — so every level of the tree gets the same lookahead.
+///
+/// Errors from the prefetch are silently dropped — the real
+/// `resolve()` call later in [`resolve_node`] surfaces the same error
+/// to the caller through the normal error path.
+fn prefetch_packuments(
+    resolver: &Arc<dyn Resolver>,
+    base_opts: &Arc<ResolveOptions>,
+    specs: &[(String, String, bool)],
+) {
+    for (name, range, optional) in specs {
+        let resolver = Arc::clone(resolver);
+        let base_opts = Arc::clone(base_opts);
+        let wanted = WantedDependency {
+            alias: Some(name.clone()),
+            bare_specifier: Some(range.clone()),
+            optional: Some(*optional),
+            ..WantedDependency::default()
+        };
+        tokio::spawn(async move {
+            let _ = resolver.resolve(&wanted, &base_opts).await;
+        });
+    }
 }
 
 /// Resolve one `(alias, range)` edge, register the resolved package in
@@ -377,17 +437,13 @@ where
 /// each other into `graph.insert`, and an empty-children entry for the
 /// cycled occurrence can overwrite the real one.
 #[async_recursion]
-async fn resolve_node<Chain>(
+async fn resolve_node(
     ctx: &TreeCtx,
-    resolver: &Chain,
     wanted: WantedDependency,
     ancestor_ids: &[String],
     depth: i32,
     parent_optional: bool,
-) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
-where
-    Chain: Resolver + ?Sized,
-{
+) -> Result<Option<DirectDep>, ResolveDependencyTreeError> {
     let current_is_optional = wanted.optional.unwrap_or(false) || parent_optional;
 
     // Memoise the per-wanted resolve. The first caller for a given
@@ -408,10 +464,9 @@ where
     let result = match cached {
         Some(result) => result,
         None => {
-            let result =
-                resolver.resolve(&wanted, &ctx.base_opts).await.map_err(|err: ResolveError| {
-                    ResolveDependencyTreeError::Resolve(err.to_string())
-                })?;
+            let result = ctx.resolver.resolve(&wanted, &ctx.base_opts).await.map_err(
+                |err: ResolveError| ResolveDependencyTreeError::Resolve(err.to_string()),
+            )?;
             let Some(result) = result else {
                 return Err(ResolveDependencyTreeError::SpecNotSupported {
                     specifier: render_specifier(&wanted),
@@ -525,6 +580,7 @@ where
             specs
         }
     };
+    prefetch_packuments(&ctx.resolver, &ctx.base_opts, &child_specs);
     let child_results = child_specs
         .iter()
         .map(|(child_name, child_range, child_optional)| {
@@ -536,15 +592,8 @@ where
             };
             let next_ancestors = next_ancestors.clone();
             async move {
-                resolve_node(
-                    ctx,
-                    resolver,
-                    child_wanted,
-                    &next_ancestors,
-                    depth + 1,
-                    current_is_optional,
-                )
-                .await
+                resolve_node(ctx, child_wanted, &next_ancestors, depth + 1, current_is_optional)
+                    .await
             }
         })
         .pipe(future::try_join_all)

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -116,15 +116,14 @@ impl From<ResolveDependencyTreeError> for ResolveImporterError {
 
 /// Resolve an importer's full dependency graph with auto-install-peers
 /// hoisting. See the module-level doc for the algorithm.
-pub async fn resolve_importer<DependencyGroupList, Chain>(
-    resolver: &Chain,
+pub async fn resolve_importer<DependencyGroupList>(
+    resolver: Arc<dyn Resolver>,
     manifest: &PackageManifest,
     dependency_groups: DependencyGroupList,
     opts: ResolveImporterOptions,
 ) -> Result<ResolveImporterResult, ResolveImporterError>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
-    Chain: Resolver + ?Sized,
 {
     let ResolveImporterOptions {
         auto_install_peers,
@@ -136,7 +135,7 @@ where
         catalogs,
     } = opts;
 
-    let ctx = TreeCtx::new(base_opts).with_patched_dependencies(patched_dependencies);
+    let ctx = TreeCtx::new(resolver, base_opts).with_patched_dependencies(patched_dependencies);
 
     // Mirrors upstream's
     // [`getAllDependenciesFromManifest({ autoInstallPeers })`](https://github.com/pnpm/pnpm/blob/097983fbca/pkg-manifest/utils/src/getAllDependenciesFromManifest.ts):
@@ -163,7 +162,7 @@ where
         })
         .collect();
     let initial_wanted = resolve_catalog_specifiers(initial_wanted, &catalogs)?;
-    let mut direct = extend_tree(&ctx, resolver, initial_wanted).await?;
+    let mut direct = extend_tree(&ctx, initial_wanted).await?;
     update_preferred_versions_with_ctx(&ctx, &mut all_preferred_versions);
 
     let mut parent_pkg_aliases: HashSet<String> =
@@ -225,7 +224,7 @@ where
             // shape inside `hoistPeers`.
             let new_wanted: Vec<(String, String, bool)> =
                 hoisted.into_iter().map(|(name, range)| (name, range, false)).collect();
-            let new_direct = extend_tree(&ctx, resolver, new_wanted).await?;
+            let new_direct = extend_tree(&ctx, new_wanted).await?;
             direct.extend(new_direct);
             update_preferred_versions_with_ctx(&ctx, &mut all_preferred_versions);
         }
@@ -247,7 +246,7 @@ where
         // non-optional matches the required-peer arm above.
         let new_wanted: Vec<(String, String, bool)> =
             hoisted_optional.into_iter().map(|(name, range)| (name, range, false)).collect();
-        let new_direct = extend_tree(&ctx, resolver, new_wanted).await?;
+        let new_direct = extend_tree(&ctx, new_wanted).await?;
         direct.extend(new_direct);
         update_preferred_versions_with_ctx(&ctx, &mut all_preferred_versions);
         all_missing_optional_peers.clear();

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Mutex};
+use std::{collections::HashMap, str::FromStr, sync::Arc, sync::Mutex};
 
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
@@ -14,7 +14,7 @@ use crate::{
 
 struct StubResolver {
     table: HashMap<(String, String), ResolveResult>,
-    calls: Mutex<Vec<(String, String)>>,
+    calls: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl Resolver for StubResolver {
@@ -115,12 +115,14 @@ async fn auto_installs_missing_required_peer() {
         ("react".to_string(), "^18.0.0".to_string()),
         fake_result("react", "18.2.0", serde_json::json!({ "name": "react", "version": "18.2.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "react-dom": "18.0.0" }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct_aliases: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -152,13 +154,15 @@ async fn does_not_hoist_when_disabled() {
             }),
         ),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "react-dom": "18.0.0" }));
 
     let mut opts = default_opts();
     opts.auto_install_peers = false;
-    let result =
-        resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
+    let result = resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], opts)
+        .await
+        .unwrap();
 
     #[expect(
         clippy::needless_collect,
@@ -205,12 +209,14 @@ async fn transitive_required_peer_is_hoisted() {
             serde_json::json!({ "name": "peer-pkg", "version": "1.2.3" }),
         ),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "outer": "1.0.0" }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -248,15 +254,17 @@ async fn reuses_preferred_version_instead_of_resolving_fresh() {
         ("react".to_string(), "18.2.0".to_string()),
         fake_result("react", "18.2.0", serde_json::json!({ "name": "react", "version": "18.2.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) =
         fake_manifest(serde_json::json!({ "react": "18.2.0", "react-dom": "18.0.0" }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     // No `react` re-resolve via a different range — the only react
     // request was the direct dep at "18.2.0".
     let react_call_count = calls.iter().filter(|(name, _)| name == "react").count();
@@ -305,12 +313,14 @@ async fn auto_install_skips_optional_peers_without_preferred_versions() {
         ("peer-a".to_string(), "^1.0.0".to_string()),
         fake_result("peer-a", "1.0.0", serde_json::json!({ "name": "peer-a", "version": "1.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "abc": "1.0.0" }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -359,15 +369,17 @@ async fn auto_install_dedupes_via_range_intersection_when_identical() {
         ("peer-c".to_string(), "1.0.0".to_string()),
         fake_result("peer-c", "1.0.0", serde_json::json!({ "name": "peer-c", "version": "1.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "wants-peer-c-1": "1.0.0",
         "wants-peer-c-1.0.0": "1.0.0",
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -413,15 +425,17 @@ async fn auto_install_does_not_install_when_no_intersection() {
             }),
         ),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "wants-peer-c-1": "1.0.0",
         "wants-peer-c-2": "1.0.0",
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -463,7 +477,8 @@ async fn auto_install_from_highest_match_installs_on_conflict() {
         ("peer-c".to_string(), "1.0.0 || 2.0.0".to_string()),
         fake_result("peer-c", "2.0.0", serde_json::json!({ "name": "peer-c", "version": "2.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "wants-peer-c-1": "1.0.0",
         "wants-peer-c-2": "1.0.0",
@@ -471,8 +486,9 @@ async fn auto_install_from_highest_match_installs_on_conflict() {
 
     let mut opts = default_opts();
     opts.auto_install_peers_from_highest_match = true;
-    let result =
-        resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
+    let result = resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], opts)
+        .await
+        .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -528,15 +544,17 @@ async fn auto_install_reuses_peer_already_brought_by_a_sibling() {
             fake_result(name, "1.0.0", serde_json::json!({ "name": name, "version": "1.0.0" })),
         );
     }
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "xyz-parent": "1.0.0",
         "xyz-with-xyz": "1.0.0",
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
@@ -549,7 +567,7 @@ async fn auto_install_reuses_peer_already_brought_by_a_sibling() {
     // called multiple times with the same `1.0.0` spec because the
     // tree walker doesn't gate the `resolve()` call on dedup; what
     // matters here is that `^1.0.0` never appears.)
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     for name in ["x", "y", "z"] {
         let ranges: Vec<&str> = calls
             .iter()
@@ -585,19 +603,21 @@ async fn auto_install_does_not_hoist_when_root_already_has_dep() {
         ("x".to_string(), "1.0.0".to_string()),
         fake_result("x", "1.0.0", serde_json::json!({ "name": "x", "version": "1.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "xyz": "1.0.0",
         "x": "1.0.0",
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     // The picker must not re-resolve `x` via the peer's `^1.0.0` range
     // when the root already pinned it at `1.0.0`.
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     let x_ranges: Vec<String> =
         calls.iter().filter(|(n, _)| n == "x").map(|(_, r)| r.clone()).collect();
     assert_eq!(
@@ -646,17 +666,19 @@ async fn auto_install_does_not_install_same_missing_peer_twice() {
         ("y".to_string(), "^1.0.0".to_string()),
         fake_result("y", "1.0.0", serde_json::json!({ "name": "y", "version": "1.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "outer": "1.0.0" }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let y_entries: Vec<&DepPath> =
         result.peers_result.graph.keys().filter(|dp| dp.to_string().starts_with("y@")).collect();
     assert_eq!(y_entries.len(), 1, "expected one y entry, got: {y_entries:?}");
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     let y_calls = calls.iter().filter(|(n, _)| n == "y").count();
     assert_eq!(y_calls, 1, "y should be resolved at most once");
 }
@@ -689,7 +711,8 @@ async fn auto_install_prefers_peer_version_pinned_in_importer_peerdeps() {
         ("y".to_string(), "^1.0.0".to_string()),
         fake_result("y", "1.0.0", serde_json::json!({ "name": "y", "version": "1.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest_json(serde_json::json!({
         "name": "root",
         "version": "0.0.0",
@@ -699,15 +722,16 @@ async fn auto_install_prefers_peer_version_pinned_in_importer_peerdeps() {
         },
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
     assert!(direct.contains(&"y"), "importer's own peer dep should land as direct: {direct:?}");
     assert!(direct.contains(&"has-y-peer"));
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     let y_ranges: Vec<String> =
         calls.iter().filter(|(n, _)| n == "y").map(|(_, r)| r.clone()).collect();
     assert_eq!(
@@ -752,15 +776,17 @@ async fn auto_install_hoisted_peer_dep_reuses_regular_dep_version() {
         ("c".to_string(), "2.0.0".to_string()),
         fake_result("c", "2.0.0", serde_json::json!({ "name": "c", "version": "2.0.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({
         "has-c-in-deps": "1.0.0",
         "wants-c": "1.0.0",
     }));
 
-    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .unwrap();
+    let result =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .unwrap();
 
     let c_entries: Vec<String> = result
         .peers_result
@@ -787,7 +813,8 @@ async fn catalog_protocol_on_direct_dep_is_rewritten() {
         ("foo".to_string(), "^1.0.0".to_string()),
         fake_result("foo", "1.2.0", serde_json::json!({ "name": "foo", "version": "1.2.0" })),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let resolver: Arc<dyn Resolver> = Arc::new(StubResolver { table, calls: Arc::clone(&calls) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "catalog:" }));
 
     let mut catalogs = pacquet_catalogs_types::Catalogs::new();
@@ -797,12 +824,13 @@ async fn catalog_protocol_on_direct_dep_is_rewritten() {
     );
 
     let opts = ResolveImporterOptions { catalogs, ..default_opts() };
-    let result =
-        resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
+    let result = resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], opts)
+        .await
+        .unwrap();
     assert_eq!(result.resolved_tree.direct.len(), 1);
     assert_eq!(result.resolved_tree.direct[0].alias, "foo");
     // The resolver chain only sees the catalog-rewritten range.
-    let calls = resolver.calls.lock().unwrap();
+    let calls = calls.lock().unwrap();
     assert_eq!(&*calls, &[("foo".to_string(), "^1.0.0".to_string())]);
 }
 
@@ -811,12 +839,14 @@ async fn catalog_protocol_on_direct_dep_is_rewritten() {
 /// error rather than falling through to `SpecNotSupported`.
 #[tokio::test]
 async fn catalog_misconfiguration_surfaces_pnpm_error_code() {
-    let resolver = StubResolver { table: HashMap::new(), calls: Mutex::new(Vec::new()) };
+    let resolver: Arc<dyn Resolver> =
+        Arc::new(StubResolver { table: HashMap::new(), calls: Arc::new(Mutex::new(Vec::new())) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "catalog:" }));
 
-    let err = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
-        .await
-        .expect_err("missing catalog entry must error");
+    let err =
+        resolve_importer(Arc::clone(&resolver), &manifest, [DependencyGroup::Prod], default_opts())
+            .await
+            .expect_err("missing catalog entry must error");
     match err {
         ResolveImporterError::Resolve(ResolveDependencyTreeError::CatalogMisconfiguration(
             inner,

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Mutex};
+use std::{collections::HashMap, str::FromStr, sync::Arc, sync::Mutex};
 
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
@@ -106,11 +106,12 @@ async fn walks_dependencies_and_builds_flat_tree() {
             }),
         ),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let resolver: Arc<dyn Resolver> =
+        Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
     let tree = resolve_dependency_tree(
-        &resolver,
+        Arc::clone(&resolver),
         &manifest,
         [DependencyGroup::Prod],
         ResolveDependencyTreeOptions {
@@ -173,11 +174,12 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
             }),
         ),
     );
-    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let resolver: Arc<dyn Resolver> =
+        Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "a": "^1.0.0", "b": "^1.0.0" }));
 
     let tree = resolve_dependency_tree(
-        &resolver,
+        Arc::clone(&resolver),
         &manifest,
         [DependencyGroup::Prod],
         ResolveDependencyTreeOptions {
@@ -216,11 +218,12 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
 /// diagnostic the chain dispatcher does.
 #[tokio::test]
 async fn declined_specifier_surfaces_spec_not_supported_error() {
-    let resolver = StubResolver { table: HashMap::new(), calls: Mutex::new(Vec::new()) };
+    let resolver: Arc<dyn Resolver> =
+        Arc::new(StubResolver { table: HashMap::new(), calls: Mutex::new(Vec::new()) });
     let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "git+ssh://example.com" }));
 
     let err = resolve_dependency_tree(
-        &resolver,
+        Arc::clone(&resolver),
         &manifest,
         [DependencyGroup::Prod],
         ResolveDependencyTreeOptions {
@@ -240,10 +243,10 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
 
 mod block_exotic_subdeps {
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     use pacquet_package_manifest::DependencyGroup;
-    use pacquet_resolving_resolver_base::ResolveOptions;
+    use pacquet_resolving_resolver_base::{ResolveOptions, Resolver};
 
     use super::{StubResolver, fake_manifest, fake_result};
     use crate::resolve_dependency_tree::{
@@ -286,11 +289,12 @@ mod block_exotic_subdeps {
                 serde_json::json!({ "name": "say-hi", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let err = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -325,12 +329,13 @@ mod block_exotic_subdeps {
                 serde_json::json!({ "name": "is-negative", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) =
             fake_manifest(serde_json::json!({ "is-negative": "kevva/is-negative#1.0.0" }));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -367,11 +372,12 @@ mod block_exotic_subdeps {
             ("bar".to_string(), "^2.0.0".to_string()),
             fake_result("bar", "2.0.0", serde_json::json!({ "name": "bar", "version": "2.0.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -410,11 +416,12 @@ mod block_exotic_subdeps {
                 serde_json::json!({ "name": "say-hi", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -433,10 +440,10 @@ mod block_exotic_subdeps {
 
 mod peers {
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     use pacquet_package_manifest::DependencyGroup;
-    use pacquet_resolving_resolver_base::ResolveOptions;
+    use pacquet_resolving_resolver_base::{ResolveOptions, Resolver};
     use pretty_assertions::assert_eq;
 
     use super::{StubResolver, fake_manifest, fake_result};
@@ -453,10 +460,11 @@ mod peers {
             ("foo".to_string(), "^1.0.0".to_string()),
             fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -502,11 +510,12 @@ mod peers {
                 }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) =
             fake_manifest(serde_json::json!({ "react": "18.0.0", "react-dom": "18.0.0" }));
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -551,10 +560,11 @@ mod peers {
                 }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "react-dom": "18.0.0" }));
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -601,11 +611,12 @@ mod peers {
                 }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) =
             fake_manifest(serde_json::json!({ "react": "17.0.0", "react-dom": "18.0.0" }));
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -659,12 +670,13 @@ mod peers {
                 serde_json::json!({ "name": "react", "version": "18.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         // Manifest order puts react-dom first.
         let (_tmp, manifest) =
             fake_manifest(serde_json::json!({ "react-dom": "18.0.0", "react": "18.0.0" }));
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -695,7 +707,7 @@ mod patched_dependencies {
 
     use pacquet_package_manifest::DependencyGroup;
     use pacquet_patching::{ExtendedPatchInfo, PatchGroup, PatchGroupRangeItem, PatchGroupRecord};
-    use pacquet_resolving_resolver_base::ResolveOptions;
+    use pacquet_resolving_resolver_base::{ResolveOptions, Resolver};
     use pretty_assertions::assert_eq;
 
     use super::{StubResolver, fake_manifest, fake_result};
@@ -727,14 +739,15 @@ mod patched_dependencies {
             ("foo".to_string(), "^1.0.0".to_string()),
             fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let mut groups: PatchGroupRecord = PatchGroupRecord::new();
         groups.insert("foo".to_string(), exact_group("1.0.0", "foo@1.0.0", "abc123"));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -766,7 +779,8 @@ mod patched_dependencies {
             ("foo".to_string(), "^1.0.0".to_string()),
             fake_result("foo", "1.2.0", serde_json::json!({ "name": "foo", "version": "1.2.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let info = ExtendedPatchInfo {
@@ -780,7 +794,7 @@ mod patched_dependencies {
         groups.insert("foo".to_string(), group);
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -805,14 +819,15 @@ mod patched_dependencies {
             ("foo".to_string(), "^1.0.0".to_string()),
             fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let mut groups: PatchGroupRecord = PatchGroupRecord::new();
         groups.insert("bar".to_string(), exact_group("2.0.0", "bar@2.0.0", "abc"));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -836,7 +851,8 @@ mod patched_dependencies {
             ("foo".to_string(), "^1.0.0".to_string()),
             fake_result("foo", "1.2.0", serde_json::json!({ "name": "foo", "version": "1.2.0" })),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": "^1.0.0" }));
 
         let mut group = PatchGroup::default();
@@ -860,7 +876,7 @@ mod patched_dependencies {
         groups.insert("foo".to_string(), group);
 
         let err = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod],
             ResolveDependencyTreeOptions {
@@ -876,8 +892,8 @@ mod patched_dependencies {
 
 mod optional_propagation {
     use super::{
-        DependencyGroup, HashMap, Mutex, PackageManifest, ResolveDependencyTreeOptions,
-        ResolveOptions, StubResolver, fake_result, resolve_dependency_tree,
+        Arc, DependencyGroup, HashMap, Mutex, PackageManifest, ResolveDependencyTreeOptions,
+        ResolveOptions, Resolver, StubResolver, fake_result, resolve_dependency_tree,
     };
 
     /// `package.json` builder that takes both `dependencies` and
@@ -921,14 +937,15 @@ mod optional_propagation {
                 serde_json::json!({ "name": "regular", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = manifest_with_groups(
             serde_json::json!({ "regular": "^1.0.0" }),
             serde_json::json!({ "opt": "^1.0.0" }),
         );
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod, DependencyGroup::Optional],
             ResolveDependencyTreeOptions {
@@ -976,12 +993,13 @@ mod optional_propagation {
                 serde_json::json!({ "name": "transitive", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) =
             manifest_with_groups(serde_json::json!({}), serde_json::json!({ "opt": "^1.0.0" }));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod, DependencyGroup::Optional],
             ResolveDependencyTreeOptions {
@@ -1037,14 +1055,15 @@ mod optional_propagation {
                 serde_json::json!({ "name": "shared", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) = manifest_with_groups(
             serde_json::json!({ "regular": "^1.0.0" }),
             serde_json::json!({ "opt": "^1.0.0" }),
         );
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod, DependencyGroup::Optional],
             ResolveDependencyTreeOptions {
@@ -1090,12 +1109,13 @@ mod optional_propagation {
                 serde_json::json!({ "name": "transitive", "version": "1.0.0" }),
             ),
         );
-        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let resolver: Arc<dyn Resolver> =
+            Arc::new(StubResolver { table, calls: Mutex::new(Vec::new()) });
         let (_tmp, manifest) =
             manifest_with_groups(serde_json::json!({ "regular": "^1.0.0" }), serde_json::json!({}));
 
         let tree = resolve_dependency_tree(
-            &resolver,
+            Arc::clone(&resolver),
             &manifest,
             [DependencyGroup::Prod, DependencyGroup::Optional],
             ResolveDependencyTreeOptions {


### PR DESCRIPTION
## Summary

Closes #11900.

Detaches packument fetches from the deps-resolver's cooperative `try_join_all` task by firing `tokio::spawn`ed `resolver.resolve()` calls just before each level of the tree walk descends. Two prefetch points, both modeled on pnpm's [`resolveDependencies` BFS-batched fan-out](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-resolver/src/resolveDependencies.ts#L690-L697):

- **Top-level prefetch in [`extend_tree`](https://github.com/pnpm/pnpm/blob/a456dc78fb/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs).** Direct deps from the importer (and each hoist iteration's freshly-picked peers) start fetching before the cooperative `try_join_all` walks them.
- **Lookahead inside [`resolve_node`](https://github.com/pnpm/pnpm/blob/a456dc78fb/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs).** As soon as a parent's manifest is known, packument fetches for every child name fire on background tasks so the recursive `resolve_node` calls below `await` a cache hit instead of a blocking fetch.

The npm resolver's per-`(registry, name)` packument fetch semaphore ([`shared_packument_fetch_locker`](https://github.com/pnpm/pnpm/blob/a456dc78fb/pacquet/crates/resolving-npm-resolver/src/pick_package.rs)) coalesces the prefetch with the later real `resolve()` call, so the recursion hits the in-memory packument cache and the per-version manifest cache instead of paying for a fresh network round-trip plus a fresh JSON parse + serde re-roundtrip per call site.

Detached spawns matter because the futures inside `try_join_all` cooperate on the current task: a CPU-heavy step in one resolve (JSON parse, semver pick, manifest serde) blocks the others until it yields. The prefetch tasks run on the multi-thread executor, so I/O and any duplicate-work-after-cache-hit can land on whichever worker is free.

## Plumbing changes

To make `tokio::spawn` possible the resolver chain is now threaded as `Arc<dyn Resolver>` (instead of `&Chain` generic) through `resolve_dependency_tree` / `resolve_importer` / `extend_tree`, and stored on `TreeCtx` alongside an `Arc<ResolveOptions>` so the detached tasks bump refcounts instead of cloning `PreferredVersions` and `PackageVersionPolicy` per spawn.

Errors from the prefetch are silently dropped — the real `resolve()` later in `resolve_node` surfaces the same error through the normal error path. The result is otherwise identical to the existing tree walk: every assertion in the 50 deps-resolver tests + 299 package-manager tests + 96 cli tests still passes.

## Test plan

- [x] `cargo nextest run -p pacquet-resolving-deps-resolver` — 50/50 pass
- [x] `cargo nextest run -p pacquet-package-manager` — 299/299 pass (3 slow, no new slowness)
- [x] `cargo nextest run -p pacquet-cli` — 96/96 pass (2 slow, expected)
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Wall-clock measurement against the [vlt.sh `clean astro` benchmark](https://benchmarks.vlt.sh/latest/chart-data.json) to confirm the issue's expected impact ratio. The change matches the upstream prefetch shape the issue calls for; a benchmark run on the same fixture is the next step.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the dependency resolution engine for safer concurrent operation, more efficient resource use, and more robust handling of complex resolution flows—resulting in faster, more reliable installs and fewer race-related issues during package resolution and prefetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->