### PR TITLE
perf(pacquet): no-op short-circuit when node_modules is up to date

### DIFF
--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -504,3 +504,60 @@ fn fresh_install_honors_enable_global_virtual_store() {
 
     drop((root, mock_instance)); // cleanup
 }
+
+/// End-to-end coverage for the no-op short-circuit. After a successful
+/// install, a second `pacquet install --frozen-lockfile` against an
+/// untouched workspace must skip materialization and emit pnpm's
+/// `name: "pnpm" / level: "info"` "Lockfile is up to date, resolution
+/// step is skipped" log. Mirrors upstream pnpm's behavior at
+/// <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L984>.
+#[test]
+fn frozen_install_short_circuits_when_node_modules_is_up_to_date() {
+    use std::process::Command;
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json...");
+    let manifest_path = workspace.join("package.json");
+    let package_json = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json.to_string()).expect("write to package.json");
+
+    eprintln!("Priming with the first install...");
+    pacquet.with_arg("install").assert().success();
+
+    eprintln!("Re-running with --frozen-lockfile + --reporter=ndjson...");
+    let pacquet_rerun = Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(&workspace);
+    let output = pacquet_rerun
+        .with_args(["--reporter=ndjson", "install", "--frozen-lockfile"])
+        .output()
+        .expect("run pacquet install --frozen-lockfile");
+    assert!(
+        output.status.success(),
+        "second install must succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr is utf-8");
+    let up_to_date = stderr
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find(|record| {
+            record.get("name").and_then(|v| v.as_str()) == Some("pnpm")
+                && record.get("level").and_then(|v| v.as_str()) == Some("info")
+                && record.get("message").and_then(|v| v.as_str())
+                    == Some("Lockfile is up to date, resolution step is skipped")
+        });
+    assert!(
+        up_to_date.is_some(),
+        "expected `name: \"pnpm\" / level: \"info\"` up-to-date log in NDJSON stderr; got:\n{stderr}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -20,13 +20,13 @@ use pacquet_lockfile_verification::{
 };
 use pacquet_modules_yaml::{
     Host, IncludedDependencies, LayoutVersion, Modules, NodeLinker as ModulesNodeLinker,
-    WriteModulesError, write_modules_manifest,
+    WriteModulesError, read_modules_manifest, write_modules_manifest,
 };
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
-    ContextLog, LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter, Stage,
-    StageLog, SummaryLog,
+    ContextLog, LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, PnpmLog, Reporter,
+    Stage, StageLog, SummaryLog,
 };
 use pacquet_resolving_npm_resolver::InMemoryPackageMetaCache;
 use pacquet_tarball::MemCache;
@@ -543,6 +543,41 @@ where
             false
         };
 
+        // No-op short-circuit. When the frozen-lockfile dispatch is
+        // eligible, the on-disk `.modules.yaml` agrees with the current
+        // config, and `<virtual_store_dir>/lock.yaml` is byte-equal to
+        // the wanted lockfile, nothing needs to be materialized — the
+        // last install already produced exactly this `node_modules`.
+        // Emit the up-to-date log, refresh the workspace-state
+        // timestamp so `pnpm run`'s `verifyDepsBeforeRun` doesn't fire
+        // spuriously, then exit. Mirrors upstream's `validateModules` +
+        // `allProjectsAreUpToDate` fast path at
+        // <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985>.
+        if take_frozen_path
+            && let Some(wanted_lockfile) = lockfile
+            && let Some(current) = current_lockfile.as_ref()
+            && wanted_lockfile == current
+            && is_modules_yaml_consistent(&config.modules_dir, config, node_linker, included)
+        {
+            Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Info,
+                message: "Lockfile is up to date, resolution step is skipped".to_string(),
+                prefix: prefix.clone(),
+            }));
+            Reporter::emit(&LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: prefix.clone(),
+                stage: Stage::ImportingDone,
+            }));
+            update_workspace_state(
+                &workspace_root,
+                &build_workspace_state(config, node_linker, included, manifest, lockfile),
+            )
+            .map_err(InstallError::WriteWorkspaceState)?;
+            Reporter::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
+            return Ok(());
+        }
+
         let (hoisted_dependencies, hoisted_locations, frozen_skipped, fresh_lockfile): (
             HoistedDependencies,
             BTreeMap<String, Vec<String>>,
@@ -995,6 +1030,40 @@ fn map_node_linker(linker: &NodeLinker) -> ModulesNodeLinker {
         NodeLinker::Hoisted => ModulesNodeLinker::Hoisted,
         NodeLinker::Pnp => ModulesNodeLinker::Pnp,
     }
+}
+
+/// Check whether `<modules_dir>/.modules.yaml` is present and its
+/// recorded layout settings (`nodeLinker`, hoist patterns, store /
+/// virtual-store paths, `virtualStoreDirMaxLength`, included dep
+/// groups, layout version) match what the current install would
+/// produce. Returns `false` when the file is missing, unreadable, or
+/// records a different layout — both cases that disqualify the no-op
+/// short-circuit.
+///
+/// Mirrors the settings checks in upstream's
+/// [`validateModules`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts)
+/// minus the prune side effects: a settings mismatch in pnpm forces a
+/// rewrite of `node_modules`, but pacquet's caller falls through to
+/// the regular install path, which rebuilds the layout from scratch
+/// anyway.
+fn is_modules_yaml_consistent(
+    modules_dir: &Path,
+    config: &Config,
+    node_linker: NodeLinker,
+    included: IncludedDependencies,
+) -> bool {
+    let Some(modules) = read_modules_manifest::<Host>(modules_dir).ok().flatten() else {
+        return false;
+    };
+    modules.layout_version == Some(LayoutVersion)
+        && modules.node_linker == Some(map_node_linker(&node_linker))
+        && modules.included == included
+        && modules.hoist_pattern == config.hoist_pattern
+        && modules.public_hoist_pattern == config.public_hoist_pattern
+        && modules.virtual_store_dir_max_length == config.virtual_store_dir_max_length
+        && modules.store_dir == config.store_dir.display().to_string()
+        && modules.virtual_store_dir
+            == config.effective_virtual_store_dir().to_string_lossy().as_ref()
 }
 
 /// Assemble the [`Modules`] payload for [`write_modules_manifest`].

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -4395,3 +4395,286 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         "stale-lockfile fall-through must not surface as OutdatedLockfile, got {err:?}",
     );
 }
+
+/// [`super::is_modules_yaml_consistent`] returns `false` when
+/// `.modules.yaml` is missing, so a first install (no prior state)
+/// can't be mistaken for an up-to-date install.
+#[test]
+fn is_modules_yaml_consistent_returns_false_when_modules_yaml_absent() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+    let mut config = Config::new();
+    config.modules_dir = modules_dir.clone();
+    let config = config.leak();
+
+    assert!(!super::is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::default(),
+        pacquet_modules_yaml::IncludedDependencies::default(),
+    ));
+}
+
+/// [`super::is_modules_yaml_consistent`] returns `true` when every
+/// layout-determining setting matches what
+/// [`super::build_modules_manifest`] would write for the current
+/// config / linker / dependency-group selection. The roundtrip needs
+/// to be exact because a single drifted setting forces the next
+/// install to rebuild the modules directory.
+#[test]
+fn is_modules_yaml_consistent_returns_true_when_settings_match() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let included = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: true,
+        optional_dependencies: true,
+    };
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        included,
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    assert!(super::is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::default(),
+        included,
+    ));
+}
+
+/// `nodeLinker` drift between `.modules.yaml` and the current config
+/// disqualifies the up-to-date short-circuit. Mirrors upstream's
+/// `validateModules` behavior — a different linker forces a full
+/// rebuild of `node_modules` rather than a fast no-op.
+#[test]
+fn is_modules_yaml_consistent_returns_false_when_node_linker_drifts() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Hoisted),
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    assert!(!super::is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        pacquet_modules_yaml::IncludedDependencies::default(),
+    ));
+}
+
+/// Dependency-group drift between `.modules.yaml.included` and the
+/// current install request disqualifies the short-circuit. A
+/// previously installed `--no-optional` setup can't be re-used to
+/// satisfy an install that needs optional dependencies.
+#[test]
+fn is_modules_yaml_consistent_returns_false_when_included_drifts() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let prod_only = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: false,
+    };
+    let with_optional = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: true,
+    };
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        included: prod_only,
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    assert!(!super::is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        with_optional,
+    ));
+}
+
+/// End-to-end: when `.modules.yaml`, `<virtual_store_dir>/lock.yaml`,
+/// and the wanted lockfile all agree, [`Install::run`] must emit the
+/// `name: "pnpm"` "Lockfile is up to date" log and return without
+/// running materialization. Mirrors upstream pnpm's
+/// `allProjectsAreUpToDate` + `validateModules` short-circuit at
+/// <https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985>.
+#[tokio::test]
+async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    // A sibling `link:` dependency keeps the lockfile non-empty without
+    // requiring registry fetches — the gate fires on the eligibility
+    // checks alone, materialization is never reached so the
+    // (non-existent) link target doesn't matter.
+    manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.clone().into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      sibling:"
+        "        specifier: link:../sibling"
+        "        version: link:../sibling"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse minimal v9 lockfile with one link dep");
+
+    let included = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: false,
+    };
+
+    // Seed the on-disk state a previous install would have left.
+    let seed_modules = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        included,
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed_modules).expect("seed .modules.yaml");
+    lockfile.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Isolated,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("up-to-date install should succeed via the short-circuit");
+
+    let captured = EVENTS.lock().unwrap();
+    let up_to_date = captured.iter().find_map(|event| match event {
+        LogEvent::Pnpm(log) => Some(log),
+        _ => None,
+    });
+    let up_to_date = up_to_date.expect(
+        "the `name: \"pnpm\"` up-to-date log must be emitted when the install short-circuits",
+    );
+    assert_eq!(up_to_date.message, "Lockfile is up to date, resolution step is skipped");
+
+    assert!(
+        captured.iter().any(|e| matches!(e, LogEvent::Stage(s) if s.stage == Stage::ImportingDone)),
+        "ImportingDone must close the importing bracket on the fast path",
+    );
+    assert!(
+        captured.iter().any(|e| matches!(e, LogEvent::Summary(_))),
+        "Summary must fire so `pnpm:root` history renders even on the fast path",
+    );
+
+    // Materialization is skipped: no `node_modules/sibling` symlink
+    // is created (link: deps would be symlinked by the regular path).
+    let sibling_link = modules_dir.join("sibling");
+    assert!(
+        !sibling_link.exists(),
+        "the link: dep must NOT be materialized when the gate fires; \
+         a present {sibling_link:?} would mean the install ran the full pipeline",
+    );
+
+    // Workspace state is still refreshed so the next `pnpm run`'s
+    // `verifyDepsBeforeRun` doesn't fire spuriously.
+    let written = load_workspace_state(&project_root)
+        .expect("read workspace state")
+        .expect("workspace state must be written");
+    assert!(
+        written.last_validated_timestamp > 0,
+        "last_validated_timestamp must be refreshed on the fast path",
+    );
+
+    drop(dir);
+}

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -4639,14 +4639,14 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
     .expect("up-to-date install should succeed via the short-circuit");
 
     let captured = EVENTS.lock().unwrap();
-    let up_to_date = captured.iter().find_map(|event| match event {
-        LogEvent::Pnpm(log) => Some(log),
-        _ => None,
-    });
-    let up_to_date = up_to_date.expect(
-        "the `name: \"pnpm\"` up-to-date log must be emitted when the install short-circuits",
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Pnpm(log)
+                if log.message == "Lockfile is up to date, resolution step is skipped"
+        )),
+        r#"the `name: "pnpm"` up-to-date log must be emitted when the install short-circuits"#,
     );
-    assert_eq!(up_to_date.message, "Lockfile is up to date, resolution step is skipped");
 
     assert!(
         captured.iter().any(|e| matches!(e, LogEvent::Stage(s) if s.stage == Stage::ImportingDone)),
@@ -4657,11 +4657,14 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         "Summary must fire so `pnpm:root` history renders even on the fast path",
     );
 
-    // Materialization is skipped: no `node_modules/sibling` symlink
-    // is created (link: deps would be symlinked by the regular path).
+    // `Path::exists()` follows symlinks and returns `false` for a
+    // broken target — `symlink_metadata` is the right call to detect
+    // the symlink entry itself, so a dangling sibling symlink would
+    // still fail this assertion. Materialization on the regular
+    // install path always creates the link before falling through.
     let sibling_link = modules_dir.join("sibling");
     assert!(
-        !sibling_link.exists(),
+        std::fs::symlink_metadata(&sibling_link).is_err(),
         "the link: dep must NOT be materialized when the gate fires; \
          a present {sibling_link:?} would mean the install ran the full pipeline",
     );

--- a/pacquet/crates/reporter/src/lib.rs
+++ b/pacquet/crates/reporter/src/lib.rs
@@ -187,6 +187,18 @@ pub enum LogEvent {
     /// Emit site: <https://github.com/pnpm/pnpm/blob/2a9bd897bf/installing/deps-installer/src/install/verifyLockfileResolutions.ts#L134-L168>.
     #[serde(rename = "pnpm:lockfile-verification")]
     LockfileVerification(LockfileVerificationLog),
+
+    /// Generic global-logger message (`name: "pnpm"`). Mirrors
+    /// pnpm's [`globalLogger`](https://github.com/pnpm/pnpm/blob/a456dc78fb/packages/logger/src/index.ts)
+    /// `logger.info({ message, prefix })` emits — for example, the
+    /// "Lockfile is up to date, resolution step is skipped" line the
+    /// frozen-install short-circuit prints at
+    /// [`installing/deps-installer/src/install/index.ts:984`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L984).
+    /// `@pnpm/cli.default-reporter` routes these into the "other" log
+    /// stream at
+    /// [`cli/default-reporter/src/index.ts:222`](https://github.com/pnpm/pnpm/blob/a456dc78fb/cli/default-reporter/src/index.ts#L222).
+    #[serde(rename = "pnpm")]
+    Pnpm(PnpmLog),
 }
 
 /// `pnpm:context` payload.
@@ -703,6 +715,16 @@ pub enum LockfileVerificationMessage {
         #[serde(rename = "lockfilePath", skip_serializing_if = "Option::is_none")]
         lockfile_path: Option<String>,
     },
+}
+
+/// Generic-channel (`name: "pnpm"`) payload, used for `logger.info`-style
+/// emits with no dedicated channel. `prefix` carries the install root the
+/// message applies to, matching pnpm's wire shape.
+#[derive(Debug, Clone, Serialize)]
+pub struct PnpmLog {
+    pub level: LogLevel,
+    pub message: String,
+    pub prefix: String,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/pacquet/crates/reporter/src/tests.rs
+++ b/pacquet/crates/reporter/src/tests.rs
@@ -9,9 +9,10 @@ use crate::{
     FetchingProgressMessage, GetHostName, Host, IgnoredScriptsLog, LifecycleLog, LifecycleMessage,
     LifecycleStdio, LockfileVerificationLog, LockfileVerificationMessage, LogEvent, LogLevel,
     PackageImportMethod, PackageImportMethodLog, PackageManifestLog, PackageManifestMessage,
-    ProgressLog, ProgressMessage, RemovedRoot, Reporter, RequestRetryError, RequestRetryLog,
-    RootLog, RootMessage, SilentReporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
-    SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    PnpmLog, ProgressLog, ProgressMessage, RemovedRoot, Reporter, RequestRetryError,
+    RequestRetryLog, RootLog, RootMessage, SilentReporter, SkippedOptionalDependencyLog,
+    SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
+    SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -91,6 +92,32 @@ fn summary_event_matches_pnpm_wire_shape() {
 
     assert_eq!(json["name"], "pnpm:summary");
     assert_eq!(json["level"], "debug");
+    assert_eq!(json["prefix"], "/some/project");
+}
+
+/// Generic-channel (`name: "pnpm"`) log carries the bare `pnpm`
+/// channel name — without a `:`-suffix — matching the shape pnpm's
+/// global logger writes. `@pnpm/cli.default-reporter` routes these
+/// records through the "other" stream branch; a typo on the channel
+/// name would silently fail to render.
+#[test]
+fn pnpm_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Info,
+        message: "Lockfile is up to date, resolution step is skipped".to_string(),
+        prefix: "/some/project".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm");
+    assert_eq!(json["level"], "info");
+    assert_eq!(json["message"], "Lockfile is up to date, resolution step is skipped");
     assert_eq!(json["prefix"], "/some/project");
 }
 


### PR DESCRIPTION
## Summary

Adds a fast-path gate in `Install::run` that mirrors upstream pnpm's `validateModules` + `allProjectsAreUpToDate` shortcut: when the frozen-lockfile dispatch is eligible, `.modules.yaml` agrees with the current config, and `<virtual_store_dir>/lock.yaml` is byte-equal to the wanted lockfile, materialization is skipped entirely. The install emits the `name: "pnpm" / level: "info"` "Lockfile is up to date, resolution step is skipped" log, refreshes the workspace-state timestamp so `pnpm run`'s `verifyDepsBeforeRun` doesn't fire spuriously, and returns.

The gate closes the `lockfile+node_modules` benchmark variation gap (currently 2-24× slower than pnpm on every fixture). It mirrors upstream's behavior at [`installing/deps-installer/src/install/index.ts#L913-L985`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/index.ts#L913-L985) — fires under both `--frozen-lockfile` and `preferFrozenLockfile`.

Closes #11899.

## Changes

- `pacquet/crates/reporter`: new `LogEvent::Pnpm` variant for `name: "pnpm"` generic-channel logs (consumed by `@pnpm/cli.default-reporter`'s "other" stream).
- `pacquet/crates/package-manager/src/install.rs`: gate the dispatch on the new `is_modules_yaml_consistent` helper (port of `validateModules`'s settings checks) plus `current == wanted` lockfile equality. On hit, emit the up-to-date log + ImportingDone + Summary, refresh workspace state, return Ok.
- Unit tests cover the helper's four states (missing yaml, all-match, nodeLinker drift, included drift) plus an end-to-end gate test that asserts the log fires, materialization is skipped, and workspace state is refreshed.
- CLI integration test runs install twice and asserts the NDJSON "Lockfile is up to date" record appears on the second run.

## Test plan

- [x] `cargo nextest run -p pacquet-package-manager` — 304/304 pass
- [x] `cargo nextest run -p pacquet-reporter` — 28/28 pass (incl. new `pnpm_event_matches_pnpm_wire_shape`)
- [x] `cargo nextest run -p pacquet-cli --test install` — 11/11 pass (incl. new `frozen_install_short_circuits_when_node_modules_is_up_to_date`)
- [x] `just lint`, `just check`, `just fmt` — clean
- [ ] Benchmark validation against vlt.sh `lockfile+node_modules` variation

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer fast-path: frozen-lockfile installs now short-circuit when on-disk state is already up to date, skipping resolution/materialization for faster installs.
  * Improved pnpm-compatible log output so external tools can detect "lockfile is up to date" events.

* **Tests**
  * Added end-to-end and unit tests covering frozen-lockfile short-circuit behavior and module-state consistency checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->