### PR TITLE
fix(pacquet,package-manager): walk every workspace project in fresh-resolve install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2845,6 +2845,7 @@ dependencies = [
  "miette 7.6.0",
  "pacquet-catalogs-types",
  "pacquet-package-manifest",
+ "pathdiff",
  "pretty_assertions",
  "serde",
  "serde-saphyr",

--- a/pacquet/crates/cli/tests/workspace_install.rs
+++ b/pacquet/crates/cli/tests/workspace_install.rs
@@ -1,0 +1,129 @@
+//! Multi-importer fresh-resolve coverage for `pacquet install` in a
+//! `pnpm-workspace.yaml` monorepo.
+//!
+//! Issue [#11901](https://github.com/pnpm/pnpm/issues/11901): before
+//! the fix, only the workspace root manifest got walked, so sibling
+//! projects' deps never landed in the lockfile or on disk. This test
+//! installs a two-project workspace from scratch (no lockfile, no
+//! `--frozen-lockfile`) and asserts every importer has its own
+//! lockfile entry, every direct dep is symlinked under each
+//! importer's `node_modules`, and shared transitive deps land once
+//! in the virtual store.
+
+pub mod _utils;
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::is_symlink_or_junction,
+};
+use std::fs;
+
+/// A workspace with two sibling projects, each pulling in a
+/// different mocked package, runs through the fresh-resolve path and
+/// writes per-importer lockfile entries plus per-importer
+/// `node_modules` symlinks.
+#[test]
+fn fresh_resolve_walks_every_workspace_importer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // Workspace root manifest: empty so any deps installed are
+    // attributable to the sibling importers below.
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    // `packages/*` pattern picks up both siblings. Append to the
+    // pnpm-workspace.yaml the helper already wrote (which holds
+    // `storeDir` / `cacheDir`).
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    // Two siblings with distinct direct deps. Using two different
+    // packages (rather than one shared dep) makes the per-importer
+    // entry assertions less ambiguous.
+    fs::create_dir_all(workspace.join("packages/a")).expect("mkdir packages/a");
+    fs::write(
+        workspace.join("packages/a/package.json"),
+        serde_json::json!({
+            "name": "@scope/a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/a/package.json");
+
+    fs::create_dir_all(workspace.join("packages/b")).expect("mkdir packages/b");
+    fs::write(
+        workspace.join("packages/b/package.json"),
+        serde_json::json!({
+            "name": "@scope/b",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/b/package.json");
+
+    // Run the install. No --frozen-lockfile and no pre-existing
+    // lockfile → fresh-resolve path.
+    pacquet.with_arg("install").assert().success();
+
+    // Each sibling has its own direct-dep symlink. Before the fix,
+    // these were absent because pacquet only walked the root.
+    let a_dep = workspace.join("packages/a/node_modules/@pnpm.e2e/hello-world-js-bin-parent");
+    assert!(
+        is_symlink_or_junction(&a_dep).expect("query packages/a symlink"),
+        "packages/a/node_modules direct-dep symlink missing — sibling importer's deps weren't walked",
+    );
+    let b_dep = workspace.join("packages/b/node_modules/@pnpm.e2e/hello-world-js-bin");
+    assert!(
+        is_symlink_or_junction(&b_dep).expect("query packages/b symlink"),
+        "packages/b/node_modules direct-dep symlink missing — sibling importer's deps weren't walked",
+    );
+
+    // Shared virtual store: both packages land under
+    // `<workspace>/node_modules/.pnpm/<name>@<version>` exactly once.
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin-parent@1.0.0").exists(),
+        "hello-world-js-bin-parent virtual-store entry missing",
+    );
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+hello-world-js-bin@1.0.0").exists(),
+        "hello-world-js-bin virtual-store entry missing",
+    );
+
+    // Lockfile records every importer. Before the fix, only `.`
+    // appeared.
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("packages/a:"),
+        "pnpm-lock.yaml missing importers entry for packages/a:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("packages/b:"),
+        "pnpm-lock.yaml missing importers entry for packages/b:\n{lockfile}",
+    );
+    // hello-world-js-bin-parent is a direct dep of packages/a, so it
+    // should appear in that importer's specifiers — not just in the
+    // packages: section.
+    assert!(
+        lockfile.contains("hello-world-js-bin-parent"),
+        "pnpm-lock.yaml missing hello-world-js-bin-parent:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/cli/tests/workspace_install.rs
+++ b/pacquet/crates/cli/tests/workspace_install.rs
@@ -118,11 +118,18 @@ fn fresh_resolve_walks_every_workspace_importer() {
         "pnpm-lock.yaml missing importers entry for packages/b:\n{lockfile}",
     );
     // hello-world-js-bin-parent is a direct dep of packages/a, so it
-    // should appear in that importer's specifiers — not just in the
-    // packages: section.
+    // should appear in that importer's section — not just in
+    // `packages:` where any transitive could also surface the name.
+    // Slice the lockfile to packages/a's importer block and check
+    // there.
+    let a_importer_section = lockfile
+        .split("  packages/a:\n")
+        .nth(1)
+        .and_then(|tail| tail.split("\n  packages/").next())
+        .expect("pnpm-lock.yaml missing packages/a importer section");
     assert!(
-        lockfile.contains("hello-world-js-bin-parent"),
-        "pnpm-lock.yaml missing hello-world-js-bin-parent:\n{lockfile}",
+        a_importer_section.contains("hello-world-js-bin-parent"),
+        "pnpm-lock.yaml packages/a importer missing hello-world-js-bin-parent:\n{lockfile}",
     );
 
     drop((root, mock_instance));

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -11,7 +11,7 @@
 //! [`Lockfile`] already holds the two maps separately, so this adapter
 //! emits them directly.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use pacquet_lockfile::{
     ComVer, ImporterDepVersion, Lockfile, LockfileSettings, LockfileVersion, PackageKey,
@@ -19,22 +19,43 @@ use pacquet_lockfile::{
     ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_resolving_deps_resolver::{
-    DepPath, DependenciesGraph, DependenciesGraphNode, ResolveImporterResult,
-};
+use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
 use pacquet_resolving_resolver_base::ResolveResult;
 use serde_json::Value;
 
-/// Options threaded into [`dependencies_graph_to_lockfile`].
-pub struct GraphToLockfileOptions<'a> {
-    /// The on-disk `package.json` for the root importer. Used to source
+/// One importer's contribution to [`dependencies_graph_to_lockfile`].
+///
+/// Pacquet keeps the per-importer slice narrow — the manifest decides
+/// the dep-group classification of each alias, and
+/// `direct_dependencies_by_alias` (from `resolve_peers`) tells us which
+/// `DepPath` each alias resolved to. The shared `DependenciesGraph`
+/// lives outside this struct because it is importer-independent.
+pub struct ImporterLockfileInput<'a> {
+    /// The on-disk `package.json` for this importer. Used to source
     /// each direct dependency's specifier (the value the user wrote)
     /// and the importer-level dep-group classification
     /// (`dependencies` vs `devDependencies` vs `optionalDependencies`).
     pub manifest: &'a PackageManifest,
-    /// Resolver output: graph keyed by depPath plus the importer's
-    /// `alias → DepPath` map.
-    pub resolved: &'a ResolveImporterResult,
+    /// `alias → DepPath` for the direct dependencies of this importer,
+    /// as emitted by [`pacquet_resolving_deps_resolver::resolve_peers`].
+    pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
+}
+
+/// Options threaded into [`dependencies_graph_to_lockfile`].
+pub struct GraphToLockfileOptions<'a> {
+    /// One entry per workspace project being installed. Keyed by the
+    /// lockfile importer id (`"."` for the workspace root,
+    /// `"packages/<name>"` for siblings — see
+    /// [`pacquet_workspace::importer_id_from_root_dir`]). Mirrors
+    /// upstream's `importers: ImporterToResolve[]` shape on
+    /// `resolveDependencies`.
+    pub importers: BTreeMap<String, ImporterLockfileInput<'a>>,
+    /// Cross-importer dedup graph keyed by `DepPath`. The fresh-resolve
+    /// dispatch merges every per-importer `peers_result.graph` into
+    /// this one map before calling — identical snapshot keys collapse
+    /// onto one entry, matching upstream's shared
+    /// [`GenericDependenciesGraph`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/index.ts#L84).
+    pub graph: &'a DependenciesGraph,
     /// Round-tripped into the lockfile's top-level `settings:` block
     /// so a subsequent pnpm install can compare its own settings via
     /// `@pnpm/lockfile.settings-checker`'s `getOutdatedLockfileSetting`.
@@ -48,13 +69,15 @@ pub struct GraphToLockfileOptions<'a> {
 }
 
 /// Build a [`Lockfile`] from the resolver's [`DependenciesGraph`] plus
-/// the importer-side context needed to populate the `importers:` map.
+/// the per-importer context needed to populate the `importers:` map.
 ///
 /// The output reflects pnpm v9's wire shape:
 ///
-/// - `importers["."]` carries the root project's `specifiers` and the
+/// - `importers[<id>]` carries each project's `specifiers` and the
 ///   classified `dependencies` / `devDependencies` / `optionalDependencies`
-///   maps keyed by the manifest's declared alias.
+///   maps keyed by the manifest's declared alias. The root project
+///   lives under `"."`; sibling workspace projects under their POSIX
+///   path from the lockfile root (e.g. `"packages/foo"`).
 /// - `packages` carries one [`PackageMetadata`] entry per resolved
 ///   package version, keyed by the *peer-stripped* depPath (the
 ///   `pkgIdWithPatchHash`).
@@ -63,22 +86,22 @@ pub struct GraphToLockfileOptions<'a> {
 ///   snapshot row.
 pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockfile {
     let GraphToLockfileOptions {
-        manifest,
-        resolved,
+        importers: importer_inputs,
+        graph,
         auto_install_peers,
         exclude_links_from_lockfile,
         overrides,
         ignored_optional_dependencies,
     } = opts;
 
-    let importer = build_root_importer(manifest, resolved);
+    let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
+    let (packages, snapshots) = build_packages_and_snapshots(graph, &optional_overrides);
 
-    let optional_overrides = compute_corrected_optional(manifest, resolved);
-    let (packages, snapshots) =
-        build_packages_and_snapshots(&resolved.peers_result.graph, &optional_overrides);
-
-    let mut importers: HashMap<String, ProjectSnapshot> = HashMap::with_capacity(1);
-    importers.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), importer);
+    let mut importers: HashMap<String, ProjectSnapshot> =
+        HashMap::with_capacity(importer_inputs.len());
+    for (id, input) in &importer_inputs {
+        importers.insert(id.clone(), build_importer(input, graph));
+    }
 
     Lockfile {
         lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0))
@@ -93,20 +116,18 @@ pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockf
     }
 }
 
-/// Build the root importer's [`ProjectSnapshot`] from the on-disk
-/// manifest's declared deps + the resolver's per-alias `DepPath` map.
+/// Build an importer's [`ProjectSnapshot`] from its on-disk manifest
+/// plus the per-alias `DepPath` map the resolver produced for that
+/// importer.
 ///
 /// Mirrors upstream's
 /// [`addDirectDependenciesToLockfile`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/index.ts#L417-L484):
 /// the manifest decides which dep group each alias lives under, and the
 /// resolver decides the resolved version (peer-suffixed when peers are
 /// involved, alias-prefixed when the alias and real name differ).
-fn build_root_importer(
-    manifest: &PackageManifest,
-    resolved: &ResolveImporterResult,
-) -> ProjectSnapshot {
-    let direct = &resolved.peers_result.direct_dependencies_by_alias;
-    let graph = &resolved.peers_result.graph;
+fn build_importer(input: &ImporterLockfileInput<'_>, graph: &DependenciesGraph) -> ProjectSnapshot {
+    let manifest = input.manifest;
+    let direct = &input.direct_dependencies_by_alias;
 
     let mut dependencies: ResolvedDependencyMap = HashMap::new();
     let mut dev_dependencies: ResolvedDependencyMap = HashMap::new();
@@ -199,21 +220,24 @@ fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<St
 /// Build the version cell for an importer-level dependency, mirroring
 /// pnpm's [`depPathToRef`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/depPathToRef.ts):
 ///
+/// - When the depPath is a workspace-link id (`link:<rel-path>`), emit
+///   the [`ImporterDepVersion::Link`] arm so the lockfile records the
+///   sibling project's relative path instead of trying to parse it as
+///   `name@version`.
 /// - When the resolved real name equals the manifest alias and the
 ///   depPath starts with `<name>@`, drop the prefix so the importer
 ///   carries just the version-with-peer string.
 /// - Otherwise — npm-alias entries, where the alias and real name
 ///   differ — keep the full `<real>@<version-with-peer>` string so the
 ///   snapshot key the importer points at is unambiguous.
-///
-/// `link:` shows up only on the snapshot-level path (workspace siblings
-/// are routed through [`crate::InstallWithFreshLockfile::workspace_packages`]
-/// today), so this function doesn't emit [`ImporterDepVersion::Link`];
-/// the workspace-importer port adds that arm.
 fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDepVersion {
-    let real_name = real_name(&node.resolve_result);
     let dep_path_str = node.dep_path.as_str();
 
+    if let Some(target) = dep_path_str.strip_prefix("link:") {
+        return ImporterDepVersion::Link(target.to_string());
+    }
+
+    let real_name = real_name(&node.resolve_result);
     if let Some(real) = real_name.as_deref() {
         let prefix = format!("{real}@");
         if alias == real
@@ -425,11 +449,11 @@ fn build_snapshot_entry(
 }
 
 /// Re-derive each snapshot's `optional` flag by walking the graph
-/// from the importer's direct deps, classifying each starting edge by
-/// the dep-group it lives in on the manifest. A package ends up
-/// `optional: false` iff every visit didn't land on it through an
-/// `optionalDependencies` edge — i.e. there exists at least one path
-/// from any importer to it whose edges are all non-optional.
+/// from every importer's direct deps, classifying each starting edge
+/// by the dep-group it lives in on that importer's manifest. A
+/// package ends up `optional: false` iff at least one walk reached it
+/// only through non-optional edges — i.e. there exists at least one
+/// path from any importer to it whose edges are all non-optional.
 ///
 /// Ports upstream pnpm's
 /// [`copyDependencySubGraph`](https://github.com/pnpm/pnpm/blob/b9de85dcb6/lockfile/pruner/src/index.ts#L160-L205)
@@ -446,25 +470,26 @@ fn build_snapshot_entry(
 /// back to [`DependenciesGraphNode::optional`] for those, matching
 /// upstream's "untouched depLockfile keeps its existing flag" arm.
 fn compute_corrected_optional(
-    manifest: &PackageManifest,
-    resolved: &ResolveImporterResult,
+    importer_inputs: &BTreeMap<String, ImporterLockfileInput<'_>>,
+    graph: &DependenciesGraph,
 ) -> HashMap<DepPath, bool> {
-    let graph = &resolved.peers_result.graph;
-    let direct = &resolved.peers_result.direct_dependencies_by_alias;
-    let alias_to_group = manifest_alias_to_group(manifest);
-
-    // Partition importer deps by group, mirroring the
+    // Partition every importer's deps by group, mirroring the
     // `(devDepPaths, optionalDepPaths, prodDepPaths)` split upstream
-    // hands to `copyDependencySubGraph`.
+    // hands to `copyDependencySubGraph`. Across importers the union
+    // of non-optional reach is what matters, so seeds are pooled
+    // before walking.
     let mut dev_seeds: Vec<&DepPath> = Vec::new();
     let mut optional_seeds: Vec<&DepPath> = Vec::new();
     let mut prod_seeds: Vec<&DepPath> = Vec::new();
-    for (alias, dep_path) in direct {
-        let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
-        match group {
-            DependencyGroup::Dev => dev_seeds.push(dep_path),
-            DependencyGroup::Optional => optional_seeds.push(dep_path),
-            DependencyGroup::Prod | DependencyGroup::Peer => prod_seeds.push(dep_path),
+    for input in importer_inputs.values() {
+        let alias_to_group = manifest_alias_to_group(input.manifest);
+        for (alias, dep_path) in &input.direct_dependencies_by_alias {
+            let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
+            match group {
+                DependencyGroup::Dev => dev_seeds.push(dep_path),
+                DependencyGroup::Optional => optional_seeds.push(dep_path),
+                DependencyGroup::Prod | DependencyGroup::Peer => prod_seeds.push(dep_path),
+            }
         }
     }
 
@@ -539,15 +564,18 @@ fn optional_children_of(node: &DependenciesGraphNode) -> HashSet<String> {
 }
 
 /// Build the `<alias>: <ref>` value the snapshot writes per child edge.
-/// `link:` snapshots aren't produced here — workspace siblings live
-/// outside the dep graph today. The plain / alias discrimination
-/// mirrors importer-side [`importer_dep_version`].
+/// Mirrors importer-side [`importer_dep_version`]: the `link:` branch
+/// emits [`SnapshotDepRef::Link`] for workspace siblings, plain /
+/// alias otherwise.
 fn snapshot_dep_ref(
     alias: &str,
     child_dep_path: &DepPath,
     graph: &DependenciesGraph,
 ) -> Option<SnapshotDepRef> {
     let dep_path_str = child_dep_path.as_str();
+    if let Some(target) = dep_path_str.strip_prefix("link:") {
+        return Some(SnapshotDepRef::Link(target.to_string()));
+    }
     let real_name = graph.get(child_dep_path).and_then(|n| real_name(&n.resolve_result));
     if let Some(real) = real_name.as_deref() {
         let prefix = format!("{real}@");

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -484,7 +484,18 @@ fn compute_corrected_optional(
     for input in importer_inputs.values() {
         let alias_to_group = manifest_alias_to_group(input.manifest);
         for (alias, dep_path) in &input.direct_dependencies_by_alias {
-            let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
+            // Skip aliases the manifest doesn't declare — auto-installed
+            // peers hoisted into `direct_dependencies_by_alias` when
+            // `autoInstallPeers: true` is on never make it into the
+            // importer's lockfile entry (see [`build_importer`]), so
+            // upstream's [`pruneSharedLockfile`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/lockfile/pruner/src/index.ts#L27-L29)
+            // doesn't seed from them either. Seeding them here would
+            // force their snapshots' `optional` flag to `false` purely
+            // by virtue of being pulled in to satisfy an optional
+            // parent's peer.
+            let Some(group) = alias_to_group.get(alias).copied() else {
+                continue;
+            };
             match group {
                 DependencyGroup::Dev => dev_seeds.push(dep_path),
                 DependencyGroup::Optional => optional_seeds.push(dep_path),

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -821,3 +821,209 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
     assert!(packages.contains_key(&lodash_key), "single shared snapshot");
     assert_eq!(packages.len(), 1, "shared dep deduped to one entry");
 }
+
+/// Multi-importer cross-importer pruner BFS. Ported from upstream
+/// pnpm's [`pruneSharedLockfile`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/lockfile/pruner/src/index.ts#L17)
+/// behavior — `copyPackageSnapshots` pools every importer's
+/// `(devDepPaths, optionalDepPaths, prodDepPaths)` via `unnest(...)`
+/// before the three `copyDependencySubGraph` walks, so a depPath
+/// reachable via a non-optional path from any importer must end up
+/// `optional: false` even when another importer reaches it only via
+/// an optional path.
+///
+/// Scenario:
+/// - `packages/a` has `prod-only` as a prod dep; `prod-only` →
+///   `shared` as a non-optional child.
+/// - `packages/b` has `opt-only` as an optional dep; `opt-only` →
+///   `shared` as a non-optional child (so the optional flag flows
+///   purely from the importer-level edge).
+///
+/// `shared`'s resolver-side `node.optional` is left as `true`
+/// (simulating the resolver having first reached it via the optional
+/// chain). The BFS must flip it back to `false` because importer A's
+/// path is all non-optional.
+#[test]
+fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches_via_prod() {
+    let (_a_tmp, a_manifest) = write_manifest(json!({
+        "name": "a",
+        "version": "1.0.0",
+        "dependencies": { "prod-only": "^1.0.0" },
+    }));
+    let (_b_tmp, b_manifest) = write_manifest(json!({
+        "name": "b",
+        "version": "1.0.0",
+        "optionalDependencies": { "opt-only": "^1.0.0" },
+    }));
+
+    // Stale-optional flag on `shared` — the resolver tagged it
+    // `optional: true` because the optional chain was walked first.
+    // The pruner BFS should re-derive it from importer-rooted
+    // reachability and flip it to false.
+    let shared = make_node_with_optional(
+        "shared",
+        "1.0.0",
+        json!({ "name": "shared", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+        true,
+    );
+
+    let mut prod_only_children = BTreeMap::new();
+    prod_only_children.insert("shared".to_string(), DepPath::from("shared@1.0.0".to_string()));
+    let prod_only = make_node_with_optional(
+        "prod-only",
+        "1.0.0",
+        json!({
+            "name": "prod-only",
+            "version": "1.0.0",
+            "dependencies": { "shared": "^1.0.0" },
+        }),
+        prod_only_children,
+        BTreeMap::new(),
+        HashSet::new(),
+        false,
+    );
+
+    let mut opt_only_children = BTreeMap::new();
+    opt_only_children.insert("shared".to_string(), DepPath::from("shared@1.0.0".to_string()));
+    let opt_only = make_node_with_optional(
+        "opt-only",
+        "1.0.0",
+        json!({
+            "name": "opt-only",
+            "version": "1.0.0",
+            "dependencies": { "shared": "^1.0.0" },
+        }),
+        opt_only_children,
+        BTreeMap::new(),
+        HashSet::new(),
+        true,
+    );
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(shared.dep_path.clone(), shared);
+    graph.insert(prod_only.dep_path.clone(), prod_only);
+    graph.insert(opt_only.dep_path.clone(), opt_only);
+
+    let mut a_direct = BTreeMap::new();
+    a_direct.insert("prod-only".to_string(), DepPath::from("prod-only@1.0.0".to_string()));
+    let mut b_direct = BTreeMap::new();
+    b_direct.insert("opt-only".to_string(), DepPath::from("opt-only@1.0.0".to_string()));
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        "packages/a".to_string(),
+        ImporterLockfileInput { manifest: &a_manifest, direct_dependencies_by_alias: a_direct },
+    );
+    importers.insert(
+        "packages/b".to_string(),
+        ImporterLockfileInput { manifest: &b_manifest, direct_dependencies_by_alias: b_direct },
+    );
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        importers,
+        graph: &graph,
+        auto_install_peers: false,
+        exclude_links_from_lockfile: false,
+        overrides: None,
+        ignored_optional_dependencies: None,
+    });
+
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
+    let prod_only_key: PackageKey = "prod-only@1.0.0".parse().unwrap();
+    let opt_only_key: PackageKey = "opt-only@1.0.0".parse().unwrap();
+    let shared_key: PackageKey = "shared@1.0.0".parse().unwrap();
+    assert!(!snapshots[&prod_only_key].optional, "prod-only is a direct prod dep of packages/a");
+    assert!(snapshots[&opt_only_key].optional, "opt-only is only reachable via packages/b's optional");
+    assert!(
+        !snapshots[&shared_key].optional,
+        "shared is reachable via packages/a → prod-only → shared (all non-optional)",
+    );
+}
+
+/// Multi-importer with a `workspace:` link between two siblings.
+/// Ported from the spirit of upstream pnpm's
+/// [`headless install is used when package linked to another package in the workspace`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/installing/deps-installer/test/install/multipleImporters.ts#L540)
+/// scenario, narrowed to the lockfile-rendering side: importer `a`
+/// depends on importer `b` via a `link:` resolved depPath, so
+/// `importers["packages/a"].dependencies.b` renders as
+/// `ImporterDepVersion::Link("../b")` and `importers["packages/b"]`
+/// gets its own entry — no cross-pollution into `packages:` /
+/// `snapshots:`.
+#[test]
+fn workspace_sibling_link_renders_per_importer_with_link_ref() {
+    let (_a_tmp, a_manifest) = write_manifest(json!({
+        "name": "@scope/a",
+        "version": "1.0.0",
+        "dependencies": { "b": "workspace:*" },
+    }));
+    let (_b_tmp, b_manifest) = write_manifest(json!({
+        "name": "@scope/b",
+        "version": "1.0.0",
+        "dependencies": { "lodash": "^4.17.21" },
+    }));
+
+    let link_node = make_link_node("../b", json!({ "name": "@scope/b", "version": "1.0.0" }));
+    let lodash = make_node(
+        "lodash",
+        "4.17.21",
+        json!({ "name": "lodash", "version": "4.17.21" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(link_node.dep_path.clone(), link_node.clone());
+    graph.insert(lodash.dep_path.clone(), lodash);
+
+    let mut a_direct = BTreeMap::new();
+    a_direct.insert("b".to_string(), link_node.dep_path);
+    let mut b_direct = BTreeMap::new();
+    b_direct.insert("lodash".to_string(), DepPath::from("lodash@4.17.21".to_string()));
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        "packages/a".to_string(),
+        ImporterLockfileInput { manifest: &a_manifest, direct_dependencies_by_alias: a_direct },
+    );
+    importers.insert(
+        "packages/b".to_string(),
+        ImporterLockfileInput { manifest: &b_manifest, direct_dependencies_by_alias: b_direct },
+    );
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        importers,
+        graph: &graph,
+        auto_install_peers: false,
+        exclude_links_from_lockfile: false,
+        overrides: None,
+        ignored_optional_dependencies: None,
+    });
+
+    // Importer a points at b via a link: ref carrying the relative
+    // path the resolver produced.
+    let a_snap = lockfile.importers.get("packages/a").expect("importer a");
+    let b_in_a =
+        a_snap.dependencies.as_ref().unwrap().get(&PkgName::parse("b").unwrap()).expect("b in a");
+    assert_eq!(b_in_a.specifier, "workspace:*");
+    match &b_in_a.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, "../b"),
+        other => panic!("expected Link(..), got {other:?}"),
+    }
+
+    // Importer b has its own lockfile entry, independent of importer a.
+    let b_snap = lockfile.importers.get("packages/b").expect("importer b");
+    assert!(
+        b_snap.dependencies.as_ref().unwrap().contains_key(&PkgName::parse("lodash").unwrap()),
+        "importer b carries its own deps",
+    );
+
+    // The link: node never lands in packages: / snapshots: — it's a
+    // sibling project, not a resolved registry package.
+    let packages = lockfile.packages.as_ref().expect("packages");
+    let lodash_key: PackageKey = "lodash@4.17.21".parse().unwrap();
+    assert!(packages.contains_key(&lodash_key));
+    assert_eq!(packages.len(), 1, "only lodash lands in packages:");
+}

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1,22 +1,46 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
 
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
-    ImporterDepVersion, LockfileResolution, PackageKey, PkgName, PkgNameVer, RegistryResolution,
-    SnapshotDepRef,
+    DirectoryResolution, ImporterDepVersion, LockfileResolution, PackageKey, PkgName, PkgNameVer,
+    RegistryResolution, SnapshotDepRef,
 };
 use pacquet_package_manifest::PackageManifest;
-use pacquet_resolving_deps_resolver::{
-    DependenciesGraph, DependenciesGraphNode, PeerDep, PeerDependencyIssues, ResolveImporterResult,
-    ResolvePeersResult, ResolvedTree,
-};
-use pacquet_resolving_resolver_base::ResolveResult;
+use pacquet_resolving_deps_resolver::{DependenciesGraph, DependenciesGraphNode, PeerDep};
+use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use serde_json::json;
 use ssri::Integrity;
 use tempfile::TempDir;
 
-use super::{GraphToLockfileOptions, dependencies_graph_to_lockfile};
+use super::{GraphToLockfileOptions, ImporterLockfileInput, dependencies_graph_to_lockfile};
+
+/// Build a single-importer [`GraphToLockfileOptions`] under the root key
+/// (`"."`). Every existing test exercises the single-importer shape;
+/// multi-importer cases are constructed inline.
+fn single_importer_opts<'a>(
+    manifest: &'a PackageManifest,
+    graph: &'a DependenciesGraph,
+    direct: BTreeMap<String, DepPath>,
+    auto_install_peers: bool,
+    exclude_links_from_lockfile: bool,
+    overrides: Option<HashMap<String, String>>,
+    ignored_optional_dependencies: Option<Vec<String>>,
+) -> GraphToLockfileOptions<'a> {
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        ".".to_string(),
+        ImporterLockfileInput { manifest, direct_dependencies_by_alias: direct },
+    );
+    GraphToLockfileOptions {
+        importers,
+        graph,
+        auto_install_peers,
+        exclude_links_from_lockfile,
+        overrides,
+        ignored_optional_dependencies,
+    }
+}
 
 const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
 
@@ -123,23 +147,9 @@ fn fresh_install_records_a_single_direct_dependency() {
     let mut direct = BTreeMap::new();
     direct.insert("react".to_string(), DepPath::from("react@17.0.2".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: true,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
 
     assert_eq!(lockfile.lockfile_version.major, 9);
 
@@ -199,23 +209,9 @@ fn dev_and_optional_direct_deps_split_into_distinct_importer_sections() {
     direct.insert("typescript".to_string(), DepPath::from("typescript@5.1.6".to_string()));
     direct.insert("fsevents".to_string(), DepPath::from("fsevents@2.3.2".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: false,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
     let importer = lockfile.root_project().expect("root importer");
     assert!(importer.dependencies.is_none(), "no prod deps declared");
@@ -292,23 +288,9 @@ fn peer_suffixed_dep_path_splits_into_distinct_snapshot_and_package_keys() {
     direct.insert("react".to_string(), DepPath::from("react@17.0.2".to_string()));
     direct.insert("react-dom".to_string(), react_dom_dep_path);
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: true,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots");
     let snap_key: PackageKey = "react-dom@17.0.2(react@17.0.2)".parse().unwrap();
@@ -371,23 +353,9 @@ fn snapshot_partitions_optional_children_by_manifest_optional_dependencies() {
     let mut direct = BTreeMap::new();
     direct.insert("outer".to_string(), DepPath::from("outer@1.0.0".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: false,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().unwrap();
     let outer_key: PackageKey = "outer@1.0.0".parse().unwrap();
@@ -428,23 +396,9 @@ fn snapshot_records_transitive_peer_dependencies_sorted() {
     let mut direct = BTreeMap::new();
     direct.insert("outer".to_string(), DepPath::from("outer@1.0.0".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: true,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().unwrap();
     let outer_key: PackageKey = "outer@1.0.0".parse().unwrap();
@@ -496,23 +450,9 @@ fn snapshot_optional_flag_round_trips_from_dependencies_graph_node() {
     direct.insert("regular".to_string(), DepPath::from("regular@1.0.0".to_string()));
     direct.insert("opt".to_string(), DepPath::from("opt@1.0.0".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: false,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
     let regular_key: PackageKey = "regular@1.0.0".parse().unwrap();
@@ -593,23 +533,9 @@ fn transitive_optional_is_recomputed_for_packages_reachable_via_a_non_optional_p
     direct.insert("a".to_string(), DepPath::from("a@1.0.0".to_string()));
     direct.insert("b".to_string(), DepPath::from("b@1.0.0".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: false,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
     let a_key: PackageKey = "a@1.0.0".parse().unwrap();
@@ -696,23 +622,9 @@ fn shared_subdep_reached_through_dev_optional_and_prod_paths_is_marked_non_optio
     direct.insert("parent".to_string(), DepPath::from("parent@1.0.0".to_string()));
     direct.insert("prod-parent".to_string(), DepPath::from("prod-parent@1.0.0".to_string()));
 
-    let resolved = ResolveImporterResult {
-        resolved_tree: ResolvedTree::default(),
-        peers_result: ResolvePeersResult {
-            graph,
-            direct_dependencies_by_alias: direct,
-            peer_dependency_issues: PeerDependencyIssues::default(),
-        },
-    };
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest: &manifest,
-        resolved: &resolved,
-        auto_install_peers: false,
-        exclude_links_from_lockfile: false,
-        overrides: None,
-        ignored_optional_dependencies: None,
-    });
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
     let snapshots = lockfile.snapshots.as_ref().unwrap();
     let subdep_key: PackageKey = "subdep@1.0.0".parse().unwrap();
@@ -722,4 +634,190 @@ fn shared_subdep_reached_through_dev_optional_and_prod_paths_is_marked_non_optio
         !snapshots[&subdep2_key].optional,
         "subdep2 is reachable via prod-parent → subdep2 (all non-optional)",
     );
+}
+
+/// Build a fake `DependenciesGraphNode` whose id is a `link:` workspace
+/// reference. The local resolver produces these for `workspace:` specs
+/// and leaves `name_ver` as `None`. Used in the link-shape lockfile
+/// tests below.
+fn make_link_node(target: &str, manifest: serde_json::Value) -> DependenciesGraphNode {
+    let id_text = format!("link:{target}");
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(id_text.clone()),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(std::sync::Arc::new(manifest)),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: target.to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: None,
+        policy_violation: None,
+    };
+    DependenciesGraphNode {
+        dep_path: DepPath::from(id_text.clone()),
+        resolved_package_id: id_text,
+        resolve_result: std::sync::Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 0,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    }
+}
+
+/// A direct dependency resolved to a workspace sibling lands as
+/// `ImporterDepVersion::Link(<rel-path>)` instead of failing to parse
+/// the depPath as `name@version`. Mirrors upstream's
+/// [`depPathToRef`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/depPathToRef.ts)
+/// branch for `link:` resolutions.
+#[test]
+fn workspace_link_direct_dep_renders_as_importer_link() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": { "shared": "workspace:*" },
+    }));
+
+    let link_node = make_link_node("../shared", json!({ "name": "shared", "version": "1.0.0" }));
+    let mut graph = DependenciesGraph::new();
+    graph.insert(link_node.dep_path.clone(), link_node.clone());
+
+    let mut direct = BTreeMap::new();
+    direct.insert("shared".to_string(), link_node.dep_path);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let importer = lockfile.root_project().expect("root importer");
+    let dep = importer.dependencies.as_ref().expect("dependencies map");
+    let entry = dep.get(&PkgName::parse("shared").unwrap()).expect("shared entry");
+    assert_eq!(entry.specifier, "workspace:*");
+    match &entry.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, "../shared"),
+        other => panic!("expected Link(..), got {other:?}"),
+    }
+
+    // `link:` nodes don't make it into packages: / snapshots: — the
+    // sibling project carries its own importer entry, and the symlink
+    // is materialized by `SymlinkDirectDependencies`.
+    assert!(lockfile.packages.is_none() || lockfile.packages.as_ref().unwrap().is_empty());
+    assert!(lockfile.snapshots.is_none() || lockfile.snapshots.as_ref().unwrap().is_empty());
+}
+
+/// A transitive dep that depends on a workspace sibling renders the
+/// edge as `SnapshotDepRef::Link(<rel-path>)` instead of dropping it
+/// from the snapshot's `dependencies` map.
+#[test]
+fn workspace_link_child_renders_as_snapshot_link() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": { "wrapper": "^1.0.0" },
+    }));
+
+    let link_node = make_link_node("../shared", json!({ "name": "shared", "version": "1.0.0" }));
+
+    let mut wrapper_children = BTreeMap::new();
+    wrapper_children.insert("shared".to_string(), link_node.dep_path.clone());
+    let wrapper = make_node(
+        "wrapper",
+        "1.0.0",
+        json!({ "name": "wrapper", "version": "1.0.0" }),
+        wrapper_children,
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(wrapper.dep_path.clone(), wrapper);
+    graph.insert(link_node.dep_path.clone(), link_node);
+
+    let mut direct = BTreeMap::new();
+    direct.insert("wrapper".to_string(), DepPath::from("wrapper@1.0.0".to_string()));
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
+    let wrapper_key: PackageKey = "wrapper@1.0.0".parse().unwrap();
+    let wrapper_snap = &snapshots[&wrapper_key];
+    let deps = wrapper_snap.dependencies.as_ref().expect("wrapper dependencies");
+    match deps.get(&PkgName::parse("shared").unwrap()).expect("shared child") {
+        SnapshotDepRef::Link(target) => assert_eq!(target, "../shared"),
+        other => panic!("expected Link(..), got {other:?}"),
+    }
+}
+
+/// Multi-importer: each workspace project contributes its own
+/// `importers[<id>]` entry with its own `specifiers` and dep groups,
+/// and shared transitive deps are listed once in `packages:` /
+/// `snapshots:`.
+#[test]
+fn multi_importer_workspace_writes_per_project_lockfile_entries() {
+    let (_a_tmp, a_manifest) = write_manifest(json!({
+        "name": "a",
+        "version": "1.0.0",
+        "dependencies": { "lodash": "^4.17.21" },
+    }));
+    let (_b_tmp, b_manifest) = write_manifest(json!({
+        "name": "b",
+        "version": "1.0.0",
+        "dependencies": { "lodash": "^4.17.21" },
+    }));
+
+    // Same transitive dep shared by both importers; merging puts one
+    // entry in the unified graph.
+    let lodash = make_node(
+        "lodash",
+        "4.17.21",
+        json!({ "name": "lodash", "version": "4.17.21" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let mut graph = DependenciesGraph::new();
+    graph.insert(lodash.dep_path.clone(), lodash);
+
+    let mut a_direct = BTreeMap::new();
+    a_direct.insert("lodash".to_string(), DepPath::from("lodash@4.17.21".to_string()));
+    let mut b_direct = BTreeMap::new();
+    b_direct.insert("lodash".to_string(), DepPath::from("lodash@4.17.21".to_string()));
+
+    let mut importers = BTreeMap::new();
+    importers.insert(
+        "packages/a".to_string(),
+        ImporterLockfileInput { manifest: &a_manifest, direct_dependencies_by_alias: a_direct },
+    );
+    importers.insert(
+        "packages/b".to_string(),
+        ImporterLockfileInput { manifest: &b_manifest, direct_dependencies_by_alias: b_direct },
+    );
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        importers,
+        graph: &graph,
+        auto_install_peers: false,
+        exclude_links_from_lockfile: false,
+        overrides: None,
+        ignored_optional_dependencies: None,
+    });
+
+    let a_snap = lockfile.importers.get("packages/a").expect("importer a");
+    let b_snap = lockfile.importers.get("packages/b").expect("importer b");
+    let lodash_name = PkgName::parse("lodash").unwrap();
+    assert!(a_snap.dependencies.as_ref().unwrap().contains_key(&lodash_name));
+    assert!(b_snap.dependencies.as_ref().unwrap().contains_key(&lodash_name));
+
+    let packages = lockfile.packages.as_ref().expect("packages");
+    let lodash_key: PackageKey = "lodash@4.17.21".parse().unwrap();
+    assert!(packages.contains_key(&lodash_key), "single shared snapshot");
+    assert_eq!(packages.len(), 1, "shared dep deduped to one entry");
 }

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -935,7 +935,10 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
     let opt_only_key: PackageKey = "opt-only@1.0.0".parse().unwrap();
     let shared_key: PackageKey = "shared@1.0.0".parse().unwrap();
     assert!(!snapshots[&prod_only_key].optional, "prod-only is a direct prod dep of packages/a");
-    assert!(snapshots[&opt_only_key].optional, "opt-only is only reachable via packages/b's optional");
+    assert!(
+        snapshots[&opt_only_key].optional,
+        "opt-only is only reachable via packages/b's optional"
+    );
     assert!(
         !snapshots[&shared_key].optional,
         "shared is reachable via packages/a → prod-only → shared (all non-optional)",

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -937,7 +937,7 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
     assert!(!snapshots[&prod_only_key].optional, "prod-only is a direct prod dep of packages/a");
     assert!(
         snapshots[&opt_only_key].optional,
-        "opt-only is only reachable via packages/b's optional"
+        "opt-only is only reachable via packages/b's optional",
     );
     assert!(
         !snapshots[&shared_key].optional,

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -942,6 +942,80 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
     );
 }
 
+/// Auto-installed peers (hoisted into `direct_dependencies_by_alias`
+/// by the resolver when `autoInstallPeers: true` is on) must NOT seed
+/// the pruner BFS — they aren't in the manifest, so
+/// [`build_importer`](super::build_importer) excludes them from the
+/// importer's lockfile entry, and upstream's
+/// [`pruneSharedLockfile`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/lockfile/pruner/src/index.ts#L27-L29)
+/// seeds only from what was written to the importer entries.
+///
+/// Scenario: importer declares `parent` in `optionalDependencies`;
+/// the resolver auto-installs `parent`'s peer `peer-x` and hoists it
+/// to the importer's `direct_dependencies_by_alias`. With the
+/// undeclared-alias skip, the BFS only seeds `parent` (optional), so
+/// `peer-x` ends up `optional: true` — matching pnpm. Without the
+/// skip, `peer-x` would have been treated as a Prod-defaulted
+/// importer-level dep and forced to `optional: false`.
+#[test]
+fn auto_installed_peer_not_declared_in_manifest_is_skipped_from_pruner_seeds() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "optionalDependencies": { "parent": "^1.0.0" },
+    }));
+
+    let peer_x = make_node_with_optional(
+        "peer-x",
+        "1.0.0",
+        json!({ "name": "peer-x", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+        true,
+    );
+
+    let mut parent_children = BTreeMap::new();
+    parent_children.insert("peer-x".to_string(), DepPath::from("peer-x@1.0.0".to_string()));
+    let parent = make_node_with_optional(
+        "parent",
+        "1.0.0",
+        json!({
+            "name": "parent",
+            "version": "1.0.0",
+            "dependencies": { "peer-x": "^1.0.0" },
+        }),
+        parent_children,
+        BTreeMap::new(),
+        HashSet::new(),
+        true,
+    );
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(parent.dep_path.clone(), parent);
+    graph.insert(peer_x.dep_path.clone(), peer_x);
+
+    // The resolver hoisted `peer-x` to the importer level even though
+    // the manifest doesn't declare it — this is exactly what
+    // `auto_install_peers` does.
+    let mut direct = BTreeMap::new();
+    direct.insert("parent".to_string(), DepPath::from("parent@1.0.0".to_string()));
+    direct.insert("peer-x".to_string(), DepPath::from("peer-x@1.0.0".to_string()));
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
+
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
+    let parent_key: PackageKey = "parent@1.0.0".parse().unwrap();
+    let peer_x_key: PackageKey = "peer-x@1.0.0".parse().unwrap();
+    assert!(snapshots[&parent_key].optional, "parent is the importer's optional direct dep");
+    assert!(
+        snapshots[&peer_x_key].optional,
+        "auto-installed peer reachable only via parent's optional path stays optional",
+    );
+}
+
 /// Multi-importer with a `workspace:` link between two siblings.
 /// Ported from the spirit of upstream pnpm's
 /// [`headless install is used when package linked to another package in the workspace`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/installing/deps-installer/test/install/multipleImporters.ts#L540)

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -357,6 +357,35 @@ where
         // paths threaded into log events.
         let prefix = workspace_root.to_string_lossy().into_owned();
 
+        // Register the project against the shared store for prune
+        // tracking, once per install at the workspace root. Mirrors
+        // upstream's call into `@pnpm/store.controller`'s
+        // [`registerProject`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/store/controller/src/storeController/projectRegistry.ts)
+        // from `getContext` at
+        // <https://github.com/pnpm/pnpm/blob/d8a79a9c30/installing/context/src/index.ts#L128>:
+        // pnpm registers `opts.lockfileDir` (the workspace root) once,
+        // not per importer — store prune walks the workspace's
+        // `node_modules/.pnpm/` to find every installed package, so one
+        // registry entry per workspace is enough.
+        //
+        // Gated on `enable_global_virtual_store` because pacquet wires
+        // the prune-by-registry path only under GVS for now; pnpm
+        // registers unconditionally, so once the non-GVS prune path
+        // lands the gate should be dropped. Best-effort: a registry
+        // write failure shouldn't fail the install. Surface as
+        // `tracing::warn!` so the failure is diagnosable but the
+        // install carries on.
+        if config.enable_global_virtual_store
+            && let Err(error) =
+                pacquet_store_dir::register_project(&config.store_dir, &workspace_root)
+        {
+            tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "Failed to register workspace root in the store project registry; install continues",
+            );
+        }
+
         // `pnpm:package-manifest initial` carries the on-disk
         // `package.json` body. Mirrors pnpm's per-project emit at
         // <https://github.com/pnpm/pnpm/blob/086c5e91e8/installing/context/src/index.ts#L133>:
@@ -614,45 +643,6 @@ where
             .await
             .map_err(InstallError::FrozenLockfile)?;
 
-            // Register every importer against the shared store now
-            // that the install has materialized their `node_modules/`.
-            // Mirrors upstream's call into `@pnpm/store.controller`'s
-            // [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts),
-            // which runs once per importer — a workspace ends up with
-            // one symlink in `<store_dir>/projects/` per package, so
-            // `pacquet store prune` (tracked separately) can find
-            // every reachable consumer of `<store_dir>/links/...`.
-            //
-            // Best-effort: a registry write failure shouldn't fail
-            // the install. Surface as `tracing::warn!` so the failure
-            // is diagnosable but the install carries on. Validation
-            // of importer keys is done by
-            // [`crate::SymlinkDirectDependencies::run`] before we get
-            // here, so by this point every key is known-safe.
-            //
-            // The matching call for the fresh-resolve path lives
-            // after the `InstallWithFreshLockfile` branch below, where
-            // the root project is the only importer (workspaces in
-            // that path are pending pnpm/pacquet#431).
-            if config.enable_global_virtual_store {
-                for importer_id in importers.keys() {
-                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
-                        &workspace_root,
-                        importer_id,
-                    );
-                    if let Err(error) =
-                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
-                    {
-                        tracing::warn!(
-                            target: "pacquet::install",
-                            ?error,
-                            importer_id = %importer_id,
-                            "Failed to register importer in the global-virtual-store registry; install continues",
-                        );
-                    }
-                }
-            }
-
             (
                 frozen_result.hoisted_dependencies,
                 frozen_result.hoisted_locations,
@@ -753,37 +743,6 @@ where
             .run::<Reporter>()
             .await
             .map_err(InstallError::WithFreshLockfile)?;
-
-            // Mirror the frozen-lockfile branch: when GVS is on,
-            // register every importer that the fresh resolve walked
-            // against the shared store so `pacquet store prune` can
-            // find each consumer of `<store_dir>/links/...`. For a
-            // single-project install this loops once over the root;
-            // for a workspace install it covers every project. Best-
-            // effort: warn on failure, don't fail the install.
-            if config.enable_global_virtual_store {
-                let importer_ids: Vec<String> = fresh_result
-                    .wanted_lockfile
-                    .as_ref()
-                    .map(|lockfile| lockfile.importers.keys().cloned().collect())
-                    .unwrap_or_else(|| vec![Lockfile::ROOT_IMPORTER_KEY.to_string()]);
-                for importer_id in importer_ids {
-                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
-                        &workspace_root,
-                        &importer_id,
-                    );
-                    if let Err(error) =
-                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
-                    {
-                        tracing::warn!(
-                            target: "pacquet::install",
-                            ?error,
-                            importer_id = %importer_id,
-                            "Failed to register importer in the global-virtual-store registry; install continues",
-                        );
-                    }
-                }
-            }
 
             (
                 fresh_result.hoisted_dependencies,

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -687,23 +687,51 @@ where
             // The fresh-lockfile path has no installability check
             // (no `packages:` metadata to evaluate constraints
             // against), so its skip set is empty by construction.
-            // Build the workspace-sibling lookup the npm resolver
-            // consults for `workspace:` specs. `None` when the install
-            // isn't inside a `pnpm-workspace.yaml` workspace (no
-            // workspace root was found), so the resolver errors out
-            // on any `workspace:` spec rather than silently skipping
-            // to a registry lookup. Mirrors upstream's posture at
+            // Walk every workspace project once: the returned `Vec`
+            // feeds both the `workspace:`-spec lookup the npm resolver
+            // consults *and* the per-importer manifest list the
+            // resolver iterates over. `None` workspace projects when
+            // the install isn't inside a `pnpm-workspace.yaml`
+            // workspace (no workspace root was found) — the resolver
+            // then errors out on any `workspace:` spec rather than
+            // silently skipping to a registry lookup, matching pnpm's
+            // posture at
             // <https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L828-L830>.
-            let workspace_packages =
-                build_workspace_packages_map(&workspace_root, workspace_manifest.as_ref())
+            let workspace_projects =
+                load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
                     .map_err(InstallError::FindWorkspaceProjects)?;
+            let workspace_packages = build_workspace_packages_map(workspace_projects.as_deref());
+            // Build the per-importer manifest list. The root importer
+            // (`"."`) always reuses the in-memory `Install.manifest`
+            // — `pacquet add` mutates that value before calling install,
+            // so re-reading from disk would walk the pre-add shape and
+            // miss the freshly-added dep. Sibling importers come from
+            // the `find_workspace_projects` walk, which read them off
+            // disk for `workspace_packages` already.
+            let importer_manifests: BTreeMap<String, &PackageManifest> = {
+                let mut map = BTreeMap::new();
+                map.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), manifest);
+                if let Some(projects) = workspace_projects.as_deref() {
+                    for project in projects {
+                        let id = pacquet_workspace::importer_id_from_root_dir(
+                            &workspace_root,
+                            &project.root_dir,
+                        );
+                        if id == Lockfile::ROOT_IMPORTER_KEY {
+                            continue;
+                        }
+                        map.insert(id, &project.manifest);
+                    }
+                }
+                map
+            };
             let fresh_result = InstallWithFreshLockfile {
                 tarball_mem_cache,
                 resolved_packages,
                 http_client,
                 http_client_arc: Arc::clone(&http_client_arc),
                 config,
-                manifest,
+                importer_manifests,
                 dependency_groups,
                 logged_methods: &logged_methods,
                 requester: &prefix,
@@ -727,23 +755,34 @@ where
             .map_err(InstallError::WithFreshLockfile)?;
 
             // Mirror the frozen-lockfile branch: when GVS is on,
-            // register the project against the shared store so
-            // `pacquet store prune` can find this consumer of
-            // `<store_dir>/links/...`. Pacquet's fresh-resolve path
-            // has one importer today (workspaces tracked at
-            // pnpm/pacquet#431), so the workspace root is the only
-            // path to register. Best-effort: warn on failure, don't
-            // fail the install.
-            if config.enable_global_virtual_store
-                && let Err(error) =
-                    pacquet_store_dir::register_project(&config.store_dir, &workspace_root)
-            {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    project_dir = ?workspace_root,
-                    "Failed to register project in the global-virtual-store registry; install continues",
-                );
+            // register every importer that the fresh resolve walked
+            // against the shared store so `pacquet store prune` can
+            // find each consumer of `<store_dir>/links/...`. For a
+            // single-project install this loops once over the root;
+            // for a workspace install it covers every project. Best-
+            // effort: warn on failure, don't fail the install.
+            if config.enable_global_virtual_store {
+                let importer_ids: Vec<String> = fresh_result
+                    .wanted_lockfile
+                    .as_ref()
+                    .map(|lockfile| lockfile.importers.keys().cloned().collect())
+                    .unwrap_or_else(|| vec![Lockfile::ROOT_IMPORTER_KEY.to_string()]);
+                for importer_id in importer_ids {
+                    let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
+                        &workspace_root,
+                        &importer_id,
+                    );
+                    if let Err(error) =
+                        pacquet_store_dir::register_project(&config.store_dir, &project_dir)
+                    {
+                        tracing::warn!(
+                            target: "pacquet::install",
+                            ?error,
+                            importer_id = %importer_id,
+                            "Failed to register importer in the global-virtual-store registry; install continues",
+                        );
+                    }
+                }
             }
 
             (
@@ -1162,11 +1201,31 @@ fn manifest_string_field(manifest: &PackageManifest, key: &str) -> Option<String
     manifest.value().get(key).and_then(|v| v.as_str()).map(ToString::to_string)
 }
 
+/// Walk every workspace project's `package.json`. Returns `Ok(None)`
+/// when no `pnpm-workspace.yaml` exists in (or above) `workspace_root`
+/// — the install isn't a workspace install, so the caller should use
+/// the top-level `Install.manifest` as its only importer and pass
+/// `None` for the `workspace:`-spec lookup.
+///
+/// One walk feeds both [`build_workspace_packages_map`] (the npm
+/// resolver's `workspace:` lookup) and the per-importer manifest list
+/// the fresh-resolve path iterates over, so the manifests are read
+/// from disk exactly once. Mirrors upstream's
+/// [`findWorkspacePackages`](https://github.com/pnpm/pnpm/blob/3422cecfd3/workspace/find-packages/src/index.ts).
+fn load_workspace_projects(
+    workspace_root: &std::path::Path,
+    workspace_manifest: Option<&pacquet_workspace::WorkspaceManifest>,
+) -> Result<Option<Vec<pacquet_workspace::Project>>, pacquet_workspace::FindWorkspaceProjectsError>
+{
+    let Some(manifest) = workspace_manifest else { return Ok(None) };
+    let opts = pacquet_workspace::FindWorkspaceProjectsOpts { patterns: manifest.packages.clone() };
+    pacquet_workspace::find_workspace_projects(workspace_root, &opts).map(Some)
+}
+
 /// Build the `name → version → WorkspacePackage` lookup the npm
-/// resolver consults for `workspace:` specs. Returns `Ok(None)` when
-/// no `pnpm-workspace.yaml` exists in (or above) `workspace_root` —
-/// the install isn't a workspace install, so any `workspace:` spec
-/// the manifest happens to carry should surface
+/// resolver consults for `workspace:` specs. Returns `None` when
+/// `projects` is `None` (no workspace) so any `workspace:` spec the
+/// manifest happens to carry surfaces
 /// [`pacquet_resolving_npm_resolver::ResolveFromWorkspaceError::WorkspacePackagesNotLoaded`].
 ///
 /// Mirrors the slice pnpm's
@@ -1177,18 +1236,9 @@ fn manifest_string_field(manifest: &PackageManifest, key: &str) -> Option<String
 /// skipped; upstream's manifest reader emits a separate warning that
 /// pacquet doesn't carry through here.
 fn build_workspace_packages_map(
-    workspace_root: &std::path::Path,
-    workspace_manifest: Option<&pacquet_workspace::WorkspaceManifest>,
-) -> Result<
-    Option<pacquet_resolving_resolver_base::WorkspacePackages>,
-    pacquet_workspace::FindWorkspaceProjectsError,
-> {
-    // No `pnpm-workspace.yaml` → no workspace install. Skip the project
-    // walk entirely.
-    let Some(manifest) = workspace_manifest else { return Ok(None) };
-    let opts = pacquet_workspace::FindWorkspaceProjectsOpts { patterns: manifest.packages.clone() };
-    let projects = pacquet_workspace::find_workspace_projects(workspace_root, &opts)?;
-
+    projects: Option<&[pacquet_workspace::Project]>,
+) -> Option<pacquet_resolving_resolver_base::WorkspacePackages> {
+    let projects = projects?;
     let mut map: pacquet_resolving_resolver_base::WorkspacePackages =
         std::collections::BTreeMap::new();
     for project in projects {
@@ -1198,12 +1248,12 @@ fn build_workspace_packages_map(
         map.entry(name).or_default().insert(
             version,
             pacquet_resolving_resolver_base::WorkspacePackage {
-                root_dir: project.root_dir,
+                root_dir: project.root_dir.clone(),
                 manifest: project.manifest.value().clone(),
             },
         );
     }
-    Ok(Some(map))
+    Some(map)
 }
 
 /// Build the `projects` map for [`WorkspaceState`]. Mirrors upstream's

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -375,15 +375,34 @@ where
         // write failure shouldn't fail the install. Surface as
         // `tracing::warn!` so the failure is diagnosable but the
         // install carries on.
-        if config.enable_global_virtual_store
-            && let Err(error) =
+        if config.enable_global_virtual_store {
+            // Create the store root before calling `register_project` so
+            // its `path_contains` guard can canonicalize the path
+            // instead of falling through to a literal comparison that
+            // wrongly matches against `<workspace>/../pacquet-store/v11`-
+            // shaped relative store paths (resolved-on-disk: outside the
+            // workspace; lexical: starts with the workspace prefix).
+            // Mirrors pnpm's
+            // [`fs.mkdir(opts.storeDir, { recursive: true })`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/installing/context/src/index.ts#L125)
+            // call site right before `registerProject`.
+            if let Err(error) =
+                std::fs::create_dir_all(pacquet_store_dir::StoreDir::root(&config.store_dir))
+            {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "Failed to ensure store root exists before project registry write; install continues",
+                );
+            }
+            if let Err(error) =
                 pacquet_store_dir::register_project(&config.store_dir, &workspace_root)
-        {
-            tracing::warn!(
-                target: "pacquet::install",
-                ?error,
-                "Failed to register workspace root in the store project registry; install continues",
-            );
+            {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "Failed to register workspace root in the store project registry; install continues",
+                );
+            }
         }
 
         // `pnpm:package-manifest initial` carries the on-disk

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -18,7 +18,7 @@ use pacquet_workspace_state::{
     self as workspace_state, NodeLinker as WorkspaceStateNodeLinker, load_workspace_state,
 };
 use pipe_trait::Pipe;
-use std::{path::PathBuf, sync::Mutex};
+use std::sync::Mutex;
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -2127,33 +2127,29 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
     drop(dir);
 }
 
-/// Workspace install under GVS registers each importer separately.
-/// Mirrors upstream's per-project
-/// [`registerProject`](https://github.com/pnpm/pnpm/blob/94240bc046/store/controller/src/storeController/projectRegistry.ts)
-/// call site, which fires once per workspace package — a workspace
-/// with `.` (root) and `packages/web` therefore ends up with two
-/// entries in `<store_dir>/projects/`, each resolving back to its
-/// own root dir. `pacquet store prune` (tracked separately) needs
-/// every reachable importer in the registry to keep the
-/// `<store_dir>/links/...` slots they share alive.
+/// Workspace install under GVS registers the workspace root once,
+/// regardless of how many importers the workspace declares. Mirrors
+/// upstream's
+/// [`registerProject(opts.storeDir, opts.lockfileDir)`](https://github.com/pnpm/pnpm/blob/d8a79a9c30/installing/context/src/index.ts#L128)
+/// call site in `getContext`, which fires exactly once per install
+/// against the workspace root — store prune walks
+/// `<workspace>/node_modules/.pnpm/` to find every installed package,
+/// so one registry entry per workspace is enough.
 #[tokio::test]
-async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
+async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
     let dir = tempdir().unwrap();
     let store_dir = dir.path().join("pacquet-store");
     let workspace_root = dir.path().join("workspace");
     let modules_dir = workspace_root.join("node_modules");
     let virtual_store_dir = modules_dir.join(".pacquet");
 
-    // Workspace layout: root + one sub-importer. Both directories
-    // have to exist on disk because `register_project` canonicalises
-    // the target before writing the symlink.
+    // Workspace layout: root + one sub-importer. The sub-importer's
+    // directory exists on disk because the lockfile reader needs it,
+    // but registration only resolves the workspace root.
     let web_dir = workspace_root.join("packages/web");
     std::fs::create_dir_all(&web_dir).expect("create packages/web");
     let manifest_path = workspace_root.join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
-    // The sub-importer needs a `package.json` too — the freshness check
-    // satisfies on the root only today, but the per-importer registry
-    // write still resolves the target on disk.
     std::fs::write(web_dir.join("package.json"), "{}").expect("write packages/web/package.json");
 
     let mut config = Config::new();
@@ -2166,8 +2162,8 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
     let config = config.leak();
 
     // Two importers: `.` and `packages/web`. Empty dep graph so the
-    // install reaches the per-importer registry-write loop without
-    // doing any actual fetch/link work.
+    // install reaches the registry-write call without doing any actual
+    // fetch/link work.
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
         "lockfileVersion: '9.0'"
         "importers:"
@@ -2202,28 +2198,26 @@ async fn frozen_lockfile_under_gvs_registers_each_workspace_importer() {
     .await
     .expect("workspace frozen-lockfile install under GVS should succeed");
 
-    // Exactly two registry entries — one per importer. Resolve the
-    // symlink targets and confirm both project roots are present.
+    // Exactly one registry entry resolving back to the workspace
+    // root, matching pnpm's once-per-install `registerProject(storeDir,
+    // lockfileDir)` shape.
     let projects_dir = store_dir.join("v11/projects");
     assert!(
         projects_dir.is_dir(),
         "GVS-on workspace install must create <store_dir>/v11/projects/",
     );
-    let mut targets: Vec<PathBuf> = std::fs::read_dir(&projects_dir)
-        .unwrap()
-        .map(|entry| {
-            // Canonicalize the entry path so the kernel follows the
-            // (relative) symlink — see the sibling test for context.
-            dunce::canonicalize(entry.unwrap().path()).expect("canonicalize registry entry")
-        })
-        .collect();
-    targets.sort();
-    let mut expected = [
+    let entries: Vec<_> =
+        std::fs::read_dir(&projects_dir).unwrap().collect::<Result<_, _>>().unwrap();
+    assert_eq!(
+        entries.len(),
+        1,
+        "workspace install registers the workspace root once, not once per importer",
+    );
+    assert_eq!(
+        dunce::canonicalize(entries[0].path()).expect("canonicalize registry entry"),
         dunce::canonicalize(&workspace_root).expect("canonicalize workspace root"),
-        dunce::canonicalize(&web_dir).expect("canonicalize packages/web"),
-    ];
-    expected.sort();
-    assert_eq!(targets, expected, "every importer must have a registry entry");
+        "registry symlink must resolve back to the workspace root",
+    );
 
     drop(dir);
 }

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1,10 +1,10 @@
 use crate::{
     AllowBuildPolicy, CreateVirtualStore, CreateVirtualStoreError, CreateVirtualStoreOutput,
-    GraphToLockfileOptions, HoistedDependencies, InstallPackageFromRegistryError,
-    LinkVirtualStoreBins, LinkVirtualStoreBinsError, PrefetchContext, PrefetchingResolver,
-    SkippedSnapshots, SymlinkDirectDependencies, SymlinkDirectDependenciesError,
-    VersionPolicyError, VirtualStoreLayout, dependencies_graph_to_lockfile,
-    store_init::init_store_dir_best_effort,
+    GraphToLockfileOptions, HoistedDependencies, ImporterLockfileInput,
+    InstallPackageFromRegistryError, LinkVirtualStoreBins, LinkVirtualStoreBinsError,
+    PrefetchContext, PrefetchingResolver, SkippedSnapshots, SymlinkDirectDependencies,
+    SymlinkDirectDependenciesError, VersionPolicyError, VirtualStoreLayout,
+    dependencies_graph_to_lockfile, store_init::init_store_dir_best_effort,
 };
 use dashmap::DashMap;
 use derive_more::{Display, Error};
@@ -91,7 +91,14 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// stored `ThrottledClient` outlives any per-call borrow.
     pub http_client_arc: Arc<ThrottledClient>,
     pub config: &'static Config,
-    pub manifest: &'a PackageManifest,
+    /// One entry per importer to resolve, keyed by the lockfile
+    /// importer id (`"."` for the workspace root, POSIX-relative path
+    /// for sibling projects — see
+    /// [`pacquet_workspace::importer_id_from_root_dir`]). Mirrors
+    /// upstream's `importers: ImporterToResolve[]` shape on
+    /// `resolveDependencies`. For a non-workspace install this carries
+    /// a single `"."` entry pointing at the only project.
+    pub importer_manifests: BTreeMap<String, &'a PackageManifest>,
     pub dependency_groups: DependencyGroupList,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
@@ -254,7 +261,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             http_client,
             http_client_arc,
             config,
-            manifest,
+            importer_manifests,
             dependency_groups,
             // The recursive `install_subtree` path used this `DashMap`
             // as a per-snapshot watch-channel dedup gate so duplicate
@@ -487,27 +494,23 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             .transpose()
             .map_err(InstallWithFreshLockfileError::MinimumReleaseAgeExclude)?;
 
-        // Seed `allPreferredVersions` from the importer manifest +
+        // Seed `allPreferredVersions` from every importer's manifest +
         // the wanted lockfile's snapshots (when an existing one is
         // present and is being rewritten). Mirrors upstream's
         // `getPreferredVersionsFromLockfileAndManifests` shape: the
-        // manifest contributes direct-dep specifiers, the lockfile
+        // manifests contribute direct-dep specifiers, the lockfile
         // contributes concrete `(name, version)` pins that bump the
         // weight of an already-matching direct-dep entry. Without the
         // lockfile-side seed, every install on a stale lockfile would
         // resolve unrelated entries from scratch and lose their
         // recorded pins; see <https://pnpm.io/settings#preferfrozenlockfile>.
+        let manifests_for_preferred: Vec<&PackageManifest> =
+            importer_manifests.values().copied().collect();
         let all_preferred_versions =
             pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
                 wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()),
-                &[manifest],
+                manifests_for_preferred.as_slice(),
             );
-
-        // Thread the manifest's directory and the lockfile root into
-        // the resolver's `ResolveOptions` so `workspace:` and `link:`
-        // resolutions can compute the right relative paths.
-        let project_dir =
-            manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. The resolver consults the grouped record at
@@ -520,39 +523,88 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             .map_err(InstallWithFreshLockfileError::ResolvePatchedDependencies)?
             .map(Arc::new);
 
-        let importer_opts = ResolveImporterOptions {
-            auto_install_peers: config.auto_install_peers,
-            auto_install_peers_from_highest_match: config.auto_install_peers_from_highest_match,
-            resolve_peers_from_workspace_root: config.resolve_peers_from_workspace_root,
-            all_preferred_versions,
-            patched_dependencies,
-            base_opts: ResolveOptions {
-                default_tag: Some("latest".to_string()),
-                published_by,
-                published_by_exclude,
-                project_dir,
-                lockfile_dir: lockfile_dir.to_path_buf(),
-                workspace_packages,
-                block_exotic_subdeps: config.block_exotic_subdeps,
-                ..ResolveOptions::default()
-            },
-            catalogs,
-        };
-
+        // Loop per workspace project. Each importer gets its own
+        // resolve_importer call with its own `project_dir` so
+        // `workspace:` / `link:` resolutions compute paths relative
+        // to the consuming project; the shared `meta_cache`,
+        // `fetch_locker`, and `picked_manifest_cache` keep the
+        // packument and version-pick work amortized across importers.
+        // Mirrors upstream's
+        // [`resolveRootDependencies`](https://github.com/pnpm/pnpm/blob/3422cecfd3/installing/deps-resolver/src/resolveDependencies.ts#L327-L437)
+        // iteration: one shared resolution context, per-importer
+        // direct-deps slices.
         let phase_start = std::time::Instant::now();
-        let importer_result = resolve_importer(
-            &*resolver,
-            manifest,
-            dependency_groups.iter().copied(),
-            importer_opts,
-        )
-        .await
-        .map_err(InstallWithFreshLockfileError::ResolveImporter)?;
+        let mut merged_graph: pacquet_resolving_deps_resolver::DependenciesGraph =
+            std::collections::HashMap::new();
+        let mut direct_by_importer: BTreeMap<
+            String,
+            BTreeMap<String, pacquet_resolving_deps_resolver::DepPath>,
+        > = BTreeMap::new();
+        let mut total_nodes = 0usize;
+        for (importer_id, importer_manifest) in &importer_manifests {
+            let project_dir = importer_manifest
+                .path()
+                .parent()
+                .expect("manifest path always has a parent dir")
+                .to_path_buf();
+            let importer_opts = ResolveImporterOptions {
+                auto_install_peers: config.auto_install_peers,
+                auto_install_peers_from_highest_match: config.auto_install_peers_from_highest_match,
+                resolve_peers_from_workspace_root: config.resolve_peers_from_workspace_root,
+                all_preferred_versions: all_preferred_versions.clone(),
+                patched_dependencies: patched_dependencies.clone(),
+                base_opts: ResolveOptions {
+                    default_tag: Some("latest".to_string()),
+                    published_by,
+                    published_by_exclude: published_by_exclude.clone(),
+                    project_dir,
+                    lockfile_dir: lockfile_dir.to_path_buf(),
+                    workspace_packages: workspace_packages.clone(),
+                    block_exotic_subdeps: config.block_exotic_subdeps,
+                    ..ResolveOptions::default()
+                },
+                catalogs: catalogs.clone(),
+            };
+            let importer_result = resolve_importer(
+                &*resolver,
+                importer_manifest,
+                dependency_groups.iter().copied(),
+                importer_opts,
+            )
+            .await
+            .map_err(InstallWithFreshLockfileError::ResolveImporter)?;
+            total_nodes += importer_result.peers_result.graph.len();
+            // Merge this importer's per-id graph into the shared
+            // graph; identical depPaths collapse onto the existing
+            // entry. Two importers depending on the same package
+            // version produce equivalent nodes by construction of the
+            // (deterministic) resolver, so a first-writer-wins merge
+            // is safe.
+            for (key, node) in importer_result.peers_result.graph {
+                merged_graph.entry(key).or_insert(node);
+            }
+            direct_by_importer.insert(
+                importer_id.clone(),
+                importer_result.peers_result.direct_dependencies_by_alias,
+            );
+            if !importer_result.peers_result.peer_dependency_issues.missing.is_empty()
+                || !importer_result.peers_result.peer_dependency_issues.bad.is_empty()
+            {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    importer_id = %importer_id,
+                    missing = importer_result.peers_result.peer_dependency_issues.missing.len(),
+                    bad = importer_result.peers_result.peer_dependency_issues.bad.len(),
+                    "Peer dependency issues detected (issue renderer not ported yet)",
+                );
+            }
+        }
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "resolve_importer",
             elapsed_ms = phase_start.elapsed().as_millis() as u64,
-            nodes = importer_result.peers_result.graph.len(),
+            importers = importer_manifests.len(),
+            nodes = total_nodes,
             "phase complete",
         );
 
@@ -591,7 +643,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // serialize on `Arc<Mutex<StoreIndex>>` for warm packages
         // that weren't reached by the resolve-time prefetch (e.g.
         // resolutions without a structured `name@version`).
-        let cache_keys: Vec<String> = collect_prefetch_cache_keys(&importer_result.peers_result);
+        let cache_keys: Vec<String> = collect_prefetch_cache_keys_from_graph(&merged_graph);
         let cache_keys_len = cache_keys.len();
         let phase_start = std::time::Instant::now();
         let prefetch = pacquet_tarball::prefetch_cas_paths(
@@ -622,23 +674,6 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             manifest_hits = prefetched_manifests.len(),
             "phase complete",
         );
-
-        // Peer-resolution result (collected by `resolve_importer` after
-        // the hoist loop converged). Peer issues collected here are not
-        // fatal — they are reported (TODO: wire into the reporter once
-        // the issue renderer is ported) and the install proceeds with
-        // whichever candidate was reachable.
-        let peers_result = &importer_result.peers_result;
-        if !peers_result.peer_dependency_issues.missing.is_empty()
-            || !peers_result.peer_dependency_issues.bad.is_empty()
-        {
-            tracing::warn!(
-                target: "pacquet::install",
-                missing = peers_result.peer_dependency_issues.missing.len(),
-                bad = peers_result.peer_dependency_issues.bad.len(),
-                "Peer dependency issues detected (issue renderer not ported yet)",
-            );
-        }
 
         // Build the install-scoped virtual-store layout. When
         // `enable_global_virtual_store` is on, this precomputes each
@@ -674,7 +709,8 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // [`Self::wanted_lockfile`], which is the *previous* run's
         // lockfile threaded in for preferred-versions seeding.
         let phase_start = std::time::Instant::now();
-        let built_lockfile = build_fresh_lockfile(config, manifest, &importer_result);
+        let built_lockfile =
+            build_fresh_lockfile(config, &importer_manifests, &merged_graph, &direct_by_importer);
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "build_fresh_lockfile",
@@ -813,16 +849,30 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         .run::<Reporter>()
         .map_err(InstallWithFreshLockfileError::SymlinkDirectDependencies)?;
 
-        // Link bins. Direct dependencies first (root project's
+        // Link bins. Direct dependencies first (each importer's
         // `node_modules/.bin`) and then per-slot children inside the
         // virtual store. Mirrors the same two-call shape as
         // `install_frozen_lockfile.rs`. We re-walk `<modules_dir>` instead
         // of replaying the manifest because the `dependency_groups`
         // iterator was already consumed above; pnpm's own
         // `linkBins(modulesDir, binsDir)` overload uses the same
-        // strategy.
-        link_bins::<Host>(&config.modules_dir, &config.modules_dir.join(".bin"))
-            .map_err(InstallWithFreshLockfileError::LinkBins)?;
+        // strategy. One pass per importer so sibling workspace projects
+        // get their own `.bin/` populated, mirroring upstream's
+        // per-importer `linkBinsOfImporter` at
+        // <https://github.com/pnpm/pnpm/blob/3422cecfd3/installing/deps-installer/src/install/link.ts>.
+        let modules_basename = config
+            .modules_dir
+            .file_name()
+            .map(std::ffi::OsStr::to_os_string)
+            .unwrap_or_else(|| std::ffi::OsString::from("node_modules"));
+        for importer_id in importer_manifests.keys() {
+            let project_dir =
+                crate::symlink_direct_dependencies::importer_root_dir(symlink_root, importer_id);
+            let modules_dir = project_dir.join(&modules_basename);
+            let bins_dir = modules_dir.join(".bin");
+            link_bins::<Host>(&modules_dir, &bins_dir)
+                .map_err(InstallWithFreshLockfileError::LinkBins)?;
+        }
 
         // Drive the lockfile-driven `LinkVirtualStoreBins` path. The
         // bin linker iterates `snapshots:` (no per-slot `read_dir`)
@@ -901,11 +951,10 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
     }
 }
 
-/// Walk the resolver-produced graph and emit the
-/// `{integrity}\t{pkg_id}` cache keys
-/// [`pacquet_tarball::prefetch_cas_paths`] uses for its batched
-/// `SELECT ... WHERE key IN (...)` against the store index. Mirrors
-/// the equivalent collection loop in
+/// Walk the merged resolver graph and emit the `{integrity}\t{pkg_id}`
+/// cache keys [`pacquet_tarball::prefetch_cas_paths`] uses for its
+/// batched `SELECT ... WHERE key IN (...)` against the store index.
+/// Mirrors the equivalent collection loop in
 /// [`crate::CreateVirtualStore::run`] for the frozen-lockfile path —
 /// same key shape, same dedup, so the fresh-lockfile path's warm
 /// batch hits the same rows pnpm or pacquet wrote on the prior
@@ -917,11 +966,10 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
 /// shape (`pkg_id`-only) and route through the cold path. Today's
 /// `install_subtree` only handles tarball+integrity anyway, so the
 /// skipped entries can't be served from the prefetch either way.
-fn collect_prefetch_cache_keys(
-    peers_result: &pacquet_resolving_deps_resolver::ResolvePeersResult,
+fn collect_prefetch_cache_keys_from_graph(
+    graph: &pacquet_resolving_deps_resolver::DependenciesGraph,
 ) -> Vec<String> {
-    let mut keys: Vec<String> = peers_result
-        .graph
+    let mut keys: Vec<String> = graph
         .values()
         .filter_map(|node| {
             let pacquet_lockfile::LockfileResolution::Tarball(tarball) =
@@ -944,7 +992,7 @@ fn collect_prefetch_cache_keys(
 }
 
 /// Build the [`Lockfile`] for `<lockfile_dir>/pnpm-lock.yaml` from the
-/// resolver's output.
+/// merged resolver graph + per-importer direct-deps maps.
 ///
 /// Mirrors upstream's
 /// [`updateLockfile`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/updateLockfile.ts)
@@ -953,18 +1001,28 @@ fn collect_prefetch_cache_keys(
 /// fan-out, with [`dependencies_graph_to_lockfile()`] doing the wire-shape lifting.
 fn build_fresh_lockfile(
     config: &Config,
-    manifest: &PackageManifest,
-    importer_result: &pacquet_resolving_deps_resolver::ResolveImporterResult,
+    importer_manifests: &BTreeMap<String, &PackageManifest>,
+    graph: &pacquet_resolving_deps_resolver::DependenciesGraph,
+    direct_by_importer: &BTreeMap<
+        String,
+        BTreeMap<String, pacquet_resolving_deps_resolver::DepPath>,
+    >,
 ) -> Lockfile {
+    let mut importers = BTreeMap::new();
+    for (id, manifest) in importer_manifests {
+        let direct = direct_by_importer.get(id).cloned().unwrap_or_default();
+        importers.insert(
+            id.clone(),
+            ImporterLockfileInput { manifest, direct_dependencies_by_alias: direct },
+        );
+    }
     dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        manifest,
-        resolved: importer_result,
+        importers,
+        graph,
         auto_install_peers: config.auto_install_peers,
         // `excludeLinksFromLockfile` isn't ported to pacquet's `Config`
-        // yet (pnpm/pacquet#431 brings workspace support, which is
-        // when the knob starts mattering). Default to `false` —
-        // matches upstream's default and round-trips cleanly through
-        // `@pnpm/lockfile.settings-checker`.
+        // yet. Default to `false` — matches upstream's default and
+        // round-trips cleanly through `@pnpm/lockfile.settings-checker`.
         exclude_links_from_lockfile: false,
         overrides: config
             .overrides

--- a/pacquet/crates/store-dir/src/project_registry.rs
+++ b/pacquet/crates/store-dir/src/project_registry.rs
@@ -363,12 +363,36 @@ fn is_enoent_or_einval(error: &io::Error) -> bool {
 /// Both paths are compared by their canonical (resolved) form so
 /// symlinks don't fool the check. When either path can't be
 /// canonicalized (typically the store dir hasn't been created yet),
-/// fall back to a lexical comparison so the guard stays defensive
-/// against the legacy "store inside the project" case.
+/// fall back to a *lexical* normalization that collapses `.` and `..`
+/// segments — matching upstream's `path.relative`-backed
+/// [`is-subdir`](https://github.com/whitecolor/is-subdir/blob/main/index.js)
+/// check, which is purely lexical. A raw `starts_with` on the
+/// unnormalized path would treat `<workspace>/../pacquet-store` as
+/// inside `<workspace>` even though resolving `..` puts it outside.
 fn path_contains(outer: &Path, inner: &Path) -> bool {
-    let outer_canonical = dunce::canonicalize(outer).unwrap_or_else(|_| outer.to_path_buf());
-    let inner_canonical = dunce::canonicalize(inner).unwrap_or_else(|_| inner.to_path_buf());
+    let outer_canonical =
+        dunce::canonicalize(outer).unwrap_or_else(|_| lexical_normalize(outer));
+    let inner_canonical =
+        dunce::canonicalize(inner).unwrap_or_else(|_| lexical_normalize(inner));
     inner_canonical.starts_with(&outer_canonical)
+}
+
+/// Lexically resolve `.` and `..` components without touching the
+/// filesystem. Used as a fallback inside [`path_contains`] when
+/// `canonicalize` fails because the path doesn't exist yet.
+fn lexical_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
 }
 
 /// Best-effort canonicalization for a symlink target: if the target is
@@ -388,10 +412,35 @@ fn canonicalize_or_join(link_path: &Path, target: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{create_short_hash, get_registered_projects, register_project};
+    use super::{create_short_hash, get_registered_projects, path_contains, register_project};
     use crate::StoreDir;
     use std::fs;
+    use std::path::Path;
     use tempfile::tempdir;
+
+    /// `path_contains` must resolve `..` segments lexically when the
+    /// paths don't exist on disk yet. A raw `starts_with` on
+    /// `<workspace>/../pacquet-store/v11` against `<workspace>` would
+    /// wrongly say the store lives inside the workspace, since the
+    /// string-prefix check ignores that `..` walks back up. The fresh-
+    /// install dispatch calls [`register_project`] before the store
+    /// dir is created, so canonicalize fails and the lexical fallback
+    /// is the only thing keeping the guard correct.
+    #[test]
+    fn path_contains_resolves_parent_components_when_paths_do_not_exist() {
+        let outer = Path::new("/tmp/nonexistent-workspace");
+        let inner_sibling = Path::new("/tmp/nonexistent-workspace/../sibling/v11");
+        assert!(
+            !path_contains(outer, inner_sibling),
+            "`<workspace>/../sibling/v11` lexically resolves to `/tmp/sibling/v11` — outside the workspace",
+        );
+
+        let inner_child = Path::new("/tmp/nonexistent-workspace/child/v11");
+        assert!(
+            path_contains(outer, inner_child),
+            "`<workspace>/child/v11` is genuinely inside the workspace",
+        );
+    }
 
     /// `create_short_hash` is sha256-hex truncated to 32 chars.
     /// Matches upstream's

--- a/pacquet/crates/store-dir/src/project_registry.rs
+++ b/pacquet/crates/store-dir/src/project_registry.rs
@@ -370,10 +370,8 @@ fn is_enoent_or_einval(error: &io::Error) -> bool {
 /// unnormalized path would treat `<workspace>/../pacquet-store` as
 /// inside `<workspace>` even though resolving `..` puts it outside.
 fn path_contains(outer: &Path, inner: &Path) -> bool {
-    let outer_canonical =
-        dunce::canonicalize(outer).unwrap_or_else(|_| lexical_normalize(outer));
-    let inner_canonical =
-        dunce::canonicalize(inner).unwrap_or_else(|_| lexical_normalize(inner));
+    let outer_canonical = dunce::canonicalize(outer).unwrap_or_else(|_| lexical_normalize(outer));
+    let inner_canonical = dunce::canonicalize(inner).unwrap_or_else(|_| lexical_normalize(inner));
     inner_canonical.starts_with(&outer_canonical)
 }
 

--- a/pacquet/crates/store-dir/src/project_registry.rs
+++ b/pacquet/crates/store-dir/src/project_registry.rs
@@ -378,14 +378,28 @@ fn path_contains(outer: &Path, inner: &Path) -> bool {
 /// Lexically resolve `.` and `..` components without touching the
 /// filesystem. Used as a fallback inside [`path_contains`] when
 /// `canonicalize` fails because the path doesn't exist yet.
+///
+/// Semantics:
+/// - `foo/../bar` → `bar` (pop a real segment).
+/// - `/..` → `/` (POSIX rule: root has no parent).
+/// - `../foo` → `../foo` (preserve leading `..` in relative paths).
+/// - `foo/./bar` → `foo/bar` (drop `.`).
 fn lexical_normalize(path: &Path) -> PathBuf {
     use std::path::Component;
     let mut out = PathBuf::new();
     for component in path.components() {
         match component {
-            Component::ParentDir => {
-                out.pop();
-            }
+            Component::ParentDir => match out.components().next_back() {
+                // Normal segment — collapse it with the `..`.
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                // At an absolute root — drop the `..` (`/..` is `/`).
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                // Empty path or leading `..` chain — preserve the `..`
+                // so relative paths like `../foo` round-trip.
+                _ => out.push(".."),
+            },
             Component::CurDir => {}
             other => out.push(other.as_os_str()),
         }
@@ -438,6 +452,29 @@ mod tests {
             path_contains(outer, inner_child),
             "`<workspace>/child/v11` is genuinely inside the workspace",
         );
+    }
+
+    /// [`lexical_normalize`] preserves leading `..` segments in
+    /// relative paths but drops `..` immediately after an absolute
+    /// root — matching Go's `path.Clean` and POSIX's "root has no
+    /// parent" rule.
+    #[test]
+    fn lexical_normalize_handles_parent_dir_corner_cases() {
+        use super::lexical_normalize;
+        use std::path::PathBuf;
+
+        // Real segment + `..` collapses.
+        assert_eq!(lexical_normalize(Path::new("foo/../bar")), PathBuf::from("bar"));
+        // `.` is dropped.
+        assert_eq!(lexical_normalize(Path::new("foo/./bar")), PathBuf::from("foo/bar"));
+        // `/..` is `/` — root has no parent.
+        assert_eq!(lexical_normalize(Path::new("/../foo")), PathBuf::from("/foo"));
+        // Leading `..` in a relative path is preserved.
+        assert_eq!(lexical_normalize(Path::new("../foo")), PathBuf::from("../foo"));
+        // Multiple leading `..`s stack.
+        assert_eq!(lexical_normalize(Path::new("../../foo")), PathBuf::from("../../foo"));
+        // Interior `..` after an absolute root collapses normally.
+        assert_eq!(lexical_normalize(Path::new("/a/b/../c")), PathBuf::from("/a/c"));
     }
 
     /// `create_short_hash` is sha256-hex truncated to 32 chars.

--- a/pacquet/crates/workspace/Cargo.toml
+++ b/pacquet/crates/workspace/Cargo.toml
@@ -16,6 +16,7 @@ pacquet-package-manifest = { workspace = true }
 
 derive_more  = { workspace = true }
 miette       = { workspace = true }
+pathdiff     = { workspace = true }
 serde        = { workspace = true }
 serde-saphyr = { workspace = true }
 wax          = { workspace = true }

--- a/pacquet/crates/workspace/src/importer_id.rs
+++ b/pacquet/crates/workspace/src/importer_id.rs
@@ -1,0 +1,54 @@
+//! Compute the lockfile importer key for a workspace project.
+//!
+//! Mirrors upstream's
+//! [`(path.relative(lockfileDir, p.rootDir) || '.').split(path.sep).join('/')`](https://github.com/pnpm/pnpm/blob/212315de16/pnpm/src/main.ts#L2469)
+//! call site, used by `pkg-manager/core` to derive the `importers:` keys
+//! the lockfile carries.
+
+use std::path::Path;
+
+/// Returns `"."` for the root importer; otherwise the POSIX (forward-
+/// slash) relative path from `lockfile_dir` to `project_dir`. Used as
+/// the key into `Lockfile::importers` so both the lockfile writer and
+/// `symlink_direct_dependencies::importer_root_dir` (the reverse
+/// direction) agree on the spelling.
+pub fn importer_id_from_root_dir(lockfile_dir: &Path, project_dir: &Path) -> String {
+    if project_dir == lockfile_dir {
+        return ".".to_string();
+    }
+    match pathdiff::diff_paths(project_dir, lockfile_dir) {
+        Some(rel) => {
+            let rendered = rel.to_string_lossy().into_owned();
+            if rendered.is_empty() || rendered == "." {
+                ".".to_string()
+            } else {
+                rendered.replace('\\', "/")
+            }
+        }
+        None => project_dir.to_string_lossy().replace('\\', "/"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::importer_id_from_root_dir;
+    use std::path::Path;
+
+    #[test]
+    fn returns_dot_for_root() {
+        assert_eq!(importer_id_from_root_dir(Path::new("/ws"), Path::new("/ws")), ".");
+    }
+
+    #[test]
+    fn returns_posix_relative_for_subproject() {
+        assert_eq!(
+            importer_id_from_root_dir(Path::new("/ws"), Path::new("/ws/packages/a")),
+            "packages/a",
+        );
+    }
+
+    #[test]
+    fn nested_subproject() {
+        assert_eq!(importer_id_from_root_dir(Path::new("/ws"), Path::new("/ws/a/b/c")), "a/b/c",);
+    }
+}

--- a/pacquet/crates/workspace/src/importer_id.rs
+++ b/pacquet/crates/workspace/src/importer_id.rs
@@ -49,6 +49,6 @@ mod tests {
 
     #[test]
     fn nested_subproject() {
-        assert_eq!(importer_id_from_root_dir(Path::new("/ws"), Path::new("/ws/a/b/c")), "a/b/c",);
+        assert_eq!(importer_id_from_root_dir(Path::new("/ws"), Path::new("/ws/a/b/c")), "a/b/c");
     }
 }

--- a/pacquet/crates/workspace/src/lib.rs
+++ b/pacquet/crates/workspace/src/lib.rs
@@ -18,12 +18,14 @@
 //!   Public entry point: [`find_workspace_projects`].
 
 mod api;
+mod importer_id;
 mod manifest;
 mod project_manifest;
 mod projects;
 mod root_finder;
 
 pub use api::{EnvVarOs, Host};
+pub use importer_id::importer_id_from_root_dir;
 pub use manifest::{
     InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
     WorkspaceManifest, read_workspace_manifest,


### PR DESCRIPTION
## Summary

Closes #11901.

Pacquet's fresh-resolve install path (no `--frozen-lockfile`, no usable
lockfile) previously only walked the workspace root manifest, so sibling
workspace projects' own dependencies never landed in the lockfile or on
disk. Per the issue, this was the dominant factor in the `babylon`
benchmark's 4–7× slowdown across every variation.

This PR makes the fresh-resolve dispatch:

- Load every workspace project's manifest once via `find_workspace_projects`
  (re-used by the existing `workspace:`-spec lookup so each manifest is
  read off disk exactly once).
- Call `resolve_importer` per importer with its own `project_dir`, sharing
  the install-scoped `meta_cache` / `fetch_locker` / `picked_manifest_cache`
  so packument and JSON-parse work is amortized across importers.
- Merge per-importer graphs into one `DependenciesGraph` for
  `dependencies_graph_to_lockfile`.
- Emit one `importers[<id>]` entry per project in `pnpm-lock.yaml`.
- Loop `link_bins` per importer so each project gets its own
  `node_modules/.bin`.
- Loop GVS `register_project` over every importer key the freshly-built
  lockfile carries, mirroring the frozen-lockfile branch.

Mirrors upstream's
[`resolveRootDependencies`](https://github.com/pnpm/pnpm/blob/3422cecfd3/installing/deps-resolver/src/resolveDependencies.ts#L327-L437)
iteration shape: one shared resolution context, per-importer direct-deps
slices.

### `link:` lockfile rendering

`importer_dep_version` and `snapshot_dep_ref` learned a `link:`
short-circuit so workspace-sibling edges render as
`ImporterDepVersion::Link(<rel-path>)` /
`SnapshotDepRef::Link(<rel-path>)` instead of failing to parse as
`name@version`. The existing variants on those enums already supported
the shape — only the conversion needed wiring.

### Test plan

- [x] New integration test `pacquet/crates/cli/tests/workspace_install.rs`
  spins up a two-project workspace (`packages/a`, `packages/b`), runs a
  fresh `pacquet install`, and asserts each importer's `node_modules`
  symlinks exist and the lockfile records both `importers[packages/a]`
  and `importers[packages/b]`.
- [x] New unit tests in
  `pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs`:
  workspace-link direct dep → `ImporterDepVersion::Link`; workspace-link
  child edge → `SnapshotDepRef::Link`; multi-importer workspace → one
  `importers[<id>]` entry per project, shared transitive dep deduped to
  one snapshot.
- [x] `cargo nextest run -p pacquet-package-manager` — 302/302 pass.
- [x] `cargo nextest run -p pacquet-cli --test add` — 5/5 pass
  (`Install.manifest` exception for `pacquet add`'s in-memory manifest
  mutation: the root importer reuses the in-memory manifest, sibling
  importers come from the freshly-read workspace walk).
- [x] `cargo nextest run -p pacquet-resolving-deps-resolver`,
  `pacquet-workspace` — clean.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings`
  — clean.
- [x] `cargo fmt` / `taplo format` / `typos pacquet` — clean.

## Out of scope (follow-ups)

- **Cross-importer `TreeCtx` sharing.** Each `resolve_importer` call
  still allocates its own `TreeCtx`, so transitive packages get resolved
  per importer. Network-side caches amortize the HTTP and packument JSON
  parsing — only per-resolve semver matching duplicates. Full upstream
  parity (one shared resolution context with per-importer hoist loops in
  the resolver crate) is a separate refactor that touches `TreeCtx`,
  `ResolvedTree`, `resolve_peers`, and ~30 test files.
- **Per-importer `pnpm:package-manifest initial` reporter emit.** Still
  root-only.
- **`WantedKey` widening to include `project_dir`.** Sidestepped by the
  per-importer `TreeCtx`; the cross-importer-sharing follow-up will
  need it to keep `workspace:*` cache entries unambiguous.

## Notes for reviewers

- The `Install::run` dispatch carves out the root importer to reuse
  `Install.manifest` (rather than the freshly-read root manifest from
  `find_workspace_projects`). `pacquet add` mutates `Install.manifest`
  in memory before calling install; re-reading from disk would walk
  the pre-add shape and miss the freshly-added dep. The `add` tests
  caught this in the first pass.
- Per the pacquet AGENTS.md, no changeset is included — this is a
  pacquet-only change and pacquet doesn't ship via the same release
  pipeline.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration and unit tests covering fresh-resolve multi-project installs, per-importer behavior, workspace sibling linking, lockfile importer sections, and registry/store canonicalization.

* **Refactor**
  * Install and lockfile flows now operate across multiple workspace projects: per-importer manifests, merged dependency graph, per-project .bin linking, and single root registration.

* **Bug Fixes**
  * Improved path normalization to handle lexical ../ and . cases for registry/store checks.

* **Chores**
  * Exported importer ID helper and added a workspace utility dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->