### PR TITLE
fix: clarify non-root resolutions warning

### DIFF
--- a/.changeset/clear-resolutions-warning.md
+++ b/.changeset/clear-resolutions-warning.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/workspace.projects-reader": patch
+---
+
+Clarify that non-root `resolutions` does not take effect and dependency overrides should be configured with `overrides` in `pnpm-workspace.yaml`.

--- a/workspace/projects-reader/src/index.ts
+++ b/workspace/projects-reader/src/index.ts
@@ -71,8 +71,12 @@ function checkNonRootProjectManifest ({ manifest, rootDir }: Project): void {
 }
 
 function printNonRootFieldWarning (prefix: string, propertyPath: string): void {
+  const message = propertyPath === 'resolutions'
+    ? `The field "${propertyPath}" was found in ${prefix}/package.json. This will not take effect. Configure dependency overrides in pnpm-workspace.yaml using the "overrides" field instead.`
+    : `The field "${propertyPath}" was found in ${prefix}/package.json. This will not take effect. You should configure "${propertyPath}" at the root of the workspace instead.`
+
   logger.warn({
-    message: `The field "${propertyPath}" was found in ${prefix}/package.json. This will not take effect. You should configure "${propertyPath}" at the root of the workspace instead.`,
+    message,
     prefix,
   })
 }

--- a/workspace/projects-reader/test/index.ts
+++ b/workspace/projects-reader/test/index.ts
@@ -49,6 +49,6 @@ test('findWorkspaceProjects() outputs warnings for non-root workspace project', 
     jest.mocked(logger.warn).mock.calls
       .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
   ).toStrictEqual([
-    [{ prefix: barPath, message: `The field "resolutions" was found in ${barPath}/package.json. This will not take effect. You should configure "resolutions" at the root of the workspace instead.` }],
+    [{ prefix: barPath, message: `The field "resolutions" was found in ${barPath}/package.json. This will not take effect. Configure dependency overrides in pnpm-workspace.yaml using the "overrides" field instead.` }],
   ])
 })


### PR DESCRIPTION
Fixes #11757.

## Summary
- update the non-root `resolutions` warning so it points users to `overrides` in `pnpm-workspace.yaml`
- keep the existing warning behavior, but avoid suggesting that root `package.json` `resolutions` is the right migration path
- update the workspace projects reader test expectation

## Tests
- `pnpm --filter @pnpm/workspace.projects-reader exec tsgo --build`
- `pnpm --filter @pnpm/workspace.projects-reader exec eslint "src/**/*.ts" "test/**/*.ts"`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --filter @pnpm/workspace.projects-reader exec jest index.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning message for non-root workspace configurations, clarifying that dependency overrides should be configured in workspace settings rather than at the root level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->