### PR TITLE
fix: write fish setup to conf.d

### DIFF
--- a/.changeset/fresh-fish-setup.md
+++ b/.changeset/fresh-fish-setup.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/engine.pm.commands": patch
+---
+
+Write `pnpm setup` fish shell configuration to `~/.config/fish/conf.d/pnpm.fish`.

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender.rs
@@ -100,14 +100,18 @@ pub(crate) enum PathExtenderError {
     #[display("Could not determine the home directory")]
     NoHomeDir,
 
+    #[display(r#"Refusing to write shell configuration at "{}": {reason}"#, path.display())]
+    #[diagnostic(code(ERR_PNPM_UNSAFE_SHELL_CONFIG))]
+    UnsafeShellConfig { path: PathBuf, reason: &'static str },
+
     #[display(r#"Invalid proxyVarSubDir: "{sub_dir}""#)]
     #[diagnostic(code(ERR_PNPM_INVALID_SUBDIR))]
     InvalidSubDir { sub_dir: String },
 
     // Hardening beyond pnpm's `@pnpm/os.env.path-extender`: a path-separator
     // (`:` on POSIX, `;` on Windows), a `%` (Windows `%PNPM_HOME%`
-    // expansion), or a newline in `PNPM_HOME` would split the persisted
-    // `PATH` into extra entries, so it is rejected rather than written.
+    // expansion), or a control character in `PNPM_HOME` would split or
+    // corrupt the persisted `PATH`, so it is rejected rather than written.
     #[display(
         r#"The pnpm home directory "{dir}" contains a character ({character:?}) that is unsafe for the PATH"#
     )]
@@ -170,20 +174,22 @@ pub(super) fn validate_pnpm_home_dir(dir: &Path) -> Result<(), PathExtenderError
     if cfg!(windows) { validate_windows_pnpm_home(dir) } else { validate_posix_pnpm_home(dir) }
 }
 
-/// Reject `:` (the POSIX `PATH` separator), newlines, and NUL.
+/// Reject `:` (the POSIX `PATH` separator) and control characters.
 pub(super) fn validate_posix_pnpm_home(dir: &Path) -> Result<(), PathExtenderError> {
-    reject_unsafe_chars(dir, &[':', '\n', '\r', '\0'])
+    reject_unsafe_chars(dir, &[':'])
 }
 
 /// Reject `;` (the Windows `Path` separator), `%` (`%PNPM_HOME%` expansion),
-/// and newlines. `:` is allowed because Windows paths contain drive letters.
+/// and control characters. `:` is allowed because Windows paths contain drive letters.
 pub(super) fn validate_windows_pnpm_home(dir: &Path) -> Result<(), PathExtenderError> {
-    reject_unsafe_chars(dir, &[';', '%', '\n', '\r'])
+    reject_unsafe_chars(dir, &[';', '%'])
 }
 
 fn reject_unsafe_chars(dir: &Path, unsafe_chars: &[char]) -> Result<(), PathExtenderError> {
     let dir = dir.to_string_lossy();
-    if let Some(character) = dir.chars().find(|character| unsafe_chars.contains(character)) {
+    if let Some(character) =
+        dir.chars().find(|character| unsafe_chars.contains(character) || character.is_control())
+    {
         return Err(PathExtenderError::UnsafePnpmHome { dir: dir.into_owned(), character });
     }
     Ok(())

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -203,6 +203,7 @@ fn get_fish_config_home() -> Result<PathBuf, PathExtenderError> {
                 reason: "XDG_CONFIG_HOME must be an absolute path",
             });
         }
+        reject_control_chars_in_config_home(&config_home, "XDG_CONFIG_HOME")?;
         return Ok(config_home);
     }
     let config_home = home_dir()?.join(".config");
@@ -212,7 +213,24 @@ fn get_fish_config_home() -> Result<PathBuf, PathExtenderError> {
             reason: "the home directory must resolve to an absolute path",
         });
     }
+    reject_control_chars_in_config_home(&config_home, "the home directory")?;
     Ok(config_home)
+}
+
+fn reject_control_chars_in_config_home(
+    config_home: &Path,
+    source: &'static str,
+) -> Result<(), PathExtenderError> {
+    if config_home.to_string_lossy().chars().any(char::is_control) {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: config_home.to_path_buf(),
+            reason: match source {
+                "XDG_CONFIG_HOME" => "XDG_CONFIG_HOME cannot contain control characters",
+                _ => "the home directory config path cannot contain control characters",
+            },
+        });
+    }
+    Ok(())
 }
 
 fn update_fish_confd_config(

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix.rs
@@ -136,10 +136,10 @@ fn setup_fish_shell(
     dir: &Path,
     opts: &AddDirToEnvPathOpts,
 ) -> Result<PathExtenderReport, PathExtenderError> {
-    let config_file = home_dir()?.join(".config/fish/config.fish");
+    let config_file = get_fish_config_file()?;
     let new_settings = render_fish_settings(&dir.to_string_lossy(), opts);
-    let content = wrap_settings(opts.config_section_name, &new_settings);
-    let (change_type, old_settings) = update_shell_config(&config_file, &content, opts)?;
+    let (change_type, old_settings) =
+        update_fish_confd_config(&config_file, &format!("{new_settings}\n"), opts)?;
     Ok(PathExtenderReport {
         config_file: Some(ConfigReport { path: config_file, change_type }),
         old_settings,
@@ -186,6 +186,163 @@ fn create_fish_path_value(position: AddingPosition, entry: &str) -> String {
         AddingPosition::Start => format!("{entry} $PATH"),
         AddingPosition::End => format!("$PATH {entry}"),
     }
+}
+
+fn get_fish_config_file() -> Result<PathBuf, PathExtenderError> {
+    Ok(get_fish_config_home()?.join("fish/conf.d/pnpm.fish"))
+}
+
+fn get_fish_config_home() -> Result<PathBuf, PathExtenderError> {
+    if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME")
+        && !config_home.is_empty()
+    {
+        let config_home = PathBuf::from(config_home);
+        if !config_home.is_absolute() {
+            return Err(PathExtenderError::UnsafeShellConfig {
+                path: config_home,
+                reason: "XDG_CONFIG_HOME must be an absolute path",
+            });
+        }
+        return Ok(config_home);
+    }
+    let config_home = home_dir()?.join(".config");
+    if !config_home.is_absolute() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: config_home,
+            reason: "the home directory must resolve to an absolute path",
+        });
+    }
+    Ok(config_home)
+}
+
+fn update_fish_confd_config(
+    config_file: &Path,
+    new_content: &str,
+    opts: &AddDirToEnvPathOpts,
+) -> Result<(ConfigFileChangeType, String), PathExtenderError> {
+    ensure_fish_config_dir(config_file)?;
+    let Some((existing_content, mode)) = read_existing_fish_config(config_file)? else {
+        write_config(config_file, new_content)?;
+        return Ok((ConfigFileChangeType::Created, String::new()));
+    };
+
+    let old_content = normalize_line_endings(&existing_content);
+    let normalized_new_content = normalize_line_endings(new_content);
+    let old_settings = trim_trailing_newline(&old_content).to_string();
+    let new_settings = trim_trailing_newline(&normalized_new_content);
+    if old_content == normalized_new_content || old_settings == new_settings {
+        return Ok((ConfigFileChangeType::Skipped, old_settings));
+    }
+    if !opts.overwrite {
+        return Err(PathExtenderError::BadShellSection {
+            config_file: config_file.to_path_buf(),
+            config_section_name: opts.config_section_name.to_string(),
+        });
+    }
+    write_config_with_mode(config_file, new_content, mode)?;
+    Ok((ConfigFileChangeType::Modified, old_settings))
+}
+
+fn ensure_fish_config_dir(config_file: &Path) -> Result<(), PathExtenderError> {
+    let conf_dir = config_file.parent().ok_or_else(|| PathExtenderError::UnsafeShellConfig {
+        path: config_file.to_path_buf(),
+        reason: "fish configuration path must have a parent directory",
+    })?;
+    let fish_dir = conf_dir.parent().ok_or_else(|| PathExtenderError::UnsafeShellConfig {
+        path: conf_dir.to_path_buf(),
+        reason: "fish configuration path must be under a fish directory",
+    })?;
+    let config_home = fish_dir.parent().ok_or_else(|| PathExtenderError::UnsafeShellConfig {
+        path: fish_dir.to_path_buf(),
+        reason: "fish configuration path must be under a config home",
+    })?;
+
+    ensure_directory_without_symlink(config_home)?;
+    ensure_directory_without_symlink(fish_dir)?;
+    ensure_directory_without_symlink(conf_dir)?;
+    Ok(())
+}
+
+fn ensure_directory_without_symlink(dir: &Path) -> Result<(), PathExtenderError> {
+    let mut metadata = match fs::symlink_metadata(dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(dir)?;
+            fs::symlink_metadata(dir)?
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: dir.to_path_buf(),
+            reason: "path component is a symbolic link",
+        });
+    }
+    if !metadata.is_dir() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: dir.to_path_buf(),
+            reason: "path component is not a directory",
+        });
+    }
+
+    // `create_dir` can race with another process. If that happened between
+    // the first stat and mkdir, re-read and classify the now-existing path.
+    metadata = fs::symlink_metadata(dir)?;
+    if metadata.file_type().is_symlink() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: dir.to_path_buf(),
+            reason: "path component is a symbolic link",
+        });
+    }
+    if !metadata.is_dir() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: dir.to_path_buf(),
+            reason: "path component is not a directory",
+        });
+    }
+    Ok(())
+}
+
+fn read_existing_fish_config(
+    config_file: &Path,
+) -> Result<Option<(String, Option<u32>)>, PathExtenderError> {
+    let metadata = match fs::symlink_metadata(config_file) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: config_file.to_path_buf(),
+            reason: "configuration file is a symbolic link",
+        });
+    }
+    if !metadata.is_file() {
+        return Err(PathExtenderError::UnsafeShellConfig {
+            path: config_file.to_path_buf(),
+            reason: "configuration path is not a regular file",
+        });
+    }
+    Ok(Some((fs::read_to_string(config_file)?, file_mode(&metadata))))
+}
+
+#[cfg(unix)]
+fn file_mode(metadata: &fs::Metadata) -> Option<u32> {
+    use std::os::unix::fs::PermissionsExt;
+    Some(metadata.permissions().mode() & 0o777)
+}
+
+#[cfg(not(unix))]
+fn file_mode(_metadata: &fs::Metadata) -> Option<u32> {
+    None
+}
+
+fn normalize_line_endings(content: &str) -> String {
+    content.replace("\r\n", "\n")
+}
+
+fn trim_trailing_newline(content: &str) -> &str {
+    content.strip_suffix('\n').unwrap_or(content)
 }
 
 fn setup_nu_shell(
@@ -284,6 +441,15 @@ fn update_shell_config(
 /// target.
 fn write_config(path: &Path, content: &str) -> Result<(), PathExtenderError> {
     pacquet_fs::ensure_file(path, content.as_bytes(), None)?;
+    Ok(())
+}
+
+fn write_config_with_mode(
+    path: &Path,
+    content: &str,
+    mode: Option<u32>,
+) -> Result<(), PathExtenderError> {
+    pacquet_fs::ensure_file(path, content.as_bytes(), mode)?;
     Ok(())
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -214,7 +214,7 @@ fn fish_setup_skips_existing_conf_d_file_with_crlf_line_endings() {
         }),
     );
     assert_eq!(report.old_settings, settings);
-    assert_eq!(fs::read_to_string(config_file).expect("read fish config"), original_config,);
+    assert_eq!(fs::read_to_string(config_file).expect("read fish config"), original_config);
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -355,7 +355,7 @@ fn fish_setup_preserves_existing_mode_on_overwrite() {
     );
     assert_eq!(
         fs::metadata(config_file).expect("stat fish config").permissions().mode() & 0o777,
-        0o600
+        0o600,
     );
 }
 

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -229,6 +229,20 @@ fn fish_setup_rejects_relative_xdg_config_home() {
     assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
 }
 
+#[test]
+fn fish_setup_rejects_control_chars_in_xdg_config_home() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg\nconfig");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("control characters in XDG_CONFIG_HOME must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+}
+
 #[cfg(unix)]
 #[test]
 fn fish_setup_rejects_symlinked_conf_d_parent() {

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -6,10 +6,11 @@
 //! `add_dir_to_posix_env_path`.
 
 use super::{
-    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, PathExtenderError,
+    AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, ConfigReport, PathExtenderError,
     add_dir_to_posix_env_path, find_section, render_fish_settings, render_nu_settings,
     render_posix_settings, replace_section, update_shell_config, wrap_settings,
 };
+use pacquet_testing_utils::env_guard::EnvGuard;
 use pretty_assertions::assert_eq;
 use std::{fs, path::Path};
 
@@ -150,6 +151,212 @@ fn rejects_pnpm_home_with_a_path_separator() {
     let err = add_dir_to_posix_env_path(Path::new("/home/pnpm:/tmp/evil"), &opts(false))
         .expect_err("a colon in PNPM_HOME must be rejected");
     assert!(matches!(err, PathExtenderError::UnsafePnpmHome { character: ':', .. }));
+}
+
+#[test]
+fn rejects_pnpm_home_with_control_characters() {
+    let err = add_dir_to_posix_env_path(Path::new("/home/pnpm\u{1b}bad"), &opts(false))
+        .expect_err("an escape character in PNPM_HOME must be rejected");
+    assert!(matches!(err, PathExtenderError::UnsafePnpmHome { character: '\u{1b}', .. }));
+}
+
+#[test]
+fn fish_setup_writes_conf_d_file() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let mut opts = opts(false);
+    opts.proxy_var_sub_dir = Some("bin");
+    let report = add_dir_to_posix_env_path(Path::new(HOME), &opts).expect("write fish setup");
+    let config_file = config_home.join("fish/conf.d/pnpm.fish");
+
+    assert_eq!(
+        report.config_file,
+        Some(ConfigReport {
+            path: config_file.clone(),
+            change_type: ConfigFileChangeType::Created,
+        }),
+    );
+    assert_eq!(report.old_settings, "");
+    assert_eq!(report.new_settings, render_fish_settings(HOME, &opts));
+    assert_eq!(
+        fs::read_to_string(config_file).expect("read fish config"),
+        format!("{}\n", report.new_settings),
+    );
+}
+
+#[test]
+fn fish_setup_skips_existing_conf_d_file_with_crlf_line_endings() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let config_file = config_home.join("fish/conf.d/pnpm.fish");
+    let mut opts = opts(false);
+    opts.proxy_var_sub_dir = Some("bin");
+    let settings = render_fish_settings(HOME, &opts);
+    fs::create_dir_all(config_file.parent().expect("config parent")).expect("create config dir");
+    fs::write(&config_file, format!("{}\r\n", settings.replace('\n', "\r\n")))
+        .expect("write CRLF fish config");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let report = add_dir_to_posix_env_path(Path::new(HOME), &opts).expect("skip fish setup");
+
+    assert_eq!(
+        report.config_file,
+        Some(ConfigReport {
+            path: config_file.clone(),
+            change_type: ConfigFileChangeType::Skipped,
+        }),
+    );
+    assert_eq!(report.old_settings, settings);
+    assert!(fs::read_to_string(config_file).expect("read fish config").contains("\r\n"));
+}
+
+#[test]
+fn fish_setup_rejects_relative_xdg_config_home() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", "relative-config");
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("relative XDG_CONFIG_HOME must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+}
+
+#[cfg(unix)]
+#[test]
+fn fish_setup_rejects_symlinked_conf_d_parent() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let fish_dir = config_home.join("fish");
+    let outside_dir = dir.path().join("outside");
+    fs::create_dir_all(&fish_dir).expect("create fish dir");
+    fs::create_dir(&outside_dir).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside_dir, fish_dir.join("conf.d")).expect("symlink conf.d");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("symlinked conf.d must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+    assert!(!outside_dir.join("pnpm.fish").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn fish_setup_rejects_symlinked_config_home() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let outside_dir = dir.path().join("outside");
+    fs::create_dir(&outside_dir).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside_dir, &config_home).expect("symlink config home");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("symlinked config home must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+    assert!(!outside_dir.join("fish/conf.d/pnpm.fish").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn fish_setup_rejects_symlinked_fish_directory() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let outside_dir = dir.path().join("outside");
+    fs::create_dir(&config_home).expect("create config home");
+    fs::create_dir(&outside_dir).expect("create outside dir");
+    std::os::unix::fs::symlink(&outside_dir, config_home.join("fish")).expect("symlink fish dir");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("symlinked fish directory must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+    assert!(!outside_dir.join("conf.d/pnpm.fish").exists());
+}
+
+#[test]
+fn fish_setup_rejects_non_regular_config_path() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let config_file = config_home.join("fish/conf.d/pnpm.fish");
+    fs::create_dir_all(&config_file).expect("create directory at config path");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("directory config path must be rejected");
+
+    assert!(matches!(err, PathExtenderError::UnsafeShellConfig { .. }));
+}
+
+#[test]
+fn fish_setup_returns_bad_shell_section_when_existing_differs() {
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let config_file = config_home.join("fish/conf.d/pnpm.fish");
+    fs::create_dir_all(config_file.parent().expect("config parent")).expect("create config dir");
+    fs::write(&config_file, "set -gx PNPM_HOME '/different'\n")
+        .expect("write existing fish config");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let err = add_dir_to_posix_env_path(Path::new(HOME), &opts(false))
+        .expect_err("different fish config without --force must error");
+
+    assert!(matches!(err, PathExtenderError::BadShellSection { .. }));
+    assert_eq!(
+        fs::read_to_string(config_file).expect("read fish config"),
+        "set -gx PNPM_HOME '/different'\n",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn fish_setup_preserves_existing_mode_on_overwrite() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let env = EnvGuard::snapshot(["FISH_VERSION", "XDG_CONFIG_HOME"]);
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let config_home = dir.path().join("xdg-config");
+    let config_file = config_home.join("fish/conf.d/pnpm.fish");
+    fs::create_dir_all(config_file.parent().expect("config parent")).expect("create config dir");
+    fs::write(&config_file, "set -gx PNPM_HOME '/different'\n")
+        .expect("write existing fish config");
+    fs::set_permissions(&config_file, fs::Permissions::from_mode(0o600))
+        .expect("set fish config mode");
+    env.set("FISH_VERSION", "3.7.0");
+    env.set("XDG_CONFIG_HOME", &config_home);
+
+    let report =
+        add_dir_to_posix_env_path(Path::new(HOME), &opts(true)).expect("overwrite fish setup");
+
+    assert_eq!(
+        report.config_file,
+        Some(ConfigReport {
+            path: config_file.clone(),
+            change_type: ConfigFileChangeType::Modified,
+        }),
+    );
+    assert_eq!(
+        fs::metadata(config_file).expect("stat fish config").permissions().mode() & 0o777,
+        0o600
+    );
 }
 
 #[test]

--- a/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/setup/path_extender/posix/tests.rs
@@ -200,6 +200,7 @@ fn fish_setup_skips_existing_conf_d_file_with_crlf_line_endings() {
     fs::create_dir_all(config_file.parent().expect("config parent")).expect("create config dir");
     fs::write(&config_file, format!("{}\r\n", settings.replace('\n', "\r\n")))
         .expect("write CRLF fish config");
+    let original_config = fs::read_to_string(&config_file).expect("read original fish config");
     env.set("FISH_VERSION", "3.7.0");
     env.set("XDG_CONFIG_HOME", &config_home);
 
@@ -213,7 +214,7 @@ fn fish_setup_skips_existing_conf_d_file_with_crlf_line_endings() {
         }),
     );
     assert_eq!(report.old_settings, settings);
-    assert!(fs::read_to_string(config_file).expect("read fish config").contains("\r\n"));
+    assert_eq!(fs::read_to_string(config_file).expect("read fish config"), original_config,);
 }
 
 #[test]
@@ -354,7 +355,11 @@ fn fish_setup_preserves_existing_mode_on_overwrite() {
         }),
     );
     assert_eq!(
-        fs::metadata(config_file).expect("stat fish config").permissions().mode() & 0o777,
+        fs::read_to_string(&config_file).expect("read overwritten fish config"),
+        format!("{}\n", render_fish_settings(HOME, &opts(true))),
+    );
+    assert_eq!(
+        fs::metadata(&config_file).expect("stat fish config").permissions().mode() & 0o777,
         0o600,
     );
 }

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -186,15 +186,16 @@ async function setupFishConfDir (
     force?: boolean
   }
 ): Promise<PathExtenderReport> {
-  const configFile = path.join(os.homedir(), '.config/fish/conf.d/pnpm.fish')
-  const newSettings = `set -gx PNPM_HOME "${pnpmHomeDir}"
+  const configFile = getFishConfigFile()
+  const newSettings = `set -gx PNPM_HOME "${escapeFishString(pnpmHomeDir)}"
 if not string match -q -- "$PNPM_HOME/bin" $PATH
   set -gx PATH "$PNPM_HOME/bin" $PATH
 end`
   const newContent = `${newSettings}\n`
-  if (!fs.existsSync(configFile)) {
+  const existingConfig = await readExistingFishConfig(configFile)
+  if (existingConfig == null) {
     await fs.promises.mkdir(path.dirname(configFile), { recursive: true })
-    await fs.promises.writeFile(configFile, newContent, 'utf8')
+    await writeFileAtomically(configFile, newContent)
     return {
       configFile: {
         path: configFile,
@@ -205,7 +206,7 @@ end`
     }
   }
 
-  const oldContent = normalizeLineEndings(await fs.promises.readFile(configFile, 'utf8'))
+  const oldContent = normalizeLineEndings(existingConfig.content)
   const normalizedNewContent = normalizeLineEndings(newContent)
   const oldSettings = trimTrailingNewline(oldContent)
   const normalizedNewSettings = trimTrailingNewline(normalizedNewContent)
@@ -222,7 +223,7 @@ end`
   if (!opts.force) {
     throw new PnpmError('BAD_SHELL_SECTION', `The config file at "${configFile}" already contains a pnpm configuration but with other settings`)
   }
-  await fs.promises.writeFile(configFile, newContent, 'utf8')
+  await writeFileAtomically(configFile, newContent, existingConfig.mode)
   return {
     configFile: {
       path: configFile,
@@ -230,6 +231,61 @@ end`
     },
     oldSettings,
     newSettings,
+  }
+}
+
+function getFishConfigFile (): string {
+  const configHome = getFishConfigHome()
+  return path.join(configHome, 'fish/conf.d/pnpm.fish')
+}
+
+function getFishConfigHome (): string {
+  if (process.env.XDG_CONFIG_HOME) {
+    if (!path.isAbsolute(process.env.XDG_CONFIG_HOME)) {
+      throw new PnpmError('UNSAFE_SHELL_CONFIG', 'XDG_CONFIG_HOME must be an absolute path when writing fish configuration')
+    }
+    return process.env.XDG_CONFIG_HOME
+  }
+  return path.join(os.homedir(), '.config')
+}
+
+function escapeFishString (value: string): string {
+  if (/[\0\r\n]/.test(value)) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'PNPM_HOME cannot contain NUL or newline characters when writing fish configuration')
+  }
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+}
+
+async function readExistingFishConfig (configFile: string): Promise<{ content: string, mode: number } | undefined> {
+  let stat: fs.Stats
+  try {
+    stat = await fs.promises.lstat(configFile)
+  } catch (err: any) { // eslint-disable-line
+    if (err.code === 'ENOENT') return undefined
+    throw err
+  }
+  if (stat.isSymbolicLink()) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', `Refusing to write fish configuration at "${configFile}" because it is a symbolic link`)
+  }
+  return {
+    content: await fs.promises.readFile(configFile, 'utf8'),
+    mode: stat.mode & 0o777,
+  }
+}
+
+async function writeFileAtomically (filePath: string, content: string, mode = 0o644): Promise<void> {
+  const tempDir = await fs.promises.mkdtemp(path.join(path.dirname(filePath), `.${path.basename(filePath)}.`))
+  const tempPath = path.join(tempDir, path.basename(filePath))
+  try {
+    await fs.promises.writeFile(tempPath, content, { encoding: 'utf8', mode })
+    await fs.promises.rename(tempPath, filePath)
+  } catch (err: any) { // eslint-disable-line
+    throw err
+  } finally {
+    await fs.promises.rm(tempDir, { force: true, recursive: true }).catch(() => undefined)
   }
 }
 

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -326,11 +326,23 @@ async function writeFileAtomically (filePath: string, content: string, mode = 0o
   const tempPath = path.join(tempDir, path.basename(filePath))
   try {
     await fs.promises.writeFile(tempPath, content, { encoding: 'utf8', mode })
-    await fs.promises.rename(tempPath, filePath)
+    await renameReplacingDestination(tempPath, filePath)
   } catch (err: any) { // eslint-disable-line
     throw err
   } finally {
     await fs.promises.rm(tempDir, { force: true, recursive: true }).catch(() => undefined)
+  }
+}
+
+async function renameReplacingDestination (tempPath: string, filePath: string): Promise<void> {
+  try {
+    await fs.promises.rename(tempPath, filePath)
+  } catch (err: any) { // eslint-disable-line
+    if (err.code !== 'EEXIST' && err.code !== 'EPERM') {
+      throw err
+    }
+    await fs.promises.rm(filePath, { force: true })
+    await fs.promises.rename(tempPath, filePath)
   }
 }
 

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -1,9 +1,11 @@
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { detectIfCurrentPkgIsExecutable, packageManager } from '@pnpm/cli.meta'
 import { docsUrl } from '@pnpm/cli.utils'
+import { PnpmError } from '@pnpm/error'
 import { logger } from '@pnpm/logger'
 import {
   addDirToEnvPath,
@@ -151,13 +153,15 @@ export async function handler (
     createAliasScripts(binDir)
   }
   try {
-    const report = await addDirToEnvPath(opts.pnpmHomeDir, {
-      configSectionName: 'pnpm',
-      proxyVarName: 'PNPM_HOME',
-      proxyVarSubDir: 'bin',
-      overwrite: opts.force,
-      position: 'start',
-    })
+    const report = isFishShell()
+      ? await setupFishConfDir(opts.pnpmHomeDir, opts)
+      : await addDirToEnvPath(opts.pnpmHomeDir, {
+        configSectionName: 'pnpm',
+        proxyVarName: 'PNPM_HOME',
+        proxyVarSubDir: 'bin',
+        overwrite: opts.force,
+        position: 'start',
+      })
     return renderSetupOutput(report)
   } catch (err: any) { // eslint-disable-line
     switch (err.code) {
@@ -170,6 +174,71 @@ export async function handler (
     }
     throw err
   }
+}
+
+function isFishShell (): boolean {
+  return Boolean(process.env.FISH_VERSION) || path.basename(process.env.SHELL ?? '') === 'fish'
+}
+
+async function setupFishConfDir (
+  pnpmHomeDir: string,
+  opts: {
+    force?: boolean
+  }
+): Promise<PathExtenderReport> {
+  const configFile = path.join(os.homedir(), '.config/fish/conf.d/pnpm.fish')
+  const newSettings = `set -gx PNPM_HOME "${pnpmHomeDir}"
+if not string match -q -- "$PNPM_HOME/bin" $PATH
+  set -gx PATH "$PNPM_HOME/bin" $PATH
+end`
+  const newContent = `${newSettings}\n`
+  if (!fs.existsSync(configFile)) {
+    await fs.promises.mkdir(path.dirname(configFile), { recursive: true })
+    await fs.promises.writeFile(configFile, newContent, 'utf8')
+    return {
+      configFile: {
+        path: configFile,
+        changeType: 'created',
+      },
+      oldSettings: '',
+      newSettings,
+    }
+  }
+
+  const oldContent = normalizeLineEndings(await fs.promises.readFile(configFile, 'utf8'))
+  const normalizedNewContent = normalizeLineEndings(newContent)
+  const oldSettings = trimTrailingNewline(oldContent)
+  const normalizedNewSettings = trimTrailingNewline(normalizedNewContent)
+  if (oldContent === normalizedNewContent || oldSettings === normalizedNewSettings) {
+    return {
+      configFile: {
+        path: configFile,
+        changeType: 'skipped',
+      },
+      oldSettings,
+      newSettings,
+    }
+  }
+  if (!opts.force) {
+    throw new PnpmError('BAD_SHELL_SECTION', `The config file at "${configFile}" already contains a pnpm configuration but with other settings`)
+  }
+  await fs.promises.writeFile(configFile, newContent, 'utf8')
+  return {
+    configFile: {
+      path: configFile,
+      changeType: 'modified',
+    },
+    oldSettings,
+    newSettings,
+  }
+}
+
+function normalizeLineEndings (content: string): string {
+  return content.replace(/\r\n/g, '\n')
+}
+
+function trimTrailingNewline (content: string): string {
+  return content.endsWith('\n') ? content.slice(0, -1) : content
 }
 
 function renderSetupOutput (report: PathExtenderReport): string {

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -192,6 +192,7 @@ if not string match -q -- "$PNPM_HOME/bin" $PATH
   set -gx PATH "$PNPM_HOME/bin" $PATH
 end`
   const newContent = `${newSettings}\n`
+  await ensureFishConfigDir(configFile)
   const existingConfig = await readExistingFishConfig(configFile)
   if (existingConfig == null) {
     await fs.promises.mkdir(path.dirname(configFile), { recursive: true })
@@ -246,17 +247,52 @@ function getFishConfigHome (): string {
     }
     return process.env.XDG_CONFIG_HOME
   }
-  return path.join(os.homedir(), '.config')
+  const configHome = path.join(os.homedir(), '.config')
+  if (!path.isAbsolute(configHome)) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'The home directory must resolve to an absolute path when writing fish configuration')
+  }
+  return configHome
 }
 
 function escapeFishString (value: string): string {
-  if (/[\0\r\n]/.test(value)) {
-    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'PNPM_HOME cannot contain NUL or newline characters when writing fish configuration')
+  if (hasControlCharacter(value)) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'PNPM_HOME cannot contain control characters when writing fish configuration')
   }
   return value
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')
     .replace(/\$/g, '\\$')
+}
+
+function hasControlCharacter (value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 0x1F || (code >= 0x7F && code <= 0x9F)
+  })
+}
+
+async function ensureFishConfigDir (configFile: string): Promise<void> {
+  const configHome = path.dirname(path.dirname(path.dirname(configFile)))
+  await ensureDirectoryWithoutSymlink(configHome)
+  await ensureDirectoryWithoutSymlink(path.join(configHome, 'fish'))
+  await ensureDirectoryWithoutSymlink(path.dirname(configFile))
+}
+
+async function ensureDirectoryWithoutSymlink (dir: string): Promise<void> {
+  let stat: fs.Stats
+  try {
+    stat = await fs.promises.lstat(dir)
+  } catch (err: any) { // eslint-disable-line
+    if (err.code !== 'ENOENT') throw err
+    await fs.promises.mkdir(dir, { recursive: true })
+    stat = await fs.promises.lstat(dir)
+  }
+  if (stat.isSymbolicLink()) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', `Refusing to write fish configuration under "${dir}" because it is a symbolic link`)
+  }
+  if (!stat.isDirectory()) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', `Refusing to write fish configuration under "${dir}" because it is not a directory`)
+  }
 }
 
 async function readExistingFishConfig (configFile: string): Promise<{ content: string, mode: number } | undefined> {
@@ -269,6 +305,9 @@ async function readExistingFishConfig (configFile: string): Promise<{ content: s
   }
   if (stat.isSymbolicLink()) {
     throw new PnpmError('UNSAFE_SHELL_CONFIG', `Refusing to write fish configuration at "${configFile}" because it is a symbolic link`)
+  }
+  if (!stat.isFile()) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', `Refusing to write fish configuration at "${configFile}" because it is not a regular file`)
   }
   return {
     content: await fs.promises.readFile(configFile, 'utf8'),

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -245,6 +245,9 @@ function getFishConfigHome (): string {
     if (!path.isAbsolute(process.env.XDG_CONFIG_HOME)) {
       throw new PnpmError('UNSAFE_SHELL_CONFIG', 'XDG_CONFIG_HOME must be an absolute path when writing fish configuration')
     }
+    if (hasControlCharacter(process.env.XDG_CONFIG_HOME)) {
+      throw new PnpmError('UNSAFE_SHELL_CONFIG', 'XDG_CONFIG_HOME cannot contain control characters when writing fish configuration')
+    }
     return process.env.XDG_CONFIG_HOME
   }
   const configHome = path.join(os.homedir(), '.config')
@@ -339,6 +342,27 @@ function trimTrailingNewline (content: string): string {
   return content.endsWith('\n') ? content.slice(0, -1) : content
 }
 
+function quoteShellPath (value: string): string {
+  if (hasControlCharacter(value)) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'The configuration path cannot contain control characters')
+  }
+  if (/^[\w@%+=:,./~-]+$/.test(value)) {
+    return value
+  }
+  if (value.startsWith('~/')) {
+    return `~/${quoteShellString(value.slice(2))}`
+  }
+  return quoteShellString(value)
+}
+
+function quoteShellString (value: string): string {
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+    .replace(/`/g, '\\`')}"`
+}
+
 function renderSetupOutput (report: PathExtenderReport): string {
   if (report.oldSettings === report.newSettings) {
     return 'No changes to the environment were made. Everything is already up to date.'
@@ -353,7 +377,7 @@ ${report.newSettings}`)
     output.push('Setup complete. Open a new terminal to start using pnpm.')
   } else if (report.configFile.changeType !== 'skipped') {
     output.push(`To start using pnpm, run:
-source ${report.configFile.path}
+source ${quoteShellPath(report.configFile.path)}
 `)
   }
   return output.join('\n\n')

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -327,8 +327,6 @@ async function writeFileAtomically (filePath: string, content: string, mode = 0o
   try {
     await fs.promises.writeFile(tempPath, content, { encoding: 'utf8', mode })
     await renameReplacingDestination(tempPath, filePath)
-  } catch (err: any) { // eslint-disable-line
-    throw err
   } finally {
     await fs.promises.rm(tempDir, { force: true, recursive: true }).catch(() => undefined)
   }

--- a/pnpm11/engine/pm/commands/src/setup/setup.ts
+++ b/pnpm11/engine/pm/commands/src/setup/setup.ts
@@ -258,6 +258,9 @@ function escapeFishString (value: string): string {
   if (hasControlCharacter(value)) {
     throw new PnpmError('UNSAFE_SHELL_CONFIG', 'PNPM_HOME cannot contain control characters when writing fish configuration')
   }
+  if (value.includes(path.delimiter)) {
+    throw new PnpmError('UNSAFE_SHELL_CONFIG', 'PNPM_HOME cannot contain the PATH delimiter when writing fish configuration')
+  }
   return value
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -226,6 +226,20 @@ test('setup rejects PNPM_HOME with control characters for fish config', async ()
   }
 })
 
+test('setup rejects PNPM_HOME with PATH delimiters for fish config', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-path-delimiter-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    await expect(setup.handler({ pnpmHomeDir: path.join(actualOs.tmpdir(), `pnpm-home${path.delimiter}evil`) })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.existsSync(path.join(tempHome, '.config/fish/conf.d/pnpm.fish'))).toBe(false)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
 testIfSymlinkSupported('setup refuses to overwrite a symlinked fish config', async () => {
   const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-symlink-'))
   jest.mocked(os.default.homedir).mockReturnValue(tempHome)

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -181,6 +181,15 @@ test('setup rejects relative XDG_CONFIG_HOME for fish config', async () => {
   })
 })
 
+test('setup rejects relative home directory fallback for fish config', async () => {
+  jest.mocked(os.default.homedir).mockReturnValue('relative-home')
+  process.env.FISH_VERSION = '3.7.0'
+
+  await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+  })
+})
+
 test('setup escapes PNPM_HOME when writing fish config', async () => {
   const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-escape-'))
   jest.mocked(os.default.homedir).mockReturnValue(tempHome)
@@ -200,6 +209,15 @@ test('setup rejects PNPM_HOME with control characters for fish config', async ()
   process.env.FISH_VERSION = '3.7.0'
   try {
     await expect(setup.handler({ pnpmHomeDir: '/pnpm-home\nset -gx BAD 1' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home\tbad' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home\x1Bbad' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home\u0085bad' })).rejects.toMatchObject({
       code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
     })
     expect(actualFs.existsSync(path.join(tempHome, '.config/fish/conf.d/pnpm.fish'))).toBe(false)
@@ -223,6 +241,82 @@ testIfSymlinkSupported('setup refuses to overwrite a symlinked fish config', asy
       code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
     })
     expect(actualFs.readFileSync(targetFile, 'utf8')).toBe('original')
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+testIfSymlinkSupported('setup refuses to write through a symlinked fish config home', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-config-home-link-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configHome = path.join(tempHome, '.config')
+    const outsideDir = path.join(tempHome, 'outside')
+    actualFs.mkdirSync(outsideDir)
+    actualFs.symlinkSync(outsideDir, configHome, 'dir')
+
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.existsSync(path.join(outsideDir, 'fish/conf.d/pnpm.fish'))).toBe(false)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+testIfSymlinkSupported('setup refuses to write through a symlinked fish config directory', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-dir-link-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configHome = path.join(tempHome, '.config')
+    const outsideDir = path.join(tempHome, 'outside')
+    actualFs.mkdirSync(configHome)
+    actualFs.mkdirSync(outsideDir)
+    actualFs.symlinkSync(outsideDir, path.join(configHome, 'fish'), 'dir')
+
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.existsSync(path.join(outsideDir, 'conf.d/pnpm.fish'))).toBe(false)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+testIfSymlinkSupported('setup refuses to write through a symlinked fish config parent directory', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-parent-link-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const fishDir = path.join(tempHome, '.config/fish')
+    const linkedConfDir = path.join(fishDir, 'conf.d')
+    const outsideDir = path.join(tempHome, 'outside')
+    actualFs.mkdirSync(fishDir, { recursive: true })
+    actualFs.mkdirSync(outsideDir)
+    actualFs.symlinkSync(outsideDir, linkedConfDir, 'dir')
+
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.existsSync(path.join(outsideDir, 'pnpm.fish'))).toBe(false)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+test('setup refuses to read a non-regular fish config path', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-non-regular-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    actualFs.mkdirSync(configFile, { recursive: true })
+
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
   } finally {
     actualFs.rmSync(tempHome, { force: true, recursive: true })
   }

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -375,6 +375,32 @@ test('setup preserves an existing fish config mode when force overwrites it', as
   }
 })
 
+test('setup retries fish config overwrite when rename cannot replace destination', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-rename-retry-'))
+  const originalRename = actualFs.promises.rename
+  const renameSpy = jest.spyOn(actualFs.promises, 'rename')
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    actualFs.mkdirSync(path.dirname(configFile), { recursive: true })
+    actualFs.writeFileSync(configFile, 'old settings\n', { mode: 0o600 })
+
+    renameSpy
+      .mockRejectedValueOnce(Object.assign(new Error('destination exists'), { code: 'EEXIST' }))
+      .mockImplementationOnce(originalRename)
+
+    await setup.handler({ force: true, pnpmHomeDir: '/pnpm-home' })
+
+    expect(renameSpy).toHaveBeenCalledTimes(2)
+    expect(actualFs.statSync(configFile).mode & 0o777).toBe(0o600)
+    expect(actualFs.readFileSync(configFile, 'utf8')).toContain('set -gx PNPM_HOME "/pnpm-home"')
+  } finally {
+    renameSpy.mockRestore()
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
 test('setup skips existing fish config with CRLF line endings', async () => {
   const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-'))
   jest.mocked(os.default.homedir).mockReturnValue(tempHome)

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -1,7 +1,6 @@
-import os from 'node:os'
 import path from 'node:path'
 
-import { expect, jest, test } from '@jest/globals'
+import { afterAll, beforeEach, expect, jest, test } from '@jest/globals'
 import { PnpmError } from '@pnpm/error'
 import type { PathExtenderReport } from '@pnpm/os.env.path-extender'
 
@@ -33,10 +32,63 @@ jest.unstable_mockModule('fs', () => {
   }
 })
 
+const actualOs = await import('node:os')
+jest.unstable_mockModule('node:os', () => {
+  const homedir = jest.fn(() => actualOs.homedir())
+  return {
+    ...actualOs,
+    default: {
+      ...actualOs,
+      homedir,
+    },
+    homedir,
+  }
+})
+
 const { addDirToEnvPath } = await import('@pnpm/os.env.path-extender')
 const { detectIfCurrentPkgIsExecutable } = await import('@pnpm/cli.meta')
 const { spawnSync } = await import('node:child_process')
 const { setup } = await import('@pnpm/engine.pm.commands')
+const os = await import('node:os')
+
+const originalFishVersion = process.env.FISH_VERSION
+const originalHome = process.env.HOME
+const originalShell = process.env.SHELL
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  delete process.env.FISH_VERSION
+  process.env.SHELL = '/bin/bash'
+  jest.mocked(os.default.homedir).mockReturnValue(originalHome ?? actualOs.homedir())
+  jest.mocked(addDirToEnvPath).mockReset()
+  jest.mocked(detectIfCurrentPkgIsExecutable).mockReturnValue(false)
+  jest.mocked(spawnSync).mockReturnValue({
+    pid: 0,
+    output: [],
+    stdout: '',
+    stderr: '',
+    status: 0,
+    signal: null,
+  })
+})
+
+afterAll(() => {
+  if (originalFishVersion == null) {
+    delete process.env.FISH_VERSION
+  } else {
+    process.env.FISH_VERSION = originalFishVersion
+  }
+  if (originalShell == null) {
+    delete process.env.SHELL
+  } else {
+    process.env.SHELL = originalShell
+  }
+  if (originalHome == null) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
+})
 
 test('setup makes no changes', async () => {
   jest.mocked(addDirToEnvPath).mockReturnValue(Promise.resolve<PathExtenderReport>({
@@ -65,6 +117,60 @@ export PNPM_HOME=dir2
 To start using pnpm, run:
 source ~/.bashrc
 `)
+})
+
+test('setup writes fish config to conf.d', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    const output = await setup.handler({ pnpmHomeDir: '/pnpm-home' })
+    expect(actualFs.readFileSync(configFile, 'utf8')).toBe(`set -gx PNPM_HOME "/pnpm-home"
+if not string match -q -- "$PNPM_HOME/bin" $PATH
+  set -gx PATH "$PNPM_HOME/bin" $PATH
+end
+`)
+    expect(jest.mocked(addDirToEnvPath)).not.toHaveBeenCalled()
+    expect(output).toBe(`Created ${configFile}
+
+Next configuration changes were made:
+set -gx PNPM_HOME "/pnpm-home"
+if not string match -q -- "$PNPM_HOME/bin" $PATH
+  set -gx PATH "$PNPM_HOME/bin" $PATH
+end
+
+To start using pnpm, run:
+source ${configFile}
+`)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+test('setup skips existing fish config with CRLF line endings', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    actualFs.mkdirSync(path.dirname(configFile), { recursive: true })
+    actualFs.writeFileSync(configFile, [
+      'set -gx PNPM_HOME "/pnpm-home"',
+      'if not string match -q -- "$PNPM_HOME/bin" $PATH',
+      '  set -gx PATH "$PNPM_HOME/bin" $PATH',
+      'end',
+      '',
+    ].join('\r\n'))
+
+    const output = await setup.handler({ pnpmHomeDir: '/pnpm-home' })
+
+    expect(actualFs.readFileSync(configFile, 'utf8')).toContain('\r\n')
+    expect(jest.mocked(addDirToEnvPath)).not.toHaveBeenCalled()
+    expect(output).toBe('No changes to the environment were made. Everything is already up to date.')
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
 })
 
 test('setup makes changes on Windows', async () => {
@@ -107,7 +213,7 @@ test('global install of the standalone executable skips its build scripts', asyn
     newSettings: 'PNPM_HOME=dir',
   }))
   jest.mocked(detectIfCurrentPkgIsExecutable).mockReturnValue(true)
-  const tmpDir = actualFs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-setup-test-'))
+  const tmpDir = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-test-'))
   const execPath = path.join(tmpDir, 'pnpm')
   const originalExecPath = process.execPath
   Object.defineProperty(process, 'execPath', { value: execPath, configurable: true })

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -52,6 +52,7 @@ const { setup } = await import('@pnpm/engine.pm.commands')
 const os = await import('node:os')
 
 const testIfSymlinkSupported = process.platform === 'win32' ? test.skip : test
+const testIfModeSupported = process.platform === 'win32' ? test.skip : test
 
 const originalFishVersion = process.env.FISH_VERSION
 const originalHome = process.env.HOME
@@ -128,6 +129,17 @@ source ~/.bashrc
 `)
 })
 
+function quoteExpectedShellPath (value: string): string {
+  if (/^[\w@%+=:,./~-]+$/.test(value)) {
+    return value
+  }
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, '\\$')
+    .replace(/`/g, '\\`')}"`
+}
+
 test('setup writes fish config to conf.d', async () => {
   const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-'))
   jest.mocked(os.default.homedir).mockReturnValue(tempHome)
@@ -150,7 +162,7 @@ if not string match -q -- "$PNPM_HOME/bin" $PATH
 end
 
 To start using pnpm, run:
-source ${configFile}
+source ${quoteExpectedShellPath(configFile)}
 `)
   } finally {
     actualFs.rmSync(tempHome, { force: true, recursive: true })
@@ -357,7 +369,7 @@ test('setup refuses to read a non-regular fish config path', async () => {
   }
 })
 
-test('setup preserves an existing fish config mode when force overwrites it', async () => {
+testIfModeSupported('setup preserves an existing fish config mode when force overwrites it', async () => {
   const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-mode-'))
   jest.mocked(os.default.homedir).mockReturnValue(tempHome)
   process.env.FISH_VERSION = '3.7.0'
@@ -393,7 +405,9 @@ test('setup retries fish config overwrite when rename cannot replace destination
     await setup.handler({ force: true, pnpmHomeDir: '/pnpm-home' })
 
     expect(renameSpy).toHaveBeenCalledTimes(2)
-    expect(actualFs.statSync(configFile).mode & 0o777).toBe(0o600)
+    if (process.platform !== 'win32') {
+      expect(actualFs.statSync(configFile).mode & 0o777).toBe(0o600)
+    }
     expect(actualFs.readFileSync(configFile, 'utf8')).toContain('set -gx PNPM_HOME "/pnpm-home"')
   } finally {
     renameSpy.mockRestore()

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -172,6 +172,27 @@ test('setup writes fish config under XDG_CONFIG_HOME when set', async () => {
   }
 })
 
+test('setup quotes fish source command for unsafe XDG_CONFIG_HOME characters', async () => {
+  const tempParent = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm setup; $xdg-'))
+  const tempConfigHome = path.join(tempParent, 'config home')
+  actualFs.mkdirSync(tempConfigHome)
+  process.env.XDG_CONFIG_HOME = tempConfigHome
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempConfigHome, 'fish/conf.d/pnpm.fish')
+    const output = await setup.handler({ pnpmHomeDir: '/pnpm-home' })
+    const quotedConfigFile = `"${configFile.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$').replace(/`/g, '\\`')}"`
+
+    expect(output).toContain(`To start using pnpm, run:
+source ${quotedConfigFile}
+`)
+    expect(output).not.toContain(`source ${configFile}
+`)
+  } finally {
+    actualFs.rmSync(tempParent, { force: true, recursive: true })
+  }
+})
+
 test('setup rejects relative XDG_CONFIG_HOME for fish config', async () => {
   process.env.XDG_CONFIG_HOME = 'relative-config'
   process.env.FISH_VERSION = '3.7.0'

--- a/pnpm11/engine/pm/commands/test/setup/setup.test.ts
+++ b/pnpm11/engine/pm/commands/test/setup/setup.test.ts
@@ -51,13 +51,17 @@ const { spawnSync } = await import('node:child_process')
 const { setup } = await import('@pnpm/engine.pm.commands')
 const os = await import('node:os')
 
+const testIfSymlinkSupported = process.platform === 'win32' ? test.skip : test
+
 const originalFishVersion = process.env.FISH_VERSION
 const originalHome = process.env.HOME
 const originalShell = process.env.SHELL
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
 
 beforeEach(() => {
   jest.clearAllMocks()
   delete process.env.FISH_VERSION
+  delete process.env.XDG_CONFIG_HOME
   process.env.SHELL = '/bin/bash'
   jest.mocked(os.default.homedir).mockReturnValue(originalHome ?? actualOs.homedir())
   jest.mocked(addDirToEnvPath).mockReset()
@@ -82,6 +86,11 @@ afterAll(() => {
     delete process.env.SHELL
   } else {
     process.env.SHELL = originalShell
+  }
+  if (originalXdgConfigHome == null) {
+    delete process.env.XDG_CONFIG_HOME
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome
   }
   if (originalHome == null) {
     delete process.env.HOME
@@ -143,6 +152,95 @@ end
 To start using pnpm, run:
 source ${configFile}
 `)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+test('setup writes fish config under XDG_CONFIG_HOME when set', async () => {
+  const tempConfigHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-xdg-'))
+  process.env.XDG_CONFIG_HOME = tempConfigHome
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempConfigHome, 'fish/conf.d/pnpm.fish')
+    const output = await setup.handler({ pnpmHomeDir: '/pnpm-home' })
+    expect(actualFs.existsSync(configFile)).toBe(true)
+    expect(jest.mocked(addDirToEnvPath)).not.toHaveBeenCalled()
+    expect(output).toContain(`Created ${configFile}`)
+  } finally {
+    actualFs.rmSync(tempConfigHome, { force: true, recursive: true })
+  }
+})
+
+test('setup rejects relative XDG_CONFIG_HOME for fish config', async () => {
+  process.env.XDG_CONFIG_HOME = 'relative-config'
+  process.env.FISH_VERSION = '3.7.0'
+
+  await expect(setup.handler({ pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+    code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+  })
+})
+
+test('setup escapes PNPM_HOME when writing fish config', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-escape-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    await setup.handler({ pnpmHomeDir: '/pnpm"$HOME\\dir' })
+    expect(actualFs.readFileSync(configFile, 'utf8')).toContain('set -gx PNPM_HOME "/pnpm\\"\\$HOME\\\\dir"')
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+test('setup rejects PNPM_HOME with control characters for fish config', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-control-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    await expect(setup.handler({ pnpmHomeDir: '/pnpm-home\nset -gx BAD 1' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.existsSync(path.join(tempHome, '.config/fish/conf.d/pnpm.fish'))).toBe(false)
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+testIfSymlinkSupported('setup refuses to overwrite a symlinked fish config', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-symlink-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    const targetFile = path.join(tempHome, 'target.fish')
+    actualFs.mkdirSync(path.dirname(configFile), { recursive: true })
+    actualFs.writeFileSync(targetFile, 'original')
+    actualFs.symlinkSync(targetFile, configFile, 'file')
+
+    await expect(setup.handler({ force: true, pnpmHomeDir: '/pnpm-home' })).rejects.toMatchObject({
+      code: 'ERR_PNPM_UNSAFE_SHELL_CONFIG',
+    })
+    expect(actualFs.readFileSync(targetFile, 'utf8')).toBe('original')
+  } finally {
+    actualFs.rmSync(tempHome, { force: true, recursive: true })
+  }
+})
+
+test('setup preserves an existing fish config mode when force overwrites it', async () => {
+  const tempHome = actualFs.mkdtempSync(path.join(actualOs.tmpdir(), 'pnpm-setup-fish-mode-'))
+  jest.mocked(os.default.homedir).mockReturnValue(tempHome)
+  process.env.FISH_VERSION = '3.7.0'
+  try {
+    const configFile = path.join(tempHome, '.config/fish/conf.d/pnpm.fish')
+    actualFs.mkdirSync(path.dirname(configFile), { recursive: true })
+    actualFs.writeFileSync(configFile, 'old settings\n', { mode: 0o600 })
+
+    await setup.handler({ force: true, pnpmHomeDir: '/pnpm-home' })
+
+    expect(actualFs.statSync(configFile).mode & 0o777).toBe(0o600)
+    expect(actualFs.readFileSync(configFile, 'utf8')).toContain('set -gx PNPM_HOME "/pnpm-home"')
   } finally {
     actualFs.rmSync(tempHome, { force: true, recursive: true })
   }


### PR DESCRIPTION
## Summary

- writes fish shell setup to `~/.config/fish/conf.d/pnpm.fish` instead of appending to `config.fish`
- keeps bash/zsh and other shell setup paths unchanged
- adds coverage for the fish setup output and written config

Closes #11852.

## Testing

- `pnpm --filter @pnpm/engine.pm.commands exec tsgo --build`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --filter @pnpm/engine.pm.commands exec jest setup.test.ts`
- `pnpm --filter @pnpm/engine.pm.commands exec eslint "src/**/*.ts" "test/**/*.ts"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm setup` now configures the Fish shell by writing `fish/conf.d/pnpm.fish`, setting `PNPM_HOME`, and updating `PATH`.
  * Fish config location uses `XDG_CONFIG_HOME` when it’s a valid absolute path; otherwise it falls back to `~/.config`.

* **Bug Fixes**
  * Added hardened validation for unsafe `PNPM_HOME` and shell config paths (including control-character and symlink protections).
  * Skips updating when the existing Fish config already matches (normalizes CRLF→LF); forced updates are atomic and preserve permissions.

* **Tests**
  * Expanded coverage for Fish setup behavior, safety edge cases, and overwrite/skip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->