### PR TITLE
fix: summarize all global update groups

### DIFF
--- a/.changeset/tidy-global-update-summary.md
+++ b/.changeset/tidy-global-update-summary.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/global.commands": patch
+---
+
+Print the global update summary after all isolated global package groups are processed.

--- a/global/commands/src/globalUpdate.ts
+++ b/global/commands/src/globalUpdate.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { linkBinsOfPackages } from '@pnpm/bins.linker'
 import { removeBin } from '@pnpm/bins.remover'
 import type { CommandHandlerMap } from '@pnpm/cli.command'
+import { summaryLogger } from '@pnpm/core-loggers'
 import {
   cleanOrphanedInstallDirs,
   createInstallDir,
@@ -66,6 +67,7 @@ export async function handleGlobalUpdate (
   for (const pkg of packagesToUpdate) {
     await updateGlobalPackageGroup(opts, globalDir, globalBinDir, pkg, commands) // eslint-disable-line no-await-in-loop
   }
+  summaryLogger.debug({ prefix: globalDir })
   return undefined
 }
 
@@ -111,6 +113,7 @@ async function updateGlobalPackageGroup (
     include,
     includeDirect: include,
     allowBuilds,
+    omitSummaryLog: true,
   }, depSpecs)
 
   await promptApproveGlobalBuilds({

--- a/global/commands/test/globalUpdate.test.ts
+++ b/global/commands/test/globalUpdate.test.ts
@@ -1,0 +1,83 @@
+import { expect, jest, test } from '@jest/globals'
+
+const linkBinsOfPackages = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+const removeBin = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+const cleanOrphanedInstallDirs = jest.fn()
+const createInstallDir = jest.fn()
+const getHashLink = jest.fn()
+const getInstalledBinNames = jest.fn<() => Promise<string[]>>().mockResolvedValue([])
+const scanGlobalPackages = jest.fn()
+const checkGlobalBinConflicts = jest.fn<() => Promise<Set<string>>>().mockResolvedValue(new Set())
+const installGlobalPackages = jest.fn<(...args: unknown[]) => Promise<{ ignoredBuilds: undefined, resolutionPolicyViolations: [] }>>()
+  .mockResolvedValue({ ignoredBuilds: undefined, resolutionPolicyViolations: [] })
+const promptApproveGlobalBuilds = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+const readInstalledPackages = jest.fn<() => Promise<[]>>().mockResolvedValue([])
+const summaryDebug = jest.fn()
+const symlinkDir = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+jest.unstable_mockModule('@pnpm/bins.linker', () => ({ linkBinsOfPackages }))
+jest.unstable_mockModule('@pnpm/bins.remover', () => ({ removeBin }))
+jest.unstable_mockModule('@pnpm/core-loggers', () => ({ summaryLogger: { debug: summaryDebug } }))
+jest.unstable_mockModule('@pnpm/global.packages', () => ({
+  cleanOrphanedInstallDirs,
+  createInstallDir,
+  getHashLink,
+  getInstalledBinNames,
+  scanGlobalPackages,
+}))
+jest.unstable_mockModule('is-subdir', () => ({ isSubdir: () => false }))
+jest.unstable_mockModule('symlink-dir', () => ({ symlinkDir }))
+jest.unstable_mockModule('../src/checkGlobalBinConflicts.js', () => ({ checkGlobalBinConflicts }))
+jest.unstable_mockModule('../src/installGlobalPackages.js', () => ({ installGlobalPackages }))
+jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptApproveGlobalBuilds }))
+jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
+
+const { handleGlobalUpdate } = await import('../src/globalUpdate.js')
+
+test('global update emits a single summary after updating all isolated groups', async () => {
+  createInstallDir
+    .mockReturnValueOnce('/global/v11/install-1')
+    .mockReturnValueOnce('/global/v11/install-2')
+  getHashLink
+    .mockReturnValueOnce('/global/v11/hash-foo')
+    .mockReturnValueOnce('/global/v11/hash-bar')
+  scanGlobalPackages.mockReturnValue([
+    {
+      dependencies: { foo: '^1.0.0' },
+      hash: 'hash-foo',
+      installDir: '/global/v11/old-foo',
+    },
+    {
+      dependencies: { bar: '^2.0.0' },
+      hash: 'hash-bar',
+      installDir: '/global/v11/old-bar',
+    },
+  ])
+
+  await handleGlobalUpdate({
+    bin: '/global/bin',
+    globalPkgDir: '/global/v11',
+  } as any, [], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(installGlobalPackages).toHaveBeenCalledTimes(2)
+  expect(installGlobalPackages).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      dir: '/global/v11/install-1',
+      global: false,
+      omitSummaryLog: true,
+    }),
+    ['foo@^1.0.0']
+  )
+  expect(installGlobalPackages).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      dir: '/global/v11/install-2',
+      global: false,
+      omitSummaryLog: true,
+    }),
+    ['bar@^2.0.0']
+  )
+  expect(summaryDebug).toHaveBeenCalledTimes(1)
+  expect(summaryDebug).toHaveBeenCalledWith({ prefix: '/global/v11' })
+})


### PR DESCRIPTION
## Summary

- suppresses per-group summaries while global update processes isolated install groups
- emits one final global summary after all selected global packages are updated
- adds regression coverage for the multi-group global update flow

Closes #11762.

## Testing

- `pnpm --filter @pnpm/global.commands exec tsgo --build`
- `pnpm --filter @pnpm/global.commands exec tsgo --build test/tsconfig.json`
- `NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" pnpm --filter @pnpm/global.commands exec jest globalUpdate.test.ts`
- `pnpm --filter @pnpm/global.commands exec eslint "src/**/*.ts" "test/**/*.ts"`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global update now shows a single consolidated summary after all isolated global package groups are processed.
* **Documentation**
  * Clarified that the global update summary is printed only once, after all groups complete.
* **Tests**
  * Added a test ensuring per-group installs do not emit individual summaries and a single global summary is produced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->