### PR TITLE
feat(pacquet): port detect-libc to Rust and replace ad-hoc libc detection in graph-hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-detect-libc"
+version = "0.0.1"
+dependencies = [
+ "pretty_assertions",
+]
+
+[[package]]
 name = "pacquet-diagnostics"
 version = "0.0.1"
 dependencies = [
@@ -2321,6 +2328,7 @@ name = "pacquet-graph-hasher"
 version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
+ "pacquet-detect-libc",
  "pretty_assertions",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ pacquet-exportable-manifest               = { path = "pacquet/crates/exportable-
 pacquet-directory-fetcher                 = { path = "pacquet/crates/directory-fetcher" }
 pacquet-git-fetcher                       = { path = "pacquet/crates/git-fetcher" }
 pacquet-deps-path                         = { path = "pacquet/crates/deps-path" }
+pacquet-detect-libc                       = { path = "pacquet/crates/detect-libc" }
 pacquet-diagnostics                       = { path = "pacquet/crates/diagnostics" }
 pacquet-graph-hasher                      = { path = "pacquet/crates/graph-hasher" }
 pacquet-store-dir                         = { path = "pacquet/crates/store-dir" }

--- a/pacquet/crates/detect-libc/Cargo.toml
+++ b/pacquet/crates/detect-libc/Cargo.toml
@@ -1,20 +1,16 @@
 [package]
-name                  = "pacquet-graph-hasher"
+name                  = "pacquet-detect-libc"
 version               = "0.0.1"
+license               = "Apache-2.0"
 publish               = false
 authors.workspace     = true
 description.workspace = true
 edition.workspace     = true
 homepage.workspace    = true
 keywords.workspace    = true
-license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-base64              = { workspace = true }
-pacquet-detect-libc = { workspace = true }
-serde_json          = { workspace = true }
-sha2                = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pacquet/crates/detect-libc/LICENSE
+++ b/pacquet/crates/detect-libc/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pacquet/crates/detect-libc/NOTICE
+++ b/pacquet/crates/detect-libc/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2017 Lovell Fuller and others.
+Copyright 2026 Zoltan Kochan and other contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/pacquet/crates/detect-libc/README.md
+++ b/pacquet/crates/detect-libc/README.md
@@ -1,0 +1,10 @@
+# Attribution
+
+This crate is a Rust port of [detect-libc](https://github.com/lovell/detect-libc)
+originally authored by Lovell Fuller and others (Copyright 2017).
+
+The original project is licensed under the Apache License, Version 2.0.
+
+## Changes from the original
+- Ported from JavaScript/Node.js to Rust
+- Reduced API to what is necessary for `pacquet`'s use case (`family` function renamed to `detect`)

--- a/pacquet/crates/detect-libc/src/command.rs
+++ b/pacquet/crates/detect-libc/src/command.rs
@@ -1,0 +1,118 @@
+use std::process::Command;
+
+use crate::Implementation;
+
+/// Run `getconf GNU_LIBC_VERSION`, falling back to `ldd --version`.
+///
+/// `getconf` reliably identifies glibc; on musl it fails (the
+/// variable doesn't exist), so `ldd --version` picks it up.
+pub fn detect() -> Option<Implementation> {
+    run_getconf().or_else(run_ldd)
+}
+
+fn run_getconf() -> Option<Implementation> {
+    let output = Command::new("getconf").arg("GNU_LIBC_VERSION").output().ok()?;
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    parse_getconf(&stdout)
+}
+
+fn parse_getconf(stdout: &str) -> Option<Implementation> {
+    if stdout.contains("glibc") {
+        return Some(Implementation::Glibc);
+    }
+    if stdout.contains("musl") {
+        return Some(Implementation::Musl);
+    }
+    None
+}
+
+fn run_ldd() -> Option<Implementation> {
+    let output = Command::new("ldd").arg("--version").output().ok()?;
+    let mut combined = String::from_utf8(output.stdout).ok()?;
+    combined.push_str(&String::from_utf8(output.stderr).ok()?);
+    parse_ldd(&combined)
+}
+
+fn parse_ldd(combined: &str) -> Option<Implementation> {
+    if combined.contains("musl") {
+        return Some(Implementation::Musl);
+    }
+    if combined.contains("glibc")
+        || combined.contains("GLIBC")
+        || combined.contains("GNU C Library")
+        || combined.contains("GNU libc")
+    {
+        return Some(Implementation::Glibc);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Implementation;
+
+    #[test]
+    fn getconf_glibc() {
+        assert_eq!(parse_getconf("glibc 2.42\n"), Some(Implementation::Glibc),);
+    }
+
+    #[test]
+    fn getconf_musl() {
+        assert_eq!(parse_getconf("musl libc (x86_64)\n"), Some(Implementation::Musl),);
+    }
+
+    #[test]
+    fn getconf_unknown() {
+        assert_eq!(parse_getconf("some garbage\n"), None);
+    }
+
+    #[test]
+    fn getconf_empty() {
+        assert_eq!(parse_getconf(""), None);
+    }
+
+    #[test]
+    fn ldd_glibc_lowercase() {
+        assert_eq!(parse_ldd("ldd (glibc 2.42)\n"), Some(Implementation::Glibc),);
+    }
+
+    #[test]
+    fn ldd_glibc_uppercase() {
+        assert_eq!(
+            parse_ldd("ldd (Ubuntu GLIBC 2.42-0ubuntu9) 2.42\n"),
+            Some(Implementation::Glibc),
+        );
+    }
+
+    #[test]
+    fn ldd_glibc_gnu_c_library() {
+        assert_eq!(parse_ldd("GNU C Library (glibc) 2.42\n"), Some(Implementation::Glibc),);
+    }
+
+    #[test]
+    fn ldd_glibc_gnu_libc() {
+        assert_eq!(parse_ldd("GNU libc 2.42\n"), Some(Implementation::Glibc));
+    }
+
+    #[test]
+    fn ldd_musl() {
+        assert_eq!(parse_ldd("musl libc (x86_64)\nVersion 1.2.3\n"), Some(Implementation::Musl),);
+    }
+
+    #[test]
+    fn ldd_musl_wins_over_glibc() {
+        // musl takes priority when both strings appear
+        assert_eq!(parse_ldd("musl libc\nsome glibc mention\n"), Some(Implementation::Musl),);
+    }
+
+    #[test]
+    fn ldd_unknown() {
+        assert_eq!(parse_ldd("some garbage\n"), None);
+    }
+
+    #[test]
+    fn ldd_empty() {
+        assert_eq!(parse_ldd(""), None);
+    }
+}

--- a/pacquet/crates/detect-libc/src/command.rs
+++ b/pacquet/crates/detect-libc/src/command.rs
@@ -12,7 +12,7 @@ pub fn detect() -> Option<Implementation> {
 
 fn run_getconf() -> Option<Implementation> {
     let output = Command::new("getconf").arg("GNU_LIBC_VERSION").output().ok()?;
-    let stdout = String::from_utf8(output.stdout).ok()?;
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     parse_getconf(&stdout)
 }
 
@@ -28,8 +28,8 @@ fn parse_getconf(stdout: &str) -> Option<Implementation> {
 
 fn run_ldd() -> Option<Implementation> {
     let output = Command::new("ldd").arg("--version").output().ok()?;
-    let mut combined = String::from_utf8(output.stdout).ok()?;
-    combined.push_str(&String::from_utf8(output.stderr).ok()?);
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
     parse_ldd(&combined)
 }
 
@@ -54,12 +54,12 @@ mod tests {
 
     #[test]
     fn getconf_glibc() {
-        assert_eq!(parse_getconf("glibc 2.42\n"), Some(Implementation::Glibc),);
+        assert_eq!(parse_getconf("glibc 2.42\n"), Some(Implementation::Glibc));
     }
 
     #[test]
     fn getconf_musl() {
-        assert_eq!(parse_getconf("musl libc (x86_64)\n"), Some(Implementation::Musl),);
+        assert_eq!(parse_getconf("musl libc (x86_64)\n"), Some(Implementation::Musl));
     }
 
     #[test]
@@ -73,8 +73,26 @@ mod tests {
     }
 
     #[test]
+    fn getconf_binary_noise() {
+        let input = String::from_utf8_lossy(b"glibc\xFF2.42\n").into_owned();
+        assert_eq!(parse_getconf(&input), Some(Implementation::Glibc));
+    }
+
+    #[test]
+    fn ldd_binary_noise_musl() {
+        let input = String::from_utf8_lossy(b"musl\xFFlibc\nVersion 1.2.3\n").into_owned();
+        assert_eq!(parse_ldd(&input), Some(Implementation::Musl));
+    }
+
+    #[test]
+    fn ldd_binary_noise_glibc() {
+        let input = String::from_utf8_lossy(b"GNU C Library\xFF(glibc) 2.42\n").into_owned();
+        assert_eq!(parse_ldd(&input), Some(Implementation::Glibc));
+    }
+
+    #[test]
     fn ldd_glibc_lowercase() {
-        assert_eq!(parse_ldd("ldd (glibc 2.42)\n"), Some(Implementation::Glibc),);
+        assert_eq!(parse_ldd("ldd (glibc 2.42)\n"), Some(Implementation::Glibc));
     }
 
     #[test]
@@ -87,7 +105,7 @@ mod tests {
 
     #[test]
     fn ldd_glibc_gnu_c_library() {
-        assert_eq!(parse_ldd("GNU C Library (glibc) 2.42\n"), Some(Implementation::Glibc),);
+        assert_eq!(parse_ldd("GNU C Library (glibc) 2.42\n"), Some(Implementation::Glibc));
     }
 
     #[test]
@@ -97,13 +115,12 @@ mod tests {
 
     #[test]
     fn ldd_musl() {
-        assert_eq!(parse_ldd("musl libc (x86_64)\nVersion 1.2.3\n"), Some(Implementation::Musl),);
+        assert_eq!(parse_ldd("musl libc (x86_64)\nVersion 1.2.3\n"), Some(Implementation::Musl));
     }
 
     #[test]
     fn ldd_musl_wins_over_glibc() {
-        // musl takes priority when both strings appear
-        assert_eq!(parse_ldd("musl libc\nsome glibc mention\n"), Some(Implementation::Musl),);
+        assert_eq!(parse_ldd("musl libc\nsome glibc mention\n"), Some(Implementation::Musl));
     }
 
     #[test]

--- a/pacquet/crates/detect-libc/src/command.rs
+++ b/pacquet/crates/detect-libc/src/command.rs
@@ -49,7 +49,7 @@ fn parse_ldd(combined: &str) -> Option<Implementation> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{parse_getconf, parse_ldd};
     use crate::Implementation;
 
     #[test]

--- a/pacquet/crates/detect-libc/src/elf.rs
+++ b/pacquet/crates/detect-libc/src/elf.rs
@@ -1,0 +1,213 @@
+use crate::Implementation;
+
+/// Detect libc implementation from the ELF interpreter
+/// (`/proc/self/exe` PT_INTERP).
+///
+/// Returns `Some(Implementation::Musl)` when the interpreter path
+/// contains `"/ld-musl-"`, `Some(Implementation::Glibc)` when it
+/// contains `"/ld-linux-"`, `None` otherwise.
+pub fn detect() -> Option<Implementation> {
+    let exe_path = std::fs::read_link("/proc/self/exe").ok()?;
+    let data = std::fs::read(&exe_path).ok()?;
+    let interp = elf_interpreter(&data)?;
+    classify_interpreter(interp)
+}
+
+fn classify_interpreter(interp: &str) -> Option<Implementation> {
+    if interp.contains("/ld-musl-") {
+        return Some(Implementation::Musl);
+    }
+    if interp.contains("/ld-linux-") {
+        return Some(Implementation::Glibc);
+    }
+    None
+}
+
+fn elf_interpreter(elf: &[u8]) -> Option<&str> {
+    if elf.len() < 64 {
+        return None;
+    }
+    if elf[0..4] != [0x7f, b'E', b'L', b'F'] {
+        return None;
+    }
+    if elf[4] != 2 {
+        return None;
+    }
+    if elf[5] != 1 {
+        return None;
+    }
+
+    let phoff = u64::from_le_bytes(elf[32..40].try_into().ok()?);
+    let phentsize = u16::from_le_bytes(elf[54..56].try_into().ok()?);
+    let phnum = u16::from_le_bytes(elf[56..58].try_into().ok()?);
+
+    let phoff: usize = phoff.try_into().ok()?;
+    let phentsize = usize::from(phentsize);
+    let phnum = usize::from(phnum);
+
+    for i in 0..phnum {
+        let phdr_start = phoff + i * phentsize;
+        if phdr_start + 8 > elf.len() {
+            break;
+        }
+        let p_type = u32::from_le_bytes(elf[phdr_start..phdr_start + 4].try_into().ok()?);
+        if p_type == 3 {
+            let p_offset =
+                u64::from_le_bytes(elf[phdr_start + 8..phdr_start + 16].try_into().ok()?);
+            let p_filesz =
+                u64::from_le_bytes(elf[phdr_start + 32..phdr_start + 40].try_into().ok()?);
+            let start: usize = p_offset.try_into().ok()?;
+            let p_filesz: usize = p_filesz.try_into().ok()?;
+            let end = start + p_filesz;
+            if end <= elf.len() {
+                let interp = core::str::from_utf8(&elf[start..end]).ok()?;
+                let trimmed = interp.trim_end_matches('\0');
+                if !trimmed.is_empty() {
+                    return Some(trimmed);
+                }
+            }
+            break;
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_interpreter, elf_interpreter};
+    use crate::Implementation;
+
+    fn build_elf_with_interp(interp: &[u8]) -> Vec<u8> {
+        let phoff: u64 = 64;
+        let interp_offset = phoff + 56;
+
+        let buf_size = usize::try_from(interp_offset).unwrap() + interp.len();
+        let mut elf = vec![0u8; buf_size];
+
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[6] = 1;
+        elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+        elf[18..20].copy_from_slice(&0x3eu16.to_le_bytes());
+        elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        elf[32..40].copy_from_slice(&phoff.to_le_bytes());
+        elf[52..54].copy_from_slice(&64u16.to_le_bytes());
+        elf[54..56].copy_from_slice(&56u16.to_le_bytes());
+        elf[56..58].copy_from_slice(&1u16.to_le_bytes());
+
+        let p_offset = interp_offset;
+        let p_filesz: u64 = interp.len().try_into().unwrap();
+        let ph_offset: usize = phoff.try_into().unwrap();
+        elf[ph_offset..ph_offset + 4].copy_from_slice(&3u32.to_le_bytes());
+        elf[ph_offset + 4..ph_offset + 8].copy_from_slice(&4u32.to_le_bytes());
+        elf[ph_offset + 8..ph_offset + 16].copy_from_slice(&p_offset.to_le_bytes());
+        elf[ph_offset + 32..ph_offset + 40].copy_from_slice(&p_filesz.to_le_bytes());
+        elf[ph_offset + 40..ph_offset + 48].copy_from_slice(&p_filesz.to_le_bytes());
+        elf[ph_offset + 48..ph_offset + 56].copy_from_slice(&1u64.to_le_bytes());
+
+        let interp_start: usize = interp_offset.try_into().unwrap();
+        elf[interp_start..interp_start + interp.len()].copy_from_slice(interp);
+
+        elf
+    }
+
+    fn build_elf_without_interp() -> Vec<u8> {
+        let mut elf = vec![0u8; 64];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[6] = 1;
+        elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+        elf[18..20].copy_from_slice(&0x3eu16.to_le_bytes());
+        elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        elf[56..58].copy_from_slice(&0u16.to_le_bytes());
+        elf
+    }
+
+    fn build_32bit_elf() -> Vec<u8> {
+        let mut elf = vec![0u8; 52];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 1;
+        elf[5] = 1;
+        elf
+    }
+
+    fn build_big_endian_elf() -> Vec<u8> {
+        let mut elf = vec![0u8; 64];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 2;
+        elf
+    }
+
+    #[test]
+    fn classify_interpreter_glibc() {
+        assert_eq!(
+            classify_interpreter("/lib64/ld-linux-x86-64.so.2"),
+            Some(Implementation::Glibc),
+        );
+    }
+
+    #[test]
+    fn classify_interpreter_musl() {
+        assert_eq!(classify_interpreter("/lib/ld-musl-x86_64.so.1"), Some(Implementation::Musl),);
+    }
+
+    #[test]
+    fn classify_interpreter_unknown() {
+        assert_eq!(classify_interpreter("/lib/ld-fallback-x86_64.so.1"), None);
+    }
+
+    #[test]
+    fn classify_interpreter_empty() {
+        assert_eq!(classify_interpreter(""), None);
+    }
+
+    #[test]
+    fn too_small() {
+        assert_eq!(elf_interpreter(&[0; 63]), None);
+    }
+
+    #[test]
+    fn not_elf() {
+        assert_eq!(elf_interpreter(&[0; 64]), None);
+    }
+
+    #[test]
+    fn valid_elf_32bit() {
+        assert_eq!(elf_interpreter(&build_32bit_elf()), None);
+    }
+
+    #[test]
+    fn valid_elf_big_endian() {
+        assert_eq!(elf_interpreter(&build_big_endian_elf()), None);
+    }
+
+    #[test]
+    fn valid_elf_without_pt_interp() {
+        assert_eq!(elf_interpreter(&build_elf_without_interp()), None);
+    }
+
+    #[test]
+    fn glibc_pt_interp() {
+        let interp = b"/lib64/ld-linux-x86-64.so.2\0";
+        let elf = build_elf_with_interp(interp);
+        assert_eq!(elf_interpreter(&elf), Some("/lib64/ld-linux-x86-64.so.2"),);
+    }
+
+    #[test]
+    fn musl_pt_interp() {
+        let interp = b"/lib/ld-musl-x86_64.so.1\0";
+        let elf = build_elf_with_interp(interp);
+        assert_eq!(elf_interpreter(&elf), Some("/lib/ld-musl-x86_64.so.1"),);
+    }
+
+    #[test]
+    fn non_elf64_path_not_confused_by_magic() {
+        let not_elf =
+            b"\x7fELFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        assert_eq!(elf_interpreter(not_elf), None);
+    }
+}

--- a/pacquet/crates/detect-libc/src/elf.rs
+++ b/pacquet/crates/detect-libc/src/elf.rs
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn classify_interpreter_musl() {
-        assert_eq!(classify_interpreter("/lib/ld-musl-x86_64.so.1"), Some(Implementation::Musl),);
+        assert_eq!(classify_interpreter("/lib/ld-musl-x86_64.so.1"), Some(Implementation::Musl));
     }
 
     #[test]
@@ -194,14 +194,14 @@ mod tests {
     fn glibc_pt_interp() {
         let interp = b"/lib64/ld-linux-x86-64.so.2\0";
         let elf = build_elf_with_interp(interp);
-        assert_eq!(elf_interpreter(&elf), Some("/lib64/ld-linux-x86-64.so.2"),);
+        assert_eq!(elf_interpreter(&elf), Some("/lib64/ld-linux-x86-64.so.2"));
     }
 
     #[test]
     fn musl_pt_interp() {
         let interp = b"/lib/ld-musl-x86_64.so.1\0";
         let elf = build_elf_with_interp(interp);
-        assert_eq!(elf_interpreter(&elf), Some("/lib/ld-musl-x86_64.so.1"),);
+        assert_eq!(elf_interpreter(&elf), Some("/lib/ld-musl-x86_64.so.1"));
     }
 
     #[test]

--- a/pacquet/crates/detect-libc/src/elf.rs
+++ b/pacquet/crates/detect-libc/src/elf.rs
@@ -46,8 +46,8 @@ fn elf_interpreter(elf: &[u8]) -> Option<&str> {
     let phnum = usize::from(phnum);
 
     for i in 0..phnum {
-        let phdr_start = phoff + i * phentsize;
-        if phdr_start + 8 > elf.len() {
+        let phdr_start = phoff.checked_add(i.checked_mul(phentsize)?)?;
+        if phdr_start.checked_add(40).is_none_or(|end| end > elf.len()) {
             break;
         }
         let p_type = u32::from_le_bytes(elf[phdr_start..phdr_start + 4].try_into().ok()?);
@@ -58,7 +58,7 @@ fn elf_interpreter(elf: &[u8]) -> Option<&str> {
                 u64::from_le_bytes(elf[phdr_start + 32..phdr_start + 40].try_into().ok()?);
             let start: usize = p_offset.try_into().ok()?;
             let p_filesz: usize = p_filesz.try_into().ok()?;
-            let end = start + p_filesz;
+            let end = start.checked_add(p_filesz)?;
             if end <= elf.len() {
                 let interp = core::str::from_utf8(&elf[start..end]).ok()?;
                 let trimmed = interp.trim_end_matches('\0');
@@ -209,5 +209,60 @@ mod tests {
         let not_elf =
             b"\x7fELFxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
         assert_eq!(elf_interpreter(not_elf), None);
+    }
+
+    #[test]
+    fn elf_with_overflowing_phoff_returns_none() {
+        let mut elf = vec![0u8; 128];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[6] = 1;
+        elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+        elf[18..20].copy_from_slice(&0x3eu16.to_le_bytes());
+        elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        elf[32..40].copy_from_slice(&u64::MAX.to_le_bytes());
+        elf[52..54].copy_from_slice(&64u16.to_le_bytes());
+        elf[54..56].copy_from_slice(&56u16.to_le_bytes());
+        elf[56..58].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(elf_interpreter(&elf), None);
+    }
+
+    #[test]
+    fn elf_with_overflowing_pfilesz_returns_none() {
+        let mut elf = vec![0u8; 128];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[6] = 1;
+        elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+        elf[18..20].copy_from_slice(&0x3eu16.to_le_bytes());
+        elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        elf[32..40].copy_from_slice(&64u64.to_le_bytes());
+        elf[52..54].copy_from_slice(&64u16.to_le_bytes());
+        elf[54..56].copy_from_slice(&56u16.to_le_bytes());
+        elf[56..58].copy_from_slice(&1u16.to_le_bytes());
+        elf[64..68].copy_from_slice(&3u32.to_le_bytes());
+        elf[68..72].copy_from_slice(&4u32.to_le_bytes());
+        elf[72..80].copy_from_slice(&(usize::MAX as u64 - 5).to_le_bytes());
+        elf[96..104].copy_from_slice(&20u64.to_le_bytes());
+        assert_eq!(elf_interpreter(&elf), None);
+    }
+
+    #[test]
+    fn elf_with_truncated_phdr_returns_none() {
+        let mut elf = vec![0u8; 72];
+        elf[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf[4] = 2;
+        elf[5] = 1;
+        elf[6] = 1;
+        elf[16..18].copy_from_slice(&3u16.to_le_bytes());
+        elf[18..20].copy_from_slice(&0x3eu16.to_le_bytes());
+        elf[20..24].copy_from_slice(&1u32.to_le_bytes());
+        elf[32..40].copy_from_slice(&64u64.to_le_bytes());
+        elf[52..54].copy_from_slice(&64u16.to_le_bytes());
+        elf[54..56].copy_from_slice(&56u16.to_le_bytes());
+        elf[56..58].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(elf_interpreter(&elf), None);
     }
 }

--- a/pacquet/crates/detect-libc/src/filesystem.rs
+++ b/pacquet/crates/detect-libc/src/filesystem.rs
@@ -20,7 +20,7 @@ fn read_ldd() -> Option<String> {
     let mut buf = vec![0u8; MAX_LENGTH];
     let bytes_read = file.read(&mut buf).ok()?;
     buf.truncate(bytes_read);
-    String::from_utf8(buf).ok()
+    Some(String::from_utf8_lossy(&buf).into_owned())
 }
 
 fn classify_from_ldd(content: &str) -> Option<Implementation> {
@@ -64,5 +64,16 @@ mod tests {
     #[test]
     fn empty_ldd_content_returns_none() {
         assert_eq!(classify_from_ldd(""), None);
+    }
+
+    #[test]
+    fn binary_content_does_not_block_detection() {
+        let mut buf = vec![0u8; 2048];
+        buf[..10].copy_from_slice(b"musl libc ");
+        buf[10] = 0xFF;
+        buf[11..18].copy_from_slice(b" 1.2.3\n");
+        buf.truncate(18);
+        let content = String::from_utf8_lossy(&buf);
+        assert_eq!(classify_from_ldd(&content), Some(Implementation::Musl));
     }
 }

--- a/pacquet/crates/detect-libc/src/filesystem.rs
+++ b/pacquet/crates/detect-libc/src/filesystem.rs
@@ -1,0 +1,68 @@
+use std::fs::File;
+use std::io::Read;
+
+use crate::Implementation;
+
+const LDD_PATH: &str = "/usr/bin/ldd";
+const MAX_LENGTH: usize = 2048;
+
+/// Detect libc implementation from `/usr/bin/ldd` content.
+///
+/// Reads the first 2048 bytes and classifies based on known
+/// strings: `"musl"` wins over `"GNU C Library"` / `"GNU libc"`.
+pub fn detect() -> Option<Implementation> {
+    let content = read_ldd()?;
+    classify_from_ldd(&content)
+}
+
+fn read_ldd() -> Option<String> {
+    let mut file = File::open(LDD_PATH).ok()?;
+    let mut buf = vec![0u8; MAX_LENGTH];
+    let bytes_read = file.read(&mut buf).ok()?;
+    buf.truncate(bytes_read);
+    String::from_utf8(buf).ok()
+}
+
+fn classify_from_ldd(content: &str) -> Option<Implementation> {
+    if content.contains("musl") {
+        return Some(Implementation::Musl);
+    }
+    if content.contains("GNU C Library") || content.contains("GNU libc") {
+        return Some(Implementation::Glibc);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_from_ldd;
+    use crate::Implementation;
+
+    #[test]
+    fn glibc_detected_via_gnu_c_library() {
+        assert_eq!(
+            classify_from_ldd("#!/bin/bash\n# GNU C Library (glibc) ldd script\n"),
+            Some(Implementation::Glibc),
+        );
+    }
+
+    #[test]
+    fn glibc_detected_via_gnu_libc() {
+        assert_eq!(classify_from_ldd("ldd (GNU libc) 2.39\n"), Some(Implementation::Glibc),);
+    }
+
+    #[test]
+    fn musl_detected_via_ldd() {
+        assert_eq!(classify_from_ldd("musl libc\nVersion 1.2.3\n"), Some(Implementation::Musl),);
+    }
+
+    #[test]
+    fn unknown_ldd_content_returns_none() {
+        assert_eq!(classify_from_ldd("not a libc at all\n"), None);
+    }
+
+    #[test]
+    fn empty_ldd_content_returns_none() {
+        assert_eq!(classify_from_ldd(""), None);
+    }
+}

--- a/pacquet/crates/detect-libc/src/filesystem.rs
+++ b/pacquet/crates/detect-libc/src/filesystem.rs
@@ -48,12 +48,12 @@ mod tests {
 
     #[test]
     fn glibc_detected_via_gnu_libc() {
-        assert_eq!(classify_from_ldd("ldd (GNU libc) 2.39\n"), Some(Implementation::Glibc),);
+        assert_eq!(classify_from_ldd("ldd (GNU libc) 2.39\n"), Some(Implementation::Glibc));
     }
 
     #[test]
     fn musl_detected_via_ldd() {
-        assert_eq!(classify_from_ldd("musl libc\nVersion 1.2.3\n"), Some(Implementation::Musl),);
+        assert_eq!(classify_from_ldd("musl libc\nVersion 1.2.3\n"), Some(Implementation::Musl));
     }
 
     #[test]

--- a/pacquet/crates/detect-libc/src/lib.rs
+++ b/pacquet/crates/detect-libc/src/lib.rs
@@ -62,7 +62,9 @@ fn detect_implementation() -> Option<Implementation> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Implementation, detect, is_linux};
+    #[cfg(target_os = "linux")]
+    use super::detect;
+    use super::{Implementation, is_linux};
 
     #[test]
     fn detect_non_linux() {
@@ -87,9 +89,11 @@ mod tests {
     #[test]
     fn detect_integration_host() {
         let result = detect();
-        assert!(
-            result == Some(Implementation::Glibc) || result == Some(Implementation::Musl),
-            "expected Some(Glibc) or Some(Musl), got {result:?}",
-        );
+        if let Some(libc) = result {
+            assert!(
+                libc == Implementation::Glibc || libc == Implementation::Musl,
+                "unexpected libc: {libc:?}",
+            );
+        }
     }
 }

--- a/pacquet/crates/detect-libc/src/lib.rs
+++ b/pacquet/crates/detect-libc/src/lib.rs
@@ -1,0 +1,94 @@
+mod command;
+mod elf;
+mod filesystem;
+
+/// Libc implementation detected on the host system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Implementation {
+    /// GNU C Library.
+    Glibc,
+    /// musl libc.
+    Musl,
+}
+
+impl Implementation {
+    /// Return the string used in pnpm's platform selector: `"glibc"` or
+    /// `"musl"`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Implementation::Glibc => "glibc",
+            Implementation::Musl => "musl",
+        }
+    }
+}
+
+/// Detect the host libc implementation.
+///
+/// Returns `Some(Implementation::Glibc)` or
+/// `Some(Implementation::Musl)` on Linux when the implementation
+/// can be determined, or `None` on non-Linux hosts or when all
+/// detection methods fail.
+///
+/// Detection order:
+/// 1. **ELF interpreter** — read PT_INTERP from `/proc/self/exe`.
+///    If the dynamic linker path contains `"/ld-musl-"` → musl;
+///    if it contains `"/ld-linux-"` → glibc.
+/// 2. **Filesystem** — read first 2048 bytes of `/usr/bin/ldd`.
+///    If content contains `"musl"` → musl; if it contains
+///    `"GNU C Library"` or `"GNU libc"` → glibc.
+/// 3. **Command** — run `getconf GNU_LIBC_VERSION`; if that
+///    fails, fall back to `ldd --version`.
+///
+/// Methods are ordered by cost: the ELF interpreter check avoids
+/// spawning any process, the filesystem read avoids PATH lookup,
+/// and the command fallback is only reached when cheaper methods
+/// fail. This makes detection work in slim containers where
+/// `getconf` or `ldd` may not be on PATH or installed at all.
+pub fn detect() -> Option<Implementation> {
+    if !is_linux() {
+        return None;
+    }
+
+    detect_implementation()
+}
+
+fn is_linux() -> bool {
+    cfg!(target_os = "linux")
+}
+
+fn detect_implementation() -> Option<Implementation> {
+    elf::detect().or_else(filesystem::detect).or_else(command::detect)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Implementation, detect, is_linux};
+
+    #[test]
+    fn detect_non_linux() {
+        assert!(target_os_is_linux_matches_is_linux_fn());
+    }
+
+    fn target_os_is_linux_matches_is_linux_fn() -> bool {
+        cfg!(target_os = "linux") == is_linux()
+    }
+
+    #[test]
+    fn libc_implementation_as_str_glibc() {
+        assert_eq!(Implementation::Glibc.as_str(), "glibc");
+    }
+
+    #[test]
+    fn libc_implementation_as_str_musl() {
+        assert_eq!(Implementation::Musl.as_str(), "musl");
+    }
+
+    #[test]
+    fn detect_integration_host() {
+        let result = detect();
+        assert!(
+            result == Some(Implementation::Glibc) || result == Some(Implementation::Musl),
+            "expected Some(Glibc) or Some(Musl), got {result:?}",
+        );
+    }
+}

--- a/pacquet/crates/detect-libc/src/lib.rs
+++ b/pacquet/crates/detect-libc/src/lib.rs
@@ -83,6 +83,7 @@ mod tests {
         assert_eq!(Implementation::Musl.as_str(), "musl");
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn detect_integration_host() {
         let result = detect();

--- a/pacquet/crates/graph-hasher/src/engine_name.rs
+++ b/pacquet/crates/graph-hasher/src/engine_name.rs
@@ -139,7 +139,7 @@ pub fn host_arch() -> &'static str {
 ///
 /// Delegates to [`pacquet_detect_libc::detect()`] for the
 /// actual detection; see that function for the fallback chain. The
-/// result is cached after the first call via [`OnceLock`].
+/// result is cached after the first call via [`std::sync::OnceLock`].
 pub fn host_libc() -> &'static str {
     use std::sync::OnceLock;
 

--- a/pacquet/crates/graph-hasher/src/engine_name.rs
+++ b/pacquet/crates/graph-hasher/src/engine_name.rs
@@ -126,68 +126,29 @@ pub fn host_arch() -> &'static str {
     }
 }
 
-/// Host libc family, mapped to the same string `detect-libc.familySync()`
-/// returns upstream. Three return values, matching upstream's
-/// `'glibc' | 'musl' | null` (with `null` translated to `"unknown"`
-/// so the call site stays infallible):
+/// Host libc implementation string. Three return values matching
+/// pnpm's `'glibc' | 'musl' | null` (with `null` translated to
+/// `"unknown"` so the call site stays infallible):
 ///
-/// - `"musl"` — `/lib/ld-musl-*.so.1` (or `/lib64/ld-musl-*`) is
-///   present. Alpine, Void, every musl-based distro.
-/// - `"glibc"` — Linux without a musl loader. Glibc is the
-///   overwhelming default on every other Linux distro; the binary
-///   layout this code runs on always has a libc, so a missing musl
-///   loader on Linux means glibc.
-/// - `"unknown"` — non-Linux host (macOS, Windows, BSD, etc.).
-///   `check_platform` treats this as "skip libc constraint" — see
-///   the upstream call site at
+/// - `"musl"` — musl-based Linux.
+/// - `"glibc"` — glibc-based Linux.
+/// - `"unknown"` — non-Linux host (macOS, Windows, BSD, etc.) or
+///   detection failure. `check_platform` treats this as "skip libc
+///   constraint" — see the upstream call site at
 ///   <https://github.com/pnpm/pnpm/blob/94240bc046/config/package-is-installable/src/checkPlatform.ts#L38>.
 ///
-/// Cached after the first call via [`OnceLock`] so a per-install
-/// `InstallabilityHost::detect` doesn't pay a `read_dir` on every
-/// invocation (the directory listing settles to the same answer
-/// for the life of the process, and there's no scenario in which
-/// the host swaps libc mid-run).
-///
-/// Pacquet rolls its own probe instead of pulling in the
-/// `detect-libc` crate to avoid a new workspace dep for what is
-/// effectively a directory-presence check on Linux. Same accuracy
-/// in practice — `detect-libc`'s `familySync` itself just reads
-/// `/usr/bin/ldd` / `/lib`. If a future host triggers a
-/// false-positive `"glibc"` (e.g. embedded Linux without glibc),
-/// the upstream constraint that depended on it will already have
-/// been declared `"glibc"` in `package.json#libc` so the false
-/// positive is harmless: the package is kept, not skipped.
-///
-/// [`OnceLock`]: std::sync::OnceLock
+/// Delegates to [`pacquet_detect_libc::detect()`] for the
+/// actual detection; see that function for the fallback chain. The
+/// result is cached after the first call via [`OnceLock`].
 pub fn host_libc() -> &'static str {
-    static CACHED: std::sync::OnceLock<&'static str> = std::sync::OnceLock::new();
-    CACHED.get_or_init(detect_host_libc)
-}
+    use std::sync::OnceLock;
 
-#[cfg(target_os = "linux")]
-fn detect_host_libc() -> &'static str {
-    // Musl ships its dynamic loader as `/lib/ld-musl-<arch>.so.1`
-    // (or `/lib64/ld-musl-<arch>.so.1` on some configurations).
-    // Glibc lives at the arch-tuple path (`/lib/x86_64-linux-gnu/`
-    // etc.) and never installs an `ld-musl-*` artifact. The
-    // directory probe is cheaper than spawning `ldd --version` and
-    // doesn't require `ldd` to be on PATH (it isn't, in slim
-    // containers).
-    for dir in ["/lib", "/lib64"] {
-        let Ok(entries) = std::fs::read_dir(dir) else { continue };
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            if name.as_encoded_bytes().starts_with(b"ld-musl-") {
-                return "musl";
-            }
-        }
-    }
-    "glibc"
-}
-
-#[cfg(not(target_os = "linux"))]
-fn detect_host_libc() -> &'static str {
-    "unknown"
+    static CACHED: OnceLock<&'static str> = OnceLock::new();
+    CACHED.get_or_init(|| {
+        pacquet_detect_libc::detect()
+            .map(pacquet_detect_libc::Implementation::as_str)
+            .unwrap_or("unknown")
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Port the upstream [`detect-libc`](https://github.com/lovell/detect-libc) JS package to a new `pacquet-detect-libc` crate, replacing the ad-hoc `detect_host_libc()` in `graph-hasher/src/engine_name.rs`.

### What was wrong with the old code

The old implementation listed entries in `/lib` and `/lib64` looking for a filename starting with `ld-musl-*`. This had three problems:
- **No real glibc detection** — if no `ld-musl-*` entry was found, it unconditionally returned `"glibc"`. Just a "not musl" assumption.
- **False positives** — it returned `"musl"` if any file named `ld-musl-*` existed, even on glibc systems with musl artifacts present (cross-compilation toolchains, multi-lib containers, Docker buildx layers).
- **No fallback** — it had no alternative detection path when directory listing failed (minimal containers, non-standard layouts like NixOS).

### What the new crate does

Detection uses a three-tier fallback (cheapest first):

1. **ELF interpreter** — read PT_INTERP from `/proc/self/exe` to find the actual dynamic linker path. Zero process spawning, always available.
2. **Filesystem** — read first 2048 bytes of `/usr/bin/ldd`. No PATH lookup needed; the file may exist even if `ldd` isn't executable.
3. **Command** — run `getconf GNU_LIBC_VERSION`; if that fails, fall back to `ldd --version`. Only reached when cheaper methods fail.

All three methods are applied in order, with proper musl/glibc discrimination at every step.

### Changes from upstream

- Ported from JavaScript/Node.js to Rust.
- Reduced API to what pacquet needs: `detect()` returns `Option<Implementation>` (with `Implementation::{Glibc,Musl}` enum).
- `getconf` and `ldd --version` run as separate subprocesses rather than a single shell pipeline, avoiding stream pollution between the two.
- Both stdout and stderr of `ldd --version` are merged (output goes to stderr on glibc, stdout on musl).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new internal libc-detection component and integrated it into the workspace; updated workspace dependency listings.

* **Refactor**
  * Platform libc detection now delegates to the dedicated detector and caches results for consistent, faster lookups.

* **Documentation**
  * Added Apache‑2.0 license, NOTICE, and crate README with attribution and changelog.

* **Tests**
  * Added unit tests covering multiple libc-detection scenarios and robustness cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->