### PR TITLE
test(pacquet/package-manager): make side-effects write test umask-agnostic

### DIFF
--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -913,6 +913,7 @@ async fn write_path_populates_side_effects_row() {
         CafsFileInfo, HASH_ALGORITHM, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter,
         store_index_key,
     };
+    use std::os::unix::fs::PermissionsExt;
 
     let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
     let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -948,7 +949,22 @@ async fn write_path_populates_side_effects_row() {
     let modules_dir = tempdir().expect("create modules dir");
     let lockfile_dir = tempdir().expect("create lockfile dir");
 
-    create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    let pkg_dir = create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+
+    // The actual mode fs::write() assigns depends on the process
+    // umask (typically 0022 → 0o644, but 0002 → 0o664 when
+    // pam_umask's `usergroups` logic matches UID to group name,
+    // the default on Debian for non-root users). Read the real
+    // mode so the pre-seeded row's CafsFileInfo matches what
+    // calculate_diff() will compare, avoiding a false-positive
+    // mode-only mismatch on unchanged files.
+    let actual_mode = {
+        let m = std::fs::metadata(pkg_dir.join("index.js"))
+            .expect("stat index.js")
+            .permissions()
+            .mode();
+        m & 0o777
+    };
 
     // Pre-seed the base PackageFilesIndex row that the WRITE
     // path will mutate. The base captures only `index.js`; the
@@ -967,7 +983,7 @@ async fn write_path_populates_side_effects_row() {
             // `module.exports = 'hi'\n`, the diff for `index.js`
             // stays empty (= no spurious entry in `added`).
             digest: sha512_hex(b"module.exports = 'hi'\n"),
-            mode: 0o644,
+            mode: actual_mode,
             size: b"module.exports = 'hi'\n".len() as u64,
             checked_at: None,
         },

--- a/pacquet/crates/package-manager/src/build_modules/tests.rs
+++ b/pacquet/crates/package-manager/src/build_modules/tests.rs
@@ -864,11 +864,22 @@ fn ignored_scripts_event_carries_returned_names() {
 /// a file (`generated.txt`) that the original tarball didn't, so
 /// the WRITE-path diff produces a non-empty `added` entry under
 /// the snapshot's cache key.
+///
+/// Returns the package directory path and the actual file mode of
+/// `index.js`. The mode is read from disk because `fs::write()`
+/// assigns permissions according to the process umask (typically
+/// 0022 → 0o644, but 0002 → 0o664 when pam_umask's `usergroups`
+/// logic matches UID to group name, the default on Debian for
+/// non-root users). Callers that pre-seed store rows should use
+/// this returned mode so `calculate_diff()` doesn't flag a
+/// mode-only mismatch on unchanged files.
 #[cfg(unix)]
 fn create_postinstall_modifies_source_fixture(
     virtual_store_dir: &Path,
     key: &PackageKey,
-) -> PathBuf {
+) -> (PathBuf, u32) {
+    use std::os::unix::fs::PermissionsExt;
+
     let key_str = key.without_peer().to_string();
     let name_version = key_str.strip_prefix('/').unwrap_or(&key_str);
     let at_idx = name_version.rfind('@').unwrap_or(name_version.len());
@@ -888,7 +899,10 @@ fn create_postinstall_modifies_source_fixture(
         "scripts": { "postinstall": "echo touched > generated.txt" },
     });
     fs::write(pkg_dir.join("package.json"), manifest.to_string()).expect("write manifest");
-    pkg_dir
+    let actual_mode =
+        std::fs::metadata(pkg_dir.join("index.js")).expect("stat index.js").permissions().mode()
+            & 0o777;
+    (pkg_dir, actual_mode)
 }
 
 /// Mirrors upstream's `'a postinstall script does not modify the
@@ -913,7 +927,6 @@ async fn write_path_populates_side_effects_row() {
         CafsFileInfo, HASH_ALGORITHM, PackageFilesIndex, StoreDir, StoreIndex, StoreIndexWriter,
         store_index_key,
     };
-    use std::os::unix::fs::PermissionsExt;
 
     let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
     let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -948,23 +961,8 @@ async fn write_path_populates_side_effects_row() {
     let virtual_store_dir = tempdir().expect("create vstore dir");
     let modules_dir = tempdir().expect("create modules dir");
     let lockfile_dir = tempdir().expect("create lockfile dir");
-
-    let pkg_dir = create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
-
-    // The actual mode fs::write() assigns depends on the process
-    // umask (typically 0022 → 0o644, but 0002 → 0o664 when
-    // pam_umask's `usergroups` logic matches UID to group name,
-    // the default on Debian for non-root users). Read the real
-    // mode so the pre-seeded row's CafsFileInfo matches what
-    // calculate_diff() will compare, avoiding a false-positive
-    // mode-only mismatch on unchanged files.
-    let actual_mode = {
-        let m = std::fs::metadata(pkg_dir.join("index.js"))
-            .expect("stat index.js")
-            .permissions()
-            .mode();
-        m & 0o777
-    };
+    let (_pkg_dir, actual_mode) =
+        create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
 
     // Pre-seed the base PackageFilesIndex row that the WRITE
     // path will mutate. The base captures only `index.js`; the
@@ -1114,7 +1112,8 @@ async fn write_path_disabled_skips_upload() {
     let modules_dir = tempdir().expect("create modules dir");
     let lockfile_dir = tempdir().expect("create lockfile dir");
 
-    create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    let (_pkg_dir, _actual_mode) =
+        create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
 
     let files_index_file = store_index_key(integrity_str, &pkg_key.without_peer().to_string());
     let base_row = PackageFilesIndex {
@@ -1406,8 +1405,8 @@ async fn write_path_cache_key_includes_patch_hash() {
     let virtual_store_dir = tempdir().expect("create vstore dir");
     let modules_dir = tempdir().expect("create modules dir");
     let lockfile_dir = tempdir().expect("create lockfile dir");
-
-    create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    let (_pkg_dir, actual_mode) =
+        create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
 
     let files_index_file = store_index_key(integrity_str, &pkg_key.without_peer().to_string());
     let mut base_files = HashMap::new();
@@ -1415,7 +1414,7 @@ async fn write_path_cache_key_includes_patch_hash() {
         "index.js".to_string(),
         CafsFileInfo {
             digest: sha512_hex(b"module.exports = 'hi'\n"),
-            mode: 0o644,
+            mode: actual_mode,
             size: b"module.exports = 'hi'\n".len() as u64,
             checked_at: None,
         },


### PR DESCRIPTION
`write_path_populates_side_effects_row` pre-seeded a `PackageFilesIndex` row with `mode: 0o644` for `index.js`, but `fs::write()` assigns mode according to the process umask — `0o644` under `0022`, `0o664` under `0002` (pam_umask usergroups, default on Debian for non-root users).

`calculate_diff()` compares both digest and mode, so the mode mismatch put `index.js` in the `added` diff map even though its content was unchanged, causing the assertion `!added.contains_key("index.js")` to fail.

Fix: read the actual file mode via `std::fs::metadata` after writing the fixture and use that in the pre-seeded row, matching whatever mode the umask produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixtures now read and return actual on-disk file permission modes instead of assuming a fixed mode.
  * Updated affected tests to consume the fixture-returned mode when seeding test data, improving cross-platform reliability and reducing permission-related flakiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->