### PR TITLE
fix(pacquet/resolving-npm-resolver): honor linkWorkspacePackages for bare-semver deps

### DIFF
--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -133,6 +133,86 @@ impl<'de> serde::Deserialize<'de> for ScriptsPrependNodePath {
     }
 }
 
+/// `linkWorkspacePackages` from `pnpm-workspace.yaml`. Tri-state: a
+/// bare-semver dependency on a workspace package may resolve to the
+/// local copy, or to a registry copy with the same name, or be
+/// matched only when the user explicitly opts in with a `workspace:`
+/// prefix.
+///
+/// Mirrors pnpm's `linkWorkspacePackages: boolean | 'deep'` at
+/// [`Config.linkWorkspacePackages`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/Config.ts#L189).
+/// Default is [`LinkWorkspacePackages::Off`], matching pnpm's
+/// [`'link-workspace-packages': false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/index.ts#L174)
+/// fallback.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum LinkWorkspacePackages {
+    /// `false`. Workspace packages are matched only when the user
+    /// writes a `workspace:`-prefixed range. A bare-semver range
+    /// always goes to the registry.
+    #[default]
+    Off,
+    /// `true`. Direct dependencies match workspace packages by name
+    /// and version, like a `workspace:` range would; transitive
+    /// dependencies still go to the registry.
+    DirectOnly,
+    /// `"deep"`. Both direct and transitive dependencies match
+    /// workspace packages.
+    Deep,
+}
+
+impl LinkWorkspacePackages {
+    /// Whether the npm resolver should consult the workspace map
+    /// when resolving a bare-semver wanted dependency. Mirrors pnpm's
+    /// [`linkWorkspacePackagesDepth >= currentDepth`](https://github.com/pnpm/pnpm/blob/5353fcbf01/installing/deps-resolver/src/resolveDependencies.ts#L1339)
+    /// gate, collapsed onto pacquet's current shape where the deps
+    /// resolver passes the same `ResolveOptions` to every depth — the
+    /// [`Self::DirectOnly`] arm only fires at the importer level
+    /// (`current_depth == 0`); pacquet's caller decides which arm
+    /// to expose by passing in the current depth.
+    pub fn enabled_at_depth(self, current_depth: u32) -> bool {
+        match self {
+            LinkWorkspacePackages::Off => false,
+            LinkWorkspacePackages::DirectOnly => current_depth == 0,
+            LinkWorkspacePackages::Deep => true,
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LinkWorkspacePackages {
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        use std::fmt;
+
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = LinkWorkspacePackages;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(r#"a boolean or the string "deep""#)
+            }
+            fn visit_bool<DeError: de::Error>(self, value: bool) -> Result<Self::Value, DeError> {
+                Ok(if value {
+                    LinkWorkspacePackages::DirectOnly
+                } else {
+                    LinkWorkspacePackages::Off
+                })
+            }
+            fn visit_str<DeError: de::Error>(self, value: &str) -> Result<Self::Value, DeError> {
+                match value {
+                    "deep" => Ok(LinkWorkspacePackages::Deep),
+                    other => Err(DeError::invalid_value(
+                        de::Unexpected::Str(other),
+                        &r#"true, false, or "deep""#,
+                    )),
+                }
+            }
+        }
+        deserializer.deserialize_any(V)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum PackageImportMethod {
@@ -470,6 +550,14 @@ pub struct Config {
     /// [`hoistingLimits`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/linking/real-hoist/src/index.ts#L10).
     /// No effect under `nodeLinker: isolated`.
     pub hoisting_limits: BTreeMap<String, BTreeSet<String>>,
+
+    /// `linkWorkspacePackages` from `pnpm-workspace.yaml`. Controls
+    /// whether the npm resolver consults the workspace map when
+    /// resolving bare-semver wanted dependencies. See
+    /// [`LinkWorkspacePackages`] for the tri-state semantics.
+    /// Default `false`, matching pnpm's
+    /// [`'link-workspace-packages': false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/index.ts#L174).
+    pub link_workspace_packages: LinkWorkspacePackages,
 
     /// Name slots reserved at the root for an external linker
     /// (the Bit CLI is the only known consumer upstream). Any

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Config, NodeLinker, PackageImportMethod, ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
-    env_replace::env_replace_lossy, resolve_child_concurrency,
+    Config, LinkWorkspacePackages, NodeLinker, PackageImportMethod, ScriptsPrependNodePath,
+    TrustPolicy, api::EnvVar, env_replace::env_replace_lossy, resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -133,6 +133,9 @@ pub struct WorkspaceSettings {
     pub auto_install_peers: Option<bool>,
     pub auto_install_peers_from_highest_match: Option<bool>,
     pub hoist_workspace_packages: Option<bool>,
+    /// `linkWorkspacePackages` from `pnpm-workspace.yaml`. Tri-state
+    /// (`true | false | "deep"`) — see [`LinkWorkspacePackages`].
+    pub link_workspace_packages: Option<LinkWorkspacePackages>,
     /// `hoistingLimits` from `pnpm-workspace.yaml`. Outer key is
     /// the importer locator (e.g. `'.@'`); inner list is the
     /// alias names whose hoisting is bordered. Mirrors upstream's
@@ -389,6 +392,7 @@ impl WorkspaceSettings {
         self.auto_install_peers = None;
         self.auto_install_peers_from_highest_match = None;
         self.hoist_workspace_packages = None;
+        self.link_workspace_packages = None;
         self.dedupe_peer_dependents = None;
         self.strict_peer_dependencies = None;
         self.resolve_peers_from_workspace_root = None;
@@ -484,6 +488,7 @@ impl WorkspaceSettings {
             dedupe_peer_dependents, strict_peer_dependencies,
             resolve_peers_from_workspace_root, verify_store_integrity,
             block_exotic_subdeps,
+            link_workspace_packages,
             side_effects_cache, side_effects_cache_readonly,
             fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -1,5 +1,7 @@
 use super::{LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings};
-use crate::{Config, NodeLinker, ScriptsPrependNodePath, TrustPolicy, api::EnvVar};
+use crate::{
+    Config, LinkWorkspacePackages, NodeLinker, ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
+};
 use pacquet_store_dir::StoreDir;
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
@@ -369,6 +371,40 @@ fn parses_scripts_prepend_node_path_warn_only_from_yaml() {
 #[test]
 fn rejects_invalid_scripts_prepend_node_path() {
     let yaml = "scriptsPrependNodePath: nonsense\n";
+    serde_saphyr::from_str::<WorkspaceSettings>(yaml).expect_err("must reject");
+}
+
+/// `linkWorkspacePackages` accepts `true | false | "deep"`. Mirrors
+/// upstream's [`Config.linkWorkspacePackages`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/Config.ts#L189)
+/// shape.
+#[test]
+fn parses_link_workspace_packages_true_from_yaml() {
+    let yaml = "linkWorkspacePackages: true\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.link_workspace_packages, Some(LinkWorkspacePackages::DirectOnly));
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.link_workspace_packages, LinkWorkspacePackages::DirectOnly);
+}
+
+#[test]
+fn parses_link_workspace_packages_false_from_yaml() {
+    let yaml = "linkWorkspacePackages: false\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.link_workspace_packages, Some(LinkWorkspacePackages::Off));
+}
+
+#[test]
+fn parses_link_workspace_packages_deep_from_yaml() {
+    let yaml = "linkWorkspacePackages: deep\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.link_workspace_packages, Some(LinkWorkspacePackages::Deep));
+}
+
+#[test]
+fn rejects_invalid_link_workspace_packages() {
+    let yaml = "linkWorkspacePackages: shallow\n";
     serde_saphyr::from_str::<WorkspaceSettings>(yaml).expect_err("must reject");
 }
 

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -11,7 +11,7 @@ use pacquet_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::{Config, NodeLinker};
+use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker};
 use pacquet_lockfile::{
     LoadLockfileError, Lockfile, SaveLockfileError, StalenessReason, satisfies_package_manifest,
 };
@@ -1171,6 +1171,18 @@ fn map_workspace_state_node_linker(linker: &NodeLinker) -> WorkspaceStateNodeLin
     }
 }
 
+/// Encode [`LinkWorkspacePackages`] into the JSON shape pnpm writes
+/// to `.pnpm-workspace-state-v1.json`. Tri-state on the wire
+/// (`true | false | "deep"`) so a future read by pnpm sees the same
+/// value pacquet ran with.
+fn link_workspace_packages_to_json(value: LinkWorkspacePackages) -> serde_json::Value {
+    match value {
+        LinkWorkspacePackages::Off => serde_json::Value::Bool(false),
+        LinkWorkspacePackages::DirectOnly => serde_json::Value::Bool(true),
+        LinkWorkspacePackages::Deep => serde_json::Value::String("deep".to_string()),
+    }
+}
+
 /// Read a string field off a project manifest, returning `None` when
 /// the field is missing or not a JSON string. Pnpm tolerates either
 /// shape — `name`/`version` are advisory metadata in this context, so
@@ -1333,6 +1345,9 @@ fn build_workspace_state(
             hoist_pattern: config.hoist_pattern.clone(),
             hoist_workspace_packages: Some(config.hoist_workspace_packages),
             ignored_optional_dependencies: config.ignored_optional_dependencies.clone(),
+            link_workspace_packages: Some(link_workspace_packages_to_json(
+                config.link_workspace_packages,
+            )),
             node_linker: Some(map_workspace_state_node_linker(&node_linker)),
             optional: Some(included.optional_dependencies),
             overrides: config.overrides.as_ref().map(|map| {

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -47,6 +47,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         auto_install_peers_from_highest_match: false,
         hoist_workspace_packages: true,
         hoisting_limits: Default::default(),
+        link_workspace_packages: Default::default(),
         external_dependencies: Default::default(),
         dedupe_peer_dependents: false,
         strict_peer_dependencies: false,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -11,7 +11,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_cmd_shim::{Host, LinkBinsError, link_bins};
-use pacquet_config::{Config, NodeLinker};
+use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker};
 use pacquet_engine_runtime_bun_resolver::BunResolver;
 use pacquet_engine_runtime_deno_resolver::DenoResolver;
 use pacquet_engine_runtime_node_resolver::NodeResolver;
@@ -561,6 +561,16 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     lockfile_dir: lockfile_dir.to_path_buf(),
                     workspace_packages: workspace_packages.clone(),
                     block_exotic_subdeps: config.block_exotic_subdeps,
+                    // Pacquet's deps-resolver doesn't thread per-call
+                    // depth into the resolver yet, so the
+                    // `linkWorkspacePackages: true` (direct-only) and
+                    // `"deep"` arms both collapse onto a flag that
+                    // applies at every depth. Matches pnpm's behavior
+                    // for `"deep"`; the (rare) `true`-only case may
+                    // resolve a transitive registry dep through the
+                    // workspace when the names collide.
+                    always_try_workspace_packages: config.link_workspace_packages
+                        != LinkWorkspacePackages::Off,
                     ..ResolveOptions::default()
                 },
                 catalogs: catalogs.clone(),

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -249,7 +249,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                 return Ok(None);
             }
             Err(err) => {
-                // Registry fetch errored (404, network failure, …).
+                // Registry fetch errored (404, network failure, ...).
                 // Mirrors upstream's
                 // [`try { pickPackage } catch`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L506-L524)
                 // — swallow the error if the workspace can satisfy

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -31,6 +31,7 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
+use node_semver::Version;
 use pacquet_config::version_policy::PackageVersionPolicy;
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
 use pacquet_network::{AuthHeaders, ThrottledClient};
@@ -38,6 +39,7 @@ use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolutionPolicyViolation, ResolveError, ResolveFuture,
     ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior, WantedDependency,
+    WorkspacePackages,
 };
 
 use crate::{
@@ -45,7 +47,11 @@ use crate::{
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
-    resolve_from_workspace::{ResolveFromWorkspaceOptions, try_resolve_from_workspace},
+    resolve_from_workspace::{
+        ResolveFromWorkspaceOptions, pick_matching_local_version_or_null,
+        resolve_from_local_package, try_resolve_from_workspace,
+        try_resolve_from_workspace_packages,
+    },
     violation_codes::MINIMUM_RELEASE_AGE_VIOLATION_CODE,
 };
 
@@ -215,10 +221,65 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         };
 
         let optional = wanted_dependency.optional.unwrap_or(false);
-        let picked = match self.pick_from_registry(&registry, &spec, opts, optional).await? {
-            Some(picked) => picked,
-            None => return Ok(None),
+        // `link-workspace-packages` gate. Mirrors upstream's
+        // [`opts.alwaysTryWorkspacePackages !== false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L435)
+        // collapse: when the install caller has flipped the flag off,
+        // the registry pick is the only path and the workspace map is
+        // ignored entirely.
+        let workspace_packages_active = opts
+            .always_try_workspace_packages
+            .then_some(opts.workspace_packages.as_ref())
+            .flatten();
+
+        let pick_result = self.pick_from_registry(&registry, &spec, opts, optional).await;
+        let picked = match pick_result {
+            Ok(Some(picked)) => picked,
+            Ok(None) => {
+                // Registry returned a packument but no version
+                // satisfies the spec. Mirrors upstream's
+                // [`pickedPackage == null` branch](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L527-L545)
+                // — fall back to the workspace before reporting "no
+                // matching version".
+                if let Some(workspace_packages) = workspace_packages_active
+                    && let Some(result) =
+                        try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
+                {
+                    return Ok(Some(result));
+                }
+                return Ok(None);
+            }
+            Err(err) => {
+                // Registry fetch errored (404, network failure, …).
+                // Mirrors upstream's
+                // [`try { pickPackage } catch`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L506-L524)
+                // — swallow the error if the workspace can satisfy
+                // the request; otherwise surface the original.
+                if let Some(workspace_packages) = workspace_packages_active
+                    && let Some(result) =
+                        try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
+                {
+                    return Ok(Some(result));
+                }
+                return Err(err);
+            }
         };
+
+        // Registry pick succeeded — prefer the workspace copy when it
+        // matches (or is newer, or `preferWorkspacePackages` is on).
+        // Mirrors upstream's
+        // [registry-pick + workspace shadow](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L550-L582).
+        if let Some(workspace_packages) = workspace_packages_active
+            && let Some(mut result) = try_workspace_shadow(
+                workspace_packages,
+                &spec,
+                &picked.version,
+                wanted_dependency,
+                opts,
+            )
+        {
+            result.latest = picked.meta.dist_tag("latest").map(str::to_string);
+            return Ok(Some(result));
+        }
 
         let result = build_resolve_result(BuildResolveResult {
             meta: &picked.meta,
@@ -364,6 +425,83 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             return Ok(Some(LatestInfo { latest_manifest: None }));
         }
         Ok(Some(LatestInfo { latest_manifest: result.manifest }))
+    }
+}
+
+/// Registry pick was unavailable (no matching version or fetch
+/// error); try the workspace as a fallback. Mirrors upstream's
+/// `tryResolveFromWorkspacePackages` invocations at
+/// [`index.ts#L505-L523`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L505-L523)
+/// and [`index.ts#L528-L543`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L528-L543).
+/// Workspace errors (missing name, no matching version) are swallowed
+/// — the caller re-raises the original registry error.
+fn try_workspace_fallback(
+    workspace_packages: &WorkspacePackages,
+    spec: &RegistryPackageSpec,
+    wanted_dependency: &WantedDependency,
+    opts: &ResolveOptions,
+) -> Option<ResolveResult> {
+    let ws_opts = workspace_fallback_options(opts);
+    try_resolve_from_workspace_packages(workspace_packages, spec, wanted_dependency, &ws_opts).ok()
+}
+
+/// Registry pick succeeded; check whether a workspace package
+/// shadows it. Mirrors upstream's
+/// [registry-pick + workspace shadow](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L550-L582):
+/// exact `name@version` match wins; otherwise a higher workspace
+/// version wins; otherwise `preferWorkspacePackages` wins.
+fn try_workspace_shadow(
+    workspace_packages: &WorkspacePackages,
+    spec: &RegistryPackageSpec,
+    picked: &PackageVersion,
+    wanted_dependency: &WantedDependency,
+    opts: &ResolveOptions,
+) -> Option<ResolveResult> {
+    let matching_name = workspace_packages.get(picked.name.as_str())?;
+    let hard_link = opts.inject_workspace_packages || wanted_dependency.injected.unwrap_or(false);
+    let project_dir = opts.project_dir.as_path();
+    let lockfile_dir = opts.lockfile_dir.as_path();
+
+    let picked_version_string = picked.version.to_string();
+    if let Some(matched) = matching_name.get(&picked_version_string) {
+        return Some(resolve_from_local_package(
+            matched,
+            wanted_dependency,
+            hard_link,
+            project_dir,
+            lockfile_dir,
+        ));
+    }
+
+    let local_version = pick_matching_local_version_or_null(matching_name, spec)?;
+    let local_parsed = Version::parse(&local_version).ok()?;
+    let prefer = opts.prefer_workspace_packages || local_parsed > picked.version;
+    if !prefer {
+        return None;
+    }
+    let local_package = matching_name.get(&local_version)?;
+    Some(resolve_from_local_package(
+        local_package,
+        wanted_dependency,
+        hard_link,
+        project_dir,
+        lockfile_dir,
+    ))
+}
+
+/// Build the [`ResolveFromWorkspaceOptions`] bag the workspace
+/// fallback helper expects. `registry` and `default_tag` are unused on
+/// the fallback path (the spec has already been parsed against the
+/// registry) so dummy values are passed through.
+fn workspace_fallback_options<'a>(opts: &'a ResolveOptions) -> ResolveFromWorkspaceOptions<'a> {
+    const UNUSED: &str = "";
+    ResolveFromWorkspaceOptions {
+        project_dir: opts.project_dir.as_path(),
+        lockfile_dir: opts.lockfile_dir.as_path(),
+        registry: UNUSED,
+        default_tag: UNUSED,
+        workspace_packages: opts.workspace_packages.as_ref(),
+        inject_workspace_packages: opts.inject_workspace_packages,
     }
 }
 

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -714,3 +714,244 @@ async fn workspace_higher_version_shadows_registry_pick() {
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace shadow");
     assert_eq!(result.resolved_via, "workspace");
 }
+
+/// Build a workspace map where each version sits in its own
+/// `root_dir`. The convenience helper [`build_workspace_packages`]
+/// reuses one dir; tests that exercise multi-version pick (like the
+/// "latest installed" port below) need per-version dirs so the
+/// resolved `link:` path proves the right version was picked.
+fn build_workspace_packages_at(name: &str, entries: &[(&str, &str)]) -> WorkspacePackages {
+    let mut by_version: WorkspacePackagesByVersion = BTreeMap::new();
+    for (version, dir) in entries {
+        by_version.insert(
+            (*version).to_string(),
+            WorkspacePackage {
+                root_dir: PathBuf::from(*dir),
+                manifest: json!({ "name": name, "version": version }),
+            },
+        );
+    }
+    let mut packages: WorkspacePackages = BTreeMap::new();
+    packages.insert(name.to_string(), by_version);
+    packages
+}
+
+/// Ports pnpm's
+/// [`resolve injected dependency from local directory when it matches the latest version of the package`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1167-L1206)
+/// — workspace-shadow branch where `injected: true` flips the
+/// resolution to a hard-link `file:` shape instead of `link:`.
+#[tokio::test]
+async fn injected_workspace_match_emits_file_resolution() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.0.0",
+            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0".to_string()),
+        injected: Some(true),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace shadow");
+    assert_eq!(result.resolved_via, "workspace");
+    // `lockfile_dir` is `/repo`; `acme` lives at `/repo/packages/acme`,
+    // so the injected `file:` path renders as `packages/acme`.
+    assert_eq!(result.id.as_str(), "file:packages/acme");
+    match &result.resolution {
+        LockfileResolution::Directory(dir) => assert_eq!(dir.directory, "packages/acme"),
+        other => panic!("expected directory resolution, got {other:?}"),
+    }
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when package is not found in the registry and latest installed`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1494-L1544)
+/// — 404 fallback path picks the highest version from a multi-version
+/// workspace.
+#[tokio::test]
+async fn workspace_fallback_picks_highest_version_for_latest_tag() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages_at(
+        "acme",
+        &[
+            ("1.0.0", "/repo/packages/acme-1.0.0"),
+            ("1.1.0", "/repo/packages/acme-1.1.0"),
+            ("2.0.0", "/repo/packages/acme-2.0.0"),
+        ],
+    );
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("latest".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme-2.0.0");
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when package is not found in the registry and local prerelease available`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1546-L1582)
+/// — 404 fallback path against a workspace whose only version is a
+/// prerelease, picked via the `*` `includePrerelease` branch in
+/// `resolve_workspace_range`.
+#[tokio::test]
+async fn workspace_fallback_picks_local_prerelease_for_latest_tag() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["3.0.0-alpha.1.2.3"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("latest".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when package is not found in the registry and specific version is requested`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1584-L1634)
+/// — 404 fallback path with a pinned version-spec lookup against the
+/// workspace.
+#[tokio::test]
+async fn workspace_fallback_resolves_specific_version_request() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages_at(
+        "acme",
+        &[
+            ("1.0.0", "/repo/packages/acme-1.0.0"),
+            ("1.1.0", "/repo/packages/acme-1.1.0"),
+            ("2.0.0", "/repo/packages/acme-2.0.0"),
+        ],
+    );
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.1.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme-1.1.0");
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when the requested version is not found in the registry but is available locally`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1636-L1672)
+/// — the `Ok(None)` fallback path (registry serves a packument but no
+/// version matches), separate from the 404 `Err` path the other
+/// fallback tests exercise.
+#[tokio::test]
+async fn workspace_fallback_kicks_in_when_registry_lacks_requested_version() {
+    let mut server = mockito::Server::new_async().await;
+    // Registry returns a packument but the picker won't find 100.0.0
+    // in it. That collapses to `Ok(None)` inside the resolver — the
+    // separate branch from the 404 `Err` cases above.
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.0.0",
+            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["100.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("100.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+}
+
+/// Ports pnpm's
+/// [`throws when workspace package version does not match and package is not found in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2092-L2121)
+/// — 404 + no satisfying workspace version must propagate the
+/// original registry error, not silently succeed.
+#[tokio::test]
+async fn registry_error_propagates_when_workspace_has_no_matching_version() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let err = resolver
+        .resolve(&wanted, &opts)
+        .await
+        .expect_err("workspace can't satisfy 2.0.0; original 404 error must surface");
+    assert!(err.to_string().contains("404"), "expected the 404 to propagate, got: {}", err,);
+}
+
+/// Ports pnpm's
+/// [`resolve from registry when workspace package version does not match the requested version`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2154-L2183)
+/// — when the registry pick succeeds and the workspace carries the
+/// same package but a different version, the registry copy wins.
+#[tokio::test]
+async fn registry_pick_wins_when_workspace_version_does_not_match() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "3.1.0",
+            "sha512-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("3.1.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
+    assert_eq!(result.resolved_via, "npm-registry");
+    assert_eq!(result.id.as_str(), "acme@3.1.0");
+}

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1,12 +1,18 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use chrono::TimeZone;
 use pacquet_lockfile::LockfileResolution;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, ResolveOptions, Resolver, UpdateBehavior, WantedDependency,
+    LatestQuery, ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackage,
+    WorkspacePackages, WorkspacePackagesByVersion,
 };
 use pretty_assertions::assert_eq;
+use serde_json::json;
 use tempfile::TempDir;
 
 use crate::{
@@ -466,4 +472,245 @@ async fn shared_manifest_cache_does_not_leak_across_registries() {
         !deps_b.contains_key("left-pad"),
         "resolver B must not see resolver A's `left-pad`: {deps_b:?}",
     );
+}
+
+/// Packument body used by the `linkWorkspacePackages` ports. Same
+/// `acme` shape as [`PACKAGE_BODY`] but trimmed to a single version
+/// so each test can mock the registry's reply against a specific
+/// version-vs-workspace relationship.
+fn single_version_body(version: &str, integrity: &str) -> String {
+    format!(
+        r#"{{
+            "name": "acme",
+            "dist-tags": {{ "latest": "{version}" }},
+            "modified": "2025-01-15T12:00:00.000Z",
+            "time": {{ "{version}": "2024-01-10T08:30:00.000Z" }},
+            "versions": {{
+                "{version}": {{
+                    "name": "acme",
+                    "version": "{version}",
+                    "dist": {{
+                        "integrity": "{integrity}",
+                        "shasum": "0000000000000000000000000000000000000000",
+                        "tarball": "https://registry/acme-{version}.tgz"
+                    }}
+                }}
+            }}
+        }}"#,
+    )
+}
+
+fn build_workspace_packages(name: &str, versions: &[&str]) -> WorkspacePackages {
+    let mut by_version: WorkspacePackagesByVersion = BTreeMap::new();
+    for version in versions {
+        by_version.insert(
+            (*version).to_string(),
+            WorkspacePackage {
+                root_dir: PathBuf::from(format!("/repo/packages/{name}")),
+                manifest: json!({ "name": name, "version": version }),
+            },
+        );
+    }
+    let mut packages: WorkspacePackages = BTreeMap::new();
+    packages.insert(name.to_string(), by_version);
+    packages
+}
+
+fn workspace_resolve_options(packages: WorkspacePackages) -> ResolveOptions {
+    ResolveOptions {
+        project_dir: Path::new("/repo/packages/consumer").to_path_buf(),
+        lockfile_dir: Path::new("/repo").to_path_buf(),
+        workspace_packages: Some(packages),
+        always_try_workspace_packages: true,
+        ..ResolveOptions::default()
+    }
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when package is not found in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1442-L1491)
+/// — the case that drives #11929 (babylon's `@dev/build-tools` is not
+/// on the public npm registry; bare-semver must still find it
+/// locally).
+#[tokio::test]
+async fn falls_back_to_workspace_when_registry_returns_404() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server.mock("GET", "/acme").with_status(404).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace fallback");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+    match &result.resolution {
+        LockfileResolution::Directory(dir) => assert_eq!(dir.directory, "../acme"),
+        other => panic!("expected directory resolution, got {other:?}"),
+    }
+}
+
+/// Ports pnpm's
+/// [`resolve from local directory when it matches the latest version of the package`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1129-L1166)
+/// — the bare-semver branch where registry pick and workspace agree
+/// on the exact `name@version`.
+#[tokio::test]
+async fn workspace_shadows_registry_when_name_and_version_match() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.0.0",
+            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace shadow");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+    // `latest` is back-stamped from the registry packument so the
+    // install layer can still surface upgrade hints.
+    assert_eq!(result.latest.as_deref(), Some("1.0.0"));
+}
+
+/// Ports pnpm's
+/// [`do not resolve from local directory when alwaysTryWorkspacePackages is false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1208-L1245)
+/// — gating the workspace lookup with the per-call flag.
+#[tokio::test]
+async fn always_try_workspace_packages_false_skips_workspace_match() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.0.0",
+            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.always_try_workspace_packages = false;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
+    assert_eq!(result.resolved_via, "npm-registry");
+    assert_eq!(result.id.as_str(), "acme@1.0.0");
+}
+
+/// Ports pnpm's
+/// [`use version from the registry if it is newer than the local one`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1315-L1357)
+/// — `preferWorkspacePackages` defaults to false, so a higher
+/// registry version wins.
+#[tokio::test]
+async fn registry_version_higher_than_workspace_keeps_registry_pick() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("registry pick");
+    assert_eq!(result.resolved_via, "npm-registry");
+    assert_eq!(result.id.as_str(), "acme@1.1.0");
+}
+
+/// Ports pnpm's
+/// [`preferWorkspacePackages: use version from the workspace even if there is newer version in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1358-L1398).
+#[tokio::test]
+async fn prefer_workspace_packages_keeps_workspace_over_newer_registry() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.1.0",
+            "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["1.0.0"]);
+    let mut opts = workspace_resolve_options(packages);
+    opts.prefer_workspace_packages = true;
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace pick");
+    assert_eq!(result.resolved_via, "workspace");
+    assert_eq!(result.id.as_str(), "link:../acme");
+}
+
+/// Ports pnpm's
+/// [`use local version if it is newer than the latest in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1399-L1441)
+/// — the workspace shadow's `semver.gt` arm.
+#[tokio::test]
+async fn workspace_higher_version_shadows_registry_pick() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(single_version_body(
+            "1.0.0",
+            "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+        ))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let packages = build_workspace_packages("acme", &["2.0.0"]);
+    let opts = workspace_resolve_options(packages);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some(">=1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace shadow");
+    assert_eq!(result.resolved_via, "workspace");
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -474,10 +474,6 @@ async fn shared_manifest_cache_does_not_leak_across_registries() {
     );
 }
 
-/// Packument body used by the `linkWorkspacePackages` ports. Same
-/// `acme` shape as [`PACKAGE_BODY`] but trimmed to a single version
-/// so each test can mock the registry's reply against a specific
-/// version-vs-workspace relationship.
 fn single_version_body(version: &str, integrity: &str) -> String {
     format!(
         r#"{{
@@ -526,11 +522,9 @@ fn workspace_resolve_options(packages: WorkspacePackages) -> ResolveOptions {
     }
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when package is not found in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1442-L1491)
-/// — the case that drives #11929 (babylon's `@dev/build-tools` is not
-/// on the public npm registry; bare-semver must still find it
-/// locally).
+/// Ports pnpm's [`index.ts#L1442-L1491`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1442-L1491);
+/// this is the case behind #11929 (babylon's `@dev/build-tools`
+/// isn't on npm, so bare-semver must resolve via the workspace).
 #[tokio::test]
 async fn falls_back_to_workspace_when_registry_returns_404() {
     let mut server = mockito::Server::new_async().await;
@@ -555,10 +549,7 @@ async fn falls_back_to_workspace_when_registry_returns_404() {
     }
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when it matches the latest version of the package`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1129-L1166)
-/// — the bare-semver branch where registry pick and workspace agree
-/// on the exact `name@version`.
+/// Ports pnpm's [`index.ts#L1129-L1166`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1129-L1166).
 #[tokio::test]
 async fn workspace_shadows_registry_when_name_and_version_match() {
     let mut server = mockito::Server::new_async().await;
@@ -590,9 +581,7 @@ async fn workspace_shadows_registry_when_name_and_version_match() {
     assert_eq!(result.latest.as_deref(), Some("1.0.0"));
 }
 
-/// Ports pnpm's
-/// [`do not resolve from local directory when alwaysTryWorkspacePackages is false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1208-L1245)
-/// — gating the workspace lookup with the per-call flag.
+/// Ports pnpm's [`index.ts#L1208-L1245`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1208-L1245).
 #[tokio::test]
 async fn always_try_workspace_packages_false_skips_workspace_match() {
     let mut server = mockito::Server::new_async().await;
@@ -622,10 +611,7 @@ async fn always_try_workspace_packages_false_skips_workspace_match() {
     assert_eq!(result.id.as_str(), "acme@1.0.0");
 }
 
-/// Ports pnpm's
-/// [`use version from the registry if it is newer than the local one`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1315-L1357)
-/// — `preferWorkspacePackages` defaults to false, so a higher
-/// registry version wins.
+/// Ports pnpm's [`index.ts#L1315-L1357`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1315-L1357).
 #[tokio::test]
 async fn registry_version_higher_than_workspace_keeps_registry_pick() {
     let mut server = mockito::Server::new_async().await;
@@ -654,8 +640,7 @@ async fn registry_version_higher_than_workspace_keeps_registry_pick() {
     assert_eq!(result.id.as_str(), "acme@1.1.0");
 }
 
-/// Ports pnpm's
-/// [`preferWorkspacePackages: use version from the workspace even if there is newer version in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1358-L1398).
+/// Ports pnpm's [`index.ts#L1358-L1398`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1358-L1398).
 #[tokio::test]
 async fn prefer_workspace_packages_keeps_workspace_over_newer_registry() {
     let mut server = mockito::Server::new_async().await;
@@ -685,9 +670,7 @@ async fn prefer_workspace_packages_keeps_workspace_over_newer_registry() {
     assert_eq!(result.id.as_str(), "link:../acme");
 }
 
-/// Ports pnpm's
-/// [`use local version if it is newer than the latest in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1399-L1441)
-/// — the workspace shadow's `semver.gt` arm.
+/// Ports pnpm's [`index.ts#L1399-L1441`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1399-L1441).
 #[tokio::test]
 async fn workspace_higher_version_shadows_registry_pick() {
     let mut server = mockito::Server::new_async().await;
@@ -715,11 +698,8 @@ async fn workspace_higher_version_shadows_registry_pick() {
     assert_eq!(result.resolved_via, "workspace");
 }
 
-/// Build a workspace map where each version sits in its own
-/// `root_dir`. The convenience helper [`build_workspace_packages`]
-/// reuses one dir; tests that exercise multi-version pick (like the
-/// "latest installed" port below) need per-version dirs so the
-/// resolved `link:` path proves the right version was picked.
+/// Per-version `root_dir`s so the resolved `link:` path identifies
+/// which workspace entry the resolver picked.
 fn build_workspace_packages_at(name: &str, entries: &[(&str, &str)]) -> WorkspacePackages {
     let mut by_version: WorkspacePackagesByVersion = BTreeMap::new();
     for (version, dir) in entries {
@@ -736,10 +716,7 @@ fn build_workspace_packages_at(name: &str, entries: &[(&str, &str)]) -> Workspac
     packages
 }
 
-/// Ports pnpm's
-/// [`resolve injected dependency from local directory when it matches the latest version of the package`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1167-L1206)
-/// — workspace-shadow branch where `injected: true` flips the
-/// resolution to a hard-link `file:` shape instead of `link:`.
+/// Ports pnpm's [`index.ts#L1167-L1206`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1167-L1206).
 #[tokio::test]
 async fn injected_workspace_match_emits_file_resolution() {
     let mut server = mockito::Server::new_async().await;
@@ -766,8 +743,6 @@ async fn injected_workspace_match_emits_file_resolution() {
     };
     let result = resolver.resolve(&wanted, &opts).await.unwrap().expect("workspace shadow");
     assert_eq!(result.resolved_via, "workspace");
-    // `lockfile_dir` is `/repo`; `acme` lives at `/repo/packages/acme`,
-    // so the injected `file:` path renders as `packages/acme`.
     assert_eq!(result.id.as_str(), "file:packages/acme");
     match &result.resolution {
         LockfileResolution::Directory(dir) => assert_eq!(dir.directory, "packages/acme"),
@@ -775,10 +750,7 @@ async fn injected_workspace_match_emits_file_resolution() {
     }
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when package is not found in the registry and latest installed`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1494-L1544)
-/// — 404 fallback path picks the highest version from a multi-version
-/// workspace.
+/// Ports pnpm's [`index.ts#L1494-L1544`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1494-L1544).
 #[tokio::test]
 async fn workspace_fallback_picks_highest_version_for_latest_tag() {
     let mut server = mockito::Server::new_async().await;
@@ -806,11 +778,8 @@ async fn workspace_fallback_picks_highest_version_for_latest_tag() {
     assert_eq!(result.id.as_str(), "link:../acme-2.0.0");
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when package is not found in the registry and local prerelease available`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1546-L1582)
-/// — 404 fallback path against a workspace whose only version is a
-/// prerelease, picked via the `*` `includePrerelease` branch in
-/// `resolve_workspace_range`.
+/// Ports pnpm's [`index.ts#L1546-L1582`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1546-L1582);
+/// exercises the `includePrerelease` arm of `resolve_workspace_range`.
 #[tokio::test]
 async fn workspace_fallback_picks_local_prerelease_for_latest_tag() {
     let mut server = mockito::Server::new_async().await;
@@ -831,10 +800,7 @@ async fn workspace_fallback_picks_local_prerelease_for_latest_tag() {
     assert_eq!(result.id.as_str(), "link:../acme");
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when package is not found in the registry and specific version is requested`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1584-L1634)
-/// — 404 fallback path with a pinned version-spec lookup against the
-/// workspace.
+/// Ports pnpm's [`index.ts#L1584-L1634`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1584-L1634).
 #[tokio::test]
 async fn workspace_fallback_resolves_specific_version_request() {
     let mut server = mockito::Server::new_async().await;
@@ -862,17 +828,12 @@ async fn workspace_fallback_resolves_specific_version_request() {
     assert_eq!(result.id.as_str(), "link:../acme-1.1.0");
 }
 
-/// Ports pnpm's
-/// [`resolve from local directory when the requested version is not found in the registry but is available locally`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1636-L1672)
-/// — the `Ok(None)` fallback path (registry serves a packument but no
-/// version matches), separate from the 404 `Err` path the other
-/// fallback tests exercise.
+/// Ports pnpm's [`index.ts#L1636-L1672`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L1636-L1672);
+/// covers the `Ok(None)` fallback arm (200 + no matching version),
+/// distinct from the `Err` 404 arm.
 #[tokio::test]
 async fn workspace_fallback_kicks_in_when_registry_lacks_requested_version() {
     let mut server = mockito::Server::new_async().await;
-    // Registry returns a packument but the picker won't find 100.0.0
-    // in it. That collapses to `Ok(None)` inside the resolver — the
-    // separate branch from the 404 `Err` cases above.
     let _mock = server
         .mock("GET", "/acme")
         .with_status(200)
@@ -898,10 +859,7 @@ async fn workspace_fallback_kicks_in_when_registry_lacks_requested_version() {
     assert_eq!(result.id.as_str(), "link:../acme");
 }
 
-/// Ports pnpm's
-/// [`throws when workspace package version does not match and package is not found in the registry`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2092-L2121)
-/// — 404 + no satisfying workspace version must propagate the
-/// original registry error, not silently succeed.
+/// Ports pnpm's [`index.ts#L2092-L2121`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2092-L2121).
 #[tokio::test]
 async fn registry_error_propagates_when_workspace_has_no_matching_version() {
     let mut server = mockito::Server::new_async().await;
@@ -924,10 +882,7 @@ async fn registry_error_propagates_when_workspace_has_no_matching_version() {
     assert!(err.to_string().contains("404"), "expected the 404 to propagate, got: {}", err);
 }
 
-/// Ports pnpm's
-/// [`resolve from registry when workspace package version does not match the requested version`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2154-L2183)
-/// — when the registry pick succeeds and the workspace carries the
-/// same package but a different version, the registry copy wins.
+/// Ports pnpm's [`index.ts#L2154-L2183`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts#L2154-L2183).
 #[tokio::test]
 async fn registry_pick_wins_when_workspace_version_does_not_match() {
     let mut server = mockito::Server::new_async().await;

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -921,7 +921,7 @@ async fn registry_error_propagates_when_workspace_has_no_matching_version() {
         .resolve(&wanted, &opts)
         .await
         .expect_err("workspace can't satisfy 2.0.0; original 404 error must surface");
-    assert!(err.to_string().contains("404"), "expected the 404 to propagate, got: {}", err,);
+    assert!(err.to_string().contains("404"), "expected the 404 to propagate, got: {}", err);
 }
 
 /// Ports pnpm's

--- a/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
@@ -166,7 +166,7 @@ pub fn try_resolve_from_workspace(
     Ok(Some(result))
 }
 
-fn try_resolve_from_workspace_packages(
+pub(crate) fn try_resolve_from_workspace_packages(
     workspace_packages: &WorkspacePackages,
     spec: &RegistryPackageSpec,
     wanted_dependency: &WantedDependency,
@@ -211,7 +211,7 @@ fn try_resolve_from_workspace_packages(
 
 /// Mirror upstream's
 /// [`pickMatchingLocalVersionOrNull`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L890-L906).
-fn pick_matching_local_version_or_null(
+pub(crate) fn pick_matching_local_version_or_null(
     versions: &WorkspacePackagesByVersion,
     spec: &RegistryPackageSpec,
 ) -> Option<String> {
@@ -238,7 +238,7 @@ fn pick_matching_local_version_or_null(
 /// doesn't carry the pinned-version / save-workspace-protocol config
 /// through to the resolver yet, so the field stays `None` until those
 /// land.
-fn resolve_from_local_package(
+pub(crate) fn resolve_from_local_package(
     local_package: &WorkspacePackage,
     wanted_dependency: &WantedDependency,
     hard_link_local_packages: bool,


### PR DESCRIPTION
## Summary

- Mirrors pnpm's three workspace branches around `pickPackage` in pacquet's npm resolver, so a bare-semver dependency on a workspace package can resolve to the local copy instead of going to (or 404-ing on) the registry.
- Adds tri-state `linkWorkspacePackages` (`true | false | "deep"`) parsing to `pnpm-workspace.yaml`, threads it through `Config`, and encodes it into `ResolveOptions::always_try_workspace_packages` at the install layer.
- Includes the new entry in `.pnpm-workspace-state-v1.json` so a subsequent `pnpm` invocation can detect a setting change.

Closes #11929.

## Why

Pacquet's `NpmResolver::resolve_impl` only routed `workspace:`-prefixed specs through `try_resolve_from_workspace`. For bare-semver specs (e.g. `\"@dev/build-tools\": \"^1.0.0\"` where `@dev/build-tools` is a workspace package), it fell straight through to the registry picker. The vlt.sh babylon fixture hits this path, gets a 404 from npm for `@dev/build-tools`, and reports DNF on every variation.

For users whose workspace package shares a name with a published npm package, the same gap silently links the wrong copy.

## How

In `resolving-npm-resolver/src/npm_resolver.rs::resolve_impl`:

- Compute `workspace_packages_active = always_try_workspace_packages ? workspace_packages : None`. Matches pnpm's `opts.alwaysTryWorkspacePackages !== false` gate at [`index.ts#L435`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L435).
- On `pick_package` returning `Ok(None)` or `Err(_)`, try `try_resolve_from_workspace_packages` (already used by the `workspace:` path) before reporting "no matching version" or surfacing the original fetch error. Workspace errors are swallowed.
- On `Ok(Some(picked))`, run the registry-pick + workspace-shadow logic from [`index.ts#L550-L582`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L550-L582): exact `name@version` match wins, a higher workspace version wins, `preferWorkspacePackages` wins.

The existing `try_resolve_from_workspace_packages`, `pick_matching_local_version_or_null`, and `resolve_from_local_package` helpers in `resolve_from_workspace.rs` are promoted to `pub(crate)` so the npm resolver can call them directly (matching the way upstream factors the same helpers).

In `pacquet-config`:

- New `LinkWorkspacePackages` tri-state enum with a custom `Deserialize` accepting `bool | "deep"`, mirroring [`Config.linkWorkspacePackages`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/Config.ts#L189).
- Added to `Config` (default `Off`) and to `WorkspaceSettings::apply_to`. Listed in `clear_workspace_only_fields` to match the global config filter at [`configFileKey.ts#L113`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/configFileKey.ts#L113).

In `pacquet-package-manager`:

- `install_with_fresh_lockfile.rs` sets `always_try_workspace_packages` from `config.link_workspace_packages != Off`.
- `install.rs` serializes the value into `WorkspaceStateSettings.link_workspace_packages` as the same tri-state JSON shape pnpm writes.

### Behavioral note

Pacquet's deps-resolver currently passes a single `base_opts` to every resolve call, with no per-depth differentiation. Pnpm gates the workspace lookup by `linkWorkspacePackagesDepth >= currentDepth` so `true` applies only to depth 0 and `"deep"` applies to every depth. With pacquet's current shape, `true` and `"deep"` both collapse onto a single flag that applies at every depth. The (rare) result is that a transitive registry dep whose name and version match a workspace package may resolve to the workspace instead of the registry under `linkWorkspacePackages: true`. Threading per-call depth into the resolver is a follow-up.

## Test plan

- [x] `cargo nextest run -p pacquet-config -p pacquet-resolving-npm-resolver -p pacquet-package-manager` — 743 passed
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings`
- [x] `cargo fmt -- --check`
- [x] Ported the upstream tests at [`resolving/npm-resolver/test/index.ts`](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/test/index.ts) covering branches 2 and 3 (`falls_back_to_workspace_when_registry_returns_404`, `workspace_shadows_registry_when_name_and_version_match`, `always_try_workspace_packages_false_skips_workspace_match`, `registry_version_higher_than_workspace_keeps_registry_pick`, `prefer_workspace_packages_keeps_workspace_over_newer_registry`, `workspace_higher_version_shadows_registry_pick`).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tri-state linkWorkspacePackages setting (off, direct-only, or "deep") — accepts true/false/"deep".
  * Resolver can consult, fallback to, or shadow registry results with workspace packages according to the new setting.
  * Workspace-level setting can be specified in workspace YAML and is persisted in workspace state so installs remember behavior.

* **Tests**
  * Added tests validating deserialization, config application, and resolver scenarios (fallback, shadowing, preference).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->