### PR TITLE
fix(pacquet/resolving-npm-resolver): singleflight verifier lookup caches

### DIFF
--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -30,6 +30,7 @@ use pacquet_resolving_resolver_base::{
 };
 use pipe_trait::Pipe;
 use serde_json::Value as JsonValue;
+use tokio::sync::OnceCell;
 
 use crate::{
     FetchAttestationOptions, FetchFullMetadataCachedOptions, TrustCheckOptions, TrustViolation,
@@ -453,15 +454,13 @@ impl NpmResolutionVerifier {
         version: &str,
     ) -> Result<Option<String>, String> {
         let key = version_key(registry, &name.to_string(), version);
-        {
-            let cache = self.lookup_context.published_at.lock().await;
-            if let Some(value) = cache.get(&key) {
-                return Ok(value.clone());
-            }
-        }
-        let value = self.resolve_published_at(registry, name, version).await?;
-        let mut cache = self.lookup_context.published_at.lock().await;
-        Ok(cache.entry(key).or_insert(value).clone())
+        let cell = {
+            let mut cache = self.lookup_context.published_at.lock().await;
+            Arc::clone(cache.entry(key).or_insert_with(|| Arc::new(OnceCell::new())))
+        };
+        cell.get_or_init(|| async { self.resolve_published_at(registry, name, version).await })
+            .await
+            .clone()
     }
 
     /// Layered publish-timestamp lookup. Ports upstream's
@@ -563,29 +562,29 @@ impl NpmResolutionVerifier {
         name: &PkgName,
     ) -> Result<Option<crate::lookup_context::AbbreviatedMetaProjection>, String> {
         let key = package_key(registry, &name.to_string());
-        {
-            let cache = self.lookup_context.abbreviated_meta.lock().await;
-            if let Some(entry) = cache.get(&key) {
-                return Ok(entry.clone());
-            }
-        }
-        let projected = if let Some(shared) = self.read_shared_meta(name) {
-            Some(project_abbreviated_meta(&shared))
-        } else {
-            let opts = FetchFullMetadataCachedOptions {
-                registry,
-                http_client: &self.http_client,
-                auth_headers: &self.auth_headers,
-                cache_dir: self.cache_dir.as_deref(),
-                full_metadata: false,
-            };
-            match fetch_full_metadata_cached(&name.to_string(), &opts).await {
-                Ok(meta) => Some(project_abbreviated_meta(&meta)),
-                Err(_) => None,
-            }
+        let cell = {
+            let mut cache = self.lookup_context.abbreviated_meta.lock().await;
+            Arc::clone(cache.entry(key).or_insert_with(|| Arc::new(OnceCell::new())))
         };
-        let mut cache = self.lookup_context.abbreviated_meta.lock().await;
-        Ok(cache.entry(key).or_insert(projected).clone())
+        let value = cell
+            .get_or_init(|| async {
+                if let Some(shared) = self.read_shared_meta(name) {
+                    return Some(project_abbreviated_meta(&shared));
+                }
+                let opts = FetchFullMetadataCachedOptions {
+                    registry,
+                    http_client: &self.http_client,
+                    auth_headers: &self.auth_headers,
+                    cache_dir: self.cache_dir.as_deref(),
+                    full_metadata: false,
+                };
+                match fetch_full_metadata_cached(&name.to_string(), &opts).await {
+                    Ok(meta) => Some(project_abbreviated_meta(&meta)),
+                    Err(_) => None,
+                }
+            })
+            .await;
+        Ok(value.clone())
     }
 
     /// Try the resolver's shared [`PackageMetaCache`] for a packument
@@ -618,20 +617,18 @@ impl NpmResolutionVerifier {
     ) -> Option<Arc<PublishedAtTimeMap>> {
         let cache_dir = self.cache_dir.as_deref()?;
         let key = package_key(registry, &name.to_string());
-        {
-            let cache = self.lookup_context.local_meta.lock().await;
-            if let Some(entry) = cache.get(&key) {
-                return entry.clone();
-            }
-        }
-        let mirror_path = crate::mirror::get_pkg_mirror_path(
-            cache_dir,
-            crate::mirror::FULL_META_DIR,
-            registry,
-            &name.to_string(),
-        )
-        .ok();
-        let time_map =
+        let cell = {
+            let mut cache = self.lookup_context.local_meta.lock().await;
+            Arc::clone(cache.entry(key).or_insert_with(|| Arc::new(OnceCell::new())))
+        };
+        cell.get_or_init(|| async {
+            let mirror_path = crate::mirror::get_pkg_mirror_path(
+                cache_dir,
+                crate::mirror::FULL_META_DIR,
+                registry,
+                &name.to_string(),
+            )
+            .ok();
             crate::mirror::load_meta_async(mirror_path.as_deref()).await.and_then(|pkg| {
                 pkg.time.as_ref().map(|raw| {
                     raw.iter()
@@ -641,9 +638,10 @@ impl NpmResolutionVerifier {
                         .collect::<PublishedAtTimeMap>()
                         .pipe(Arc::new)
                 })
-            });
-        let mut cache = self.lookup_context.local_meta.lock().await;
-        cache.entry(key).or_insert(time_map).clone()
+            })
+        })
+        .await
+        .clone()
     }
 
     async fn fetch_attestation_time(
@@ -668,26 +666,24 @@ impl NpmResolutionVerifier {
         name: &PkgName,
     ) -> Result<Option<Arc<PublishedAtTimeMap>>, String> {
         let key = package_key(registry, &name.to_string());
-        {
-            let cache = self.lookup_context.full_meta.lock().await;
-            if let Some(entry) = cache.get(&key) {
-                return Ok(entry.clone());
-            }
-        }
-        let pkg = match self.fetch_full_meta(registry, name).await {
-            Ok(pkg) => pkg,
-            Err(reason) => return Err(reason),
+        let cell = {
+            let mut cache = self.lookup_context.full_meta.lock().await;
+            Arc::clone(cache.entry(key).or_insert_with(|| Arc::new(OnceCell::new())))
         };
-        let time_map = pkg.time.as_ref().map(|raw| {
-            raw.iter()
-                .filter_map(|(version, value)| {
-                    value.as_str().map(|ts| (version.clone(), ts.to_string()))
-                })
-                .collect::<PublishedAtTimeMap>()
-                .pipe(Arc::new)
-        });
-        let mut cache = self.lookup_context.full_meta.lock().await;
-        Ok(cache.entry(key).or_insert(time_map).clone())
+        cell.get_or_init(|| async {
+            let pkg = self.fetch_full_meta(registry, name).await?;
+            let time_map = pkg.time.as_ref().map(|raw| {
+                raw.iter()
+                    .filter_map(|(version, value)| {
+                        value.as_str().map(|ts| (version.clone(), ts.to_string()))
+                    })
+                    .collect::<PublishedAtTimeMap>()
+                    .pipe(Arc::new)
+            });
+            Ok(time_map)
+        })
+        .await
+        .clone()
     }
 
     async fn fetch_full_meta_for_trust(
@@ -696,23 +692,23 @@ impl NpmResolutionVerifier {
         name: &PkgName,
     ) -> Result<Arc<Package>, String> {
         let key = package_key(registry, &name.to_string());
-        {
-            let cache = self.lookup_context.full_meta_for_trust.lock().await;
-            if let Some(entry) = cache.get(&key) {
-                return entry.clone();
+        let cell = {
+            let mut cache = self.lookup_context.full_meta_for_trust.lock().await;
+            Arc::clone(cache.entry(key.clone()).or_insert_with(|| Arc::new(OnceCell::new())))
+        };
+        cell.get_or_init(|| async {
+            // Fast path: if the resolver already pulled the full packument
+            // during the same install (`{registry}\x00{name}:full` key in
+            // the shared metaCache, populated when `pickPackage` upgrades
+            // for `minimumReleaseAge`), reuse it. Abbreviated entries are
+            // rejected here — `fail_if_trust_downgraded` needs per-version
+            // `time` and per-version trust evidence, both of which only
+            // the full form carries.
+            let shared =
+                self.meta_cache.as_ref().and_then(|cache| cache.get(&format!("{key}:full")));
+            if let Some(meta) = shared {
+                return Ok(Arc::new(project_trust_meta(meta.as_ref())));
             }
-        }
-        // Fast path: if the resolver already pulled the full packument
-        // during the same install (`{registry}\x00{name}:full` key in
-        // the shared metaCache, populated when `pickPackage` upgrades
-        // for `minimumReleaseAge`), reuse it. Abbreviated entries are
-        // rejected here — `fail_if_trust_downgraded` needs per-version
-        // `time` and per-version trust evidence, both of which only
-        // the full form carries.
-        let shared = self.meta_cache.as_ref().and_then(|cache| cache.get(&format!("{key}:full")));
-        let result = if let Some(meta) = shared {
-            Ok(Arc::new(project_trust_meta(meta.as_ref())))
-        } else {
             // Project the packument to just the fields `fail_if_trust_downgraded`
             // reads before stashing in the cache. The full document — dependency
             // graphs, dist-tags, scripts, READMEs for every version — would
@@ -725,9 +721,9 @@ impl NpmResolutionVerifier {
                 .await
                 .map(|meta| project_trust_meta(&meta))
                 .map(Arc::new)
-        };
-        let mut cache = self.lookup_context.full_meta_for_trust.lock().await;
-        cache.entry(key).or_insert(result).clone()
+        })
+        .await
+        .clone()
     }
 
     async fn fetch_full_meta(&self, registry: &str, name: &PkgName) -> Result<Package, String> {

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -807,3 +807,42 @@ async fn min_age_shortcut_falls_through_when_version_not_listed() {
     };
     assert_eq!(code, "MINIMUM_RELEASE_AGE_VIOLATION");
 }
+
+/// Concurrent verifications of the same `(registry, name, version)`
+/// share one in-flight fetch — the lookup-context caches store
+/// `Arc<OnceCell<…>>`, so 16 racing callers issue at most one
+/// abbreviated GET. Without the singleflight property the verifier
+/// regressed to N fetches per fan-out batch, which mockito's
+/// `.expect(1)` catches.
+#[tokio::test]
+async fn concurrent_verifications_share_one_fetch() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    // The abbreviated-modified shortcut answers the gate without
+    // touching the attestation or full-meta layers, so a single
+    // `.expect(1)` exhaustively pins the per-fan-out fetch count for
+    // the lookup chain.
+    let abbreviated_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(
+            abbreviated_packument_json("acme", "1.0.0", "2024-01-01T00:00:00.000Z").to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.minimum_release_age = Some(60 * 24); // 1 day
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts).expect("verifier");
+    let name: PkgName = "acme".parse().expect("parse");
+    let resolution = registry_resolution();
+    let results = futures_util::future::join_all(
+        (0..16).map(|_| verifier.verify(&resolution, ctx(&name, "1.0.0"))),
+    )
+    .await;
+    for result in results {
+        assert_eq!(result, ResolutionVerification::Ok);
+    }
+    abbreviated_mock.assert_async().await;
+}

--- a/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
@@ -7,10 +7,13 @@
 //! install should pay the disk/network costs at most once per
 //! `(registry, name)` pair (for package-scoped lookups) or once per
 //! `(registry, name, version)` triple (for the final published-at
-//! answer). The maps live behind `tokio::sync::Mutex` so the
-//! buffer-unordered fan-out the lockfile-verification runner uses
-//! can share one context across concurrent tasks without contending
-//! on the publishing record itself.
+//! answer). The outer `tokio::sync::Mutex` guards the slot map; each
+//! slot is an [`Arc<tokio::sync::OnceCell<T>>`] so two verifier tasks
+//! that race for the same key share one in-flight fetch — the second
+//! caller awaits the same init future instead of starting a duplicate.
+//! Mirrors upstream's `Map<string, Promise<T>>` singleflight pattern;
+//! the outer mutex is dropped before the await so unrelated keys stay
+//! unblocked.
 //!
 use std::{
     collections::{HashMap, HashSet},
@@ -18,7 +21,7 @@ use std::{
 };
 
 use pacquet_registry::Package;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, OnceCell};
 
 /// Per-version time map keyed by version string. The verifier only
 /// reads the publish timestamp for a specific version, so storing
@@ -43,6 +46,11 @@ pub(crate) struct AbbreviatedMetaProjection {
     pub version_names: Option<HashSet<String>>,
 }
 
+/// Slot map of singleflight cells. Outer mutex guards lookup/insert;
+/// each cell is shared so concurrent verifier tasks that race on the
+/// same key wait on a single in-flight init.
+pub(crate) type SingleflightMap<T> = Mutex<HashMap<String, Arc<OnceCell<T>>>>;
+
 /// Per-install dedup of the lookups the verifier issues. Mirrors
 /// upstream's
 /// [`PublishedAtLookupContext`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/createNpmResolutionVerifier.ts#L387-L433).
@@ -54,11 +62,11 @@ pub(crate) struct AbbreviatedMetaProjection {
 /// keys remain identical across stacks.
 #[derive(Debug, Default)]
 pub(crate) struct PublishedAtLookupContext {
-    pub published_at: Mutex<HashMap<String, Option<String>>>,
-    pub full_meta: Mutex<HashMap<String, Option<Arc<PublishedAtTimeMap>>>>,
-    pub full_meta_for_trust: Mutex<HashMap<String, Result<Arc<Package>, String>>>,
-    pub abbreviated_meta: Mutex<HashMap<String, Option<AbbreviatedMetaProjection>>>,
-    pub local_meta: Mutex<HashMap<String, Option<Arc<PublishedAtTimeMap>>>>,
+    pub published_at: SingleflightMap<Result<Option<String>, String>>,
+    pub full_meta: SingleflightMap<Result<Option<Arc<PublishedAtTimeMap>>, String>>,
+    pub full_meta_for_trust: SingleflightMap<Result<Arc<Package>, String>>,
+    pub abbreviated_meta: SingleflightMap<Option<AbbreviatedMetaProjection>>,
+    pub local_meta: SingleflightMap<Option<Arc<PublishedAtTimeMap>>>,
 }
 
 impl PublishedAtLookupContext {

--- a/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
@@ -49,7 +49,7 @@ pub(crate) struct AbbreviatedMetaProjection {
 /// Slot map of singleflight cells. Outer mutex guards lookup/insert;
 /// each cell is shared so concurrent verifier tasks that race on the
 /// same key wait on a single in-flight init.
-pub(crate) type SingleflightMap<T> = Mutex<HashMap<String, Arc<OnceCell<T>>>>;
+pub(crate) type SingleflightMap<Value> = Mutex<HashMap<String, Arc<OnceCell<Value>>>>;
 
 /// Per-install dedup of the lookups the verifier issues. Mirrors
 /// upstream's


### PR DESCRIPTION
## Summary

`NpmResolutionVerifier`'s five per-key dedup caches in `PublishedAtLookupContext` followed the release-lock-during-await anti-pattern — caller dropped the mutex guard before awaiting the fetch, then re-acquired it to insert. Two concurrent tasks that missed the same key could each perform the underlying work.

This PR converts each cache from `Mutex<HashMap<String, T>>` to `Mutex<HashMap<String, Arc<OnceCell<T>>>>`. The outer mutex still guards slot lookup/insert, but the per-key value is shared so concurrent callers wait on a single `get_or_init` future — mirroring upstream's `Map<string, Promise<T>>` singleflight contract.

Affected caches:

| Cache | Method |
|---|---|
| `published_at` | `fetch_published_at` |
| `abbreviated_meta` | `fetch_abbreviated_meta` |
| `local_meta` | `read_local_meta_time` |
| `full_meta` | `fetch_full_meta_time` |
| `full_meta_for_trust` | `fetch_full_meta_for_trust` |

## Regression test

Added `concurrent_verifications_share_one_fetch`: fans out 16 concurrent `verify()` calls for the same `(registry, name, version)` and asserts (via mockito `.expect(1)`) that the abbreviated GET fires exactly once. Verified locally that the test correctly catches the regression — temporarily reverting either `fetch_published_at` or `fetch_abbreviated_meta` causes it to fail with "received 16" instead of 1.

## Test plan

- [x] `cargo nextest run -p pacquet-resolving-npm-resolver` — 217 tests pass (216 existing + 1 new).
- [x] `cargo nextest run --workspace` — all 2192 pacquet tests pass.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean.
- [x] `cargo fmt` — applied.
- [x] No deadlock under existing `verify_lockfile_resolutions` fan-out (the regression test runs 16 concurrent verifications without hanging).

Closes #11932.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved concurrent package verification so concurrent requests for the same package share a single in-flight metadata fetch, reducing duplicate network calls and lowering resolution latency under load. Error behavior at the resolution layer is unchanged.

* **Tests**
  * Added an async test that concurrently verifies a package multiple times and asserts only one metadata fetch occurs, ensuring deduplication works under race conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->