### PR TITLE
fix(pacquet/registry): deserialize optionalDependencies and peerDependenciesMeta

### DIFF
--- a/pacquet/crates/package-manager/src/build_snapshot/tests.rs
+++ b/pacquet/crates/package-manager/src/build_snapshot/tests.rs
@@ -27,6 +27,8 @@ fn make_package(name: &str, version: &str) -> PackageVersion {
         dependencies: None,
         dev_dependencies: None,
         peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
         npm_user: None,
         deprecated: None,
     }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -895,25 +895,10 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
     drop((dir, mock_instance));
 }
 
-/// `@pnpm.e2e/abc-optional-peers@1.0.0` declares `peer-a`, `peer-b`,
-/// and `peer-c` as `peerDependencies` and marks `peer-b` / `peer-c`
-/// optional via `peerDependenciesMeta`. With the default
-/// `autoInstallPeers: true`, pacquet auto-installs only the required
-/// peer (`peer-a`): the two optional peers stay missing because nothing
-/// in the tree contributes a preferred version for them.
-///
-/// Ported from upstream's "warning is not reported when cannot resolve
-/// optional peer dependency" at
-/// [`installing/deps-installer/test/install/peerDependencies.ts`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/installing/deps-installer/test/install/peerDependencies.ts#L1181-L1255).
-/// Pacquet's slice asserts the install-side outcome (which slots
-/// materialize in the virtual store) instead of the upstream
-/// peer-dependency-issues reporter payload.
-///
-/// Regression for pnpm/pnpm#11934: before that PR, `PackageVersion`
-/// did not declare `peerDependenciesMeta`, so the resolver-side
-/// manifest dropped it; every optional peer became "required" and the
-/// `autoInstallPeers` fallback in `hoist_peers` cascaded `peer-b` and
-/// `peer-c` into the install.
+/// Regression for pnpm/pnpm#11934: `peerDependenciesMeta` must be
+/// preserved end-to-end so optional peers are not auto-installed.
+/// Ported from upstream's
+/// [`peerDependencies.ts:1181-1255`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/installing/deps-installer/test/install/peerDependencies.ts#L1181-L1255).
 #[tokio::test]
 async fn auto_install_peers_does_not_cascade_optional_peers() {
     let mock_instance = AutoMockInstance::load_or_init();
@@ -966,19 +951,12 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         .map(|entry| entry.file_name().to_string_lossy().into_owned())
         .collect();
 
-    // The required peer (auto-installed) lands in the virtual store.
     assert!(
         virtual_store_slots.iter().any(|name| name.starts_with("@pnpm.e2e+peer-a@")),
         "required peer `peer-a` must be auto-installed under \
          `autoInstallPeers: true`; virtual-store slots: {virtual_store_slots:?}",
     );
 
-    // The two optional peers must NOT reach the virtual store.
-    // peerDependenciesMeta declaring them optional is precisely what
-    // gates this. Before pnpm/pnpm#11934, the `peerDependenciesMeta`
-    // field was dropped during PackageVersion deserialization and the
-    // resolver treated every optional peer as required, cascading them
-    // (plus their transitives) into the install.
     for optional_peer in ["peer-b", "peer-c"] {
         let slot_prefix = format!("@pnpm.e2e+{optional_peer}@");
         let cascaded: Vec<&String> =
@@ -990,9 +968,6 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         );
     }
 
-    // The package itself made it through — the peer-suffixed slot exists
-    // because abc-optional-peers' peerDependencies entry for peer-a was
-    // resolved against the auto-installed peer.
     assert!(
         virtual_store_slots
             .iter()

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -1032,11 +1032,7 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
     let manifest_path = dir.path().join("package.json");
     let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
     manifest
-        .add_dependency(
-            "@pnpm.e2e/abc-optional-peers-meta-only",
-            "1.0.0",
-            DependencyGroup::Prod,
-        )
+        .add_dependency("@pnpm.e2e/abc-optional-peers-meta-only", "1.0.0", DependencyGroup::Prod)
         .unwrap();
     manifest.save().unwrap();
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -895,6 +895,209 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
     drop((dir, mock_instance));
 }
 
+/// `@pnpm.e2e/abc-optional-peers@1.0.0` declares `peer-a`, `peer-b`,
+/// and `peer-c` as `peerDependencies` and marks `peer-b` / `peer-c`
+/// optional via `peerDependenciesMeta`. With the default
+/// `autoInstallPeers: true`, pacquet auto-installs only the required
+/// peer (`peer-a`): the two optional peers stay missing because nothing
+/// in the tree contributes a preferred version for them.
+///
+/// Ported from upstream's "warning is not reported when cannot resolve
+/// optional peer dependency" at
+/// [`installing/deps-installer/test/install/peerDependencies.ts`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/installing/deps-installer/test/install/peerDependencies.ts#L1181-L1255).
+/// Pacquet's slice asserts the install-side outcome (which slots
+/// materialize in the virtual store) instead of the upstream
+/// peer-dependency-issues reporter payload.
+///
+/// Regression for pnpm/pnpm#11934: before that PR, `PackageVersion`
+/// did not declare `peerDependenciesMeta`, so the resolver-side
+/// manifest dropped it; every optional peer became "required" and the
+/// `autoInstallPeers` fallback in `hoist_peers` cascaded `peer-b` and
+/// `peer-c` into the install.
+#[tokio::test]
+async fn auto_install_peers_does_not_cascade_optional_peers() {
+    let mock_instance = AutoMockInstance::load_or_init();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+    manifest
+        .add_dependency("@pnpm.e2e/abc-optional-peers", "1.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.to_path_buf();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install with optional peers should succeed");
+
+    let virtual_store_slots: Vec<String> = std::fs::read_dir(&virtual_store_dir)
+        .expect("read virtual store dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+
+    // The required peer (auto-installed) lands in the virtual store.
+    assert!(
+        virtual_store_slots.iter().any(|name| name.starts_with("@pnpm.e2e+peer-a@")),
+        "required peer `peer-a` must be auto-installed under \
+         `autoInstallPeers: true`; virtual-store slots: {virtual_store_slots:?}",
+    );
+
+    // The two optional peers must NOT reach the virtual store.
+    // peerDependenciesMeta declaring them optional is precisely what
+    // gates this. Before pnpm/pnpm#11934, the `peerDependenciesMeta`
+    // field was dropped during PackageVersion deserialization and the
+    // resolver treated every optional peer as required, cascading them
+    // (plus their transitives) into the install.
+    for optional_peer in ["peer-b", "peer-c"] {
+        let slot_prefix = format!("@pnpm.e2e+{optional_peer}@");
+        let cascaded: Vec<&String> =
+            virtual_store_slots.iter().filter(|name| name.starts_with(&slot_prefix)).collect();
+        assert!(
+            cascaded.is_empty(),
+            "optional peer `{optional_peer}` must NOT reach the virtual store; \
+             found {cascaded:?}",
+        );
+    }
+
+    // The package itself made it through — the peer-suffixed slot exists
+    // because abc-optional-peers' peerDependencies entry for peer-a was
+    // resolved against the auto-installed peer.
+    assert!(
+        virtual_store_slots
+            .iter()
+            .any(|name| name.starts_with("@pnpm.e2e+abc-optional-peers@1.0.0")),
+        "abc-optional-peers must reach the virtual store; \
+         virtual-store slots: {virtual_store_slots:?}",
+    );
+    assert!(
+        is_symlink_or_junction(&project_root.join("node_modules/@pnpm.e2e/abc-optional-peers"))
+            .unwrap(),
+        "abc-optional-peers must be symlinked at the importer level",
+    );
+
+    drop((dir, mock_instance));
+}
+
+/// Companion to [`auto_install_peers_does_not_cascade_optional_peers`]:
+/// `@pnpm.e2e/abc-optional-peers-meta-only@1.0.0` declares `peer-b` and
+/// `peer-c` **only** through `peerDependenciesMeta`, with no matching
+/// `peerDependencies` entry. Upstream and pacquet treat such entries
+/// as optional peers with implicit range `*`; the install must still
+/// keep them out of the tree when no other consumer requests them.
+///
+/// Ported from upstream's "warning is not reported when cannot resolve
+/// optional peer dependency (specified by meta field only)" at
+/// [`installing/deps-installer/test/install/peerDependencies.ts`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/installing/deps-installer/test/install/peerDependencies.ts#L1257-L1323).
+#[tokio::test]
+async fn auto_install_peers_skips_meta_only_optional_peers() {
+    let mock_instance = AutoMockInstance::load_or_init();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+    manifest
+        .add_dependency(
+            "@pnpm.e2e/abc-optional-peers-meta-only",
+            "1.0.0",
+            DependencyGroup::Prod,
+        )
+        .unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.to_path_buf();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install with meta-only optional peers should succeed");
+
+    let virtual_store_slots: Vec<String> = std::fs::read_dir(&virtual_store_dir)
+        .expect("read virtual store dir")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+
+    // peer-a is declared in `peerDependencies` so it stays required and
+    // gets auto-installed; peer-b and peer-c are declared *only* in
+    // `peerDependenciesMeta` with `optional: true` and stay out of the
+    // tree.
+    assert!(
+        virtual_store_slots.iter().any(|name| name.starts_with("@pnpm.e2e+peer-a@")),
+        "required peer `peer-a` must be auto-installed; \
+         virtual-store slots: {virtual_store_slots:?}",
+    );
+    for optional_peer in ["peer-b", "peer-c"] {
+        let slot_prefix = format!("@pnpm.e2e+{optional_peer}@");
+        let cascaded: Vec<&String> =
+            virtual_store_slots.iter().filter(|name| name.starts_with(&slot_prefix)).collect();
+        assert!(
+            cascaded.is_empty(),
+            "meta-only optional peer `{optional_peer}` must NOT reach the virtual store; \
+             found {cascaded:?}",
+        );
+    }
+
+    drop((dir, mock_instance));
+}
+
 /// A v9 lockfile fixture pinned to a placeholder package whose
 /// integrity is bogus on purpose. Pacquet enforces tarball integrity
 /// on the install path, so any test that lets the install reach the

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -19,6 +19,8 @@ pub fn package_version_should_include_peers() {
         dependencies: Some(dependencies),
         dev_dependencies: None,
         peer_dependencies: Some(peer_dependencies),
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
         npm_user: None,
         deprecated: None,
     };
@@ -40,6 +42,8 @@ pub fn serialized_according_to_params() {
         dependencies: None,
         dev_dependencies: None,
         peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
         npm_user: None,
         deprecated: None,
     };
@@ -95,6 +99,8 @@ fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package
                     dependencies: None,
                     dev_dependencies: None,
                     peer_dependencies: None,
+                    optional_dependencies: None,
+                    peer_dependencies_meta: None,
                     npm_user: None,
                     deprecated: None,
                 },

--- a/pacquet/crates/registry/src/package_version.rs
+++ b/pacquet/crates/registry/src/package_version.rs
@@ -30,6 +30,14 @@ pub struct PackageVersion {
         skip_serializing_if = "Option::is_none"
     )]
     pub peer_dependencies: Option<HashMap<String, String>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_dependency_map",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub optional_dependencies: Option<HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>,
 
     /// npm registry's per-version publisher metadata. When
     /// `trusted_publisher` is present alongside
@@ -172,6 +180,16 @@ where
     deserializer.deserialize_any(DeprecatedVisitor)
 }
 
+/// `peerDependenciesMeta[name]` shape from the npm registry. Only the
+/// `optional` flag is consumed by the resolver; other fields the
+/// registry may serve are ignored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerDependencyMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
+}
+
 /// `_npmUser` field on a per-version manifest. The verifier reads
 /// `trusted_publisher` to assign the higher of the two trust ranks
 /// (`trustedPublisher` > `provenance` > none). `name` / `email` are
@@ -310,5 +328,54 @@ mod tests {
         .expect("server should accept the request once the bearer header is attached");
         assert_eq!(pkg_version.name, "acme");
         mock.assert_async().await;
+    }
+
+    /// The abbreviated registry response (`application/vnd.npm.install-v1+json`)
+    /// carries `optionalDependencies` and `peerDependenciesMeta` for any
+    /// package that publishes them. Both must round-trip through
+    /// [`PackageVersion`] so the resolver's `extract_children` reads the
+    /// optional-dep edges and `extract_peer_dependencies` reads the
+    /// per-peer `optional` flag. Dropping either field silently treats
+    /// optional peers as required (auto-installed via
+    /// `autoInstallPeers`) and skips `optionalDependencies` entirely.
+    #[test]
+    fn deserializes_optional_dependencies_and_peer_dependencies_meta() {
+        let body = r#"{
+            "name": "unstorage",
+            "version": "1.17.5",
+            "dist": {
+                "integrity": "sha512-AAAA",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry.test/unstorage-1.17.5.tgz"
+            },
+            "peerDependencies": {
+                "@vercel/kv": "^1 || ^2 || ^3",
+                "ioredis": "^5.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@vercel/kv": { "optional": true },
+                "ioredis": { "optional": true }
+            },
+            "optionalDependencies": {
+                "sharp": "^0.34.0"
+            }
+        }"#;
+
+        let pkg: PackageVersion =
+            serde_json::from_str(body).expect("deserialize PackageVersion fixture");
+
+        let optional = pkg.optional_dependencies.as_ref().expect("optionalDependencies present");
+        assert_eq!(optional.get("sharp").map(String::as_str), Some("^0.34.0"));
+
+        let peer_meta = pkg.peer_dependencies_meta.as_ref().expect("peerDependenciesMeta present");
+        assert_eq!(peer_meta["@vercel/kv"].optional, Some(true));
+        assert_eq!(peer_meta["ioredis"].optional, Some(true));
+
+        // The JSON shape `serde_json::to_value(pkg)` produces feeds
+        // `extract_children` / `extract_peer_dependencies` downstream;
+        // both consume the camelCase keys verbatim.
+        let value = serde_json::to_value(&pkg).expect("serialize PackageVersion");
+        assert!(value.get("optionalDependencies").is_some_and(|v| v.is_object()));
+        assert!(value.get("peerDependenciesMeta").is_some_and(|v| v.is_object()));
     }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -903,6 +903,8 @@ fn project_trust_package_version(version: &PackageVersion) -> PackageVersion {
         dependencies: None,
         dev_dependencies: None,
         peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
         npm_user,
         deprecated: None,
     }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -328,6 +328,78 @@ async fn jsr_specifier_without_selector_uses_default_tag() {
     assert_eq!(result.resolved_via, "jsr-registry");
 }
 
+/// `optionalDependencies` and `peerDependenciesMeta` round-trip from the
+/// registry's per-version manifest into [`ResolveResult::manifest`]
+/// (a [`serde_json::Value`]). Downstream
+/// `extract_children` reads the optional-dep edges and
+/// `extract_peer_dependencies` reads the per-peer `optional` flag;
+/// dropping either field silently treats optional peers as required
+/// (so `autoInstallPeers` cascades them in) and skips
+/// `optionalDependencies` entirely. See pnpm/pnpm#11934.
+#[tokio::test]
+async fn resolved_manifest_carries_optional_dependencies_and_peer_dependencies_meta() {
+    const BODY: &str = r#"{
+        "name": "consumer",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": "2025-01-15T12:00:00.000Z",
+        "versions": {
+            "1.0.0": {
+                "name": "consumer",
+                "version": "1.0.0",
+                "peerDependencies": {
+                    "@vercel/kv": "^1 || ^2 || ^3",
+                    "ioredis": "^5.4.2"
+                },
+                "peerDependenciesMeta": {
+                    "@vercel/kv": { "optional": true },
+                    "ioredis": { "optional": true }
+                },
+                "optionalDependencies": {
+                    "sharp": "^0.34.0"
+                },
+                "dist": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/consumer-1.0.0.tgz"
+                }
+            }
+        }
+    }"#;
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/consumer").with_status(200).with_body(BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted = WantedDependency {
+        alias: Some("consumer".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    let manifest = result.manifest.as_ref().expect("npm resolver populates manifest");
+
+    let optional = manifest
+        .get("optionalDependencies")
+        .and_then(serde_json::Value::as_object)
+        .expect("optionalDependencies present");
+    assert_eq!(optional.get("sharp").and_then(serde_json::Value::as_str), Some("^0.34.0"));
+
+    let peer_meta = manifest
+        .get("peerDependenciesMeta")
+        .and_then(serde_json::Value::as_object)
+        .expect("peerDependenciesMeta present");
+    assert_eq!(
+        peer_meta.get("@vercel/kv").and_then(|v| v.get("optional")).and_then(serde_json::Value::as_bool),
+        Some(true),
+    );
+    assert_eq!(
+        peer_meta.get("ioredis").and_then(|v| v.get("optional")).and_then(serde_json::Value::as_bool),
+        Some(true),
+    );
+}
+
 #[tokio::test]
 async fn jsr_specifier_with_invalid_scope_propagates_parser_error() {
     let server = mockito::Server::new_async().await;

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -391,11 +391,17 @@ async fn resolved_manifest_carries_optional_dependencies_and_peer_dependencies_m
         .and_then(serde_json::Value::as_object)
         .expect("peerDependenciesMeta present");
     assert_eq!(
-        peer_meta.get("@vercel/kv").and_then(|v| v.get("optional")).and_then(serde_json::Value::as_bool),
+        peer_meta
+            .get("@vercel/kv")
+            .and_then(|v| v.get("optional"))
+            .and_then(serde_json::Value::as_bool),
         Some(true),
     );
     assert_eq!(
-        peer_meta.get("ioredis").and_then(|v| v.get("optional")).and_then(serde_json::Value::as_bool),
+        peer_meta
+            .get("ioredis")
+            .and_then(|v| v.get("optional"))
+            .and_then(serde_json::Value::as_bool),
         Some(true),
     );
 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -27,6 +27,8 @@ fn make_pkg_version(name: &str, version: &str, deprecated: Option<&str>) -> Pack
         dependencies: None,
         dev_dependencies: None,
         peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
         npm_user: None,
         deprecated: deprecated.map(str::to_string),
     }

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -2698,7 +2698,7 @@ mod normalize_bundled_manifest_tests {
             },
         }))
         .expect("non-empty pick");
-        assert_eq!(result.get("optionalDependencies"), Some(&json!({ "sharp": "^0.34.0" })),);
+        assert_eq!(result.get("optionalDependencies"), Some(&json!({ "sharp": "^0.34.0" })));
         assert_eq!(
             result.get("peerDependenciesMeta"),
             Some(&json!({

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     DownloadTarballToStore, HttpStatusError, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
     TarballError, VerifyChecksumError, allocate_tarball_buffer, extract_tarball_entries,
-    extract_zip_entries, fetch_and_extract_with_retry, is_transient_error, prefetch_cas_paths,
+    extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
+    normalize_bundled_manifest, prefetch_cas_paths,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
@@ -2525,4 +2526,188 @@ async fn offline_mode_still_uses_prefetched_cache() {
     must_not_fire.assert_async().await;
 
     drop(store_dir_keep);
+}
+
+/// Ported from upstream's
+/// [`normalizeBundledManifest.test.ts`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/store/cafs/test/normalizeBundledManifest.test.ts).
+///
+/// Pacquet's [`normalize_bundled_manifest`] picks the subset of
+/// `package.json` fields downstream install code reads (bin lookup,
+/// peer extraction, build-script detection) and narrows `scripts` to
+/// the three lifecycle hooks. Adding a case here? Add (or mirror) the
+/// upstream case too. Two upstream cases are intentionally NOT ported:
+/// `semver.clean` normalization (pacquet keeps version verbatim, per
+/// the function's doc comment) and the missing-version default of
+/// `0.0.0` (pacquet leaves the field absent rather than synthesizing
+/// one).
+mod normalize_bundled_manifest_tests {
+    use super::normalize_bundled_manifest;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn returns_none_for_empty_manifest() {
+        assert_eq!(normalize_bundled_manifest(&json!({})), None);
+    }
+
+    #[test]
+    fn returns_none_for_non_object() {
+        // Mirrors upstream's type guard at the top of
+        // `normalizeBundledManifest` — a non-object input degrades to
+        // `None` rather than panicking.
+        assert_eq!(normalize_bundled_manifest(&json!("not an object")), None);
+        assert_eq!(normalize_bundled_manifest(&json!(null)), None);
+        assert_eq!(normalize_bundled_manifest(&json!(42)), None);
+    }
+
+    #[test]
+    fn returns_none_when_manifest_has_only_excluded_fields() {
+        assert_eq!(
+            normalize_bundled_manifest(&json!({
+                "description": "a package",
+                "keywords": ["test"],
+                "license": "MIT",
+                "author": "test",
+                "repository": "test/test",
+            })),
+            None,
+        );
+    }
+
+    #[test]
+    fn picks_included_fields_and_excludes_others() {
+        let result = normalize_bundled_manifest(&json!({
+            "name": "foo",
+            "version": "1.0.0",
+            "description": "should be excluded",
+            "license": "MIT",
+            "bin": { "foo": "./bin/foo.js" },
+            "engines": { "node": ">=18" },
+            "cpu": ["x64"],
+            "os": ["linux"],
+            "libc": ["glibc"],
+            "dependencies": { "bar": "^1.0.0" },
+            "devDependencies": { "qux": "^3.0.0" },
+            "optionalDependencies": { "baz": "^2.0.0" },
+            "peerDependencies": { "react": "^18" },
+            "peerDependenciesMeta": { "react": { "optional": true } },
+            "bundledDependencies": ["bar"],
+            "directories": { "bin": "./bin" },
+        }))
+        .expect("non-empty pick");
+        let map = result.as_object().expect("object");
+        assert_eq!(map.get("name").and_then(|v| v.as_str()), Some("foo"));
+        assert_eq!(map.get("version").and_then(|v| v.as_str()), Some("1.0.0"));
+        assert_eq!(map.get("bin"), Some(&json!({ "foo": "./bin/foo.js" })));
+        assert_eq!(map.get("engines"), Some(&json!({ "node": ">=18" })));
+        assert_eq!(map.get("cpu"), Some(&json!(["x64"])));
+        assert_eq!(map.get("os"), Some(&json!(["linux"])));
+        assert_eq!(map.get("libc"), Some(&json!(["glibc"])));
+        assert_eq!(map.get("dependencies"), Some(&json!({ "bar": "^1.0.0" })));
+        assert_eq!(map.get("devDependencies"), Some(&json!({ "qux": "^3.0.0" })));
+        assert_eq!(map.get("optionalDependencies"), Some(&json!({ "baz": "^2.0.0" })));
+        assert_eq!(map.get("peerDependencies"), Some(&json!({ "react": "^18" })));
+        assert_eq!(
+            map.get("peerDependenciesMeta"),
+            Some(&json!({ "react": { "optional": true } })),
+        );
+        assert_eq!(map.get("bundledDependencies"), Some(&json!(["bar"])));
+        assert_eq!(map.get("directories"), Some(&json!({ "bin": "./bin" })));
+        // Excluded fields stay out.
+        assert!(map.get("description").is_none());
+        assert!(map.get("license").is_none());
+        assert!(map.get("keywords").is_none());
+    }
+
+    #[test]
+    fn only_picks_lifecycle_scripts_not_all_scripts() {
+        let result = normalize_bundled_manifest(&json!({
+            "name": "foo",
+            "version": "1.0.0",
+            "scripts": {
+                "preinstall": "echo pre",
+                "install": "echo install",
+                "postinstall": "echo post",
+                "test": "jest",
+                "build": "tsc",
+                "start": "node index.js",
+                "prepare": "tsc",
+            },
+        }))
+        .expect("non-empty pick");
+        assert_eq!(
+            result.get("scripts").expect("scripts present"),
+            &json!({
+                "preinstall": "echo pre",
+                "install": "echo install",
+                "postinstall": "echo post",
+            }),
+        );
+    }
+
+    #[test]
+    fn omits_scripts_key_when_no_lifecycle_scripts_exist() {
+        let result = normalize_bundled_manifest(&json!({
+            "name": "foo",
+            "version": "1.0.0",
+            "scripts": {
+                "test": "jest",
+                "build": "tsc",
+            },
+        }))
+        .expect("non-empty pick");
+        assert!(
+            result.get("scripts").is_none(),
+            "scripts key must be absent when no lifecycle hook is present",
+        );
+    }
+
+    /// Upstream skips `null` and `undefined` fields. Rust's
+    /// [`serde_json::Value`] has no `undefined`, but JSON `null`
+    /// reaches the picker as [`serde_json::Value::Null`] and must be
+    /// filtered the same way (`if (...!v.is_null())` in the source).
+    #[test]
+    fn skips_null_fields() {
+        let result = normalize_bundled_manifest(&json!({
+            "name": "foo",
+            "version": "1.0.0",
+            "bin": null,
+            "engines": null,
+        }))
+        .expect("non-empty pick");
+        assert!(result.get("bin").is_none(), "null `bin` must be dropped");
+        assert!(result.get("engines").is_none(), "null `engines` must be dropped");
+        assert_eq!(result.get("name").and_then(|v| v.as_str()), Some("foo"));
+        assert_eq!(result.get("version").and_then(|v| v.as_str()), Some("1.0.0"));
+    }
+
+    /// The bundled manifest is downstream-fed into
+    /// [`extract_peer_dependencies`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs#L776-L824)
+    /// and `extract_children`; dropping `peerDependenciesMeta` or
+    /// `optionalDependencies` here would replicate the pnpm/pnpm#11934
+    /// resolver-side bug on the install-side. Pin the keys explicitly.
+    #[test]
+    fn preserves_optional_dependencies_and_peer_dependencies_meta_keys() {
+        let result = normalize_bundled_manifest(&json!({
+            "name": "consumer",
+            "version": "1.0.0",
+            "optionalDependencies": { "sharp": "^0.34.0" },
+            "peerDependenciesMeta": {
+                "@vercel/kv": { "optional": true },
+                "ioredis": { "optional": true },
+            },
+        }))
+        .expect("non-empty pick");
+        assert_eq!(
+            result.get("optionalDependencies"),
+            Some(&json!({ "sharp": "^0.34.0" })),
+        );
+        assert_eq!(
+            result.get("peerDependenciesMeta"),
+            Some(&json!({
+                "@vercel/kv": { "optional": true },
+                "ioredis": { "optional": true },
+            })),
+        );
+    }
 }

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -2698,10 +2698,7 @@ mod normalize_bundled_manifest_tests {
             },
         }))
         .expect("non-empty pick");
-        assert_eq!(
-            result.get("optionalDependencies"),
-            Some(&json!({ "sharp": "^0.34.0" })),
-        );
+        assert_eq!(result.get("optionalDependencies"), Some(&json!({ "sharp": "^0.34.0" })),);
         assert_eq!(
             result.get("peerDependenciesMeta"),
             Some(&json!({


### PR DESCRIPTION
## Summary

`PackageVersion` (the per-version registry manifest the npm resolver parses) was missing the `optionalDependencies` and `peerDependenciesMeta` fields. The resolver builds `ResolveResult.manifest` via `serde_json::to_value(picked)` and downstream walks it with [`extract_children`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs#L752-L759) (reads `optionalDependencies`) and [`extract_peer_dependencies`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs#L776-L824) (reads `peerDependenciesMeta`). Without those fields on the struct, both reads always saw nothing — so `optionalDependencies` edges were silently dropped, and every optional peer was treated as required, then auto-installed via the `autoInstallPeers` fallback in [`hoist_peers`](https://github.com/pnpm/pnpm/blob/1fb8a2d5d8/pacquet/crates/resolving-deps-resolver/src/hoist_peers.rs#L134-L136).

## Astro cascade

On the vlt [`astro`](https://github.com/vltpkg/benchmarks/tree/main/fixtures/astro) fixture, `unstorage` (a transitive of astro) declares 19 optional peers via `peerDependenciesMeta` (`@azure/*`, `@vercel/*`, `@netlify/blobs`, `@upstash/redis`, `@deno/kv`, `ioredis`, `uploadthing`, …). Pacquet's resolver auto-installed every one of them and walked their transitive trees; astro's own `optionalDependencies` (`sharp`) went missing entirely.

The supposed "5.5× astro deep-tree slowdown" tracked in #11902 was almost all wasted work, not a real perf bug. None of the candidate hypotheses listed there (`async_recursion` Box-pinning, per-node `lock_recoverable` mutex acquires, manifest `serde_json::to_value` cost, tarball extraction) were the bottleneck.

## Before / after on vlt astro

| Metric | Before | After | pnpm 11.3.0 |
|---|---:|---:|---:|
| `pacquet install` wall time (warm store) | 39.6 s | 8.5 s | 7.0 s |
| Lockfile lines | 13,364 | 3,037 | 3,444 |
| `resolution:` entries | 1,535 | 377 | 377 |
| Astro root peer suffixes | 30 (`@azure/...`, `@vercel/...`, ...) | `(rollup@4.60.4)(typescript@5.9.3)` | `(rollup@4.60.4)(typescript@5.9.3)` |
| `sharp` (`optionalDependencies`) refs in lockfile | 0 | 110 | 85 |

Warm-cache hyperfine (3 runs, fresh `node_modules` + lockfile each time):

```
pacquet (patched):   670 ms ± 72 ms
pnpm 11.3.0:        1270 ms ±  7 ms
pacquet is 1.89 ± 0.20 times faster than pnpm
```

Closes the astro column in #11902.

## Implementation

- Add `optional_dependencies: Option<HashMap<String, String>>` and `peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>` to `PackageVersion`. The existing `#[serde(rename_all = "camelCase")]` handles wire format.
- Add a `PeerDependencyMeta` newtype with just the `optional` field (the only field the resolver consumes).
- Fix up the four struct-literal construction sites in tests + the trust-evidence projection.
- Add a regression test that deserializes a fixture with both fields populated and asserts they round-trip through `serde_json::to_value` — which is what the resolver consumes.

## Test plan

- [x] `cargo nextest run -p pacquet-registry` — 17/17 pass (incl. new test).
- [x] `cargo nextest run -p pacquet-resolving-npm-resolver` — 232/232 pass.
- [x] Affected `pacquet-package-manager` `install::tests::fresh_install_*` tests pass.
- [x] `cargo clippy -p pacquet-registry --all-targets -- --deny warnings` clean.
- [x] Manual: `pacquet install` on the vlt astro fixture produces a lockfile structurally matching pnpm's (377 resolutions, 2-peer astro suffix, sharp present).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package versions now carry optionalDependencies and per-peer metadata, preserved during registry-style serialization/deserialization

* **Tests**
  * Updated test fixtures and helpers to match the expanded package shape
  * Added integration tests verifying peer auto-install respects per-peer optional flags
  * Added resolver and manifest normalization tests to ensure optionalDependencies and per-peer metadata are carried and preserved

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->