### PR TITLE
fix(pacquet): port pnpm's workspace-link short-circuit and depPath helpers

### DIFF
--- a/pacquet/crates/deps-path/src/is_runtime_dep_path.rs
+++ b/pacquet/crates/deps-path/src/is_runtime_dep_path.rs
@@ -1,0 +1,50 @@
+/// `true` when `dep_path` is a runtime engine entry of the shape
+/// `(node|bun|deno)@runtime:…`. Mirrors pnpm's
+/// [`isRuntimeDepPath`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L215-L219)
+/// — the only three runtimes pnpm v11 recognises as engine deps.
+///
+/// The check is byte-level (not parsed) so callers that hold the raw
+/// snapshot key can filter without round-tripping through [`crate::DepPath`].
+pub fn is_runtime_dep_path(dep_path: &str) -> bool {
+    for prefix in ["node@runtime:", "bun@runtime:", "deno@runtime:"] {
+        if let Some(rest) = dep_path.strip_prefix(prefix)
+            && !rest.is_empty()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_runtime_dep_path;
+
+    /// Mirrors pnpm's `isRuntimeDepPath` test in
+    /// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L146-L149):
+    /// `node@runtime:20.1.0` is a runtime entry, plain `node@20.1.0` is not.
+    #[test]
+    fn matches_pnpm_test_cases() {
+        assert!(is_runtime_dep_path("node@runtime:20.1.0"));
+        assert!(!is_runtime_dep_path("node@20.1.0"));
+    }
+
+    #[test]
+    fn matches_all_three_runtime_prefixes() {
+        assert!(is_runtime_dep_path("node@runtime:22.0.0"));
+        assert!(is_runtime_dep_path("bun@runtime:1.1.0"));
+        assert!(is_runtime_dep_path("deno@runtime:1.46.0"));
+    }
+
+    #[test]
+    fn rejects_unrelated_runtimes_and_partials() {
+        assert!(!is_runtime_dep_path("python@runtime:3.12.0"));
+        // The prefix matcher requires a non-empty body so a stray
+        // `node@runtime:` with nothing after the colon doesn't
+        // masquerade as a runtime entry.
+        assert!(!is_runtime_dep_path("node@runtime:"));
+        // Anchored at the start of the string — a name that happens
+        // to contain `node@runtime:` as a substring is not a match.
+        assert!(!is_runtime_dep_path("@scope/node@runtime:1.0.0"));
+    }
+}

--- a/pacquet/crates/deps-path/src/lib.rs
+++ b/pacquet/crates/deps-path/src/lib.rs
@@ -15,13 +15,17 @@
 mod create_peer_dep_graph_hash;
 mod dep_path;
 mod dep_path_to_filename;
+mod is_runtime_dep_path;
 mod peer_id;
 mod suffix_index;
+mod try_get_package_id;
 
 pub use create_peer_dep_graph_hash::create_peer_dep_graph_hash;
 pub use dep_path::DepPath;
 pub use dep_path_to_filename::dep_path_to_filename;
+pub use is_runtime_dep_path::is_runtime_dep_path;
 pub use peer_id::PeerId;
 pub use suffix_index::{
     DepPathSuffixIndex, get_pkg_id_with_patch_hash, index_of_dep_path_suffix, remove_suffix,
 };
+pub use try_get_package_id::try_get_package_id;

--- a/pacquet/crates/deps-path/src/suffix_index.rs
+++ b/pacquet/crates/deps-path/src/suffix_index.rs
@@ -182,7 +182,7 @@ mod tests {
     fn scoped_name_with_patch_hash_and_peer_keeps_only_patch_hash() {
         let dep_path = "@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)";
         assert_eq!(remove_suffix(dep_path), "@foo/bar@1.0.0");
-        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=zzzz)",);
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=zzzz)");
     }
 
     /// Mirrors `tryGetPackageId('/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))')`.

--- a/pacquet/crates/deps-path/src/suffix_index.rs
+++ b/pacquet/crates/deps-path/src/suffix_index.rs
@@ -132,4 +132,83 @@ mod tests {
         let got = index_of_dep_path_suffix(dep_path);
         assert_eq!(got.peers_index, Some("foo@1.0.0".len()));
     }
+
+    /// Mirrors the `getPkgIdWithPatchHash('node@runtime:24.11.1')` leg of
+    /// pnpm's [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L119):
+    /// a runtime depPath has no parenthesised suffix, so both helpers
+    /// return the path verbatim.
+    #[test]
+    fn runtime_dep_path_has_no_suffix() {
+        let dep_path = "node@runtime:24.11.1";
+        let got = index_of_dep_path_suffix(dep_path);
+        assert_eq!(got, DepPathSuffixIndex { peers_index: None, patch_hash_index: None });
+        assert_eq!(remove_suffix(dep_path), "node@runtime:24.11.1");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "node@runtime:24.11.1");
+    }
+
+    /// Mirrors the scoped-name leg of pnpm's `getPkgIdWithPatchHash`:
+    /// `@foo/bar@1.0.0` round-trips verbatim through both helpers.
+    /// See [`deps/path/test/index.ts:134`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L134).
+    #[test]
+    fn scoped_name_without_suffix_round_trips() {
+        let dep_path = "@foo/bar@1.0.0";
+        assert_eq!(remove_suffix(dep_path), "@foo/bar@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0");
+    }
+
+    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(patch_hash=yyyy)')`.
+    /// See [`deps/path/test/index.ts:137`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L137).
+    #[test]
+    fn scoped_name_with_patch_hash_keeps_patch_hash() {
+        let dep_path = "@foo/bar@1.0.0(patch_hash=yyyy)";
+        assert_eq!(remove_suffix(dep_path), "@foo/bar@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=yyyy)");
+    }
+
+    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(@types/node@18.0.0)')`.
+    /// See [`deps/path/test/index.ts:140`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140).
+    #[test]
+    fn scoped_name_with_peer_strips_to_bare() {
+        let dep_path = "@foo/bar@1.0.0(@types/node@18.0.0)";
+        assert_eq!(remove_suffix(dep_path), "@foo/bar@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0");
+    }
+
+    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)')`.
+    /// `remove_suffix` strips both, while `get_pkg_id_with_patch_hash`
+    /// keeps the patch-hash segment.
+    /// See [`deps/path/test/index.ts:143`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L143).
+    #[test]
+    fn scoped_name_with_patch_hash_and_peer_keeps_only_patch_hash() {
+        let dep_path = "@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)";
+        assert_eq!(remove_suffix(dep_path), "@foo/bar@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=zzzz)",);
+    }
+
+    /// Mirrors `tryGetPackageId('/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))')`.
+    /// A nested peer-on-peer segment stays balanced; the outer `(`
+    /// is the start of the (single) peer-graph segment.
+    /// See [`deps/path/test/index.ts:112`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112).
+    #[test]
+    fn leading_slash_legacy_with_nested_peer_strips_to_bare() {
+        // Pacquet doesn't parse the leading-slash legacy shape via
+        // `PkgNameVerPeer`, but the lower-level depPath helpers do
+        // operate on the raw string — keep the contract pinned.
+        let dep_path = "/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))";
+        assert_eq!(remove_suffix(dep_path), "/foo@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "/foo@1.0.0");
+    }
+
+    /// Mirrors `tryGetPackageId('/@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)')`.
+    /// The `(-.-)` parens belong to the scope name, not a peer suffix —
+    /// the balanced-paren scan from the right correctly recognises the
+    /// trailing `(@types/babel__core@7.1.14)` as the single peer
+    /// segment and leaves the scope intact.
+    /// See [`deps/path/test/index.ts:113`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L113).
+    #[test]
+    fn scope_with_parens_does_not_confuse_suffix_scan() {
+        let dep_path = "/@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)";
+        assert_eq!(remove_suffix(dep_path), "/@(-.-)/foo@1.0.0");
+        assert_eq!(get_pkg_id_with_patch_hash(dep_path), "/@(-.-)/foo@1.0.0");
+    }
 }

--- a/pacquet/crates/deps-path/src/suffix_index.rs
+++ b/pacquet/crates/deps-path/src/suffix_index.rs
@@ -133,10 +133,8 @@ mod tests {
         assert_eq!(got.peers_index, Some("foo@1.0.0".len()));
     }
 
-    /// Mirrors the `getPkgIdWithPatchHash('node@runtime:24.11.1')` leg of
-    /// pnpm's [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L119):
-    /// a runtime depPath has no parenthesised suffix, so both helpers
-    /// return the path verbatim.
+    /// Mirrors pnpm's `getPkgIdWithPatchHash` test, runtime leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L119)).
     #[test]
     fn runtime_dep_path_has_no_suffix() {
         let dep_path = "node@runtime:24.11.1";
@@ -146,9 +144,8 @@ mod tests {
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "node@runtime:24.11.1");
     }
 
-    /// Mirrors the scoped-name leg of pnpm's `getPkgIdWithPatchHash`:
-    /// `@foo/bar@1.0.0` round-trips verbatim through both helpers.
-    /// See [`deps/path/test/index.ts:134`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L134).
+    /// Mirrors pnpm's `getPkgIdWithPatchHash` test, scoped-name leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L134)).
     #[test]
     fn scoped_name_without_suffix_round_trips() {
         let dep_path = "@foo/bar@1.0.0";
@@ -156,8 +153,8 @@ mod tests {
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0");
     }
 
-    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(patch_hash=yyyy)')`.
-    /// See [`deps/path/test/index.ts:137`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L137).
+    /// Mirrors pnpm's `getPkgIdWithPatchHash` test, scoped + patch-hash leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L137)).
     #[test]
     fn scoped_name_with_patch_hash_keeps_patch_hash() {
         let dep_path = "@foo/bar@1.0.0(patch_hash=yyyy)";
@@ -165,8 +162,8 @@ mod tests {
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=yyyy)");
     }
 
-    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(@types/node@18.0.0)')`.
-    /// See [`deps/path/test/index.ts:140`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140).
+    /// Mirrors pnpm's `getPkgIdWithPatchHash` test, scoped + peer leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140)).
     #[test]
     fn scoped_name_with_peer_strips_to_bare() {
         let dep_path = "@foo/bar@1.0.0(@types/node@18.0.0)";
@@ -174,10 +171,10 @@ mod tests {
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0");
     }
 
-    /// Mirrors `getPkgIdWithPatchHash('@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)')`.
-    /// `remove_suffix` strips both, while `get_pkg_id_with_patch_hash`
-    /// keeps the patch-hash segment.
-    /// See [`deps/path/test/index.ts:143`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L143).
+    /// Mirrors pnpm's `getPkgIdWithPatchHash` test, scoped + patch-hash + peer leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L143)).
+    /// Pins both helpers in one shot — the divergence between
+    /// `remove_suffix` and `get_pkg_id_with_patch_hash` lives here.
     #[test]
     fn scoped_name_with_patch_hash_and_peer_keeps_only_patch_hash() {
         let dep_path = "@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)";
@@ -185,26 +182,22 @@ mod tests {
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "@foo/bar@1.0.0(patch_hash=zzzz)");
     }
 
-    /// Mirrors `tryGetPackageId('/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))')`.
-    /// A nested peer-on-peer segment stays balanced; the outer `(`
-    /// is the start of the (single) peer-graph segment.
-    /// See [`deps/path/test/index.ts:112`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112).
+    /// Mirrors pnpm's `tryGetPackageId` test, leading-slash legacy + nested-peer leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112)).
+    /// `PkgNameVerPeer` rejects the leading-slash shape, but the
+    /// string-level helpers still need to handle it for older lockfile
+    /// readers.
     #[test]
     fn leading_slash_legacy_with_nested_peer_strips_to_bare() {
-        // Pacquet doesn't parse the leading-slash legacy shape via
-        // `PkgNameVerPeer`, but the lower-level depPath helpers do
-        // operate on the raw string — keep the contract pinned.
         let dep_path = "/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))";
         assert_eq!(remove_suffix(dep_path), "/foo@1.0.0");
         assert_eq!(get_pkg_id_with_patch_hash(dep_path), "/foo@1.0.0");
     }
 
-    /// Mirrors `tryGetPackageId('/@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)')`.
-    /// The `(-.-)` parens belong to the scope name, not a peer suffix —
-    /// the balanced-paren scan from the right correctly recognises the
-    /// trailing `(@types/babel__core@7.1.14)` as the single peer
-    /// segment and leaves the scope intact.
-    /// See [`deps/path/test/index.ts:113`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L113).
+    /// Mirrors pnpm's `tryGetPackageId` test, scope-with-parens leg
+    /// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L113)).
+    /// The right-to-left balanced scan is what makes this work — a
+    /// left-to-right `find('(')` would split inside `(-.-)`.
     #[test]
     fn scope_with_parens_does_not_confuse_suffix_scan() {
         let dep_path = "/@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)";

--- a/pacquet/crates/deps-path/src/try_get_package_id.rs
+++ b/pacquet/crates/deps-path/src/try_get_package_id.rs
@@ -1,0 +1,99 @@
+use crate::suffix_index::index_of_dep_path_suffix;
+
+/// Extract the `pkgId` substring from a `dep_path`, mirroring pnpm's
+/// [`tryGetPackageId`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L72-L88).
+///
+/// The function combines two transforms:
+///
+/// 1. Strip the peer-graph suffix and the `(patch_hash=…)` segment via
+///    [`index_of_dep_path_suffix`] — same balanced-paren scan
+///    [`crate::remove_suffix`] uses.
+/// 2. When the trimmed result contains a `:`, drop the leading
+///    `<name>@` prefix so the returned id is the bare resolution id
+///    (a tarball URL, a git URL, …). Pnpm keeps the prefix for
+///    `runtime:` engine entries — those carry their name in the
+///    pkgId by design.
+///
+/// The result is a borrowed slice of `dep_path` when neither transform
+/// applies, or an owned [`String`] when the second transform (name
+/// prefix strip) runs. Callers that always need ownership can
+/// `.to_string()`.
+pub fn try_get_package_id(dep_path: &str) -> std::borrow::Cow<'_, str> {
+    let suffix_index = index_of_dep_path_suffix(dep_path);
+    let sep_index = suffix_index.patch_hash_index.or(suffix_index.peers_index);
+    let trimmed = match sep_index {
+        Some(idx) => &dep_path[..idx],
+        None => dep_path,
+    };
+    if !trimmed.contains(':') {
+        return std::borrow::Cow::Borrowed(trimmed);
+    }
+    // Drop the leading `<name>@` prefix. `indexOf('@', 1)` in pnpm
+    // skips position 0 so a leading `@` on a scoped name doesn't
+    // count as the separator.
+    let Some(at_idx) = trimmed[1..].find('@').map(|off| off + 1) else {
+        return std::borrow::Cow::Borrowed(trimmed);
+    };
+    let new_pkg_id = &trimmed[at_idx + 1..];
+    if new_pkg_id.starts_with("runtime:") {
+        return std::borrow::Cow::Borrowed(trimmed);
+    }
+    std::borrow::Cow::Owned(new_pkg_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::try_get_package_id;
+
+    /// Mirrors pnpm's `tryGetPackageId` test in
+    /// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L110-L115).
+    #[test]
+    fn matches_pnpm_test_cases() {
+        assert_eq!(try_get_package_id("/foo@1.0.0(@types/babel__core@7.1.14)"), "/foo@1.0.0");
+        assert_eq!(
+            try_get_package_id("/foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))"),
+            "/foo@1.0.0",
+        );
+        assert_eq!(
+            try_get_package_id("/@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)"),
+            "/@(-.-)/foo@1.0.0",
+        );
+        assert_eq!(
+            try_get_package_id("foo@1.0.0(patch_hash=xxxx)(@types/babel__core@7.1.14)"),
+            "foo@1.0.0",
+        );
+    }
+
+    /// A bare `name@version` has no suffix and no `:`, so it round-trips
+    /// verbatim.
+    #[test]
+    fn bare_name_version_round_trips() {
+        assert_eq!(try_get_package_id("foo@1.0.0"), "foo@1.0.0");
+        assert_eq!(try_get_package_id("@foo/bar@1.0.0"), "@foo/bar@1.0.0");
+    }
+
+    /// A URL-shaped resolution id (`<name>@<url>`) drops the name
+    /// prefix — that's the whole reason the `:` branch exists. The
+    /// transform unconditionally applies once a `:` is present and
+    /// the body isn't `runtime:`.
+    #[test]
+    fn url_shape_drops_name_prefix() {
+        assert_eq!(
+            try_get_package_id("foo@https://example.com/foo.tgz"),
+            "https://example.com/foo.tgz",
+        );
+        assert_eq!(
+            try_get_package_id("foo@git+https://github.com/x/foo#abc"),
+            "git+https://github.com/x/foo#abc",
+        );
+    }
+
+    /// `runtime:` entries keep the `<name>@runtime:<version>` form —
+    /// pnpm's `tryGetPackageId` carves this out via the
+    /// `!newPkgId.startsWith('runtime:')` guard.
+    #[test]
+    fn runtime_entries_keep_name_prefix() {
+        assert_eq!(try_get_package_id("node@runtime:22.0.0"), "node@runtime:22.0.0");
+        assert_eq!(try_get_package_id("node@runtime:22.0.0(some@peer)"), "node@runtime:22.0.0",);
+    }
+}

--- a/pacquet/crates/deps-path/src/try_get_package_id.rs
+++ b/pacquet/crates/deps-path/src/try_get_package_id.rs
@@ -94,6 +94,6 @@ mod tests {
     #[test]
     fn runtime_entries_keep_name_prefix() {
         assert_eq!(try_get_package_id("node@runtime:22.0.0"), "node@runtime:22.0.0");
-        assert_eq!(try_get_package_id("node@runtime:22.0.0(some@peer)"), "node@runtime:22.0.0",);
+        assert_eq!(try_get_package_id("node@runtime:22.0.0(some@peer)"), "node@runtime:22.0.0");
     }
 }

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -53,12 +53,7 @@ impl PkgNameVerPeer {
     /// `packages:` entry `node@runtime:22.0.0` rather than the
     /// non-existent `node@22.0.0`.
     pub fn without_peer(&self) -> PkgNameVerPeer {
-        let prefix = self.suffix.prefix();
-        let bare_input = format!("{}{}", prefix, self.suffix.version());
-        let bare = bare_input
-            .parse::<PkgVerPeer>()
-            .expect("a prefix + the displayed version is always a valid PkgVerPeer");
-        PkgNameVerPeer::new(self.name.clone(), bare)
+        PkgNameVerPeer::new(self.name.clone(), self.suffix.without_peer())
     }
 }
 

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -193,7 +193,7 @@ fn without_peer_handles_workspace_link_with_peer_suffix() {
         rendered.starts_with("link:../../../dev/sharedUiComponents("),
         "name half of the key must survive verbatim; got {rendered:?}",
     );
-    assert!(!rendered.contains(")("), "peer suffix must be stripped; got {rendered:?}",);
+    assert!(!rendered.contains(")("), "peer suffix must be stripped; got {rendered:?}");
 }
 
 /// The user-reported macOS errno-63 case: a vitest snapshot key whose

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -34,6 +34,50 @@ fn parse() {
     case("@algolia/autocomplete-core@1.9.3", name_peer_ver("@algolia/autocomplete-core", "1.9.3"));
 }
 
+/// Mirrors the `tar-pkg@file:../tar-pkg-1.0.0.tgz` leg of pnpm's
+/// `parse()` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L61-L66):
+/// the version slot is a `file:` URL rather than a semver. Pacquet's
+/// `PkgVerPeer` carries the file body under [`VersionPart::File`] and
+/// the round-trip preserves the raw string byte-for-byte.
+#[test]
+fn parse_local_tarball_file_protocol() {
+    let key: PkgNameVerPeer =
+        "tar-pkg@file:../tar-pkg-1.0.0.tgz".parse().expect("parse file: tarball key");
+    assert_eq!(key.to_string(), "tar-pkg@file:../tar-pkg-1.0.0.tgz");
+}
+
+/// Mirrors the `foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)`
+/// leg of pnpm's `parse()` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73).
+/// Pacquet's `PkgVerPeer` doesn't model the patch-hash slot
+/// separately; it lumps the entire `(patch_hash=…)(<peers>)` tail into
+/// the `peer` field, so the round-trip preserves the raw key.
+#[test]
+fn parse_patch_hash_and_peer_suffix_round_trip() {
+    let raw = "foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)";
+    let key: PkgNameVerPeer = raw.parse().expect("parse patch-hash + peer-variant key");
+    assert_eq!(key.to_string(), raw);
+}
+
+/// Mirrors the scope-with-parens leg of pnpm's `parse()` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L54-L59).
+/// Pnpm permits arbitrary characters in a package scope, including
+/// `(...)` — the `@scope/bare@version(peers)` split happens on the
+/// `/` between scope and bare, then on the first `@` after that,
+/// neither of which is confused by parens inside the scope.
+#[test]
+fn parse_scope_with_parens_round_trip() {
+    let raw = "@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)(foo@1.0.0)";
+    let key: PkgNameVerPeer = raw.parse().expect("parse scope-with-parens key");
+    assert_eq!(key.to_string(), raw);
+    assert_eq!(
+        key.without_peer().to_string(),
+        "@(-.-)/foo@1.0.0",
+        "without_peer must preserve the parens inside the scope",
+    );
+}
+
 #[test]
 fn to_virtual_store_name() {
     fn case(input: &'static str, expected: &'static str) {

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -34,12 +34,8 @@ fn parse() {
     case("@algolia/autocomplete-core@1.9.3", name_peer_ver("@algolia/autocomplete-core", "1.9.3"));
 }
 
-/// Mirrors the `tar-pkg@file:../tar-pkg-1.0.0.tgz` leg of pnpm's
-/// `parse()` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L61-L66):
-/// the version slot is a `file:` URL rather than a semver. Pacquet's
-/// `PkgVerPeer` carries the file body under [`VersionPart::File`] and
-/// the round-trip preserves the raw string byte-for-byte.
+/// Mirrors pnpm's `parse()` test, `file:` leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L61-L66)).
 #[test]
 fn parse_local_tarball_file_protocol() {
     let key: PkgNameVerPeer =
@@ -47,12 +43,10 @@ fn parse_local_tarball_file_protocol() {
     assert_eq!(key.to_string(), "tar-pkg@file:../tar-pkg-1.0.0.tgz");
 }
 
-/// Mirrors the `foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)`
-/// leg of pnpm's `parse()` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73).
-/// Pacquet's `PkgVerPeer` doesn't model the patch-hash slot
-/// separately; it lumps the entire `(patch_hash=…)(<peers>)` tail into
-/// the `peer` field, so the round-trip preserves the raw key.
+/// Mirrors pnpm's `parse()` test, patch-hash + peer leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73)).
+/// `PkgVerPeer` lumps `(patch_hash=...)(<peers>)` into the `peer`
+/// field — the raw key still round-trips.
 #[test]
 fn parse_patch_hash_and_peer_suffix_round_trip() {
     let raw = "foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)";
@@ -60,12 +54,8 @@ fn parse_patch_hash_and_peer_suffix_round_trip() {
     assert_eq!(key.to_string(), raw);
 }
 
-/// Mirrors the scope-with-parens leg of pnpm's `parse()` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L54-L59).
-/// Pnpm permits arbitrary characters in a package scope, including
-/// `(...)` — the `@scope/bare@version(peers)` split happens on the
-/// `/` between scope and bare, then on the first `@` after that,
-/// neither of which is confused by parens inside the scope.
+/// Mirrors pnpm's `parse()` test, scope-with-parens leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L54-L59)).
 #[test]
 fn parse_scope_with_parens_round_trip() {
     let raw = "@(-.-)/foo@1.0.0(@types/babel__core@7.1.14)(foo@1.0.0)";
@@ -111,16 +101,12 @@ fn without_peer_strips_peer_suffix() {
     assert_eq!(bare.to_string(), "react-dom@17.0.2");
 }
 
-/// Mirrors pnpm's `removeSuffix` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L151-L153):
-/// the patch-hash segment and the peer-graph segment both get stripped.
-/// Pacquet's [`PkgVerPeer`] doesn't model the patch-hash slot separately
-/// — it lumps the whole parenthesised tail into `peer`, so `without_peer`
-/// returns the same bare `name@version` shape `removeSuffix` does. The
-/// `packages:` map key that pnpm would normally key by the
-/// `pkgIdWithPatchHash` (patch-hash retained) instead loses the patch
-/// segment here; that's tracked as a separate parity gap outside this
-/// test's scope.
+/// Mirrors pnpm's `removeSuffix` test
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L151-L153)).
+/// Pacquet's `PkgVerPeer` lumps the patch-hash and peer segments into
+/// one `peer` field, so `without_peer` strips both. The `packages:`
+/// key shape diverges from `getPkgIdWithPatchHash` here — separate
+/// parity gap, separate PR.
 #[test]
 fn without_peer_strips_patch_hash_alongside_peer_suffix() {
     let key: PkgNameVerPeer = "foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)"
@@ -130,11 +116,8 @@ fn without_peer_strips_patch_hash_alongside_peer_suffix() {
     assert_eq!(bare.to_string(), "foo@1.0.0");
 }
 
-/// Mirrors the scoped-name leg of pnpm's `getPkgIdWithPatchHash` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140-L143).
-/// Scoped names carry a leading `@<scope>/`, and `PkgNameSuffix::FromStr`
-/// must keep that intact while still splitting the suffix at the first
-/// post-scope `@`.
+/// Mirrors pnpm's `getPkgIdWithPatchHash` test, scoped-name leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140-L143)).
 #[test]
 fn without_peer_strips_peer_from_scoped_name() {
     let key: PkgNameVerPeer = "@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)"
@@ -144,10 +127,8 @@ fn without_peer_strips_peer_from_scoped_name() {
     assert_eq!(bare.to_string(), "@foo/bar@1.0.0");
 }
 
-/// Mirrors the nested-peer leg of pnpm's `tryGetPackageId` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112):
-/// a transitive peer that itself carries a `(…)` segment is one balanced
-/// suffix and must strip as a unit.
+/// Mirrors pnpm's `tryGetPackageId` test, nested-peer leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112)).
 #[test]
 fn without_peer_strips_peer_with_nested_parens() {
     let key: PkgNameVerPeer = "foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))"
@@ -157,10 +138,9 @@ fn without_peer_strips_peer_with_nested_parens() {
     assert_eq!(bare.to_string(), "foo@1.0.0");
 }
 
-/// A runtime depPath like `node@runtime:22.0.0(some@peer)` strips down to
-/// `node@runtime:22.0.0`, not `node@22.0.0`. Pacquet preserves the
-/// `runtime:` scheme prefix because the metadata-map key has to match the
-/// `packages:` entry pnpm writes, which carries the same prefix.
+/// Runtime entries keep their `runtime:` prefix on the metadata-map
+/// key — pnpm's `packages:` entry carries the same prefix, so
+/// dropping it would unhook the snapshot from its metadata.
 #[test]
 fn without_peer_preserves_runtime_prefix() {
     let key: PkgNameVerPeer =
@@ -170,15 +150,9 @@ fn without_peer_preserves_runtime_prefix() {
 }
 
 /// Regression for [#11939](https://github.com/pnpm/pnpm/issues/11939):
-/// the suffix slot of a snapshot key isn't guaranteed to round-trip
-/// through `PkgVerPeer`'s display-then-parse path. The babylon fixture
-/// exercises this with workspace `link:` deps under
-/// `linkWorkspacePackages: true`, where the resolver builds a depPath of
-/// the shape `link:<rel-path>(<peers>)`. `PkgNameSuffix::FromStr` splits
-/// on the first `@`, leaving the `(` as part of the package name and a
-/// suffix whose `version()` form retains an unbalanced `)`. `without_peer`
-/// must not panic on such inputs — peer stripping is a structural
-/// operation, not a re-parse.
+/// the babylon shape `link:<rel-path>(<peers>)` parses into a
+/// `PkgNameVerPeer` whose `version()` retains an unbalanced `)`. Peer
+/// stripping is structural and must not re-parse.
 #[test]
 fn without_peer_handles_workspace_link_with_peer_suffix() {
     let key: PkgNameVerPeer = "link:../../../dev/sharedUiComponents(\

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -59,6 +59,53 @@ fn to_virtual_store_name() {
     );
 }
 
+#[test]
+fn without_peer_strips_peer_suffix() {
+    let key: PkgNameVerPeer =
+        "react-dom@17.0.2(react@17.0.2)".parse().expect("parse react-dom peer-variant key");
+    let bare = key.without_peer();
+    assert_eq!(bare.to_string(), "react-dom@17.0.2");
+}
+
+/// A runtime depPath like `node@runtime:22.0.0(some@peer)` strips down to
+/// `node@runtime:22.0.0`, not `node@22.0.0`. Pacquet preserves the
+/// `runtime:` scheme prefix because the metadata-map key has to match the
+/// `packages:` entry pnpm writes, which carries the same prefix.
+#[test]
+fn without_peer_preserves_runtime_prefix() {
+    let key: PkgNameVerPeer =
+        "node@runtime:22.0.0(react@17.0.2)".parse().expect("parse runtime peer-variant key");
+    let bare = key.without_peer();
+    assert_eq!(bare.to_string(), "node@runtime:22.0.0");
+}
+
+/// Regression for [#11939](https://github.com/pnpm/pnpm/issues/11939):
+/// the suffix slot of a snapshot key isn't guaranteed to round-trip
+/// through `PkgVerPeer`'s display-then-parse path. The babylon fixture
+/// exercises this with workspace `link:` deps under
+/// `linkWorkspacePackages: true`, where the resolver builds a depPath of
+/// the shape `link:<rel-path>(<peers>)`. `PkgNameSuffix::FromStr` splits
+/// on the first `@`, leaving the `(` as part of the package name and a
+/// suffix whose `version()` form retains an unbalanced `)`. `without_peer`
+/// must not panic on such inputs — peer stripping is a structural
+/// operation, not a re-parse.
+#[test]
+fn without_peer_handles_workspace_link_with_peer_suffix() {
+    let key: PkgNameVerPeer = "link:../../../dev/sharedUiComponents(\
+        @fluentui/react-components@9.73.8)\
+        (react-dom@18.3.1)\
+        (react@18.3.1)"
+        .parse()
+        .expect("parse workspace link with peer suffix");
+    let bare = key.without_peer();
+    let rendered = bare.to_string();
+    assert!(
+        rendered.starts_with("link:../../../dev/sharedUiComponents("),
+        "name half of the key must survive verbatim; got {rendered:?}",
+    );
+    assert!(!rendered.contains(")("), "peer suffix must be stripped; got {rendered:?}",);
+}
+
 /// The user-reported macOS errno-63 case: a vitest snapshot key whose
 /// escaped filename blows past 120 bytes. The shortening must produce a
 /// name that fits inside `max_length` so `fs::create_dir_all` doesn't

--- a/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -67,6 +67,52 @@ fn without_peer_strips_peer_suffix() {
     assert_eq!(bare.to_string(), "react-dom@17.0.2");
 }
 
+/// Mirrors pnpm's `removeSuffix` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L151-L153):
+/// the patch-hash segment and the peer-graph segment both get stripped.
+/// Pacquet's [`PkgVerPeer`] doesn't model the patch-hash slot separately
+/// — it lumps the whole parenthesised tail into `peer`, so `without_peer`
+/// returns the same bare `name@version` shape `removeSuffix` does. The
+/// `packages:` map key that pnpm would normally key by the
+/// `pkgIdWithPatchHash` (patch-hash retained) instead loses the patch
+/// segment here; that's tracked as a separate parity gap outside this
+/// test's scope.
+#[test]
+fn without_peer_strips_patch_hash_alongside_peer_suffix() {
+    let key: PkgNameVerPeer = "foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)"
+        .parse()
+        .expect("parse patch-hash plus peer-variant key");
+    let bare = key.without_peer();
+    assert_eq!(bare.to_string(), "foo@1.0.0");
+}
+
+/// Mirrors the scoped-name leg of pnpm's `getPkgIdWithPatchHash` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L140-L143).
+/// Scoped names carry a leading `@<scope>/`, and `PkgNameSuffix::FromStr`
+/// must keep that intact while still splitting the suffix at the first
+/// post-scope `@`.
+#[test]
+fn without_peer_strips_peer_from_scoped_name() {
+    let key: PkgNameVerPeer = "@foo/bar@1.0.0(patch_hash=zzzz)(@types/node@18.0.0)"
+        .parse()
+        .expect("parse scoped patch-hash + peer-variant key");
+    let bare = key.without_peer();
+    assert_eq!(bare.to_string(), "@foo/bar@1.0.0");
+}
+
+/// Mirrors the nested-peer leg of pnpm's `tryGetPackageId` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L112):
+/// a transitive peer that itself carries a `(…)` segment is one balanced
+/// suffix and must strip as a unit.
+#[test]
+fn without_peer_strips_peer_with_nested_parens() {
+    let key: PkgNameVerPeer = "foo@1.0.0(@types/babel__core@7.1.14(is-odd@1.0.0))"
+        .parse()
+        .expect("parse nested-peer key");
+    let bare = key.without_peer();
+    assert_eq!(bare.to_string(), "foo@1.0.0");
+}
+
 /// A runtime depPath like `node@runtime:22.0.0(some@peer)` strips down to
 /// `node@runtime:22.0.0`, not `node@22.0.0`. Pacquet preserves the
 /// `runtime:` scheme prefix because the metadata-map key has to match the

--- a/pacquet/crates/lockfile/src/pkg_ver_peer.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer.rs
@@ -133,6 +133,20 @@ impl PkgVerPeer {
         let PkgVerPeer { prefix: _, version, peer } = self;
         (version, peer)
     }
+
+    /// Return a copy with the peer-dependency suffix cleared.
+    ///
+    /// The result preserves the original `prefix` and `version` slots
+    /// byte-for-byte, so no parse-and-render round-trip runs. Callers
+    /// that need the metadata-map key for a peer-variant snapshot key
+    /// should reach for this instead of stringifying and re-parsing —
+    /// some legitimately-resolved snapshot keys carry a `version` slot
+    /// (e.g. a workspace `link:<rel-path>(peer@x)` shape under
+    /// `linkWorkspacePackages: true`) whose `Display` form would not
+    /// re-parse as a [`PkgVerPeer`].
+    pub fn without_peer(&self) -> PkgVerPeer {
+        PkgVerPeer { prefix: self.prefix, version: self.version.clone(), peer: String::new() }
+    }
 }
 
 /// Error when parsing [`PkgVerPeer`] from a string.

--- a/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -255,6 +255,24 @@ fn parse_non_semver_with_peer_suffix() {
     assert_eq!(parsed.to_string(), "https://example.com/foo.tgz(peer@1.0.0)");
 }
 
+/// Mirrors the `foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)`
+/// leg of pnpm's `parse()` test in
+/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73)
+/// at the [`PkgVerPeer`] (suffix-only) level. Pacquet's parser splits
+/// the version slot at the first `(` and folds the patch-hash segment
+/// into the `peer` field — pnpm models the slots separately, but the
+/// round-trip preserves the raw string, which is what every byte-level
+/// consumer (lockfile YAML, on-disk snapshot keys) compares against.
+#[test]
+fn parse_patch_hash_then_peer_suffix_round_trip() {
+    let raw = "1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)";
+    let parsed: PkgVerPeer = raw.parse().expect("parse patch-hash + peer");
+    assert_eq!(parsed.version_semver(), Some(&"1.0.0".parse::<Version>().unwrap()));
+    assert_eq!(parsed.peer(), "(patch_hash=0000)(@types/babel__core@7.1.14)");
+    assert_eq!(parsed.to_string(), raw);
+    assert_eq!(parsed.without_peer().to_string(), "1.0.0");
+}
+
 #[test]
 fn serde_round_trip_non_semver() {
     let url = "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/0848bc83347720c322c5087f3bd0d6cd086ffa4b";

--- a/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
+++ b/pacquet/crates/lockfile/src/pkg_ver_peer/tests.rs
@@ -255,14 +255,11 @@ fn parse_non_semver_with_peer_suffix() {
     assert_eq!(parsed.to_string(), "https://example.com/foo.tgz(peer@1.0.0)");
 }
 
-/// Mirrors the `foo@1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)`
-/// leg of pnpm's `parse()` test in
-/// [`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73)
-/// at the [`PkgVerPeer`] (suffix-only) level. Pacquet's parser splits
-/// the version slot at the first `(` and folds the patch-hash segment
-/// into the `peer` field — pnpm models the slots separately, but the
-/// round-trip preserves the raw string, which is what every byte-level
-/// consumer (lockfile YAML, on-disk snapshot keys) compares against.
+/// Parity check for pnpm's `parse()` test, patch-hash + peer leg
+/// ([`deps/path/test/index.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/test/index.ts#L68-L73)).
+/// `PkgVerPeer` folds patch-hash into the `peer` field; only the raw
+/// string is what byte-level consumers (lockfile YAML, snapshot keys)
+/// compare against.
 #[test]
 fn parse_patch_hash_then_peer_suffix_round_trip() {
     let raw = "1.0.0(patch_hash=0000)(@types/babel__core@7.1.14)";

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -6,6 +6,7 @@ use derive_more::{Display, Error};
 use futures_util::future;
 use miette::Diagnostic;
 use pacquet_config::{Config, NodeLinker};
+use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgNameVerPeer,
     SnapshotEntry, select_platform_variant,
@@ -624,7 +625,13 @@ impl<'a> CreateVirtualStore<'a> {
         let mut cas_paths_by_pkg_id: Option<CasPathsByPkgId> = is_hoisted.then(|| {
             let mut map = CasPathsByPkgId::with_capacity(warm.len());
             for (snapshot_key, _snapshot, cas_paths) in &warm {
-                let pkg_id = PkgIdWithPatchHash::from(snapshot_key.to_string());
+                // Mirrors upstream's `getPkgIdWithPatchHash` — strip
+                // the peer-graph suffix but keep `(patch_hash=…)` so
+                // patched packages share one CAS-paths entry across
+                // their peer variants.
+                let pkg_id = PkgIdWithPatchHash::from(
+                    get_pkg_id_with_patch_hash(&snapshot_key.to_string()).to_string(),
+                );
                 map.entry(pkg_id).or_insert_with(|| (***cas_paths).clone());
             }
             map
@@ -834,7 +841,13 @@ impl<'a> CreateVirtualStore<'a> {
         if let Some(map) = cas_paths_by_pkg_id.as_mut() {
             map.reserve(cold_cas_paths.len());
             for (snapshot_key, paths) in cold_cas_paths {
-                let pkg_id = PkgIdWithPatchHash::from(snapshot_key.to_string());
+                // Mirrors upstream's `getPkgIdWithPatchHash` — strip
+                // the peer-graph suffix but keep `(patch_hash=…)` so
+                // patched packages share one CAS-paths entry across
+                // their peer variants.
+                let pkg_id = PkgIdWithPatchHash::from(
+                    get_pkg_id_with_patch_hash(&snapshot_key.to_string()).to_string(),
+                );
                 map.entry(pkg_id).or_insert(paths);
             }
         }

--- a/pacquet/crates/package-manager/src/create_virtual_store.rs
+++ b/pacquet/crates/package-manager/src/create_virtual_store.rs
@@ -626,7 +626,7 @@ impl<'a> CreateVirtualStore<'a> {
             let mut map = CasPathsByPkgId::with_capacity(warm.len());
             for (snapshot_key, _snapshot, cas_paths) in &warm {
                 // Mirrors upstream's `getPkgIdWithPatchHash` — strip
-                // the peer-graph suffix but keep `(patch_hash=…)` so
+                // the peer-graph suffix but keep `(patch_hash=...)` so
                 // patched packages share one CAS-paths entry across
                 // their peer variants.
                 let pkg_id = PkgIdWithPatchHash::from(
@@ -842,7 +842,7 @@ impl<'a> CreateVirtualStore<'a> {
             map.reserve(cold_cas_paths.len());
             for (snapshot_key, paths) in cold_cas_paths {
                 // Mirrors upstream's `getPkgIdWithPatchHash` — strip
-                // the peer-graph suffix but keep `(patch_hash=…)` so
+                // the peer-graph suffix but keep `(patch_hash=...)` so
                 // patched packages share one CAS-paths entry across
                 // their peer variants.
                 let pkg_id = PkgIdWithPatchHash::from(

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use pacquet_deps_path::remove_suffix;
 use pacquet_lockfile::{
     ComVer, ImporterDepVersion, Lockfile, LockfileSettings, LockfileVersion, PackageKey,
     PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
@@ -233,7 +234,17 @@ fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<St
 fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDepVersion {
     let dep_path_str = node.dep_path.as_str();
 
-    if let Some(target) = dep_path_str.strip_prefix("link:") {
+    if dep_path_str.starts_with("link:") {
+        // Pnpm's `resolvePeersOfNode` short-circuits link nodes (depth
+        // === -1) so their depPath never gains a peer-graph suffix —
+        // the importer entry is just `link:<rel-path>`. Pacquet's
+        // resolver doesn't yet model the `depth === -1` arm, so a
+        // workspace-link node with peer-carrying manifest still picks
+        // up a trailing `(<peers>)` segment here. Strip it via the
+        // balanced-paren scan so the emitted importer value matches
+        // pnpm byte-for-byte.
+        let bare = remove_suffix(dep_path_str);
+        let target = bare.strip_prefix("link:").expect("dep_path_str starts with link:");
         return ImporterDepVersion::Link(target.to_string());
     }
 
@@ -281,6 +292,17 @@ fn build_packages_and_snapshots(
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
 
     for node in graph.values() {
+        // Pnpm leaves workspace-link nodes out of `lockfile.packages`
+        // entirely — `resolvePeersOfNode` returns early on `depth === -1`,
+        // so the link node never enters `dependenciesGraph` and the
+        // splitter that emits `packages:` / `snapshots:` never sees it.
+        // Pacquet's resolver doesn't yet skip link nodes, but the v9
+        // lockfile must still not carry them: a `link:` dep_path with
+        // a parenthesised peer suffix would otherwise mis-parse as a
+        // `PackageKey` and pollute both maps with a malformed key.
+        if node.dep_path.as_str().starts_with("link:") {
+            continue;
+        }
         let Ok(snapshot_key) = node.dep_path.as_str().parse::<PackageKey>() else { continue };
         let metadata_key = snapshot_key.without_peer();
 

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -13,7 +13,6 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use pacquet_deps_path::remove_suffix;
 use pacquet_lockfile::{
     ComVer, ImporterDepVersion, Lockfile, LockfileSettings, LockfileVersion, PackageKey,
     PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
@@ -138,7 +137,6 @@ fn build_importer(input: &ImporterLockfileInput<'_>, graph: &DependenciesGraph) 
     let alias_to_group = manifest_alias_to_group(manifest);
 
     for (alias, dep_path) in direct {
-        let Some(node) = graph.get(dep_path) else { continue };
         let Ok(name_for_key) = PkgName::parse(alias.as_str()) else { continue };
         // Skip aliases the manifest doesn't declare. The resolver's
         // `direct_dependencies_by_alias` includes auto-installed peers
@@ -151,7 +149,17 @@ fn build_importer(input: &ImporterLockfileInput<'_>, graph: &DependenciesGraph) 
         // through `satisfies_package_manifest` and force every later
         // install onto the fresh-resolve path.
         let Some(specifier) = read_manifest_specifier(manifest, alias) else { continue };
-        let version = importer_dep_version(alias, node);
+        // Workspace-link nodes don't enter the graph (the resolver
+        // short-circuits them at `depth = -1`); resolve the importer
+        // version directly from the `link:` depPath instead. Non-link
+        // direct deps must be present in the graph — a missing entry
+        // means the resolver dropped the edge, so skip.
+        let version = if let Some(target) = dep_path.as_str().strip_prefix("link:") {
+            ImporterDepVersion::Link(target.to_string())
+        } else {
+            let Some(node) = graph.get(dep_path) else { continue };
+            importer_dep_version(alias, node)
+        };
         let spec = ResolvedDependencySpec { specifier: specifier.clone(), version };
         specifiers.insert(alias.clone(), specifier);
         let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
@@ -234,17 +242,7 @@ fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<St
 fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDepVersion {
     let dep_path_str = node.dep_path.as_str();
 
-    if dep_path_str.starts_with("link:") {
-        // Pnpm's `resolvePeersOfNode` short-circuits link nodes (depth
-        // === -1) so their depPath never gains a peer-graph suffix —
-        // the importer entry is just `link:<rel-path>`. Pacquet's
-        // resolver doesn't yet model the `depth === -1` arm, so a
-        // workspace-link node with peer-carrying manifest still picks
-        // up a trailing `(<peers>)` segment here. Strip it via the
-        // balanced-paren scan so the emitted importer value matches
-        // pnpm byte-for-byte.
-        let bare = remove_suffix(dep_path_str);
-        let target = bare.strip_prefix("link:").expect("dep_path_str starts with link:");
+    if let Some(target) = dep_path_str.strip_prefix("link:") {
         return ImporterDepVersion::Link(target.to_string());
     }
 
@@ -292,17 +290,6 @@ fn build_packages_and_snapshots(
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
 
     for node in graph.values() {
-        // Pnpm leaves workspace-link nodes out of `lockfile.packages`
-        // entirely — `resolvePeersOfNode` returns early on `depth === -1`,
-        // so the link node never enters `dependenciesGraph` and the
-        // splitter that emits `packages:` / `snapshots:` never sees it.
-        // Pacquet's resolver doesn't yet skip link nodes, but the v9
-        // lockfile must still not carry them: a `link:` dep_path with
-        // a parenthesised peer suffix would otherwise mis-parse as a
-        // `PackageKey` and pollute both maps with a malformed key.
-        if node.dep_path.as_str().starts_with("link:") {
-            continue;
-        }
         let Ok(snapshot_key) = node.dep_path.as_str().parse::<PackageKey>() else { continue };
         let metadata_key = snapshot_key.without_peer();
 

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -711,59 +711,6 @@ fn workspace_link_direct_dep_renders_as_importer_link() {
     assert!(lockfile.snapshots.is_none() || lockfile.snapshots.as_ref().unwrap().is_empty());
 }
 
-/// Regression for [#11939](https://github.com/pnpm/pnpm/issues/11939):
-/// a workspace-link node whose linked package carries peer dependencies
-/// (the babylon `@dev/shared-ui-components` shape) picks up a
-/// `(<peers>)` suffix on its dep_path inside pacquet's resolver. Pnpm's
-/// own resolver short-circuits link nodes via the `depth === -1` arm so
-/// the suffix never appears, but until that arm is ported the
-/// lockfile-emit layer must paper over the difference:
-///
-/// 1. The importer's `version:` cell strips the peer-graph suffix —
-///    upstream emits `link:<rel-path>` exactly, with no parens, so the
-///    `installing/linking` layer can compute the symlink target.
-/// 2. The node never lands in `packages:` / `snapshots:` — pnpm puts
-///    nothing about a link node into those maps.
-#[test]
-fn workspace_link_with_peer_suffix_strips_to_bare_link_target() {
-    let (_tmp, manifest) = write_manifest(json!({
-        "name": "app",
-        "version": "1.0.0",
-        "dependencies": { "shared": "workspace:*" },
-    }));
-
-    let mut link_node =
-        make_link_node("../shared", json!({ "name": "shared", "version": "1.0.0" }));
-    let suffixed_dep_path = "link:../shared(react-dom@18.3.1)(react@18.3.1)".to_string();
-    link_node.dep_path = DepPath::from(suffixed_dep_path.clone());
-    link_node.resolved_package_id = suffixed_dep_path;
-
-    let mut graph = DependenciesGraph::new();
-    graph.insert(link_node.dep_path.clone(), link_node.clone());
-
-    let mut direct = BTreeMap::new();
-    direct.insert("shared".to_string(), link_node.dep_path);
-
-    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
-        &manifest, &graph, direct, false, false, None, None,
-    ));
-
-    let importer = lockfile.root_project().expect("root importer");
-    let entry = importer
-        .dependencies
-        .as_ref()
-        .expect("dependencies map")
-        .get(&PkgName::parse("shared").unwrap())
-        .expect("shared entry");
-    match &entry.version {
-        ImporterDepVersion::Link(target) => assert_eq!(target, "../shared"),
-        other => panic!("expected Link(\"../shared\"), got {other:?}"),
-    }
-
-    assert!(lockfile.packages.is_none() || lockfile.packages.as_ref().unwrap().is_empty());
-    assert!(lockfile.snapshots.is_none() || lockfile.snapshots.as_ref().unwrap().is_empty());
-}
-
 /// A transitive dep that depends on a workspace sibling renders the
 /// edge as `SnapshotDepRef::Link(<rel-path>)` instead of dropping it
 /// from the snapshot's `dependencies` map.

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -711,6 +711,59 @@ fn workspace_link_direct_dep_renders_as_importer_link() {
     assert!(lockfile.snapshots.is_none() || lockfile.snapshots.as_ref().unwrap().is_empty());
 }
 
+/// Regression for [#11939](https://github.com/pnpm/pnpm/issues/11939):
+/// a workspace-link node whose linked package carries peer dependencies
+/// (the babylon `@dev/shared-ui-components` shape) picks up a
+/// `(<peers>)` suffix on its dep_path inside pacquet's resolver. Pnpm's
+/// own resolver short-circuits link nodes via the `depth === -1` arm so
+/// the suffix never appears, but until that arm is ported the
+/// lockfile-emit layer must paper over the difference:
+///
+/// 1. The importer's `version:` cell strips the peer-graph suffix —
+///    upstream emits `link:<rel-path>` exactly, with no parens, so the
+///    `installing/linking` layer can compute the symlink target.
+/// 2. The node never lands in `packages:` / `snapshots:` — pnpm puts
+///    nothing about a link node into those maps.
+#[test]
+fn workspace_link_with_peer_suffix_strips_to_bare_link_target() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": { "shared": "workspace:*" },
+    }));
+
+    let mut link_node =
+        make_link_node("../shared", json!({ "name": "shared", "version": "1.0.0" }));
+    let suffixed_dep_path = "link:../shared(react-dom@18.3.1)(react@18.3.1)".to_string();
+    link_node.dep_path = DepPath::from(suffixed_dep_path.clone());
+    link_node.resolved_package_id = suffixed_dep_path;
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(link_node.dep_path.clone(), link_node.clone());
+
+    let mut direct = BTreeMap::new();
+    direct.insert("shared".to_string(), link_node.dep_path);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .expect("dependencies map")
+        .get(&PkgName::parse("shared").unwrap())
+        .expect("shared entry");
+    match &entry.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, "../shared"),
+        other => panic!("expected Link(\"../shared\"), got {other:?}"),
+    }
+
+    assert!(lockfile.packages.is_none() || lockfile.packages.as_ref().unwrap().is_empty());
+    assert!(lockfile.snapshots.is_none() || lockfile.snapshots.as_ref().unwrap().is_empty());
+}
+
 /// A transitive dep that depends on a workspace sibling renders the
 /// edge as `SnapshotDepRef::Link(<rel-path>)` instead of dropping it
 /// from the snapshot's `dependencies` map.

--- a/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
@@ -34,6 +34,7 @@
 use derive_more::{Display, Error, From};
 use indexmap::IndexSet;
 use miette::Diagnostic;
+use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_lockfile::{
     Lockfile, LockfileResolution, PackageKey, ParsePkgNameVerPeerError, PkgIdWithPatchHash,
 };
@@ -696,7 +697,12 @@ fn walk_deps(
         let node = DependenciesGraphNode {
             alias: Some(dep.0.name.clone()),
             dep_path: DepPath::from(reference.clone()),
-            pkg_id_with_patch_hash: PkgIdWithPatchHash::from(pkg_key.to_string()),
+            // `pkgIdWithPatchHash` strips peer-graph hashes but
+            // keeps `(patch_hash=…)`. Mirrors upstream's
+            // [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70).
+            pkg_id_with_patch_hash: PkgIdWithPatchHash::from(
+                get_pkg_id_with_patch_hash(&pkg_key.to_string()).to_string(),
+            ),
             dir: dir.clone(),
             modules: modules.to_path_buf(),
             children: BTreeMap::new(),

--- a/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/pacquet/crates/package-manager/src/hoisted_dep_graph.rs
@@ -698,7 +698,7 @@ fn walk_deps(
             alias: Some(dep.0.name.clone()),
             dep_path: DepPath::from(reference.clone()),
             // `pkgIdWithPatchHash` strips peer-graph hashes but
-            // keeps `(patch_hash=…)`. Mirrors upstream's
+            // keeps `(patch_hash=...)`. Mirrors upstream's
             // [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70).
             pkg_id_with_patch_hash: PkgIdWithPatchHash::from(
                 get_pkg_id_with_patch_hash(&pkg_key.to_string()).to_string(),

--- a/pacquet/crates/package-manager/src/virtual_store_layout.rs
+++ b/pacquet/crates/package-manager/src/virtual_store_layout.rs
@@ -22,6 +22,7 @@
 
 use crate::{AllowBuildPolicy, install_frozen_lockfile::find_own_runtime_node_major};
 use pacquet_config::Config;
+use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_graph_hasher::{
     DepsGraphNode, DepsStateCache, calc_graph_node_hash, engine_name,
     format_global_virtual_store_path,
@@ -313,7 +314,14 @@ fn lockfile_to_dep_graph(
         .map(|(snapshot_key, snapshot)| {
             let children = collect_children(snapshot);
             let metadata_key = snapshot_key.without_peer();
-            let pkg_id_with_patch_hash = PkgIdWithPatchHash::from(metadata_key.to_string());
+            // `pkgIdWithPatchHash` strips only the peer-graph suffix,
+            // not the `(patch_hash=…)` segment. Mirrors upstream's
+            // [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70).
+            // The metadata-map key (peer- and patch-hash-stripped) is
+            // still derived via `without_peer` for the `packages:` lookup.
+            let pkg_id_with_patch_hash = PkgIdWithPatchHash::from(
+                get_pkg_id_with_patch_hash(&snapshot_key.to_string()).to_string(),
+            );
             let resolution =
                 packages.and_then(|map| map.get(&metadata_key)).map(|meta| &meta.resolution);
             let full_pkg_id = create_full_pkg_id(&pkg_id_with_patch_hash, resolution);
@@ -738,5 +746,50 @@ mod tests {
         let slot_22 = layout.slot_dir(&pins_22);
         let slot_20 = layout.slot_dir(&pins_20);
         assert_ne!(slot_22, slot_20, "cross-pinning builders must land on distinct GVS slots");
+    }
+
+    /// `lockfile_to_dep_graph` builds each node's `pkg_id_with_patch_hash`
+    /// via upstream's `getPkgIdWithPatchHash` semantics — strip the
+    /// peer-graph suffix but **keep** the `(patch_hash=…)` segment. Two
+    /// patched snapshots with different peer suffixes therefore land on
+    /// one `pkg_id_with_patch_hash`, mirroring pnpm's side-effects-cache
+    /// keying. See
+    /// [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70).
+    #[test]
+    fn full_pkg_id_keeps_patch_hash_when_present() {
+        let patched_key: PackageKey =
+            "foo@1.0.0(patch_hash=abc)(react@18.0.0)".parse().expect("parse patched key");
+        let metadata_key = patched_key.without_peer();
+        let mut packages = HashMap::new();
+        packages.insert(
+            metadata_key,
+            PackageMetadata {
+                resolution: LockfileResolution::Registry(RegistryResolution {
+                    integrity: "sha512-PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP"
+                        .parse()
+                        .expect("parse integrity"),
+                }),
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        );
+        let mut snapshots = HashMap::new();
+        snapshots.insert(patched_key.clone(), SnapshotEntry::default());
+
+        let graph = super::lockfile_to_dep_graph(&snapshots, Some(&packages));
+        let node = graph.get(&patched_key).expect("patched snapshot node");
+        assert!(
+            node.full_pkg_id.starts_with("foo@1.0.0(patch_hash=abc):"),
+            "full_pkg_id must keep the patch-hash segment; got {:?}",
+            node.full_pkg_id,
+        );
     }
 }

--- a/pacquet/crates/package-manager/src/virtual_store_layout.rs
+++ b/pacquet/crates/package-manager/src/virtual_store_layout.rs
@@ -315,7 +315,7 @@ fn lockfile_to_dep_graph(
             let children = collect_children(snapshot);
             let metadata_key = snapshot_key.without_peer();
             // `pkgIdWithPatchHash` strips only the peer-graph suffix,
-            // not the `(patch_hash=…)` segment. Mirrors upstream's
+            // not the `(patch_hash=...)` segment. Mirrors upstream's
             // [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70).
             // The metadata-map key (peer- and patch-hash-stripped) is
             // still derived via `without_peer` for the `packages:` lookup.

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -496,7 +496,17 @@ where
     // which sets `isLeaf` once on `resolvedPkgsById[id]` and lets
     // [`buildTree`](https://github.com/pnpm/pnpm/blob/b9de85dcb6/installing/deps-resolver/src/resolveDependencyTree.ts#L381)
     // read it back.
-    let is_leaf = pkg_is_leaf(&result);
+    // Workspace-link nodes follow upstream's
+    // [`isLinkedDependency` arm](https://github.com/pnpm/pnpm/blob/cc4ff817aa/installing/deps-resolver/src/resolveDependencies.ts#L926-L937):
+    // children are empty (the linked project resolves its own deps as
+    // a separate importer), `depth = -1` flags the node for the
+    // peer-resolution short-circuit, and the [`ResolvedPackage`] carries
+    // no peer dependencies (peer matching is the linked importer's
+    // responsibility, not the parent's). The node id is collapsed to a
+    // leaf so every reference to the same workspace path shares one
+    // [`NodeId`], matching upstream's `createNodeIdForLinkedLocalPkg`.
+    let is_link = id.starts_with("link:");
+    let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
     let is_revisit;
@@ -508,7 +518,8 @@ where
                 is_revisit = true;
             }
             None => {
-                let peer_dependencies = extract_peer_dependencies(&result);
+                let peer_dependencies =
+                    if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
                 // Collect peer names for the peer-resolution stage's
                 // `parentPkgs` filter (only peers count as parents).
                 {
@@ -550,7 +561,13 @@ where
     // `packages`, `all_peer_dep_names`, and the per-pkg resolver
     // caches get populated for every transitive package — without
     // that pass, lazy revisits would have nothing to expand.
-    let children = if is_revisit {
+    let children = if is_link {
+        // Linked nodes don't walk their manifest's deps — see the
+        // `is_link` comment block above. Empty `Realized` map matches
+        // upstream's `children: {}` for the `isLinkedDependency`
+        // branch.
+        crate::resolved_tree::TreeChildren::Realized(BTreeMap::new())
+    } else if is_revisit {
         crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::new(next_ancestors.clone()) }
     } else {
         // Look up cached children specs first; only walk the manifest on
@@ -624,17 +641,21 @@ where
     // [`Math.min(...)` arm](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1636-L1637).
     // Per-occurrence counter ids are unique by construction, so the
     // `and_modify` arm is dead for non-leaves.
+    // Linked nodes carry `depth = -1` so the peer-resolution pass
+    // short-circuits them in `resolve_node`. Mirrors upstream's
+    // `depth: -1` on the `isLinkedDependency` arm.
+    let node_depth = if is_link { -1 } else { depth };
     lock_recoverable(&ctx.dependencies_tree)
         .entry(node_id.clone())
         .and_modify(|node| {
-            if node.depth > depth {
-                node.depth = depth;
+            if node.depth > node_depth {
+                node.depth = node_depth;
             }
         })
         .or_insert_with(|| DependenciesTreeNode {
             resolved_package_id: id.clone(),
             children,
-            depth,
+            depth: node_depth,
             installable: true,
         });
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -399,6 +399,21 @@ impl<'tree> Walker<'tree> {
         if self.tree.dependencies_tree.contains_key(&node_id) {
             let tree_node_depth = self.tree.dependencies_tree[&node_id].depth;
             let pkg_id = self.tree.dependencies_tree[&node_id].resolved_package_id.clone();
+            // Workspace-link short-circuit: mirrors upstream's
+            // [`if (node.depth === -1) return ...`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/installing/deps-resolver/src/resolvePeers.ts#L396)
+            // in `resolvePeersOfNode`. The linked package's depPath is
+            // its `link:<rel-path>` id verbatim — no peer-graph suffix,
+            // no graph entry. Peer matching for the linked package is
+            // the linked importer's responsibility, not the parent's.
+            if tree_node_depth == -1 {
+                let dep_path = DepPath::from(pkg_id);
+                self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+                return NodeOutput {
+                    dep_path,
+                    external_resolved_peers: HashMap::new(),
+                    missing_peers: HashMap::new(),
+                };
+            }
             let pkg_peer_dependencies_empty =
                 self.tree.packages[&pkg_id].peer_dependencies.is_empty();
             if self.pure_pkgs.contains(&pkg_id) && pkg_peer_dependencies_empty {

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -207,6 +207,85 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
     assert_eq!(shared_occurrences, 1);
 }
 
+/// Regression for [#11939](https://github.com/pnpm/pnpm/issues/11939):
+/// a workspace-link dependency whose linked package declares peer
+/// dependencies (the babylon `@dev/shared-ui-components` shape) must
+/// short-circuit in the tree builder. Mirrors upstream's
+/// [`isLinkedDependency` arm](https://github.com/pnpm/pnpm/blob/cc4ff817aa/installing/deps-resolver/src/resolveDependencies.ts#L926-L937):
+///
+/// 1. The tree node carries `depth = -1`.
+/// 2. The tree node's `children` map is empty — the link target
+///    resolves its own deps as a separate importer, not as nested
+///    transitive deps of the parent.
+/// 3. The package's `peer_dependencies` is empty — peer matching is
+///    the linked importer's responsibility.
+///
+/// Together these ensure the peer-resolution stage's `depth == -1`
+/// short-circuit kicks in and the link node's depPath stays
+/// `link:<rel-path>` with no peer-graph suffix.
+#[tokio::test]
+async fn workspace_link_node_is_short_circuited_in_tree() {
+    use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+    use pacquet_resolving_resolver_base::PkgResolutionId;
+
+    let link_id = "link:../shared";
+    let mut table = HashMap::new();
+    table.insert(
+        ("shared".to_string(), "workspace:*".to_string()),
+        ResolveResult {
+            id: PkgResolutionId::from(link_id.to_string()),
+            name_ver: None,
+            latest: None,
+            published_at: None,
+            manifest: Some(std::sync::Arc::new(serde_json::json!({
+                "name": "shared",
+                "version": "1.0.0",
+                // The linked package itself carries peers — these
+                // must NOT propagate to the parent's tree because
+                // pnpm's `isLinkedDependency` branch sets
+                // `resolvedPackage: { name, version }` only.
+                "peerDependencies": { "react": "^18.0.0" },
+                "dependencies": { "lodash": "^4.0.0" },
+            }))),
+            resolution: LockfileResolution::Directory(DirectoryResolution {
+                directory: "../shared".to_string(),
+            }),
+            resolved_via: "workspace".to_string(),
+            normalized_bare_specifier: None,
+            alias: Some("shared".to_string()),
+            policy_violation: None,
+        },
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "shared": "workspace:*" }));
+
+    let tree = resolve_dependency_tree(
+        &resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+        },
+    )
+    .await
+    .expect("resolve tree");
+
+    assert_eq!(tree.direct.len(), 1);
+    let link_node_id = &tree.direct[0].node_id;
+    let link_node = tree.dependencies_tree.get(link_node_id).expect("link tree node");
+    assert_eq!(link_node.depth, -1, "link node must carry depth = -1");
+    assert!(
+        link_node.children.realized().is_empty(),
+        "link node must have empty children — link target resolves its own deps separately",
+    );
+    let pkg = tree.packages.get(link_id).expect("link package entry");
+    assert!(
+        pkg.peer_dependencies.is_empty(),
+        "link node's ResolvedPackage must carry no peer_dependencies — peer matching is the linked importer's responsibility",
+    );
+}
+
 /// A chain that declines every spec (every `resolve()` returns
 /// `Ok(None)`) must NOT silently drop the edge — that would leave
 /// installs missing transitive deps and report success. The walker


### PR DESCRIPTION
## Summary

`pacquet install` was panicking on the babylon vlt fixture under the `node_modules` and `lockfile+node_modules` variations. The crash surfaced in [`PkgNameVerPeer::without_peer`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/pacquet/crates/lockfile/src/pkg_name_ver_peer.rs#L55-L62), but the root cause was an unported piece of pnpm's resolver: workspace `link:` nodes weren't short-circuited and flowed through peer resolution, producing depPaths of the shape `link:<rel-path>(<peers>)` that downstream code wasn't prepared for. This PR ports the missing short-circuit, fixes the panic, and closes the parity gaps the audit surfaced.

### Workspace-link short-circuit (the root fix)

Ported upstream's [`isLinkedDependency`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/installing/deps-resolver/src/resolveDependencies.ts#L926-L937) arm plus the [`depth === -1`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/installing/deps-resolver/src/resolvePeers.ts#L396) short-circuit in `resolvePeers.ts`. Workspace `link:` deps now:

- Skip child recursion in the tree walker (`TreeChildren::Realized(empty)`).
- Carry `depth = -1` on the tree node.
- Carry empty `peer_dependencies` on the `ResolvedPackage` — peer matching is the linked importer's concern.
- Use a leaf [`NodeId`] so every reference to the same workspace path shares one id.

`resolve_peers::resolve_node` early-returns for `depth == -1` nodes with `dep_path = pkg.id` (just `link:<rel-path>`). The link node never enters the graph, so `packages:` / `snapshots:` stay clean and the importer's `version:` cell carries `link:<rel-path>` exactly.

### `PkgNameVerPeer::without_peer` no longer panics

Construct the bare key through the typed fields rather than reformatting `{prefix}{version}` and re-parsing under `.expect(...)`. The new `PkgVerPeer::without_peer` clones the existing `prefix`/`version` slots and returns a `PkgVerPeer` with an empty peer string. No round-trip, no `.expect(...)`. Defensive even after the upstream fix lands — `without_peer` is called on values from the lockfile, which can be hand-edited.

### `pkgIdWithPatchHash` is now strip-peer-only at every site

Four call sites built a [`PkgIdWithPatchHash`] from the wrong baseline:

- `virtual_store_layout::lockfile_to_dep_graph` stripped both segments (`PkgNameVerPeer::without_peer().to_string()`) — patched variants of the same `name@version` collided in the dep-graph hash input.
- `create_virtual_store`'s two `cas_paths_by_pkg_id` inserts and `hoisted_dep_graph`'s `pkg_id_with_patch_hash` initialiser stripped nothing (raw `snapshot_key.to_string()`) — peer variants of the same patched package got separate CAS-paths entries instead of sharing one.

All four now go through `pacquet_deps_path::get_pkg_id_with_patch_hash` (the balanced-paren scan upstream's [`getPkgIdWithPatchHash`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/path/src/index.ts#L63-L70) uses): strip the peer-graph suffix, keep `(patch_hash=…)`. Non-patched packages are unaffected.

### New helpers in `pacquet-deps-path`

- `is_runtime_dep_path` — matches `^(?:node|bun|deno)@runtime:` byte-level. Pnpm filters the runtime-only install pass with this.
- `try_get_package_id` — strips peer-graph + patch-hash suffix, then drops the `<name>@` prefix on URL-shaped resolution ids while keeping `runtime:` entries intact.

### Ported `deps/path/test/index.ts` cases

| Suite | Cases ported |
|---|---|
| `pacquet-deps-path::suffix_index` | runtime, scoped, scoped + patch-hash, scoped + peer, scoped + both, leading-slash-legacy nested-peer, scope-with-parens |
| `pacquet-deps-path::is_runtime_dep_path` | pnpm's `isRuntimeDepPath` test + carve-outs |
| `pacquet-deps-path::try_get_package_id` | pnpm's `tryGetPackageId` test + URL-shape, bare, runtime carve-outs |
| `pacquet-lockfile::PkgVerPeer` | patch-hash + peer round-trip |
| `pacquet-lockfile::PkgNameVerPeer` | file-protocol tarball, patch-hash + peer, scope-with-parens, babylon regression |
| `pacquet-resolving-deps-resolver::tests` | babylon-shape: workspace dep with peers → `depth = -1`, empty children, no peer_dependencies |
| `pacquet-package-manager::virtual_store_layout::tests` | patched snapshot → `full_pkg_id` retains `(patch_hash=…)` |

Resolves #11939.

## Test plan

- [x] Every new regression test catches its corresponding bug when the fix is temporarily reverted (verified individually).
- [x] `cargo nextest run -p pacquet-deps-path -p pacquet-lockfile -p pacquet-resolving-deps-resolver -p pacquet-package-manager` — 574/574 pass.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] Manually re-ran `pacquet install` on the babylon fixture: the panic is gone, the install completes (`exit=0`), `@dev/build-tools` correctly symlinks to the workspace sibling.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of workspace-linked dependencies to prevent them from being unexpectedly dropped during resolution.
  * Improved peer dependency and patch hash preservation during dependency graph construction.

* **Tests**
  * Added comprehensive test coverage for edge cases in workspace linking, peer dependency suffixes, and patch hash handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->