### PR TITLE
fix(pacquet): require pnpm-lock.yaml for single-project optimisticRepeatInstall fast path

### DIFF
--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -394,6 +394,7 @@ where
                 node_linker,
                 included,
                 &project_manifests,
+                workspace_manifest.is_some(),
             )
         {
             Reporter::emit(&LogEvent::Pnpm(PnpmLog {

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5320,7 +5320,9 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
     std::fs::create_dir_all(&project_root).expect("create project root");
     let manifest_path = project_root.join("package.json");
     let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
-    manifest.add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest
+        .add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod)
+        .unwrap();
     manifest.save().unwrap();
 
     let mut config = Config::new();
@@ -5363,9 +5365,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         "first install must write pnpm-lock.yaml next to the manifest",
     );
     assert!(
-        load_workspace_state(&project_root)
-            .expect("read workspace state")
-            .is_some(),
+        load_workspace_state(&project_root).expect("read workspace state").is_some(),
         "first install must record .pnpm-workspace-state-v1.json",
     );
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -4883,6 +4883,15 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
     manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
+    // Single-project optimistic-repeat-install requires `pnpm-lock.yaml`
+    // on disk (matching pnpm's
+    // <https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L396-L401>
+    // `throwLockfileNotFound`). Write a minimal v9 lockfile next to
+    // the manifest so the freshness gate passes — the fast path only
+    // checks existence, not contents.
+    std::fs::write(project_root.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
+        .expect("seed pnpm-lock.yaml");
+
     let mut config = Config::new();
     config.lockfile = false;
     config.store_dir = store_dir.clone().into();
@@ -5137,4 +5146,147 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
     // covers that emit), and downstream code asserts on its
     // presence; we only assert here that the *optimistic* log is
     // absent so the polarity of the gate is clear.
+}
+
+/// Regression: a single-project install where `node_modules` is
+/// still on disk (so the workspace-state file survives) but
+/// `pnpm-lock.yaml` is gone must NOT short-circuit. This is the
+/// `cache+node_modules` and `node_modules`-only benchmark scenario
+/// pnpm finishes in ~5 s and pacquet was silently completing in
+/// ~35 ms before the single-project lockfile gate landed. Mirrors
+/// pnpm's [`throwLockfileNotFound`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L396-L401)
+/// converting into `upToDate: false`. Companion to the workspace-
+/// mode tolerance proved by
+/// [`returns_up_to_date_in_workspace_mode_without_lockfile`](crate::optimistic_repeat_install::tests::returns_up_to_date_in_workspace_mode_without_lockfile).
+#[tokio::test]
+async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    std::fs::create_dir_all(&modules_dir).expect("create modules dir so the deps gate passes");
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path.clone()).unwrap();
+    manifest.add_dependency("sibling", "link:../sibling", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    // Deliberately do NOT write `pnpm-lock.yaml` — that's the
+    // scenario under test.
+
+    let mut config = Config::new();
+    config.lockfile = false;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      sibling:"
+        "        specifier: link:../sibling"
+        "        version: link:../sibling"
+        "packages: {}"
+        "snapshots: {}"
+    })
+    .expect("parse lockfile");
+
+    let included = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: false,
+    };
+
+    // Seed `.modules.yaml` and a fresh workspace state — same shape
+    // as the happy-path optimistic test above. The only difference
+    // is the missing `pnpm-lock.yaml`.
+    let seed_modules = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        included,
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed_modules).expect("seed .modules.yaml");
+
+    let mut projects = std::collections::BTreeMap::new();
+    projects.insert(
+        project_root.to_string_lossy().into_owned(),
+        workspace_state::ProjectEntry {
+            name: Some("project".to_string()),
+            version: Some("1.0.0".to_string()),
+        },
+    );
+    let settings = crate::optimistic_repeat_install::current_settings(
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        included,
+    );
+    workspace_state::update_workspace_state(
+        &project_root,
+        &pacquet_workspace_state::WorkspaceState {
+            last_validated_timestamp: pacquet_workspace_state::now_millis() + 60_000,
+            projects,
+            pnpmfiles: Vec::new(),
+            filtered_install: false,
+            config_dependencies: None,
+            settings,
+        },
+    )
+    .expect("seed workspace state");
+
+    // We're not testing the full install pipeline here — without a
+    // lockfile on disk the fresh-resolve path would try to resolve
+    // `link:../sibling` against a directory that doesn't exist. We
+    // only need to prove the optimistic short-circuit did NOT fire,
+    // so swallow the install result.
+    let _ = Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: Some(&lockfile),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::Isolated,
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await;
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        !captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Pnpm(log) if log.message == "Already up to date"
+        )),
+        "the optimistic 'Already up to date' log MUST NOT fire when \
+         `pnpm-lock.yaml` is missing in a single-project install; got events: {captured:#?}",
+    );
 }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -5290,3 +5290,148 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
          `pnpm-lock.yaml` is missing in a single-project install; got events: {captured:#?}",
     );
 }
+
+/// Round-trip the optimistic short-circuit end-to-end on a real
+/// single-project install (no `pnpm-workspace.yaml`):
+///
+/// 1. First [`Install::run`] resolves through the registry mock,
+///    writes `pnpm-lock.yaml` next to the manifest, lays out
+///    `node_modules`, and records `.pnpm-workspace-state-v1.json`.
+/// 2. A second [`Install::run`] against the same manifest must hit
+///    the optimistic fast path — emit `Already up to date` and skip
+///    every install-setup event (`pnpm:context`, `pnpm:stage`,
+///    `pnpm:lockfile-verification`).
+///
+/// Proves the single-project lockfile gate added in this commit
+/// doesn't break the warm-reinstall fast path it's intended to
+/// preserve. Companion to
+/// [`optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing`]
+/// (which covers the negative direction).
+#[tokio::test]
+async fn optimistic_repeat_install_round_trips_on_single_project_install() {
+    let mock_instance = AutoMockInstance::load_or_init();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    std::fs::create_dir_all(&project_root).expect("create project root");
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    manifest.add_dependency("@pnpm.e2e/hello-world-js-bin", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    // First install: fresh-resolve path. Writes `pnpm-lock.yaml` next
+    // to the manifest (via `install_with_fresh_lockfile`) and the
+    // workspace state next to `node_modules` (via
+    // `Install::run`'s end-of-run `update_workspace_state` call).
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        resolved_packages: &Default::default(),
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("first install must succeed");
+
+    // Sanity check the first install left both artifacts the
+    // optimistic check keys off on disk.
+    assert!(
+        project_root.join("pnpm-lock.yaml").exists(),
+        "first install must write pnpm-lock.yaml next to the manifest",
+    );
+    assert!(
+        load_workspace_state(&project_root)
+            .expect("read workspace state")
+            .is_some(),
+        "first install must record .pnpm-workspace-state-v1.json",
+    );
+
+    // Now run the second install against the same manifest. Capture
+    // events to prove the fast path fired.
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        // Don't pass the in-memory lockfile — the optimistic check
+        // doesn't need it, and we want to prove the fast path runs
+        // *before* the lockfile is even loaded. (Matching pnpm's
+        // dispatch ordering: `checkDepsStatus` runs before any
+        // lockfile parse.)
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        resolved_packages: &Default::default(),
+    }
+    .run::<RecordingReporter>()
+    .await
+    .expect("second install must succeed via the optimistic short-circuit");
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Pnpm(log) if log.message == "Already up to date"
+        )),
+        "second install must emit `Already up to date`; got events: {captured:#?}",
+    );
+
+    // The fast path runs before any of the install setup, so none
+    // of these events should fire on the second install.
+    let install_emits = captured
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                LogEvent::Context(_) | LogEvent::Stage(_) | LogEvent::LockfileVerification(_),
+            )
+        })
+        .count();
+    assert_eq!(
+        install_emits, 0,
+        "the second install must not run any install-setup steps; got events: {captured:#?}",
+    );
+
+    drop((dir, mock_instance));
+}

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -43,6 +43,7 @@ use std::{
 };
 
 use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker};
+use pacquet_lockfile::Lockfile;
 use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_package_manifest::PackageManifest;
 use pacquet_workspace_state::{
@@ -79,6 +80,16 @@ pub enum Decision {
 /// function rediscovering it) so the same walk seeds the regular
 /// install path on the fall-through.
 ///
+/// `is_workspace_install` is `true` when a `pnpm-workspace.yaml`
+/// drives the install — that selects pnpm's
+/// [`allProjects && workspaceDir` branch](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L187)
+/// which exits purely on the per-manifest mtime check. `false` (no
+/// workspace manifest) selects the
+/// [single-project branch](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L387-L462)
+/// which additionally requires `pnpm-lock.yaml` to exist on disk —
+/// pnpm throws `RUN_CHECK_DEPS_LOCKFILE_NOT_FOUND` otherwise, which
+/// the outer `try` converts into `upToDate: false`.
+///
 /// Always returns `Decision::Skipped` when
 /// `config.optimistic_repeat_install` is `false`.
 pub fn check_optimistic_repeat_install(
@@ -87,6 +98,7 @@ pub fn check_optimistic_repeat_install(
     node_linker: NodeLinker,
     included: IncludedDependencies,
     project_manifests: &[(PathBuf, &PackageManifest)],
+    is_workspace_install: bool,
 ) -> Decision {
     if !config.optimistic_repeat_install {
         return Decision::Skipped { reason: "optimistic_repeat_install disabled" };
@@ -122,6 +134,20 @@ pub fn check_optimistic_repeat_install(
         return Decision::Skipped {
             reason: "project has dependencies but no node_modules directory",
         };
+    }
+
+    // Single-project installs require `pnpm-lock.yaml` on disk to
+    // even attempt the fast path. Upstream's single-project branch
+    // at <https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L396-L401>
+    // throws `RUN_CHECK_DEPS_LOCKFILE_NOT_FOUND` when
+    // `wantedLockfileStats` is absent, which the outer `try`
+    // converts into `upToDate: false`. Workspace installs skip this
+    // gate — pnpm's workspace branch returns `upToDate: true` purely
+    // off the manifest-mtime check (its only lockfile probe,
+    // `findConflictedLockfileDir`, silently `continue`s on ENOENT at
+    // <https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L593-L596>).
+    if !is_workspace_install && !workspace_root.join(Lockfile::FILE_NAME).exists() {
+        return Decision::Skipped { reason: "wanted lockfile missing" };
     }
 
     // The fast-path conclusion. Upstream walks every manifest and

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1,5 +1,6 @@
 use super::{Decision, check_optimistic_repeat_install, current_settings};
 use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
 use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_package_manifest::PackageManifest;
 use pacquet_workspace_state::{
@@ -10,6 +11,14 @@ use tempfile::tempdir;
 
 fn isolated_included() -> IncludedDependencies {
     IncludedDependencies { dependencies: true, dev_dependencies: true, optional_dependencies: true }
+}
+
+/// Write an empty `pnpm-lock.yaml` to satisfy the single-project
+/// branch's lockfile-existence gate. The fast path only checks
+/// existence, not contents.
+fn write_empty_lockfile(workspace_root: &std::path::Path) {
+    fs::write(workspace_root.join(Lockfile::FILE_NAME), "lockfileVersion: '9.0'\n")
+        .expect("write pnpm-lock.yaml");
 }
 
 fn write_state(
@@ -53,6 +62,13 @@ fn setup_fresh_install(
     fs::write(&manifest_path, manifest_body).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
 
+    // Seed `pnpm-lock.yaml` so the single-project branch's lockfile
+    // gate passes — most tests run in single-project mode (no
+    // `pnpm-workspace.yaml`) and would otherwise short-circuit on
+    // the missing-lockfile reason regardless of what they intend
+    // to exercise.
+    write_empty_lockfile(workspace_root);
+
     // Sleep long enough for the filesystem clock to advance past the
     // manifest's mtime before stamping the workspace state. Without
     // this, fast filesystems (APFS / tmpfs) leave both timestamps in
@@ -78,7 +94,8 @@ fn setup_fresh_install(
 }
 
 /// Happy path: state is fresh, manifest hasn't been touched since
-/// the validation, modules dir exists. The fast path fires.
+/// the validation, modules dir exists, `pnpm-lock.yaml` exists.
+/// The fast path fires.
 #[test]
 fn returns_up_to_date_when_state_and_manifests_agree() {
     let (dir, config, manifest) =
@@ -90,6 +107,7 @@ fn returns_up_to_date_when_state_and_manifests_agree() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(dir.path().to_path_buf(), &manifest)],
+        false,
     );
     assert_eq!(decision, Decision::UpToDate);
 }
@@ -117,6 +135,7 @@ fn returns_skipped_when_config_disabled() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("disabled")));
 }
@@ -141,6 +160,7 @@ fn returns_skipped_when_no_state_file() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(
         matches!(decision, Decision::Skipped { reason } if reason.contains("no workspace state")),
@@ -166,6 +186,7 @@ fn returns_skipped_when_manifest_is_newer_than_validation() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(dir.path().to_path_buf(), &refreshed_manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("newer")));
 }
@@ -184,6 +205,7 @@ fn returns_skipped_when_node_linker_drifts() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(dir.path().to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -218,6 +240,7 @@ fn returns_skipped_when_workspace_project_set_changes() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(dir.path().to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("project list")));
 }
@@ -267,6 +290,7 @@ fn returns_skipped_when_overrides_drift() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -309,6 +333,7 @@ fn returns_skipped_when_ignored_optional_dependencies_drift() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -354,6 +379,7 @@ fn returns_skipped_when_patched_dependencies_drift() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -395,6 +421,7 @@ fn returns_skipped_when_allow_builds_drift() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -447,6 +474,7 @@ fn returns_skipped_when_unported_pnpm_settings_present() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(workspace_root.to_path_buf(), &manifest)],
+        false,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
@@ -499,6 +527,69 @@ fn returns_skipped_when_sibling_node_modules_missing_for_project_with_deps() {
         pacquet_config::NodeLinker::Isolated,
         isolated_included(),
         &[(dir.path().to_path_buf(), &root_manifest), (sibling_dir, &sibling_manifest)],
+        true,
     );
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("node_modules")));
+}
+
+/// Regression: a single-project install with `node_modules` present
+/// but no `pnpm-lock.yaml` on disk must NOT short-circuit. Mirrors
+/// pnpm's [single-project branch](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L396-L401)
+/// throwing `RUN_CHECK_DEPS_LOCKFILE_NOT_FOUND`, which the outer
+/// `try`/`catch` converts into `upToDate: false`. Without this gate,
+/// pacquet's fast path fires whenever the workspace-state file and
+/// manifests agree — independent of whether the lockfile exists —
+/// which silently turns `pnpm.io`'s `cache+node_modules` and
+/// `node_modules`-only benchmark scenarios into a 35 ms no-op.
+#[test]
+fn returns_skipped_when_lockfile_missing_in_single_project_mode() {
+    let (dir, config, manifest) =
+        setup_fresh_install(pacquet_config::NodeLinker::Isolated, "root", "1.0.0", "");
+
+    // `setup_fresh_install` seeds `pnpm-lock.yaml` for happy-path
+    // tests; delete it here so this test exercises the missing-
+    // lockfile branch.
+    fs::remove_file(dir.path().join(Lockfile::FILE_NAME)).expect("remove seeded lockfile");
+
+    let decision = check_optimistic_repeat_install(
+        dir.path(),
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &[(dir.path().to_path_buf(), &manifest)],
+        false,
+    );
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("wanted lockfile")),
+        "expected Skipped(wanted lockfile missing), got {decision:?}",
+    );
+}
+
+/// Workspace installs do NOT require `pnpm-lock.yaml` on disk for
+/// the fast path — pnpm's
+/// [workspace branch](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L268-L271)
+/// returns `upToDate: true` purely off the per-manifest mtime check
+/// without any wanted-lockfile probe (its merge-conflict scan,
+/// `findConflictedLockfileDir`, silently `continue`s on ENOENT at
+/// <https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L593-L596>).
+/// Pacquet must match that polarity so a workspace install state
+/// file written by either tool round-trips through the other.
+#[test]
+fn returns_up_to_date_in_workspace_mode_without_lockfile() {
+    let (dir, config, manifest) =
+        setup_fresh_install(pacquet_config::NodeLinker::Isolated, "root", "1.0.0", "");
+
+    // Same seeded state as the happy path, but the lockfile gets
+    // wiped first — the workspace branch shouldn't care.
+    fs::remove_file(dir.path().join(Lockfile::FILE_NAME)).expect("remove seeded lockfile");
+
+    let decision = check_optimistic_repeat_install(
+        dir.path(),
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &[(dir.path().to_path_buf(), &manifest)],
+        true,
+    );
+    assert_eq!(decision, Decision::UpToDate);
 }


### PR DESCRIPTION
## Summary

Follow-up to #11943. The `optimisticRepeatInstall` port applied pnpm's [workspace-branch mtime-only exit](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L263-L271) to **every** install, including single-project ones. Pnpm's [single-project branch](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L396-L401) additionally throws `RUN_CHECK_DEPS_LOCKFILE_NOT_FOUND` when `pnpm-lock.yaml` is missing — the outer `try` converts that to `upToDate: false`. Pacquet skipped that gate, so a single-project install with `node_modules` present but no lockfile silently short-circuited as "Already up to date" in ~35 ms (vs pnpm running the real install at ~5–7 s on the same fixture).

This was visible in the `pnpm.io` benchmarks the day #11943 landed:

| action  | cache | lockfile | node_modules| pnpm | pacquet (before) |
| ---     | ---   | ---      | ---         | --- | --- |
| install |   |   | ✔ | 7.1s | **35ms** ⚠️ |
| install | ✔ |   | ✔ | 5s   | **37ms** ⚠️ |

Both rows have **no lockfile** but pacquet was hitting the optimistic fast path anyway.

## Fix

- Add an `is_workspace_install: bool` parameter to `check_optimistic_repeat_install`.
- In single-project mode (no `pnpm-workspace.yaml`), require `<workspace_root>/pnpm-lock.yaml` to exist before returning `UpToDate`.
- Workspace mode is unchanged — pnpm's workspace branch's only lockfile probe (`findConflictedLockfileDir`) silently `continue`s on ENOENT ([checkDepsStatus.ts:593-596](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/src/checkDepsStatus.ts#L593-L596)), so pacquet matches that polarity.

Caller in `install.rs` passes `workspace_manifest.is_some()`.

## Tests ported / added

- `returns_skipped_when_lockfile_missing_in_single_project_mode` — unit test; the direct regression catcher.
- `returns_up_to_date_in_workspace_mode_without_lockfile` — unit test; proves the workspace branch still tolerates a missing lockfile, matching pnpm.
- `optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing` — install-level integration test; observes the absence of the `Already up to date` log when `pnpm-lock.yaml` is missing.
- Existing happy-path tests now seed `pnpm-lock.yaml` via a new `write_empty_lockfile` helper inside `setup_fresh_install` so they exercise the realistic single-project layout.

Verified per pacquet conventions by temporarily disabling the new gate — both new tests fail; with the gate restored, all 332 `pacquet-package-manager` tests pass. `just fmt`/`check`/`lint` are clean.

## Test plan

- [x] `cargo nextest run -p pacquet-package-manager optimistic_repeat` (16 tests, all pass)
- [x] `cargo nextest run -p pacquet-package-manager` full crate (332 pass)
- [x] `just fmt`, `just check`, `just lint`
- [x] Temporarily disabled the new check to confirm the two new tests fail, then re-enabled to confirm they pass

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved "Already up to date" detection to correctly distinguish between single-project and workspace installations, ensuring the fast-path optimization properly validates installation state.

* **Tests**
  * Added regression tests to verify correct behavior when lockfiles are present or missing in different installation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->