### PR TITLE
fix(pacquet/package-manager): build workspace state from project list, not lockfile

### DIFF
--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -668,7 +668,7 @@ where
             }));
             update_workspace_state(
                 &workspace_root,
-                &build_workspace_state(config, node_linker, included, manifest, lockfile),
+                &build_workspace_state(config, node_linker, included, &project_manifests),
             )
             .map_err(InstallError::WriteWorkspaceState)?;
             Reporter::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
@@ -910,7 +910,7 @@ where
         // committed install.
         update_workspace_state(
             &workspace_root,
-            &build_workspace_state(config, node_linker, included, manifest, lockfile),
+            &build_workspace_state(config, node_linker, included, &project_manifests),
         )
         .map_err(InstallError::WriteWorkspaceState)?;
 
@@ -1313,44 +1313,18 @@ fn build_workspace_packages_map(
 /// re-run install in that case (the project count won't match), so a
 /// best-effort entry beats failing the install over a transient read.
 fn build_projects_map(
-    workspace_root: &std::path::Path,
-    manifest: &PackageManifest,
-    lockfile: Option<&Lockfile>,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> BTreeMap<String, ProjectEntry> {
-    let mut projects: BTreeMap<String, ProjectEntry> = BTreeMap::new();
-    let root_entry = ProjectEntry {
-        name: manifest_string_field(manifest, "name"),
-        version: manifest_string_field(manifest, "version"),
-    };
-    let importer_ids: Vec<String> = match lockfile {
-        Some(lf) => lf.importers.keys().cloned().collect(),
-        None => vec![Lockfile::ROOT_IMPORTER_KEY.to_string()],
-    };
-    for importer_id in importer_ids {
-        let project_dir =
-            crate::symlink_direct_dependencies::importer_root_dir(workspace_root, &importer_id);
-        let entry = if importer_id == Lockfile::ROOT_IMPORTER_KEY {
-            root_entry.clone()
-        } else {
-            match PackageManifest::from_path(project_dir.join("package.json")) {
-                Ok(sub_manifest) => ProjectEntry {
-                    name: manifest_string_field(&sub_manifest, "name"),
-                    version: manifest_string_field(&sub_manifest, "version"),
-                },
-                Err(error) => {
-                    tracing::warn!(
-                        target: "pacquet::install",
-                        ?error,
-                        importer_id = %importer_id,
-                        "Failed to read sub-importer manifest while recording workspace state",
-                    );
-                    ProjectEntry::default()
-                }
-            }
-        };
-        projects.insert(project_dir.to_string_lossy().into_owned(), entry);
-    }
-    projects
+    project_manifests
+        .iter()
+        .map(|(project_dir, manifest)| {
+            let entry = ProjectEntry {
+                name: manifest_string_field(manifest, "name"),
+                version: manifest_string_field(manifest, "version"),
+            };
+            (project_dir.to_string_lossy().into_owned(), entry)
+        })
+        .collect()
 }
 
 /// Assemble the [`WorkspaceState`] payload for [`update_workspace_state`].
@@ -1366,18 +1340,11 @@ fn build_workspace_state(
     config: &Config,
     node_linker: NodeLinker,
     included: IncludedDependencies,
-    manifest: &PackageManifest,
-    lockfile: Option<&Lockfile>,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> WorkspaceState {
-    let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
-    let workspace_root = pacquet_workspace::find_workspace_dir(manifest_dir)
-        .ok()
-        .flatten()
-        .unwrap_or_else(|| manifest_dir.to_path_buf());
-
     WorkspaceState {
         last_validated_timestamp: now_millis(),
-        projects: build_projects_map(&workspace_root, manifest, lockfile),
+        projects: build_projects_map(project_manifests),
         // Pacquet doesn't run pnpmfiles yet; record the empty list so
         // pnpm's `patchesOrHooksAreModified` doesn't trip on a missing
         // field.

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1300,18 +1300,16 @@ fn build_workspace_packages_map(
     Some(map)
 }
 
-/// Build the `projects` map for [`WorkspaceState`]. Mirrors upstream's
+/// Build the `projects` map for [`WorkspaceState`] from the
+/// in-memory `(root_dir, manifest)` list the caller already
+/// assembled. Mirrors upstream's
 /// `Object.fromEntries(opts.allProjects.map(...))` at
 /// <https://github.com/pnpm/pnpm/blob/7ff112bac6/workspace/state/src/createWorkspaceState.ts>.
 ///
-/// For workspace installs (frozen-lockfile with sub-importers), pacquet
-/// reads each sub-importer's `package.json` to capture `name` / `version`
-/// the same way pnpm's `find_workspace_projects` does. The root
-/// importer (`.`) reuses the already-loaded `manifest` — re-reading it
-/// would double the I/O for no behavior change. A missing or unreadable
-/// sub-manifest is logged and skipped: pnpm would already correctly
-/// re-run install in that case (the project count won't match), so a
-/// best-effort entry beats failing the install over a transient read.
+/// Pure in-memory: no file I/O, no read-failure warnings, no lockfile
+/// or importer traversal. Every project — root and siblings alike —
+/// reuses the [`PackageManifest`] reference already loaded for the
+/// install dispatch.
 fn build_projects_map(
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> BTreeMap<String, ProjectEntry> {

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -811,6 +811,87 @@ async fn install_writes_workspace_state() {
     drop(dir);
 }
 
+/// Unit tests for [`super::build_projects_map`] / [`super::build_workspace_state`].
+/// Ports the cases in upstream's
+/// [`createWorkspaceState.test.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/workspace/state/test/createWorkspaceState.test.ts):
+/// the `projects` map must contain one entry per project in the list,
+/// keyed on the project root dir. Pacquet's `build_projects_map`
+/// derives the list directly from `project_manifests` — same shape as
+/// pnpm's `createWorkspaceState` taking `allProjects` — so a fresh
+/// install that hasn't written a `pnpm-lock.yaml` yet still records
+/// every workspace project, not just the root.
+mod build_workspace_state_tests {
+    use super::super::build_workspace_state;
+    use pacquet_config::Config;
+    use pacquet_modules_yaml::IncludedDependencies;
+    use pacquet_package_manifest::PackageManifest;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn write_manifest(dir: &std::path::Path, name: &str, version: &str) -> PackageManifest {
+        let manifest_path = dir.join("package.json");
+        std::fs::write(&manifest_path, format!(r#"{{"name":"{name}","version":"{version}"}}"#))
+            .unwrap();
+        PackageManifest::from_path(manifest_path).unwrap()
+    }
+
+    /// Ports `createWorkspaceState() on empty list`: a zero-project
+    /// input produces an empty `projects` map but still populates the
+    /// timestamp.
+    #[test]
+    fn empty_project_list_produces_empty_projects_map() {
+        let config = Config::new();
+        let state = build_workspace_state(
+            &config,
+            pacquet_config::NodeLinker::default(),
+            IncludedDependencies::default(),
+            &[],
+        );
+        assert!(state.projects.is_empty());
+        assert!(state.last_validated_timestamp > 0);
+    }
+
+    /// Ports `createWorkspaceState() on non-empty list`: every project
+    /// in the list lands in `state.projects` keyed by its root_dir.
+    /// Regression catch for the bug where a workspace fresh install
+    /// (no `pnpm-lock.yaml` on disk) recorded only the root importer.
+    #[test]
+    fn records_every_workspace_project_keyed_by_root_dir() {
+        let dir = tempdir().unwrap();
+        let packages = ["a", "b", "c", "d"];
+        let manifests: Vec<(PathBuf, PackageManifest)> = packages
+            .iter()
+            .map(|name| {
+                let project_dir = dir.path().join("packages").join(name);
+                std::fs::create_dir_all(&project_dir).unwrap();
+                let manifest = write_manifest(&project_dir, name, "1.0.0");
+                (project_dir, manifest)
+            })
+            .collect();
+        let project_manifests: Vec<(PathBuf, &PackageManifest)> =
+            manifests.iter().map(|(p, m)| (p.clone(), m)).collect();
+
+        let config = Config::new();
+        let state = build_workspace_state(
+            &config,
+            pacquet_config::NodeLinker::default(),
+            IncludedDependencies::default(),
+            &project_manifests,
+        );
+
+        assert_eq!(state.projects.len(), packages.len());
+        for (project_dir, _) in &manifests {
+            let key = project_dir.to_string_lossy().into_owned();
+            let entry = state
+                .projects
+                .get(&key)
+                .unwrap_or_else(|| panic!("project entry for {key:?} should exist"));
+            assert_eq!(entry.version.as_deref(), Some("1.0.0"));
+            assert!(packages.contains(&entry.name.as_deref().unwrap_or_default(),));
+        }
+    }
+}
+
 /// Ports `'do not fail on an optional dependency that has a non-optional
 /// dependency with a failing postinstall script'` at
 /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/installing/deps-installer/test/install/optionalDependencies.ts#L563-L572>.


### PR DESCRIPTION
## Summary

`build_projects_map` derived workspace projects from `lockfile.importers.keys()`. On the fresh-install path the wanted lockfile is `None` (no `pnpm-lock.yaml` on disk yet), so the function fell into its no-lockfile arm and recorded **only the root importer** — even for an 87-project workspace like babylon.

That broke the [`optimistic_repeat_install`](https://github.com/pnpm/pnpm/blob/6b3ba4d337/pacquet/crates/package-manager/src/optimistic_repeat_install.rs) fast path on the *next* install: `project_structure_matches` compared the recorded project list (`len = 1`) against the workspace projects the resolver discovered (`len = 87`), returned `false`, and the install fell through to the full resolve + verify path even though the on-disk state was already a no-op.

## Fix

Upstream pnpm's [`createWorkspaceState`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/workspace/state/src/createWorkspaceState.ts#L14-L27) takes `allProjects: ProjectsList` as input and emits one entry per project — the lockfile isn't involved. Pacquet already builds the matching `project_manifests: &[(PathBuf, &PackageManifest)]` at the top of `Install::run` (for the optimistic-repeat fast path); thread it through to `build_workspace_state` instead of re-deriving from the lockfile.

The new `build_projects_map` is half the size of the old one and can't fall into a "lockfile missing" arm — the project list always comes from the same scan the rest of the install uses.

## Impact

Re-bench against the vlt `babylon` fixture (87-project monorepo) shows every `*+node_modules` cell collapsing from "very slow" to "faster than pnpm":

| Variation | Before | After |
|---|---:|---:|
| `node_modules` | 37.87× | **0.09×** (11× faster than pnpm) |
| `lockfile+node_modules` | 25.52× | **0.07×** (14× faster) |
| `cache+node_modules` | 11.55× | **0.15×** (6.7× faster) |
| `cache+lockfile+node_modules` | 11.35× | **0.17×** (5.9× faster) |

These were the four worst cells in the vlt benchmark chart for babylon (all flagged DNF before #11944 fixed the underlying panic). After #11944 babylon stopped DNF'ing but stayed 11-37× slower because of this workspace-state writing bug.

The fast path only failed for workspace installs whose wanted lockfile was absent on the first install of the iteration — i.e. exactly the vlt benchmark's `node_modules` and `*+node_modules` shape. Single-project installs always recorded the root correctly because the no-lockfile fallback already emitted the root entry.

Found while validating #11944's claim that the babylon DNF cells would collapse on the next pacquet release (#11902).

## Tests

Ports the two scenarios from upstream's [`createWorkspaceState.test.ts`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/workspace/state/test/createWorkspaceState.test.ts) into `install::tests::build_workspace_state_tests`:

- `empty_project_list_produces_empty_projects_map` — zero projects in, empty `projects` map out, timestamp still populated. Mirrors pnpm's `createWorkspaceState() on empty list`.
- `records_every_workspace_project_keyed_by_root_dir` — four projects in, four entries in `projects`, each keyed by `root_dir`. Mirrors pnpm's `createWorkspaceState() on non-empty list`. Verified to fail on the pre-fix shape (returned 1 entry instead of 4) when `build_projects_map` is temporarily restricted to the root.

## Test plan

- [x] New unit tests pass.
- [x] Confirmed the regression test fails on the pre-fix shape (verified locally by temporarily restricting `build_projects_map` to `.take(1)`).
- [x] `cargo nextest run -p pacquet-package-manager` — 335/335 pass.
- [x] `cargo clippy --locked --workspace --all-targets -- --deny warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] End-to-end: babylon's `node_modules/.pnpm-workspace-state-v1.json` after a fresh install now contains 87 projects (was 1); 2nd install fires the no-op fast path in 0.097s.
- [x] Re-ran `bench run --pms=pnpm,pacquet --fixtures=babylon --variation={node_modules,cache+node_modules,lockfile+node_modules,cache+lockfile+node_modules}` — every cell now under 1.0× and per-iteration times stable at 0.06–0.11s (was 0.09–29s).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install now reliably records workspace projects from provided manifests so project entries (name/version) remain consistent after install, including fresh installs without a prior lockfile or prior state.
* **Tests**
  * Added unit tests that validate workspace state and project recording behavior for empty and multi-project workspaces, ensuring correct project entries and timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->