### PR TITLE
fix: pnpm runtime set defaults to devEngines

### DIFF
--- a/.changeset/runtime-set-default-devengines.md
+++ b/.changeset/runtime-set-default-devengines.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.runtime.commands": minor
+"pnpm": minor
+---
+
+`pnpm runtime set <name> <version>` now saves the runtime to `devEngines.runtime` by default instead of `engines.runtime`. Pass `--save-prod` (or `-P`) to save it to `engines.runtime` instead [#11948](https://github.com/pnpm/pnpm/issues/11948).

--- a/engine/runtime/commands/src/runtime/runtime.ts
+++ b/engine/runtime/commands/src/runtime/runtime.ts
@@ -12,6 +12,8 @@ export type RuntimeCommandOptions = Pick<Config,
 > & Partial<Pick<Config,
 | 'storeDir'
 | 'cacheDir'
+| 'saveDev'
+| 'saveProd'
 >>
 
 export const skipPackageManagerCheck = true
@@ -23,6 +25,8 @@ export function rcOptionsTypes (): Record<string, unknown> {
 export function cliOptionsTypes (): Record<string, unknown> {
   return {
     global: Boolean,
+    'save-dev': Boolean,
+    'save-prod': Boolean,
   }
 }
 
@@ -49,11 +53,22 @@ export function help (): string {
             name: '--global',
             shortAlias: '-g',
           },
+          {
+            description: 'Save the runtime to `devEngines.runtime`. This is the default',
+            name: '--save-dev',
+            shortAlias: '-D',
+          },
+          {
+            description: 'Save the runtime to `engines.runtime`',
+            name: '--save-prod',
+            shortAlias: '-P',
+          },
         ],
       },
     ],
     url: docsUrl('runtime'),
     usages: [
+      'pnpm runtime set node 22',
       'pnpm runtime set node 22 -g',
       'pnpm runtime set node lts -g',
       'pnpm runtime set node rc/22 -g',
@@ -91,6 +106,9 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
   const versionSpec = params[1]?.trim()
 
   const args = ['add', `${runtimeName}@runtime:${versionSpec ?? ''}`]
+  // Default to `devEngines.runtime`; the manifest writer maps a
+  // `devDependencies.<runtime>: runtime:<version>` entry to it.
+  args.push(opts.saveProd ? '--save-prod' : '--save-dev')
   if (opts.global) {
     args.push('--global')
     if (opts.bin) args.push('--global-bin-dir', opts.bin)

--- a/engine/runtime/commands/src/runtime/runtime.ts
+++ b/engine/runtime/commands/src/runtime/runtime.ts
@@ -108,7 +108,12 @@ function runtimeSet (opts: RuntimeCommandOptions, params: string[]): void {
   const args = ['add', `${runtimeName}@runtime:${versionSpec ?? ''}`]
   // Default to `devEngines.runtime`; the manifest writer maps a
   // `devDependencies.<runtime>: runtime:<version>` entry to it.
-  args.push(opts.saveProd ? '--save-prod' : '--save-dev')
+  // `saveDev` wins over `saveProd` to match `getSaveType` precedence.
+  if (opts.saveDev || !opts.saveProd) {
+    args.push('--save-dev')
+  } else {
+    args.push('--save-prod')
+  }
   if (opts.global) {
     args.push('--global')
     if (opts.bin) args.push('--global-bin-dir', opts.bin)

--- a/engine/runtime/commands/test/runtime.test.ts
+++ b/engine/runtime/commands/test/runtime.test.ts
@@ -23,12 +23,12 @@ test('runtime set calls pnpm add with the correct arguments globally', async () 
   }, ['set', 'node', '22'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'node@runtime:22', '--global', '--global-bin-dir', '/usr/local/bin', '--store-dir', '/tmp/store', '--cache-dir', '/tmp/cache'],
+    ['add', 'node@runtime:22', '--save-dev', '--global', '--global-bin-dir', '/usr/local/bin', '--store-dir', '/tmp/store', '--cache-dir', '/tmp/cache'],
     { cwd: '/tmp/pnpm-home' }
   )
 })
 
-test('runtime set uses project dir when not global', async () => {
+test('runtime set defaults to --save-dev so the runtime lands in devEngines', async () => {
   await runtime.handler({
     bin: '/usr/local/bin',
     dir: '/tmp/project',
@@ -37,7 +37,37 @@ test('runtime set uses project dir when not global', async () => {
   }, ['set', 'node', '22'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'node@runtime:22', '--ignore-workspace-root-check'],
+    ['add', 'node@runtime:22', '--save-dev', '--ignore-workspace-root-check'],
+    { cwd: '/tmp/project' }
+  )
+})
+
+test('runtime set with --save-prod saves the runtime under engines', async () => {
+  await runtime.handler({
+    bin: '/usr/local/bin',
+    dir: '/tmp/project',
+    global: false,
+    pnpmHomeDir: '/tmp/pnpm-home',
+    saveProd: true,
+  }, ['set', 'node', '22'])
+
+  expect(mockRunPnpmCli).toHaveBeenCalledWith(
+    ['add', 'node@runtime:22', '--save-prod', '--ignore-workspace-root-check'],
+    { cwd: '/tmp/project' }
+  )
+})
+
+test('runtime set with --save-dev keeps the runtime under devEngines (matches the default)', async () => {
+  await runtime.handler({
+    bin: '/usr/local/bin',
+    dir: '/tmp/project',
+    global: false,
+    pnpmHomeDir: '/tmp/pnpm-home',
+    saveDev: true,
+  }, ['set', 'node', '22'])
+
+  expect(mockRunPnpmCli).toHaveBeenCalledWith(
+    ['add', 'node@runtime:22', '--save-dev', '--ignore-workspace-root-check'],
     { cwd: '/tmp/project' }
   )
 })
@@ -51,7 +81,7 @@ test('runtime set without version spec', async () => {
   }, ['set', 'node'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'node@runtime:', '--global', '--global-bin-dir', '/usr/local/bin'],
+    ['add', 'node@runtime:', '--save-dev', '--global', '--global-bin-dir', '/usr/local/bin'],
     { cwd: '/tmp/pnpm-home' }
   )
 })
@@ -65,7 +95,7 @@ test('runtime set works with deno', async () => {
   }, ['set', 'deno', '2'])
 
   expect(mockRunPnpmCli).toHaveBeenCalledWith(
-    ['add', 'deno@runtime:2', '--global', '--global-bin-dir', '/usr/local/bin'],
+    ['add', 'deno@runtime:2', '--save-dev', '--global', '--global-bin-dir', '/usr/local/bin'],
     { cwd: '/tmp/pnpm-home' }
   )
 })

--- a/engine/runtime/commands/test/runtime.test.ts
+++ b/engine/runtime/commands/test/runtime.test.ts
@@ -72,6 +72,22 @@ test('runtime set with --save-dev keeps the runtime under devEngines (matches th
   )
 })
 
+test('runtime set with both --save-dev and --save-prod prefers --save-dev (matches getSaveType precedence)', async () => {
+  await runtime.handler({
+    bin: '/usr/local/bin',
+    dir: '/tmp/project',
+    global: false,
+    pnpmHomeDir: '/tmp/pnpm-home',
+    saveDev: true,
+    saveProd: true,
+  }, ['set', 'node', '22'])
+
+  expect(mockRunPnpmCli).toHaveBeenCalledWith(
+    ['add', 'node@runtime:22', '--save-dev', '--ignore-workspace-root-check'],
+    { cwd: '/tmp/project' }
+  )
+})
+
 test('runtime set without version spec', async () => {
   await runtime.handler({
     bin: '/usr/local/bin',


### PR DESCRIPTION
## Summary

- `pnpm runtime set <name> <version>` now saves the runtime to `devEngines.runtime` by default (previously it landed in `engines.runtime`).
- Pass `--save-prod` (or `-P`) to opt back into `engines.runtime`.
- Internally the command now appends `--save-dev` to the underlying `pnpm add` call by default, or `--save-prod` when requested; the manifest writer maps `devDependencies.<runtime>: "runtime:<version>"` to `devEngines.runtime` and the symmetric path for prod.

Closes #11948.

## Test plan

- [x] `pnpm --filter @pnpm/engine.runtime.commands test` (9/9 unit tests pass, including new cases for `--save-prod` and `--save-dev`)
- [ ] Manual smoke: `pnpm runtime set node 22` writes `devEngines.runtime`; `pnpm runtime set node 22 --save-prod` writes `engines.runtime`
- [ ] Docs PR in pnpm.io updating `docs/cli/runtime.md` with the new flags + default

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `runtime set` command now defaults to saving runtimes as development engine dependencies.
  * `--save-prod` (or `-P`) is available to save runtimes as production engine dependencies instead.
* **Documentation**
  * CLI help and usage guidance updated to reflect the new default and available flags.
* **Tests**
  * Test suite updated to align with the new default behavior and flag precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->