### PR TITLE
fix(patching/apply-patch): reject patch paths that escape the patched directory

### DIFF
--- a/.changeset/patch-path-traversal.md
+++ b/.changeset/patch-path-traversal.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/patching.apply-patch": patch
+"pnpm": patch
+---
+
+Reject patch files whose `diff --git` headers reference paths outside the patched package directory. Previously a malicious `.patch` file added via a pull request could write, delete, or rename arbitrary files reachable by the user running `pnpm install`.

--- a/__typings__/local.d.ts
+++ b/__typings__/local.d.ts
@@ -101,6 +101,16 @@ declare module '@pnpm/patch-package/dist/applyPatches.js' {
   export function applyPatch (opts: any): boolean
 }
 
+declare module '@pnpm/patch-package/dist/patch/parse.js' {
+  export interface PatchFilePart {
+    type: 'file deletion' | 'file creation' | 'patch' | 'mode change' | 'rename'
+    path?: string
+    fromPath?: string
+    toPath?: string
+  }
+  export function parsePatchFile (file: string): PatchFilePart[]
+}
+
 declare module 'ramda/src/map' {
   function map <K extends string | number | symbol, V, U> (fn: (x: V) => U, obj: Record<K, V>): Record<K, U>
   export = map

--- a/patching/apply-patch/__fixtures__/path-traversal.patch
+++ b/patching/apply-patch/__fixtures__/path-traversal.patch
@@ -1,0 +1,7 @@
+diff --git a/../../../../../../../../../../tmp/pnpm-patch-traversal-pwned b/../../../../../../../../../../tmp/pnpm-patch-traversal-pwned
+new file mode 100644
+index 0000000..3b18e51
+--- /dev/null
++++ b/../../../../../../../../../../tmp/pnpm-patch-traversal-pwned
+@@ -0,0 +1 @@
++pwned

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import { applyPatch } from '@pnpm/patch-package/dist/applyPatches.js'
@@ -21,11 +22,12 @@ export function applyPatchToDir (opts: ApplyPatchToDirOpts): boolean {
     success = applyPatch({
       patchFilePath: opts.patchFilePath,
     })
-  } catch (err: any) { // eslint-disable-line
-    if (err.code === 'ENOENT') {
+  } catch (err) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
       throw new PnpmError('PATCH_NOT_FOUND', `Patch file not found: ${opts.patchFilePath}`)
     }
-    throw new PnpmError('INVALID_PATCH', `Applying patch "${opts.patchFilePath}" failed: ${err.message as string}`)
+    const message = util.types.isNativeError(err) ? err.message : String(err)
+    throw new PnpmError('INVALID_PATCH', `Applying patch "${opts.patchFilePath}" failed: ${message}`)
   } finally {
     process.chdir(cwd)
   }
@@ -42,8 +44,8 @@ function assertPatchPathsStayInside (opts: ApplyPatchToDirOpts): void {
   let patchContent: string
   try {
     patchContent = fs.readFileSync(opts.patchFilePath, 'utf8')
-  } catch (err: any) { // eslint-disable-line
-    if (err.code === 'ENOENT') {
+  } catch (err) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
       throw new PnpmError('PATCH_NOT_FOUND', `Patch file not found: ${opts.patchFilePath}`)
     }
     throw err

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -54,8 +54,8 @@ function assertPatchPathsStayInside (opts: ApplyPatchToDirOpts): void {
   try {
     effects = parsePatchFile(patchContent)
   } catch {
-    // Defer parse-error reporting to applyPatch so the message and exit behavior
-    // stay identical to the unvalidated path.
+    // Defer parse-error reporting to applyPatch so its existing
+    // ERR_PNPM_INVALID_PATCH path produces the message and exit behavior.
     return
   }
   const root = path.resolve(opts.patchedDir)

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -70,18 +70,20 @@ function assertPatchPathsStayInside (opts: ApplyPatchToDirOpts): void {
         path.isAbsolute(candidate) ||
         candidate.split(/[/\\]/).includes('..')
       ) {
-        throw patchPathEscapesError(opts, candidate)
+        throw new PatchPathEscapesError(opts, candidate)
       }
       const resolved = path.resolve(root, candidate)
       if (resolved !== root && !resolved.startsWith(rootWithSep)) {
-        throw patchPathEscapesError(opts, candidate)
+        throw new PatchPathEscapesError(opts, candidate)
       }
     }
   }
 }
 
-function patchPathEscapesError (opts: ApplyPatchToDirOpts, badPath: string): PnpmError {
-  return new PnpmError('PATCH_FAILED',
-    `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}: ` +
-    `patch path escapes target dir: ${badPath}`)
+export class PatchPathEscapesError extends PnpmError {
+  constructor (opts: ApplyPatchToDirOpts, badPath: string) {
+    super('PATCH_FAILED',
+      `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}: ` +
+      `patch path escapes target dir: ${badPath}`)
+  }
 }

--- a/patching/apply-patch/src/index.ts
+++ b/patching/apply-patch/src/index.ts
@@ -1,5 +1,9 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { PnpmError } from '@pnpm/error'
 import { applyPatch } from '@pnpm/patch-package/dist/applyPatches.js'
+import { parsePatchFile } from '@pnpm/patch-package/dist/patch/parse.js'
 
 export interface ApplyPatchToDirOpts {
   patchedDir: string
@@ -9,6 +13,7 @@ export interface ApplyPatchToDirOpts {
 export function applyPatchToDir (opts: ApplyPatchToDirOpts): boolean {
   // Ideally, we would just run "patch" or "git apply".
   // However, "patch" is not available on Windows and "git apply" is hard to execute on a subdirectory of an existing repository
+  assertPatchPathsStayInside(opts)
   const cwd = process.cwd()
   process.chdir(opts.patchedDir)
   let success = false
@@ -28,4 +33,53 @@ export function applyPatchToDir (opts: ApplyPatchToDirOpts): boolean {
     throw new PnpmError('PATCH_FAILED', `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}`)
   }
   return success
+}
+
+// A patch file is attacker-controlled data: `diff --git a/../../X b/../../X` headers
+// would otherwise let the applier traverse out of the package directory and write,
+// delete, or rename files anywhere the install user can.
+function assertPatchPathsStayInside (opts: ApplyPatchToDirOpts): void {
+  let patchContent: string
+  try {
+    patchContent = fs.readFileSync(opts.patchFilePath, 'utf8')
+  } catch (err: any) { // eslint-disable-line
+    if (err.code === 'ENOENT') {
+      throw new PnpmError('PATCH_NOT_FOUND', `Patch file not found: ${opts.patchFilePath}`)
+    }
+    throw err
+  }
+  let effects
+  try {
+    effects = parsePatchFile(patchContent)
+  } catch {
+    // Defer parse-error reporting to applyPatch so the message and exit behavior
+    // stay identical to the unvalidated path.
+    return
+  }
+  const root = path.resolve(opts.patchedDir)
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep
+  for (const effect of effects) {
+    const candidates: Array<string | undefined> = effect.type === 'rename'
+      ? [effect.fromPath, effect.toPath]
+      : [effect.path]
+    for (const candidate of candidates) {
+      if (!candidate) continue
+      if (
+        path.isAbsolute(candidate) ||
+        candidate.split(/[/\\]/).includes('..')
+      ) {
+        throw patchPathEscapesError(opts, candidate)
+      }
+      const resolved = path.resolve(root, candidate)
+      if (resolved !== root && !resolved.startsWith(rootWithSep)) {
+        throw patchPathEscapesError(opts, candidate)
+      }
+    }
+  }
+}
+
+function patchPathEscapesError (opts: ApplyPatchToDirOpts, badPath: string): PnpmError {
+  return new PnpmError('PATCH_FAILED',
+    `Could not apply patch ${opts.patchFilePath} to ${opts.patchedDir}: ` +
+    `patch path escapes target dir: ${badPath}`)
 }

--- a/patching/apply-patch/test/applyPatchToDir.ts
+++ b/patching/apply-patch/test/applyPatchToDir.ts
@@ -70,4 +70,19 @@ describe('applyPatchToDir()', () => {
       })
     }).toThrow('Patch file not found')
   })
+  it('should reject a patch whose paths escape the patched directory', () => {
+    const patchFilePath = f.find('path-traversal.patch')
+    const patchedDir = tempDir()
+    const sentinel = path.join('/tmp', 'pnpm-patch-traversal-pwned')
+    try {
+      fs.unlinkSync(sentinel)
+    } catch {}
+    expect(() => {
+      applyPatchToDir({
+        patchFilePath,
+        patchedDir,
+      })
+    }).toThrow(/patch path escapes target dir/)
+    expect(fs.existsSync(sentinel)).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

A malicious `.patch` file with `diff --git a/../../X b/../../X` headers can currently make `applyPatchToDir` traverse out of the patched package directory — writing, deleting, or renaming files anywhere the user running `pnpm install` can reach. The applier `process.chdir`s into the package dir and then trusts the parsed patch paths verbatim. Reproduced locally before fixing: a sentinel patch wrote `/tmp/vuln3_pwned` from a package directory deep under `node_modules/.pnpm/`.

The Rust port already guards against this in `pacquet/crates/patching/src/apply.rs` (`resolve_target`, lines 177-186 on this branch). This PR closes the gap on the TypeScript side.

## Fix

`patching/apply-patch/src/index.ts` now parses the patch with `parsePatchFile` from `@pnpm/patch-package` before delegating, and rejects any effect whose path:

- is absolute, or
- contains a `..` segment (split on both `/` and `\` so Windows-style separators don't slip through on POSIX), or
- resolves outside `patchedDir` via `path.resolve` + prefix check.

Rejection throws `ERR_PNPM_PATCH_FAILED` with `patch path escapes target dir: <path>` — same error code and message shape as pacquet. Parse errors are deferred to `applyPatch` so the existing `ERR_PNPM_INVALID_PATCH` path is unchanged.

## Test plan

- [x] New unit test `should reject a patch whose paths escape the patched directory` in `patching/apply-patch/test/applyPatchToDir.ts`, with a fixture `__fixtures__/path-traversal.patch` that targets `/tmp/pnpm-patch-traversal-pwned`. The test asserts both the thrown error and that the sentinel file is not created.
- [x] All 5 `applyPatchToDir` tests pass (`pnpm --filter @pnpm/patching.apply-patch test`).
- [x] Lint clean (`pnpm --filter @pnpm/patching.apply-patch run lint`).
- [x] Original PoC re-run against the rebuilt module: throws `ERR_PNPM_PATCH_FAILED: patch path escapes target dir: ...` and no sentinel file appears.
- [ ] CI green.

## Credit

Reported by [AutoFyn](https://github.com/SignalPilot-Labs/AutoFyn).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patch application now rejects patches that reference paths outside the target package directory, preventing malicious patches from creating, deleting, or renaming files outside the package.

* **Tests**
  * Added a test to verify path-traversal patches are rejected and do not create files outside the target directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->