### PR TITLE
feat(pacquet/config): `--recursive`, `--workspace-concurrency`

### DIFF
--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -159,15 +159,8 @@ impl CliArgs {
                 let cfg = config()?;
                 cfg.offline = cfg.offline || args.offline;
                 cfg.prefer_offline = cfg.prefer_offline || args.prefer_offline;
-                // `--workspace-concurrency`, when passed, overrides the
-                // config-resolved value for this invocation. Resolved
-                // through the same `getWorkspaceConcurrency` port the
-                // yaml / env path uses so a negative CLI value means
-                // `parallelism - |value|`.
-                if let Some(value) = args.workspace_concurrency {
-                    cfg.workspace_concurrency =
-                        pacquet_config::resolve_child_concurrency(Some(value));
-                }
+                cfg.workspace_concurrency =
+                    args.resolve_workspace_concurrency(cfg.workspace_concurrency);
                 let require_lockfile = args.frozen_lockfile;
                 let state = State::init(manifest_path(), cfg, require_lockfile)
                     .wrap_err("initialize the state")?;

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -31,6 +31,15 @@ pub struct CliArgs {
     #[clap(short = 'C', long, default_value = ".")]
     pub dir: PathBuf,
 
+    /// Run the command for every project in the workspace instead of
+    /// only the project in `--dir`. Mirrors pnpm's global `-r` /
+    /// `--recursive` flag and sets
+    /// [`pacquet_config::Config::recursive`]. pacquet's `install`
+    /// already spans the whole workspace, so the flag is a surface
+    /// no-op there today; see the field docs.
+    #[clap(short = 'r', long, global = true)]
+    pub recursive: bool,
+
     /// Reporter output format.
     #[clap(long, value_enum, default_value_t = ReporterType::Silent, global = true)]
     pub reporter: ReporterType,
@@ -78,7 +87,7 @@ impl CliArgs {
     /// `Config` is loaded, mirroring pnpm 11's
     /// "CLI > yaml > .npmrc > defaults" precedence.
     pub async fn run(self, config_overrides: &ConfigOverrides) -> miette::Result<()> {
-        let CliArgs { command, dir, reporter } = self;
+        let CliArgs { command, dir, recursive, reporter } = self;
         // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
         // the reporter is the same absolute, symlink-resolved path that
         // `@pnpm/cli.default-reporter` derives via `process.cwd()`. Without
@@ -107,6 +116,11 @@ impl CliArgs {
                 .current::<Host>(&dir)
                 .map(|mut cfg| {
                     config_overrides.apply(&mut cfg);
+                    // `--recursive` / `-r` is CLI-only upstream (not a
+                    // `.npmrc` / yaml key), so it is set here from the
+                    // global flag rather than through the yaml / env
+                    // overlay. Mirrors pnpm's `Config.recursive`.
+                    cfg.recursive = recursive;
                     Config::leak(cfg)
                 })
                 .map_err(miette::Report::new)
@@ -145,6 +159,15 @@ impl CliArgs {
                 let cfg = config()?;
                 cfg.offline = cfg.offline || args.offline;
                 cfg.prefer_offline = cfg.prefer_offline || args.prefer_offline;
+                // `--workspace-concurrency`, when passed, overrides the
+                // config-resolved value for this invocation. Resolved
+                // through the same `getWorkspaceConcurrency` port the
+                // yaml / env path uses so a negative CLI value means
+                // `parallelism - |value|`.
+                if let Some(value) = args.workspace_concurrency {
+                    cfg.workspace_concurrency =
+                        pacquet_config::resolve_child_concurrency(Some(value));
+                }
                 let require_lockfile = args.frozen_lockfile;
                 let state = State::init(manifest_path(), cfg, require_lockfile)
                     .wrap_err("initialize the state")?;
@@ -178,3 +201,6 @@ impl CliArgs {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -206,9 +206,6 @@ impl InstallArgs {
             offline: _,
             prefer_offline: _,
             trust_lockfile,
-            // Applied to `config.workspace_concurrency` at the CLI
-            // dispatch (`CliArgs::run`) while `Config` is still
-            // mutable, the same way `offline` / `prefer_offline` are.
             workspace_concurrency: _,
         } = self;
 

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -279,6 +279,23 @@ impl InstallArgs {
 
         Ok(())
     }
+
+    /// Effective `workspaceConcurrency` for this invocation: the
+    /// `--workspace-concurrency` flag when passed (resolved through
+    /// [`pacquet_config::resolve_child_concurrency`], so a non-positive
+    /// value means `parallelism - |value|`, floored at 1), otherwise
+    /// the already-resolved `config_value` from
+    /// `.npmrc` / `pnpm-workspace.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY`.
+    ///
+    /// Mirrors upstream's final `workspaceConcurrency =
+    /// getWorkspaceConcurrency(...)` pass at
+    /// <https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L641>.
+    pub(crate) fn resolve_workspace_concurrency(&self, config_value: u32) -> u32 {
+        match self.workspace_concurrency {
+            Some(value) => pacquet_config::resolve_child_concurrency(Some(value)),
+            None => config_value,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -173,6 +173,21 @@ pub struct InstallArgs {
     /// Added for [pnpm/pnpm#11860](https://github.com/pnpm/pnpm/issues/11860).
     #[clap(long = "trust-lockfile")]
     pub trust_lockfile: bool,
+
+    /// Maximum number of workspace projects to process in parallel.
+    /// Mirrors pnpm's `--workspace-concurrency`. Overrides the
+    /// `workspaceConcurrency` value resolved from `.npmrc` /
+    /// `pnpm-workspace.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY` for
+    /// this invocation. A non-positive value is read as
+    /// `parallelism - |value|` (floored at 1), matching upstream's
+    /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34).
+    /// `None` (flag absent) leaves the config-resolved value in place.
+    ///
+    /// Applied to [`pacquet_config::Config::workspace_concurrency`] at
+    /// the CLI dispatch in [`crate::cli_args::CliArgs::run`]; see that
+    /// field for why it has no consumption point on `install` yet.
+    #[clap(long = "workspace-concurrency")]
+    pub workspace_concurrency: Option<i32>,
 }
 
 impl InstallArgs {
@@ -191,6 +206,10 @@ impl InstallArgs {
             offline: _,
             prefer_offline: _,
             trust_lockfile,
+            // Applied to `config.workspace_concurrency` at the CLI
+            // dispatch (`CliArgs::run`) while `Config` is still
+            // mutable, the same way `offline` / `prefer_offline` are.
+            workspace_concurrency: _,
         } = self;
 
         // `--prefer-frozen-lockfile` / `--no-prefer-frozen-lockfile`

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -176,8 +176,8 @@ pub struct InstallArgs {
 
     /// Maximum number of workspace projects to process in parallel.
     /// Mirrors pnpm's `--workspace-concurrency`. Overrides the
-    /// `workspaceConcurrency` value resolved from `.npmrc` /
-    /// `pnpm-workspace.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY` for
+    /// `workspaceConcurrency` value resolved from `pnpm-workspace.yaml` /
+    /// global `config.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY` for
     /// this invocation. A non-positive value is read as
     /// `parallelism - |value|` (floored at 1), matching upstream's
     /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34).
@@ -284,8 +284,8 @@ impl InstallArgs {
     /// `--workspace-concurrency` flag when passed (resolved through
     /// [`pacquet_config::resolve_child_concurrency`], so a non-positive
     /// value means `parallelism - |value|`, floored at 1), otherwise
-    /// the already-resolved `config_value` from
-    /// `.npmrc` / `pnpm-workspace.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY`.
+    /// the already-resolved `config_value` from `pnpm-workspace.yaml` /
+    /// global `config.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY`.
     ///
     /// Mirrors upstream's final `workspaceConcurrency =
     /// getWorkspaceConcurrency(...)` pass at

--- a/pacquet/crates/cli/src/cli_args/install/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/install/tests.rs
@@ -122,6 +122,34 @@ fn ignore_manifest_check_flag_parses() {
     assert!(parsed.args.ignore_manifest_check, "flag present → true");
 }
 
+/// `--workspace-concurrency` is absent by default, so the override
+/// is `None` and the config-resolved value stays in effect.
+#[test]
+fn workspace_concurrency_default_is_none() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");
+    assert_eq!(parsed.args.workspace_concurrency, None, "flag absent → None");
+}
+
+/// A positive `--workspace-concurrency` parses to its value verbatim.
+#[test]
+fn workspace_concurrency_parses_positive() {
+    let parsed =
+        InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency", "3"])
+            .expect("parses --workspace-concurrency 3");
+    assert_eq!(parsed.args.workspace_concurrency, Some(3));
+}
+
+/// A negative `--workspace-concurrency` parses to the signed value;
+/// the `parallelism - |value|` interpretation happens later at the
+/// CLI dispatch via `resolve_child_concurrency`. Mirrors pnpm
+/// accepting `--workspace-concurrency=-1`.
+#[test]
+fn workspace_concurrency_parses_negative() {
+    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency=-1"])
+        .expect("parses --workspace-concurrency=-1");
+    assert_eq!(parsed.args.workspace_concurrency, Some(-1));
+}
+
 /// `NodeLinkerArg::into_config` maps every variant 1:1 to the
 /// canonical `pacquet_config::NodeLinker` enum. Tied to the
 /// `ValueEnum` derive's kebab-case rename — if a future variant

--- a/pacquet/crates/cli/src/cli_args/install/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/install/tests.rs
@@ -150,6 +150,37 @@ fn workspace_concurrency_parses_negative() {
     assert_eq!(parsed.args.workspace_concurrency, Some(-1));
 }
 
+/// No `--workspace-concurrency` flag → the already-resolved config
+/// value passes through untouched.
+#[test]
+fn resolve_workspace_concurrency_keeps_config_value_when_flag_absent() {
+    let args = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses").args;
+    assert_eq!(args.resolve_workspace_concurrency(7), 7);
+}
+
+/// A positive `--workspace-concurrency` replaces the config value
+/// verbatim (it does not fall through to `config_value`).
+#[test]
+fn resolve_workspace_concurrency_positive_flag_overrides_config() {
+    let args = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency", "3"])
+        .expect("parses")
+        .args;
+    assert_eq!(args.resolve_workspace_concurrency(7), 3);
+}
+
+/// A non-positive `--workspace-concurrency` resolves to
+/// `max(1, parallelism - |value|)` via `getWorkspaceConcurrency`,
+/// independent of the config value. Pinned exactly against the host's
+/// reported parallelism.
+#[test]
+fn resolve_workspace_concurrency_negative_flag_resolves_to_offset() {
+    let args = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency=-1"])
+        .expect("parses")
+        .args;
+    let expected = pacquet_config::available_parallelism().saturating_sub(1).max(1);
+    assert_eq!(args.resolve_workspace_concurrency(7), expected);
+}
+
 /// `NodeLinkerArg::into_config` maps every variant 1:1 to the
 /// canonical `pacquet_config::NodeLinker` enum. Tied to the
 /// `ValueEnum` derive's kebab-case rename — if a future variant

--- a/pacquet/crates/cli/src/cli_args/install/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/install/tests.rs
@@ -2,6 +2,7 @@ use super::{InstallArgs, InstallDependencyOptions, NodeLinkerArg};
 use clap::Parser;
 use pacquet_config::NodeLinker;
 use pacquet_package_manifest::DependencyGroup;
+use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -126,16 +127,16 @@ fn ignore_manifest_check_flag_parses() {
 /// is `None` and the config-resolved value stays in effect.
 #[test]
 fn workspace_concurrency_default_is_none() {
-    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses");
+    let parsed = ["pacquet-test"].pipe(InstallArgsHarness::try_parse_from).expect("parses");
     assert_eq!(parsed.args.workspace_concurrency, None, "flag absent → None");
 }
 
 /// A positive `--workspace-concurrency` parses to its value verbatim.
 #[test]
 fn workspace_concurrency_parses_positive() {
-    let parsed =
-        InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency", "3"])
-            .expect("parses --workspace-concurrency 3");
+    let parsed = ["pacquet-test", "--workspace-concurrency", "3"]
+        .pipe(InstallArgsHarness::try_parse_from)
+        .expect("parses --workspace-concurrency 3");
     assert_eq!(parsed.args.workspace_concurrency, Some(3));
 }
 
@@ -145,7 +146,8 @@ fn workspace_concurrency_parses_positive() {
 /// accepting `--workspace-concurrency=-1`.
 #[test]
 fn workspace_concurrency_parses_negative() {
-    let parsed = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency=-1"])
+    let parsed = ["pacquet-test", "--workspace-concurrency=-1"]
+        .pipe(InstallArgsHarness::try_parse_from)
         .expect("parses --workspace-concurrency=-1");
     assert_eq!(parsed.args.workspace_concurrency, Some(-1));
 }
@@ -154,7 +156,7 @@ fn workspace_concurrency_parses_negative() {
 /// value passes through untouched.
 #[test]
 fn resolve_workspace_concurrency_keeps_config_value_when_flag_absent() {
-    let args = InstallArgsHarness::try_parse_from(["pacquet-test"]).expect("parses").args;
+    let args = ["pacquet-test"].pipe(InstallArgsHarness::try_parse_from).expect("parses").args;
     assert_eq!(args.resolve_workspace_concurrency(7), 7);
 }
 
@@ -162,7 +164,8 @@ fn resolve_workspace_concurrency_keeps_config_value_when_flag_absent() {
 /// verbatim (it does not fall through to `config_value`).
 #[test]
 fn resolve_workspace_concurrency_positive_flag_overrides_config() {
-    let args = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency", "3"])
+    let args = ["pacquet-test", "--workspace-concurrency", "3"]
+        .pipe(InstallArgsHarness::try_parse_from)
         .expect("parses")
         .args;
     assert_eq!(args.resolve_workspace_concurrency(7), 3);
@@ -174,7 +177,8 @@ fn resolve_workspace_concurrency_positive_flag_overrides_config() {
 /// reported parallelism.
 #[test]
 fn resolve_workspace_concurrency_negative_flag_resolves_to_offset() {
-    let args = InstallArgsHarness::try_parse_from(["pacquet-test", "--workspace-concurrency=-1"])
+    let args = ["pacquet-test", "--workspace-concurrency=-1"]
+        .pipe(InstallArgsHarness::try_parse_from)
         .expect("parses")
         .args;
     let expected = pacquet_config::available_parallelism().saturating_sub(1).max(1);

--- a/pacquet/crates/cli/src/cli_args/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/tests.rs
@@ -1,0 +1,25 @@
+use super::{CliArgs, CliCommand};
+use clap::Parser;
+
+/// `--recursive` / `-r` defaults to `false` when absent. Mirrors
+/// pnpm, where `recursive` is unset unless the flag (or a recursive
+/// command form) is used.
+#[test]
+fn recursive_default_is_false() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "install"]).expect("parses");
+    assert!(!parsed.recursive, "flag absent → false");
+}
+
+/// `-r` is a global flag, so it parses both before and after the
+/// subcommand. Mirrors pnpm's global `-r` / `--recursive`.
+#[test]
+fn recursive_flag_is_global_and_parses_either_side_of_subcommand() {
+    let before = CliArgs::try_parse_from(["pacquet", "-r", "install"]).expect("parses -r install");
+    assert!(before.recursive, "`-r install` → recursive");
+    assert!(matches!(before.command, CliCommand::Install(_)));
+
+    let after = CliArgs::try_parse_from(["pacquet", "install", "--recursive"])
+        .expect("parses install --recursive");
+    assert!(after.recursive, "`install --recursive` → recursive");
+    assert!(matches!(after.command, CliCommand::Install(_)));
+}

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -275,6 +275,20 @@ pub fn default_child_concurrency_with_parallelism(parallelism: u32) -> u32 {
     parallelism.min(4)
 }
 
+/// Default `workspaceConcurrency` matching upstream's
+/// [`getDefaultWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L21-L23),
+/// the default for `workspace-concurrency` at
+/// [`config/reader/src/index.ts:208`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L208).
+///
+/// Identical in value to [`default_child_concurrency`] — both pnpm
+/// settings default through the same upstream `getDefaultWorkspaceConcurrency`
+/// — but exposed under its own name so the
+/// [`crate::Config::workspace_concurrency`] field default reads at its
+/// own call site.
+pub fn default_workspace_concurrency() -> u32 {
+    default_child_concurrency()
+}
+
 /// Available CPU parallelism, mirroring upstream's
 /// [`getAvailableParallelism`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L5-L13).
 /// Floors at 1.

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -280,7 +280,7 @@ pub fn default_child_concurrency_with_parallelism(parallelism: u32) -> u32 {
 /// the default for `workspace-concurrency` at
 /// [`config/reader/src/index.ts:208`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L208).
 ///
-/// Identical in value to [`default_child_concurrency`] — both pnpm
+/// Identical in value to `default_child_concurrency` — both pnpm
 /// settings default through the same upstream `getDefaultWorkspaceConcurrency`
 /// — but exposed under its own name so the
 /// [`crate::Config::workspace_concurrency`] field default reads at its

--- a/pacquet/crates/config/src/defaults/tests.rs
+++ b/pacquet/crates/config/src/defaults/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    default_cache_dir, default_child_concurrency_with_parallelism, default_config_dir,
-    default_store_dir, default_unsafe_perm, is_unsafe_perm_posix, resolve_child_concurrency,
-    resolve_child_concurrency_with_parallelism,
+    default_cache_dir, default_child_concurrency, default_child_concurrency_with_parallelism,
+    default_config_dir, default_store_dir, default_unsafe_perm, default_workspace_concurrency,
+    is_unsafe_perm_posix, resolve_child_concurrency, resolve_child_concurrency_with_parallelism,
 };
 use crate::api::{EnvVar, GetCurrentDir, GetHomeDir};
 use pacquet_store_dir::{STORE_VERSION, StoreDir};
@@ -275,6 +275,15 @@ fn default_child_concurrency_with_parallelism_above_four() {
 #[test]
 fn default_child_concurrency_with_parallelism_at_four() {
     assert_eq!(default_child_concurrency_with_parallelism(4), 4);
+}
+
+/// `workspaceConcurrency` and `childConcurrency` default through the
+/// same upstream `getDefaultWorkspaceConcurrency`, so the two pacquet
+/// defaults must agree. This pins that parity so a future change to
+/// one default that forgets the other fails here.
+#[test]
+fn default_workspace_concurrency_matches_default_child_concurrency() {
+    assert_eq!(default_workspace_concurrency(), default_child_concurrency());
 }
 
 /// Port of upstream

--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -158,6 +158,7 @@ impl WorkspaceSettings {
         enum_field!(scripts_prepend_node_path, "SCRIPTS_PREPEND_NODE_PATH", ScriptsPrependNodePath);
         json_field!(unsafe_perm, "UNSAFE_PERM");
         json_field!(child_concurrency, "CHILD_CONCURRENCY");
+        json_field!(workspace_concurrency, "WORKSPACE_CONCURRENCY");
         json_field!(git_shallow_hosts, "GIT_SHALLOW_HOSTS");
         json_field!(supported_architectures, "SUPPORTED_ARCHITECTURES");
         json_field!(ignored_optional_dependencies, "IGNORED_OPTIONAL_DEPENDENCIES");
@@ -251,6 +252,37 @@ mod tests {
         assert_eq!(
             parse_json_or_string::<ScriptsPrependNodePath>("warn-only"),
             Some(ScriptsPrependNodePath::WarnOnly),
+        );
+    }
+
+    /// `PNPM_CONFIG_WORKSPACE_CONCURRENCY` parses as a JSON number
+    /// into the signed `workspace_concurrency` slot — including the
+    /// negative-offset form that upstream's `getWorkspaceConcurrency`
+    /// reads as `parallelism - |value|`. The uppercase env name is
+    /// honoured (the lowercase `pnpm_config_*` form is covered by the
+    /// shared [`read_env`] helper).
+    #[test]
+    fn workspace_concurrency_env_var_parses_signed_number() {
+        struct EnvPositive;
+        impl EnvVar for EnvPositive {
+            fn var(name: &str) -> Option<String> {
+                (name == "PNPM_CONFIG_WORKSPACE_CONCURRENCY").then(|| "6".to_owned())
+            }
+        }
+        assert_eq!(
+            WorkspaceSettings::from_pnpm_config_env::<EnvPositive>().workspace_concurrency,
+            Some(6),
+        );
+
+        struct EnvNegative;
+        impl EnvVar for EnvNegative {
+            fn var(name: &str) -> Option<String> {
+                (name == "PNPM_CONFIG_WORKSPACE_CONCURRENCY").then(|| "-2".to_owned())
+            }
+        }
+        assert_eq!(
+            WorkspaceSettings::from_pnpm_config_env::<EnvNegative>().workspace_concurrency,
+            Some(-2),
         );
     }
 

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -24,7 +24,8 @@ use std::{
 
 pub use crate::defaults::{
     available_parallelism, default_git_shallow_hosts, default_unsafe_perm,
-    default_virtual_store_dir_max_length, is_unsafe_perm_posix, resolve_child_concurrency,
+    default_virtual_store_dir_max_length, default_workspace_concurrency, is_unsafe_perm_posix,
+    resolve_child_concurrency,
 };
 use crate::defaults::{
     default_cache_dir, default_child_concurrency, default_config_dir,
@@ -775,6 +776,45 @@ pub struct Config {
     /// [`runGroups(getWorkspaceConcurrency(opts.childConcurrency), groups)`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/building/during-install/src/index.ts#L124).
     #[default(_code = "default_child_concurrency()")]
     pub child_concurrency: u32,
+
+    /// `workspaceConcurrency` from `.npmrc` / `pnpm-workspace.yaml` /
+    /// `PNPM_CONFIG_WORKSPACE_CONCURRENCY`, overridable per-invocation
+    /// by the `--workspace-concurrency` CLI flag. The maximum number
+    /// of workspace projects pnpm processes in parallel during a
+    /// recursive operation. Resolved through
+    /// [`resolve_child_concurrency`] (upstream's
+    /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34))
+    /// so a non-positive yaml/CLI value is read as
+    /// `parallelism - |value|` (floored at 1).
+    ///
+    /// Default: `min(4, availableParallelism())`, matching upstream's
+    /// [`getDefaultWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L21-L23)
+    /// default at
+    /// [`config/reader/src/index.ts:208`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L208).
+    ///
+    /// Parsed and stored for parity with pnpm's config surface.
+    /// pacquet's frozen-lockfile install materializes the whole
+    /// workspace in a single shared pass rather than one project at a
+    /// time, so there is no per-project parallel loop for this limit
+    /// to throttle yet — the same "read now, consume as the
+    /// architecture lands" posture as [`Self::prefer_offline`].
+    #[default(_code = "default_workspace_concurrency()")]
+    pub workspace_concurrency: u32,
+
+    /// `--recursive` / `-r`. When set, a command operates on every
+    /// project in the workspace rather than only the project in the
+    /// current directory. Mirrors pnpm's CLI-only
+    /// [`recursive`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/Config.ts#L130)
+    /// boolean: it is not a `.npmrc` / `pnpm-workspace.yaml` key, so
+    /// the yaml / env overlay never populates it — the CLI layer sets
+    /// it from the flag.
+    ///
+    /// pacquet's install already spans the whole workspace (it reads
+    /// every importer from the shared lockfile), so the flag is a
+    /// surface no-op on `install` today. Stored for parity and for
+    /// future commands where recursive vs. single-project selection
+    /// diverges.
+    pub recursive: bool,
 
     /// Git host names where pacquet should clone via `git init` +
     /// `git remote add` + `git fetch --depth 1 origin <commit>` instead

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -777,11 +777,11 @@ pub struct Config {
     #[default(_code = "default_child_concurrency()")]
     pub child_concurrency: u32,
 
-    /// `workspaceConcurrency` from `.npmrc` / `pnpm-workspace.yaml` /
-    /// `PNPM_CONFIG_WORKSPACE_CONCURRENCY`, overridable per-invocation
-    /// by the `--workspace-concurrency` CLI flag. The maximum number
-    /// of workspace projects pnpm processes in parallel during a
-    /// recursive operation. Resolved through
+    /// `workspaceConcurrency` from `pnpm-workspace.yaml` / global
+    /// `config.yaml` / `PNPM_CONFIG_WORKSPACE_CONCURRENCY`, overridable
+    /// per-invocation by the `--workspace-concurrency` CLI flag. The
+    /// maximum number of workspace projects pnpm processes in parallel
+    /// during a recursive operation. Resolved through
     /// [`resolve_child_concurrency`] (upstream's
     /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34))
     /// so a non-positive yaml/CLI value is read as

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -217,8 +217,8 @@ pub struct WorkspaceSettings {
     /// `parallelism - |value|`) round-trip cleanly.
     pub child_concurrency: Option<i32>,
 
-    /// `workspaceConcurrency` from `pnpm-workspace.yaml` /
-    /// `.npmrc` / global `config.yaml`. Resolved through
+    /// `workspaceConcurrency` from `pnpm-workspace.yaml` / global
+    /// `config.yaml`. Resolved through
     /// [`crate::resolve_child_concurrency`] in `apply_to`, the same
     /// way `childConcurrency` is — both upstream settings run through
     /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34).

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -217,6 +217,17 @@ pub struct WorkspaceSettings {
     /// `parallelism - |value|`) round-trip cleanly.
     pub child_concurrency: Option<i32>,
 
+    /// `workspaceConcurrency` from `pnpm-workspace.yaml` /
+    /// `.npmrc` / global `config.yaml`. Resolved through
+    /// [`crate::resolve_child_concurrency`] in `apply_to`, the same
+    /// way `childConcurrency` is — both upstream settings run through
+    /// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34).
+    /// Signed `i32` so negative values (interpreted as
+    /// `parallelism - |value|`) round-trip cleanly. A genuine
+    /// config-file key (so it is kept, not cleared, in
+    /// [`Self::clear_workspace_only_fields`]).
+    pub workspace_concurrency: Option<i32>,
+
     /// `gitShallowHosts` from `pnpm-workspace.yaml`. Overrides
     /// [`Config::git_shallow_hosts`] wholesale when set (mirrors
     /// pnpm's settings precedence, where `pnpm-workspace.yaml`
@@ -587,6 +598,13 @@ impl WorkspaceSettings {
         // negative) goes through the upstream resolver.
         if let Some(v) = self.child_concurrency {
             config.child_concurrency = resolve_child_concurrency(Some(v));
+        }
+        // `workspaceConcurrency` resolves through the same upstream
+        // `getWorkspaceConcurrency` as `childConcurrency`; `None`
+        // keeps the smart-default, `Some(n)` (including negative)
+        // goes through the resolver.
+        if let Some(v) = self.workspace_concurrency {
+            config.workspace_concurrency = resolve_child_concurrency(Some(v));
         }
         if let Some(v) = self.supported_architectures {
             config.supported_architectures = Some(v);

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -475,6 +475,55 @@ fn parses_negative_child_concurrency_from_yaml_and_resolves() {
     assert!(config.child_concurrency <= parallelism, "must not exceed available parallelism");
 }
 
+/// A positive `workspaceConcurrency` is taken verbatim — same
+/// [`getWorkspaceConcurrency`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/concurrency.ts#L25-L34)
+/// resolution as `childConcurrency`.
+#[test]
+fn parses_positive_workspace_concurrency_from_yaml_and_applies() {
+    let yaml = "workspaceConcurrency: 8\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.workspace_concurrency, Some(8));
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.workspace_concurrency, 8);
+}
+
+/// A non-positive `workspaceConcurrency` is interpreted as
+/// `max(1, parallelism - |value|)`. The exact result depends on the
+/// host's reported parallelism, so bound-check it like the
+/// `childConcurrency` sibling does.
+#[test]
+fn parses_negative_workspace_concurrency_from_yaml_and_resolves() {
+    let yaml = "workspaceConcurrency: -1\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.workspace_concurrency, Some(-1));
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    let parallelism = crate::available_parallelism();
+    assert!(config.workspace_concurrency >= 1, "must floor at 1");
+    assert!(config.workspace_concurrency <= parallelism, "must not exceed available parallelism");
+}
+
+/// `workspaceConcurrency` and `childConcurrency` are independent
+/// settings: setting one must not move the other off its default.
+/// Mirrors upstream, where they are separate config keys
+/// ([`config/reader/src/index.ts:208`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L208)
+/// vs the `childConcurrency` build path).
+#[test]
+fn workspace_and_child_concurrency_are_independent() {
+    let yaml = "workspaceConcurrency: 7\n";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    assert_eq!(settings.child_concurrency, None);
+
+    let mut config = Config::new();
+    let child_default = config.child_concurrency;
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.workspace_concurrency, 7);
+    assert_eq!(config.child_concurrency, child_default, "childConcurrency stays at its default");
+}
+
 #[test]
 fn apply_leaves_unset_fields_alone() {
     let yaml = "storeDir: /s\n";

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -68,6 +68,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         scripts_prepend_node_path: Default::default(),
         unsafe_perm: true,
         child_concurrency: 1,
+        workspace_concurrency: 1,
+        recursive: false,
         git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),
         supported_architectures: None,
         ignored_optional_dependencies: None,


### PR DESCRIPTION
## Summary

Ports two pnpm settings into pacquet's Rust config layer.

- **`workspace-concurrency`** — read from `pnpm-workspace.yaml`, global `config.yaml`, and `PNPM_CONFIG_WORKSPACE_CONCURRENCY`, overridable per-invocation by the `--workspace-concurrency` install flag. Stored as `Config::workspace_concurrency`; default `min(4, cores)`; resolved through `resolve_child_concurrency` (the port of `getWorkspaceConcurrency`), so a non-positive value means `parallelism - |value|`, floored at 1. Not read from `.npmrc` — pacquet applies only the auth/network subset of `.npmrc`, same as the sibling `childConcurrency`.
- **`recursive`** — the global CLI-only `-r` / `--recursive` boolean, stored as `Config::recursive`. Not a yaml / env / `.npmrc` key, matching pnpm.

Both are parsed and stored for config-surface parity. pacquet's frozen install materializes the whole workspace in one shared pass, so neither value has a per-project consumption point yet (same "read now, consume as the architecture lands" posture as `preferOffline`).

## Tests

Default parity; yaml (positive / negative / independent-from-`childConcurrency`); `PNPM_CONFIG_*` env parsing; CLI parsing (including the global `-r` before and after the subcommand); and the `--workspace-concurrency` override resolution.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global `--recursive` / `-r` flag and `--workspace-concurrency` option to the CLI
  * Workspace concurrency exposed in config, env vars, and workspace YAML

* **Tests**
  * Added parsing and resolution tests for the new CLI flags, env var, and workspace YAML behavior

* **Documentation**
  * Added default value and docs for workspace concurrency settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->