### PR TITLE
fix(pacquet/integrated-benchmark): use --ignore-failure singular hyperfine flag

### DIFF
--- a/pacquet/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pacquet/tasks/integrated-benchmark/src/cli_args.rs
@@ -272,7 +272,7 @@ impl HyperfineOptions {
             hyperfine_command.arg("--show-output");
         }
         if ignore_failure {
-            hyperfine_command.arg("--ignore-failures");
+            hyperfine_command.arg("--ignore-failure");
         }
     }
 }


### PR DESCRIPTION
## Summary

The Benchmarks CI job was aborting with exit 134:

```
error: unexpected argument '--ignore-failures' found
  tip: a similar argument exists: '--ignore-failure'
Usage: hyperfine --prepare <CMD> --warmup <NUM> --runs <NUM> --ignore-failure <command>...

thread 'main' (8011) panicked at pacquet/tasks/integrated-benchmark/src/verify.rs:107:9:
Process exits with non-zero status: hyperfine
```

Hyperfine's flag is `--ignore-failure` (singular); the Rust harness in `pacquet/tasks/integrated-benchmark/src/cli_args.rs` was passing `--ignore-failures` (plural). `benchmarks/bench.sh` already uses the correct singular form, so this only ever broke when `--ignore-failure` flowed through the Rust binary's flag-mirroring path.

Failing run: https://github.com/pnpm/pnpm/actions/runs/26449612662/job/77866338236

## Test plan

- [ ] Benchmarks workflow runs without the `unexpected argument` abort

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected command-line flag handling in the integrated benchmark utility to ensure proper configuration during benchmark execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->