### PR TITLE
fix(pacquet/workspace): support negated workspace package globs

### DIFF
--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -131,6 +131,28 @@ pub fn find_workspace_projects_no_check(
         None => &default_patterns,
     };
 
+    // Upstream (tinyglobby) treats `!`-prefixed patterns as negations.
+    // wax does not accept `!` inside `Glob::new()`, so split them out
+    // and feed them through `.not()` instead. `!/…` remains a no-op:
+    // relative workspace paths never match that absolute form.
+    let mut include_patterns: Vec<&str> = Vec::new();
+    let mut user_negation_globs: Vec<String> = Vec::new();
+    for p in patterns {
+        if let Some(body) = p.strip_prefix('!') {
+            if body.starts_with('/') {
+                continue;
+            }
+            let normalized = normalize_pattern(body);
+            Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                pattern: p.to_string(),
+                message: err.to_string(),
+            })?;
+            user_negation_globs.push(normalized);
+        } else {
+            include_patterns.push(p);
+        }
+    }
+
     // wax's `not` takes a single pattern; combine the ignores with
     // `wax::any` so the walk filters them all in one pass, matching
     // upstream's `ignore: ['**/node_modules/**', '**/bower_components/**']`.
@@ -138,25 +160,26 @@ pub fn find_workspace_projects_no_check(
     // `Walk::not` call (both `Glob` and `Any` derive `Clone` in wax),
     // since `IGNORE_PATTERNS` is a constant and reparsing it on every
     // user-supplied pattern is wasted work.
-    let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
-        FindWorkspaceProjectsError::InvalidGlob {
-            pattern: "<built-in ignore>".to_string(),
-            message: err.to_string(),
-        }
+    let ignore_template = wax::any(
+        IGNORE_PATTERNS.iter().copied().chain(user_negation_globs.iter().map(|s| s.as_str())),
+    )
+    .map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+        pattern: "<built-in ignore>".to_string(),
+        message: err.to_string(),
     })?;
 
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
-    for pattern in patterns {
+    for pattern in include_patterns {
         let normalized = normalize_pattern(pattern);
         let glob =
             Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.clone(),
+                pattern: pattern.to_string(),
                 message: err.to_string(),
             })?;
 
         let walk = glob.walk(workspace_root).not(ignore_template.clone()).map_err(|err| {
             FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.clone(),
+                pattern: pattern.to_string(),
                 message: err.to_string(),
             }
         })?;

--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -133,7 +133,7 @@ pub fn find_workspace_projects_no_check(
 
     // Upstream (tinyglobby) treats `!`-prefixed patterns as negations.
     // wax does not accept `!` inside `Glob::new()`, so split them out
-    // and feed them through `.not()` instead. `!/…` remains a no-op:
+    // and feed them through `.not()` instead. `!/...` remains a no-op:
     // relative workspace paths never match that absolute form.
     let mut include_patterns: Vec<&str> = Vec::new();
     let mut user_negation_globs: Vec<String> = Vec::new();

--- a/pacquet/crates/workspace/src/projects.rs
+++ b/pacquet/crates/workspace/src/projects.rs
@@ -137,19 +137,19 @@ pub fn find_workspace_projects_no_check(
     // relative workspace paths never match that absolute form.
     let mut include_patterns: Vec<&str> = Vec::new();
     let mut user_negation_globs: Vec<String> = Vec::new();
-    for p in patterns {
-        if let Some(body) = p.strip_prefix('!') {
+    for pattern in patterns {
+        if let Some(body) = pattern.strip_prefix('!') {
             if body.starts_with('/') {
                 continue;
             }
             let normalized = normalize_pattern(body);
             Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: p.to_string(),
+                pattern: pattern.to_string(),
                 message: err.to_string(),
             })?;
             user_negation_globs.push(normalized);
         } else {
-            include_patterns.push(p);
+            include_patterns.push(pattern);
         }
     }
 

--- a/pacquet/crates/workspace/src/projects/tests.rs
+++ b/pacquet/crates/workspace/src/projects/tests.rs
@@ -138,7 +138,7 @@ fn negation_pattern_excludes_matching_projects() {
 
     let names: Vec<String> = projects
         .iter()
-        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
         .collect();
     assert!(
         !names.contains(&"foo".to_string()),
@@ -169,7 +169,7 @@ fn negation_pattern_with_leading_slash_is_noop() {
 
     let names: Vec<String> = projects
         .iter()
-        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
         .collect();
     assert!(
         names.contains(&"foo".to_string()),

--- a/pacquet/crates/workspace/src/projects/tests.rs
+++ b/pacquet/crates/workspace/src/projects/tests.rs
@@ -119,6 +119,64 @@ fn default_patterns_when_packages_omitted() {
     assert_eq!(names, vec!["root".to_string(), "web".to_string()]);
 }
 
+/// Negation patterns exclude matching workspace projects.
+#[test]
+fn negation_pattern_excludes_matching_projects() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "components/component-1", "component-1");
+    make_project(tmp.path(), "components/component-2", "component-2");
+    make_project(tmp.path(), "libs/foo", "foo");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["**".to_string(), "!libs/**".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !names.contains(&"foo".to_string()),
+        "libs/foo must be excluded by `!libs/**`: {names:?}",
+    );
+    assert!(
+        names.contains(&"component-1".to_string()) && names.contains(&"component-2".to_string()),
+        "components must still be included: {names:?}",
+    );
+}
+
+/// A negation starting with `!/` is a no-op for relative workspace paths.
+#[test]
+fn negation_pattern_with_leading_slash_is_noop() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "components/component-1", "component-1");
+    make_project(tmp.path(), "components/component-2", "component-2");
+    make_project(tmp.path(), "libs/foo", "foo");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["**".to_string(), "!/libs/**".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|p| p.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.contains(&"foo".to_string()),
+        "`!/libs/**` must be a no-op; expected libs/foo to be included: {names:?}",
+    );
+}
+
 /// `packages: []` (explicit empty array) is *not* the same as
 /// omitted: it means "enumerate only the workspace root project,"
 /// matching upstream's `opts.patterns ?? defaults` where `[]` is a


### PR DESCRIPTION
## Summary

Fixes #11949.

Pacquet fails with `pacquet_workspace::invalid_glob` when `pnpm-workspace.yaml` uses negated `packages` patterns such as `!**/tools/*`.

The failure occurs because `wax` only supports `!` within character classes (e.g., `[!a]`), not as a leading glob negation.

This change separates negated patterns from include patterns and applies them via `wax`'s ignore path. It also preserves pnpm's `!/foo` behavior, which is a no-op for relative workspace paths.

This PR keeps the changes minimal and local to workspace project discovery, avoiding unnecessary refactoring or moving logic into shared crates.

Added workspace tests covering both `!libs/**` exclusion and the `!/libs/**` no-op case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace configuration now supports `!`-prefixed negation patterns so you can exclude specific projects from workspace operations; negations combine with built-in ignore rules. Leading `!/` negations are treated as no-ops for relative workspace paths.

* **Tests**
  * Added tests validating negation behavior and the no-op handling of leading `!/` patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->