### PR TITLE
ci(test): use prebuilt @pnpm/pnpr from npm instead of building locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,6 @@ jobs:
         name: compiled-packages
     - name: Extract compiled artifacts
       run: tar -xzf compiled.tar.gz
-    # pnpm-registry is the Rust HTTP server the test harness spawns
-    # in place of verdaccio (see __utils__/jest-config/with-registry/globalSetup.js).
-    # Built per-platform here because the binary is native code and the
-    # ubuntu and windows test jobs each need their own.
-    - name: Install Rust toolchain
-      uses: ./.github/actions/rustup
-    - name: Build pnpm-registry
-      shell: bash
-      run: cargo build --release -p pnpm-registry --locked
     - name: Determine test scope
       id: test-scope
       shell: bash

--- a/__utils__/jest-config/package.json
+++ b/__utils__/jest-config/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@babel/core": "catalog:",
     "@babel/plugin-transform-explicit-resource-management": "catalog:",
+    "@pnpm/pnpr": "catalog:",
     "@pnpm/registry-mock": "catalog:",
     "@pnpm/testing.registry-mock": "workspace:*",
     "@pnpm/worker": "workspace:*",

--- a/__utils__/jest-config/with-registry/globalSetup.js
+++ b/__utils__/jest-config/with-registry/globalSetup.js
@@ -1,7 +1,5 @@
 import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import path from 'node:path'
 import { scheduler } from 'node:timers/promises'
 import { promisify } from 'node:util'
 
@@ -88,50 +86,35 @@ function readStoragePath (port) {
 }
 
 /**
- * Locate the `pnpm-registry` binary that this monorepo's cargo
- * workspace built. Same lookup order as pacquet's
- * `pnpm_registry_binary()` in
- * `pacquet/tasks/registry-mock/src/pnpm_registry_command.rs`:
+ * Locate the `pnpm-registry` binary. Lookup order:
  *
- * 1. `PNPM_REGISTRY_BIN` env var override (useful in CI or when
- *    pointing at a binary not in `target/`).
- * 2. `$CARGO_TARGET_DIR/release/pnpm-registry` — preferred for
- *    speed (debug builds are 20%+ slower on registry fan-out).
- * 3. `$CARGO_TARGET_DIR/debug/pnpm-registry` — local-dev fallback.
+ * 1. `PNPM_REGISTRY_BIN` env var override (escape hatch for local
+ *    Rust work — point it at `target/release/pnpm-registry` to test
+ *    in-progress changes to the registry crate).
+ * 2. The platform binary that `pnpm install` pulled in as an
+ *    optionalDependency of `@pnpm/pnpr` — i.e.
+ *    `@pnpm/pnpr.<platform>-<arch>/pnpr[.exe]`. The resolution goes
+ *    through the `@pnpm/pnpr` wrapper's path because the platform
+ *    sub-package lives in the wrapper's own `node_modules`, not
+ *    anywhere on the parent chain of this file.
  */
 function resolvePnpmRegistryBin () {
   if (process.env.PNPM_REGISTRY_BIN) {
     return process.env.PNPM_REGISTRY_BIN
   }
-  const exe = `pnpm-registry${process.platform === 'win32' ? '.exe' : ''}`
-  const targetDir = process.env.CARGO_TARGET_DIR ?? path.join(repoRoot(), 'target')
-  const release = path.join(targetDir, 'release', exe)
-  if (existsSync(release)) return release
-  const debug = path.join(targetDir, 'debug', exe)
-  if (existsSync(debug)) return debug
-  throw new Error(
-    `pnpm-registry binary not found at ${release} or ${debug}. ` +
-    'Build it once with `cargo build --release -p pnpm-registry` ' +
-    '(or `cargo build -p pnpm-registry`) before running tests, ' +
-    'or set PNPM_REGISTRY_BIN to its absolute path.'
-  )
-}
-
-/**
- * Walk up from this file until we hit the directory that owns the
- * cargo workspace's `Cargo.toml`. We can't hard-code a relative
- * path because this file moves around as tests are restructured;
- * walking up is robust to that.
- */
-function repoRoot () {
-  let dir = path.resolve(import.meta.dirname)
-  for (let i = 0; i < 10; i++) {
-    if (existsSync(path.join(dir, 'Cargo.toml'))) return dir
-    const parent = path.dirname(dir)
-    if (parent === dir) break
-    dir = parent
+  const ext = process.platform === 'win32' ? '.exe' : ''
+  const platformPkg = `@pnpm/pnpr.${process.platform}-${process.arch}`
+  try {
+    const wrapperRequire = createRequire(require.resolve('@pnpm/pnpr/bin/pnpr'))
+    return wrapperRequire.resolve(`${platformPkg}/pnpr${ext}`)
+  } catch {
+    throw new Error(
+      `pnpm-registry binary not found. The test suite expects ${platformPkg} ` +
+      'to be installed (it ships as an optionalDependency of @pnpm/pnpr — ' +
+      'run `pnpm install` at the repo root to pull it in), or set ' +
+      'PNPM_REGISTRY_BIN to an absolute path to a locally-built binary.'
+    )
   }
-  throw new Error('failed to locate cargo workspace root (no Cargo.toml in any parent)')
 }
 
 const UNUSUAL_REGISTRY_STARTUP_THRESHOLD = 15 // seconds

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,9 @@ catalogs:
     '@pnpm/patch-package':
       specifier: 0.0.1
       version: 0.0.1
+    '@pnpm/pnpr':
+      specifier: 0.0.0-26052601
+      version: 0.0.0-26052601
     '@pnpm/registry-mock':
       specifier: 6.0.0
       version: 6.0.0
@@ -1361,6 +1364,9 @@ importers:
       '@babel/plugin-transform-explicit-resource-management':
         specifier: 'catalog:'
         version: 7.28.6(@babel/core@7.29.0)
+      '@pnpm/pnpr':
+        specifier: 'catalog:'
+        version: 0.0.0-26052601
       '@pnpm/registry-mock':
         specifier: 'catalog:'
         version: 6.0.0(encoding@0.1.13)
@@ -11602,6 +11608,41 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^1001.0.1
 
+  '@pnpm/pnpr.darwin-arm64@0.0.0-26052601':
+    resolution: {integrity: sha512-BukEliQFokg9zQ/GKt/A4TnAhKCUDQ29qcz9/sXYXPkdQeginI7yxH9XJ/b+gCkx3hOpekRyqut29IG5SXoUDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/pnpr.darwin-x64@0.0.0-26052601':
+    resolution: {integrity: sha512-DLdOBWomdecwKBQpajETN20VSqzkMuNibusnnNtx2My2vHOqruedFKRzYvwbVMDPWc6Hh8ES7mdCm0kamJj9lg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/pnpr.linux-arm64@0.0.0-26052601':
+    resolution: {integrity: sha512-RSc7x5pBy9mLd3Sy2jfKSA7o3UU5LVLeQTYHx6sN8Dx0OYFejjFH67IvrM1wacXp07/zX1oS/8xk4m88WV89mA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/pnpr.linux-x64@0.0.0-26052601':
+    resolution: {integrity: sha512-ApMvaIQJVE2d9SyXlsw781loUlBYp7jFsPpVoHFkxbrWT+zTtGTN50WtopMxGnXK1q+xoVR19ZVay9E9w/EB5Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/pnpr.win32-arm64@0.0.0-26052601':
+    resolution: {integrity: sha512-ritSjCVcugMie4qzV4mx9Mb5DFmiqDAFT2Ky1ReQMTSRd5dV24h0+K7o/e/ifMeiQymyJS+WOV8cG14hSZi2RA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/pnpr.win32-x64@0.0.0-26052601':
+    resolution: {integrity: sha512-E2wIukAlr2Nq4HdOFGw9SCO4+VVHdY/NXklRx+e+LQUW4D+TOMAT5+z+aTZg7PdLoJ7N3t9Pc4tERQw3ve0DXw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@pnpm/pnpr@0.0.0-26052601':
+    resolution: {integrity: sha512-Ap8KTuvDTG5OxSJO543mKkVzw6yNIHjzNIShDZ7Li7lg2tpwZSxj7CjYjIz44LoPyS5wY31CVgB9/Q/rkgDEnA==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   '@pnpm/prepare-package@1001.0.7':
     resolution: {integrity: sha512-dTgxVav2jWqdlLdKDTTioR8k07301E5T/+00ylu22UlnlA/h7dyzdhEThDmYBTEYxe6TIYFjLYmoWRGJSy1y/Q==}
     engines: {node: '>=18.12'}
@@ -19485,6 +19526,33 @@ snapshots:
       '@pnpm/types': 1001.3.0
       chalk: 4.1.2
       path-absolute: 1.0.1
+
+  '@pnpm/pnpr.darwin-arm64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr.darwin-x64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr.linux-arm64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr.linux-x64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr.win32-arm64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr.win32-x64@0.0.0-26052601':
+    optional: true
+
+  '@pnpm/pnpr@0.0.0-26052601':
+    optionalDependencies:
+      '@pnpm/pnpr.darwin-arm64': 0.0.0-26052601
+      '@pnpm/pnpr.darwin-x64': 0.0.0-26052601
+      '@pnpm/pnpr.linux-arm64': 0.0.0-26052601
+      '@pnpm/pnpr.linux-x64': 0.0.0-26052601
+      '@pnpm/pnpr.win32-arm64': 0.0.0-26052601
+      '@pnpm/pnpr.win32-x64': 0.0.0-26052601
 
   '@pnpm/prepare-package@1001.0.7(@pnpm/logger@1001.0.1)(typanion@3.14.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,6 +94,7 @@ catalog:
   '@pnpm/npm-package-arg': ^2.0.0
   '@pnpm/os.env.path-extender': ^3.0.0
   '@pnpm/patch-package': 0.0.1
+  '@pnpm/pnpr': 0.0.0-26052601
   '@pnpm/registry-mock': 6.0.0
   '@pnpm/semver-diff': ^2.0.0
   '@pnpm/tabtab': ^0.5.4


### PR DESCRIPTION
## Summary

The e2e/integration test harness spawns `pnpm-registry` as a faster verdaccio replacement. Until now, CI installed the Rust toolchain and ran `cargo build --release -p pnpm-registry --locked` on every test job, adding a few minutes per platform.

`@pnpm/pnpr` is now publishing prebuilt binaries to npm via [#11963](https://github.com/pnpm/pnpm/pull/11963), so the cargo build is redundant. `pnpm install` already pulls in the matching `@pnpm/pnpr.<platform>-<arch>` package via optionalDependencies; the Jest globalSetup now resolves the binary out of that.

### Changes

- **`pnpm-workspace.yaml`**: add `@pnpm/pnpr` to the catalog pinned at `0.0.0-26052601`.
- **`__utils__/jest-config/package.json`**: depend on `@pnpm/pnpr` via `catalog:`.
- **`__utils__/jest-config/with-registry/globalSetup.js`**: replace the `\$CARGO_TARGET_DIR` lookup with `require.resolve('@pnpm/pnpr.\${platform}-\${arch}/pnpr[.exe]')`. Resolution goes through the `@pnpm/pnpr` wrapper's own module path because the platform sub-packages live in the wrapper's `node_modules`, not on the parent chain of `globalSetup.js`. `PNPM_REGISTRY_BIN` is still honored as the escape hatch for contributors who want to test in-progress changes to the Rust crate.
- **`.github/workflows/test.yml`**: drop the `Install Rust toolchain` and `Build pnpm-registry` steps.

### Verification

Ran `cache/commands`' test suite locally on darwin-arm64 — globalSetup spawned the binary from `@pnpm/pnpr.darwin-arm64@0.0.0-26052601`, the server reported `pnpm-registry listening listen=127.0.0.1:53469`, and the suite passed.

## Test plan

- [ ] CI's `test` matrix (ubuntu + windows, multiple Node versions) all pass
- [ ] Compare wall-clock time of `test` jobs before vs. after — expect to save the time previously spent on `Install Rust toolchain` + `Build pnpm-registry`
- [ ] Locally: run any with-registry test suite; confirm registry server starts and tests pass

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined test infrastructure setup by adopting pre-built binaries, reducing CI execution time.
  * Updated test dependencies and workspace configuration to support improved registry binary resolution during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->