### PR TITLE
ci(pacquet): pin cargo-dylint to 6.0.0 to unblock CI

### DIFF
--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -265,7 +265,13 @@ jobs:
       - name: Install cargo-dylint and dylint-link
         uses: ./.github/actions/binstall
         with:
-          packages: cargo-dylint dylint-link
+          # Pin to 6.0.0 until trailofbits/dylint cuts a 6.0.2. The
+          # 6.0.1 binstall artifacts (published 2026-05-26 17:51 UTC)
+          # fail at driver bootstrap with `failed to read
+          # /home/runner/work/dylint/dylint/driver/Cargo.toml`, the
+          # path baked in by dylint's own CI checkout. Downstream
+          # runners don't have that workspace so the step aborts.
+          packages: cargo-dylint@6.0.0 dylint-link@6.0.0
 
       - name: Run dylint
         # `-D warnings` must come in via `RUSTFLAGS`, not as a trailing


### PR DESCRIPTION
## Summary

[trailofbits/dylint 6.0.1](https://github.com/trailofbits/dylint/releases/tag/6.0.1) (published 2026-05-26 17:51 UTC) ships prebuilt `cargo-binstall` artifacts whose driver-bootstrap step references the dylint repo's own CI workspace path:

```
error: failed to get `dylint_driver` as a dependency of package
  `dylint_driver-nightly-2026-04-16-x86_64-unknown-linux-gnu v0.1.0`
Caused by:
  failed to read `/home/runner/work/dylint/dylint/driver/Cargo.toml`
Caused by:
  No such file or directory (os error 2)
```

Downstream runners don't have `/home/runner/work/dylint/dylint/`, so the bootstrap fails before any lint runs and the Dylint job goes red on every open PR (e.g. #11967, #11968). 6.0.0 — the version `main` was green on 90 minutes before the release dropped — is unaffected.

Pin both `cargo-dylint` and `dylint-link` to `6.0.0` until upstream cuts 6.0.2.

## Test plan

- [ ] Dylint job goes green on this PR.
- [ ] Reverify other in-flight PRs (#11967, #11968) by retrying CI once this lands.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions CI/CD workflow configuration to use pinned versions of build dependencies for improved stability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->