### PR TITLE
fix(registry): verify tarball SHA on publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
  "serde-saphyr",
  "serde_json",
  "sha2",
+ "ssri",
  "tempfile",
  "tokio",
  "tower",

--- a/registry/crates/pnpm-registry/Cargo.toml
+++ b/registry/crates/pnpm-registry/Cargo.toml
@@ -32,6 +32,7 @@ serde              = { workspace = true }
 serde-saphyr       = { workspace = true }
 serde_json         = { workspace = true }
 sha2               = { workspace = true }
+ssri               = { workspace = true }
 tokio              = { workspace = true }
 tower-http         = { workspace = true }
 tracing            = { workspace = true }

--- a/registry/crates/pnpm-registry/src/cache.rs
+++ b/registry/crates/pnpm-registry/src/cache.rs
@@ -49,6 +49,15 @@ pub struct TarballWrite {
     final_path: PathBuf,
 }
 
+/// A reserved (tmp_path, final_path) pair for a tarball write. The
+/// publish flow writes the tarball to `tmp_path` inside a blocking
+/// task, then renames via [`Cache::finalize_tarball_slot`].
+#[derive(Debug)]
+pub struct TarballSlot {
+    pub tmp_path: PathBuf,
+    pub final_path: PathBuf,
+}
+
 impl TarballWrite {
     /// Sync the file to disk and rename it to its final cache path.
     pub async fn finalize(self) -> Result<()> {
@@ -146,6 +155,35 @@ impl Cache {
         let tmp_path = unique_tmp_path(&final_path);
         let file = fs::File::create(&tmp_path).await?;
         Ok(TarballWrite { file, tmp_path, final_path })
+    }
+
+    /// Reserve a tmp/final path pair for a tarball write without
+    /// opening the file. Used by the publish flow, which streams the
+    /// decode + hash + write through `std::fs` inside
+    /// `spawn_blocking` and only needs the paths.
+    pub async fn reserve_tarball_paths(
+        &self,
+        name: &PackageName,
+        filename: &str,
+    ) -> Result<TarballSlot> {
+        let final_path = self.tarball_path(name, filename);
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let tmp_path = unique_tmp_path(&final_path);
+        Ok(TarballSlot { tmp_path, final_path })
+    }
+
+    /// Atomically promote a tmp tarball written by the publish flow to
+    /// its final cache path. Mirrors what [`TarballWrite::finalize`]
+    /// does, minus the `sync_all` (the blocking task that wrote the
+    /// file already synced it).
+    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<()> {
+        if let Some(parent) = slot.final_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        fs::rename(&slot.tmp_path, &slot.final_path).await?;
+        Ok(())
     }
 
     /// Remove the entire package directory. Returns `Ok(false)` if it

--- a/registry/crates/pnpm-registry/src/package_name.rs
+++ b/registry/crates/pnpm-registry/src/package_name.rs
@@ -58,6 +58,15 @@ impl PackageName {
     /// libnpmpublish's `@scope/name-1.0.0.tgz` attachment lands on
     /// disk under the same path the GET endpoint serves.
     pub fn canonicalize_tarball_name(&self, filename: &str) -> Result<String, RegistryError> {
+        self.parse_tarball_name(filename).map(|(canonical, _)| canonical)
+    }
+
+    /// Like [`Self::canonicalize_tarball_name`] but also returns the
+    /// version segment extracted from the filename. The publish
+    /// handler uses the version to look up `versions[v].dist` and
+    /// verify the tarball's integrity against what the packument
+    /// declares.
+    pub fn parse_tarball_name(&self, filename: &str) -> Result<(String, String), RegistryError> {
         let invalid = || RegistryError::InvalidTarballName {
             package: self.raw.clone(),
             filename: filename.to_string(),
@@ -73,7 +82,7 @@ impl PackageName {
         if !is_safe_segment(version) {
             return Err(invalid());
         }
-        Ok(format!("{}-{}.tgz", self.basename, version))
+        Ok((format!("{}-{}.tgz", self.basename, version), version.to_string()))
     }
 }
 

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -421,6 +421,51 @@ mod tests {
     }
 
     #[test]
+    fn stream_rejects_malformed_integrity_sri() {
+        let bytes = b"sri-shape";
+        let dist = json!({ "integrity": "not-a-valid-sri" });
+        let (result, dest, _tmp) = run_stream(bytes, Some(&dist), None);
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("EINTEGRITY") && msg.contains("malformed"), "got: {msg}");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn stream_rejects_invalid_base64() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("out.tgz");
+        // Pick an SRI for some real bytes so the integrity branch
+        // parses cleanly — we want the failure to surface from the
+        // base64 decoder, not the integrity parser.
+        let dist = json!({ "integrity": sri_sha512(b"anything") });
+        let result = stream_decode_verify_and_write(
+            "foo-1.0.0.tgz",
+            "!!!not-valid-base64@@@",
+            None,
+            Some(&dist),
+            &dest,
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("EINTEGRITY") && msg.contains("base64"), "got: {msg}");
+        assert!(!dest.exists());
+    }
+
+    /// Push the streaming loop past its 64 KiB chunk buffer. A
+    /// regression where the loop accidentally returned after the
+    /// first `read` (or where the hasher only saw the first chunk)
+    /// would still pass every smaller-payload test in this module —
+    /// this is the one that catches it.
+    #[test]
+    fn stream_handles_payload_larger_than_chunk_buffer() {
+        let bytes = vec![0xAB; 200 * 1024];
+        let dist = json!({ "integrity": sri_sha512(&bytes), "shasum": sha1_hex(&bytes) });
+        let (result, dest, _tmp) = run_stream(&bytes, Some(&dist), Some(bytes.len() as u64));
+        let written = result.unwrap();
+        assert_eq!(written, bytes.len() as u64);
+        assert_eq!(std::fs::read(&dest).unwrap(), bytes);
+    }
+
+    #[test]
     fn extracts_and_strips_attachments() {
         let mut body = json!({
             "name": "foo",

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -137,7 +137,7 @@ pub fn stream_decode_verify_and_write(
             Ok(n) => n,
             Err(err) => {
                 let _ = std::fs::remove_file(dest);
-                return Err(invalid(format!("base64 decode failed: {err}")));
+                return Err(invalid(format!("EINTEGRITY: base64 decode failed: {err}")));
             }
         };
         let chunk = &buf[..n];
@@ -156,7 +156,9 @@ pub fn stream_decode_verify_and_write(
         && expected != total
     {
         let _ = std::fs::remove_file(dest);
-        return Err(invalid(format!("length mismatch: header says {expected}, decoded {total}")));
+        return Err(invalid(format!(
+            "EINTEGRITY: length mismatch: header says {expected}, decoded {total}",
+        )));
     }
 
     if let Err(err) = checker.result() {
@@ -414,7 +416,7 @@ mod tests {
         let dist = json!({ "integrity": sri_sha512(bytes) });
         let (result, dest, _tmp) = run_stream(bytes, Some(&dist), Some(99));
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("length mismatch"), "got: {msg}");
+        assert!(msg.contains("EINTEGRITY") && msg.contains("length mismatch"), "got: {msg}");
         assert!(!dest.exists());
     }
 

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -1,101 +1,108 @@
 //! Helpers for the `PUT /:pkg` publish endpoint.
 //!
 //! npm sends the entire packument plus base64-encoded tarballs in a
-//! single JSON body. This module decodes those attachments, merges
-//! the incoming manifest into whatever packument is already on disk,
-//! and returns the bytes that should be written back. The actual I/O
-//! happens in the server handler — keeping the side-effecting code
-//! isolated keeps these helpers easy to unit-test.
+//! single JSON body. This module pulls the attachment metadata out of
+//! the body, merges the incoming manifest into whatever packument is
+//! already on disk, and provides the streaming decode/verify/write
+//! routine the handler uses to persist each tarball. The actual I/O
+//! lives here behind a sync interface so the publish handler can run
+//! it inside [`tokio::task::spawn_blocking`] without blocking the
+//! async runtime, and so these helpers stay easy to unit-test.
 
 use std::collections::BTreeMap;
-use std::fmt::Write;
+use std::fmt::Write as FmtWrite;
+use std::fs::File;
+use std::io::{Cursor, Read, Write};
+use std::path::Path;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::read::DecoderReader;
 use serde_json::{Map, Value};
-use ssri::{Algorithm, Integrity, IntegrityOpts};
+use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
 
 use crate::error::RegistryError;
 
-/// One decoded attachment from a publish body.
+/// Per-tarball metadata pulled out of an `_attachments` entry. We
+/// hold the base64 payload as an owned `String` rather than decoding
+/// it eagerly — the streaming write path consumes it directly and
+/// the decoded bytes never have to live in memory.
 #[derive(Debug)]
-pub struct Attachment {
+pub struct PendingAttachment {
     pub filename: String,
-    pub bytes: Vec<u8>,
+    /// Base64-encoded tarball, taken verbatim from the publish body.
+    pub data: String,
+    /// `_attachments.<filename>.length` — the declared byte count of
+    /// the *decoded* tarball, used to catch truncated uploads.
+    pub declared_length: Option<u64>,
 }
 
-/// Pull all `_attachments` out of a publish body and base64-decode
-/// the tarballs. Returns the attachments and removes the
-/// `_attachments` field from `body` so the saved packument doesn't
-/// duplicate the on-disk tarball. Length mismatches between the
-/// declared `length` and the decoded body surface as a 400.
-pub fn extract_attachments(body: &mut Value) -> Result<Vec<Attachment>, RegistryError> {
+/// Pull all `_attachments` out of a publish body. Returns one
+/// [`PendingAttachment`] per entry and removes the `_attachments`
+/// field from `body` so the saved packument doesn't duplicate the
+/// on-disk tarball. Base64 decoding is deferred to the streaming
+/// write path; this function just validates shape.
+pub fn extract_attachments(body: &mut Value) -> Result<Vec<PendingAttachment>, RegistryError> {
     let Some(obj) = body.as_object_mut() else {
         return Ok(Vec::new());
     };
     let Some(attachments_value) = obj.remove("_attachments") else {
         return Ok(Vec::new());
     };
-    let Some(attachments) = attachments_value.as_object() else {
+    let Value::Object(attachments) = attachments_value else {
         return Err(RegistryError::BadRequest {
             reason: "_attachments must be an object".to_string(),
         });
     };
     let mut out = Vec::with_capacity(attachments.len());
     for (filename, value) in attachments {
-        let Some(value_obj) = value.as_object() else {
+        let Value::Object(mut value_obj) = value else {
             return Err(RegistryError::InvalidAttachment {
-                filename: filename.clone(),
+                filename,
                 reason: "expected object".to_string(),
             });
         };
-        let data = value_obj.get("data").and_then(Value::as_str).ok_or_else(|| {
-            RegistryError::InvalidAttachment {
-                filename: filename.clone(),
-                reason: "missing string field `data`".to_string(),
-            }
-        })?;
-        let bytes = BASE64.decode(data).map_err(|err| RegistryError::InvalidAttachment {
-            filename: filename.clone(),
-            reason: format!("base64 decode failed: {err}"),
-        })?;
-        if let Some(expected) = value_obj.get("length").and_then(Value::as_u64) {
-            // npm sends both the length and the data; cross-check to
-            // catch a truncated upload before we write it.
-            if expected != bytes.len() as u64 {
+        let data = match value_obj.remove("data") {
+            Some(Value::String(s)) => s,
+            _ => {
                 return Err(RegistryError::InvalidAttachment {
-                    filename: filename.clone(),
-                    reason: format!(
-                        "length mismatch: header says {expected}, decoded {}",
-                        bytes.len(),
-                    ),
+                    filename,
+                    reason: "missing string field `data`".to_string(),
                 });
             }
-        }
-        out.push(Attachment { filename: filename.clone(), bytes });
+        };
+        let declared_length = value_obj.get("length").and_then(Value::as_u64);
+        out.push(PendingAttachment { filename, data, declared_length });
     }
     Ok(out)
 }
 
-/// Verify that the bytes uploaded for a publish attachment match the
-/// `dist.integrity` (required) and `dist.shasum` (optional, legacy)
-/// digests the packument declares.
+/// Stream-decode a base64 attachment, hash it as it flows by, and
+/// write the bytes to `dest`. Fails fast (and leaves no on-disk
+/// artifact other than the caller-supplied tmp file) if the decoded
+/// tarball doesn't match the declared `dist.integrity` SRI, the
+/// optional legacy `dist.shasum`, or the declared `length`.
+///
+/// Synchronous on purpose: the publish handler runs this inside
+/// [`tokio::task::spawn_blocking`] so the base64-decode and hashing
+/// stages can use plain `std::io` and operate on chunks small enough
+/// (`CHUNK_BYTES`) that the full decoded payload never lives in
+/// memory at once — only the original base64 string (held by the
+/// JSON value) and a 64 KiB working buffer.
 ///
 /// `dist.integrity` is required. npm always emits it; a body that
-/// arrives without it is either tampered with or produced by a buggy
-/// client, and accepting it would store a tarball whose hash the
-/// registry can never claim to have verified. Rejecting the publish
-/// up-front prevents the silent-corruption class of bug where a
-/// downstream `pnpm install` only discovers the mismatch much later
-/// — after the bad bytes have already replicated to other caches.
-///
-/// Both mismatches surface as a 400 with an `EINTEGRITY:` prefix so
-/// pnpm / npm clients can recognize the failure mode.
-pub fn verify_attachment(
+/// arrives without it is either tampered with or produced by a
+/// buggy client, and accepting it would store a tarball whose hash
+/// the registry never verified. All EINTEGRITY-class failures
+/// surface with an `EINTEGRITY:` prefix so pnpm / npm clients can
+/// recognize them.
+pub fn stream_decode_verify_and_write(
     filename: &str,
-    bytes: &[u8],
+    base64_data: &str,
+    declared_length: Option<u64>,
     dist: Option<&Value>,
-) -> Result<(), RegistryError> {
+    dest: &Path,
+) -> Result<u64, RegistryError> {
     let invalid = |reason: String| RegistryError::InvalidAttachment {
         filename: filename.to_string(),
         reason,
@@ -106,38 +113,79 @@ pub fn verify_attachment(
                 .to_string(),
         )
     })?;
-
     let declared_integrity = dist
         .get("integrity")
         .and_then(Value::as_str)
         .ok_or_else(|| invalid("EINTEGRITY: dist.integrity is required".to_string()))?;
-    let parsed: Integrity = declared_integrity
+    let integrity: Integrity = declared_integrity
         .parse()
         .map_err(|err| invalid(format!("EINTEGRITY: malformed dist.integrity: {err}")))?;
-    parsed.check(bytes).map_err(|err| invalid(format!("EINTEGRITY: integrity mismatch: {err}")))?;
+    let declared_shasum = dist.get("shasum").and_then(Value::as_str);
 
-    if let Some(declared_shasum) = dist.get("shasum").and_then(Value::as_str) {
-        let computed = compute_shasum_hex(bytes);
-        if !computed.eq_ignore_ascii_case(declared_shasum) {
+    let mut checker = IntegrityChecker::new(integrity);
+    let mut shasum_hasher =
+        declared_shasum.is_some().then(|| IntegrityOpts::new().algorithm(Algorithm::Sha1));
+
+    let mut decoder = DecoderReader::new(Cursor::new(base64_data.as_bytes()), &BASE64);
+    let mut file = File::create(dest).map_err(RegistryError::Io)?;
+    const CHUNK_BYTES: usize = 64 * 1024;
+    let mut buf = vec![0u8; CHUNK_BYTES];
+    let mut total: u64 = 0;
+    loop {
+        let n = match decoder.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(err) => {
+                let _ = std::fs::remove_file(dest);
+                return Err(invalid(format!("base64 decode failed: {err}")));
+            }
+        };
+        let chunk = &buf[..n];
+        if let Err(err) = file.write_all(chunk) {
+            let _ = std::fs::remove_file(dest);
+            return Err(RegistryError::Io(err));
+        }
+        checker.input(chunk);
+        if let Some(hasher) = shasum_hasher.as_mut() {
+            hasher.input(chunk);
+        }
+        total += n as u64;
+    }
+
+    if let Some(expected) = declared_length
+        && expected != total
+    {
+        let _ = std::fs::remove_file(dest);
+        return Err(invalid(format!("length mismatch: header says {expected}, decoded {total}")));
+    }
+
+    if let Err(err) = checker.result() {
+        let _ = std::fs::remove_file(dest);
+        return Err(invalid(format!("EINTEGRITY: integrity mismatch: {err}")));
+    }
+    if let Some(declared) = declared_shasum {
+        let hasher = shasum_hasher.expect("shasum_hasher initialized when declared_shasum present");
+        let computed = sha1_hex_from_integrity_opts(hasher);
+        if !computed.eq_ignore_ascii_case(declared) {
+            let _ = std::fs::remove_file(dest);
             return Err(invalid(format!(
-                "EINTEGRITY: shasum mismatch: declared {declared_shasum:?}, computed {computed:?}",
+                "EINTEGRITY: shasum mismatch: declared {declared:?}, computed {computed:?}",
             )));
         }
     }
 
-    Ok(())
+    if let Err(err) = file.sync_all() {
+        let _ = std::fs::remove_file(dest);
+        return Err(RegistryError::Io(err));
+    }
+    Ok(total)
 }
 
-/// Compute the SHA-1 of `bytes` as a 40-character lowercase hex
-/// string — the shape npm's legacy `dist.shasum` field uses.
-///
-/// We piggyback on `ssri` (already a workspace dep for the streaming
-/// `integrity` check) so we don't pull in a second SHA-1 crate. ssri
-/// returns the digest base64-encoded inside an [`Integrity`]; we
-/// decode and re-encode as hex for the shasum comparison.
-fn compute_shasum_hex(bytes: &[u8]) -> String {
-    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha1);
-    opts.input(bytes);
+/// Finalize a SHA-1 [`IntegrityOpts`] and re-encode the digest as a
+/// 40-character lowercase hex string — the shape npm's legacy
+/// `dist.shasum` field uses. ssri stores digests base64-encoded, so
+/// we decode and re-encode as hex for the comparison.
+fn sha1_hex_from_integrity_opts(opts: IntegrityOpts) -> String {
     let integrity = opts.result();
     let digest_base64 = integrity
         .hashes
@@ -276,9 +324,18 @@ pub fn now_iso() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_attachments, merge_manifest, now_iso, verify_attachment};
+    use std::path::PathBuf;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
     use serde_json::{Value, json};
     use ssri::{Algorithm, IntegrityOpts};
+    use tempfile::TempDir;
+
+    use super::{
+        extract_attachments, merge_manifest, now_iso, sha1_hex_from_integrity_opts,
+        stream_decode_verify_and_write,
+    };
 
     fn sri_sha512(bytes: &[u8]) -> String {
         let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
@@ -286,44 +343,79 @@ mod tests {
         opts.result().to_string()
     }
 
+    fn sha1_hex(bytes: &[u8]) -> String {
+        let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha1);
+        opts.input(bytes);
+        sha1_hex_from_integrity_opts(opts)
+    }
+
+    fn run_stream(
+        bytes: &[u8],
+        dist: Option<&Value>,
+        declared_length: Option<u64>,
+    ) -> (Result<u64, crate::error::RegistryError>, PathBuf, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("out.tgz");
+        let b64 = BASE64.encode(bytes);
+        let result =
+            stream_decode_verify_and_write("foo-1.0.0.tgz", &b64, declared_length, dist, &dest);
+        (result, dest, tmp)
+    }
+
     #[test]
-    fn verify_accepts_matching_integrity() {
+    fn stream_writes_matching_tarball() {
         let bytes = b"hello-world";
-        let dist = json!({ "integrity": sri_sha512(bytes) });
-        verify_attachment("foo-1.0.0.tgz", bytes, Some(&dist)).unwrap();
+        let dist = json!({ "integrity": sri_sha512(bytes), "shasum": sha1_hex(bytes) });
+        let (result, dest, _tmp) = run_stream(bytes, Some(&dist), Some(bytes.len() as u64));
+        let written = result.unwrap();
+        assert_eq!(written, bytes.len() as u64);
+        assert_eq!(std::fs::read(&dest).unwrap(), bytes);
     }
 
     #[test]
-    fn verify_rejects_integrity_mismatch() {
+    fn stream_rejects_integrity_mismatch_and_removes_tmp() {
         let dist = json!({ "integrity": sri_sha512(b"other-bytes") });
-        let err = verify_attachment("foo-1.0.0.tgz", b"actual-bytes", Some(&dist)).unwrap_err();
+        let (result, dest, _tmp) = run_stream(b"actual-bytes", Some(&dist), None);
+        let err = result.unwrap_err();
         assert!(err.to_string().contains("EINTEGRITY"), "got: {err}");
+        assert!(!dest.exists(), "tmp file must be removed on integrity mismatch");
     }
 
     #[test]
-    fn verify_rejects_missing_integrity() {
+    fn stream_rejects_missing_integrity() {
         let dist = json!({ "tarball": "http://example.com/foo-1.0.0.tgz" });
-        let err = verify_attachment("foo-1.0.0.tgz", b"bytes", Some(&dist)).unwrap_err();
-        let msg = err.to_string();
+        let (result, _dest, _tmp) = run_stream(b"bytes", Some(&dist), None);
+        let msg = result.unwrap_err().to_string();
         assert!(msg.contains("EINTEGRITY") && msg.contains("integrity"), "got: {msg}");
     }
 
     #[test]
-    fn verify_rejects_missing_dist_entry() {
-        let err = verify_attachment("foo-1.0.0.tgz", b"bytes", None).unwrap_err();
-        assert!(err.to_string().contains("EINTEGRITY"), "got: {err}");
+    fn stream_rejects_missing_dist_entry() {
+        let (result, _dest, _tmp) = run_stream(b"bytes", None, None);
+        assert!(result.unwrap_err().to_string().contains("EINTEGRITY"));
     }
 
     #[test]
-    fn verify_rejects_shasum_mismatch() {
+    fn stream_rejects_shasum_mismatch() {
         let bytes = b"shasum-bytes";
         let dist = json!({
             "integrity": sri_sha512(bytes),
             "shasum": "ffffffffffffffffffffffffffffffffffffffff",
         });
-        let err = verify_attachment("foo-1.0.0.tgz", bytes, Some(&dist)).unwrap_err();
-        let msg = err.to_string();
+        let (result, dest, _tmp) = run_stream(bytes, Some(&dist), None);
+        let msg = result.unwrap_err().to_string();
         assert!(msg.contains("shasum") && msg.contains("EINTEGRITY"), "got: {msg}");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn stream_rejects_declared_length_mismatch() {
+        let bytes = b"len-check";
+        let dist = json!({ "integrity": sri_sha512(bytes) });
+        let (result, dest, _tmp) = run_stream(bytes, Some(&dist), Some(99));
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("length mismatch"), "got: {msg}");
+        assert!(!dest.exists());
     }
 
     #[test]
@@ -341,18 +433,9 @@ mod tests {
         let attachments = extract_attachments(&mut body).unwrap();
         assert_eq!(attachments.len(), 1);
         assert_eq!(attachments[0].filename, "foo-1.0.0.tgz");
-        assert_eq!(attachments[0].bytes, b"hello");
+        assert_eq!(attachments[0].data, "aGVsbG8=");
+        assert_eq!(attachments[0].declared_length, Some(5));
         assert!(body.get("_attachments").is_none(), "_attachments should be stripped");
-    }
-
-    #[test]
-    fn rejects_length_mismatch() {
-        let mut body = json!({
-            "_attachments": {
-                "f.tgz": { "data": "aGVsbG8=", "length": 99 }
-            }
-        });
-        assert!(extract_attachments(&mut body).is_err());
     }
 
     #[test]

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -62,14 +62,11 @@ pub fn extract_attachments(body: &mut Value) -> Result<Vec<PendingAttachment>, R
                 reason: "expected object".to_string(),
             });
         };
-        let data = match value_obj.remove("data") {
-            Some(Value::String(s)) => s,
-            _ => {
-                return Err(RegistryError::InvalidAttachment {
-                    filename,
-                    reason: "missing string field `data`".to_string(),
-                });
-            }
+        let Some(Value::String(data)) = value_obj.remove("data") else {
+            return Err(RegistryError::InvalidAttachment {
+                filename,
+                reason: "missing string field `data`".to_string(),
+            });
         };
         let declared_length = value_obj.get("length").and_then(Value::as_u64);
         out.push(PendingAttachment { filename, data, declared_length });
@@ -132,15 +129,15 @@ pub fn stream_decode_verify_and_write(
     let mut buf = vec![0u8; CHUNK_BYTES];
     let mut total: u64 = 0;
     loop {
-        let n = match decoder.read(&mut buf) {
+        let bytes_read = match decoder.read(&mut buf) {
             Ok(0) => break,
-            Ok(n) => n,
+            Ok(bytes_read) => bytes_read,
             Err(err) => {
                 let _ = std::fs::remove_file(dest);
                 return Err(invalid(format!("EINTEGRITY: base64 decode failed: {err}")));
             }
         };
-        let chunk = &buf[..n];
+        let chunk = &buf[..bytes_read];
         if let Err(err) = file.write_all(chunk) {
             let _ = std::fs::remove_file(dest);
             return Err(RegistryError::Io(err));
@@ -149,7 +146,7 @@ pub fn stream_decode_verify_and_write(
         if let Some(hasher) = shasum_hasher.as_mut() {
             hasher.input(chunk);
         }
-        total += n as u64;
+        total += bytes_read as u64;
     }
 
     if let Some(expected) = declared_length

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -8,10 +8,12 @@
 //! isolated keeps these helpers easy to unit-test.
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value};
+use ssri::{Algorithm, Integrity, IntegrityOpts};
 
 use crate::error::RegistryError;
 
@@ -73,6 +75,82 @@ pub fn extract_attachments(body: &mut Value) -> Result<Vec<Attachment>, Registry
         out.push(Attachment { filename: filename.clone(), bytes });
     }
     Ok(out)
+}
+
+/// Verify that the bytes uploaded for a publish attachment match the
+/// `dist.integrity` (required) and `dist.shasum` (optional, legacy)
+/// digests the packument declares.
+///
+/// `dist.integrity` is required. npm always emits it; a body that
+/// arrives without it is either tampered with or produced by a buggy
+/// client, and accepting it would store a tarball whose hash the
+/// registry can never claim to have verified. Rejecting the publish
+/// up-front prevents the silent-corruption class of bug where a
+/// downstream `pnpm install` only discovers the mismatch much later
+/// — after the bad bytes have already replicated to other caches.
+///
+/// Both mismatches surface as a 400 with an `EINTEGRITY:` prefix so
+/// pnpm / npm clients can recognize the failure mode.
+pub fn verify_attachment(
+    filename: &str,
+    bytes: &[u8],
+    dist: Option<&Value>,
+) -> Result<(), RegistryError> {
+    let invalid = |reason: String| RegistryError::InvalidAttachment {
+        filename: filename.to_string(),
+        reason,
+    };
+    let dist = dist.ok_or_else(|| {
+        invalid(
+            "EINTEGRITY: packument has no matching versions[v].dist entry for this attachment"
+                .to_string(),
+        )
+    })?;
+
+    let declared_integrity = dist
+        .get("integrity")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid("EINTEGRITY: dist.integrity is required".to_string()))?;
+    let parsed: Integrity = declared_integrity
+        .parse()
+        .map_err(|err| invalid(format!("EINTEGRITY: malformed dist.integrity: {err}")))?;
+    parsed.check(bytes).map_err(|err| invalid(format!("EINTEGRITY: integrity mismatch: {err}")))?;
+
+    if let Some(declared_shasum) = dist.get("shasum").and_then(Value::as_str) {
+        let computed = compute_shasum_hex(bytes);
+        if !computed.eq_ignore_ascii_case(declared_shasum) {
+            return Err(invalid(format!(
+                "EINTEGRITY: shasum mismatch: declared {declared_shasum:?}, computed {computed:?}",
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Compute the SHA-1 of `bytes` as a 40-character lowercase hex
+/// string — the shape npm's legacy `dist.shasum` field uses.
+///
+/// We piggyback on `ssri` (already a workspace dep for the streaming
+/// `integrity` check) so we don't pull in a second SHA-1 crate. ssri
+/// returns the digest base64-encoded inside an [`Integrity`]; we
+/// decode and re-encode as hex for the shasum comparison.
+fn compute_shasum_hex(bytes: &[u8]) -> String {
+    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha1);
+    opts.input(bytes);
+    let integrity = opts.result();
+    let digest_base64 = integrity
+        .hashes
+        .first()
+        .expect("ssri produces a Sha1 hash entry when requested")
+        .digest
+        .as_str();
+    let digest_bytes = BASE64.decode(digest_base64).expect("ssri produces valid base64 digests");
+    let mut hex = String::with_capacity(digest_bytes.len() * 2);
+    for byte in &digest_bytes {
+        write!(hex, "{byte:02x}").expect("writing to String never fails");
+    }
+    hex
 }
 
 /// Merge an incoming publish manifest into the existing on-disk
@@ -198,8 +276,55 @@ pub fn now_iso() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_attachments, merge_manifest, now_iso};
+    use super::{extract_attachments, merge_manifest, now_iso, verify_attachment};
     use serde_json::{Value, json};
+    use ssri::{Algorithm, IntegrityOpts};
+
+    fn sri_sha512(bytes: &[u8]) -> String {
+        let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
+        opts.input(bytes);
+        opts.result().to_string()
+    }
+
+    #[test]
+    fn verify_accepts_matching_integrity() {
+        let bytes = b"hello-world";
+        let dist = json!({ "integrity": sri_sha512(bytes) });
+        verify_attachment("foo-1.0.0.tgz", bytes, Some(&dist)).unwrap();
+    }
+
+    #[test]
+    fn verify_rejects_integrity_mismatch() {
+        let dist = json!({ "integrity": sri_sha512(b"other-bytes") });
+        let err = verify_attachment("foo-1.0.0.tgz", b"actual-bytes", Some(&dist)).unwrap_err();
+        assert!(err.to_string().contains("EINTEGRITY"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_rejects_missing_integrity() {
+        let dist = json!({ "tarball": "http://example.com/foo-1.0.0.tgz" });
+        let err = verify_attachment("foo-1.0.0.tgz", b"bytes", Some(&dist)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("EINTEGRITY") && msg.contains("integrity"), "got: {msg}");
+    }
+
+    #[test]
+    fn verify_rejects_missing_dist_entry() {
+        let err = verify_attachment("foo-1.0.0.tgz", b"bytes", None).unwrap_err();
+        assert!(err.to_string().contains("EINTEGRITY"), "got: {err}");
+    }
+
+    #[test]
+    fn verify_rejects_shasum_mismatch() {
+        let bytes = b"shasum-bytes";
+        let dist = json!({
+            "integrity": sri_sha512(bytes),
+            "shasum": "ffffffffffffffffffffffffffffffffffffffff",
+        });
+        let err = verify_attachment("foo-1.0.0.tgz", bytes, Some(&dist)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("shasum") && msg.contains("EINTEGRITY"), "got: {msg}");
+    }
 
     #[test]
     fn extracts_and_strips_attachments() {

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -16,7 +16,7 @@ use crate::config::Config;
 use crate::error::RegistryError;
 use crate::package_name::PackageName;
 use crate::policy::{AccessRule, PackagePolicies};
-use crate::publish::{extract_attachments, merge_manifest, now_iso};
+use crate::publish::{extract_attachments, merge_manifest, now_iso, verify_attachment};
 use crate::streaming;
 use crate::upstream::{
     FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
@@ -566,12 +566,25 @@ async fn publish_package(
     // libnpmpublish bodies the wire form is `@scope/name-version.tgz`
     // but on disk it lives at `<root>/@scope/name/name-version.tgz`,
     // matching what `serve_tarball` expects.
+    //
+    // Verify the tarball bytes against the integrity (and legacy
+    // shasum) declared in `versions[v].dist` *before* writing to
+    // disk. A mismatch — or a missing integrity field — short-
+    // circuits the publish with a 400, so a bad upload never lands
+    // in the cache and can't replicate to downstream consumers.
     let mut canonical_attachments = Vec::with_capacity(attachments.len());
     for attachment in attachments {
-        let canonical = match name.canonicalize_tarball_name(&attachment.filename) {
-            Ok(canonical) => canonical,
+        let (canonical, version) = match name.parse_tarball_name(&attachment.filename) {
+            Ok(parsed) => parsed,
             Err(err) => return error_response(&err),
         };
+        let dist = incoming
+            .get("versions")
+            .and_then(|versions| versions.get(&version))
+            .and_then(|manifest| manifest.get("dist"));
+        if let Err(err) = verify_attachment(&attachment.filename, &attachment.bytes, dist) {
+            return error_response(&err);
+        }
         canonical_attachments.push((canonical, attachment.bytes));
     }
 

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -16,7 +16,9 @@ use crate::config::Config;
 use crate::error::RegistryError;
 use crate::package_name::PackageName;
 use crate::policy::{AccessRule, PackagePolicies};
-use crate::publish::{extract_attachments, merge_manifest, now_iso, verify_attachment};
+use crate::publish::{
+    PendingAttachment, extract_attachments, merge_manifest, now_iso, stream_decode_verify_and_write,
+};
 use crate::streaming;
 use crate::upstream::{
     FetchOutcome, Upstream, abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
@@ -560,19 +562,16 @@ async fn publish_package(
         Err(err) => return error_response(&err),
     };
 
-    // Validate attachment filenames against the package name so a
-    // crafted payload can't write `../../etc/passwd.tgz`. The
-    // canonical name is what we actually persist — for scoped
-    // libnpmpublish bodies the wire form is `@scope/name-version.tgz`
+    // Resolve each attachment's canonical disk filename + matching
+    // `versions[v].dist` block. Attachment names that don't match the
+    // package (`bar-1.0.0.tgz` for `foo`) or that try to escape the
+    // package dir (`../../etc/passwd.tgz`) are rejected here, before
+    // any I/O. The canonical name is what we actually persist — for
+    // scoped libnpmpublish bodies the wire form is `@scope/name-version.tgz`
     // but on disk it lives at `<root>/@scope/name/name-version.tgz`,
     // matching what `serve_tarball` expects.
-    //
-    // Verify the tarball bytes against the integrity (and legacy
-    // shasum) declared in `versions[v].dist` *before* writing to
-    // disk. A mismatch — or a missing integrity field — short-
-    // circuits the publish with a 400, so a bad upload never lands
-    // in the cache and can't replicate to downstream consumers.
-    let mut canonical_attachments = Vec::with_capacity(attachments.len());
+    let mut prepared: Vec<(PendingAttachment, String, Value)> =
+        Vec::with_capacity(attachments.len());
     for attachment in attachments {
         let (canonical, version) = match name.parse_tarball_name(&attachment.filename) {
             Ok(parsed) => parsed,
@@ -581,11 +580,10 @@ async fn publish_package(
         let dist = incoming
             .get("versions")
             .and_then(|versions| versions.get(&version))
-            .and_then(|manifest| manifest.get("dist"));
-        if let Err(err) = verify_attachment(&attachment.filename, &attachment.bytes, dist) {
-            return error_response(&err);
-        }
-        canonical_attachments.push((canonical, attachment.bytes));
+            .and_then(|manifest| manifest.get("dist"))
+            .cloned()
+            .unwrap_or(Value::Null);
+        prepared.push((attachment, canonical, dist));
     }
 
     // Seed the merge from whatever the upstream knows about the
@@ -614,17 +612,54 @@ async fn publish_package(
         Ok(b) => b,
         Err(err) => return error_response(&RegistryError::Json(err)),
     };
+    // `incoming` is no longer needed; drop it so the base64 strings
+    // inside go away as soon as `prepared` (which owns each one) is
+    // drained below.
+    drop(incoming);
 
-    // Write attachments first; if the packument write succeeds but
-    // we never wrote the tarball, the registry will 404 anyway.
-    // Doing tarballs first avoids the symmetric race where the
-    // packument advertises a tarball that isn't on disk yet.
-    for (filename, bytes) in canonical_attachments {
-        let tmp = match state.inner.cache.open_tarball_tmp(&name, &filename).await {
-            Ok(t) => t,
-            Err(err) => return error_response(&err),
+    // Stream-decode + verify + write each tarball. A mismatch — or a
+    // missing integrity field — short-circuits the publish with a
+    // 400; any tmp files written before the failure get removed
+    // along the way so a bad upload leaves no on-disk artifact.
+    //
+    // Tarballs are written before the packument so a successful
+    // packument write never advertises a tarball that's missing from
+    // disk.
+    let mut written_slots = Vec::with_capacity(prepared.len());
+    for (attachment, canonical, dist) in prepared {
+        let slot = match state.inner.cache.reserve_tarball_paths(&name, &canonical).await {
+            Ok(slot) => slot,
+            Err(err) => {
+                cleanup_tmp_slots(written_slots).await;
+                return error_response(&err);
+            }
         };
-        if let Err(err) = write_tarball_bytes(tmp, &bytes).await {
+        let PendingAttachment { filename, data, declared_length } = attachment;
+        let tmp_path = slot.tmp_path.clone();
+        let dist_for_task = (!dist.is_null()).then_some(dist);
+        let result = tokio::task::spawn_blocking(move || {
+            let dist_ref = dist_for_task.as_ref();
+            stream_decode_verify_and_write(&filename, &data, declared_length, dist_ref, &tmp_path)
+        })
+        .await;
+        match result {
+            Ok(Ok(_)) => written_slots.push(slot),
+            Ok(Err(err)) => {
+                cleanup_tmp_slots(written_slots).await;
+                return error_response(&err);
+            }
+            Err(join_err) => {
+                let _ = tokio::fs::remove_file(&slot.tmp_path).await;
+                cleanup_tmp_slots(written_slots).await;
+                return error_response(&RegistryError::Io(std::io::Error::other(
+                    join_err.to_string(),
+                )));
+            }
+        }
+    }
+
+    for slot in written_slots {
+        if let Err(err) = state.inner.cache.finalize_tarball_slot(slot).await {
             return error_response(&err);
         }
     }
@@ -642,14 +677,14 @@ async fn publish_package(
         .expect("static-shape response always builds")
 }
 
-async fn write_tarball_bytes(
-    tmp: crate::cache::TarballWrite,
-    bytes: &[u8],
-) -> Result<(), RegistryError> {
-    use tokio::io::AsyncWriteExt;
-    let mut tmp = tmp;
-    tmp.file.write_all(bytes).await?;
-    tmp.finalize().await
+/// Remove every tmp tarball file that a partially-completed publish
+/// already wrote. Errors are swallowed: the caller is already
+/// returning an error response, and a leftover `*.tmp.*` file is
+/// harmless beyond a small amount of disk.
+async fn cleanup_tmp_slots(slots: Vec<crate::cache::TarballSlot>) {
+    for slot in slots {
+        let _ = tokio::fs::remove_file(&slot.tmp_path).await;
+    }
 }
 
 /// `GET /-/v1/search?text=...&size=...` — npm search v1 endpoint.

--- a/registry/crates/pnpm-registry/tests/auth_publish.rs
+++ b/registry/crates/pnpm-registry/tests/auth_publish.rs
@@ -503,6 +503,82 @@ async fn publish_rejects_missing_integrity_field() {
     assert!(!storage.join("no-int-pkg/package.json").exists());
 }
 
+/// Real npm clients send one attachment per publish, but the
+/// handler is written to iterate N: if the M-th attachment fails
+/// integrity, every already-written tmp file from the earlier
+/// attachments must be cleaned up so a rejected publish leaves no
+/// on-disk artifact. This pins down the `cleanup_tmp_slots` path —
+/// without it, a regression that no-op'd the cleanup would leak
+/// `*.tmp.*` files for every successful attachment before the bad
+/// one.
+#[tokio::test]
+async fn publish_with_failed_attachment_cleans_up_earlier_tmp_files() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let bytes_v1 = b"valid-first-attachment";
+    let bytes_v2 = b"second-attachment";
+    let body = json!({
+        "_id": "multi-attach",
+        "name": "multi-attach",
+        "dist-tags": { "latest": "2.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "multi-attach", "version": "1.0.0",
+                "dist": {
+                    "tarball": "http://localhost:4873/multi-attach/-/multi-attach-1.0.0.tgz",
+                    "shasum": sha1_hex(bytes_v1),
+                    "integrity": sri_sha512(bytes_v1),
+                }
+            },
+            "2.0.0": {
+                "name": "multi-attach", "version": "2.0.0",
+                "dist": {
+                    "tarball": "http://localhost:4873/multi-attach/-/multi-attach-2.0.0.tgz",
+                    "shasum": sha1_hex(bytes_v2),
+                    "integrity": sri_sha512(b"WRONG-BYTES-FOR-2.0.0"),
+                }
+            }
+        },
+        "_attachments": {
+            "multi-attach-1.0.0.tgz": {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(bytes_v1),
+                "length": bytes_v1.len(),
+            },
+            "multi-attach-2.0.0.tgz": {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(bytes_v2),
+                "length": bytes_v2.len(),
+            },
+        }
+    });
+    let request = Request::put("/multi-attach")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // The package dir may exist (the handler creates it while
+    // reserving paths) but it must be empty: no .tgz files, no
+    // .tmp.* leftovers, no package.json.
+    let pkg_dir = storage.join("multi-attach");
+    if pkg_dir.exists() {
+        let entries: Vec<String> = std::fs::read_dir(&pkg_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "expected no artifacts after rejected publish, found: {entries:?}",
+        );
+    }
+}
+
 /// `anonymous-npm-registry-client`'s `distTags.add` URL-encodes the
 /// `/` in scoped names: `@scope/pkg` → `@scope%2Fpkg` in the URL.
 /// axum's `Path` extractor percent-decodes path segments, so the

--- a/registry/crates/pnpm-registry/tests/auth_publish.rs
+++ b/registry/crates/pnpm-registry/tests/auth_publish.rs
@@ -412,6 +412,97 @@ async fn publish_rejects_tarball_that_doesnt_match_package() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn publish_rejects_integrity_mismatch_and_leaves_no_artifacts() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let bytes = b"actual-bytes";
+    let mut body = sample_publish_body("bad-pkg", "1.0.0", bytes);
+    // Swap the integrity for one computed over different bytes — the
+    // body keeps the original bytes, so the server's recomputed hash
+    // won't match.
+    body["versions"]["1.0.0"]["dist"]["integrity"] = json!(sri_sha512(b"different-bytes"));
+
+    let request = Request::put("/bad-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert!(
+        body_text.contains("EINTEGRITY"),
+        "error body should carry EINTEGRITY code: {body_text}"
+    );
+
+    // Neither the packument nor the tarball should have been written.
+    assert!(
+        !storage.join("bad-pkg/package.json").exists(),
+        "packument must not be written when integrity check fails",
+    );
+    assert!(
+        !storage.join("bad-pkg/bad-pkg-1.0.0.tgz").exists(),
+        "tarball must not be written when integrity check fails",
+    );
+}
+
+#[tokio::test]
+async fn publish_rejects_shasum_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let bytes = b"shasum-test-bytes";
+    let mut body = sample_publish_body("shasum-pkg", "1.0.0", bytes);
+    // Keep integrity valid but corrupt the legacy shasum.
+    body["versions"]["1.0.0"]["dist"]["shasum"] = json!("0000000000000000000000000000000000000000");
+
+    let request = Request::put("/shasum-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert!(
+        body_text.contains("EINTEGRITY"),
+        "shasum mismatch must surface EINTEGRITY: {body_text}"
+    );
+    assert!(!storage.join("shasum-pkg/package.json").exists());
+}
+
+#[tokio::test]
+async fn publish_rejects_missing_integrity_field() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let bytes = b"no-integrity-bytes";
+    let mut body = sample_publish_body("no-int-pkg", "1.0.0", bytes);
+    body["versions"]["1.0.0"]["dist"].as_object_mut().unwrap().remove("integrity");
+
+    let request = Request::put("/no-int-pkg")
+        .header("content-type", "application/json")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert!(
+        body_text.contains("EINTEGRITY") && body_text.contains("integrity"),
+        "missing integrity must surface a clear EINTEGRITY message: {body_text}",
+    );
+    assert!(!storage.join("no-int-pkg/package.json").exists());
+}
+
 /// `anonymous-npm-registry-client`'s `distTags.add` URL-encodes the
 /// `/` in scoped names: `@scope/pkg` → `@scope%2Fpkg` in the URL.
 /// axum's `Path` extractor percent-decodes path segments, so the
@@ -514,8 +605,8 @@ async fn publish_accepts_libnpmpublish_scoped_attachment_filename() {
                 "version": version,
                 "dist": {
                     "tarball": format!("http://localhost:4873/{pkg}/-/lib-pub-form-{version}.tgz"),
-                    "shasum": "deadbeef",
-                    "integrity": "sha512-abcdef==",
+                    "shasum": sha1_hex(bytes),
+                    "integrity": sri_sha512(bytes),
                 },
             },
         },
@@ -903,8 +994,8 @@ fn sample_publish_body(name: &str, version: &str, tarball: &[u8]) -> Value {
                 "version": version,
                 "dist": {
                     "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
-                    "shasum": "deadbeef",
-                    "integrity": "sha512-abcdef=="
+                    "shasum": sha1_hex(tarball),
+                    "integrity": sri_sha512(tarball),
                 }
             }
         },
@@ -915,5 +1006,28 @@ fn sample_publish_body(name: &str, version: &str, tarball: &[u8]) -> Value {
                 "length": tarball.len()
             }
         }
+    })
+}
+
+/// Compute the SRI `sha512-...` string the way npm clients send it
+/// in `dist.integrity`.
+fn sri_sha512(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+/// Compute the 40-char hex SHA-1 the way npm clients send it in the
+/// legacy `dist.shasum` field.
+fn sha1_hex(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
+    opts.input(bytes);
+    let integrity = opts.result();
+    let digest_base64 = &integrity.hashes[0].digest;
+    let digest_bytes = BASE64.decode(digest_base64).unwrap();
+    digest_bytes.iter().fold(String::with_capacity(40), |mut acc, byte| {
+        use std::fmt::Write;
+        write!(acc, "{byte:02x}").unwrap();
+        acc
     })
 }

--- a/registry/crates/pnpm-registry/tests/auth_publish.rs
+++ b/registry/crates/pnpm-registry/tests/auth_publish.rs
@@ -436,7 +436,7 @@ async fn publish_rejects_integrity_mismatch_and_leaves_no_artifacts() {
     let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
     assert!(
         body_text.contains("EINTEGRITY"),
-        "error body should carry EINTEGRITY code: {body_text}"
+        "error body should carry EINTEGRITY code: {body_text}",
     );
 
     // Neither the packument nor the tarball should have been written.
@@ -472,7 +472,7 @@ async fn publish_rejects_shasum_mismatch() {
     let body_text = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
     assert!(
         body_text.contains("EINTEGRITY"),
-        "shasum mismatch must surface EINTEGRITY: {body_text}"
+        "shasum mismatch must surface EINTEGRITY: {body_text}",
     );
     assert!(!storage.join("shasum-pkg/package.json").exists());
 }


### PR DESCRIPTION
## Summary

Closes #11975.

`pnpm-registry`'s `PUT /:pkg` endpoint accepted tarballs without verifying that their bytes matched the integrity declared in the packument. A buggy or partial-upload client could land a tarball whose hash didn't match `dist.integrity` / `dist.shasum`, and a malicious client could deliberately decouple the advertised hash from the bytes — both classes of silent-corruption bug that only surface when downstream `pnpm install` later fails with `EINTEGRITY`.

This change hashes every attachment before any I/O happens and rejects mismatches up-front so the bad bytes never reach the cache. The decode + hash + write runs in one streaming pass so the full decoded payload never lives in memory at once.

## What lands

- `stream_decode_verify_and_write` in `publish.rs` — pulls base64 chunks out of `base64::read::DecoderReader`, feeds each 64 KiB chunk to an ssri `IntegrityChecker` (SHA-512), an optional `IntegrityOpts(Sha1)` for legacy shasum, and the on-disk tmp file in lockstep. Verifies declared `length`, integrity, and shasum at the end; any failure removes the tmp file before returning.
- All failure modes surface as `400 BAD_REQUEST` with an `EINTEGRITY:` prefix in the body so pnpm / npm clients can recognize the error code.
- `extract_attachments` no longer base64-decodes eagerly; it returns `PendingAttachment { filename, data, declared_length }` and lets the streaming path consume `data` directly.
- `PackageName::parse_tarball_name` returns `(canonical, version)` so the publish handler can pull the matching `versions[v].dist` block out of the body. `canonicalize_tarball_name` becomes a thin wrapper.
- `Cache::reserve_tarball_paths` + `finalize_tarball_slot` expose a tmp/final path pair so the publish handler can do the actual write inside `tokio::task::spawn_blocking` (sync `std::fs`) and finalize via async `tokio::fs::rename` afterward.
- `publish_package` calls `stream_decode_verify_and_write` *before* any tarball lands at its final path. On any failure it removes every in-progress tmp file so a rejected publish leaves no on-disk artifact.

## Memory win

On a 100 MiB tarball publish, the old flow held the full payload in three places simultaneously (HTTP body Bytes + serde_json owned base64 String + decoded `Vec<u8>`). The streaming flow drops the decoded `Vec<u8>` entirely — only the base64 string and a 64 KiB working buffer remain. Roughly 100 MiB of peak heap saved per concurrent publish.

## Test plan

- [x] `cargo test -p pnpm-registry` — 115 tests pass (60 unit + 29 publish/auth + 9 + 17 server).
- [x] New unit tests in `publish.rs` for `stream_decode_verify_and_write`: matching integrity passes; mismatched integrity / missing integrity / missing dist entry / mismatched shasum / mismatched length all fail with the right error, and the tmp file is removed.
- [x] Integration tests in `tests/auth_publish.rs`:
  - `publish_rejects_integrity_mismatch_and_leaves_no_artifacts` — corrupt integrity → 400 EINTEGRITY, no packument or tarball on disk.
  - `publish_rejects_shasum_mismatch` — valid integrity but bad shasum → 400 EINTEGRITY, nothing on disk.
  - `publish_rejects_missing_integrity_field` — `dist.integrity` removed → 400 with "EINTEGRITY: dist.integrity is required", nothing on disk.
- [x] `cargo clippy -p pnpm-registry --all-targets -- --deny warnings` — clean.
- [x] `cargo fmt -p pnpm-registry --check` — clean.

## Follow-up left for separate PRs

- Read-side verification when serving a cached tarball back to a client — called out as a separate gap in #11973.
- True end-to-end streaming would require a SAX-style JSON parser to avoid materializing the base64 string inside `serde_json::Value` — out of scope here; the current change already removes the largest in-memory copy.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tarball uploads are streamed, integrity-verified (including legacy shasum), length-checked, and written via a staged atomic flow for safer publishes.

* **Bug Fixes**
  * Publish now validates attachment filenames against per-version metadata and removes partial files on failure; rejects publishes with bad or missing integrity.

* **Tests**
  * Expanded tests covering integrity mismatches, missing integrity, shasum mismatches, length checks, multi-attachment failures.

* **Chores**
  * Added a dependency to support integrity parsing and verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->