### PR TITLE
fix: merge root resolutions with workspace overrides

### DIFF
--- a/.changeset/merge-root-resolutions-workspace-overrides.md
+++ b/.changeset/merge-root-resolutions-workspace-overrides.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/plugin-commands-installation": patch
+"pnpm": patch
+---
+
+Fixed workspace installs so root `package.json#resolutions` are merged with `pnpm-workspace.yaml#overrides` instead of replacing workspace overrides during lockfile generation.

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -40,6 +40,7 @@ import {
   recursive,
 } from './recursive.js'
 import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies.js'
+import { mergeOverrides } from './mergeOverrides.js'
 
 const OVERWRITE_UPDATE_OPTIONS = {
   allowNew: true,
@@ -73,6 +74,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'linkWorkspacePackages'
 | 'lockfileDir'
 | 'lockfileOnly'
+| 'overrides'
 | 'production'
 | 'preferWorkspacePackages'
 | 'rawLocalConfig'
@@ -215,11 +217,12 @@ when running add/update with the --workspace option')
         linkWorkspacePackages: Boolean(opts.linkWorkspacePackages),
       }).graph
 
+      const rootManifestOptions = getOptionsFromRootManifest(opts.rootProjectManifestDir, opts.rootProjectManifest ?? {})
       await recursiveInstallThenUpdateWorkspaceState(allProjects,
         params,
         {
           ...opts,
-          ...getOptionsFromRootManifest(opts.rootProjectManifestDir, opts.rootProjectManifest ?? {}),
+          ...mergeOverrides(rootManifestOptions, opts.overrides),
           forceHoistPattern,
           forcePublicHoistPattern,
           allProjectsGraph,
@@ -250,9 +253,10 @@ when running add/update with the --workspace option')
     manifest = {}
   }
 
+  const rootManifestOptions = getOptionsFromRootManifest(opts.dir, (opts.dir === opts.rootProjectManifestDir ? opts.rootProjectManifest ?? manifest : manifest))
   const installOpts: Omit<MutateModulesOptions, 'allProjects'> = {
     ...opts,
-    ...getOptionsFromRootManifest(opts.dir, (opts.dir === opts.rootProjectManifestDir ? opts.rootProjectManifest ?? manifest : manifest)),
+    ...mergeOverrides(rootManifestOptions, opts.overrides),
     forceHoistPattern,
     forcePublicHoistPattern,
     // In case installation is done in a multi-package repository

--- a/pkg-manager/plugin-commands-installation/src/mergeOverrides.ts
+++ b/pkg-manager/plugin-commands-installation/src/mergeOverrides.ts
@@ -1,0 +1,15 @@
+import { type OptionsFromRootManifest } from '@pnpm/config'
+
+export function mergeOverrides (
+  rootManifestOptions: OptionsFromRootManifest,
+  overrides?: Record<string, string>
+): OptionsFromRootManifest {
+  if (!rootManifestOptions.overrides || !overrides) return rootManifestOptions
+  return {
+    ...rootManifestOptions,
+    overrides: {
+      ...rootManifestOptions.overrides,
+      ...overrides,
+    },
+  }
+}

--- a/pkg-manager/plugin-commands-installation/src/recursive.ts
+++ b/pkg-manager/plugin-commands-installation/src/recursive.ts
@@ -52,6 +52,7 @@ import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './u
 import { getSaveType } from './getSaveType.js'
 import { getPinnedVersion } from './getPinnedVersion.js'
 import { type PreferredVersions } from '@pnpm/resolver-base'
+import { mergeOverrides } from './mergeOverrides.js'
 
 export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'bail'
@@ -68,6 +69,7 @@ export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'lockfileDir'
 | 'lockfileOnly'
 | 'modulesDir'
+| 'overrides'
 | 'rawLocalConfig'
 | 'registries'
 | 'rootProjectManifest'
@@ -146,8 +148,9 @@ export async function recursive (
   const workspacePackages: WorkspacePackages = arrayOfWorkspacePackagesToMap(allProjects) as WorkspacePackages
   const targetDependenciesField = getSaveType(opts)
   const rootManifestDir = (opts.lockfileDir ?? opts.dir) as ProjectRootDir
+  const rootManifestOptions = getOptionsFromRootManifest(rootManifestDir, manifestsByPath[rootManifestDir]?.manifest ?? {})
   const installOpts = Object.assign(opts, {
-    ...getOptionsFromRootManifest(rootManifestDir, manifestsByPath[rootManifestDir]?.manifest ?? {}),
+    ...mergeOverrides(rootManifestOptions, opts.overrides),
     allProjects: getAllProjects(manifestsByPath, opts.allProjectsGraph, opts.sort),
     linkWorkspacePackagesDepth: opts.linkWorkspacePackages === 'deep' ? Infinity : opts.linkWorkspacePackages ? 0 : -1,
     ownLifecycleHooksStdio: 'pipe',
@@ -397,7 +400,7 @@ export async function recursive (
           {
             ...installOpts,
             ...localConfig,
-            ...getOptionsFromRootManifest(rootDir, manifest),
+            ...mergeOverrides(getOptionsFromRootManifest(rootDir, manifest), installOpts.overrides),
             ...opts.allProjectsGraph[rootDir]?.package,
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,

--- a/pnpm/test/config.ts
+++ b/pnpm/test/config.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { prepare } from '@pnpm/prepare'
+import { sync as readYamlFile } from 'read-yaml-file'
+import { sync as writeYamlFile } from 'write-yaml-file'
 import { execPnpmSync } from './utils/index.js'
 
 test('read settings from pnpm-workspace.yaml', async () => {
@@ -8,4 +10,37 @@ test('read settings from pnpm-workspace.yaml', async () => {
   fs.writeFileSync('pnpm-workspace.yaml', 'useLockfile: false', 'utf8')
   expect(execPnpmSync(['install']).status).toBe(0)
   expect(fs.existsSync(WANTED_LOCKFILE)).toBeFalsy()
+})
+
+test('root resolutions are merged with workspace overrides', async () => {
+  prepare({
+    resolutions: {
+      'is-odd': '3.0.1',
+    },
+  })
+  fs.mkdirSync('packages/app', { recursive: true })
+  fs.writeFileSync('packages/app/package.json', JSON.stringify({
+    name: 'app',
+    version: '1.0.0',
+    dependencies: {
+      'is-even': '^1.0.0',
+    },
+  }))
+  writeYamlFile('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    overrides: {
+      'is-number': '7.0.0',
+      'is-odd': '3.0.1',
+    },
+  })
+
+  expect(execPnpmSync(['install', '--lockfile-only']).status).toBe(0)
+
+  const lockfile = readYamlFile<any>(WANTED_LOCKFILE) // eslint-disable-line
+  expect(lockfile.overrides).toStrictEqual({
+    'is-number': '7.0.0',
+    'is-odd': '3.0.1',
+  })
+  expect(lockfile.packages).toHaveProperty(['is-number@7.0.0'])
+  expect(lockfile.packages).not.toHaveProperty(['is-number@6.0.0'])
 })


### PR DESCRIPTION
## Summary

Merges root `package.json#resolutions` with `pnpm-workspace.yaml#overrides` during workspace install option construction.

This prevents root Yarn-compatible resolutions from replacing workspace-level pnpm overrides during lockfile generation.

## What Changed

- Added a small helper to merge root manifest overrides with already-loaded config overrides.
- Applied the merge when install and recursive install paths re-read root manifest options.
- Added a CLI regression test covering root `resolutions` plus workspace `overrides`.
- Added a changeset for `pnpm` and `@pnpm/plugin-commands-installation`.

## Why

`pnpm config get overrides` can show overrides from `pnpm-workspace.yaml`, but v10 install paths re-apply root manifest options later. When root `package.json#resolutions` exists, those root options replace the workspace overrides before lockfile generation.

The fix keeps root `resolutions` compatibility while preserving workspace override precedence.

## Test Plan

- `pnpm --filter pnpm run test pnpm/test/config.ts -t "root resolutions are merged with workspace overrides"`
- `pnpm --filter @pnpm/plugin-commands-installation run compile`
- `git diff --check`
- Pre-push lint ran successfully during `git push`.

## Related Issues

Fixes #10675
