### PR TITLE
fix: reject path-traversal segments in dependency aliases (v10 backport)

### DIFF
--- a/.changeset/reject-traversal-dependency-aliases.md
+++ b/.changeset/reject-traversal-dependency-aliases.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolve-dependencies": patch
+"@pnpm/symlink-dependency": patch
+"pnpm": patch
+---
+
+Reject dependency aliases that aren't a valid npm package name. A transitive registry package could previously use an alias like `@x/../../../../../.git/hooks` to make `pnpm install` create a symlink outside the intended `node_modules` directory, because the alias was passed straight into `path.join(modulesDir, alias)` without checking that the joined path stayed inside `modulesDir`. Aliases are now validated at manifest-read time (both the importer's manifest and every transitive package manifest) and re-checked at the symlink layer as defense in depth.

--- a/fs/symlink-dependency/src/index.ts
+++ b/fs/symlink-dependency/src/index.ts
@@ -1,6 +1,7 @@
-import path from 'path'
 import { linkLogger } from '@pnpm/core-loggers'
 import symlinkDir from 'symlink-dir'
+
+import { safeJoinModulesDir } from './safeJoinModulesDir.js'
 
 export { symlinkDirectRootDependency } from './symlinkDirectRootDependency.js'
 
@@ -9,7 +10,7 @@ export async function symlinkDependency (
   destModulesDir: string,
   importAs: string
 ): Promise<{ reused: boolean, warn?: string }> {
-  const link = path.join(destModulesDir, importAs)
+  const link = safeJoinModulesDir(destModulesDir, importAs)
   linkLogger.debug({ target: dependencyRealLocation, link })
   return symlinkDir(dependencyRealLocation, link)
 }
@@ -19,7 +20,7 @@ export function symlinkDependencySync (
   destModulesDir: string,
   importAs: string
 ): { reused: boolean, warn?: string } {
-  const link = path.join(destModulesDir, importAs)
+  const link = safeJoinModulesDir(destModulesDir, importAs)
   linkLogger.debug({ target: dependencyRealLocation, link })
   return symlinkDir.sync(dependencyRealLocation, link)
 }

--- a/fs/symlink-dependency/src/safeJoinModulesDir.ts
+++ b/fs/symlink-dependency/src/safeJoinModulesDir.ts
@@ -1,0 +1,19 @@
+import path from 'node:path'
+
+// `path.join(modulesDir, alias)` paired with a containment check, so a
+// caller can't accidentally use the joined path without verifying that
+// it lives inside `modulesDir`. Earlier passes reject path-traversal
+// aliases at manifest-read time, but this layer also runs for paths
+// reconstructed from lockfiles and snapshots, so the check stays here
+// as a final guarantee.
+export function safeJoinModulesDir (modulesDir: string, alias: string): string {
+  const link = path.join(modulesDir, alias)
+  const resolvedDir = path.resolve(modulesDir)
+  const resolvedLink = path.resolve(link)
+  if (resolvedLink === resolvedDir || !resolvedLink.startsWith(resolvedDir + path.sep)) {
+    const error = new Error(`Refusing to symlink dependency outside ${modulesDir}: alias ${JSON.stringify(alias)} resolves to ${resolvedLink}`) as Error & { code: string }
+    error.code = 'ERR_PNPM_INVALID_DEPENDENCY_NAME'
+    throw error
+  }
+  return link
+}

--- a/fs/symlink-dependency/src/symlinkDirectRootDependency.ts
+++ b/fs/symlink-dependency/src/symlinkDirectRootDependency.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs'
-import path from 'path'
 import util from 'util'
 import {
   type DependencyType,
@@ -7,6 +6,8 @@ import {
 } from '@pnpm/core-loggers'
 import { type DependenciesField } from '@pnpm/types'
 import symlinkDir from 'symlink-dir'
+
+import { safeJoinModulesDir } from './safeJoinModulesDir.js'
 
 const DEP_TYPE_BY_DEPS_FIELD_NAME = {
   dependencies: 'prod',
@@ -44,7 +45,7 @@ export async function symlinkDirectRootDependency (
     }
   }
 
-  const dest = path.join(destModulesDirReal, importAs)
+  const dest = safeJoinModulesDir(destModulesDirReal, importAs)
   const { reused } = await symlinkDir(dependencyLocation, dest)
   if (reused) return // if the link was already present, don't log
   rootLogger.debug({

--- a/fs/symlink-dependency/test/safeJoinModulesDir.test.ts
+++ b/fs/symlink-dependency/test/safeJoinModulesDir.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { symlinkDependency, symlinkDependencySync, symlinkDirectRootDependency } from '@pnpm/symlink-dependency'
+import { tempDir } from '@pnpm/prepare'
+
+const escapeAliases = ['@x/../../../etc', '../sibling', '', '.']
+
+test.each(escapeAliases)('symlinkDependency refuses alias %p', async (alias) => {
+  const tmp = tempDir(false)
+  const destModulesDir = path.join(tmp, 'node_modules')
+  fs.mkdirSync(destModulesDir)
+  await expect(
+    symlinkDependency(path.join(tmp, 'dep'), destModulesDir, alias)
+  ).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
+})
+
+test.each(escapeAliases)('symlinkDependencySync refuses alias %p', (alias) => {
+  const tmp = tempDir(false)
+  const destModulesDir = path.join(tmp, 'node_modules')
+  fs.mkdirSync(destModulesDir)
+  expect(() => {
+    symlinkDependencySync(path.join(tmp, 'dep'), destModulesDir, alias)
+  }).toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
+})
+
+test.each(escapeAliases)('symlinkDirectRootDependency refuses alias %p', async (alias) => {
+  const tmp = tempDir(false)
+  const destModulesDir = path.join(tmp, 'node_modules')
+  fs.mkdirSync(destModulesDir)
+  await expect(symlinkDirectRootDependency(path.join(tmp, 'dep'), destModulesDir, alias, {
+    linkedPackage: { name: 'dep', version: '1.0.0' },
+    prefix: '',
+  })).rejects.toThrow(expect.objectContaining({ code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME' }))
+})

--- a/pkg-manager/resolve-dependencies/package.json
+++ b/pkg-manager/resolve-dependencies/package.json
@@ -71,6 +71,7 @@
     "safe-promise-defer": "catalog:",
     "semver": "catalog:",
     "semver-range-intersect": "catalog:",
+    "validate-npm-package-name": "catalog:",
     "version-selector-type": "catalog:"
   },
   "peerDependencies": {
@@ -81,7 +82,8 @@
     "@pnpm/resolve-dependencies": "workspace:*",
     "@types/normalize-path": "catalog:",
     "@types/ramda": "catalog:",
-    "@types/semver": "catalog:"
+    "@types/semver": "catalog:",
+    "@types/validate-npm-package-name": "catalog:"
   },
   "engines": {
     "node": ">=18.12"

--- a/pkg-manager/resolve-dependencies/src/getNonDevWantedDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/getNonDevWantedDependencies.ts
@@ -1,6 +1,8 @@
 import { type Dependencies, type DependencyManifest, type DependenciesMeta } from '@pnpm/types'
 import pickBy from 'ramda/src/pickBy'
 
+import { assertValidDependencyAliases } from './validateDependencyAlias.js'
+
 export interface WantedDependency {
   alias: string
   bareSpecifier: string // package reference
@@ -10,9 +12,17 @@ export interface WantedDependency {
   saveCatalogName?: string
 }
 
-type GetNonDevWantedDependenciesManifest = Pick<DependencyManifest, 'bundleDependencies' | 'bundledDependencies' | 'optionalDependencies' | 'dependencies' | 'dependenciesMeta'>
+type GetNonDevWantedDependenciesManifest = Pick<DependencyManifest, 'bundleDependencies' | 'bundledDependencies' | 'optionalDependencies' | 'dependencies' | 'dependenciesMeta'> & {
+  name?: string
+  version?: string
+}
 
 export function getNonDevWantedDependencies (pkg: GetNonDevWantedDependenciesManifest): WantedDependency[] {
+  const pkgDescription = pkg.name != null
+    ? `Package "${pkg.name}${pkg.version != null ? `@${pkg.version}` : ''}"`
+    : 'Package'
+  assertValidDependencyAliases(pkg.dependencies, pkgDescription)
+  assertValidDependencyAliases(pkg.optionalDependencies, pkgDescription)
   let bd = pkg.bundledDependencies ?? pkg.bundleDependencies
   if (bd === true) {
     bd = pkg.dependencies != null ? Object.keys(pkg.dependencies) : []

--- a/pkg-manager/resolve-dependencies/src/getWantedDependencies.ts
+++ b/pkg-manager/resolve-dependencies/src/getWantedDependencies.ts
@@ -6,6 +6,8 @@ import {
   type ProjectManifest,
 } from '@pnpm/types'
 
+import { assertValidDependencyAliases } from './validateDependencyAlias.js'
+
 export interface WantedDependency {
   alias: string
   bareSpecifier: string // package reference
@@ -25,6 +27,10 @@ export function getWantedDependencies (
     nodeExecPath?: string
   }
 ): WantedDependency[] {
+  assertValidDependencyAliases(pkg.dependencies, 'The current package')
+  assertValidDependencyAliases(pkg.devDependencies, 'The current package')
+  assertValidDependencyAliases(pkg.optionalDependencies, 'The current package')
+  assertValidDependencyAliases(pkg.peerDependencies, 'The current package')
   let depsToInstall = filterDependenciesByType(pkg,
     opts?.includeDirect ?? {
       dependencies: true,

--- a/pkg-manager/resolve-dependencies/src/validateDependencyAlias.ts
+++ b/pkg-manager/resolve-dependencies/src/validateDependencyAlias.ts
@@ -1,0 +1,31 @@
+import { PnpmError } from '@pnpm/error'
+import validateNpmPackageName from 'validate-npm-package-name'
+
+// An alias is the directory name pnpm creates inside `node_modules`, so
+// it must be a valid npm package name. Anything else (path-traversal
+// shapes such as `@x/../../../../../.git/hooks`, control characters,
+// names that collide with pnpm's own `node_modules` layout such as
+// `.bin` / `.pnpm` / `node_modules`) is rejected. Matches the
+// `validForOldPackages` check `parseWantedDependency` applies to
+// CLI-given names.
+export function isValidDependencyAlias (alias: string): boolean {
+  return typeof alias === 'string' && validateNpmPackageName(alias).validForOldPackages
+}
+
+export function assertValidDependencyAliases (
+  deps: Record<string, unknown> | undefined,
+  parentPkgDescription: string
+): void {
+  if (deps == null) return
+  for (const alias of Object.keys(deps)) {
+    if (!isValidDependencyAlias(alias)) {
+      throw new PnpmError(
+        'INVALID_DEPENDENCY_NAME',
+        `${parentPkgDescription} contains a dependency with an invalid name: ${JSON.stringify(alias)}`,
+        {
+          hint: 'A dependency name must be a valid npm package name — a single `name` or `@scope/name` consisting of URL-friendly characters, with no leading `.` or `_`, and not equal to reserved names such as `node_modules`.',
+        }
+      )
+    }
+  }
+}

--- a/pkg-manager/resolve-dependencies/test/validateDependencyAlias.test.ts
+++ b/pkg-manager/resolve-dependencies/test/validateDependencyAlias.test.ts
@@ -1,0 +1,65 @@
+import { assertValidDependencyAliases, isValidDependencyAlias } from '../lib/validateDependencyAlias.js'
+
+test.each([
+  ['foo'],
+  ['Foo'],
+  ['@scope/name'],
+  ['@s/x'],
+  ['lodash.merge'],
+  ['a_b'],
+  ['a-b'],
+  ['x'],
+  ['underscore'],
+])('accepts %p', (alias) => {
+  expect(isValidDependencyAlias(alias)).toBe(true)
+})
+
+test.each([
+  ['', 'empty string'],
+  ['..', 'parent traversal'],
+  ['.', 'current dir'],
+  ['/foo', 'absolute posix'],
+  ['foo/bar', 'unscoped slash'],
+  ['@scope/name/extra', 'scoped with extra segment'],
+  ['@scope/../etc', 'scope with parent traversal'],
+  ['@x/../../../../../.git/hooks', 'PoC payload'],
+  ['foo\\bar', 'backslash'],
+  ['C:\\Windows\\System32', 'windows absolute'],
+  ['foo\0bar', 'null byte'],
+  ['scope/name', 'two segments without @'],
+  ['./foo', 'current dir prefix'],
+  ['.bin', 'leading dot (collides with pnpm .bin)'],
+  ['.pnpm', 'leading dot (collides with pnpm .pnpm)'],
+  ['_foo', 'leading underscore'],
+  ['node_modules', 'reserved name'],
+  ['favicon.ico', 'reserved name'],
+  ['  foo  ', 'leading/trailing whitespace'],
+  ['foo bar', 'embedded whitespace'],
+  ['foo?bar', 'non-url-friendly character'],
+])('rejects %s (%s)', (alias) => {
+  expect(isValidDependencyAlias(alias)).toBe(false)
+})
+
+test('assertValidDependencyAliases throws ERR_PNPM_INVALID_DEPENDENCY_NAME for malicious aliases', () => {
+  expect(() => {
+    assertValidDependencyAliases({ '@x/../../../../../.git/hooks': '1.0.0' }, 'Package "bad@1.0.0"')
+  }).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_DEPENDENCY_NAME',
+    message: expect.stringContaining('Package "bad@1.0.0" contains a dependency with an invalid name'),
+  }))
+})
+
+test('assertValidDependencyAliases is a no-op for undefined and empty input', () => {
+  expect(() => {
+    assertValidDependencyAliases(undefined, 'pkg')
+  }).not.toThrow()
+  expect(() => {
+    assertValidDependencyAliases({}, 'pkg')
+  }).not.toThrow()
+})
+
+test('assertValidDependencyAliases is a no-op for valid aliases', () => {
+  expect(() => {
+    assertValidDependencyAliases({ foo: '1.0.0', '@scope/bar': '2.0.0' }, 'pkg')
+  }).not.toThrow()
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6224,6 +6224,9 @@ importers:
       semver-range-intersect:
         specifier: 'catalog:'
         version: 0.3.1
+      validate-npm-package-name:
+        specifier: 'catalog:'
+        version: 5.0.0
       version-selector-type:
         specifier: 'catalog:'
         version: 3.0.0
@@ -6243,6 +6246,9 @@ importers:
       '@types/semver':
         specifier: 'catalog:'
         version: 7.5.3
+      '@types/validate-npm-package-name':
+        specifier: 'catalog:'
+        version: 4.0.2
 
   pkg-manifest/exportable-manifest:
     dependencies:


### PR DESCRIPTION
Backport of #11954 to `release/10`.

## Summary

A transitive registry package can use a dependency-alias key like `@x/../../../../../.git/hooks` to make `pnpm install` create a symlink outside the intended `node_modules` directory. pnpm joins the alias straight into `path.join(modulesDir, alias)` without checking that the joined path stays inside `modulesDir`, so the resulting symlink can land at an attacker-chosen path under any predictable prefix (the global store, the user's home, the project directory if the depth matches up). `--ignore-scripts` does not block this: no lifecycle script runs; only the symlink is created during install, and the payload executes the next time the victim runs anything that loads from the replaced path (`git commit` invoking a hook, a CI step using a local action, `pnpm publish` packaging a replaced `dist/`, etc.).

## Fix

Reject aliases that aren't a valid npm package name (`validForOldPackages` per `validate-npm-package-name`):

- `pkg-manager/resolve-dependencies/src/validateDependencyAlias.ts` — new `isValidDependencyAlias` predicate + `assertValidDependencyAliases` asserter. Rejects path-traversal shapes, embedded slashes, backslashes, null bytes, reserved names (`node_modules`, `.bin`, `.pnpm`), names with a leading `.`/`_`, and non-URL-friendly characters.
- `getNonDevWantedDependencies.ts` — validates every transitive `dependencies` / `optionalDependencies` entry. Error names the offending parent package.
- `getWantedDependencies.ts` — same check for the importer's own manifest.
- `fs/symlink-dependency/src/safeJoinModulesDir.ts` — defense-in-depth check at the symlink layer. Re-validates after `path.resolve(destModulesDir, alias)` that the target still lives under `destModulesDir`. Wired into `symlinkDependency`, `symlinkDependencySync`, and `symlinkDirectRootDependency`.

The new error code is `ERR_PNPM_INVALID_DEPENDENCY_NAME`.

## Backport notes

- The TypeScript port differs from main only in file/package layout: v10's `@pnpm/resolve-dependencies` package (in `pkg-manager/resolve-dependencies/`) instead of main's `@pnpm/installing.deps-resolver` (in `installing/deps-resolver/`); v10's `@pnpm/symlink-dependency` package instead of `@pnpm/fs.symlink-dependency`.
- The pacquet (Rust) side of #11954 is intentionally omitted — pacquet does not exist on `release/10`.

## Test plan

- [x] `pnpm --filter @pnpm/resolve-dependencies test` — 71/71 passing (33 new for the validator).
- [x] `pnpm --filter @pnpm/symlink-dependency test` — 13/13 passing (12 new for safeJoinModulesDir across the three symlink helpers).
- [x] Lint clean on both touched packages.

---
Written by an agent (Claude Code, claude-opus-4-7).