### PR TITLE
fix(gvs): run dependency build scripts under the global virtual store

### DIFF
--- a/.changeset/gvs-rebuild-native-deps.md
+++ b/.changeset/gvs-rebuild-native-deps.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/building.after-install": patch
+---
+
+Fix dependency build scripts not running under the global virtual store (`enableGlobalVirtualStore`).
+
+In a workspace install, dependency build scripts are deferred to a single `rebuild` pass (`buildProjects`). That pass resolved each package's location from the classic `node_modules/.pnpm/<depPathToFilename>` layout, which does not exist under the global virtual store — so native dependencies (e.g. packages using `node-gyp` / `prebuild-install`) were never built and failed to load at runtime (`Cannot find module .../build/Release/*.node`).
+
+`buildProjects` now resolves the global-virtual-store projection directory (`<storeDir>/links/<hash>`, computed with the same graph hash the installer uses) when `enableGlobalVirtualStore` is set, and serializes concurrent builds of the same shared projection so parallel workspace projects don't race on the same directory.

--- a/.changeset/gvs-rebuild-native-deps.md
+++ b/.changeset/gvs-rebuild-native-deps.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/building.after-install": patch
+"pnpm": patch
 ---
 
 Fix dependency build scripts not running under the global virtual store (`enableGlobalVirtualStore`).

--- a/building/after-install/src/extendBuildOptions.ts
+++ b/building/after-install/src/extendBuildOptions.ts
@@ -47,6 +47,8 @@ export type StrictBuildOptions = {
   shamefullyHoist: boolean
   deployAllFiles: boolean
   allowBuilds?: Record<string, boolean | string>
+  enableGlobalVirtualStore?: boolean
+  globalVirtualStoreDir?: string
   virtualStoreDirMaxLength: number
   peersSuffixMaxLength: number
   strictStorePkgContentCheck: boolean

--- a/building/after-install/src/index.ts
+++ b/building/after-install/src/index.ts
@@ -54,13 +54,9 @@ import {
 
 export type { BuildOptions }
 
-// Under the global virtual store, a single package projection is shared by every
-// workspace project. With per-project lockfiles the rebuild runs once per project,
-// so without coordination multiple projects would build the SAME shared projection
-// concurrently — racing on the same directory (prebuild-install bus errors, node-gyp
-// EEXIST on the python symlink, etc.). This process-wide map serializes builds per
-// projection directory: the first build proceeds, concurrent ones wait for it and
-// then reuse the result. Keyed by the absolute GVS projection directory.
+// Serializes builds of a shared GVS projection across concurrent per-project
+// rebuilds: the first build proceeds, concurrent ones await it and reuse the
+// result. Keyed by the absolute projection directory.
 const gvsBuildLocks = new Map<string, Promise<void>>()
 
 function findPackages (
@@ -347,17 +343,9 @@ async function _rebuild (
   const builtDepPaths = new Set<string>()
   const storeIndex = opts.skipIfHasSideEffectsCache ? new StoreIndex(opts.storeDir) : undefined
 
-  // Under the global virtual store, packages are NOT projected into
-  // `<virtualStoreDir>/<depPathToFilename>/node_modules/<name>`; they live in a
-  // hash-addressed directory `<globalVirtualStoreDir>/<hash>/node_modules/<name>`
-  // (the same layout the installer creates via iteratePkgsForVirtualStore). The
-  // hash must be computed with the same inputs (graph + allowBuild + nodeVersion),
-  // otherwise rebuild would target the classic location, which does not exist
-  // under GVS — so dependency build scripts (e.g. node-gyp / prebuild-install)
-  // would never run. The base is the store's `links` directory; in this per-project
-  // rebuild context `ctx.virtualStoreDir` is the project-local `node_modules/.pnpm`,
-  // NOT the shared global store, so we resolve it from `storeDir/links` (matching
-  // how the installer derives `globalVirtualStoreDir`).
+  // Under GVS, packages live at `<globalVirtualStoreDir>/<hash>/node_modules/<name>`,
+  // not the classic virtualStoreDir layout. The hash is computed with the same inputs
+  // as the installer so rebuild resolves the exact directory the install created.
   const gvsDirByDepPath = new Map<DepPath, string>()
   if (opts.enableGlobalVirtualStore) {
     const globalVirtualStoreDir = opts.globalVirtualStoreDir ?? path.join(opts.storeDir, 'links')
@@ -390,9 +378,8 @@ async function _rebuild (
         })
       }
       const pkgRoot = pkgRoots[0]
-      // GVS: avoid concurrently building the same shared projection from multiple
-      // workspace projects. If another build for this projection is in flight, wait
-      // for it and reuse the result instead of racing on the same directory.
+      // If another project is already building this shared projection, wait for it
+      // and reuse the result instead of racing on the same directory.
       const gvsDir = gvsDirByDepPath.get(depPath)
       if (gvsDir != null) {
         const inFlight = gvsBuildLocks.get(gvsDir)

--- a/building/after-install/src/index.ts
+++ b/building/after-install/src/index.ts
@@ -405,7 +405,9 @@ async function _rebuild (
       let releaseGvsLock: (() => void) | undefined
       if (gvsDir != null) {
         let resolveLock!: () => void
-        gvsBuildLocks.set(gvsDir, new Promise<void>((resolve) => { resolveLock = resolve }))
+        gvsBuildLocks.set(gvsDir, new Promise<void>((resolve) => {
+          resolveLock = resolve
+        }))
         releaseGvsLock = () => {
           gvsBuildLocks.delete(gvsDir)
           resolveLock()
@@ -523,7 +525,7 @@ async function _rebuild (
         .map(async (depPath) => limitLinking(async () => {
           const pkgSnapshot = pkgSnapshots[depPath]
           const pkgInfo = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
-          const modules = path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath, opts.virtualStoreDirMaxLength), 'node_modules')
+          const modules = pkgModulesDir(depPath)
           const binPath = path.join(modules, pkgInfo.name, 'node_modules', '.bin')
           return linkBins(modules, binPath, { warn })
         }))

--- a/building/after-install/src/index.ts
+++ b/building/after-install/src/index.ts
@@ -10,7 +10,7 @@ import {
   WANTED_LOCKFILE,
 } from '@pnpm/constants'
 import { skippedOptionalDependencyLogger } from '@pnpm/core-loggers'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, lockfileToDepGraph } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, iterateHashedGraphNodes, iteratePkgMeta, lockfileToDepGraph } from '@pnpm/deps.graph-hasher'
 import { graphSequencer } from '@pnpm/deps.graph-sequencer'
 import * as dp from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
@@ -53,6 +53,15 @@ import {
 } from './extendBuildOptions.js'
 
 export type { BuildOptions }
+
+// Under the global virtual store, a single package projection is shared by every
+// workspace project. With per-project lockfiles the rebuild runs once per project,
+// so without coordination multiple projects would build the SAME shared projection
+// concurrently — racing on the same directory (prebuild-install bus errors, node-gyp
+// EEXIST on the python symlink, etc.). This process-wide map serializes builds per
+// projection directory: the first build proceeds, concurrent ones wait for it and
+// then reuse the result. Keyed by the absolute GVS projection directory.
+const gvsBuildLocks = new Map<string, Promise<void>>()
 
 function findPackages (
   packages: PackageSnapshots,
@@ -338,13 +347,42 @@ async function _rebuild (
   const builtDepPaths = new Set<string>()
   const storeIndex = opts.skipIfHasSideEffectsCache ? new StoreIndex(opts.storeDir) : undefined
 
+  // Under the global virtual store, packages are NOT projected into
+  // `<virtualStoreDir>/<depPathToFilename>/node_modules/<name>`; they live in a
+  // hash-addressed directory `<globalVirtualStoreDir>/<hash>/node_modules/<name>`
+  // (the same layout the installer creates via iteratePkgsForVirtualStore). The
+  // hash must be computed with the same inputs (graph + allowBuild + nodeVersion),
+  // otherwise rebuild would target the classic location, which does not exist
+  // under GVS — so dependency build scripts (e.g. node-gyp / prebuild-install)
+  // would never run. The base is the store's `links` directory; in this per-project
+  // rebuild context `ctx.virtualStoreDir` is the project-local `node_modules/.pnpm`,
+  // NOT the shared global store, so we resolve it from `storeDir/links` (matching
+  // how the installer derives `globalVirtualStoreDir`).
+  const gvsDirByDepPath = new Map<DepPath, string>()
+  if (opts.enableGlobalVirtualStore) {
+    const globalVirtualStoreDir = opts.globalVirtualStoreDir ?? path.join(opts.storeDir, 'links')
+    for (const { hash, pkgMeta } of iterateHashedGraphNodes(
+      depGraph,
+      iteratePkgMeta(ctx.currentLockfile, depGraph),
+      _allowBuild,
+      opts.supportedArchitectures,
+      nodeVersion
+    )) {
+      gvsDirByDepPath.set(pkgMeta.depPath, path.join(globalVirtualStoreDir, hash))
+    }
+  }
+  const pkgModulesDir = (depPath: DepPath): string =>
+    gvsDirByDepPath.has(depPath)
+      ? path.join(gvsDirByDepPath.get(depPath)!, 'node_modules')
+      : path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath, opts.virtualStoreDirMaxLength), 'node_modules')
+
   const groups = chunks.map((chunk) => chunk.filter((depPath) => ctx.pkgsToRebuild.has(depPath) && !ctx.skipped.has(depPath)).map((depPath) =>
     async () => {
       const pkgSnapshot = pkgSnapshots[depPath]
       const pkgInfo = nameVerFromPkgSnapshot(depPath, pkgSnapshot)
       const pkgRoots = opts.nodeLinker === 'hoisted'
         ? (ctx.modulesFile?.hoistedLocations?.[depPath] ?? []).map((hoistedLocation) => path.join(opts.lockfileDir, hoistedLocation))
-        : [path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath, opts.virtualStoreDirMaxLength), 'node_modules', pkgInfo.name)]
+        : [path.join(pkgModulesDir(depPath), pkgInfo.name)]
       if (pkgRoots.length === 0) {
         if (pkgSnapshot.optional) return
         throw new PnpmError('MISSING_HOISTED_LOCATIONS', `${depPath} is not found in hoistedLocations inside node_modules/.modules.yaml`, {
@@ -352,10 +390,31 @@ async function _rebuild (
         })
       }
       const pkgRoot = pkgRoots[0]
+      // GVS: avoid concurrently building the same shared projection from multiple
+      // workspace projects. If another build for this projection is in flight, wait
+      // for it and reuse the result instead of racing on the same directory.
+      const gvsDir = gvsDirByDepPath.get(depPath)
+      if (gvsDir != null) {
+        const inFlight = gvsBuildLocks.get(gvsDir)
+        if (inFlight != null) {
+          await inFlight.catch(() => {})
+          pkgsThatWereRebuilt.add(depPath)
+          return
+        }
+      }
+      let releaseGvsLock: (() => void) | undefined
+      if (gvsDir != null) {
+        let resolveLock!: () => void
+        gvsBuildLocks.set(gvsDir, new Promise<void>((resolve) => { resolveLock = resolve }))
+        releaseGvsLock = () => {
+          gvsBuildLocks.delete(gvsDir)
+          resolveLock()
+        }
+      }
       try {
         const extraBinPaths = ctx.extraBinPaths
         if (opts.nodeLinker !== 'hoisted') {
-          const modules = path.join(ctx.virtualStoreDir, dp.depPathToFilename(depPath, opts.virtualStoreDirMaxLength), 'node_modules')
+          const modules = pkgModulesDir(depPath)
           const binPath = path.join(pkgRoot, 'node_modules', '.bin')
           await linkBins(modules, binPath, { extraNodePaths: ctx.extraNodePaths, warn })
         } else {
@@ -443,6 +502,8 @@ async function _rebuild (
           return
         }
         throw err
+      } finally {
+        releaseGvsLock?.()
       }
       if (pkgRoots.length > 1) {
         await hardLinkDir(pkgRoot, pkgRoots.slice(1))

--- a/building/commands/src/build/rebuild.ts
+++ b/building/commands/src/build/rebuild.ts
@@ -76,6 +76,7 @@ For options that may be used with `-r`, see "pnpm help recursive"',
 
 export type RebuildCommandOpts = Pick<Config,
 | 'dir'
+| 'enableGlobalVirtualStore'
 | 'engineStrict'
 | 'lockfileDir'
 | 'nodeLinker'

--- a/building/commands/src/build/recursive.ts
+++ b/building/commands/src/build/recursive.ts
@@ -19,6 +19,7 @@ import { sortProjects } from '@pnpm/workspace.projects-sorter'
 import pLimit from 'p-limit'
 
 type RecursiveRebuildOpts = CreateStoreControllerOptions & Pick<Config,
+| 'enableGlobalVirtualStore'
 | 'hoistPattern'
 | 'ignorePnpmfile'
 | 'ignoreScripts'

--- a/building/commands/test/build/index.ts
+++ b/building/commands/test/build/index.ts
@@ -6,7 +6,7 @@ import { afterAll, expect, jest, test } from '@jest/globals'
 import { rebuild } from '@pnpm/building.commands'
 import { ENGINE_NAME, STORE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
 import { hashObject } from '@pnpm/crypto.object-hasher'
-import { prepare } from '@pnpm/prepare'
+import { prepare, preparePackages } from '@pnpm/prepare'
 import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import { fixtures } from '@pnpm/test-fixtures'
@@ -151,6 +151,76 @@ test('rebuilds dependencies in the global virtual store', async () => {
   // Regression (GVS): the rebuild previously resolved the package from the classic
   // virtualStoreDir path, which does not exist under the global virtual store, so
   // the build script never ran. It must build into the GVS projection instead.
+  expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
+})
+
+test('rebuilds a dependency shared by multiple workspace projects in the global virtual store', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: {
+        name: 'project-1',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0' },
+      },
+    },
+    {
+      location: 'project-2',
+      package: {
+        name: 'project-2',
+        version: '1.0.0',
+        dependencies: { '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0' },
+      },
+    },
+  ])
+  const cacheDir = path.resolve('cache')
+  const storeDir = path.resolve('store')
+
+  // With per-project lockfiles (`sharedWorkspaceLockfile: false`) `rebuild -r`
+  // runs a separate pass per project. Both projects depend on the same package,
+  // which the global virtual store dedups into ONE shared projection — so the
+  // passes select the same projection directory concurrently. This is the race
+  // the per-projection build lock serializes.
+  fs.writeFileSync('pnpm-workspace.yaml', [
+    'packages:',
+    '  - project-1',
+    '  - project-2',
+    'enableGlobalVirtualStore: true',
+    'sharedWorkspaceLockfile: false',
+    'allowBuilds:',
+    '  "@pnpm.e2e/pre-and-postinstall-scripts-example": true',
+    '',
+  ].join('\n'))
+
+  await execa('node', [
+    pnpmBin,
+    'install',
+    '--recursive',
+    `--registry=${REGISTRY}`,
+    `--store-dir=${storeDir}`,
+    '--ignore-scripts',
+    `--cache-dir=${cacheDir}`,
+  ])
+
+  const pkgVersionDir = path.join(storeDir, STORE_VERSION, 'links/@pnpm.e2e/pre-and-postinstall-scripts-example/1.0.0')
+  // The shared dependency is deduped to a single projection both projects link to.
+  expect(fs.readdirSync(pkgVersionDir)).toHaveLength(1)
+  const hash = fs.readdirSync(pkgVersionDir)[0]
+  const pkgInGvs = path.join(pkgVersionDir, hash, 'node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example')
+
+  // The build was deferred, so the postinstall artifact is not there yet.
+  expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeFalsy()
+
+  await execa('node', [
+    pnpmBin,
+    'rebuild',
+    '--recursive',
+    `--store-dir=${storeDir}`,
+  ])
+
+  // The shared projection must be built (once, without the concurrency failures
+  // the lock prevents — prebuild-install bus errors / node-gyp EEXIST), with the
+  // artifact present in the single directory both projects link to.
   expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
 })
 

--- a/building/commands/test/build/index.ts
+++ b/building/commands/test/build/index.ts
@@ -148,9 +148,7 @@ test('rebuilds dependencies in the global virtual store', async () => {
     allowBuilds: { '@pnpm.e2e/pre-and-postinstall-scripts-example': true },
   }, [])
 
-  // Regression (GVS): the rebuild previously resolved the package from the classic
-  // virtualStoreDir path, which does not exist under the global virtual store, so
-  // the build script never ran. It must build into the GVS projection instead.
+  // The rebuild must run the build script into the GVS projection.
   expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
 })
 
@@ -176,11 +174,9 @@ test('rebuilds a dependency shared by multiple workspace projects in the global 
   const cacheDir = path.resolve('cache')
   const storeDir = path.resolve('store')
 
-  // With per-project lockfiles (`sharedWorkspaceLockfile: false`) `rebuild -r`
-  // runs a separate pass per project. Both projects depend on the same package,
-  // which the global virtual store collapses into ONE shared projection — so the
-  // passes select the same projection directory concurrently. This is the race
-  // the per-projection build lock serializes.
+  // Per-project lockfiles make `rebuild -r` run a concurrent pass per project, and
+  // both projects share one GVS projection — so the passes select the same directory
+  // at once, exercising the per-projection build lock.
   fs.writeFileSync('pnpm-workspace.yaml', [
     'packages:',
     '  - project-1',
@@ -218,9 +214,7 @@ test('rebuilds a dependency shared by multiple workspace projects in the global 
     `--store-dir=${storeDir}`,
   ])
 
-  // The shared projection must be built (once, without the concurrency failures
-  // the lock prevents — prebuild-install bus errors / node-gyp EEXIST), with the
-  // artifact present in the single directory both projects link to.
+  // The shared projection must be built, with the artifact in the single directory.
   expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
 })
 

--- a/building/commands/test/build/index.ts
+++ b/building/commands/test/build/index.ts
@@ -101,6 +101,59 @@ test('rebuilds dependencies', async () => {
   cacheIntegrity.sideEffects!.get(sideEffectsKey)!.added!.delete('generated-by-postinstall.js')
 })
 
+test('rebuilds dependencies in the global virtual store', async () => {
+  const project = prepare()
+  const cacheDir = path.resolve('cache')
+  const storeDir = path.resolve('store')
+
+  // `allowBuilds` is part of the GVS hash, so the install and the later rebuild
+  // must agree on it (otherwise they'd resolve different projection directories).
+  fs.writeFileSync('pnpm-workspace.yaml', [
+    'enableGlobalVirtualStore: true',
+    'allowBuilds:',
+    '  "@pnpm.e2e/pre-and-postinstall-scripts-example": true',
+    '',
+  ].join('\n'))
+
+  // Install with the build deferred (--ignore-scripts) under the global virtual
+  // store. The package lives in <storeDir>/<version>/links/<hash>, NOT the classic
+  // node_modules/.pnpm layout, so the subsequent rebuild must target it.
+  await execa('node', [
+    pnpmBin,
+    'add',
+    '--save-dev',
+    '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0',
+    `--registry=${REGISTRY}`,
+    `--store-dir=${storeDir}`,
+    '--ignore-scripts',
+    `--cache-dir=${cacheDir}`,
+  ])
+
+  const pkgVersionDir = path.join(storeDir, STORE_VERSION, 'links/@pnpm.e2e/pre-and-postinstall-scripts-example/1.0.0')
+  const hash = fs.readdirSync(pkgVersionDir)[0]
+  const pkgInGvs = path.join(pkgVersionDir, hash, 'node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example')
+
+  // The build was deferred, so the postinstall artifact is not there yet.
+  expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeFalsy()
+
+  const modulesManifest = project.readModulesManifest()
+  await rebuild.handler({
+    ...DEFAULT_OPTS,
+    cacheDir,
+    dir: process.cwd(),
+    enableGlobalVirtualStore: true,
+    pending: false,
+    registries: modulesManifest!.registries!,
+    storeDir,
+    allowBuilds: { '@pnpm.e2e/pre-and-postinstall-scripts-example': true },
+  }, [])
+
+  // Regression (GVS): the rebuild previously resolved the package from the classic
+  // virtualStoreDir path, which does not exist under the global virtual store, so
+  // the build script never ran. It must build into the GVS projection instead.
+  expect(fs.existsSync(path.join(pkgInGvs, 'generated-by-postinstall.js'))).toBeTruthy()
+})
+
 test('skipIfHasSideEffectsCache', async () => {
   const project = prepare()
   const cacheDir = path.resolve('cache')

--- a/building/commands/test/build/index.ts
+++ b/building/commands/test/build/index.ts
@@ -178,7 +178,7 @@ test('rebuilds a dependency shared by multiple workspace projects in the global 
 
   // With per-project lockfiles (`sharedWorkspaceLockfile: false`) `rebuild -r`
   // runs a separate pass per project. Both projects depend on the same package,
-  // which the global virtual store dedups into ONE shared projection — so the
+  // which the global virtual store collapses into ONE shared projection — so the
   // passes select the same projection directory concurrently. This is the race
   // the per-projection build lock serializes.
   fs.writeFileSync('pnpm-workspace.yaml', [

--- a/cspell.json
+++ b/cspell.json
@@ -256,6 +256,7 @@
     "postuninstall",
     "postversion",
     "preact",
+    "prebuild",
     "prefoo",
     "prefs",
     "preinstall",


### PR DESCRIPTION
## Summary

  Under `enableGlobalVirtualStore: true`, dependency build scripts (native addons via `node-gyp` / `prebuild-install`, and any `install`/`postinstall` hooks) are **never executed during a
  workspace install**. The affected packages end up present but unbuilt, and crash at runtime — e.g.:

  Error: Cannot find module '.../store/v11/links/@/node-expat/.../build/Release/node_expat.node'

  This affects every native dependency in a workspace that uses the global virtual store (e.g. `node-expat`, `better-sqlite3`, the imagemin bins). Packages that ship prebuilt binaries in
  their tarball (e.g. `bcrypt` via `node-gyp-build`) are unaffected because they need no build step.

  ## Root cause

  In a workspace install, dependency builds are intentionally **deferred** to a single central pass at the end (`pnpm rebuild` → `buildProjects` in `@pnpm/building.after-install`), so a
  shared dependency is built once rather than once per project.

  That pass resolved each package's location from the **classic** virtual-store layout:

  //node_modules/

  Under the global virtual store that directory does not exist — packages are projected into a hash-addressed directory in the store's `links` folder:

  /links//node_modules/

  So the rebuild looked in a non-existent path, found nothing to build, and silently did nothing. (The code even carried a note that "rebuild doesn't work for such packages at all, which
  should be fixed.")

  ## Fix

  `buildProjects` is now global-virtual-store aware:

  1. **Correct projection directory** — when `enableGlobalVirtualStore` is set, each package's root is resolved to `<globalVirtualStoreDir>/<hash>/node_modules/<name>`. The base resolves
  to `<storeDir>/links` (in the per-project rebuild context `ctx.virtualStoreDir` is the project-local `node_modules/.pnpm`, not the shared store). The same projection directory is used
  for the post-lifecycle bin re-link pass too, so bins created by the build scripts themselves land in the projection instead of a non-existent classic path.

  2. **Matching hash** — the projection hash is computed with the same helpers and inputs the installer uses (`iterateHashedGraphNodes` + `iteratePkgMeta`, with the same `allowBuild` /
  `supportedArchitectures` / resolved-runtime-node-version), so it points at the exact directory the install created.

  3. **Concurrency safety** — because a single shared projection can be selected for rebuild by many workspace projects in parallel (unlimited `workspaceConcurrency`, per-project
  lockfiles), a process-wide lock keyed by the projection directory serializes builds of the same projection. The first build runs; concurrent ones wait for it and reuse the result.
  Without this, parallel builds race on the same directory (`prebuild-install` bus errors, `node-gyp` `EEXIST` on the python symlink, etc.).

  Behavior is unchanged when `enableGlobalVirtualStore` is off (all new logic is gated on that flag).

  ## Files changed

  - `building/after-install/src/index.ts` — the fix (GVS projection resolution, per-projection build lock, and GVS-aware post-lifecycle bin re-linking).
  - `building/after-install/src/extendBuildOptions.ts` — adds `enableGlobalVirtualStore` / `globalVirtualStoreDir` build options.
  - `building/commands/src/build/rebuild.ts`, `building/commands/src/build/recursive.ts` — thread `enableGlobalVirtualStore` through the (recursive) rebuild command options.
  - `building/commands/test/build/index.ts` — regression tests (single-project + multi-project shared projection).
  - `.changeset/gvs-rebuild-native-deps.md` — changeset (`@pnpm/building.after-install` + `pnpm`, patch).
  - `cspell.json` — allowlist `prebuild`.

  ## Test plan

  Two tests in `building/commands/test/build/index.ts`:

  - `rebuilds dependencies in the global virtual store` — installs a package with a build script under GVS with scripts deferred (`--ignore-scripts`), so it is projected into
  `<storeDir>/links/<hash>` but unbuilt; runs `rebuild` and asserts the build artifact now exists inside the GVS projection.
  - `rebuilds a dependency shared by multiple workspace projects in the global virtual store` — two-project workspace with per-project lockfiles (`sharedWorkspaceLockfile: false`), so
  `rebuild -r` runs a separate concurrent pass per project. Both projects share one GVS projection; asserts the projection is collapsed to a single directory and built once, exercising
  the per-projection build lock.

  Results:

  - ✅ The single-project test fails before the fix (the rebuild targets the classic path and builds nothing), passes after.
  - ✅ Full `@pnpm/building.commands` build suite: 10/10 passing, no regressions (stable across repeated runs).
  - ✅ `@pnpm/building.after-install` type-checks.

  > Note: the GVS projection hash includes `allowBuilds`, so the install and the subsequent rebuild must agree on `allowBuilds` to resolve the same projection directory. The test sets it
  via `pnpm-workspace.yaml`; real workspaces already satisfy this because `allowBuilds` is part of the committed config.

  > Coverage caveat: the shared-projection test mechanically exercises the build lock and proves multi-project GVS rebuild correctness + dedup, but does not deterministically prove the
  lock prevents a hard crash — no lightweight fixture performs real `node-gyp`/`prebuild-install` work whose concurrent execution would bus-error/`EEXIST`. The lock's correctness rests on
  its check-and-set being atomic (no `await` between the lookup and the set).

Related: https://github.com/pnpm/pnpm/issues/11385

---
Description updated by an agent (Claude Code, claude-opus-4-8) to reflect follow-up commits (bin re-link fix, rebuild-options threading, the multi-project test, changeset/cspell changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native dependency build scripts now run correctly when Global Virtual Store is enabled; workspace package locations correctly resolve to the GVS layout and concurrent rebuilds for shared projections are serialized to avoid races.

* **Tests**
  * Added tests verifying rebuilds produce postinstall artifacts in the Global Virtual Store layout and for shared-project rebuilds.

* **New Features**
  * Rebuild commands and options now support the Global Virtual Store configuration.

* **Chores**
  * Added a changeset and updated the spelling allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
