### PR TITLE
ci(release): clone ldid from ProcursusTeam GitHub mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install git build-essential libplist-dev libssl-dev openssl qemu-user-binfmt pkg-config
           cd /tmp
-          git clone https://gitlab.com/opensource-saurik/ldid.git
+          git clone https://github.com/ProcursusTeam/ldid.git
           cd ldid
           git checkout c2f8abf013b22c335f44241a6a552a7767e73419
           git submodule update --init


### PR DESCRIPTION
## Summary

The v10 release workflow clones `ldid` from `https://gitlab.com/opensource-saurik/ldid.git` (saurik's original project). That GitLab repo is no longer publicly accessible — Cloudflare returns HTTP 401 and the project page redirects to `gitlab.com/users/sign_in`. `git clone` therefore prompts for a username and fails non-interactively with:

```
fatal: could not read Username for 'https://gitlab.com': No such device or address
```

This blocks every v10 release (latest failure: https://github.com/pnpm/pnpm/actions/runs/26512547815/job/78082600161).

`ProcursusTeam/ldid` is the maintained GitHub fork that the iOS/jailbreak community has converged on. It contains the exact commit the workflow pins (`c2f8abf013b22c335f44241a6a552a7767e73419`), and the libplist submodule already resolves to `github.com/libimobiledevice/libplist.git`, so a one-line URL swap is the entire fix — no submodule or commit-pin churn.

`main` no longer hits this code path because the release workflow there was rewritten to sign darwin artifacts with native `codesign` on a macOS runner; that rewrite is too invasive to backport, hence this minimal fix.

## Test plan

- [ ] Re-run the release workflow (or cut a v10 patch tag) and confirm the `Install ldid` step succeeds and the rest of the release proceeds.

---
Written by an agent (Claude Code, claude-opus-4-7).