### PR TITLE
fix: publish with default access

### DIFF
--- a/.changeset/chilly-meteors-enter.md
+++ b/.changeset/chilly-meteors-enter.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/releasing.commands": patch
+---
+
+Fix scoped packages without a publishConfig.access setting being published with public access.

--- a/releasing/commands/src/publish/otp.ts
+++ b/releasing/commands/src/publish/otp.ts
@@ -8,6 +8,10 @@ import type { PublishOptions } from 'libnpmpublish'
 
 import { SHARED_CONTEXT } from './utils/shared-context.js'
 
+export type PublishOptionsWithDefaultAccess = Omit<PublishOptions, 'access'> & {
+  access?: PublishOptions['access'] | null
+}
+
 export interface OtpPublishResponse {
   readonly ok: boolean
   readonly status: number
@@ -20,7 +24,7 @@ export interface OtpPublishResponse {
 export type OtpPublishFn = (
   manifest: ExportedManifest,
   tarballData: Buffer,
-  options: PublishOptions
+  options: PublishOptionsWithDefaultAccess
 ) => Promise<OtpPublishResponse>
 
 export interface OtpContext extends BaseOtpContext {
@@ -30,7 +34,7 @@ export interface OtpContext extends BaseOtpContext {
 export interface OtpParams {
   context?: OtpContext
   manifest: ExportedManifest
-  publishOptions: PublishOptions
+  publishOptions: PublishOptionsWithDefaultAccess
   tarballData: Buffer
 }
 

--- a/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/releasing/commands/src/publish/publishPackedPkg.ts
@@ -17,7 +17,7 @@ import { createFailedToPublishError } from './FailedToPublishError.js'
 import { AuthTokenError, fetchAuthToken } from './oidc/authToken.js'
 import { getIdToken, IdTokenError } from './oidc/idToken.js'
 import { determineProvenance, ProvenanceError } from './oidc/provenance.js'
-import { type OtpContext, publishWithOtpHandling } from './otp.js'
+import { type OtpContext, type PublishOptionsWithDefaultAccess, publishWithOtpHandling } from './otp.js'
 import type { PackResult } from './pack.js'
 import { allRegistryConfigKeys, type NormalizedRegistryUrl, parseSupportedRegistryUrl } from './registryConfigKeys.js'
 import { SHARED_CONTEXT } from './utils/shared-context.js'
@@ -114,7 +114,7 @@ export function createPublishContext (opts: PublishPackedPkgOptions): OtpContext
   }
 }
 
-type StagePublishOptions = PublishOptions & {
+type StagePublishOptions = PublishOptionsWithDefaultAccess & {
   command?: string
   stage?: boolean
 }
@@ -123,7 +123,7 @@ type StagePublishOptions = PublishOptions & {
  * @internal Exported for unit testing of the access / registry / auth fallback rules. Not part of the package's
  *   public API.
  */
-export async function createPublishOptions (manifest: ExportedManifest, options: PublishPackedPkgOptions): Promise<PublishOptions> {
+export async function createPublishOptions (manifest: ExportedManifest, options: PublishPackedPkgOptions): Promise<StagePublishOptions> {
   const publishConfigRegistry = typeof manifest.publishConfig?.registry === 'string'
     ? manifest.publishConfig.registry
     : undefined
@@ -131,7 +131,7 @@ export async function createPublishOptions (manifest: ExportedManifest, options:
   const { creds, tls } = config ?? {}
 
   const publishConfigAccess = manifest.publishConfig?.access
-  const access = options.access ?? (isPublishAccess(publishConfigAccess) ? publishConfigAccess : undefined)
+  const access = options.access ?? (isPublishAccess(publishConfigAccess) ? publishConfigAccess : null)
 
   const {
     ci: isFromCI,
@@ -380,7 +380,7 @@ export async function fetchTokenAndProvenanceByOidc (
  * instead of `token`.
  * This function fixes that by making sure the registry specific authentication information exists.
  */
-function appendAuthOptionsForRegistry (targetPublishOptions: PublishOptions, registry: NormalizedRegistryUrl): void {
+function appendAuthOptionsForRegistry (targetPublishOptions: StagePublishOptions, registry: NormalizedRegistryUrl): void {
   const registryInfo = parseSupportedRegistryUrl(registry)
   if (!registryInfo) {
     globalWarn(`The registry ${registry} cannot be converted into a config key. Supplement is skipped. Subsequent libnpmpublish call may fail.`)

--- a/releasing/commands/src/publish/utils/shared-context.ts
+++ b/releasing/commands/src/publish/utils/shared-context.ts
@@ -5,12 +5,12 @@ import { fetch } from '@pnpm/network.fetch'
 import type { ExportedManifest } from '@pnpm/releasing.exportable-manifest'
 import ciInfo from 'ci-info'
 import enquirer from 'enquirer'
-import { publish as _publish, type PublishOptions } from 'libnpmpublish'
+import { publish as _publish } from 'libnpmpublish'
 
 import type { AuthTokenContext } from '../oidc/authToken.js'
 import type { IdTokenContext } from '../oidc/idToken.js'
 import type { ProvenanceContext } from '../oidc/provenance.js'
-import type { OtpContext } from '../otp.js'
+import type { OtpContext, PublishOptionsWithDefaultAccess } from '../otp.js'
 
 // @types/libnpmpublish uses an outdated PackageJson type that is incompatible
 // with ExportedManifest. This intermediate type bridges only that manifest
@@ -18,7 +18,7 @@ import type { OtpContext } from '../otp.js'
 type PublishWithExportedManifest = (
   manifest: ExportedManifest,
   tarballData: Buffer,
-  options: PublishOptions
+  options: PublishOptionsWithDefaultAccess
 ) => ReturnType<typeof _publish>
 const publish = _publish as PublishWithExportedManifest
 

--- a/releasing/commands/test/publish/publishConfigAccess.test.ts
+++ b/releasing/commands/test/publish/publishConfigAccess.test.ts
@@ -49,19 +49,19 @@ describe('createPublishOptions: access', () => {
     expect(opts.access).toBe('public')
   })
 
-  test('access is omitted when neither CLI nor publishConfig set it', async () => {
+  test('access defaults to null when neither CLI nor publishConfig set it', async () => {
     const opts = await createPublishOptions(
       { name: '@scope/pkg', version: '1.0.0' },
       baseOpts()
     )
-    expect(opts.access).toBeUndefined()
+    expect(opts.access).toBeNull()
   })
 
-  test('invalid publishConfig.access values are ignored', async () => {
+  test('invalid publishConfig.access values fall back to default access', async () => {
     const opts = await createPublishOptions(
       { name: '@scope/pkg', version: '1.0.0', publishConfig: { access: 'bogus' as 'public' } },
       baseOpts()
     )
-    expect(opts.access).toBeUndefined()
+    expect(opts.access).toBeNull()
   })
 })


### PR DESCRIPTION
_Fixes: #11983_

## Summary

Fixes `pnpm publish` so scoped packages without an explicit `--access` or `publishConfig.access` preserve npm’s default publish access behavior.

When no access is configured, pnpm now passes `access: null` through to `libnpmpublish`, matching npm CLI behavior. This prevents `libnpmpublish` from applying its own fallback of `access: "public"`.

## Background

npm CLI defines the default `access` config as `null`. That `null` value is passed through to `libnpmpublish`, overriding `libnpmpublish`’s internal default of `"public"` and allowing the registry to apply default access semantics.

This matters for scoped packages:

- npm docs say scoped packages are not public by default.
- npm CLI preserves that behavior by passing `access: null`.
- pnpm was omitting `access` when neither CLI nor `publishConfig.access` was set.
- `libnpmpublish` treats omitted access as `"public"`.

So `pnpm publish` could publish a scoped package publicly by default where `npm publish` would not.

### Implementation

I'm not 100% sold on all elements of this change. It's unfortunate that `libnpmpublish`'s types don't match the actual usage/behaviour from the npm cli.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scoped package publishing when `publishConfig.access` is not explicitly configured. Previously, such packages were incorrectly published with public access. Access configuration handling has been corrected to ensure proper defaults for scoped packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/11991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->