### PR TITLE
ci(release): pin Node 20 for v10 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,13 +31,20 @@ jobs:
         uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
         with:
           standalone: true
+      # Pin Node to the latest version still compatible with `esm@3.2.25`,
+      # which is pulled in transitively by `publish-packed` and crashes the
+      # `pnpm/bundle.ts` step on the runner's default Node. See #11988 /
+      # release 10.34.0 incident for context.
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
       - name: npm install
         run: pnpm install --global npm@11.6.2
       - name: pnpm install
         # We use --force because we want all artifacts of @reflink/reflink to be installed.
         run: pnpm install --force
       - name: Publish Packages
-        continue-on-error: true
         env:
           # setting the "npm_config_//registry.npmjs.org/:_authToken" env variable directly doesn't work.
           # probably "pnpm release" doesn't pass auth tokens to child processes


### PR DESCRIPTION
## Summary

The v10.34.0 release (run [26514415942](https://github.com/pnpm/pnpm/actions/runs/26514415942/job/78087374340)) reported ✓ green but actually **failed mid-publish** — most workspace packages went out, but `pnpm@10.34.0` itself never reached npm (currently 404). The job is hidden behind `continue-on-error: true` on the Publish step.

The crash is on the `pnpm/bundle` step:

\`\`\`
> pnpm@10.34.0 bundle
> ts-node bundle.ts

/home/runner/work/pnpm/pnpm/node_modules/.pnpm/esm@3.2.25/node_modules/esm/esm.js:1
ELIFECYCLE  Command failed with exit code 1.
\`\`\`

`ts-node bundle.ts` transitively loads `esm@3.2.25` via `publish-packed → all-module-paths → esm`. `esm@3.2.25` was last released in 2019 and monkey-patches Node internals that have been removed in Node 22+. The workflow runs on `ubuntu-latest` with no Node pin, so GitHub bumping the runner's default Node version sometime after the 10.33.4 release (May 6) silently broke the v10 release pipeline.

This PR:
- Pins **Node 20** via `actions/setup-node` before the publish step — the most recent line `esm@3.2.25` still works on.
- Removes `continue-on-error: true` from the Publish step so future failures aren't hidden behind a green workflow status.

A more durable fix (replacing `ts-node bundle.ts` with the native-TS Node runtime that v11 uses, or pre-compiling `bundle.ts`) belongs in a follow-up — this PR just unblocks 10.34.0 (which will need a re-tag once merged).

## Test plan

- [ ] Push a fresh `v10.34.0` (or `v10.34.1`) tag after merge and confirm the Publish step completes; `pnpm@10.34.0` becomes available on npm.
- [ ] Verify the Setup Node step actually runs Node 20 (visible in the runner log).
- [ ] Confirm a real publish failure now fails the workflow (e.g. push a tag that would 409 a republish).

---
Written by an agent (Claude Code, claude-opus-4-7).