### PR TITLE
perf(pacquet/package-manager): treat unsupported settings as no-opinion in optimistic-repeat-install

### DIFF
--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -163,10 +163,29 @@ pub fn check_optimistic_repeat_install(
 }
 
 /// Compare today's settings against what the previous install
-/// recorded. Returns `false` on any drift the workspace-state schema
-/// covers; missing fields in the cached record (older write or fields
-/// pacquet doesn't track yet) round-trip as `None` and are treated as
-/// "no opinion" — same posture as pnpm's `Object.entries` walk.
+/// recorded.
+///
+/// Only the fields pacquet actively populates via [`current_settings`]
+/// participate in the comparison. Fields the upstream pnpm CLI writes
+/// but pacquet hasn't ported yet (e.g. `peersSuffixMaxLength`,
+/// `dedupeDirectDeps`) are ignored — pacquet doesn't consume them
+/// during install, so a difference can't affect the materialised
+/// `node_modules`. Without this carve-out a cross-package-manager
+/// scenario (pnpm wrote the state, pacquet reads it next) would
+/// always reject the fast path because pnpm's defaults fill those
+/// fields while pacquet's `current_settings` leaves them `None`.
+///
+/// As each ported setting in pnpm/pnpm#12009 lands end-to-end and
+/// gets surfaced through `current_settings`, it joins the comparison
+/// here automatically.
+///
+/// Mirrors pnpm's `Object.entries(workspaceState.settings)` walk in
+/// [`checkDepsStatus`](https://github.com/pnpm/pnpm/blob/72d997cc34/deps/status/src/checkDepsStatus.ts):
+/// pnpm iterates fields *in the state*, which by symmetry only
+/// includes fields the writer cared about. The `allowBuilds` coercion
+/// mirrors pnpm's [`opts.allowBuilds ?? {}`](https://github.com/pnpm/pnpm/blob/72d997cc34/deps/status/src/checkDepsStatus.ts#L141)
+/// on the read side and pnpm's tolerance of an absent
+/// `allowBuilds` key in the recorded state on the write side.
 fn settings_match(
     state: &WorkspaceState,
     config: &Config,
@@ -174,7 +193,54 @@ fn settings_match(
     included: IncludedDependencies,
 ) -> bool {
     let current = current_settings(config, node_linker, included);
-    state.settings == current
+    let recorded = &state.settings;
+    let live = &current;
+    allow_builds_match(recorded.allow_builds.as_ref(), live.allow_builds.as_ref())
+        && recorded.auto_install_peers == live.auto_install_peers
+        && recorded.dedupe_peer_dependents == live.dedupe_peer_dependents
+        && recorded.dev == live.dev
+        && recorded.hoist_pattern == live.hoist_pattern
+        && recorded.hoist_workspace_packages == live.hoist_workspace_packages
+        && recorded.ignored_optional_dependencies == live.ignored_optional_dependencies
+        && recorded.link_workspace_packages == live.link_workspace_packages
+        && recorded.node_linker == live.node_linker
+        && recorded.optional == live.optional
+        && recorded.overrides == live.overrides
+        && recorded.patched_dependencies == live.patched_dependencies
+        && recorded.production == live.production
+        && recorded.public_hoist_pattern == live.public_hoist_pattern
+    // Deliberately *not* compared (tracked at pnpm/pnpm#12009 — drop
+    // each from this list once `current_settings` writes its value):
+    //   catalogs                    (pnpm always ignores; see
+    //                                ignoredSettings.add('catalogs'))
+    //   dedupeDirectDeps
+    //   dedupeInjectedDeps
+    //   dedupePeers
+    //   excludeLinksFromLockfile
+    //   injectWorkspacePackages
+    //   minimumReleaseAge*          (pacquet supports it but doesn't
+    //                                round-trip through workspace state
+    //                                yet — separate follow-up).
+    //   packageExtensions
+    //   peersSuffixMaxLength
+    //   preferWorkspacePackages
+    //   trustPolicy*                (same situation as minimumReleaseAge)
+    //   workspacePackagePatterns    (already covered via
+    //                                pnpm-workspace.yaml `packages:`)
+}
+
+/// Pnpm writes `Some({})` for an empty `allowBuilds`; pacquet writes
+/// `None` for the same effective value. Treat them as equivalent so
+/// cross-package-manager state files don't trip the comparison.
+fn allow_builds_match(
+    state_value: Option<&std::collections::BTreeMap<String, serde_json::Value>>,
+    current_value: Option<&std::collections::BTreeMap<String, serde_json::Value>>,
+) -> bool {
+    match (state_value, current_value) {
+        (None, None) => true,
+        (Some(map), None) | (None, Some(map)) => map.is_empty(),
+        (Some(state_map), Some(current_map)) => state_map == current_map,
+    }
 }
 
 /// Build the [`WorkspaceStateSettings`] that today's install would

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -426,28 +426,28 @@ fn returns_skipped_when_allow_builds_drift() {
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
 
-/// State written by pnpm with a field pacquet doesn't yet read (e.g.
-/// `packageExtensions`, `peersSuffixMaxLength`) is detected as drift
-/// rather than silently trusted. The mismatch comes from pacquet's
-/// `current_settings` producing `None` for those fields while the
-/// stored state carries `Some(...)`. This proves
-/// `WorkspaceStateSettings::PartialEq` field-by-field comparison
-/// covers fields the writer side doesn't populate yet.
+/// State written by pnpm with a field pacquet doesn't read or
+/// consume during install (e.g. `peersSuffixMaxLength`,
+/// `packageExtensions`, `dedupeDirectDeps`) does NOT trip the
+/// settings-drift gate. Pacquet ignores those fields because its
+/// install pipeline doesn't react to them — invalidating the
+/// fast path on a value pacquet can't actually consume would force
+/// a redundant reinstall every time a user runs `pacquet install`
+/// after `pnpm install` in the same project, which is the
+/// scenario the vlt benchmark exercises (pnpm/pnpm#11992).
 ///
-/// Tracks
-/// [`checkDepsStatus.test.ts:85-113`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/test/checkDepsStatus.test.ts#L85-L113)
-/// and
-/// [`:175-203`](https://github.com/pnpm/pnpm/blob/cc4ff817aa/deps/status/test/checkDepsStatus.test.ts#L175-L203)
-/// (`packageExtensions` and `peersSuffixMaxLength` drift). Once
-/// pacquet reads either yaml field into `Config`, this test should
-/// expand into the more specific per-field drift checks pnpm has.
+/// As each setting is ported end-to-end (yaml plumbing, `Config`
+/// field, real consumer, and joined into `current_settings`), it
+/// joins [`settings_match`]'s comparison automatically and a
+/// drift on it starts rejecting again. Tracked in pnpm/pnpm#12009.
 #[test]
-fn returns_skipped_when_unported_pnpm_settings_present() {
+fn returns_up_to_date_when_state_carries_unported_pnpm_settings() {
     let dir = tempdir().unwrap();
     let workspace_root = dir.path();
     let manifest_path = workspace_root.join("package.json");
     fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
     let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    write_empty_lockfile(workspace_root);
 
     let mut config = Config::new();
     config.modules_dir = workspace_root.join("node_modules");
@@ -456,10 +456,26 @@ fn returns_skipped_when_unported_pnpm_settings_present() {
 
     let mut settings =
         current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included());
-    // Inject a pnpm-only field pacquet doesn't write to today.
-    // Either field is sufficient to prove the equality check catches
-    // it; pick the simpler scalar.
+    // Populate every field pacquet doesn't surface through
+    // `current_settings` today. Each is an upstream pnpm setting
+    // listed in pnpm/pnpm#12009.
+    settings.dedupe_direct_deps = Some(false);
+    settings.dedupe_injected_deps = Some(true);
+    settings.dedupe_peers = Some(false);
+    settings.exclude_links_from_lockfile = Some(false);
+    settings.inject_workspace_packages = Some(true);
+    settings.package_extensions =
+        Some(serde_json::json!({"foo": {"peerDependencies": {"bar": "*"}}}));
     settings.peers_suffix_max_length = Some(42);
+    settings.prefer_workspace_packages = Some(true);
+    // `catalogs` is always ignored by pnpm itself; pacquet
+    // mirrors that.
+    settings.catalogs = Some(serde_json::json!({"default": {"react": "^18.0.0"}}));
+    // `workspacePackagePatterns` is recorded by pnpm from
+    // pnpm-workspace.yaml's `packages:` field, which pacquet
+    // tracks via `WorkspaceManifest.packages` instead of this
+    // state-file field.
+    settings.workspace_package_patterns = Some(vec!["packages/**/*".to_string()]);
 
     let mut projects = BTreeMap::new();
     projects.insert(
@@ -476,7 +492,53 @@ fn returns_skipped_when_unported_pnpm_settings_present() {
         &[(workspace_root.to_path_buf(), &manifest)],
         false,
     );
-    assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
+    assert_eq!(decision, Decision::UpToDate);
+}
+
+/// `allowBuilds` is the one field where pnpm and pacquet round-trip
+/// an empty configured value differently: pnpm writes `Some({})` for
+/// an empty allow-list, while pacquet's [`current_settings`] writes
+/// `None`. The comparison must treat the two as equivalent —
+/// otherwise the cross-package-manager scenario from pnpm/pnpm#11992
+/// rejects the fast path on every iteration where pnpm wrote the
+/// state. Mirrors pnpm's [`opts.allowBuilds ?? {}`](https://github.com/pnpm/pnpm/blob/72d997cc34/deps/status/src/checkDepsStatus.ts#L141)
+/// coercion on the read side.
+#[test]
+fn returns_up_to_date_when_state_has_empty_allow_builds_and_current_has_none() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let manifest_path = workspace_root.join("package.json");
+    fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+    write_empty_lockfile(workspace_root);
+
+    let mut config = Config::new();
+    config.modules_dir = workspace_root.join("node_modules");
+    fs::create_dir_all(&config.modules_dir).unwrap();
+    let config = config.leak();
+
+    let mut settings =
+        current_settings(config, pacquet_config::NodeLinker::Isolated, isolated_included());
+    // Simulate a pnpm-written state: empty `allowBuilds` map
+    // serialized as `{}`, where pacquet would have written `None`.
+    settings.allow_builds = Some(BTreeMap::new());
+
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis() + 60_000, settings, projects);
+
+    let decision = check_optimistic_repeat_install(
+        workspace_root,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &[(workspace_root.to_path_buf(), &manifest)],
+        false,
+    );
+    assert_eq!(decision, Decision::UpToDate);
 }
 
 /// Workspace install where a sibling project declares dependencies


### PR DESCRIPTION
## Summary

`state.settings == current` in [`settings_match`](https://github.com/pnpm/pnpm/blob/72d997cc34/pacquet/crates/package-manager/src/optimistic_repeat_install.rs) compared every field on `WorkspaceStateSettings`, including settings pacquet doesn't yet implement (`peersSuffixMaxLength`, `dedupeDirectDeps`, `packageExtensions`, …). Pnpm's defaults populate those fields when it writes the state; pacquet's `current_settings` leaves them `None`. So any cross-package-manager scenario — pnpm wrote the workspace-state file, pacquet runs next — rejected the optimistic fast path and fell into the slower frozen no-op short-circuit on iter 1. That's the 9.09× `babylon × lockfile+node_modules` regression in #11992.

This PR switches `settings_match` to compare only the fields `current_settings` actively writes, mirroring pnpm's [`Object.entries(workspaceState.settings)`](https://github.com/pnpm/pnpm/blob/72d997cc34/deps/status/src/checkDepsStatus.ts) walk semantically. It also special-cases `allowBuilds` so pnpm's `Some({})` and pacquet's `None` match (both mean "no opinion"), mirroring pnpm's `opts.allowBuilds ?? {}` coercion on the read side.

## What's not compared, and why

Each entry below has a matching line in `settings_match`'s skip-list comment. As each one is ported end-to-end (yaml plumbing → `Config` field → real install consumer → joined into `current_settings`), it drops out of the skip-list and starts gating the fast path. See #12009 for the porting tracker.

**Tracked at #12009** (genuinely unimplemented in pacquet today):
- `dedupeDirectDeps`, `dedupeInjectedDeps`, `dedupePeers`
- `excludeLinksFromLockfile`
- `injectWorkspacePackages`
- `packageExtensions`
- `peersSuffixMaxLength`
- `preferWorkspacePackages`

**Hitch a ride on the same skip-list** (pacquet *does* consume them during install, but they aren't surfaced into the workspace-state crate yet — separate short follow-up):
- `minimumReleaseAge`, `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`, `minimumReleaseAgeStrict`
- `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`

**Permanently outside the comparison**:
- `catalogs` — pnpm itself always ignores ([`ignoredSettings.add('catalogs')`](https://github.com/pnpm/pnpm/blob/72d997cc34/deps/status/src/checkDepsStatus.ts#L137))
- `workspacePackagePatterns` — already tracked via `WorkspaceManifest.packages` from `pnpm-workspace.yaml`

## Test plan

End-to-end on `vltpkg/benchmarks/fixtures/babylon`, after pnpm has written the workspace-state file:

| Step | Before | After |
|---|---:|---:|
| pacquet iter-1 (sees pnpm state) | ~531 ms (frozen no-op) | **~96 ms** (optimistic fast path) |
| pacquet iter-2+ (sees own state) | ~90 ms | ~90 ms |
| pnpm itself, warm | ~687 ms | ~687 ms |

After the fix, pacquet's iter-1 is **7× faster than pnpm's warm install** on the same fixture, matching iter-2's behavior.

- [x] `cargo nextest run -p pacquet-package-manager optimistic_repeat_install` — 18/18 pass (the conservative-posture test `returns_skipped_when_unported_pnpm_settings_present` was replaced with `returns_up_to_date_when_state_carries_unported_pnpm_settings` covering every #12009 setting + `catalogs` + `workspacePackagePatterns`; second new test locks in the `allowBuilds` empty-vs-`None` coercion).
- [x] `cargo clippy --locked -p pacquet-package-manager --all-targets -- --deny warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] End-to-end repro on babylon fixture: pacquet iter-1 after pnpm wrote state hits the optimistic fast path; pnpm-shape state file is preserved (pacquet's fast path doesn't overwrite it, matching pnpm).

Closes #11992. Refs #12009.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings comparison so cached workspace state is correctly recognized as up-to-date, avoiding unnecessary reinstalls. Empty allow-lists and absent values are treated as equivalent to prevent false mismatches.

* **Tests**
  * Expanded test coverage for settings-compatibility edge cases, including unconsumed/external settings and allow-list normalization to validate the fast-path behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->