### PR TITLE
feat(registry): add whoami, profile, and token CRUD endpoints

### DIFF
--- a/registry/crates/pnpm-registry/src/auth.rs
+++ b/registry/crates/pnpm-registry/src/auth.rs
@@ -336,12 +336,17 @@ impl TokenStore {
     /// Remove a token by its key (the SHA-256 hex digest). Returns
     /// the deleted record so the caller can check ownership before
     /// committing the revocation in a higher layer.
+    ///
+    /// SQLite gets the `DELETE` *before* the in-memory map is mutated.
+    /// If the disk write fails, both views still hold the token and
+    /// the caller sees a 5xx — the opposite ordering would leave a
+    /// "revoked in memory but resurrected on restart" hole.
     pub async fn revoke_by_key(&self, key: &str) -> Result<Option<TokenRecord>> {
-        let removed = {
-            let mut inner = self.inner.lock().expect("TokenStore mutex poisoned");
-            inner.tokens.remove(key)
+        let snapshot = {
+            let inner = self.inner.lock().expect("TokenStore mutex poisoned");
+            inner.tokens.get(key).cloned()
         };
-        let Some(record) = removed else {
+        let Some(record) = snapshot else {
             return Ok(None);
         };
         if let Some(path) = self.persist.clone() {
@@ -352,6 +357,10 @@ impl TokenStore {
                 Ok(())
             })
             .await??;
+        }
+        {
+            let mut inner = self.inner.lock().expect("TokenStore mutex poisoned");
+            inner.tokens.remove(key);
         }
         Ok(Some(record))
     }

--- a/registry/crates/pnpm-registry/src/auth.rs
+++ b/registry/crates/pnpm-registry/src/auth.rs
@@ -309,6 +309,60 @@ impl TokenStore {
         let inner = self.inner.lock().expect("TokenStore mutex poisoned");
         inner.tokens.get(&token_hash).map(|record| record.username.clone())
     }
+
+    /// Snapshot the record for a token by its key (SHA-256 hex). Used
+    /// to check ownership before revocation — the revoke handler
+    /// rejects a delete from a non-owner with 403 before touching the
+    /// store.
+    pub fn find_by_key(&self, key: &str) -> Option<TokenRecord> {
+        let inner = self.inner.lock().expect("TokenStore mutex poisoned");
+        inner.tokens.get(key).cloned()
+    }
+
+    /// All tokens owned by `username`. Returns `(key, record)` pairs
+    /// where `key` is the SHA-256 hex digest of the raw token — the
+    /// same value the `/-/npm/v1/tokens` listing surfaces, and what
+    /// `npm token revoke` sends back to the delete endpoint.
+    pub fn list_for_user(&self, username: &str) -> Vec<(String, TokenRecord)> {
+        let inner = self.inner.lock().expect("TokenStore mutex poisoned");
+        inner
+            .tokens
+            .iter()
+            .filter(|(_, record)| record.username == username)
+            .map(|(hash, record)| (hash.clone(), record.clone()))
+            .collect()
+    }
+
+    /// Remove a token by its key (the SHA-256 hex digest). Returns
+    /// the deleted record so the caller can check ownership before
+    /// committing the revocation in a higher layer.
+    pub async fn revoke_by_key(&self, key: &str) -> Result<Option<TokenRecord>> {
+        let removed = {
+            let mut inner = self.inner.lock().expect("TokenStore mutex poisoned");
+            inner.tokens.remove(key)
+        };
+        let Some(record) = removed else {
+            return Ok(None);
+        };
+        if let Some(path) = self.persist.clone() {
+            let key = key.to_string();
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let conn = Connection::open(&path)?;
+                delete_token(&conn, &key)?;
+                Ok(())
+            })
+            .await??;
+        }
+        Ok(Some(record))
+    }
+
+    /// Remove a token by its raw value. The `DELETE /-/user/token/:tok`
+    /// (npm logout) path puts the bearer token verbatim in the URL,
+    /// so this hashes first and then defers to [`Self::revoke_by_key`].
+    pub async fn revoke_by_raw(&self, raw: &str) -> Result<Option<TokenRecord>> {
+        let key = sha256_hex(raw.as_bytes());
+        self.revoke_by_key(&key).await
+    }
 }
 
 impl Default for TokenStore {
@@ -511,6 +565,11 @@ fn load_all_tokens(conn: &Connection) -> Result<HashMap<String, TokenRecord>> {
         );
     }
     Ok(out)
+}
+
+fn delete_token(conn: &Connection, token_hash: &str) -> Result<()> {
+    conn.execute("DELETE FROM tokens WHERE token_hash = ?1", rusqlite::params![token_hash])?;
+    Ok(())
 }
 
 fn upsert_token(conn: &Connection, token_hash: &str, record: &TokenRecord) -> Result<()> {

--- a/registry/crates/pnpm-registry/src/publish.rs
+++ b/registry/crates/pnpm-registry/src/publish.rs
@@ -298,7 +298,15 @@ fn merge_objects(existing: Option<&Value>, incoming: &Value) -> Value {
 pub fn now_iso() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let since_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
-    let millis = since_epoch.as_millis() as i64;
+    iso_from_unix_millis(since_epoch.as_millis() as i64)
+}
+
+/// Format a unix-millis timestamp as an ISO-8601 / RFC-3339 string
+/// with millisecond precision. The token-listing endpoint surfaces
+/// `TokenRecord::created_at` (seconds since epoch) through this same
+/// helper so both `time.modified` on packuments and `created` on
+/// tokens render with identical shape.
+pub fn iso_from_unix_millis(millis: i64) -> String {
     // Civil-time conversion without pulling in `chrono`.
     // 86_400_000 ms in a day.
     let (days, ms_in_day) = (millis / 86_400_000, millis.rem_euclid(86_400_000));

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -181,7 +181,7 @@ async fn get_two_segments(
     Path((first, second)): Path<(String, String)>,
 ) -> Response {
     if first == "-" && second == "whoami" {
-        return serve_whoami(&state, &headers);
+        return private_no_cache(serve_whoami(&state, &headers));
     }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
@@ -237,10 +237,10 @@ async fn get_four_segments(
         return get_dist_tags(&state, &headers, &c).await;
     }
     if a == "-" && b == "npm" && c == "v1" && d == "user" {
-        return serve_profile(&state, &headers);
+        return private_no_cache(serve_profile(&state, &headers));
     }
     if a == "-" && b == "npm" && c == "v1" && d == "tokens" {
-        return list_tokens(&state, &headers);
+        return private_no_cache(list_tokens(&state, &headers));
     }
     not_found()
 }
@@ -347,7 +347,7 @@ async fn delete_four_segments(
     Path((a, b, c, d)): Path<(String, String, String, String)>,
 ) -> Response {
     if a == "-" && b == "user" && c == "token" {
-        return logout(&state, &headers, &d).await;
+        return private_no_cache(logout(&state, &headers, &d).await);
     }
     not_found()
 }
@@ -386,7 +386,7 @@ async fn delete_six_segments(
     Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
 ) -> Response {
     if a == "-" && b == "npm" && c == "v1" && d == "tokens" && e == "token" {
-        return revoke_token_by_key(&state, &headers, &f).await;
+        return private_no_cache(revoke_token_by_key(&state, &headers, &f).await);
     }
     if a.starts_with('@') && c == "-" && e == "-rev" {
         let _ = f; // revision token is unused
@@ -696,6 +696,21 @@ fn json_response(status: StatusCode, body: &Value) -> Response {
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(bytes))
         .expect("static-shape response always builds")
+}
+
+/// Mark a response as caller-scoped and uncacheable. The auth
+/// endpoints (whoami, profile, token list/revoke, logout) return
+/// per-user data keyed on the `Authorization` header, so a shared
+/// HTTP cache that ignored `Vary` could happily hand one user's
+/// identity to another. Applied to *every* branch of those handlers
+/// — success and error alike — so an intermediary can't latch onto
+/// a 401 either.
+fn private_no_cache(mut response: Response) -> Response {
+    use axum::http::HeaderValue;
+    let headers = response.headers_mut();
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("private, no-store"));
+    headers.insert(header::VARY, HeaderValue::from_static("Authorization"));
+    response
 }
 
 /// `PUT /:pkg` — publish a new version (or republish). Body is the

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -17,7 +17,8 @@ use crate::error::RegistryError;
 use crate::package_name::PackageName;
 use crate::policy::{AccessRule, PackagePolicies};
 use crate::publish::{
-    PendingAttachment, extract_attachments, merge_manifest, now_iso, stream_decode_verify_and_write,
+    PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
+    stream_decode_verify_and_write,
 };
 use crate::streaming;
 use crate::upstream::{
@@ -179,6 +180,9 @@ async fn get_two_segments(
     headers: HeaderMap,
     Path((first, second)): Path<(String, String)>,
 ) -> Response {
+    if first == "-" && second == "whoami" {
+        return serve_whoami(&state, &headers);
+    }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
         serve_packument(&state, &headers, &full).await
@@ -219,8 +223,11 @@ async fn get_tarball_scoped(
     serve_tarball(&state, &headers, &full, &filename).await
 }
 
-/// 4-segment GET: `/-/package/{pkg}/dist-tags`. Returns the
-/// packument's `dist-tags` object.
+/// 4-segment GET:
+/// * `/-/package/{pkg}/dist-tags` — packument's `dist-tags` object.
+/// * `/-/npm/v1/user` — caller's profile (`npm profile get`).
+/// * `/-/npm/v1/tokens` — list bearer tokens for the caller
+///   (`npm token list`).
 async fn get_four_segments(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -228,6 +235,12 @@ async fn get_four_segments(
 ) -> Response {
     if a == "-" && b == "package" && d == "dist-tags" {
         return get_dist_tags(&state, &headers, &c).await;
+    }
+    if a == "-" && b == "npm" && c == "v1" && d == "user" {
+        return serve_profile(&state, &headers);
+    }
+    if a == "-" && b == "npm" && c == "v1" && d == "tokens" {
+        return list_tokens(&state, &headers);
     }
     not_found()
 }
@@ -325,12 +338,17 @@ async fn put_five_segments(
     not_found()
 }
 
-/// `DELETE /{a}/{b}/{c}/{d}` — not a real npm shape; sits here so
-/// the route is symmetric with PUT/GET. Returns 404.
+/// `DELETE /-/user/token/{tok}` — npm logout. `{tok}` is the raw
+/// bearer token sent verbatim. We hash it and remove the matching
+/// row from the token store.
 async fn delete_four_segments(
-    State(_state): State<AppState>,
-    Path(_): Path<(String, String, String, String)>,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((a, b, c, d)): Path<(String, String, String, String)>,
 ) -> Response {
+    if a == "-" && b == "user" && c == "token" {
+        return logout(&state, &headers, &d).await;
+    }
     not_found()
 }
 
@@ -353,16 +371,23 @@ async fn delete_five_segments(
     not_found()
 }
 
-/// `DELETE /{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
-/// tarball. The pnpm unpublish flow gets here when the tarball URL it
-/// reconstructs from the packument is the literal-slash scoped form
-/// (`http://host/@scope/name/-/name-1.0.0.tgz`), so the request lands
-/// here unencoded rather than as a 5-seg `@scope%2Fname` URL.
+/// 6-segment DELETE:
+/// * `/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
+///   tarball. The pnpm unpublish flow gets here when the tarball URL
+///   it reconstructs from the packument is the literal-slash scoped
+///   form (`http://host/@scope/name/-/name-1.0.0.tgz`), so the
+///   request lands here unencoded rather than as a 5-seg
+///   `@scope%2Fname` URL.
+/// * `/-/npm/v1/tokens/token/{key}` — revoke a bearer token by its
+///   listing-side `key` (`npm token revoke`).
 async fn delete_six_segments(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
 ) -> Response {
+    if a == "-" && b == "npm" && c == "v1" && d == "tokens" && e == "token" {
+        return revoke_token_by_key(&state, &headers, &f).await;
+    }
     if a.starts_with('@') && c == "-" && e == "-rev" {
         let _ = f; // revision token is unused
         let full = format!("{a}/{b}");
@@ -524,6 +549,151 @@ async fn add_user(state: &AppState, name: &str, body: &[u8]) -> Response {
         .status(StatusCode::CREATED)
         .header(header::CONTENT_TYPE, "application/json")
         .header(header::CACHE_CONTROL, "no-cache")
+        .body(Body::from(bytes))
+        .expect("static-shape response always builds")
+}
+
+/// `GET /-/whoami` — return the username of the caller, or 401 if
+/// the request is anonymous. `npm whoami` reads this. The check is
+/// pure auth: no per-package policy applies, so anonymous always
+/// gets 401 even when `$all` would let it through for packument
+/// reads.
+fn serve_whoami(state: &AppState, headers: &HeaderMap) -> Response {
+    let Some(username) = caller_username(state, headers) else {
+        return error_response(&RegistryError::Unauthenticated {
+            resource: "user identity".to_string(),
+        });
+    };
+    json_response(StatusCode::OK, &json!({ "username": username }))
+}
+
+/// `GET /-/npm/v1/user` — return the profile of the authenticated
+/// caller. `npm profile get` reads this. pnpr doesn't track email,
+/// 2FA, or anything beyond the username; the absent fields surface
+/// as their zero-value defaults so the npm CLI's table renderer
+/// doesn't choke on a missing key.
+fn serve_profile(state: &AppState, headers: &HeaderMap) -> Response {
+    let Some(username) = caller_username(state, headers) else {
+        return error_response(&RegistryError::Unauthenticated {
+            resource: "user profile".to_string(),
+        });
+    };
+    json_response(
+        StatusCode::OK,
+        &json!({
+            "name": username,
+            "email": "",
+            "email_verified": false,
+            "tfa": false,
+            "fullname": "",
+            "cidr_whitelist": null,
+        }),
+    )
+}
+
+/// `GET /-/npm/v1/tokens` — list every bearer token issued to the
+/// authenticated caller. Returns the npm-CLI-compatible wrapper
+/// (`{ objects, urls }`) so `npm token list` parses it cleanly. The
+/// raw token itself is never persisted; the `token` field surfaces
+/// the leading 6 hex characters of the key as a preview, matching
+/// what verdaccio does when it can't reconstruct the original.
+fn list_tokens(state: &AppState, headers: &HeaderMap) -> Response {
+    let Some(username) = caller_username(state, headers) else {
+        return error_response(&RegistryError::Unauthenticated {
+            resource: "token list".to_string(),
+        });
+    };
+    let objects: Vec<Value> = state
+        .inner
+        .auth
+        .tokens
+        .list_for_user(&username)
+        .into_iter()
+        .map(|(key, record)| token_response_object(&key, &record))
+        .collect();
+    json_response(StatusCode::OK, &json!({ "objects": objects, "urls": {} }))
+}
+
+/// `DELETE /-/npm/v1/tokens/token/:key` — revoke a token by its
+/// listing-side key. The caller must be the owner of the token
+/// (anonymous is 401, a different authenticated user is 403); an
+/// unknown key returns 404. `npm token revoke` calls this with the
+/// `key` it pulled from [`list_tokens`].
+async fn revoke_token_by_key(state: &AppState, headers: &HeaderMap, key: &str) -> Response {
+    let Some(username) = caller_username(state, headers) else {
+        return error_response(&RegistryError::Unauthenticated {
+            resource: "token revocation".to_string(),
+        });
+    };
+    match state.inner.auth.tokens.find_by_key(key) {
+        Some(record) if record.username != username => error_response(&RegistryError::Forbidden {
+            user: username,
+            action: "revoke",
+            resource: "this token".to_string(),
+        }),
+        Some(_) => match state.inner.auth.tokens.revoke_by_key(key).await {
+            Ok(Some(_)) => json_response(StatusCode::OK, &json!({ "ok": "token revoked" })),
+            Ok(None) => not_found(),
+            Err(err) => error_response(&err),
+        },
+        None => not_found(),
+    }
+}
+
+/// `DELETE /-/user/token/:tok` — npm logout. The path holds the raw
+/// bearer token (npm sends it verbatim alongside an
+/// `Authorization: Bearer <tok>` header). We require authentication
+/// and require that the auth identifies the same user who owns the
+/// token being deleted.
+async fn logout(state: &AppState, headers: &HeaderMap, raw_token: &str) -> Response {
+    let Some(username) = caller_username(state, headers) else {
+        return error_response(&RegistryError::Unauthenticated { resource: "logout".to_string() });
+    };
+    let Some(target_owner) = state.inner.auth.tokens.lookup(raw_token) else {
+        return not_found();
+    };
+    if target_owner != username {
+        return error_response(&RegistryError::Forbidden {
+            user: username,
+            action: "revoke",
+            resource: "this token".to_string(),
+        });
+    }
+    match state.inner.auth.tokens.revoke_by_raw(raw_token).await {
+        Ok(Some(_)) => json_response(StatusCode::OK, &json!({ "ok": true })),
+        Ok(None) => not_found(),
+        Err(err) => error_response(&err),
+    }
+}
+
+fn token_response_object(key: &str, record: &crate::auth::TokenRecord) -> Value {
+    let preview: String = key.chars().take(6).collect();
+    let created = iso_from_unix_millis((record.created_at as i64) * 1000);
+    let updated = iso_from_unix_millis((record.last_used_at as i64) * 1000);
+    json!({
+        "key": key,
+        "token": preview,
+        "user": record.username,
+        "cidr_whitelist": record.cidr_whitelist,
+        "readonly": record.readonly,
+        "created": created,
+        "updated": updated,
+    })
+}
+
+fn caller_username(state: &AppState, headers: &HeaderMap) -> Option<String> {
+    identify(
+        headers.get(header::AUTHORIZATION).and_then(|value| value.to_str().ok()),
+        &state.inner.auth.users,
+        &state.inner.auth.tokens,
+    )
+}
+
+fn json_response(status: StatusCode, body: &Value) -> Response {
+    let bytes = serde_json::to_vec(body).expect("static-shape JSON serializes");
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(bytes))
         .expect("static-shape response always builds")
 }

--- a/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
+++ b/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
@@ -336,6 +336,66 @@ async fn logout_requires_auth() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
+/// Every auth-endpoint response — success, 401, 403, 404 alike —
+/// must mark itself uncacheable so an intermediary HTTP cache that
+/// ignores `Vary` can't latch onto one user's identity and serve it
+/// to another.
+#[tokio::test]
+async fn auth_endpoints_set_private_no_cache_headers() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, alice_token) = add_user_and_get_token(app, "alice", "secret").await;
+    let (app, bob_token) = add_user_and_get_token(app, "bob", "secret").await;
+
+    // Bob's key — used to drive the 403 cross-user revoke branch below.
+    let response =
+        app.clone().oneshot(get_with_bearer("/-/npm/v1/tokens", &bob_token)).await.unwrap();
+    let bob_key =
+        body_json(response.into_body()).await["objects"][0]["key"].as_str().unwrap().to_string();
+
+    // (request, authenticated-or-not, expected-status). Each entry
+    // exercises a branch that must still carry the privacy headers.
+    let cases: Vec<(Request<Body>, StatusCode)> = vec![
+        (get_with_bearer("/-/whoami", &alice_token), StatusCode::OK),
+        (Request::get("/-/whoami").body(Body::empty()).unwrap(), StatusCode::UNAUTHORIZED),
+        (get_with_bearer("/-/npm/v1/user", &alice_token), StatusCode::OK),
+        (get_with_bearer("/-/npm/v1/tokens", &alice_token), StatusCode::OK),
+        (
+            delete_with_bearer(&format!("/-/npm/v1/tokens/token/{bob_key}"), &alice_token),
+            StatusCode::FORBIDDEN,
+        ),
+        (
+            delete_with_bearer(&format!("/-/npm/v1/tokens/token/{}", "0".repeat(64)), &alice_token),
+            StatusCode::NOT_FOUND,
+        ),
+        (delete_with_bearer("/-/user/token/not-real", &alice_token), StatusCode::NOT_FOUND),
+    ];
+
+    for (request, expected_status) in cases {
+        let path = request.uri().path().to_string();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), expected_status, "unexpected status for {path}");
+        let cache_control = response
+            .headers()
+            .get("cache-control")
+            .map(|v| v.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        let vary = response
+            .headers()
+            .get("vary")
+            .map(|v| v.to_str().unwrap().to_string())
+            .unwrap_or_default();
+        assert_eq!(
+            cache_control, "private, no-store",
+            "{path}: cache-control must lock the response to the caller"
+        );
+        assert_eq!(
+            vary, "Authorization",
+            "{path}: Vary must include Authorization so shared caches partition by credentials"
+        );
+    }
+}
+
 /// Revocation must persist across a restart — once a token is
 /// revoked, reopening the SQLite store must not reload it.
 #[tokio::test]

--- a/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
+++ b/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
@@ -1,0 +1,366 @@
+//! Acceptance tests for the npm-CLI-compatible user and token
+//! endpoints — `whoami`, profile, token listing, token revocation,
+//! and logout. The token-listing endpoint backs `npm token list`;
+//! the rest gate behind a valid bearer token in the same way as
+//! `npm whoami` / `npm profile get` / `npm logout` expect.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::path::PathBuf;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use pnpm_registry::{
+    AuthConfig, AuthState, Config, HtpasswdConfig, MaxUsers, TokensConfig, router, router_with_auth,
+};
+
+fn listen() -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873))
+}
+
+fn static_config(storage: PathBuf) -> Config {
+    let mut config = Config::static_serve(listen(), storage);
+    config.public_url = "http://example.test".to_string();
+    config
+}
+
+fn persistent_config(storage: PathBuf, htpasswd: PathBuf, tokens_db: PathBuf) -> Config {
+    let mut config = static_config(storage);
+    config.auth = AuthConfig {
+        htpasswd: HtpasswdConfig { file: Some(htpasswd), max_users: MaxUsers::Unlimited },
+        tokens: TokensConfig { file: Some(tokens_db) },
+    };
+    config
+}
+
+async fn body_bytes(body: Body) -> Vec<u8> {
+    to_bytes(body, usize::MAX).await.expect("read body").to_vec()
+}
+
+async fn body_json(body: Body) -> Value {
+    serde_json::from_slice(&body_bytes(body).await).expect("body parses as JSON")
+}
+
+fn put_json(path: &str, body: Value) -> Request<Body> {
+    Request::put(path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap()
+}
+
+fn get_with_bearer(path: &str, token: &str) -> Request<Body> {
+    Request::get(path)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn delete_with_bearer(path: &str, token: &str) -> Request<Body> {
+    Request::delete(path)
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn adduser_body(username: &str, password: &str) -> Value {
+    json!({
+        "_id": format!("org.couchdb.user:{username}"),
+        "name": username,
+        "password": password,
+        "email": "foo@bar.net",
+        "type": "user",
+        "roles": [],
+    })
+}
+
+/// Register a user via the adduser PUT and return the bearer token.
+async fn add_user_and_get_token(
+    app: axum::Router,
+    username: &str,
+    password: &str,
+) -> (axum::Router, String) {
+    let path = format!("/-/user/org.couchdb.user:{username}");
+    let response =
+        app.clone().oneshot(put_json(&path, adduser_body(username, password))).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let payload = body_json(response.into_body()).await;
+    let token = payload["token"].as_str().expect("token in response").to_string();
+    (app, token)
+}
+
+#[tokio::test]
+async fn whoami_returns_username_for_authenticated_caller() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let response = app.oneshot(get_with_bearer("/-/whoami", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response.into_body()).await;
+    assert_eq!(payload["username"].as_str(), Some("alice"));
+}
+
+#[tokio::test]
+async fn whoami_returns_401_when_unauthenticated() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let response =
+        app.oneshot(Request::get("/-/whoami").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn whoami_returns_401_for_unknown_bearer() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let response = app.oneshot(get_with_bearer("/-/whoami", "not-a-real-token")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn profile_returns_user_info() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let response = app.oneshot(get_with_bearer("/-/npm/v1/user", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response.into_body()).await;
+    assert_eq!(payload["name"].as_str(), Some("alice"));
+    assert_eq!(payload["tfa"].as_bool(), Some(false));
+    // npm CLI's table renderer expects these keys to be present even
+    // when empty — make sure we don't omit them.
+    assert!(payload.get("email").is_some(), "email field must be present");
+    assert!(payload.get("cidr_whitelist").is_some(), "cidr_whitelist field must be present");
+}
+
+#[tokio::test]
+async fn profile_returns_401_when_unauthenticated() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let response =
+        app.oneshot(Request::get("/-/npm/v1/user").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn token_list_returns_only_callers_tokens() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, alice_token) = add_user_and_get_token(app, "alice", "secret").await;
+    let (app, _bob_token) = add_user_and_get_token(app, "bob", "secret").await;
+
+    // Issue a second token to alice so the listing has more than one.
+    let (app, _alice_token_2) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let response = app.oneshot(get_with_bearer("/-/npm/v1/tokens", &alice_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response.into_body()).await;
+    let objects = payload["objects"].as_array().expect("objects array");
+    assert_eq!(objects.len(), 2, "alice owns two tokens, bob's must not leak");
+    for entry in objects {
+        assert_eq!(entry["user"].as_str(), Some("alice"));
+        let key = entry["key"].as_str().expect("key field");
+        assert_eq!(key.len(), 64, "key is the SHA-256 hex of the raw token");
+        let preview = entry["token"].as_str().expect("token preview");
+        assert_eq!(preview.len(), 6, "token preview is the leading 6 chars of the key");
+        assert!(key.starts_with(preview), "preview must match the key prefix");
+    }
+}
+
+#[tokio::test]
+async fn token_list_returns_401_when_unauthenticated() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let response =
+        app.oneshot(Request::get("/-/npm/v1/tokens").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn revoke_token_by_key_removes_the_token() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, alice_token) = add_user_and_get_token(app, "alice", "secret").await;
+    let (app, victim_token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    // Read the key for the victim token via the list endpoint.
+    let response =
+        app.clone().oneshot(get_with_bearer("/-/npm/v1/tokens", &alice_token)).await.unwrap();
+    let payload = body_json(response.into_body()).await;
+    let objects = payload["objects"].as_array().unwrap();
+    let alice_key = objects[0]["key"].as_str().unwrap();
+    let alice_other = objects[1]["key"].as_str().unwrap();
+    // Pick whichever key matches the victim token's hash by querying
+    // each: revoke one and check that the other still authenticates.
+    let target_key = if uses_token(&app, &victim_token, alice_key).await {
+        alice_key.to_string()
+    } else {
+        alice_other.to_string()
+    };
+
+    let path = format!("/-/npm/v1/tokens/token/{target_key}");
+    let response = app.clone().oneshot(delete_with_bearer(&path, &alice_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The revoked token must no longer authenticate.
+    let response = app.clone().oneshot(get_with_bearer("/-/whoami", &victim_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    // The other token still works.
+    let response = app.oneshot(get_with_bearer("/-/whoami", &alice_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Returns true when `key` is the hash of `raw_token`. We can't
+/// inspect the store from the test, so we drive a revocation through
+/// the public API and check whether the raw token stopped working.
+/// Used by [`revoke_token_by_key_removes_the_token`] to pick which of
+/// the two listed keys belongs to the token we want to revoke.
+async fn uses_token(app: &axum::Router, raw_token: &str, candidate_key: &str) -> bool {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(raw_token.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest.iter() {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    let _ = app; // app is unused but kept for symmetry with the other helpers
+    hex == candidate_key
+}
+
+#[tokio::test]
+async fn revoke_token_by_key_404s_for_unknown_key() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let path = format!("/-/npm/v1/tokens/token/{}", "0".repeat(64));
+    let response = app.oneshot(delete_with_bearer(&path, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn revoke_token_by_key_rejects_revoking_someone_elses_token() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, alice_token) = add_user_and_get_token(app, "alice", "secret").await;
+    let (app, bob_token) = add_user_and_get_token(app, "bob", "secret").await;
+
+    // Pull bob's key out of bob's listing.
+    let response =
+        app.clone().oneshot(get_with_bearer("/-/npm/v1/tokens", &bob_token)).await.unwrap();
+    let payload = body_json(response.into_body()).await;
+    let bob_key = payload["objects"][0]["key"].as_str().unwrap().to_string();
+
+    // Alice cannot revoke bob's token.
+    let path = format!("/-/npm/v1/tokens/token/{bob_key}");
+    let response = app.clone().oneshot(delete_with_bearer(&path, &alice_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Bob's token must still work.
+    let response = app.oneshot(get_with_bearer("/-/whoami", &bob_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn revoke_token_by_key_requires_auth() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let path = format!("/-/npm/v1/tokens/token/{}", "0".repeat(64));
+    let response = app.oneshot(Request::delete(&path).body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn logout_deletes_the_callers_token() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let path = format!("/-/user/token/{token}");
+    let response = app.clone().oneshot(delete_with_bearer(&path, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The token must no longer authenticate.
+    let response = app.oneshot(get_with_bearer("/-/whoami", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn logout_returns_404_for_unknown_token() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    let path = "/-/user/token/not-a-real-token";
+    let response = app.oneshot(delete_with_bearer(path, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn logout_requires_caller_to_own_the_token() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, alice_token) = add_user_and_get_token(app, "alice", "secret").await;
+    let (app, bob_token) = add_user_and_get_token(app, "bob", "secret").await;
+
+    // Alice asks to log out using bob's token — forbidden.
+    let path = format!("/-/user/token/{bob_token}");
+    let response = app.clone().oneshot(delete_with_bearer(&path, &alice_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Bob's token must still work.
+    let response = app.oneshot(get_with_bearer("/-/whoami", &bob_token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn logout_requires_auth() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let response = app
+        .oneshot(Request::delete("/-/user/token/anything").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Revocation must persist across a restart — once a token is
+/// revoked, reopening the SQLite store must not reload it.
+#[tokio::test]
+async fn revocation_survives_restart() {
+    let auth_dir = TempDir::new().unwrap();
+    let storage = TempDir::new().unwrap();
+    let htpasswd = auth_dir.path().join("htpasswd");
+    let tokens_db = auth_dir.path().join("tokens.db");
+
+    let config =
+        persistent_config(storage.path().to_path_buf(), htpasswd.clone(), tokens_db.clone());
+    let auth = AuthState::load(&config.auth).expect("first boot");
+    let app = router_with_auth(config.clone(), auth);
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    // Logout (revoke own token).
+    let path = format!("/-/user/token/{token}");
+    let response = app.clone().oneshot(delete_with_bearer(&path, &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    drop(app);
+    let auth = AuthState::load(&config.auth).expect("reload after restart");
+    let app = router_with_auth(config, auth);
+
+    // Token must remain revoked after restart.
+    let response = app.oneshot(get_with_bearer("/-/whoami", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}

--- a/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
+++ b/registry/crates/pnpm-registry/tests/auth_user_endpoints.rs
@@ -378,20 +378,20 @@ async fn auth_endpoints_set_private_no_cache_headers() {
         let cache_control = response
             .headers()
             .get("cache-control")
-            .map(|v| v.to_str().unwrap().to_string())
+            .map(|value| value.to_str().unwrap().to_string())
             .unwrap_or_default();
         let vary = response
             .headers()
             .get("vary")
-            .map(|v| v.to_str().unwrap().to_string())
+            .map(|value| value.to_str().unwrap().to_string())
             .unwrap_or_default();
         assert_eq!(
             cache_control, "private, no-store",
-            "{path}: cache-control must lock the response to the caller"
+            "{path}: cache-control must lock the response to the caller",
         );
         assert_eq!(
             vary, "Authorization",
-            "{path}: Vary must include Authorization so shared caches partition by credentials"
+            "{path}: Vary must include Authorization so shared caches partition by credentials",
         );
     }
 }


### PR DESCRIPTION
## Summary

Wires the five remaining auth surfaces from the [pnpr parity tracking issue](https://github.com/pnpm/pnpm/issues/11973) — everything under **Auth & user endpoints** except the pluggable-auth decision.

- `GET /-/whoami` — `{ username }` for the bearer caller, 401 anonymous.
- `GET /-/npm/v1/user` — profile shape (`name`, `tfa`, `email`, `cidr_whitelist`, `fullname`) that `npm profile get`'s table renderer parses cleanly.
- `GET /-/npm/v1/tokens` — `{ objects, urls }` listing only the caller's tokens. `key` is the SHA-256 hex digest of the raw token (matches what `npm token revoke` sends back); `token` is the 6-char preview surfaced when the original value isn't recoverable, which is what verdaccio does for the same reason.
- `DELETE /-/npm/v1/tokens/token/:key` — `npm token revoke`. Ownership-gated: 401 anonymous, 403 cross-user, 404 unknown key. Persists through the SQLite store so a restart can't resurrect a revoked token.
- `DELETE /-/user/token/:tok` — `npm logout`. Looks up by raw token, revokes by hash; same gating as the listing-side revoke.

`TokenStore` gains `find_by_key`, `list_for_user`, `revoke_by_key`, and `revoke_by_raw`; `publish::now_iso` is split so token timestamps render in the same ISO-8601 shape as `time.modified`.

## Test plan

- [x] `cargo test -p pnpm-registry` — 140 passed (16 new acceptance tests in `tests/auth_user_endpoints.rs` covering success, ownership boundaries, 401/403/404, and persistence of revocation across a restart).
- [x] `cargo clippy --all-targets --deny warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --workspace --all-targets` clean.

Closes the corresponding boxes under **Auth & user endpoints** in #11973 (everything except the pluggable-auth decision, which is left out per the issue's "decision required" note).

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm-compatible user and token endpoints: whoami, user profile, token listing, token revoke, and logout.
  * Improved token management: lookup, per-user enumeration, and revocation that operate in-memory and with optional persistent storage.
  * Unified timestamp formatting for token created/updated fields to consistent ISO-8601 millisecond precision.
  * Auth endpoints now set Cache-Control: private, no-store and Vary: Authorization.

* **Tests**
  * Added acceptance tests for auth endpoints, token operations, ownership checks, caching/privacy headers, and persistence across restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->