### PR TITLE
fix: hang on cyclic aliased peer dependency

### DIFF
--- a/.changeset/fix-cyclic-aliased-peer-hang.md
+++ b/.changeset/fix-cyclic-aliased-peer-hang.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fix pnpm hanging during peer resolution when an aliased install pulls in transitive packages with mutual peer cycles at different depths in the dependency tree (for example, `pnpm i nuxt@npm:nuxt-nightly@5x`). Cycles whose members hit the `findHit` cache instead of running their own `calculateDepPath` are now short-circuited by sibling resolutions at the level where the cycle is detected, so the cached path promises no longer deadlock. [#11999](https://github.com/pnpm/pnpm/issues/11999).

--- a/installing/deps-installer/test/install/cyclicPeerDeterminism.ts
+++ b/installing/deps-installer/test/install/cyclicPeerDeterminism.ts
@@ -116,3 +116,106 @@ test('cyclic transitive peer dependencies resolve deterministically across insta
     expect(subsequent).toEqual(first)
   }
 })
+
+// Regression test for https://github.com/pnpm/pnpm/issues/11999.
+//
+// An aliased install (`a@npm:a-real`) pulls in two siblings `b` and `c` that
+// each bring a transitive package — `x` under `b`, `y` under `c` — declaring
+// each other as peer dependencies. Both `x` and `y` are auto-installed at the
+// importer root via the missing-peer hoist. The aliased install also yields a
+// transitive peer back to `a`. The deep instances of `x` and `y` populate the
+// peersCache during `a`'s subtree walk, so the auto-installed top-level
+// instances hit findHit instead of running their own calculateDepPath. The
+// cycle between `x` and `y` is detected at the project root level but does
+// not include the root alias `a`, so awaiting it must not deadlock.
+test('aliased install with a transitive mutual-peer cycle should not hang', async () => {
+  const rootProject = prepareEmpty()
+  const lockfileDir = rootProject.dir()
+
+  const aRealName = '@pnpm.e2e/aliased-cycle-a-real'
+  const bRealName = '@pnpm.e2e/aliased-cycle-b-real'
+  const cRealName = '@pnpm.e2e/aliased-cycle-c-real'
+  const xName = '@pnpm.e2e/aliased-cycle-x'
+  const yName = '@pnpm.e2e/aliased-cycle-y'
+
+  const manifest: ProjectManifest = {
+    name: 'root',
+    dependencies: {
+      a: `npm:${aRealName}@1.0.0`,
+    },
+  }
+  const allProjects: ProjectOptions[] = [{
+    buildIndex: 0,
+    manifest,
+    rootDir: lockfileDir as ProjectRootDir,
+  }]
+  const options = {
+    ...testDefaults(
+      { allProjects, autoInstallPeers: true, forceFullResolution: true },
+      { retry: { retries: 0 } }
+    ),
+    lockfileDir,
+    lockfileOnly: true,
+  } satisfies MutateModulesOptions
+
+  const installProjects: MutatedProject[] = [{
+    mutation: 'install',
+    rootDir: lockfileDir as ProjectRootDir,
+  }]
+
+  const registryUrl = options.registries.default.replace(/\/$/, '')
+
+  function makeMeta (name: string, deps: Record<string, string>, peerDeps: Record<string, string>): PackageMeta {
+    return {
+      name,
+      versions: {
+        '1.0.0': {
+          name,
+          version: '1.0.0',
+          dependencies: deps,
+          peerDependencies: peerDeps,
+          dist: {
+            shasum: '0000000000000000000000000000000000000000',
+            tarball: `${options.registries.default}/${encodeURIComponent(name)}-1.0.0.tgz`,
+          },
+        },
+      },
+      'dist-tags': { latest: '1.0.0' },
+    }
+  }
+
+  const metaByName = {
+    [aRealName]: makeMeta(aRealName, {
+      b: `npm:${bRealName}@1.0.0`,
+      c: `npm:${cRealName}@1.0.0`,
+    }, {}),
+    [bRealName]: makeMeta(bRealName, {
+      [xName]: '1.0.0',
+    }, {
+      a: `npm:${aRealName}@1.0.0`,
+    }),
+    [cRealName]: makeMeta(cRealName, {
+      [yName]: '1.0.0',
+    }, {
+      a: `npm:${aRealName}@1.0.0`,
+    }),
+    [xName]: makeMeta(xName, {}, {
+      [yName]: '1.0.0',
+    }),
+    [yName]: makeMeta(yName, {}, {
+      [xName]: '1.0.0',
+    }),
+  }
+
+  await setupMockAgent()
+  const agent = getMockAgent().get(registryUrl)
+  for (const [name, meta] of Object.entries(metaByName)) {
+    agent.intercept({ path: `/${name.replaceAll('/', '%2F')}`, method: 'GET' }).reply(200, meta).persist()
+  }
+
+  options.storeController.clearResolutionCache()
+  await mutateModules(installProjects, options)
+
+  const lockfile = rootProject.readLockfile()
+  expect(lockfile.importers?.['.']?.dependencies?.a?.version).toContain(`${aRealName}@1.0.0`)
+})

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -555,9 +555,16 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     pendingPeerNodes: PendingPeer[],
     cycles: string[][]
   ): Promise<void> {
-    const cyclicPeerAliases = new Set()
+    const cyclicPeerAliases = new Set<string>()
+    const pendingPeerAliases = new Set(pendingPeerNodes.map((p) => p.alias))
     for (const cycle of cycles) {
-      if (cycle.includes(currentAlias)) {
+      // A cycle has to be short-circuited at this level whenever any of
+      // its members is involved in the current resolution — either as
+      // currentAlias or among the pending peers we are about to await.
+      // When a cycle member hits the `findHit` cache instead of running
+      // its own calculateDepPath, only the awaiting siblings at this
+      // level can release the cached promise. See pnpm/pnpm#11999.
+      if (cycle.includes(currentAlias) || cycle.some((alias) => pendingPeerAliases.has(alias))) {
         for (const peerAlias of cycle) {
           cyclicPeerAliases.add(peerAlias)
         }

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -556,7 +556,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     cycles: string[][]
   ): Promise<void> {
     const cyclicPeerAliases = new Set<string>()
-    const pendingPeerAliases = new Set(pendingPeerNodes.map((p) => p.alias))
+    const pendingPeerAliases = new Set(pendingPeerNodes.map(({ alias }) => alias))
     for (const cycle of cycles) {
       // A cycle has to be short-circuited at this level whenever any of
       // its members is involved in the current resolution — either as

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -829,3 +829,151 @@ async fn catalog_misconfiguration_surfaces_pnpm_error_code() {
         other => panic!("expected CatalogMisconfiguration, got {other:?}"),
     }
 }
+
+/// Build a [`ResolveResult`] for an `npm:`-aliased install. `local_alias`
+/// is the alias the importer uses in `node_modules/` (and in
+/// `parentPkgs`); `real_name`/`version` identify the resolved package.
+/// Mirrors the real npm-resolver's behaviour at
+/// [`npm_resolver.rs:288`](https://github.com/pnpm/pnpm/blob/2a0032edc0/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs#L288):
+/// the result carries the local alias, while `name_ver` and `id` point
+/// at the underlying package.
+fn aliased_fake_result(
+    local_alias: &str,
+    real_name: &str,
+    version: &str,
+    manifest: serde_json::Value,
+) -> ResolveResult {
+    let mut result = fake_result(real_name, version, manifest);
+    result.alias = Some(local_alias.to_string());
+    result
+}
+
+/// Regression test for <https://github.com/pnpm/pnpm/issues/11999>.
+///
+/// The TypeScript fix (`installing/deps-resolver/src/resolvePeers.ts`)
+/// broadens which cycles `calculateDepPath` short-circuits. Pacquet's
+/// `resolve_peers` walks synchronously with an `in_progress` set, so
+/// the deadlock that hit pnpm does not occur here — but the scenario
+/// has to keep terminating with a graph entry for the aliased root and
+/// for each pair of mutually-peer-depending leaves.
+///
+/// Layout (from the upstream bug): an aliased install `a@npm:a-real`
+/// pulls in `b-real` and `c-real`. Each of those depends on one half
+/// of a mutual-peer pair (`x` ↔ `y`) and peer-depends on the aliased
+/// root (`a@npm:a-real`). The hoist loop auto-installs `x` and `y` at
+/// the importer level, where their cycle surfaces.
+#[tokio::test]
+async fn aliased_install_with_transitive_mutual_peer_cycle_terminates() {
+    let mut table = HashMap::new();
+    // Root install: `a@npm:a-real@1.0.0`.
+    table.insert(
+        ("a".to_string(), "npm:a-real@1.0.0".to_string()),
+        aliased_fake_result(
+            "a",
+            "a-real",
+            "1.0.0",
+            serde_json::json!({
+                "name": "a-real",
+                "version": "1.0.0",
+                "dependencies": {
+                    "b": "npm:b-real@1.0.0",
+                    "c": "npm:c-real@1.0.0",
+                },
+            }),
+        ),
+    );
+    // `b@npm:b-real@1.0.0`: depends on `x`, peer-depends on the aliased
+    // root.
+    table.insert(
+        ("b".to_string(), "npm:b-real@1.0.0".to_string()),
+        aliased_fake_result(
+            "b",
+            "b-real",
+            "1.0.0",
+            serde_json::json!({
+                "name": "b-real",
+                "version": "1.0.0",
+                "dependencies": { "x": "1.0.0" },
+                "peerDependencies": { "a": "npm:a-real@1.0.0" },
+            }),
+        ),
+    );
+    // `c@npm:c-real@1.0.0`: depends on `y`, peer-depends on the aliased
+    // root.
+    table.insert(
+        ("c".to_string(), "npm:c-real@1.0.0".to_string()),
+        aliased_fake_result(
+            "c",
+            "c-real",
+            "1.0.0",
+            serde_json::json!({
+                "name": "c-real",
+                "version": "1.0.0",
+                "dependencies": { "y": "1.0.0" },
+                "peerDependencies": { "a": "npm:a-real@1.0.0" },
+            }),
+        ),
+    );
+    // `x` ↔ `y` mutual peer cycle.
+    table.insert(
+        ("x".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "x",
+            "1.0.0",
+            serde_json::json!({
+                "name": "x",
+                "version": "1.0.0",
+                "peerDependencies": { "y": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("y".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "y",
+            "1.0.0",
+            serde_json::json!({
+                "name": "y",
+                "version": "1.0.0",
+                "peerDependencies": { "x": "1.0.0" },
+            }),
+        ),
+    );
+
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "a": "npm:a-real@1.0.0" }));
+
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], default_opts())
+        .await
+        .unwrap();
+
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert!(direct.contains(&"a"), "aliased root must surface as a direct dep: {direct:?}");
+    assert!(direct.contains(&"x"), "missing peer x must be auto-installed: {direct:?}");
+    assert!(direct.contains(&"y"), "missing peer y must be auto-installed: {direct:?}");
+
+    // The aliased root's dep path resolves to the real package id.
+    let a_dep_path = result
+        .peers_result
+        .direct_dependencies_by_alias
+        .get("a")
+        .expect("alias `a` must be in the result")
+        .to_string();
+    assert!(
+        a_dep_path.starts_with("a-real@1.0.0"),
+        "aliased dep path must start with the real package id, got {a_dep_path}",
+    );
+
+    // Both mutually-peer-depending leaves land in the graph.
+    let dep_paths: std::collections::HashSet<String> =
+        result.peers_result.graph.keys().map(ToString::to_string).collect();
+    assert!(
+        dep_paths.iter().any(|dp| dp.starts_with("x@1.0.0")),
+        "x must appear in the graph: {dep_paths:?}",
+    );
+    assert!(
+        dep_paths.iter().any(|dp| dp.starts_with("y@1.0.0")),
+        "y must appear in the graph: {dep_paths:?}",
+    );
+}


### PR DESCRIPTION
## Summary

- `pnpm i nuxt@npm:nuxt-nightly@5x` (and similar aliased installs) hung at 0% CPU during peer resolution after `resolved N, reused 0, downloaded N, added 0`.
- `resolvePeers.calculateDepPath` only short-circuited cycles whose members included `currentAlias`. When two peers form a mutual cycle (e.g. `vite` ↔ `@vitejs/devtools`) and both hit the `findHit` cache instead of running their own `calculateDepPath`, the cycle surfaced at a level where no participant could break it — a sibling's `calculateDepPath` saw the cycle in the `cycles` argument but kept awaiting `pathsByNodeIdPromises` on cyclic peer node IDs.
- The fix expands `cyclicPeerAliases` to also include any cycle that intersects the current call's pending peers, so awaiting siblings emit the `name@version` peer id and the cached promise gets released.
- Pacquet's `resolve_peers` walks synchronously with an `in_progress` set and returns already-realized `DepPath` values from `find_hit`, so the deadlock does not occur there. A pacquet regression test locks in that the aliased-install + transitive-mutual-peer scenario terminates with the expected graph entries.

Closes #11999.

## Test plan

- [x] New regression test `aliased install with a transitive mutual-peer cycle should not hang` in `cyclicPeerDeterminism.ts` — verified to fail with a 15 s timeout without the pnpm-side fix and to pass with it.
- [x] New pacquet regression test `aliased_install_with_transitive_mutual_peer_cycle_terminates` in `pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs` — exercises the same shape against `resolve_importer` and asserts the aliased root + auto-installed peers + leaf graph entries.
- [x] `pnpm i nuxt@npm:nuxt-nightly@5x` completes in ~2 s instead of hanging.
- [x] `pnpm i nuxt-nightly@5x` (the un-aliased baseline) still completes in ~2 s.
- [x] `pacquet install` of the same `nuxt@npm:nuxt-nightly@5x` package.json completes successfully.
- [x] All 93 tests in `@pnpm/installing.deps-resolver` pass.
- [x] All 61 tests in `pacquet-resolving-deps-resolver` pass (incl. the new regression test).
- [x] All 67 enabled tests in `installing/deps-installer/test/install/peerDependencies.ts` pass.
- [x] `cyclicPeerDeterminism.ts`, `deepRecursive.ts`, and `install should not hang on circular peer dependencies` in `misc.ts` all pass.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a hang during peer dependency resolution for aliased installs that create transitive mutual peer cycles by short‑circuiting cyclic sibling resolutions to avoid deadlocks (regression for issue `#11999`).
* **Tests**
  * Added regression tests to verify installs and peer resolution complete correctly for aliased packages involved in mutual peer cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->