### PR TITLE
fix: retry pacquet metadata fetches with a shared, config-driven retry policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3005,7 +3006,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "smart-default",
  "ssri",
  "tar",
  "tempfile",

--- a/pacquet/crates/network/Cargo.toml
+++ b/pacquet/crates/network/Cargo.toml
@@ -15,7 +15,8 @@ derive_more = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
 reqwest     = { workspace = true }
-tokio       = { workspace = true }
+tokio       = { workspace = true, features = ["time"] }
+tracing     = { workspace = true }
 
 [dev-dependencies]
 mockito           = { workspace = true }

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -1,11 +1,13 @@
 mod auth;
 mod proxy;
+mod retry;
 #[cfg(test)]
 mod tests;
 mod tls;
 
 pub use auth::{AuthHeaders, base64_encode, nerf_dart};
 pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
+pub use retry::{RetryOpts, send_with_retry, should_retry_status};
 pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use proxy::{NoProxyMatcher, parse_proxy_url, strip_userinfo};

--- a/pacquet/crates/network/src/retry.rs
+++ b/pacquet/crates/network/src/retry.rs
@@ -1,0 +1,171 @@
+//! Shared request-retry policy for registry network access.
+//!
+//! pnpm wraps every registry request — metadata *and* tarball — in
+//! `@zkochan/retry` with one [`RetryTimeoutOptions`] budget sourced
+//! from the `fetch-retries` family
+//! ([`network/fetch/src/fetch.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetch.ts)).
+//! This module is pacquet's single home for that budget and its
+//! exponential-backoff math, so the metadata fetchers, pnpr's upstream
+//! proxy, and the tarball downloader all share one [`RetryOpts`] type
+//! and one algorithm.
+//!
+//! [`send_with_retry`] is the one-HTTP-round-trip helper the metadata
+//! fetchers and pnpr use. The tarball path keeps its own loop — its
+//! retry boundary wraps the whole fetch + integrity + decode + extract
+//! pipeline, not just a single request — but reuses [`RetryOpts`].
+//!
+//! [`RetryTimeoutOptions`]: https://github.com/pnpm/pnpm/blob/1819226b51/network/fetch/src/fetch.ts
+
+use std::time::Duration;
+
+use reqwest::{Client, RequestBuilder, Response, StatusCode};
+
+use crate::{ThrottledClient, ThrottledClientGuard};
+
+/// Settings for the per-request retry loop. Mirrors pnpm's
+/// `fetch-retries` / `fetch-retry-factor` / `fetch-retry-mintimeout` /
+/// `fetch-retry-maxtimeout` and the `@zkochan/retry` algorithm pnpm
+/// uses in `network/fetch/src/fetch.ts`:
+///
+/// `delay = min(min_timeout * factor.pow(attempt), max_timeout)`
+///
+/// `attempt` is zero-indexed, so the first post-failure wait is
+/// `min_timeout`. `retries` is the number of *retries* — total
+/// attempts is `retries + 1`.
+///
+/// # Pathological configurations
+///
+/// We don't sanitize these here because pnpm doesn't either — the
+/// config plumbing is meant to be byte-equivalent to upstream. The
+/// total number of attempts is always bounded by `retries`, so even a
+/// degenerate `delay_for` only removes the backoff:
+///
+/// * `factor == 0` keeps the first wait at `min_timeout` (`0u32.pow(0)
+///   == 1`), but every subsequent wait is `0` — i.e. no backoff
+///   between retries. Same as pnpm.
+/// * `factor == 1` waits `min_timeout` between every attempt. Same as
+///   pnpm.
+/// * `max_timeout < min_timeout` makes every wait `max_timeout`. Same
+///   as pnpm.
+///
+/// If a caller wants stricter validation (warn / reject these configs),
+/// it belongs above the `Config` boundary, alongside any other npmrc
+/// sanity checks pnpm grows over time.
+///
+/// Defaults match pnpm's
+/// [`config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/config/reader/src/index.ts#L146-L149)
+/// (2 retries, factor 10, 10 s floor, 60 s cap).
+#[derive(Debug, Clone, Copy)]
+pub struct RetryOpts {
+    pub retries: u32,
+    pub factor: u32,
+    pub min_timeout: Duration,
+    pub max_timeout: Duration,
+}
+
+impl Default for RetryOpts {
+    fn default() -> Self {
+        Self {
+            retries: 2,
+            factor: 10,
+            min_timeout: Duration::from_millis(10_000),
+            max_timeout: Duration::from_millis(60_000),
+        }
+    }
+}
+
+impl RetryOpts {
+    /// Backoff to wait before the `(attempt + 1)`-th attempt, where
+    /// `attempt` is the zero-indexed number of failures so far. Matches
+    /// `@zkochan/retry`'s formula with `randomize: false`.
+    pub fn delay_for(self, attempt: u32) -> Duration {
+        // `Duration::as_millis` returns `u128` because a `Duration` can
+        // hold values that overflow `u64` milliseconds, but
+        // `Duration::from_millis` only takes `u64`. Saturate on the way
+        // down so a pathological caller-supplied timeout produces the
+        // largest expressible delay rather than a silently truncated
+        // one.
+        let min_ms = u64::try_from(self.min_timeout.as_millis()).unwrap_or(u64::MAX);
+        let max_ms = u64::try_from(self.max_timeout.as_millis()).unwrap_or(u64::MAX);
+        let pow = u64::from(self.factor).checked_pow(attempt).unwrap_or(u64::MAX);
+        Duration::from_millis(min_ms.saturating_mul(pow).min(max_ms))
+    }
+}
+
+/// Registry responses worth retrying: request timeout (408), too many
+/// requests (429), and any 5xx. Matches the retryable set
+/// `make-fetch-happen` applies under pnpm's metadata fetch.
+pub fn should_retry_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+/// Issue the request built by `build_request` against `url`, retrying
+/// transport errors and retryable responses ([`should_retry_status`])
+/// under `retry_opts`'s exponential backoff.
+///
+/// Returns the final [`Response`] of *any* status — including 304, 404,
+/// and non-retryable 4xx — paired with the [`ThrottledClientGuard`]
+/// whose permit was held for the winning attempt. The caller inspects
+/// the status (`error_for_status`, 304/404 short-circuits, ...) and keeps
+/// the guard alive through body streaming; dropping it earlier would
+/// stop the semaphore from bounding the real concurrent socket count
+/// (see [`ThrottledClientGuard`]).
+///
+/// The network permit is acquired once per attempt *inside* the loop,
+/// and both the response and its guard are dropped before each backoff
+/// sleep, so a flapping registry never pins a socket or parks a
+/// concurrency permit during the wait.
+pub async fn send_with_retry<'client>(
+    http_client: &'client ThrottledClient,
+    url: &str,
+    retry_opts: RetryOpts,
+    mut build_request: impl FnMut(&Client) -> RequestBuilder,
+) -> Result<(ThrottledClientGuard<'client>, Response), reqwest::Error> {
+    let mut attempt = 0;
+    loop {
+        let client = http_client.acquire_for_url(url).await;
+        match build_request(&client).send().await {
+            Ok(response)
+                if should_retry_status(response.status()) && attempt < retry_opts.retries =>
+            {
+                let status = response.status();
+                drop(response);
+                drop(client);
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_network::retry",
+                    url,
+                    ?status,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Request failed; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Ok(response) => return Ok((client, response)),
+            Err(error) if attempt < retry_opts.retries => {
+                drop(client);
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_network::retry",
+                    url,
+                    ?error,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Request errored; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/network/src/retry/tests.rs
+++ b/pacquet/crates/network/src/retry/tests.rs
@@ -1,0 +1,56 @@
+use std::time::Duration;
+
+use reqwest::StatusCode;
+
+use super::{RetryOpts, should_retry_status};
+
+#[test]
+fn default_matches_pnpm_fetch_retries() {
+    let opts = RetryOpts::default();
+    assert_eq!(opts.retries, 2);
+    assert_eq!(opts.factor, 10);
+    assert_eq!(opts.min_timeout, Duration::from_millis(10_000));
+    assert_eq!(opts.max_timeout, Duration::from_millis(60_000));
+}
+
+#[test]
+fn delay_for_grows_exponentially_then_caps_at_max() {
+    let opts = RetryOpts {
+        retries: 5,
+        factor: 10,
+        min_timeout: Duration::from_millis(1_000),
+        max_timeout: Duration::from_millis(60_000),
+    };
+    assert_eq!(opts.delay_for(0), Duration::from_millis(1_000), "first wait is min_timeout");
+    assert_eq!(opts.delay_for(1), Duration::from_millis(10_000), "min * factor^1");
+    // min * factor^2 = 100_000 ms, capped to max_timeout.
+    assert_eq!(opts.delay_for(2), Duration::from_millis(60_000), "capped at max_timeout");
+}
+
+#[test]
+fn delay_for_saturates_instead_of_overflowing() {
+    let opts = RetryOpts {
+        retries: 100,
+        factor: 10,
+        min_timeout: Duration::from_millis(1),
+        max_timeout: Duration::from_millis(u64::MAX),
+    };
+    // factor.pow(50) overflows u64; saturate to the largest expressible
+    // delay rather than wrapping or panicking.
+    assert_eq!(opts.delay_for(50), Duration::from_millis(u64::MAX));
+}
+
+#[test]
+fn retryable_statuses_match_pnpm() {
+    assert!(should_retry_status(StatusCode::REQUEST_TIMEOUT)); // 408
+    assert!(should_retry_status(StatusCode::TOO_MANY_REQUESTS)); // 429
+    assert!(should_retry_status(StatusCode::INTERNAL_SERVER_ERROR)); // 500
+    assert!(should_retry_status(StatusCode::BAD_GATEWAY)); // 502
+    assert!(should_retry_status(StatusCode::SERVICE_UNAVAILABLE)); // 503
+
+    assert!(!should_retry_status(StatusCode::OK)); // 200
+    assert!(!should_retry_status(StatusCode::NOT_MODIFIED)); // 304
+    assert!(!should_retry_status(StatusCode::UNAUTHORIZED)); // 401
+    assert!(!should_retry_status(StatusCode::FORBIDDEN)); // 403
+    assert!(!should_retry_status(StatusCode::NOT_FOUND)); // 404
+}

--- a/pacquet/crates/package-manager/src/build_resolution_verifiers.rs
+++ b/pacquet/crates/package-manager/src/build_resolution_verifiers.rs
@@ -29,6 +29,8 @@ use pacquet_resolving_npm_resolver::{
 };
 use pacquet_resolving_resolver_base::ResolutionVerifier;
 
+use crate::retry_config::retry_opts_from_config;
+
 /// Error from [`build_resolution_verifiers`]. Today the only thing
 /// that can fail is `create_package_version_policy` rejecting an
 /// invalid `minimumReleaseAgeExclude` / `trustPolicyExclude`
@@ -120,6 +122,7 @@ pub fn build_resolution_verifiers(
         auth_headers: Arc::clone(&config.auth_headers),
         cache_dir: Some(config.cache_dir.clone()),
         meta_cache,
+        retry_opts: retry_opts_from_config(config),
         now: None,
     };
 

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -1,7 +1,7 @@
 use super::{InstallPackageFromRegistry, InstallPackageFromRegistryError};
 use pacquet_config::Config;
 use pacquet_lockfile::{LockfileResolution, TarballResolution};
-use pacquet_network::ThrottledClient;
+use pacquet_network::{RetryOpts, ThrottledClient};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter, SilentReporter};
 use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, NpmResolver, shared_packument_fetch_locker,
@@ -138,6 +138,7 @@ async fn resolve_via_mock(
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
     let wanted = WantedDependency {
         alias: Some(alias.to_string()),

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -548,6 +548,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             // demand it. Mirrors upstream's
             // [`fullMetadata`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/store/connection-manager/src/createNewStoreController.ts#L69-L74).
             full_metadata,
+            retry_opts: crate::retry_config::retry_opts_from_config(config),
         });
         let git_resolver = GitResolver::new(
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
@@ -629,6 +630,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             ignore_missing_time_field: config.minimum_release_age_ignore_missing_time,
             // Same rationale as `NpmResolver.full_metadata` above.
             full_metadata,
+            retry_opts: crate::retry_config::retry_opts_from_config(config),
         };
         // Order mirrors upstream's chain at
         // <https://github.com/pnpm/pnpm/blob/1627943d2a/resolving/default-resolver/src/index.ts#L128-L147>:

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -25,7 +25,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 use chrono::{DateTime, Utc};
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName};
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Approver, NpmUser, Package, PackageDistribution, PackageVersion};
 use pacquet_resolving_resolver_base::{
     ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture,
@@ -106,6 +106,10 @@ pub struct CreateNpmResolutionVerifierOptions {
     /// unit tests don't have a resolver running alongside, in which
     /// case the verifier falls back to its own fetch chain.
     pub meta_cache: Option<Arc<dyn PackageMetaCache>>,
+    /// Retry budget for the verifier's metadata and attestation
+    /// fetches. Sourced from the same `fetch-retries` config the
+    /// resolver and tarball paths use.
+    pub retry_opts: RetryOpts,
     /// Override for `Utc::now()` when computing the age cutoff and
     /// the `trustPolicyIgnoreAfter` window. `None` falls back to
     /// wall-clock at construction time.
@@ -135,6 +139,7 @@ pub struct NpmResolutionVerifier {
     auth_headers: Arc<AuthHeaders>,
     cache_dir: Option<PathBuf>,
     meta_cache: Option<Arc<dyn PackageMetaCache>>,
+    retry_opts: RetryOpts,
     now: Option<DateTime<Utc>>,
     policy_snapshot: serde_json::Map<String, JsonValue>,
     lookup_context: PublishedAtLookupContext,
@@ -214,6 +219,7 @@ pub fn create_npm_resolution_verifier(
         auth_headers: opts.auth_headers,
         cache_dir: opts.cache_dir,
         meta_cache: opts.meta_cache,
+        retry_opts: opts.retry_opts,
         now: opts.now,
         policy_snapshot,
         lookup_context: PublishedAtLookupContext::new(),
@@ -641,7 +647,7 @@ impl NpmResolutionVerifier {
                     auth_headers: &self.auth_headers,
                     cache_dir: self.cache_dir.as_deref(),
                     full_metadata: false,
-                    retry_opts: Default::default(),
+                    retry_opts: self.retry_opts,
                 };
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
                     Ok(meta) => Some(project_abbreviated_meta(&meta)),
@@ -800,7 +806,7 @@ impl NpmResolutionVerifier {
             // The verifier reads `time` and trust evidence per-version,
             // both of which the abbreviated form drops. Always full.
             full_metadata: true,
-            retry_opts: Default::default(),
+            retry_opts: self.retry_opts,
         };
         fetch_full_metadata_cached(&name.to_string(), &opts).await.map_err(|err| err.to_string())
     }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -641,6 +641,7 @@ impl NpmResolutionVerifier {
                     auth_headers: &self.auth_headers,
                     cache_dir: self.cache_dir.as_deref(),
                     full_metadata: false,
+                    retry_opts: Default::default(),
                 };
                 match fetch_full_metadata_cached(&name.to_string(), &opts).await {
                     Ok(meta) => Some(project_abbreviated_meta(&meta)),
@@ -799,6 +800,7 @@ impl NpmResolutionVerifier {
             // The verifier reads `time` and trust evidence per-version,
             // both of which the abbreviated form drops. Always full.
             full_metadata: true,
+            retry_opts: Default::default(),
         };
         fetch_full_metadata_cached(&name.to_string(), &opts).await.map_err(|err| err.to_string())
     }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use chrono::{DateTime, Utc};
 use pacquet_config::{TrustPolicy, version_policy::create_package_version_policy};
 use pacquet_lockfile::{LockfileResolution, PkgName, RegistryResolution, TarballResolution};
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{ResolutionVerification, ResolutionVerifier, VerifyCtx};
 use pretty_assertions::assert_eq;
 use ssri::Integrity;
@@ -48,6 +48,10 @@ fn default_opts(registry_url: &str) -> CreateNpmResolutionVerifierOptions {
         auth_headers: Arc::new(AuthHeaders::default()),
         cache_dir: None,
         meta_cache: None,
+        // No retries: tests that point an endpoint at an unmocked /
+        // erroring upstream would otherwise wait out the full pnpm
+        // backoff (10 s + 60 s) on every run.
+        retry_opts: RetryOpts { retries: 0, ..RetryOpts::default() },
         now: None,
     }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -20,10 +20,9 @@
 //! Ports the request half of upstream's
 //! [`fetchMetadataFromFromRegistry`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetch.ts#L118-L204).
 
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, send_with_retry};
 use pacquet_registry::Package;
-use reqwest::{RequestBuilder, Response, StatusCode, header};
-use std::time::Duration;
+use reqwest::{StatusCode, header};
 
 use crate::{FetchMetadataError, registry_url::to_registry_url};
 
@@ -36,94 +35,6 @@ pub(crate) const ACCEPT_FULL_DOC: &str = "application/json; q=1.0, */*";
 /// [`ACCEPT_ABBREVIATED_DOC`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/network/fetch/src/fetchFromRegistry.ts#L15).
 pub(crate) const ACCEPT_ABBREVIATED_DOC: &str =
     "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
-
-/// Metadata fetch retry settings. Defaults match pnpm's
-/// `fetch-retries` family and the tarball path's retry policy.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct MetadataRetryOpts {
-    pub retries: u32,
-    pub factor: u32,
-    pub min_timeout: Duration,
-    pub max_timeout: Duration,
-}
-
-impl Default for MetadataRetryOpts {
-    fn default() -> Self {
-        Self {
-            retries: 2,
-            factor: 10,
-            min_timeout: Duration::from_millis(10_000),
-            max_timeout: Duration::from_millis(60_000),
-        }
-    }
-}
-
-impl MetadataRetryOpts {
-    fn delay_for(self, attempt: u32) -> Duration {
-        let min_ms = u64::try_from(self.min_timeout.as_millis()).unwrap_or(u64::MAX);
-        let max_ms = u64::try_from(self.max_timeout.as_millis()).unwrap_or(u64::MAX);
-        let pow = u64::from(self.factor).checked_pow(attempt).unwrap_or(u64::MAX);
-        Duration::from_millis(min_ms.saturating_mul(pow).min(max_ms))
-    }
-}
-
-fn should_retry_status(status: StatusCode) -> bool {
-    status == StatusCode::REQUEST_TIMEOUT
-        || status == StatusCode::TOO_MANY_REQUESTS
-        || status.is_server_error()
-}
-
-pub(crate) async fn send_metadata_request_with_retry(
-    url: &str,
-    retry_opts: MetadataRetryOpts,
-    mut build_request: impl FnMut() -> RequestBuilder,
-) -> Result<Response, FetchMetadataError> {
-    let mut attempt = 0;
-    loop {
-        match build_request().send().await {
-            Ok(response) if response.status() == StatusCode::NOT_MODIFIED => return Ok(response),
-            Ok(response)
-                if should_retry_status(response.status()) && attempt < retry_opts.retries =>
-            {
-                let status = response.status();
-                let delay = retry_opts.delay_for(attempt);
-                tracing::warn!(
-                    target: "pacquet_resolving_npm_resolver::metadata",
-                    url,
-                    ?status,
-                    attempt = attempt + 1,
-                    max_attempts = retry_opts.retries + 1,
-                    ?delay,
-                    "Metadata fetch failed; retrying after backoff",
-                );
-                tokio::time::sleep(delay).await;
-                attempt += 1;
-            }
-            Ok(response) => {
-                return response
-                    .error_for_status()
-                    .map_err(|error| FetchMetadataError::Network { url: url.to_string(), error });
-            }
-            Err(error) if attempt < retry_opts.retries => {
-                let delay = retry_opts.delay_for(attempt);
-                tracing::warn!(
-                    target: "pacquet_resolving_npm_resolver::metadata",
-                    url,
-                    ?error,
-                    attempt = attempt + 1,
-                    max_attempts = retry_opts.retries + 1,
-                    ?delay,
-                    "Metadata fetch errored; retrying after backoff",
-                );
-                tokio::time::sleep(delay).await;
-                attempt += 1;
-            }
-            Err(error) => {
-                return Err(FetchMetadataError::Network { url: url.to_string(), error });
-            }
-        }
-    }
-}
 
 /// Options bundle for [`fetch_full_metadata`]. Mirrors upstream's
 /// `FetchFullMetadataCachedOptions` minus the cache-directory field;
@@ -150,7 +61,7 @@ pub struct FetchFullMetadataOptions<'a> {
     /// the body re-download. Mirrors upstream's `modified` option at
     /// the same call site.
     pub modified: Option<&'a str>,
-    pub(crate) retry_opts: MetadataRetryOpts,
+    pub(crate) retry_opts: RetryOpts,
 }
 
 /// Outcome of a [`fetch_full_metadata`] call. Mirrors upstream's
@@ -198,8 +109,7 @@ pub async fn fetch_full_metadata(
     // path segment, not two.
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let client = opts.http_client.acquire_for_url(&url).await;
-    let response = send_metadata_request_with_retry(&url, opts.retry_opts, || {
+    let (_client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
         let mut request = client.get(&url).header(header::ACCEPT, accept);
         if let Some(value) = opts.auth_headers.for_url(&url) {
             request = request.header(header::AUTHORIZATION, value);
@@ -212,10 +122,14 @@ pub async fn fetch_full_metadata(
         }
         request
     })
-    .await?;
+    .await
+    .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
     if response.status() == StatusCode::NOT_MODIFIED {
         return Ok(FetchFullMetadataOutcome::NotModified);
     }
+    let response = response
+        .error_for_status()
+        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
     // Decode in two steps so a JSON-shape mismatch surfaces as
     // `FetchMetadataError::Decode` (with the serde_json error), not
     // as `Network` (which `.json::<T>()` would do, conflating

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -22,7 +22,8 @@
 
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_registry::Package;
-use reqwest::{StatusCode, header};
+use reqwest::{RequestBuilder, Response, StatusCode, header};
+use std::time::Duration;
 
 use crate::{FetchMetadataError, registry_url::to_registry_url};
 
@@ -35,6 +36,94 @@ pub(crate) const ACCEPT_FULL_DOC: &str = "application/json; q=1.0, */*";
 /// [`ACCEPT_ABBREVIATED_DOC`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/network/fetch/src/fetchFromRegistry.ts#L15).
 pub(crate) const ACCEPT_ABBREVIATED_DOC: &str =
     "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+
+/// Metadata fetch retry settings. Defaults match pnpm's
+/// `fetch-retries` family and the tarball path's retry policy.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MetadataRetryOpts {
+    pub retries: u32,
+    pub factor: u32,
+    pub min_timeout: Duration,
+    pub max_timeout: Duration,
+}
+
+impl Default for MetadataRetryOpts {
+    fn default() -> Self {
+        Self {
+            retries: 2,
+            factor: 10,
+            min_timeout: Duration::from_millis(10_000),
+            max_timeout: Duration::from_millis(60_000),
+        }
+    }
+}
+
+impl MetadataRetryOpts {
+    fn delay_for(self, attempt: u32) -> Duration {
+        let min_ms = u64::try_from(self.min_timeout.as_millis()).unwrap_or(u64::MAX);
+        let max_ms = u64::try_from(self.max_timeout.as_millis()).unwrap_or(u64::MAX);
+        let pow = u64::from(self.factor).checked_pow(attempt).unwrap_or(u64::MAX);
+        Duration::from_millis(min_ms.saturating_mul(pow).min(max_ms))
+    }
+}
+
+fn should_retry_status(status: StatusCode) -> bool {
+    status == StatusCode::REQUEST_TIMEOUT
+        || status == StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+}
+
+pub(crate) async fn send_metadata_request_with_retry(
+    url: &str,
+    retry_opts: MetadataRetryOpts,
+    mut build_request: impl FnMut() -> RequestBuilder,
+) -> Result<Response, FetchMetadataError> {
+    let mut attempt = 0;
+    loop {
+        match build_request().send().await {
+            Ok(response) if response.status() == StatusCode::NOT_MODIFIED => return Ok(response),
+            Ok(response)
+                if should_retry_status(response.status()) && attempt < retry_opts.retries =>
+            {
+                let status = response.status();
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_resolving_npm_resolver::metadata",
+                    url,
+                    ?status,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Metadata fetch failed; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Ok(response) => {
+                return response
+                    .error_for_status()
+                    .map_err(|error| FetchMetadataError::Network { url: url.to_string(), error });
+            }
+            Err(error) if attempt < retry_opts.retries => {
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_resolving_npm_resolver::metadata",
+                    url,
+                    ?error,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Metadata fetch errored; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => {
+                return Err(FetchMetadataError::Network { url: url.to_string(), error });
+            }
+        }
+    }
+}
 
 /// Options bundle for [`fetch_full_metadata`]. Mirrors upstream's
 /// `FetchFullMetadataCachedOptions` minus the cache-directory field;
@@ -61,6 +150,7 @@ pub struct FetchFullMetadataOptions<'a> {
     /// the body re-download. Mirrors upstream's `modified` option at
     /// the same call site.
     pub modified: Option<&'a str>,
+    pub(crate) retry_opts: MetadataRetryOpts,
 }
 
 /// Outcome of a [`fetch_full_metadata`] call. Mirrors upstream's
@@ -108,27 +198,24 @@ pub async fn fetch_full_metadata(
     // path segment, not two.
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let mut request =
-        opts.http_client.acquire_for_url(&url).await.get(&url).header(header::ACCEPT, accept);
-    if let Some(value) = opts.auth_headers.for_url(&url) {
-        request = request.header(header::AUTHORIZATION, value);
-    }
-    if let Some(etag) = opts.etag {
-        request = request.header(header::IF_NONE_MATCH, etag);
-    }
-    if let Some(modified) = opts.modified {
-        request = request.header(header::IF_MODIFIED_SINCE, modified);
-    }
-    let response = request
-        .send()
-        .await
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+    let client = opts.http_client.acquire_for_url(&url).await;
+    let response = send_metadata_request_with_retry(&url, opts.retry_opts, || {
+        let mut request = client.get(&url).header(header::ACCEPT, accept);
+        if let Some(value) = opts.auth_headers.for_url(&url) {
+            request = request.header(header::AUTHORIZATION, value);
+        }
+        if let Some(etag) = opts.etag {
+            request = request.header(header::IF_NONE_MATCH, etag);
+        }
+        if let Some(modified) = opts.modified {
+            request = request.header(header::IF_MODIFIED_SINCE, modified);
+        }
+        request
+    })
+    .await?;
     if response.status() == StatusCode::NOT_MODIFIED {
         return Ok(FetchFullMetadataOutcome::NotModified);
     }
-    let response = response
-        .error_for_status()
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
     // Decode in two steps so a JSON-shape mismatch surfaces as
     // `FetchMetadataError::Decode` (with the serde_json error), not
     // as `Network` (which `.json::<T>()` would do, conflating

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -1,9 +1,7 @@
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use std::time::Duration;
 
-use super::{
-    FetchFullMetadataOptions, FetchFullMetadataOutcome, MetadataRetryOpts, fetch_full_metadata,
-};
+use super::{FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata};
 
 /// Unwrap a [`FetchFullMetadataOutcome::Modified`], panicking on
 /// `NotModified`. Used by the success-path tests below where the
@@ -17,12 +15,12 @@ fn expect_modified(outcome: FetchFullMetadataOutcome) -> pacquet_registry::Packa
     }
 }
 
-fn no_retry_opts() -> MetadataRetryOpts {
-    MetadataRetryOpts { retries: 0, ..Default::default() }
+fn no_retry_opts() -> RetryOpts {
+    RetryOpts { retries: 0, ..Default::default() }
 }
 
-fn fast_retry_opts() -> MetadataRetryOpts {
-    MetadataRetryOpts {
+fn fast_retry_opts() -> RetryOpts {
+    RetryOpts {
         retries: 1,
         min_timeout: Duration::from_millis(1),
         max_timeout: Duration::from_millis(1),

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -1,6 +1,9 @@
 use pacquet_network::{AuthHeaders, ThrottledClient};
+use std::time::Duration;
 
-use super::{FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata};
+use super::{
+    FetchFullMetadataOptions, FetchFullMetadataOutcome, MetadataRetryOpts, fetch_full_metadata,
+};
 
 /// Unwrap a [`FetchFullMetadataOutcome::Modified`], panicking on
 /// `NotModified`. Used by the success-path tests below where the
@@ -11,6 +14,19 @@ fn expect_modified(outcome: FetchFullMetadataOutcome) -> pacquet_registry::Packa
         FetchFullMetadataOutcome::NotModified => {
             panic!("expected Modified outcome, got NotModified")
         }
+    }
+}
+
+fn no_retry_opts() -> MetadataRetryOpts {
+    MetadataRetryOpts { retries: 0, ..Default::default() }
+}
+
+fn fast_retry_opts() -> MetadataRetryOpts {
+    MetadataRetryOpts {
+        retries: 1,
+        min_timeout: Duration::from_millis(1),
+        max_timeout: Duration::from_millis(1),
+        ..Default::default()
     }
 }
 
@@ -71,6 +87,7 @@ async fn fetch_full_metadata_targets_full_endpoint_with_auth() {
         full_metadata: true,
         etag: None,
         modified: None,
+        retry_opts: no_retry_opts(),
     };
 
     let pkg =
@@ -103,6 +120,7 @@ async fn fetch_full_metadata_surfaces_5xx_as_network_error() {
         full_metadata: true,
         etag: None,
         modified: None,
+        retry_opts: no_retry_opts(),
     };
 
     let err = fetch_full_metadata("acme", &opts).await.expect_err("503 must surface");
@@ -113,6 +131,53 @@ async fn fetch_full_metadata_surfaces_5xx_as_network_error() {
     let text = format!("{err:?}");
     assert!(text.contains("acme"), "error mentions the failing URL: {text}");
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_full_metadata_retries_transient_status() {
+    let mut server = mockito::Server::new_async().await;
+    let first = server.mock("GET", "/acme").with_status(503).expect(1).create_async().await;
+    let body = r#"{
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/acme-1.0.0.tgz"
+                }
+            }
+        }
+    }"#;
+    let second = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: None,
+        retry_opts: fast_retry_opts(),
+    };
+
+    let pkg = expect_modified(fetch_full_metadata("acme", &opts).await.expect("503 retries"));
+    assert_eq!(pkg.name, "acme");
+    first.assert_async().await;
+    second.assert_async().await;
 }
 
 /// Scoped names percent-encode the `/` between the `@scope` prefix
@@ -158,6 +223,7 @@ async fn fetch_full_metadata_encodes_scoped_name() {
         full_metadata: true,
         etag: None,
         modified: None,
+        retry_opts: no_retry_opts(),
     };
 
     let pkg = expect_modified(
@@ -193,6 +259,7 @@ async fn fetch_full_metadata_surfaces_decode_failure_distinctly() {
         full_metadata: true,
         etag: None,
         modified: None,
+        retry_opts: no_retry_opts(),
     };
 
     let err = fetch_full_metadata("acme", &opts).await.expect_err("malformed JSON must surface");
@@ -233,6 +300,7 @@ async fn fetch_full_metadata_returns_not_modified_on_304() {
         full_metadata: true,
         etag: Some(r#"W/"fresh""#),
         modified: Some("Wed, 15 Jan 2025 12:00:00 GMT"),
+        retry_opts: no_retry_opts(),
     };
 
     let outcome = fetch_full_metadata("acme", &opts).await.expect("304 must succeed");

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -25,7 +25,10 @@ use reqwest::{StatusCode, header};
 
 use crate::{
     FetchMetadataError,
-    fetch_full_metadata::{ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC},
+    fetch_full_metadata::{
+        ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC, MetadataRetryOpts,
+        send_metadata_request_with_retry,
+    },
     mirror::{
         ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
         load_meta_headers_async, prepare_json_for_disk, save_meta,
@@ -56,6 +59,7 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     /// [`fetchAbbreviatedMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts#L47-L53)
     /// dispatch.
     pub full_metadata: bool,
+    pub(crate) retry_opts: MetadataRetryOpts,
 }
 
 /// Fetch the full registry metadata document for `pkg_name`, reusing
@@ -120,24 +124,23 @@ pub async fn fetch_full_metadata_cached(
 
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let mut request =
-        opts.http_client.acquire_for_url(&url).await.get(&url).header(header::ACCEPT, accept);
-    if let Some(value) = opts.auth_headers.for_url(&url) {
-        request = request.header(header::AUTHORIZATION, value);
-    }
-    if let Some(headers) = cache_headers.as_ref() {
-        if let Some(etag) = headers.etag.as_deref() {
-            request = request.header(header::IF_NONE_MATCH, etag);
+    let client = opts.http_client.acquire_for_url(&url).await;
+    let response = send_metadata_request_with_retry(&url, opts.retry_opts, || {
+        let mut request = client.get(&url).header(header::ACCEPT, accept);
+        if let Some(value) = opts.auth_headers.for_url(&url) {
+            request = request.header(header::AUTHORIZATION, value);
         }
-        if let Some(modified) = headers.modified.as_deref() {
-            request = request.header(header::IF_MODIFIED_SINCE, modified);
+        if let Some(headers) = cache_headers.as_ref() {
+            if let Some(etag) = headers.etag.as_deref() {
+                request = request.header(header::IF_NONE_MATCH, etag);
+            }
+            if let Some(modified) = headers.modified.as_deref() {
+                request = request.header(header::IF_MODIFIED_SINCE, modified);
+            }
         }
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
+        request
+    })
+    .await?;
 
     if response.status() == StatusCode::NOT_MODIFIED {
         let Some(path) = mirror_path else {
@@ -153,9 +156,6 @@ pub async fn fetch_full_metadata_cached(
         });
     }
 
-    let response = response
-        .error_for_status()
-        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
     let etag = response
         .headers()
         .get(header::ETAG)

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -18,17 +18,14 @@
 
 use std::path::Path;
 
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, send_with_retry};
 use pacquet_registry::Package;
 use pipe_trait::Pipe;
 use reqwest::{StatusCode, header};
 
 use crate::{
     FetchMetadataError,
-    fetch_full_metadata::{
-        ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC, MetadataRetryOpts,
-        send_metadata_request_with_retry,
-    },
+    fetch_full_metadata::{ACCEPT_ABBREVIATED_DOC, ACCEPT_FULL_DOC},
     mirror::{
         ABBREVIATED_META_DIR, FULL_META_DIR, get_pkg_mirror_path, load_meta_async,
         load_meta_headers_async, prepare_json_for_disk, save_meta,
@@ -59,7 +56,7 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     /// [`fetchAbbreviatedMetadataCached`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/fetchFullMetadataCached.ts#L47-L53)
     /// dispatch.
     pub full_metadata: bool,
-    pub(crate) retry_opts: MetadataRetryOpts,
+    pub(crate) retry_opts: RetryOpts,
 }
 
 /// Fetch the full registry metadata document for `pkg_name`, reusing
@@ -124,8 +121,7 @@ pub async fn fetch_full_metadata_cached(
 
     let url = to_registry_url(opts.registry, pkg_name);
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
-    let client = opts.http_client.acquire_for_url(&url).await;
-    let response = send_metadata_request_with_retry(&url, opts.retry_opts, || {
+    let (_client, response) = send_with_retry(opts.http_client, &url, opts.retry_opts, |client| {
         let mut request = client.get(&url).header(header::ACCEPT, accept);
         if let Some(value) = opts.auth_headers.for_url(&url) {
             request = request.header(header::AUTHORIZATION, value);
@@ -140,7 +136,8 @@ pub async fn fetch_full_metadata_cached(
         }
         request
     })
-    .await?;
+    .await
+    .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
 
     if response.status() == StatusCode::NOT_MODIFIED {
         let Some(path) = mirror_path else {
@@ -155,6 +152,10 @@ pub async fn fetch_full_metadata_cached(
             FetchMetadataError::CacheMissingAfter304 { pkg_name: pkg_name.to_string() }
         });
     }
+
+    let response = response
+        .error_for_status()
+        .map_err(|error| FetchMetadataError::Network { url: url.clone(), error })?;
 
     let etag = response
         .headers()

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -1,7 +1,7 @@
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use tempfile::TempDir;
 
-use super::{FetchFullMetadataCachedOptions, MetadataRetryOpts, fetch_full_metadata_cached};
+use super::{FetchFullMetadataCachedOptions, fetch_full_metadata_cached};
 use crate::mirror::{FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers};
 
 const PACKAGE_BODY: &str = r#"{
@@ -22,8 +22,8 @@ const PACKAGE_BODY: &str = r#"{
     }
 }"#;
 
-fn no_retry_opts() -> MetadataRetryOpts {
-    MetadataRetryOpts { retries: 0, ..Default::default() }
+fn no_retry_opts() -> RetryOpts {
+    RetryOpts { retries: 0, ..Default::default() }
 }
 
 /// Cold cache (no mirror file) → registry returns 200 → mirror is

--- a/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -1,7 +1,7 @@
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use tempfile::TempDir;
 
-use super::{FetchFullMetadataCachedOptions, fetch_full_metadata_cached};
+use super::{FetchFullMetadataCachedOptions, MetadataRetryOpts, fetch_full_metadata_cached};
 use crate::mirror::{FULL_META_DIR, get_pkg_mirror_path, load_meta, load_meta_headers};
 
 const PACKAGE_BODY: &str = r#"{
@@ -21,6 +21,10 @@ const PACKAGE_BODY: &str = r#"{
         }
     }
 }"#;
+
+fn no_retry_opts() -> MetadataRetryOpts {
+    MetadataRetryOpts { retries: 0, ..Default::default() }
+}
 
 /// Cold cache (no mirror file) → registry returns 200 → mirror is
 /// populated with the response body + etag.
@@ -47,6 +51,7 @@ async fn cold_cache_writes_mirror_on_200() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        retry_opts: no_retry_opts(),
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 → ok");
@@ -94,6 +99,7 @@ async fn warm_cache_serves_from_mirror_on_304() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        retry_opts: no_retry_opts(),
     };
 
     let _first_pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 populates cache");
@@ -140,6 +146,7 @@ async fn stale_cache_refreshes_mirror_on_200() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        retry_opts: no_retry_opts(),
     };
 
     let _ = fetch_full_metadata_cached("acme", &opts).await.expect("populate");
@@ -177,6 +184,7 @@ async fn no_cache_dir_skips_mirror_io() {
         auth_headers: &auth_headers,
         cache_dir: None,
         full_metadata: true,
+        retry_opts: no_retry_opts(),
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("200 → ok");
@@ -215,6 +223,7 @@ async fn read_only_cache_dir_does_not_fail_the_call() {
         auth_headers: &auth_headers,
         cache_dir: Some(cache.path()),
         full_metadata: true,
+        retry_opts: no_retry_opts(),
     };
 
     let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("read-only must not fail");

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -22,7 +22,7 @@ use std::{
     sync::Arc,
 };
 
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
     ResolveResult, Resolver, UpdateBehavior, WantedDependency,
@@ -86,6 +86,10 @@ pub struct NamedRegistryResolver<Cache: PackageMetaCache> {
     /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
     /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
     pub full_metadata: bool,
+    /// Retry budget threaded through to
+    /// [`PickPackageContext::retry_opts`]. Same `fetch-retries`-sourced
+    /// budget the sibling [`crate::NpmResolver`] uses.
+    pub retry_opts: RetryOpts,
 }
 
 impl<Cache: PackageMetaCache + 'static> Resolver for NamedRegistryResolver<Cache> {
@@ -218,6 +222,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            retry_opts: self.retry_opts,
         };
 
         let pick_result = pick_package(&ctx, spec, &pick_opts)

--- a/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use pacquet_lockfile::LockfileResolution;
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
@@ -78,6 +78,7 @@ fn build_resolver(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)
 }

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -31,7 +31,7 @@ use chrono::{DateTime, Utc};
 use node_semver::Version;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolutionPolicyViolation, ResolveError, ResolveFuture,
@@ -120,6 +120,10 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     /// [`PickPackageContext::full_metadata`]. Mirrors upstream's
     /// [`ctx.fullMetadata`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/resolving/npm-resolver/src/pickPackage.ts#L175).
     pub full_metadata: bool,
+    /// Retry budget threaded through to
+    /// [`PickPackageContext::retry_opts`]. Sourced from the install's
+    /// `fetch-retries` config.
+    pub retry_opts: RetryOpts,
 }
 
 impl<Cache: PackageMetaCache + 'static> Resolver for NpmResolver<Cache> {
@@ -384,6 +388,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             prefer_offline: self.prefer_offline,
             ignore_missing_time_field: self.ignore_missing_time_field,
             full_metadata: self.full_metadata,
+            retry_opts: self.retry_opts,
         };
 
         let pick_result = pick_package(&ctx, spec, &pick_opts)

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -7,7 +7,7 @@ use std::{
 use chrono::TimeZone;
 use pacquet_config::TrustPolicy;
 use pacquet_lockfile::LockfileResolution;
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{
     LatestQuery, ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackage,
     WorkspacePackages, WorkspacePackagesByVersion,
@@ -77,6 +77,7 @@ fn build_resolver_with_registries(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
     (resolver, cache_dir)
 }
@@ -598,6 +599,7 @@ async fn shared_manifest_cache_does_not_leak_across_registries() {
             prefer_offline: false,
             ignore_missing_time_field: false,
             full_metadata: false,
+            retry_opts: RetryOpts::default(),
         };
         (resolver, cache_dir)
     };

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -61,7 +61,7 @@ use dashmap::DashMap;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_resolver_base::VersionSelectors;
 use tokio::sync::Semaphore;
@@ -237,6 +237,11 @@ pub struct PickPackageContext<'a, Cache: PackageMetaCache> {
     /// `false`; the verifier-time fetcher sets it `true` because
     /// it needs `time` and trust evidence for every entry.
     pub full_metadata: bool,
+    /// Retry budget for the picker's metadata fetches. Sourced from
+    /// the same `fetch-retries` config the verifier and tarball paths
+    /// use, so a registry flap during a pick retries (and a user who
+    /// sets `fetch-retries=0` fails fast) exactly as in pnpm.
+    pub retry_opts: RetryOpts,
 }
 
 /// Per-call options the orchestrator threads to the picker. Mirrors
@@ -602,7 +607,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         auth_headers: ctx.auth_headers,
         cache_dir: ctx.cache_dir,
         full_metadata,
-        retry_opts: Default::default(),
+        retry_opts: ctx.retry_opts,
     };
 
     let fetch_result = fetch_full_metadata_cached(&spec.name, &fetch_opts).await;
@@ -1084,7 +1089,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         full_metadata: true,
         etag: meta.etag.as_deref(),
         modified: meta.modified.as_deref(),
-        retry_opts: Default::default(),
+        retry_opts: ctx.retry_opts,
     };
     match fetch_full_metadata(&spec.name, &fetch_opts).await? {
         FetchFullMetadataOutcome::Modified(upgraded) => {

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package.rs
@@ -602,6 +602,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         auth_headers: ctx.auth_headers,
         cache_dir: ctx.cache_dir,
         full_metadata,
+        retry_opts: Default::default(),
     };
 
     let fetch_result = fetch_full_metadata_cached(&spec.name, &fetch_opts).await;
@@ -1083,6 +1084,7 @@ async fn maybe_upgrade_abbreviated_meta_for_release_age<Cache: PackageMetaCache>
         full_metadata: true,
         etag: meta.etag.as_deref(),
         modified: meta.modified.as_deref(),
+        retry_opts: Default::default(),
     };
     match fetch_full_metadata(&spec.name, &fetch_opts).await? {
         FetchFullMetadataOutcome::Modified(upgraded) => {

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1,4 +1,4 @@
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -106,6 +106,7 @@ async fn cold_pick_fetches_and_picks_max_in_range() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -154,6 +155,7 @@ async fn warm_in_memory_cache_skips_network() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -191,6 +193,7 @@ async fn offline_with_mirror_picks_from_disk() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -221,6 +224,7 @@ async fn offline_without_mirror_errors() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let err = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -257,6 +261,7 @@ async fn version_spec_with_mirror_takes_fast_path() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
@@ -321,6 +326,7 @@ async fn version_spec_missing_in_mirror_fetches() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &version_spec("acme", "1.0.0"), &default_opts(&registry))
@@ -361,6 +367,7 @@ async fn dry_run_skips_in_memory_cache() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let mut opts = default_opts(&registry);
@@ -399,6 +406,7 @@ async fn pick_lowest_version_picks_min() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let mut opts = default_opts(&registry);
@@ -482,6 +490,7 @@ async fn in_memory_cache_does_not_leak_across_registries() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let pick_a = pick_package(&ctx, &range_spec("acme", "*"), &default_opts(&registry_a))
@@ -524,6 +533,7 @@ async fn invalid_package_name_errors_synchronously() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let err = pick_package(&ctx, &range_spec("foo/bar", "*"), &default_opts(&registry))
@@ -591,6 +601,7 @@ async fn default_pick_targets_abbreviated_endpoint_and_mirror() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
@@ -640,6 +651,7 @@ async fn optional_opt_forces_full_metadata_endpoint() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let mut opts = default_opts(&registry);
@@ -696,6 +708,7 @@ async fn cache_key_separates_abbreviated_from_full() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     // First call: default (abbreviated).
@@ -763,6 +776,7 @@ async fn published_by_triggers_upgrade_when_modified_after_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let mut opts = default_opts(&registry);
@@ -829,6 +843,7 @@ async fn published_by_skips_upgrade_when_modified_equals_cutoff() {
         prefer_offline: false,
         ignore_missing_time_field: true,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let mut opts = default_opts(&registry);
@@ -874,6 +889,7 @@ async fn published_by_exclude_skips_upgrade_for_abbreviated_meta_without_time() 
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let policy = create_package_version_policy(["acme"]).expect("policy");
@@ -956,6 +972,7 @@ async fn published_by_excluded_package_bypasses_mtime_shortcut_and_revalidates()
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let policy = create_package_version_policy(["acme"]).expect("policy");
@@ -1018,6 +1035,7 @@ async fn concurrent_picks_for_same_key_share_one_network_fetch() {
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     };
 
     let spec = range_spec("acme", "^1.0.0");

--- a/pacquet/crates/resolving-npm-resolver/tests/chain.rs
+++ b/pacquet/crates/resolving-npm-resolver/tests/chain.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use pacquet_lockfile::LockfileResolution;
-use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_local_resolver::{
     LocalPathResolver, LocalResolverContext, LocalSchemeResolver,
@@ -48,6 +48,7 @@ fn named_registry_resolver(
         prefer_offline: false,
         ignore_missing_time_field: false,
         full_metadata: false,
+        retry_opts: RetryOpts::default(),
     }
 }
 

--- a/pacquet/crates/tarball/Cargo.toml
+++ b/pacquet/crates/tarball/Cargo.toml
@@ -17,23 +17,22 @@ pacquet-network     = { workspace = true }
 pacquet-reporter    = { workspace = true }
 pacquet-store-dir   = { workspace = true }
 
-dashmap       = { workspace = true }
-derive_more   = { workspace = true }
-futures-util  = { workspace = true }
-miette        = { workspace = true }
-num_cpus      = { workspace = true }
-pipe-trait    = { workspace = true }
-rayon         = { workspace = true }
-reqwest       = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-smart-default = { workspace = true }
-ssri          = { workspace = true }
-tar           = { workspace = true }
-tokio         = { workspace = true }
-tracing       = { workspace = true }
-zip           = { workspace = true }
-zune-inflate  = { workspace = true }
+dashmap      = { workspace = true }
+derive_more  = { workspace = true }
+futures-util = { workspace = true }
+miette       = { workspace = true }
+num_cpus     = { workspace = true }
+pipe-trait   = { workspace = true }
+rayon        = { workspace = true }
+reqwest      = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+ssri         = { workspace = true }
+tar          = { workspace = true }
+tokio        = { workspace = true }
+tracing      = { workspace = true }
+zip          = { workspace = true }
+zune-inflate = { workspace = true }
 
 [dev-dependencies]
 dashmap           = { workspace = true, features = ["raw-api"] }

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -10,6 +10,7 @@ use dashmap::DashMap;
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;
 use pacquet_fs::file_mode;
+pub use pacquet_network::RetryOpts;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::{
     FetchingProgressLog, FetchingProgressMessage, LogEvent, LogLevel, ProgressLog, ProgressMessage,
@@ -21,7 +22,6 @@ use pacquet_store_dir::{
 };
 use pipe_trait::Pipe;
 use rayon::prelude::*;
-use smart_default::SmartDefault;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use tar::Archive;
 use tokio::sync::{Notify, RwLock, Semaphore};
@@ -74,72 +74,6 @@ fn walk_reqwest_chain(error: &reqwest::Error) -> String {
         error = src;
     }
     out
-}
-
-/// Settings for the per-fetch retry loop. Mirrors pnpm's
-/// `fetch-retries` / `fetch-retry-factor` /
-/// `fetch-retry-mintimeout` / `fetch-retry-maxtimeout` and the
-/// `@zkochan/retry` algorithm pnpm uses in
-/// `network/fetch/src/fetch.ts`:
-///
-/// `delay = min(min_timeout * factor.pow(attempt), max_timeout)`
-///
-/// `attempt` is zero-indexed, so the first post-failure wait is
-/// `min_timeout`. `retries` is the number of *retries* — total
-/// attempts is `retries + 1`.
-///
-/// # Pathological configurations
-///
-/// We don't sanitize these here because pnpm doesn't either —
-/// the config plumbing is meant to be byte-equivalent to upstream.
-/// The total number of attempts is always bounded by `retries`, so
-/// even a degenerate `delay_for` only removes the backoff:
-///
-/// * `factor == 0` keeps the first wait at `min_timeout` (`0u32.pow(0)
-///   == 1`), but every subsequent wait is `0` — i.e. no backoff
-///   between retries. Same as pnpm.
-/// * `factor == 1` waits `min_timeout` between every attempt. Same as
-///   pnpm.
-/// * `max_timeout < min_timeout` makes every wait `max_timeout`. Same
-///   as pnpm.
-///
-/// If a caller wants stricter validation (warn / reject these
-/// configs), it belongs above the `Config` boundary, alongside any
-/// other npmrc sanity checks pnpm grows over time.
-///
-/// Defaults (via [`SmartDefault`]) match pnpm's
-/// [`config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/1819226b51/config/reader/src/index.ts#L146-L149)
-/// (2 retries, factor 10, 10 s floor, 60 s cap).
-#[derive(Debug, Clone, Copy, SmartDefault)]
-pub struct RetryOpts {
-    #[default = 2]
-    pub retries: u32,
-    #[default = 10]
-    pub factor: u32,
-    #[default(Duration::from_millis(10_000))]
-    pub min_timeout: Duration,
-    #[default(Duration::from_millis(60_000))]
-    pub max_timeout: Duration,
-}
-
-impl RetryOpts {
-    /// Backoff to wait before the `(attempt + 1)`-th attempt, where
-    /// `attempt` is the zero-indexed number of failures so far.
-    /// Matches `@zkochan/retry`'s formula with `randomize: false`.
-    fn delay_for(self, attempt: u32) -> Duration {
-        // `Duration::as_millis` returns `u128` because a `Duration` can
-        // hold values that overflow `u64` milliseconds, but
-        // `Duration::from_millis` only takes `u64`. Saturate on the way
-        // down so a pathological caller-supplied timeout produces the
-        // largest expressible delay rather than a silently truncated one.
-        let min_ms = self.min_timeout.as_millis().pipe(u64::try_from).unwrap_or(u64::MAX);
-        let max_ms = self.max_timeout.as_millis().pipe(u64::try_from).unwrap_or(u64::MAX);
-        let factor = u64::from(self.factor);
-        let pow = factor.checked_pow(attempt).unwrap_or(u64::MAX);
-        let ms = min_ms.saturating_mul(pow);
-        let capped = ms.min(max_ms);
-        Duration::from_millis(capped)
-    }
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]


### PR DESCRIPTION
## Problem

`pacquet` metadata fetches made a single registry request, so a transient
network failure or a retryable HTTP response (`408`/`429`/`5xx`) aborted
resolution — even though the tarball path already followed pnpm's retry policy.
pnpm wraps **every** registry request, metadata and tarball, in `@zkochan/retry`
under one `fetch-retries` budget; pacquet only retried tarballs, and the
metadata retry that was added in the first cut duplicated the tarball budget and
ignored the user's config.

Fixes #11841.

## Solution

A single retry primitive now lives in `pacquet-network` and is driven by config
on the install paths, matching pnpm exactly.

- **One shared `RetryOpts`.** The retry budget (`fetch-retries` /
  `-factor` / `-mintimeout` / `-maxtimeout`) plus its exponential-backoff math
  moves into `pacquet-network`, next to `should_retry_status` and a generic
  `send_with_retry(client, url, opts, build_request) -> (guard, Response)`
  helper. `pacquet-tarball` re-exports `RetryOpts`; the metadata fetchers use
  `send_with_retry`. This removes the duplicate `MetadataRetryOpts`.
- **No parked sockets/permits during backoff.** `send_with_retry` acquires the
  network permit *per attempt* and drops the response and its guard before each
  backoff sleep, so a flapping registry can't pin sockets or hold a concurrency
  permit while it waits. On the winning attempt the guard rides out with the
  `Response` so the caller keeps the permit through body streaming.
- **Config-driven retries on every metadata path.** A config-sourced
  `RetryOpts` (via the existing `retry_opts_from_config`) is threaded through the
  resolution verifier, `NpmResolver`, `NamedRegistryResolver`, and
  `PickPackageContext`, so the metadata and verify paths honor the user's
  `fetch-retries*` settings instead of a hardcoded default — the same way the
  tarball path already did.

### Parity bug fixed

Because the verifier and resolver hardcoded the default retry budget, a `5xx`
flap on the main resolve/verify paths hung for **~70 s** (`10 s + 60 s` default
backoff) regardless of the user's `fetch-retries` setting — a user who set
`fetch-retries=0` to fail fast would still wait. Driving the budget from config
fixes this; test harnesses use a zero-retry budget so failure-path cases don't
wait out the backoff.

### Not pnpr

`pnpr` is intentionally untouched. Retry is an install-time concern: pnpr's
`/v1/install` accelerator already retries through pacquet's resolver and tarball
fetcher, while the verdaccio-style registry-**proxy** path must fail fast (and
serve stale on failure) rather than block a client request behind a 70 s
backoff. The shared `RetryOpts` re-export keeps the accelerator's existing
tarball-download retry compiling unchanged.

## Testing

- `cargo check` / `cargo clippy --workspace --all-targets -- --deny warnings`
- `cargo fmt --check`, `taplo format --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `cargo nextest run` — network, tarball, resolving-npm-resolver, pnpr, and the
  affected package-manager tests all pass with no slow cases.

---
Written by an agent (Claude Code, claude-opus-4-8).
