### PR TITLE
feat(pacquet/config): port preferWorkspacePackages setting

### DIFF
--- a/pacquet/crates/config/src/env_overlay.rs
+++ b/pacquet/crates/config/src/env_overlay.rs
@@ -143,6 +143,7 @@ impl WorkspaceSettings {
         json_field!(external_dependencies, "EXTERNAL_DEPENDENCIES");
         json_field!(dedupe_peer_dependents, "DEDUPE_PEER_DEPENDENTS");
         json_field!(dedupe_peers, "DEDUPE_PEERS");
+        json_field!(prefer_workspace_packages, "PREFER_WORKSPACE_PACKAGES");
         json_field!(strict_peer_dependencies, "STRICT_PEER_DEPENDENCIES");
         json_field!(resolve_peers_from_workspace_root, "RESOLVE_PEERS_FROM_WORKSPACE_ROOT");
         json_field!(block_exotic_subdeps, "BLOCK_EXOTIC_SUBDEPS");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -578,6 +578,16 @@ pub struct Config {
     /// [`'link-workspace-packages': false`](https://github.com/pnpm/pnpm/blob/5353fcbf01/config/reader/src/index.ts#L174).
     pub link_workspace_packages: LinkWorkspacePackages,
 
+    /// When `true`, prefer a workspace package over a registry pick
+    /// even when the registry version is newer than the workspace
+    /// one. Mirrors pnpm's
+    /// [`preferWorkspacePackages`](https://github.com/pnpm/pnpm/blob/3b62f9da31/config/reader/src/Config.ts#L191).
+    /// Consumed by the npm resolver's
+    /// [registry-pick + workspace shadow](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L550-L582).
+    /// Default `false`, matching pnpm's
+    /// [`'prefer-workspace-packages': false`](https://github.com/pnpm/pnpm/blob/a23956e3ab/config/reader/src/index.ts#L183).
+    pub prefer_workspace_packages: bool,
+
     /// Name slots reserved at the root for an external linker
     /// (the Bit CLI is the only known consumer upstream). Any
     /// dependency whose alias matches one of these names is

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -155,6 +155,7 @@ pub struct WorkspaceSettings {
     pub external_dependencies: Option<BTreeSet<String>>,
     pub dedupe_peer_dependents: Option<bool>,
     pub dedupe_peers: Option<bool>,
+    pub prefer_workspace_packages: Option<bool>,
     pub strict_peer_dependencies: Option<bool>,
     pub resolve_peers_from_workspace_root: Option<bool>,
     pub block_exotic_subdeps: Option<bool>,
@@ -412,6 +413,7 @@ impl WorkspaceSettings {
         self.link_workspace_packages = None;
         self.dedupe_peer_dependents = None;
         self.dedupe_peers = None;
+        self.prefer_workspace_packages = None;
         self.strict_peer_dependencies = None;
         self.resolve_peers_from_workspace_root = None;
         self.block_exotic_subdeps = None;
@@ -508,6 +510,7 @@ impl WorkspaceSettings {
             resolve_peers_from_workspace_root, verify_store_integrity,
             block_exotic_subdeps,
             link_workspace_packages,
+            prefer_workspace_packages,
             side_effects_cache, side_effects_cache_readonly,
             fetch_retries, fetch_retry_factor,
             fetch_retry_mintimeout, fetch_retry_maxtimeout,

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -15,6 +15,7 @@ registry: https://reg.example
 lockfile: false
 autoInstallPeers: true
 dedupePeers: true
+preferWorkspacePackages: true
 nodeLinker: hoisted
 packages:
   - packages/*
@@ -25,6 +26,7 @@ packages:
     assert_eq!(settings.lockfile, Some(false));
     assert_eq!(settings.auto_install_peers, Some(true));
     assert_eq!(settings.dedupe_peers, Some(true));
+    assert_eq!(settings.prefer_workspace_packages, Some(true));
     assert!(matches!(settings.node_linker, Some(NodeLinker::Hoisted)));
 }
 

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -859,6 +859,7 @@ async fn install_writes_workspace_state() {
     assert_eq!(settings.auto_install_peers, Some(true));
     assert_eq!(settings.dedupe_peer_dependents, Some(true));
     assert_eq!(settings.dedupe_peers, Some(false));
+    assert_eq!(settings.prefer_workspace_packages, Some(false));
     assert_eq!(settings.hoist_workspace_packages, Some(true));
     assert_eq!(settings.hoist_pattern.as_deref(), Some(&["*".to_string()][..]));
 

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -49,6 +49,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         hoist_workspace_packages: true,
         hoisting_limits: Default::default(),
         link_workspace_packages: Default::default(),
+        prefer_workspace_packages: false,
         external_dependencies: Default::default(),
         dedupe_peer_dependents: false,
         dedupe_peers: false,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -578,6 +578,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     // workspace when the names collide.
                     always_try_workspace_packages: config.link_workspace_packages
                         != LinkWorkspacePackages::Off,
+                    prefer_workspace_packages: config.prefer_workspace_packages,
                     update_checksums,
                     ..ResolveOptions::default()
                 },

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install.rs
@@ -208,6 +208,7 @@ fn settings_match(
         && recorded.optional == live.optional
         && recorded.overrides == live.overrides
         && recorded.patched_dependencies == live.patched_dependencies
+        && recorded.prefer_workspace_packages == live.prefer_workspace_packages
         && recorded.production == live.production
         && recorded.public_hoist_pattern == live.public_hoist_pattern
     // Deliberately *not* compared (tracked at pnpm/pnpm#12009 — drop
@@ -223,7 +224,6 @@ fn settings_match(
     //                                yet — separate follow-up).
     //   packageExtensions
     //   peersSuffixMaxLength
-    //   preferWorkspacePackages
     //   trustPolicy*                (same situation as minimumReleaseAge)
     //   workspacePackagePatterns    (already covered via
     //                                pnpm-workspace.yaml `packages:`)
@@ -274,6 +274,7 @@ pub(crate) fn current_settings(
             .as_ref()
             .map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()),
         patched_dependencies: config.patched_dependencies.clone(),
+        prefer_workspace_packages: Some(config.prefer_workspace_packages),
         production: Some(included.dependencies),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
         ..Default::default()

--- a/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pacquet/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -425,6 +425,48 @@ fn returns_skipped_when_dedupe_peers_drift() {
     assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
 }
 
+/// Drift in `preferWorkspacePackages` invalidates the cached state.
+/// Mirrors pnpm's per-key
+/// [`checkDepsStatus` settings walk](https://github.com/pnpm/pnpm/blob/180aee9ba5/deps/status/src/checkDepsStatus.ts#L138-L149)
+/// — the same condition the optimistic-repeat-install gate checks
+/// here.
+#[test]
+fn returns_skipped_when_prefer_workspace_packages_drift() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let manifest_path = workspace_root.join("package.json");
+    fs::write(&manifest_path, r#"{"name":"root","version":"1.0.0"}"#).unwrap();
+    let manifest = PackageManifest::from_path(manifest_path).unwrap();
+
+    let mut config = Config::new();
+    config.modules_dir = workspace_root.join("node_modules");
+    fs::create_dir_all(&config.modules_dir).unwrap();
+    config.prefer_workspace_packages = true;
+    let config = config.leak();
+
+    let mut stale_config = Config::new();
+    stale_config.modules_dir = config.modules_dir.clone();
+    stale_config.prefer_workspace_packages = false;
+    let stale_settings =
+        current_settings(&stale_config, pacquet_config::NodeLinker::Isolated, isolated_included());
+    let mut projects = BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        ProjectEntry { name: Some("root".into()), version: Some("1.0.0".into()) },
+    );
+    write_state(workspace_root, now_millis() + 60_000, stale_settings, projects);
+
+    let decision = check_optimistic_repeat_install(
+        workspace_root,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        isolated_included(),
+        &[(workspace_root.to_path_buf(), &manifest)],
+        false,
+    );
+    assert!(matches!(decision, Decision::Skipped { reason } if reason.contains("settings")));
+}
+
 /// Drift in `allowBuilds` invalidates the cached state.
 ///
 /// Ports
@@ -507,7 +549,6 @@ fn returns_up_to_date_when_state_carries_unported_pnpm_settings() {
     settings.package_extensions =
         Some(serde_json::json!({"foo": {"peerDependencies": {"bar": "*"}}}));
     settings.peers_suffix_max_length = Some(42);
-    settings.prefer_workspace_packages = Some(true);
     // `catalogs` is always ignored by pnpm itself; pacquet
     // mirrors that.
     settings.catalogs = Some(serde_json::json!({"default": {"react": "^18.0.0"}}));


### PR DESCRIPTION
## Summary

Port the [`preferWorkspacePackages`](https://pnpm.io/settings#preferworkspacepackages) setting from pnpm. When enabled, a workspace package wins over a newer registry pick during resolution. Default `false`, matching pnpm.

- **Config plumbing:** `Config.prefer_workspace_packages`, `WorkspaceSettings.prefer_workspace_packages`, `PNPM_CONFIG_PREFER_WORKSPACE_PACKAGES` env overlay, and the `clear_workspace_only_fields` / `apply_to` wiring.
- **Install pipeline:** thread `config.prefer_workspace_packages` into the `ResolveOptions` built by `install_with_fresh_lockfile`. The npm resolver's [`try_workspace_shadow`](https://github.com/pnpm/pnpm/blob/7ecaf3d5a6/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs#L454-L491) already consumes this flag, mirroring pnpm's [registry-pick + workspace shadow](https://github.com/pnpm/pnpm/blob/5353fcbf01/resolving/npm-resolver/src/index.ts#L550-L582).
- **Optimistic-repeat-install drift:** `WorkspaceStateSettings.prefer_workspace_packages` is now compared by `settings_match` and written by `current_settings`. A switch to the setting between installs invalidates the cached-modules fast path.

Closes one of the items on #12009.

## Test plan

Ported / extended from upstream pnpm:

- [x] Extended `parses_common_settings_from_yaml` to assert `preferWorkspacePackages: true` round-trips from `pnpm-workspace.yaml`.
- [x] `returns_skipped_when_prefer_workspace_packages_drift` in the optimistic-repeat-install drift suite — mirrors pnpm's per-key [`checkDepsStatus` settings walk](https://github.com/pnpm/pnpm/blob/180aee9ba5/deps/status/src/checkDepsStatus.ts#L138-L149) and matches the `dedupe_peers` drift test added in #12022.
- [x] `current_settings` test asserts `prefer_workspace_packages: Some(false)` is now written to `WorkspaceStateSettings`.
- [x] `returns_up_to_date_when_state_carries_unported_pnpm_settings` no longer overrides `prefer_workspace_packages` — it is now a ported setting and the drift gate must honor it.

Resolver behavior was already covered by `prefer_workspace_packages_keeps_workspace_over_newer_registry` (ports the upstream npm-resolver test); this PR makes the flag actually reachable from end-user configuration.

Local checks:

- [x] `cargo check --workspace --all-targets`, `cargo clippy --locked --workspace --all-targets -- --deny warnings`, `cargo fmt --check`, `taplo format --check`, `typos pacquet/` all clean.
- [x] `pacquet-config` (230 tests), `pacquet-package-manager` (341 tests), and the relevant `pacquet-resolving-npm-resolver` test pass locally.

---
Written by an agent (Claude Code, claude-opus-4-7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `prefer_workspace_packages` configuration option, allowing users to control whether workspace packages are preferred over registry packages during dependency resolution. This setting can be configured via environment variables, workspace configuration files, or global settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->