### PR TITLE
feat(registry): add logging support for requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,6 +3055,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "getrandom 0.3.4",
+ "home",
  "indexmap",
  "miette 7.6.0",
  "mockito",
@@ -4269,6 +4270,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4278,12 +4289,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "libc",
  "miette 7.6.0",
  "node-semver",
+ "pacquet-config-dir",
  "pacquet-env-replace",
  "pacquet-network",
  "pacquet-package-is-installable",
@@ -2185,6 +2186,10 @@ dependencies = [
  "tempfile",
  "tracing",
 ]
+
+[[package]]
+name = "pacquet-config-dir"
+version = "0.0.1"
 
 [[package]]
 name = "pacquet-config-parse-overrides"
@@ -3059,6 +3064,7 @@ dependencies = [
  "indexmap",
  "miette 7.6.0",
  "mockito",
+ "pacquet-config-dir",
  "pacquet-env-replace",
  "pacquet-network",
  "pipe-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ pacquet-lockfile-verification             = { path = "pacquet/crates/lockfile-ve
 pacquet-modules-yaml                      = { path = "pacquet/crates/modules-yaml" }
 pacquet-network                           = { path = "pacquet/crates/network" }
 pacquet-config                            = { path = "pacquet/crates/config" }
+pacquet-config-dir                        = { path = "pacquet/crates/config-dir" }
 pacquet-config-parse-overrides            = { path = "pacquet/crates/config-parse-overrides" }
 pacquet-executor                          = { path = "pacquet/crates/executor" }
 pacquet-exportable-manifest               = { path = "pacquet/crates/exportable-manifest" }

--- a/pacquet/crates/config-dir/Cargo.toml
+++ b/pacquet/crates/config-dir/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name                  = "pacquet-config-dir"
+version               = "0.0.1"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/pacquet/crates/config-dir/src/lib.rs
+++ b/pacquet/crates/config-dir/src/lib.rs
@@ -66,7 +66,7 @@ mod tests {
         for os in ["linux", "macos", "windows"] {
             // The home thunk panics: the XDG branch must short-circuit
             // before it is ever called.
-            let dir = config_dir("pnpm", os, Some("/srv/xdg"), Some("C:\\LocalAppData"), || {
+            let dir = config_dir("pnpm", os, Some("/srv/xdg"), Some(r"C:\LocalAppData"), || {
                 unreachable!("home must not be consulted when XDG_CONFIG_HOME is set")
             });
             assert_eq!(dir, Some(PathBuf::from("/srv/xdg").join("pnpm")), "{os}");
@@ -94,33 +94,20 @@ mod tests {
             "pnpm",
             "windows",
             None,
-            Some("C:\\Users\\u\\AppData\\Local"),
-            home("C:\\Users\\u"),
+            Some(r"C:\Users\u\AppData\Local"),
+            home(r"C:\Users\u"),
         );
-        assert_eq!(
-            dir,
-            Some(Path::new("C:\\Users\\u\\AppData\\Local").join("pnpm").join("config"))
-        );
+        assert_eq!(dir, Some(Path::new(r"C:\Users\u\AppData\Local").join("pnpm").join("config")));
     }
 
     #[test]
     fn windows_without_local_app_data_falls_back_to_dot_config() {
-        let dir = config_dir("pnpm", "windows", None, None, home("C:\\Users\\u"));
-        assert_eq!(dir, Some(Path::new("C:\\Users\\u").join(".config").join("pnpm")));
+        let dir = config_dir("pnpm", "windows", None, None, home(r"C:\Users\u"));
+        assert_eq!(dir, Some(Path::new(r"C:\Users\u").join(".config").join("pnpm")));
     }
 
     #[test]
     fn none_when_home_missing_and_env_bypass_unset() {
         assert!(config_dir("pnpm", "linux", None, None, no_home).is_none());
-    }
-
-    #[test]
-    fn app_name_is_the_leaf_on_every_branch() {
-        assert!(
-            config_dir("pnpr", "linux", None, None, home("/home/u")).unwrap().ends_with("pnpr")
-        );
-        assert!(
-            config_dir("pnpm", "linux", None, None, home("/home/u")).unwrap().ends_with("pnpm")
-        );
     }
 }

--- a/pacquet/crates/config-dir/src/lib.rs
+++ b/pacquet/crates/config-dir/src/lib.rs
@@ -1,0 +1,126 @@
+use std::path::{Path, PathBuf};
+
+/// Resolve the directory pnpm reads its global `config.yaml` from,
+/// for an application that follows pnpm's config-dir convention under
+/// its own `app_name` leaf (`"pnpm"` for pnpm/pacquet, `"pnpr"` for
+/// the registry server).
+///
+/// Port of pnpm's
+/// [`getConfigDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L67-L86).
+/// Resolution order:
+///
+/// 1. `$XDG_CONFIG_HOME/<app_name>`;
+/// 2. Windows: `%LOCALAPPDATA%/<app_name>/config` (falling back to
+///    `~/.config/<app_name>` when `LOCALAPPDATA` is unset);
+/// 3. macOS: `~/Library/Preferences/<app_name>`;
+/// 4. other: `~/.config/<app_name>`.
+///
+/// Returns `None` only when the home directory is unavailable and the
+/// env vars that bypass it are unset — the caller treats that as "no
+/// global config."
+///
+/// `os`, the env values, and `home` are passed in rather than read
+/// from the process so callers keep their own environment seam and
+/// every branch is unit-testable without mutating process state.
+/// `os` is a [`std::env::consts::OS`] string (`"macos"`, `"windows"`,
+/// `"linux"`, ...). `home` is a thunk so the (potentially I/O-bound)
+/// home-dir lookup is skipped whenever an env var short-circuits the
+/// resolution.
+pub fn config_dir(
+    app_name: &str,
+    os: &str,
+    xdg_config_home: Option<&str>,
+    local_app_data: Option<&str>,
+    home: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(xdg_config_home) = xdg_config_home {
+        return Some(Path::new(xdg_config_home).join(app_name));
+    }
+    if os == "windows"
+        && let Some(local_app_data) = local_app_data
+    {
+        return Some(Path::new(local_app_data).join(app_name).join("config"));
+    }
+    let home = home()?;
+    Some(match os {
+        "macos" => home.join("Library").join("Preferences").join(app_name),
+        _ => home.join(".config").join(app_name),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::config_dir;
+    use std::path::{Path, PathBuf};
+
+    fn home(path: &str) -> impl FnOnce() -> Option<PathBuf> + use<'_> {
+        move || Some(PathBuf::from(path))
+    }
+
+    fn no_home() -> Option<PathBuf> {
+        None
+    }
+
+    #[test]
+    fn prefers_xdg_config_home_on_every_os_without_consulting_home() {
+        for os in ["linux", "macos", "windows"] {
+            // The home thunk panics: the XDG branch must short-circuit
+            // before it is ever called.
+            let dir = config_dir("pnpm", os, Some("/srv/xdg"), Some("C:\\LocalAppData"), || {
+                unreachable!("home must not be consulted when XDG_CONFIG_HOME is set")
+            });
+            assert_eq!(dir, Some(PathBuf::from("/srv/xdg").join("pnpm")), "{os}");
+        }
+    }
+
+    #[test]
+    fn macos_uses_library_preferences() {
+        let dir = config_dir("pnpr", "macos", None, None, home("/Users/u"));
+        assert_eq!(
+            dir,
+            Some(Path::new("/Users/u").join("Library").join("Preferences").join("pnpr")),
+        );
+    }
+
+    #[test]
+    fn linux_uses_dot_config() {
+        let dir = config_dir("pnpr", "linux", None, None, home("/home/u"));
+        assert_eq!(dir, Some(Path::new("/home/u").join(".config").join("pnpr")));
+    }
+
+    #[test]
+    fn windows_uses_local_app_data() {
+        let dir = config_dir(
+            "pnpm",
+            "windows",
+            None,
+            Some("C:\\Users\\u\\AppData\\Local"),
+            home("C:\\Users\\u"),
+        );
+        assert_eq!(
+            dir,
+            Some(Path::new("C:\\Users\\u\\AppData\\Local").join("pnpm").join("config"))
+        );
+    }
+
+    #[test]
+    fn windows_without_local_app_data_falls_back_to_dot_config() {
+        let dir = config_dir("pnpm", "windows", None, None, home("C:\\Users\\u"));
+        assert_eq!(dir, Some(Path::new("C:\\Users\\u").join(".config").join("pnpm")));
+    }
+
+    #[test]
+    fn none_when_home_missing_and_env_bypass_unset() {
+        assert!(config_dir("pnpm", "linux", None, None, no_home).is_none());
+    }
+
+    #[test]
+    fn app_name_is_the_leaf_on_every_branch() {
+        assert!(
+            config_dir("pnpr", "linux", None, None, home("/home/u")).unwrap().ends_with("pnpr")
+        );
+        assert!(
+            config_dir("pnpm", "linux", None, None, home("/home/u")).unwrap().ends_with("pnpm")
+        );
+    }
+}

--- a/pacquet/crates/config/Cargo.toml
+++ b/pacquet/crates/config/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-config-dir             = { workspace = true }
 pacquet-env-replace            = { workspace = true }
 pacquet-network                = { workspace = true }
 pacquet-package-is-installable = { workspace = true }

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -127,38 +127,23 @@ pub fn default_modules_dir() -> PathBuf {
 }
 
 /// Resolve the directory pnpm reads `config.yaml` (the global config
-/// file) from.
-///
-/// Port of pnpm's
-/// [`getConfigDir`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/config/reader/src/dirs.ts#L67-L86).
-/// Resolution order:
-///
-/// 1. `$XDG_CONFIG_HOME/pnpm`.
-/// 2. macOS: `~/Library/Preferences/pnpm`.
-/// 3. Other non-Windows: `~/.config/pnpm`.
-/// 4. Windows: `%LOCALAPPDATA%/pnpm/config`, falling back to
-///    `~/.config/pnpm` when `LOCALAPPDATA` is unset.
-///
-/// Returns `None` when the home directory is unavailable and the env
-/// vars that bypass it are also unset — the caller treats that as
-/// "no global config file."
+/// file) from. Threads this crate's [`EnvVar`] / [`GetHomeDir`] seam
+/// into [`pacquet_config_dir::config_dir`] — the shared port of
+/// pnpm's `getConfigDir`, also used by the registry server — under
+/// the `pnpm` leaf.
 pub fn default_config_dir<Sys>() -> Option<PathBuf>
 where
     Sys: EnvVar + GetHomeDir,
 {
-    if let Some(xdg_config_home) = Sys::var("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(xdg_config_home).join("pnpm"));
-    }
-    if env::consts::OS == "windows"
-        && let Some(local_app_data) = Sys::var("LOCALAPPDATA")
-    {
-        return Some(PathBuf::from(local_app_data).join("pnpm/config"));
-    }
-    let home_dir = Sys::home_dir()?;
-    Some(match env::consts::OS {
-        "macos" => home_dir.join("Library/Preferences/pnpm"),
-        _ => home_dir.join(".config/pnpm"),
-    })
+    let xdg_config_home = Sys::var("XDG_CONFIG_HOME");
+    let local_app_data = Sys::var("LOCALAPPDATA");
+    pacquet_config_dir::config_dir(
+        "pnpm",
+        env::consts::OS,
+        xdg_config_home.as_deref(),
+        local_app_data.as_deref(),
+        Sys::home_dir,
+    )
 }
 
 /// Resolve the default packument-cache directory.

--- a/registry/crates/pnpm-registry/Cargo.toml
+++ b/registry/crates/pnpm-registry/Cargo.toml
@@ -19,6 +19,7 @@ name = "pnpm-registry"
 path = "src/main.rs"
 
 [dependencies]
+pacquet-config-dir  = { workspace = true }
 pacquet-env-replace = { workspace = true }
 pacquet-network     = { workspace = true }
 axum                = { workspace = true }

--- a/registry/crates/pnpm-registry/Cargo.toml
+++ b/registry/crates/pnpm-registry/Cargo.toml
@@ -28,6 +28,7 @@ clap                = { workspace = true }
 derive_more         = { workspace = true }
 futures-util        = { workspace = true }
 getrandom           = { workspace = true }
+home                = { workspace = true }
 indexmap            = { workspace = true }
 miette              = { workspace = true }
 reqwest             = { workspace = true }
@@ -40,7 +41,7 @@ ssri                = { workspace = true }
 tokio               = { workspace = true }
 tower-http          = { workspace = true }
 tracing             = { workspace = true }
-tracing-subscriber  = { workspace = true }
+tracing-subscriber  = { workspace = true, features = ["json"] }
 wax                 = { workspace = true }
 
 [dev-dependencies]

--- a/registry/crates/pnpm-registry/config.yaml
+++ b/registry/crates/pnpm-registry/config.yaml
@@ -66,8 +66,8 @@ packages:
     publish: $authenticated
     proxy: npmjs
 
-# log settings
-logs:
-  - type: stdout
-    format: pretty
-    level: error
+# log settings (verdaccio 6+ shape: a single `log:` object, not a list)
+log:
+  type: stdout
+  format: pretty
+  level: error

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -23,8 +23,8 @@ pub const DEFAULT_CONFIG_YAML: &str = include_str!("../config.yaml");
 pub enum ConfigSource {
     /// User passed `-c` / `--config`.
     Cli(PathBuf),
-    /// Loaded from the auto-discovered path
-    /// (`$HOME/.config/pnpm-registry/config.yaml`).
+    /// Loaded from the auto-discovered global config (the `pnpr`
+    /// config dir; see [`Config::auto_config_path`]).
     DefaultPath(PathBuf),
     /// No file was found; the bundled [`DEFAULT_CONFIG_YAML`] was
     /// used.
@@ -392,19 +392,24 @@ impl Config {
             .expect("bundled DEFAULT_CONFIG_YAML must always parse")
     }
 
-    /// Resolve the auto-discovery path for a config file. Returns
-    /// `Some(<home>/.config/pnpm-registry/config.yaml)` when both
-    /// `home` is provided **and** that file exists; returns `None`
-    /// otherwise. Callers (typically the binary's `main`) then fall
-    /// back to [`Self::from_default_yaml`] for the bundled config.
+    /// Resolve the auto-discovery path for the global `config.yaml`,
+    /// reading the process environment. Returns the path only when it
+    /// exists as a file; otherwise `None`, so the caller falls back to
+    /// [`Self::from_default_yaml`] for the bundled config.
     ///
-    /// The function takes `home` as a parameter rather than calling
-    /// `home::home_dir()` directly so tests can drive it with a
-    /// `TempDir` without racing on the global `$HOME` env var.
-    pub fn auto_config_path(home: Option<&Path>) -> Option<PathBuf> {
-        let home = home?;
-        let path = home.join(".config").join("pnpm-registry").join("config.yaml");
-        path.is_file().then_some(path)
+    /// The directory follows pnpm's own global-config-dir rules (via
+    /// the shared [`pacquet_config_dir::config_dir`]) under a `pnpr`
+    /// leaf, so an operator who knows where `pnpm config` looks knows
+    /// where pnpr looks too.
+    pub fn auto_config_path() -> Option<PathBuf> {
+        let dir = pacquet_config_dir::config_dir(
+            "pnpr",
+            std::env::consts::OS,
+            std::env::var("XDG_CONFIG_HOME").ok().as_deref(),
+            std::env::var("LOCALAPPDATA").ok().as_deref(),
+            home::home_dir,
+        );
+        config_file_in(dir)
     }
 
     /// Pick the right config source in precedence order:
@@ -518,6 +523,14 @@ fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
     }
 }
 
+/// Join `config.yaml` onto a resolved config directory and keep the
+/// path only when it points at an existing file (so a directory or a
+/// missing entry falls back to the bundled config).
+fn config_file_in(dir: Option<PathBuf>) -> Option<PathBuf> {
+    let path = dir?.join("config.yaml");
+    path.is_file().then_some(path)
+}
+
 /// `tokens.db` next to the htpasswd file. The sibling layout lets an
 /// operator lock the auth directory down with a single chmod and
 /// stops the tokens file from leaking into a `storage` directory
@@ -565,8 +578,8 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, pattern_matches,
-        resolve_relative,
+        Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, config_file_in,
+        pattern_matches, resolve_relative,
     };
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::{Path, PathBuf};
@@ -968,44 +981,41 @@ log:
         }
     }
 
-    // ----- auto_config_path -------------------------------------------------
+    // ----- config_file_in (existence gating) --------------------------------
 
     #[test]
-    fn auto_config_path_returns_none_when_home_is_none() {
-        assert!(Config::auto_config_path(None).is_none());
+    fn config_file_in_returns_none_for_none_dir() {
+        assert!(config_file_in(None).is_none());
     }
 
     #[test]
-    fn auto_config_path_returns_none_when_file_is_missing() {
-        // A fresh tempdir has no `.config/pnpm-registry/config.yaml`.
-        let home = tempfile::tempdir().unwrap();
-        assert!(Config::auto_config_path(Some(home.path())).is_none());
+    fn config_file_in_returns_none_when_file_is_missing() {
+        // A fresh tempdir has no `config.yaml`.
+        let dir = tempfile::tempdir().unwrap();
+        assert!(config_file_in(Some(dir.path().to_path_buf())).is_none());
     }
 
     #[test]
-    fn auto_config_path_returns_path_when_file_exists() {
-        let home = tempfile::tempdir().unwrap();
-        let dir = home.path().join(".config").join("pnpm-registry");
-        std::fs::create_dir_all(&dir).unwrap();
-        let expected = dir.join("config.yaml");
+    fn config_file_in_returns_path_when_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let expected = dir.path().join("config.yaml");
         std::fs::write(&expected, "storage: ./s\nuplinks: {}\npackages: {}\n").unwrap();
-        let resolved = Config::auto_config_path(Some(home.path())).expect("file is present");
+        let resolved = config_file_in(Some(dir.path().to_path_buf())).expect("file is present");
         assert_eq!(resolved, expected);
     }
 
     #[test]
-    fn auto_config_path_rejects_a_directory_at_the_target() {
-        // If the path exists but is a directory (or symlink to one,
-        // etc.), `is_file()` returns false. Auto-discovery should
+    fn config_file_in_rejects_a_directory_at_the_target() {
+        // If `config.yaml` exists but is a directory (or symlink to
+        // one, etc.), `is_file()` returns false. Auto-discovery should
         // bail rather than try to read it.
-        let home = tempfile::tempdir().unwrap();
-        let target = home.path().join(".config").join("pnpm-registry").join("config.yaml");
-        std::fs::create_dir_all(&target).unwrap();
-        assert!(Config::auto_config_path(Some(home.path())).is_none());
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("config.yaml")).unwrap();
+        assert!(config_file_in(Some(dir.path().to_path_buf())).is_none());
     }
 
     #[test]
-    fn auto_config_path_resolved_file_round_trips_through_from_yaml() {
+    fn config_file_in_resolved_file_round_trips_through_from_yaml() {
         // The whole point of returning a path is that `from_yaml` can
         // load it. This is the end-to-end happy path for the
         // auto-discovery flow.
@@ -1015,10 +1025,8 @@ log:
         // (Windows requires a drive-letter prefix to satisfy
         // `Path::is_absolute()`; a Unix-style "/tmp/auto" is not
         // absolute there and gets joined to the config's parent dir).
-        let home = tempfile::tempdir().unwrap();
-        let dir = home.path().join(".config").join("pnpm-registry");
-        std::fs::create_dir_all(&dir).unwrap();
-        let storage = home.path().join("registry-storage");
+        let dir = tempfile::tempdir().unwrap();
+        let storage = dir.path().join("registry-storage");
         let yaml = format!(
             "\
 storage: {storage}
@@ -1034,8 +1042,8 @@ log:
 ",
             storage = storage.display(),
         );
-        std::fs::write(dir.join("config.yaml"), yaml).unwrap();
-        let path = Config::auto_config_path(Some(home.path())).unwrap();
+        std::fs::write(dir.path().join("config.yaml"), yaml).unwrap();
+        let path = config_file_in(Some(dir.path().to_path_buf())).unwrap();
         let config = Config::from_yaml(&path, listen(), None).unwrap();
         assert_eq!(config.storage, storage);
         assert_eq!(config.logs.format, LogFormat::Json);
@@ -1184,7 +1192,7 @@ log:
     fn resolve_propagates_missing_file_error_for_default_path() {
         // Symmetric to the CLI case — a bad default path is just as
         // fatal as a bad CLI path. (In practice callers only pass a
-        // default path that already passed `auto_config_path`'s
+        // default path that already passed `config_file_in`'s
         // `is_file()` check, so this is a defense-in-depth assertion.)
         let err = Config::resolve(None, Some(Path::new("/no/such/file.yml")), listen(), None)
             .unwrap_err();

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -61,6 +61,10 @@ pub struct Config {
     /// are `None`, matching the original `@pnpm/registry-mock` mode
     /// where every restart wipes accounts.
     pub auth: AuthConfig,
+    /// Format and level for the `tracing-subscriber` the binary
+    /// installs at startup. Sourced from the first entry of the
+    /// YAML `logs:` list. Defaults to pretty/info.
+    pub logs: LogConfig,
 }
 
 /// Auth-related runtime configuration. Built from the YAML
@@ -115,6 +119,72 @@ impl MaxUsers {
     }
 }
 
+/// Runtime logging configuration. Mirrors the first entry of the
+/// YAML `logs:` list (verdaccio's shape). Drives the
+/// `tracing-subscriber` init in the binary: format selects
+/// human-readable vs NDJSON, level seeds the default `EnvFilter`.
+///
+/// Only `type: stdout` is supported — file sinks and multiple-sink
+/// fan-out are future work. The full list is parsed from YAML so
+/// nothing breaks when a verdaccio user copies their config in;
+/// extra entries beyond the first are dropped.
+#[derive(Debug, Clone)]
+pub struct LogConfig {
+    pub format: LogFormat,
+    pub level: LogLevel,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self { format: LogFormat::Pretty, level: LogLevel::default() }
+    }
+}
+
+/// Wire format for log records. `Pretty` is human-readable with
+/// colors when stdout is a TTY; `Json` is NDJSON (one JSON object
+/// per record) suitable for log shippers — the same shape pino
+/// emits.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogFormat {
+    #[default]
+    Pretty,
+    Json,
+}
+
+/// Severity threshold. Maps onto `tracing::Level` plus a synthetic
+/// `Http` mid-tier (between info and debug) that mirrors what
+/// verdaccio and pino call "the request-log level."
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Http,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    /// Convert to an `EnvFilter` directive string. `http` is not a
+    /// tracing level, so we expand it to `info` for the framework
+    /// plus a `pnpm_registry::access=info` target so the per-request
+    /// access log surfaces even when the rest of the crate is
+    /// quieter.
+    pub fn as_filter_directive(self) -> &'static str {
+        match self {
+            LogLevel::Trace => "trace",
+            LogLevel::Debug => "debug",
+            LogLevel::Http => "info,pnpm_registry::access=info",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+}
+
 /// Verdaccio-shaped uplink declaration. Only `url` is honored —
 /// other fields verdaccio supports (auth headers, timeouts, agent
 /// options) are not implemented yet.
@@ -150,6 +220,27 @@ struct ConfigFile {
     packages: IndexMap<String, PackageAccess>,
     #[serde(default)]
     auth: AuthFile,
+    /// Verdaccio 6+ shape: `log:` is a single object at the top
+    /// level, not a list. The older `logs:` list shape is
+    /// intentionally not accepted.
+    #[serde(default)]
+    log: Option<LogEntryFile>,
+}
+
+/// The YAML `log:` object. Mirrors verdaccio 6's logger config.
+#[derive(Debug, Deserialize)]
+struct LogEntryFile {
+    #[serde(default = "default_log_type")]
+    #[allow(dead_code)] // file/syslog sinks are future work
+    r#type: String,
+    #[serde(default)]
+    format: Option<LogFormat>,
+    #[serde(default)]
+    level: Option<LogLevel>,
+}
+
+fn default_log_type() -> String {
+    "stdout".to_string()
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -206,6 +297,7 @@ impl Config {
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
+            logs: LogConfig::default(),
         }
     }
 
@@ -221,6 +313,7 @@ impl Config {
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
             policies: PackagePolicies::registry_mock_defaults(),
             auth: AuthConfig::default(),
+            logs: LogConfig::default(),
         }
     }
 
@@ -265,6 +358,21 @@ impl Config {
             .expect("bundled DEFAULT_CONFIG_YAML must always parse")
     }
 
+    /// Resolve the auto-discovery path for a config file. Returns
+    /// `Some(<home>/.config/pnpm-registry/config.yaml)` when both
+    /// `home` is provided **and** that file exists; returns `None`
+    /// otherwise. Callers (typically the binary's `main`) then fall
+    /// back to [`Self::from_default_yaml`] for the bundled config.
+    ///
+    /// The function takes `home` as a parameter rather than calling
+    /// `home::home_dir()` directly so tests can drive it with a
+    /// `TempDir` without racing on the global `$HOME` env var.
+    pub fn auto_config_path(home: Option<&Path>) -> Option<PathBuf> {
+        let home = home?;
+        let path = home.join(".config").join("pnpm-registry").join("config.yaml");
+        path.is_file().then_some(path)
+    }
+
     fn from_yaml_str(
         raw: &str,
         base_dir: &Path,
@@ -279,6 +387,7 @@ impl Config {
         let storage = resolve_relative(&file.storage, base_dir);
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
+        let logs = build_log_config(file.log.as_ref());
         Ok(Self {
             listen,
             public_url,
@@ -293,6 +402,7 @@ impl Config {
             // hard-coded defaults — same as `proxy` / `static_serve`.
             policies: PackagePolicies::registry_mock_defaults(),
             auth,
+            logs,
         })
     }
 
@@ -334,6 +444,14 @@ fn build_auth_config(file: &AuthFile, base_dir: &Path) -> AuthConfig {
         },
         tokens: TokensConfig { file: tokens_file },
     }
+}
+
+/// Lift the YAML `log:` object's `format` / `level` onto runtime
+/// defaults. Missing block = default pretty/info config; missing
+/// individual fields fall back to their `Default` impls.
+fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
+    let Some(entry) = entry else { return LogConfig::default() };
+    LogConfig { format: entry.format.unwrap_or_default(), level: entry.level.unwrap_or_default() }
 }
 
 /// `tokens.db` next to the htpasswd file. The sibling layout lets an
@@ -382,7 +500,9 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, DEFAULT_CONFIG_YAML, pattern_matches, resolve_relative};
+    use super::{
+        Config, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, pattern_matches, resolve_relative,
+    };
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::{Path, PathBuf};
 
@@ -668,5 +788,222 @@ packages: {}
 ";
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
         assert_eq!(config.auth.htpasswd.max_users, super::MaxUsers::Limited(5));
+    }
+
+    #[test]
+    fn logs_default_when_yaml_omits_block() {
+        let yaml = "storage: ./s\nuplinks: {}\npackages: {}\n";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Pretty);
+        assert_eq!(config.logs.level, LogLevel::Info);
+    }
+
+    #[test]
+    fn log_pretty_and_level_picked_from_singular_block() {
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+log:
+  type: stdout
+  format: pretty
+  level: warn
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Pretty);
+        assert_eq!(config.logs.level, LogLevel::Warn);
+    }
+
+    #[test]
+    fn log_json_format_parses() {
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+log:
+  type: stdout
+  format: json
+  level: debug
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Json);
+        assert_eq!(config.logs.level, LogLevel::Debug);
+    }
+
+    #[test]
+    fn log_legacy_plural_list_is_ignored() {
+        // Verdaccio 4/5 used `logs:` as a list. We only honor the
+        // verdaccio-6 `log:` (singular) shape, so the older spelling
+        // is silently dropped and defaults apply.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+logs:
+  - type: stdout
+    format: json
+    level: error
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Pretty);
+        assert_eq!(config.logs.level, LogLevel::Info);
+    }
+
+    #[test]
+    fn log_missing_fields_fall_back_to_defaults() {
+        // Only `type:` is given. Format and level default individually.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+log:
+  type: stdout
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Pretty);
+        assert_eq!(config.logs.level, LogLevel::Info);
+    }
+
+    #[test]
+    fn log_level_filter_directives_are_valid() {
+        // Each LogLevel must map to a directive string that
+        // `EnvFilter::new` accepts at runtime — guards against typos.
+        for level in [
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Http,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+        ] {
+            let directive = level.as_filter_directive();
+            tracing_subscriber::EnvFilter::try_new(directive)
+                .unwrap_or_else(|err| panic!("{level:?} -> `{directive}`: {err}"));
+        }
+    }
+
+    // ----- auto_config_path -------------------------------------------------
+
+    #[test]
+    fn auto_config_path_returns_none_when_home_is_none() {
+        assert!(Config::auto_config_path(None).is_none());
+    }
+
+    #[test]
+    fn auto_config_path_returns_none_when_file_is_missing() {
+        // A fresh tempdir has no `.config/pnpm-registry/config.yaml`.
+        let home = tempfile::tempdir().unwrap();
+        assert!(Config::auto_config_path(Some(home.path())).is_none());
+    }
+
+    #[test]
+    fn auto_config_path_returns_path_when_file_exists() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = home.path().join(".config").join("pnpm-registry");
+        std::fs::create_dir_all(&dir).unwrap();
+        let expected = dir.join("config.yaml");
+        std::fs::write(&expected, "storage: ./s\nuplinks: {}\npackages: {}\n").unwrap();
+        let resolved = Config::auto_config_path(Some(home.path())).expect("file is present");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn auto_config_path_rejects_a_directory_at_the_target() {
+        // If the path exists but is a directory (or symlink to one,
+        // etc.), `is_file()` returns false. Auto-discovery should
+        // bail rather than try to read it.
+        let home = tempfile::tempdir().unwrap();
+        let target = home.path().join(".config").join("pnpm-registry").join("config.yaml");
+        std::fs::create_dir_all(&target).unwrap();
+        assert!(Config::auto_config_path(Some(home.path())).is_none());
+    }
+
+    #[test]
+    fn auto_config_path_resolved_file_round_trips_through_from_yaml() {
+        // The whole point of returning a path is that `from_yaml` can
+        // load it. This is the end-to-end happy path for the
+        // auto-discovery flow.
+        let home = tempfile::tempdir().unwrap();
+        let dir = home.path().join(".config").join("pnpm-registry");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config.yaml"),
+            "\
+storage: /tmp/auto
+uplinks:
+  npmjs: { url: https://registry.npmjs.org/ }
+packages:
+  '**':
+    proxy: npmjs
+log:
+  type: stdout
+  format: json
+  level: info
+",
+        )
+        .unwrap();
+        let path = Config::auto_config_path(Some(home.path())).unwrap();
+        let config = Config::from_yaml(&path, listen(), None).unwrap();
+        assert_eq!(config.storage, PathBuf::from("/tmp/auto"));
+        assert_eq!(config.logs.format, LogFormat::Json);
+        assert_eq!(config.logs.level, LogLevel::Info);
+        assert_eq!(config.resolve_uplink("lodash").unwrap().0, "npmjs");
+    }
+
+    // ----- LogFormat / LogLevel serde behavior ------------------------------
+
+    /// Helper: deserialize a YAML scalar into the requested enum.
+    /// Lets us assert the variant mapping concisely.
+    fn parse_log_yaml<T: serde::de::DeserializeOwned>(yaml: &str) -> Result<T, String> {
+        serde_saphyr::from_str::<T>(yaml).map_err(|err| err.to_string())
+    }
+
+    #[test]
+    fn log_format_accepts_each_known_variant() {
+        assert_eq!(parse_log_yaml::<LogFormat>("pretty").unwrap(), LogFormat::Pretty);
+        assert_eq!(parse_log_yaml::<LogFormat>("json").unwrap(), LogFormat::Json);
+    }
+
+    #[test]
+    fn log_format_rejects_unknown_variant() {
+        // `format: xml` (or anything else) should fail parsing
+        // rather than silently fall back. Matches verdaccio: an
+        // unknown enum value is a typo, not a request for a default.
+        let err = parse_log_yaml::<LogFormat>("xml").unwrap_err();
+        assert!(err.contains("xml") || err.to_lowercase().contains("unknown"));
+    }
+
+    #[test]
+    fn log_format_is_case_sensitive() {
+        // `rename_all = "lowercase"` means we accept only lowercase
+        // tokens; pino is case-sensitive too.
+        assert!(parse_log_yaml::<LogFormat>("Pretty").is_err());
+        assert!(parse_log_yaml::<LogFormat>("JSON").is_err());
+    }
+
+    #[test]
+    fn log_level_accepts_each_known_variant() {
+        let pairs: &[(&str, LogLevel)] = &[
+            ("trace", LogLevel::Trace),
+            ("debug", LogLevel::Debug),
+            ("http", LogLevel::Http),
+            ("info", LogLevel::Info),
+            ("warn", LogLevel::Warn),
+            ("error", LogLevel::Error),
+        ];
+        for (yaml, expected) in pairs {
+            let parsed: LogLevel = parse_log_yaml(yaml).unwrap();
+            assert_eq!(parsed, *expected, "{yaml}");
+        }
+    }
+
+    #[test]
+    fn log_level_rejects_unknown_variant() {
+        // `fatal` (pino has it) and `silly` (npm's logger had it)
+        // are not in our set — we want a hard error, not a silent
+        // fallback.
+        assert!(parse_log_yaml::<LogLevel>("fatal").is_err());
+        assert!(parse_log_yaml::<LogLevel>("silly").is_err());
+        assert!(parse_log_yaml::<LogLevel>("verbose").is_err());
     }
 }

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -77,8 +77,8 @@ pub struct Config {
     /// where every restart wipes accounts.
     pub auth: AuthConfig,
     /// Format and level for the `tracing-subscriber` the binary
-    /// installs at startup. Sourced from the first entry of the
-    /// YAML `logs:` list. Defaults to pretty/info.
+    /// installs at startup. Sourced from the YAML `log:` object
+    /// (Verdaccio 6+ shape). Defaults to pretty/info.
     pub logs: LogConfig,
 }
 
@@ -134,24 +134,42 @@ impl MaxUsers {
     }
 }
 
-/// Runtime logging configuration. Mirrors the first entry of the
-/// YAML `logs:` list (verdaccio's shape). Drives the
-/// `tracing-subscriber` init in the binary: format selects
-/// human-readable vs NDJSON, level seeds the default `EnvFilter`.
+/// Runtime logging configuration. Mirrors the YAML `log:` object
+/// (Verdaccio 6+ shape). Drives the `tracing-subscriber` init in the
+/// binary: format selects human-readable vs NDJSON, level seeds the
+/// default `EnvFilter`.
 ///
-/// Only `type: stdout` is supported — file sinks and multiple-sink
-/// fan-out are future work. The full list is parsed from YAML so
-/// nothing breaks when a verdaccio user copies their config in;
-/// extra entries beyond the first are dropped.
+/// Only `type: stdout` is honored — file and syslog sinks are future
+/// work. An unsupported `type:` still parses (so a verdaccio config
+/// can be copied in untouched) but is ignored at runtime, with a
+/// warning logged once the subscriber is up.
 #[derive(Debug, Clone)]
 pub struct LogConfig {
     pub format: LogFormat,
     pub level: LogLevel,
+    /// The configured sink (`log.type`). Only [`Self::STDOUT_SINK`]
+    /// is implemented; any other value is recorded here so the binary
+    /// can warn about it at startup.
+    pub sink: String,
+}
+
+impl LogConfig {
+    /// The single sink pnpm-registry actually writes to.
+    pub const STDOUT_SINK: &'static str = "stdout";
+
+    /// Whether the configured sink is one the server implements.
+    pub fn sink_is_supported(&self) -> bool {
+        self.sink == Self::STDOUT_SINK
+    }
 }
 
 impl Default for LogConfig {
     fn default() -> Self {
-        Self { format: LogFormat::Pretty, level: LogLevel::default() }
+        Self {
+            format: LogFormat::Pretty,
+            level: LogLevel::default(),
+            sink: Self::STDOUT_SINK.to_string(),
+        }
     }
 }
 
@@ -246,7 +264,6 @@ struct ConfigFile {
 #[derive(Debug, Deserialize)]
 struct LogEntryFile {
     #[serde(default = "default_log_type")]
-    #[allow(dead_code)] // file/syslog sinks are future work
     r#type: String,
     #[serde(default)]
     format: Option<LogFormat>,
@@ -255,7 +272,7 @@ struct LogEntryFile {
 }
 
 fn default_log_type() -> String {
-    "stdout".to_string()
+    LogConfig::STDOUT_SINK.to_string()
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -345,7 +362,9 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> std::io::Result<Self> {
-        let raw = std::fs::read_to_string(path)?;
+        let raw = std::fs::read_to_string(path).map_err(|err| {
+            std::io::Error::new(err.kind(), format!("read {}: {err}", path.display()))
+        })?;
         let base = path.parent().unwrap_or_else(|| Path::new("."));
         Self::from_yaml_str(&raw, base, listen, public_url).map_err(|err| {
             std::io::Error::new(
@@ -492,7 +511,11 @@ fn build_auth_config(file: &AuthFile, base_dir: &Path) -> AuthConfig {
 /// individual fields fall back to their `Default` impls.
 fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
     let Some(entry) = entry else { return LogConfig::default() };
-    LogConfig { format: entry.format.unwrap_or_default(), level: entry.level.unwrap_or_default() }
+    LogConfig {
+        format: entry.format.unwrap_or_default(),
+        level: entry.level.unwrap_or_default(),
+        sink: entry.r#type.clone(),
+    }
 }
 
 /// `tokens.db` next to the htpasswd file. The sibling layout lets an
@@ -838,6 +861,27 @@ packages: {}
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
         assert_eq!(config.logs.format, LogFormat::Pretty);
         assert_eq!(config.logs.level, LogLevel::Info);
+        assert_eq!(config.logs.sink, "stdout");
+        assert!(config.logs.sink_is_supported());
+    }
+
+    #[test]
+    fn log_unsupported_sink_type_is_recorded_but_flagged_unsupported() {
+        // `type: file` parses (verdaccio compatibility) but is not a
+        // sink the server implements, so `sink_is_supported` is false
+        // and the binary warns at startup. Format/level still apply.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+log:
+  type: file
+  format: json
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.sink, "file");
+        assert!(!config.logs.sink_is_supported());
+        assert_eq!(config.logs.format, LogFormat::Json);
     }
 
     #[test]
@@ -1196,5 +1240,8 @@ log:
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
         assert_eq!(config.logs.format, LogFormat::Json);
         assert_eq!(config.logs.level, LogLevel::Warn);
+        // `type:` omitted entirely falls back to the supported stdout sink.
+        assert_eq!(config.logs.sink, "stdout");
+        assert!(config.logs.sink_is_supported());
     }
 }

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -1003,8 +1003,8 @@ log:
 
     /// Helper: deserialize a YAML scalar into the requested enum.
     /// Lets us assert the variant mapping concisely.
-    fn parse_log_yaml<T: serde::de::DeserializeOwned>(yaml: &str) -> Result<T, String> {
-        serde_saphyr::from_str::<T>(yaml).map_err(|err| err.to_string())
+    fn parse_log_yaml<Target: serde::de::DeserializeOwned>(yaml: &str) -> Result<Target, String> {
+        serde_saphyr::from_str::<Target>(yaml).map_err(|err| err.to_string())
     }
 
     #[test]
@@ -1097,15 +1097,28 @@ log:
     fn resolve_cli_wins_over_default_path() {
         // Both paths exist. CLI must take priority — the auto-discovered
         // path is a *fallback*, not a merge target.
+        //
+        // Storage paths are derived from `tmp` so they're absolute on
+        // every OS (Windows needs a drive-letter prefix to satisfy
+        // `Path::is_absolute()`; a Unix-style `/a` is not absolute
+        // there and gets joined to the config file's parent dir).
         let tmp = tempfile::tempdir().unwrap();
-        let cli =
-            write_yaml(tmp.path(), "explicit.yml", "storage: /a\nuplinks: {}\npackages: {}\n");
-        let default =
-            write_yaml(tmp.path(), "default.yml", "storage: /b\nuplinks: {}\npackages: {}\n");
+        let cli_storage = tmp.path().join("from-cli");
+        let default_storage = tmp.path().join("from-default");
+        let cli = write_yaml(
+            tmp.path(),
+            "explicit.yml",
+            &format!("storage: {}\nuplinks: {{}}\npackages: {{}}\n", cli_storage.display()),
+        );
+        let default = write_yaml(
+            tmp.path(),
+            "default.yml",
+            &format!("storage: {}\nuplinks: {{}}\npackages: {{}}\n", default_storage.display()),
+        );
         let (config, source) = Config::resolve(Some(&cli), Some(&default), listen(), None).unwrap();
         assert_eq!(source, ConfigSource::Cli(cli));
         // Confirms the *content* came from the CLI file, not the default.
-        assert_eq!(config.storage, PathBuf::from("/a"));
+        assert_eq!(config.storage, cli_storage);
     }
 
     #[test]

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -16,6 +16,21 @@ use crate::policy::PackagePolicies;
 /// routing applied.
 pub const DEFAULT_CONFIG_YAML: &str = include_str!("../config.yaml");
 
+/// Where the live [`Config`] came from. Returned alongside
+/// [`Config::resolve`] so the binary can log the resolved source
+/// (path or "bundled") after the tracing subscriber is up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// User passed `-c` / `--config`.
+    Cli(PathBuf),
+    /// Loaded from the auto-discovered path
+    /// (`$HOME/.config/pnpm-registry/config.yaml`).
+    DefaultPath(PathBuf),
+    /// No file was found; the bundled [`DEFAULT_CONFIG_YAML`] was
+    /// used.
+    Bundled,
+}
+
 /// Runtime configuration for the pnpm registry server.
 ///
 /// The persisted (YAML) shape follows verdaccio's `config.yaml` —
@@ -373,6 +388,32 @@ impl Config {
         path.is_file().then_some(path)
     }
 
+    /// Pick the right config source in precedence order:
+    /// 1. `explicit` (the binary's `-c` / `--config` flag);
+    /// 2. `default_path` (typically [`Self::auto_config_path`]'s
+    ///    result);
+    /// 3. the bundled [`DEFAULT_CONFIG_YAML`].
+    ///
+    /// Returns the resolved [`Config`] alongside a [`ConfigSource`]
+    /// describing which branch fired so the binary can log it
+    /// after the subscriber is up.
+    pub fn resolve(
+        explicit: Option<&Path>,
+        default_path: Option<&Path>,
+        listen: SocketAddr,
+        public_url: Option<String>,
+    ) -> std::io::Result<(Self, ConfigSource)> {
+        if let Some(path) = explicit {
+            let config = Self::from_yaml(path, listen, public_url)?;
+            return Ok((config, ConfigSource::Cli(path.to_path_buf())));
+        }
+        if let Some(path) = default_path {
+            let config = Self::from_yaml(path, listen, public_url)?;
+            return Ok((config, ConfigSource::DefaultPath(path.to_path_buf())));
+        }
+        Ok((Self::from_default_yaml(Path::new("."), listen, public_url), ConfigSource::Bundled))
+    }
+
     fn from_yaml_str(
         raw: &str,
         base_dir: &Path,
@@ -501,7 +542,8 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Config, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, pattern_matches, resolve_relative,
+        Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, pattern_matches,
+        resolve_relative,
     };
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::{Path, PathBuf};
@@ -1012,5 +1054,134 @@ log:
         assert!(parse_log_yaml::<LogLevel>("fatal").is_err());
         assert!(parse_log_yaml::<LogLevel>("silly").is_err());
         assert!(parse_log_yaml::<LogLevel>("verbose").is_err());
+    }
+
+    // ----- Config::resolve precedence ---------------------------------------
+
+    /// Helper: write a config file under a tempdir and hand back the
+    /// path. Tests use this to populate both the explicit `-c` arg
+    /// and the auto-discovered default path.
+    fn write_yaml(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, contents).expect("write yaml fixture");
+        path
+    }
+
+    const MINIMAL_YAML: &str = "storage: ./s\nuplinks: {}\npackages: {}\n";
+
+    #[test]
+    fn resolve_bundled_when_no_path_supplied() {
+        let (config, source) = Config::resolve(None, None, listen(), None).unwrap();
+        assert_eq!(source, ConfigSource::Bundled);
+        // The bundled config has the `npmjs` uplink + `**` route.
+        assert!(config.uplinks.contains_key("npmjs"));
+    }
+
+    #[test]
+    fn resolve_default_path_when_only_default_supplied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_yaml(tmp.path(), "config.yaml", MINIMAL_YAML);
+        let (_, source) = Config::resolve(None, Some(&path), listen(), None).unwrap();
+        assert_eq!(source, ConfigSource::DefaultPath(path));
+    }
+
+    #[test]
+    fn resolve_cli_when_only_cli_supplied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_yaml(tmp.path(), "explicit.yml", MINIMAL_YAML);
+        let (_, source) = Config::resolve(Some(&path), None, listen(), None).unwrap();
+        assert_eq!(source, ConfigSource::Cli(path));
+    }
+
+    #[test]
+    fn resolve_cli_wins_over_default_path() {
+        // Both paths exist. CLI must take priority — the auto-discovered
+        // path is a *fallback*, not a merge target.
+        let tmp = tempfile::tempdir().unwrap();
+        let cli =
+            write_yaml(tmp.path(), "explicit.yml", "storage: /a\nuplinks: {}\npackages: {}\n");
+        let default =
+            write_yaml(tmp.path(), "default.yml", "storage: /b\nuplinks: {}\npackages: {}\n");
+        let (config, source) = Config::resolve(Some(&cli), Some(&default), listen(), None).unwrap();
+        assert_eq!(source, ConfigSource::Cli(cli));
+        // Confirms the *content* came from the CLI file, not the default.
+        assert_eq!(config.storage, PathBuf::from("/a"));
+    }
+
+    #[test]
+    fn resolve_propagates_missing_file_error_for_cli_path() {
+        let err = Config::resolve(Some(Path::new("/no/such/file.yml")), None, listen(), None)
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn resolve_propagates_parse_error_for_cli_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_yaml(tmp.path(), "broken.yml", "storage: [not, a, string\n");
+        let err = Config::resolve(Some(&path), None, listen(), None).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn resolve_propagates_missing_file_error_for_default_path() {
+        // Symmetric to the CLI case — a bad default path is just as
+        // fatal as a bad CLI path. (In practice callers only pass a
+        // default path that already passed `auto_config_path`'s
+        // `is_file()` check, so this is a defense-in-depth assertion.)
+        let err = Config::resolve(None, Some(Path::new("/no/such/file.yml")), listen(), None)
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn resolve_public_url_override_threads_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_yaml(tmp.path(), "config.yaml", MINIMAL_YAML);
+        let (config, _) =
+            Config::resolve(Some(&path), None, listen(), Some("http://override.test".to_string()))
+                .unwrap();
+        assert_eq!(config.public_url, "http://override.test");
+    }
+
+    #[test]
+    fn resolve_bundled_branch_honors_public_url_override() {
+        let (config, source) =
+            Config::resolve(None, None, listen(), Some("http://from-cli.test".to_string()))
+                .unwrap();
+        assert_eq!(source, ConfigSource::Bundled);
+        assert_eq!(config.public_url, "http://from-cli.test");
+    }
+
+    // ----- serde defaults ---------------------------------------------------
+
+    #[test]
+    fn yaml_with_no_storage_uses_default_storage_string() {
+        // `storage:` is absent entirely — `default_storage_string`
+        // supplies `"./storage"`, which `resolve_relative` then joins
+        // to the config-file's parent dir.
+        let yaml = "uplinks: {}\npackages: {}\n";
+        let config = Config::from_yaml_str(yaml, Path::new("/etc/pnpr"), listen(), None).unwrap();
+        assert_eq!(config.storage, PathBuf::from("/etc/pnpr/./storage"));
+    }
+
+    #[test]
+    fn yaml_log_block_with_no_type_field_uses_default_log_type() {
+        // `type:` omitted but `format:` and `level:` present. The
+        // `default_log_type` serde default kicks in for the missing
+        // field; we don't otherwise care about its value at runtime,
+        // we just need the parse to succeed (and the runtime config
+        // to reflect the supplied format/level).
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages: {}
+log:
+  format: json
+  level: warn
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.logs.format, LogFormat::Json);
+        assert_eq!(config.logs.level, LogLevel::Warn);
     }
 }

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -923,15 +923,21 @@ log:
         // The whole point of returning a path is that `from_yaml` can
         // load it. This is the end-to-end happy path for the
         // auto-discovery flow.
+        //
+        // The `storage:` value is computed at runtime so it's a
+        // genuinely absolute path on whichever OS the test runs on
+        // (Windows requires a drive-letter prefix to satisfy
+        // `Path::is_absolute()`; a Unix-style "/tmp/auto" is not
+        // absolute there and gets joined to the config's parent dir).
         let home = tempfile::tempdir().unwrap();
         let dir = home.path().join(".config").join("pnpm-registry");
         std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(
-            dir.join("config.yaml"),
+        let storage = home.path().join("registry-storage");
+        let yaml = format!(
             "\
-storage: /tmp/auto
+storage: {storage}
 uplinks:
-  npmjs: { url: https://registry.npmjs.org/ }
+  npmjs: {{ url: https://registry.npmjs.org/ }}
 packages:
   '**':
     proxy: npmjs
@@ -940,11 +946,12 @@ log:
   format: json
   level: info
 ",
-        )
-        .unwrap();
+            storage = storage.display(),
+        );
+        std::fs::write(dir.join("config.yaml"), yaml).unwrap();
         let path = Config::auto_config_path(Some(home.path())).unwrap();
         let config = Config::from_yaml(&path, listen(), None).unwrap();
-        assert_eq!(config.storage, PathBuf::from("/tmp/auto"));
+        assert_eq!(config.storage, storage);
         assert_eq!(config.logs.format, LogFormat::Json);
         assert_eq!(config.logs.level, LogLevel::Info);
         assert_eq!(config.resolve_uplink("lodash").unwrap().0, "npmjs");

--- a/registry/crates/pnpm-registry/src/lib.rs
+++ b/registry/crates/pnpm-registry/src/lib.rs
@@ -21,8 +21,8 @@ mod upstream;
 
 pub use auth::{AuthState, TokenStore, UserStore, identify};
 pub use config::{
-    AuthConfig, Config, DEFAULT_CONFIG_YAML, HtpasswdConfig, MaxUsers, PackageAccess, TokensConfig,
-    UplinkConfig,
+    AuthConfig, Config, DEFAULT_CONFIG_YAML, HtpasswdConfig, LogConfig, LogFormat, LogLevel,
+    MaxUsers, PackageAccess, TokensConfig, UplinkConfig,
 };
 pub use error::{RegistryError, Result};
 pub use policy::{AccessRule, PackagePolicies, PackagePolicy};

--- a/registry/crates/pnpm-registry/src/lib.rs
+++ b/registry/crates/pnpm-registry/src/lib.rs
@@ -21,8 +21,8 @@ mod upstream;
 
 pub use auth::{AuthState, TokenStore, UserStore, identify};
 pub use config::{
-    AuthConfig, Config, DEFAULT_CONFIG_YAML, HtpasswdConfig, LogConfig, LogFormat, LogLevel,
-    MaxUsers, PackageAccess, TokensConfig, UplinkConfig,
+    AuthConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML, HtpasswdConfig, LogConfig, LogFormat,
+    LogLevel, MaxUsers, PackageAccess, TokensConfig, UplinkConfig,
 };
 pub use error::{RegistryError, Result};
 pub use policy::{AccessRule, PackagePolicies, PackagePolicy};

--- a/registry/crates/pnpm-registry/src/main.rs
+++ b/registry/crates/pnpm-registry/src/main.rs
@@ -1,11 +1,11 @@
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use pnpm_registry::{Config, LogConfig, LogFormat, serve};
+use pnpm_registry::{Config, ConfigSource, LogConfig, LogFormat, serve};
 
 #[derive(Debug, Parser)]
 #[command(name = "pnpm-registry", version, about = "pnpm-compatible npm registry server")]
@@ -38,58 +38,26 @@ struct Args {
     packument_ttl_secs: Option<u64>,
 }
 
-/// Where the config came from. Used after the subscriber is up to
-/// log the resolved path (or note that the bundled default applies).
-enum ConfigSource {
-    Cli(PathBuf),
-    DefaultPath(PathBuf),
-    Bundled,
-}
-
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Args::parse();
-    let (config, source) = load_config(&args)?;
-    init_logging(&config.logs);
-    log_config_source(&source);
-    serve(config).await.map_err(|err| miette::miette!("{err}"))
-}
-
-fn load_config(args: &Args) -> miette::Result<(Config, ConfigSource)> {
-    let (mut config, source) = match args.config.as_deref() {
-        Some(path) => {
-            let displayed = path.display();
-            let config = Config::from_yaml(path, args.listen, args.public_url.clone())
-                .map_err(|err| miette::miette!("load {displayed}: {err}"))?;
-            (config, ConfigSource::Cli(path.to_path_buf()))
-        }
-        None => match default_config_path() {
-            Some(path) => {
-                let displayed = path.display();
-                let config = Config::from_yaml(&path, args.listen, args.public_url.clone())
-                    .map_err(|err| miette::miette!("load {displayed}: {err}"))?;
-                (config, ConfigSource::DefaultPath(path))
-            }
-            None => (
-                Config::from_default_yaml(Path::new("."), args.listen, args.public_url.clone()),
-                ConfigSource::Bundled,
-            ),
-        },
-    };
-    if let Some(storage) = args.storage.clone() {
+    let auto_path = Config::auto_config_path(home::home_dir().as_deref());
+    let (mut config, source) = Config::resolve(
+        args.config.as_deref(),
+        auto_path.as_deref(),
+        args.listen,
+        args.public_url.clone(),
+    )
+    .map_err(|err| miette::miette!("{err}"))?;
+    if let Some(storage) = args.storage {
         config.storage = storage;
     }
     if let Some(ttl_secs) = args.packument_ttl_secs {
         config.packument_ttl = Duration::from_secs(ttl_secs);
     }
-    Ok((config, source))
-}
-
-/// `$HOME/.config/pnpm-registry/config.yaml` when it exists.
-/// Returns `None` if the file is absent or `HOME` is unset — the
-/// caller falls back to the bundled config in that case.
-fn default_config_path() -> Option<PathBuf> {
-    Config::auto_config_path(home::home_dir().as_deref())
+    init_logging(&config.logs);
+    log_config_source(&source);
+    serve(config).await.map_err(|err| miette::miette!("{err}"))
 }
 
 /// Install the `tracing-subscriber` for this process based on the

--- a/registry/crates/pnpm-registry/src/main.rs
+++ b/registry/crates/pnpm-registry/src/main.rs
@@ -70,8 +70,18 @@ fn init_logging(logs: &LogConfig) {
         .unwrap_or_else(|_| EnvFilter::new(logs.level.as_filter_directive()));
     let builder = tracing_subscriber::fmt().with_env_filter(filter);
     match logs.format {
-        LogFormat::Json => builder.json().with_current_span(false).with_span_list(false).init(),
+        // `with_current_span(true)` keeps the per-request span's
+        // `method`/`uri` fields attached to the single access event;
+        // `with_span_list(false)` drops the redundant entered-span
+        // array so each JSON line stays one flat access record.
+        LogFormat::Json => builder.json().with_current_span(true).with_span_list(false).init(),
         LogFormat::Pretty => builder.compact().init(),
+    }
+    if !logs.sink_is_supported() {
+        tracing::warn!(
+            sink = %logs.sink,
+            "unsupported `log.type`; only `stdout` is implemented — logging to stdout",
+        );
     }
 }
 

--- a/registry/crates/pnpm-registry/src/main.rs
+++ b/registry/crates/pnpm-registry/src/main.rs
@@ -5,13 +5,14 @@ use std::time::Duration;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use pnpm_registry::{Config, serve};
+use pnpm_registry::{Config, LogConfig, LogFormat, serve};
 
 #[derive(Debug, Parser)]
 #[command(name = "pnpm-registry", version, about = "pnpm-compatible npm registry server")]
 struct Args {
     /// Path to a verdaccio-shaped YAML config (storage, uplinks,
-    /// packages). When omitted, the bundled default config is used.
+    /// packages, log). When omitted, `~/.config/pnpm-registry/config.yaml`
+    /// is used if it exists, otherwise the bundled default config.
     #[arg(short = 'c', long)]
     config: Option<PathBuf>,
 
@@ -37,30 +38,81 @@ struct Args {
     packument_ttl_secs: Option<u64>,
 }
 
+/// Where the config came from. Used after the subscriber is up to
+/// log the resolved path (or note that the bundled default applies).
+enum ConfigSource {
+    Cli(PathBuf),
+    DefaultPath(PathBuf),
+    Bundled,
+}
+
 #[tokio::main]
 async fn main() -> miette::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
-
     let args = Args::parse();
-    let mut config = match args.config.as_deref() {
+    let (config, source) = load_config(&args)?;
+    init_logging(&config.logs);
+    log_config_source(&source);
+    serve(config).await.map_err(|err| miette::miette!("{err}"))
+}
+
+fn load_config(args: &Args) -> miette::Result<(Config, ConfigSource)> {
+    let (mut config, source) = match args.config.as_deref() {
         Some(path) => {
-            Config::from_yaml(path, args.listen, args.public_url.clone()).map_err(|err| {
-                let path = path.display();
-                miette::miette!("load {path}: {err}")
-            })?
+            let config = Config::from_yaml(path, args.listen, args.public_url.clone())
+                .map_err(|err| miette::miette!("load {}: {err}", path.display()))?;
+            (config, ConfigSource::Cli(path.to_path_buf()))
         }
-        None => Config::from_default_yaml(Path::new("."), args.listen, args.public_url.clone()),
+        None => match default_config_path() {
+            Some(path) => {
+                let config = Config::from_yaml(&path, args.listen, args.public_url.clone())
+                    .map_err(|err| miette::miette!("load {}: {err}", path.display()))?;
+                (config, ConfigSource::DefaultPath(path))
+            }
+            None => (
+                Config::from_default_yaml(Path::new("."), args.listen, args.public_url.clone()),
+                ConfigSource::Bundled,
+            ),
+        },
     };
-    if let Some(storage) = args.storage {
+    if let Some(storage) = args.storage.clone() {
         config.storage = storage;
     }
     if let Some(ttl_secs) = args.packument_ttl_secs {
         config.packument_ttl = Duration::from_secs(ttl_secs);
     }
+    Ok((config, source))
+}
 
-    serve(config).await.map_err(|err| miette::miette!("{err}"))
+/// `$HOME/.config/pnpm-registry/config.yaml` when it exists.
+/// Returns `None` if the file is absent or `HOME` is unset — the
+/// caller falls back to the bundled config in that case.
+fn default_config_path() -> Option<PathBuf> {
+    Config::auto_config_path(home::home_dir().as_deref())
+}
+
+/// Install the `tracing-subscriber` for this process based on the
+/// resolved log config. `RUST_LOG` always wins over the YAML/CLI
+/// level — same precedence Node ecosystem tools use for their
+/// `LOG_LEVEL`/`DEBUG` env vars, and what existing pnpm-registry
+/// operators will already expect.
+fn init_logging(logs: &LogConfig) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(logs.level.as_filter_directive()));
+    let builder = tracing_subscriber::fmt().with_env_filter(filter);
+    match logs.format {
+        LogFormat::Json => builder.json().with_current_span(false).with_span_list(false).init(),
+        LogFormat::Pretty => builder.compact().init(),
+    }
+}
+
+fn log_config_source(source: &ConfigSource) {
+    match source {
+        ConfigSource::Cli(path) => {
+            tracing::info!(path = %path.display(), "loaded config from --config")
+        }
+        ConfigSource::DefaultPath(path) => {
+            tracing::info!(path = %path.display(), "loaded config from default path")
+        }
+        ConfigSource::Bundled => tracing::info!("loaded bundled default config"),
+    }
 }

--- a/registry/crates/pnpm-registry/src/main.rs
+++ b/registry/crates/pnpm-registry/src/main.rs
@@ -11,8 +11,9 @@ use pnpm_registry::{Config, ConfigSource, LogConfig, LogFormat, serve};
 #[command(name = "pnpm-registry", version, about = "pnpm-compatible npm registry server")]
 struct Args {
     /// Path to a verdaccio-shaped YAML config (storage, uplinks,
-    /// packages, log). When omitted, `~/.config/pnpm-registry/config.yaml`
-    /// is used if it exists, otherwise the bundled default config.
+    /// packages, log). When omitted, the global `config.yaml` in
+    /// pnpr's config dir (pnpm's config-dir rules, under `pnpr`) is
+    /// used if it exists, otherwise the bundled default config.
     #[arg(short = 'c', long)]
     config: Option<PathBuf>,
 
@@ -41,7 +42,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Args::parse();
-    let auto_path = Config::auto_config_path(home::home_dir().as_deref());
+    let auto_path = Config::auto_config_path();
     let (mut config, source) = Config::resolve(
         args.config.as_deref(),
         auto_path.as_deref(),

--- a/registry/crates/pnpm-registry/src/main.rs
+++ b/registry/crates/pnpm-registry/src/main.rs
@@ -58,14 +58,16 @@ async fn main() -> miette::Result<()> {
 fn load_config(args: &Args) -> miette::Result<(Config, ConfigSource)> {
     let (mut config, source) = match args.config.as_deref() {
         Some(path) => {
+            let displayed = path.display();
             let config = Config::from_yaml(path, args.listen, args.public_url.clone())
-                .map_err(|err| miette::miette!("load {}: {err}", path.display()))?;
+                .map_err(|err| miette::miette!("load {displayed}: {err}"))?;
             (config, ConfigSource::Cli(path.to_path_buf()))
         }
         None => match default_config_path() {
             Some(path) => {
+                let displayed = path.display();
                 let config = Config::from_yaml(&path, args.listen, args.public_url.clone())
-                    .map_err(|err| miette::miette!("load {}: {err}", path.display()))?;
+                    .map_err(|err| miette::miette!("load {displayed}: {err}"))?;
                 (config, ConfigSource::DefaultPath(path))
             }
             None => (

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -1,16 +1,16 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::Router;
 use axum::body::Body;
-use axum::extract::{DefaultBodyLimit, OriginalUri, Path, State};
+use axum::extract::{DefaultBodyLimit, OriginalUri, Path, Request, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get};
 use indexmap::IndexMap;
 use serde_json::{Value, json};
-use tower_http::LatencyUnit;
-use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
-use tracing::Level;
+use tower_http::trace::TraceLayer;
+use tracing::Span;
 
 use crate::auth::{AuthState, UpsertOutcome, identify};
 use crate::cache::Cache;
@@ -103,18 +103,32 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         // One structured access record per HTTP request: a span
         // carrying method + URI plus a single `finished processing
         // request` event on the response with status and latency.
-        // `on_request(())` / `on_failure(())` suppress tower-http's
-        // default emissions so each request produces exactly one
-        // record. The format and level are picked up from the
-        // subscriber installed in `main.rs` (driven by the YAML
-        // `logs:` block — pretty or NDJSON).
+        // Both the span and the event use the `pnpm_registry::access`
+        // target so `LogLevel::Http`'s filter directive can scope to
+        // them. `on_request(())` / `on_failure(())` suppress
+        // tower-http's default emissions so each request produces
+        // exactly one record. The format and level are picked up from
+        // the subscriber installed in `main.rs` (driven by the YAML
+        // `log:` block — pretty or NDJSON).
         .layer(
             TraceLayer::new_for_http()
-                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .make_span_with(|request: &Request<Body>| {
+                    tracing::info_span!(
+                        target: "pnpm_registry::access",
+                        "request",
+                        method = %request.method(),
+                        uri = %request.uri(),
+                    )
+                })
                 .on_request(())
-                .on_response(
-                    DefaultOnResponse::new().level(Level::INFO).latency_unit(LatencyUnit::Millis),
-                )
+                .on_response(|response: &Response<Body>, latency: Duration, _span: &Span| {
+                    tracing::info!(
+                        target: "pnpm_registry::access",
+                        status = response.status().as_u16(),
+                        latency_ms = latency.as_millis() as u64,
+                        "finished processing request",
+                    );
+                })
                 .on_failure(()),
         )
         .with_state(state)

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -8,7 +8,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get};
 use indexmap::IndexMap;
 use serde_json::{Value, json};
-use tower_http::trace::TraceLayer;
+use tower_http::LatencyUnit;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
+use tracing::Level;
 
 use crate::auth::{AuthState, UpsertOutcome, identify};
 use crate::cache::Cache;
@@ -98,7 +100,23 @@ pub fn router_with_auth(config: Config, auth: AuthState) -> Router {
         // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`
         .route("/{a}/{b}/{c}/{d}/{e}/{f}", delete(delete_six_segments))
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
-        .layer(TraceLayer::new_for_http())
+        // One structured access record per HTTP request: a span
+        // carrying method + URI plus a single `finished processing
+        // request` event on the response with status and latency.
+        // `on_request(())` / `on_failure(())` suppress tower-http's
+        // default emissions so each request produces exactly one
+        // record. The format and level are picked up from the
+        // subscriber installed in `main.rs` (driven by the YAML
+        // `logs:` block — pretty or NDJSON).
+        .layer(
+            TraceLayer::new_for_http()
+                .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                .on_request(())
+                .on_response(
+                    DefaultOnResponse::new().level(Level::INFO).latency_unit(LatencyUnit::Millis),
+                )
+                .on_failure(()),
+        )
         .with_state(state)
 }
 


### PR DESCRIPTION
## Summary

Adds YAML-driven logging to `pnpm-registry`. Format (`pretty` or `json`) and level come from a `log:` block in `config.yaml`. Every HTTP request emits one structured access record (method, URI, status, latency) under the `pnpm_registry::access` tracing target — pino-shaped. When `-c` isn't passed, the global `config.yaml` is auto-discovered using the same per-OS rules pnpm uses for its own config dir, under a `pnpr` leaf.

```yaml
log:
  type: stdout
  format: json
  level: info
```

## What's in

- New `LogConfig` / `LogFormat` / `LogLevel` types; defaults to pretty/info.
- `init_logging` picks `.json()` vs `.compact()` from the resolved config; `RUST_LOG` still overrides. JSON keeps the request span's `method`/`uri` on each access record (`with_current_span(true)`).
- `TraceLayer` emits exactly one INFO access record per request — both the span and the completion event under `target: "pnpm_registry::access"`, with tower-http's default emissions suppressed — so `LogLevel::Http`'s filter directive can scope to them.
- Global-config auto-discovery follows pnpm's `getConfigDir` rules (`XDG_CONFIG_HOME` / macOS `Library/Preferences` / Windows `LOCALAPPDATA` / `~/.config`) under a `pnpr` leaf. That resolution is shared with `pacquet-config` via a new dependency-free `pacquet-config-dir` crate, parameterized by app-name leaf.
- Verdaccio 6+ shape (`log:`, singular). The older plural `logs:` is silently ignored.
- `log.type` values other than `stdout` parse (verdaccio compatibility) but are ignored at runtime with a startup warning; only `stdout` is implemented.

## Notes

- File/syslog sinks are future work.
- New crate: `pacquet-config-dir` (std-only, used by both `pacquet-config` and `pnpm-registry`). New `pnpm-registry` deps: `home` and `tracing-subscriber`'s `json` feature — both already in `[workspace.dependencies]`.

Ref: https://github.com/pnpm/pnpm/issues/11973

## Test plan

- [x] Unit tests for YAML parsing, enum serde (incl. rejection of unknown values), the `pnpr`/`pnpm` config-dir branches (XDG / macOS / Windows / Linux), config-file existence gating, and the unsupported-sink path.
- [x] `cargo fmt --check`, `cargo clippy --deny warnings`, `cargo dylint` (perfectionist), and `cargo doc -D warnings` clean across the workspace.
- [x] Smoke-tested JSON + pretty output and global-config auto-discovery end-to-end.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic config-file discovery in the user home path.
  * Option to choose JSON-formatted logging in addition to pretty output.
  * HTTP request tracing now emits a single info record per request with status and millisecond latency.
  * Startup logs which config source was used (CLI, default path, or bundled); config precedence clarified (CLI > default path > bundled).

* **Chores**
  * Updated logging config to Verdaccio 6+ `log:` style and improved runtime log-level/format handling with RUST_LOG fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12033?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
