### PR TITLE
[replaced] feat(registry): implement health check endpoints and config env var substitution

### DIFF
--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -270,7 +270,8 @@ impl Config {
         listen: SocketAddr,
         public_url: Option<String>,
     ) -> Result<Self, serde_saphyr::Error> {
-        let file: ConfigFile = serde_saphyr::from_str(raw)?;
+        let substituted = substitute_env_vars(raw);
+        let file: ConfigFile = serde_saphyr::from_str(&substituted)?;
         let storage = resolve_relative(&file.storage, base_dir);
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
@@ -375,14 +376,84 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
     pattern == name
 }
 
+/// Scans the raw YAML config string and replaces `${VAR}` or `${VAR:-DEFAULT}`
+/// with the environment variable value, or the default, or empty string.
+fn substitute_env_vars(raw: &str) -> String {
+    let mut result = String::new();
+    let mut chars = raw.char_indices().peekable();
+    while let Some((_, c)) = chars.next() {
+        if c == '$' && chars.peek().map(|&(_, char_val)| char_val == '{').unwrap_or(false) {
+            chars.next(); // consume '{'
+            let mut var_content = String::new();
+            let mut found_close = false;
+            for (_, vc) in chars.by_ref() {
+                if vc == '}' {
+                    found_close = true;
+                    break;
+                }
+                var_content.push(vc);
+            }
+            if found_close {
+                if let Some(pos) = var_content.find(":-") {
+                    let name = &var_content[..pos];
+                    let default = &var_content[pos + 2..];
+                    let val = std::env::var(name).unwrap_or_else(|_| default.to_string());
+                    result.push_str(&val);
+                } else {
+                    let val = std::env::var(&var_content).unwrap_or_default();
+                    result.push_str(&val);
+                }
+            } else {
+                result.push_str("${");
+                result.push_str(&var_content);
+            }
+            continue;
+        }
+        result.push(c);
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Config, DEFAULT_CONFIG_YAML, pattern_matches, resolve_relative};
+    use super::{
+        Config, DEFAULT_CONFIG_YAML, pattern_matches, resolve_relative, substitute_env_vars,
+    };
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::{Path, PathBuf};
 
     fn listen() -> SocketAddr {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873))
+    }
+
+    #[test]
+    fn substitute_env_vars_works() {
+        unsafe {
+            std::env::set_var("PNPR_TEST_VAR_1", "hello");
+            std::env::set_var("PNPR_TEST_VAR_2", "world");
+            std::env::remove_var("PNPR_TEST_VAR_UNSET");
+        }
+
+        assert_eq!(substitute_env_vars(""), "");
+        assert_eq!(substitute_env_vars("plain string"), "plain string");
+        assert_eq!(substitute_env_vars("var: ${PNPR_TEST_VAR_1}"), "var: hello");
+        assert_eq!(
+            substitute_env_vars("vars: ${PNPR_TEST_VAR_1} and ${PNPR_TEST_VAR_2}"),
+            "vars: hello and world"
+        );
+        assert_eq!(substitute_env_vars("unset: ${PNPR_TEST_VAR_UNSET}"), "unset: ");
+        assert_eq!(
+            substitute_env_vars("default: ${PNPR_TEST_VAR_UNSET:-default_val}"),
+            "default: default_val"
+        );
+        assert_eq!(
+            substitute_env_vars("default_set: ${PNPR_TEST_VAR_1:-default_val}"),
+            "default_set: hello"
+        );
+        assert_eq!(
+            substitute_env_vars("malformed: ${PNPR_TEST_VAR_UNSET"),
+            "malformed: ${PNPR_TEST_VAR_UNSET"
+        );
     }
 
     #[test]

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -172,6 +172,12 @@ async fn get_packument_unscoped(
     headers: HeaderMap,
     Path(name): Path<String>,
 ) -> Response {
+    if name == "healthz" {
+        return serve_healthz();
+    }
+    if name == "readyz" {
+        return serve_readyz(&state).await;
+    }
     serve_packument(&state, &headers, &name).await
 }
 
@@ -182,6 +188,9 @@ async fn get_two_segments(
 ) -> Response {
     if first == "-" && second == "whoami" {
         return private_no_cache(serve_whoami(&state, &headers));
+    }
+    if first == "-" && second == "ping" {
+        return serve_ping();
     }
     if first.starts_with('@') {
         let full = format!("{first}/{second}");
@@ -1409,4 +1418,21 @@ fn error_response(err: &RegistryError) -> Response {
     let status = err.status_code();
     tracing::error!(%err, %status, "request failed");
     (status, err.to_string()).into_response()
+}
+
+fn serve_ping() -> Response {
+    (StatusCode::OK, axum::Json(serde_json::json!({}))).into_response()
+}
+
+fn serve_healthz() -> Response {
+    (StatusCode::OK, "OK").into_response()
+}
+
+async fn serve_readyz(state: &AppState) -> Response {
+    match std::fs::metadata(&state.inner.config.storage) {
+        Ok(meta) if meta.is_dir() => (StatusCode::OK, "OK").into_response(),
+        _ => {
+            (StatusCode::SERVICE_UNAVAILABLE, "Storage directory is not accessible").into_response()
+        }
+    }
 }

--- a/registry/crates/pnpm-registry/tests/server.rs
+++ b/registry/crates/pnpm-registry/tests/server.rs
@@ -548,3 +548,53 @@ async fn await_no_tgz(dir: &std::path::Path, budget: Duration) -> bool {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
+
+#[tokio::test]
+async fn ping_endpoint_returns_json_empty_object() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    let app = router(config);
+
+    let response = app.oneshot(Request::get("/-/ping").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = body_bytes(response.into_body()).await;
+    let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body, json!({}));
+}
+
+#[tokio::test]
+async fn healthz_endpoint_returns_ok() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    let app = router(config);
+
+    let response =
+        app.oneshot(Request::get("/healthz").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body, "OK");
+}
+
+#[tokio::test]
+async fn readyz_endpoint_returns_ok_when_storage_healthy() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    let app = router(config);
+
+    let response = app.oneshot(Request::get("/readyz").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body, "OK");
+}
+
+#[tokio::test]
+async fn readyz_endpoint_returns_service_unavailable_when_storage_not_exists() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_for("http://upstream.invalid", tmp.path().join("non_existent_folder"));
+    let app = router(config);
+
+    let response = app.oneshot(Request::get("/readyz").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body, "Storage directory is not accessible");
+}


### PR DESCRIPTION
This PR implements the `/healthz`, `/readyz`, and `/-/ping` endpoints and adds environment variable substitution support for the YAML configuration in pnpm-registry. All unit and integration tests compile and pass successfully.

---
Written by an agent (Antigravity, Gemini 3.5 Flash).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now support environment variable substitution using `${VAR}` and `${VAR:-DEFAULT}` syntax for dynamic configuration
  * Added monitoring endpoints `/healthz`, `/readyz`, and `/-/ping` to check registry health and readiness status

* **Tests**
  * Added integration tests to verify health check and readiness endpoint functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->