### PR TITLE
fix(package-manager): match pnpm's GVS path segment for injected file: deps

### DIFF
--- a/pacquet/crates/cli/tests/dedupe_injected_deps.rs
+++ b/pacquet/crates/cli/tests/dedupe_injected_deps.rs
@@ -8,6 +8,9 @@
 //! `file:<workspace>` back to `link:<rel>` once the dedupe pass
 //! recognizes the children-subset case.
 
+pub mod _utils;
+
+use _utils::enable_gvs_in_workspace_yaml;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
@@ -87,24 +90,15 @@ fn injected_leaf_workspace_dep_is_deduped_to_link() {
 /// `dedupeInjectedDeps: false` in `pnpm-workspace.yaml`: the injected
 /// snapshot stays as `file:packages/b` in the importer entry, the
 /// lockfile writer's [`ImporterDepVersion::File`] arm formats it, and
-/// the on-disk layout points at the virtual store slot instead of a
-/// `link:` sibling. Regression test for the writer panic on `file:`
-/// importer-level depPaths that the resolver-side dedupe used to hide.
-///
-/// Windows-skipped: pacquet's `create_virtual_store` pass does not
-/// materialise `file:<workspace>` snapshots into the virtual store
-/// yet (broader gap tracked under pnpm/pnpm#12009's
-/// `injectWorkspacePackages` line), so the symlink at
-/// `packages/a/node_modules/b` points at a non-existent target. Unix
-/// silently tolerates the broken link during the bin-link manifest
-/// walk; Windows is stricter and trips `ERROR_INVALID_NAME` reading
-/// through it with a mixed-separator path. The lockfile-writer
-/// regression this test guards is platform-independent, so the
-/// Linux + macOS coverage is enough until the materialise gap closes.
+/// `create_virtual_store` materialises the source project's contents
+/// into the (escaped) `b@file+packages+b` virtual-store slot so the
+/// per-importer symlink at `packages/a/node_modules/b` resolves to a
+/// real directory. Guards both the lockfile-writer regression on
+/// `file:` importer-level depPaths and the materialise step
+/// (pnpm/pnpm#12038).
 ///
 /// [`ImporterDepVersion::File`]: pacquet_lockfile::ImporterDepVersion::File
 #[test]
-#[cfg_attr(target_os = "windows", ignore = "file:<workspace> materialisation not ported")]
 fn injected_workspace_dep_with_dedupe_off_writes_file_arm() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -157,6 +151,89 @@ fn injected_workspace_dep_with_dedupe_off_writes_file_arm() {
         !lockfile.contains("link:../b"),
         "pnpm-lock.yaml should not rewrite the injected dep to link:../b when dedupe is disabled:\n{lockfile}",
     );
+
+    let dep = workspace.join("packages/a/node_modules/b");
+    assert!(
+        is_symlink_or_junction(&dep).expect("query packages/a/node_modules/b"),
+        "packages/a/node_modules/b should be a symlink into the virtual store when dedupe is disabled",
+    );
+    assert!(
+        dep.join("package.json").is_file(),
+        "packages/a/node_modules/b should resolve to a materialised slot — create_virtual_store must copy packages/b's contents into the file: snapshot's virtual-store directory (pnpm/pnpm#12038)",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Same `dedupeInjectedDeps: false` fixture, but with the global
+/// virtual store enabled. The GVS slot path is
+/// `<store>/links/<scope>/<name>/<version>/<hash>`, and the `<version>`
+/// segment for a `file:` directory dep has no semver to fill it: pnpm's
+/// `nameVerFromPkgSnapshot` yields `undefined`, which its
+/// `formatGlobalVirtualStorePath` renders as the literal `undefined`
+/// segment. Pacquet must do the same — emitting the raw `file:packages/b`
+/// version would put a `:` (and an embedded `/`) into the slot path,
+/// which Windows rejects with `ERROR_INVALID_NAME`. Regression test for
+/// pnpm/pnpm#12038.
+#[test]
+fn injected_workspace_dep_with_dedupe_off_materialises_under_gvs() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    enable_gvs_in_workspace_yaml(
+        &workspace,
+        "packages:\n  - 'packages/*'\ndedupeInjectedDeps: false\n",
+    );
+
+    fs::create_dir_all(workspace.join("packages/a")).expect("mkdir packages/a");
+    fs::write(
+        workspace.join("packages/a/package.json"),
+        serde_json::json!({
+            "name": "a",
+            "version": "1.0.0",
+            "dependencies": { "b": "workspace:*" },
+            "dependenciesMeta": { "b": { "injected": true } },
+        })
+        .to_string(),
+    )
+    .expect("write packages/a/package.json");
+
+    fs::create_dir_all(workspace.join("packages/b")).expect("mkdir packages/b");
+    fs::write(
+        workspace.join("packages/b/package.json"),
+        serde_json::json!({ "name": "b", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/b/package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let dep = workspace.join("packages/a/node_modules/b");
+    assert!(
+        is_symlink_or_junction(&dep).expect("query packages/a/node_modules/b"),
+        "packages/a/node_modules/b should be a symlink into the global virtual store",
+    );
+    assert!(
+        dep.join("package.json").is_file(),
+        "packages/a/node_modules/b should resolve to a materialised GVS slot (pnpm/pnpm#12038)",
+    );
+
+    // The slot path must not embed the raw `file:` version — that is
+    // the `ERROR_INVALID_NAME` shape on Windows the fix removes.
+    #[cfg(unix)]
+    {
+        let target = fs::read_link(&dep).expect("read packages/a/node_modules/b symlink");
+        assert!(
+            !target.to_string_lossy().contains("file:"),
+            "GVS slot path must not contain a `file:` segment with a colon; got {target:?}",
+        );
+    }
 
     drop((root, mock_instance));
 }

--- a/pacquet/crates/package-manager/src/virtual_store_layout.rs
+++ b/pacquet/crates/package-manager/src/virtual_store_layout.rs
@@ -28,8 +28,8 @@ use pacquet_graph_hasher::{
     format_global_virtual_store_path,
 };
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, SnapshotDepRef,
-    SnapshotEntry,
+    LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgVerPeer,
+    SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -240,7 +240,7 @@ impl VirtualStoreLayout {
             );
             let metadata_key = snapshot_key.without_peer();
             let name = metadata_key.name.to_string();
-            let version = metadata_key.suffix.version().to_string();
+            let version = gvs_version_segment(&metadata_key.suffix);
             let suffix = format_global_virtual_store_path(&name, &version, &hex_digest);
             gvs_suffixes.insert(snapshot_key.clone(), suffix);
         }
@@ -286,6 +286,26 @@ impl VirtualStoreLayout {
             None => key.to_virtual_store_name(self.virtual_store_dir_max_length),
         };
         self.package_store_dir.join(suffix)
+    }
+}
+
+/// Version segment of a snapshot's global-virtual-store path. Mirrors
+/// pnpm's
+/// [`nameVerFromPkgSnapshot`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/utils/src/nameVerFromPkgSnapshot.ts#L12-L23)
+/// (`pkgSnapshot.version ?? pkgInfo.version`) feeding
+/// [`formatGlobalVirtualStorePath`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L283-L286).
+///
+/// An injected `file:` workspace dep carries no `version` field in the
+/// lockfile, and its depPath version is non-semver, so upstream's
+/// `nameVerFromPkgSnapshot` returns `undefined` and the template-literal
+/// `formatGlobalVirtualStorePath` stringifies it to the literal segment
+/// `undefined`. Emitting the raw `file:<path>` here instead would put a
+/// `:` (and embedded `/`) into the slot path — rejected on Windows with
+/// `ERROR_INVALID_NAME` and divergent from pnpm. See pnpm/pnpm#12038.
+fn gvs_version_segment(suffix: &PkgVerPeer) -> String {
+    match suffix.version() {
+        VersionPart::File(_) => "undefined".to_string(),
+        VersionPart::Semver(_) | VersionPart::NonSemver(_) => suffix.version().to_string(),
     }
 }
 
@@ -791,5 +811,18 @@ mod tests {
             "full_pkg_id must keep the patch-hash segment; got {:?}",
             node.full_pkg_id,
         );
+    }
+
+    /// The GVS version segment is the semver for a registry dep, and
+    /// the literal `undefined` for an injected `file:` directory dep —
+    /// mirroring pnpm's `nameVerFromPkgSnapshot` → `undefined` and
+    /// keeping the `:` out of the slot path. See pnpm/pnpm#12038.
+    #[test]
+    fn gvs_version_segment_renders_file_deps_as_undefined() {
+        let semver: PackageKey = "foo@1.2.3".parse().unwrap();
+        assert_eq!(super::gvs_version_segment(&semver.suffix), "1.2.3");
+
+        let file_dep: PackageKey = "b@file:packages/b".parse().unwrap();
+        assert_eq!(super::gvs_version_segment(&file_dep.suffix), "undefined");
     }
 }


### PR DESCRIPTION
## Problem

Closes #12038.

When materialising an injected `file:` workspace dep (`dependenciesMeta[<alias>].injected: true`, `dedupeInjectedDeps: false`) under the **global virtual store** (`enableGlobalVirtualStore: true`), pacquet built the slot path as:

```
<store>/links/@/b/file:packages/b/<hash>/node_modules/b
```

The raw `file:packages/b` version segment embeds a `:` and a `/`, which:

- is rejected on **Windows** with `ERROR_INVALID_NAME` (os error 123), failing the install; and
- **diverges from pnpm**, which renders `@/b/undefined/<hash>` (frozen-lockfile) / `@/b/1.0.0/<hash>` (fresh).

The materialise step the issue describes is **already implemented** — the `LockfileResolution::Directory` arm runs the directory fetcher (landed with the `injectWorkspacePackages` / `dedupeInjectedDeps` ports), so on non-GVS installs the dep already copies into the escaped `b@file+packages+b` slot and resolves correctly. The remaining gap was the GVS path segment.

## Fix

`gvs_version_segment()` mirrors pnpm's [`nameVerFromPkgSnapshot`](https://github.com/pnpm/pnpm/blob/94240bc046/lockfile/utils/src/nameVerFromPkgSnapshot.ts#L12-L23) (`pkgSnapshot.version ?? pkgInfo.version`) feeding [`formatGlobalVirtualStorePath`](https://github.com/pnpm/pnpm/blob/94240bc046/deps/graph-hasher/src/index.ts#L283-L286). An injected `file:` dep has no lockfile `version` and a non-semver depPath, so upstream produces the literal segment `undefined`; pacquet now does the same. Semver / non-semver deps are unchanged.

Verified pacquet now writes `…/links/@/b/undefined/<hash>/…` — colon-free and matching pnpm's `--frozen-lockfile` output.

## Tests

- Re-enabled `injected_workspace_dep_with_dedupe_off_writes_file_arm` on Windows (removed the `#[cfg_attr(target_os = "windows", ignore)]`) and strengthened it to assert the dep actually materialises (resolves to a real dir with `package.json`), not just lockfile contents.
- Added `injected_workspace_dep_with_dedupe_off_materialises_under_gvs` — a GVS regression test asserting the slot resolves and the symlink target carries no `file:`/colon segment. Confirmed it **fails** when the fix is reverted.
- Added a `gvs_version_segment` unit test.

`just fmt` + `just lint` clean; the affected cli tests and all 365 `pacquet-package-manager` unit tests pass.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility when processing workspace dependency paths.
  * Fixed global virtual store slot generation for file-based workspace dependencies.

* **Tests**
  * Enhanced test coverage for injected dependency deduplication with various virtual store configurations and materialization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->