### PR TITLE
feat(registry): enforce per-package access policy from YAML

### DIFF
--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -1357,7 +1357,7 @@ packages:
     #[test]
     fn policy_unknown_access_token_is_a_config_error() {
         // Named groups aren't modeled yet — an unrecognized token must
-        // fail the parse rather than silently mis-enforce.
+        // fail the parse rather than silently enforce the wrong rule.
         let yaml = "\
 storage: ./s
 uplinks: {}

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -540,6 +540,11 @@ fn build_policies(
             let access_rule = parse_access_rule(access.access.as_deref(), AccessRule::All)?;
             let publish_rule =
                 parse_access_rule(access.publish.as_deref(), AccessRule::Authenticated)?;
+            // `unpublish` folds into `publish` at enforcement time, but
+            // validate it here so an unknown token fails fast like the
+            // others instead of slipping through. (Defaults to the
+            // publish rule when absent, matching verdaccio.)
+            parse_access_rule(access.unpublish.as_deref(), publish_rule)?;
             PackagePolicy::new(pattern, access_rule, publish_rule)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -1364,6 +1369,24 @@ uplinks: {}
 packages:
   'lodash':
     access: admin
+";
+        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+        assert!(
+            matches!(err, super::RegistryError::InvalidAccessRule { .. }),
+            "expected InvalidAccessRule, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn policy_unknown_unpublish_token_is_a_config_error() {
+        // `unpublish` folds into `publish` at enforcement, but it's
+        // still validated so a typo can't slip through unchecked.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  'lodash':
+    unpublish: bogus
 ";
         let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
         assert!(

--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -6,7 +6,8 @@ use indexmap::IndexMap;
 use pacquet_env_replace::{SystemEnv, env_replace_lossy};
 use serde::Deserialize;
 
-use crate::policy::PackagePolicies;
+use crate::error::RegistryError;
+use crate::policy::{AccessRule, PackagePolicies, PackagePolicy};
 
 /// The bundled verdaccio-shaped YAML config, mirrored from
 /// `@pnpm/registry-mock`'s `registry/config.yaml`. Other crates can
@@ -65,11 +66,13 @@ pub struct Config {
     /// re-fetched from the resolved uplink. Ignored when no uplink
     /// matches.
     pub packument_ttl: Duration,
-    /// Per-package access and publish rules. Defaults to
-    /// [`PackagePolicies::registry_mock_defaults`] so a vanilla
-    /// `Config::proxy` / `Config::static_serve` enforces the same
-    /// `@private/*` and `@pnpm.e2e/needs-auth` policies that
-    /// `@pnpm/registry-mock` did under verdaccio.
+    /// Per-package access and publish rules. [`Config::from_yaml`]
+    /// compiles these from the YAML `packages:` block (each entry's
+    /// `access` / `publish` tokens); the programmatic
+    /// [`Config::proxy`] / [`Config::static_serve`] constructors use
+    /// [`PackagePolicies::registry_mock_defaults`] instead, enforcing
+    /// the `@private/*` and `@pnpm.e2e/needs-auth` rules
+    /// `@pnpm/registry-mock` applied under verdaccio.
     pub policies: PackagePolicies,
     /// Where to read/write the htpasswd-format user file and the
     /// token database. Both stores are in-memory when their paths
@@ -226,9 +229,11 @@ pub struct UplinkConfig {
     pub url: String,
 }
 
-/// Per-package routing rules. `access` and `publish` are parsed for
-/// config compatibility but ignored (pnpm-registry is read-only and
-/// has no auth). `proxy` selects the [`UplinkConfig`] by name.
+/// Per-package routing and access rules. `access` / `publish` are
+/// verdaccio access tokens (`$all` / `$authenticated` / `$anonymous`)
+/// compiled into the [`PackagePolicies`] that gate reads and writes;
+/// `unpublish` is parsed but currently folded into `publish` at
+/// enforcement time. `proxy` selects the [`UplinkConfig`] by name.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct PackageAccess {
     pub access: Option<String>,
@@ -443,16 +448,18 @@ impl Config {
         base_dir: &Path,
         listen: SocketAddr,
         public_url: Option<String>,
-    ) -> Result<Self, serde_saphyr::Error> {
+    ) -> Result<Self, RegistryError> {
         let (substituted, unresolved) = env_replace_lossy::<SystemEnv>(raw);
         if !unresolved.is_empty() {
             tracing::warn!(?unresolved, "config references unset environment variables");
         }
-        let file: ConfigFile = serde_saphyr::from_str(&substituted)?;
+        let file: ConfigFile = serde_saphyr::from_str(&substituted)
+            .map_err(|err| RegistryError::InvalidConfig { reason: err.to_string() })?;
         let storage = resolve_relative(&file.storage, base_dir);
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
+        let policies = build_policies(&file.packages)?;
         Ok(Self {
             listen,
             public_url,
@@ -460,12 +467,7 @@ impl Config {
             uplinks: file.uplinks,
             packages: file.packages,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
-            // Policies could be derived from `packages[*].{access,publish}`
-            // here, but the bundled `config.yaml` already matches the
-            // `registry_mock_defaults` set verbatim, and a YAML-driven
-            // policy wiring is out of scope for this rebase. Keep the
-            // hard-coded defaults — same as `proxy` / `static_serve`.
-            policies: PackagePolicies::registry_mock_defaults(),
+            policies,
             auth,
             logs,
         })
@@ -523,6 +525,34 @@ fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
     }
 }
 
+/// Compile the YAML `packages:` rules into the runtime
+/// [`PackagePolicies`], in declared order (first match wins). A
+/// missing `access` defaults to `$all`, a missing `publish` to
+/// `$authenticated` — the same safe fallback [`PackagePolicies`]
+/// applies to packages no rule matches. `unpublish` is parsed but
+/// not yet enforced separately (it folds into `publish`).
+fn build_policies(
+    packages: &IndexMap<String, PackageAccess>,
+) -> Result<PackagePolicies, RegistryError> {
+    let rules = packages
+        .iter()
+        .map(|(pattern, access)| {
+            let access_rule = parse_access_rule(access.access.as_deref(), AccessRule::All)?;
+            let publish_rule =
+                parse_access_rule(access.publish.as_deref(), AccessRule::Authenticated)?;
+            PackagePolicy::new(pattern, access_rule, publish_rule)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PackagePolicies::new(rules))
+}
+
+fn parse_access_rule(
+    value: Option<&str>,
+    default: AccessRule,
+) -> Result<AccessRule, RegistryError> {
+    value.map_or(Ok(default), str::parse)
+}
+
 /// Join `config.yaml` onto a resolved config directory and keep the
 /// path only when it points at an existing file (so a directory or a
 /// missing entry falls back to the bundled config).
@@ -578,7 +608,7 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, config_file_in,
+        AccessRule, Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, config_file_in,
         pattern_matches, resolve_relative,
     };
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -1251,5 +1281,108 @@ log:
         // `type:` omitted entirely falls back to the supported stdout sink.
         assert_eq!(config.logs.sink, "stdout");
         assert!(config.logs.sink_is_supported());
+    }
+
+    // ----- policy wiring from YAML ------------------------------------------
+
+    #[test]
+    fn policies_are_derived_from_packages_block() {
+        // The `access` / `publish` tokens in each entry drive the
+        // runtime policy — not a hard-coded default set.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  '@secret/*':
+    access: $authenticated
+    publish: $authenticated
+  '**':
+    access: $all
+    publish: $authenticated
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        let secret = config.policies.for_package("@secret/thing");
+        assert_eq!(secret.access, AccessRule::Authenticated);
+        assert_eq!(secret.publish, AccessRule::Authenticated);
+        let public = config.policies.for_package("lodash");
+        assert_eq!(public.access, AccessRule::All);
+        assert_eq!(public.publish, AccessRule::Authenticated);
+    }
+
+    #[test]
+    fn policy_first_matching_rule_wins() {
+        // `@secret/*` is declared before the `**` catch-all, so it
+        // wins for a scoped package even though both match.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  '@secret/*':
+    access: $authenticated
+  '**':
+    access: $all
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.policies.for_package("@secret/x").access, AccessRule::Authenticated);
+        assert_eq!(config.policies.for_package("anything").access, AccessRule::All);
+    }
+
+    #[test]
+    fn policy_missing_access_and_publish_default_to_all_and_authenticated() {
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  'lodash': {}
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        let effective = config.policies.for_package("lodash");
+        assert_eq!(effective.access, AccessRule::All);
+        assert_eq!(effective.publish, AccessRule::Authenticated);
+    }
+
+    #[test]
+    fn policy_anonymous_token_is_wired() {
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  '@anon/*':
+    access: $anonymous
+";
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        assert_eq!(config.policies.for_package("@anon/x").access, AccessRule::Anonymous);
+    }
+
+    #[test]
+    fn policy_unknown_access_token_is_a_config_error() {
+        // Named groups aren't modeled yet — an unrecognized token must
+        // fail the parse rather than silently mis-enforce.
+        let yaml = "\
+storage: ./s
+uplinks: {}
+packages:
+  'lodash':
+    access: admin
+";
+        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
+        assert!(
+            matches!(err, super::RegistryError::InvalidAccessRule { .. }),
+            "expected InvalidAccessRule, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn bundled_default_config_enforces_its_protections() {
+        // Building from the bundled YAML must reproduce the
+        // registry-mock protections that used to be hard-coded.
+        let config = Config::from_default_yaml(Path::new("/tmp"), listen(), None);
+        assert_eq!(
+            config.policies.for_package("@pnpm.e2e/needs-auth").access,
+            AccessRule::Authenticated,
+        );
+        assert_eq!(config.policies.for_package("@private/foo").access, AccessRule::Authenticated);
+        assert_eq!(config.policies.for_package("lodash").access, AccessRule::All);
+        assert_eq!(config.policies.for_package("lodash").publish, AccessRule::Authenticated);
     }
 }

--- a/registry/crates/pnpm-registry/src/error.rs
+++ b/registry/crates/pnpm-registry/src/error.rs
@@ -32,7 +32,9 @@ pub enum RegistryError {
         filename: String,
     },
 
-    #[display("Access rule {value:?} is not recognized (expected $all or $authenticated)")]
+    #[display(
+        "Access rule {value:?} is not recognized (expected $all, $authenticated, or $anonymous)"
+    )]
     #[from(skip)]
     InvalidAccessRule {
         #[error(not(source))]
@@ -44,6 +46,15 @@ pub enum RegistryError {
     InvalidPolicyPattern {
         #[error(not(source))]
         pattern: String,
+        reason: String,
+    },
+
+    /// The YAML config could not be parsed. Startup-only — this never
+    /// surfaces over HTTP, but `Config` parsing shares this error type.
+    #[display("Invalid config: {reason}")]
+    #[from(skip)]
+    InvalidConfig {
+        #[error(not(source))]
         reason: String,
     },
 
@@ -162,6 +173,7 @@ impl RegistryError {
             | RegistryError::InvalidTarballName { .. }
             | RegistryError::InvalidAccessRule { .. }
             | RegistryError::InvalidPolicyPattern { .. }
+            | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }
             | RegistryError::BadRequest { .. } => StatusCode::BAD_REQUEST,
             RegistryError::Unauthenticated { .. } => StatusCode::UNAUTHORIZED,

--- a/registry/crates/pnpm-registry/src/policy.rs
+++ b/registry/crates/pnpm-registry/src/policy.rs
@@ -11,9 +11,9 @@ use wax::{Glob, Program};
 use crate::error::RegistryError;
 
 /// What identities are allowed to perform an action on a package.
-/// Mirrors the verdaccio tokens with the same names. The subset is
-/// minimal because `@pnpm/registry-mock` only ever uses these two —
-/// `$anonymous` and per-group rules aren't needed for any pnpm test.
+/// Mirrors verdaccio's built-in access tokens. Named groups and
+/// per-user membership are not modeled yet — only the three special
+/// groups every caller's identity is derived from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessRule {
     /// `$all` — anyone, authenticated or not.
@@ -21,6 +21,11 @@ pub enum AccessRule {
     /// `$authenticated` — any caller carrying a valid Bearer token
     /// or Basic auth header.
     Authenticated,
+    /// `$anonymous` — only callers *without* valid credentials.
+    /// Authenticated callers are not in this group, so a rule of
+    /// `$anonymous` denies them (matching verdaccio, where the
+    /// `$anonymous` group is absent from a logged-in user's groups).
+    Anonymous,
 }
 
 impl FromStr for AccessRule {
@@ -29,6 +34,7 @@ impl FromStr for AccessRule {
         match value {
             "$all" | "all" => Ok(AccessRule::All),
             "$authenticated" | "authenticated" => Ok(AccessRule::Authenticated),
+            "$anonymous" | "anonymous" => Ok(AccessRule::Anonymous),
             other => Err(RegistryError::InvalidAccessRule { value: other.to_string() }),
         }
     }
@@ -163,5 +169,28 @@ mod tests {
         let effective = policies.for_package("anything");
         assert_eq!(effective.access, AccessRule::All);
         assert_eq!(effective.publish, AccessRule::Authenticated);
+    }
+
+    #[test]
+    fn access_rule_parses_special_tokens_with_and_without_sigil() {
+        use super::AccessRule::{All, Anonymous, Authenticated};
+        for (token, expected) in [
+            ("$all", All),
+            ("all", All),
+            ("$authenticated", Authenticated),
+            ("authenticated", Authenticated),
+            ("$anonymous", Anonymous),
+            ("anonymous", Anonymous),
+        ] {
+            assert_eq!(token.parse::<AccessRule>().unwrap(), expected, "{token}");
+        }
+    }
+
+    #[test]
+    fn access_rule_rejects_unknown_token() {
+        // Named groups aren't modeled yet, so a group name (or typo)
+        // is a hard error rather than a silent mis-enforcement.
+        assert!("admin".parse::<AccessRule>().is_err());
+        assert!("$all $authenticated".parse::<AccessRule>().is_err());
     }
 }

--- a/registry/crates/pnpm-registry/src/policy.rs
+++ b/registry/crates/pnpm-registry/src/policy.rs
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn access_rule_rejects_unknown_token() {
         // Named groups aren't modeled yet, so a group name (or typo)
-        // is a hard error rather than a silent mis-enforcement.
+        // is a hard error rather than silently enforcing the wrong rule.
         assert!("admin".parse::<AccessRule>().is_err());
         assert!("$all $authenticated".parse::<AccessRule>().is_err());
     }

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -1295,6 +1295,15 @@ enum Action {
     Publish,
 }
 
+impl Action {
+    fn label(self) -> &'static str {
+        match self {
+            Action::Access => "access",
+            Action::Publish => "publish",
+        }
+    }
+}
+
 /// Resolve the caller and check the per-package rule. Returns
 /// `Ok(())` when the call is allowed; otherwise the appropriate
 /// `Unauthenticated` / `Forbidden` error.
@@ -1315,13 +1324,21 @@ fn enforce_access(
         &state.inner.auth.users,
         &state.inner.auth.tokens,
     );
-    match (rule, authenticated, action) {
-        (AccessRule::All, _, Action::Access) => Ok(()),
-        (AccessRule::All, _, _) => Ok(()),
-        (AccessRule::Authenticated, Some(_), _) => Ok(()),
-        (AccessRule::Authenticated, None, _) => {
+    match (rule, authenticated) {
+        (AccessRule::All, _) => Ok(()),
+        (AccessRule::Authenticated, Some(_)) => Ok(()),
+        (AccessRule::Authenticated, None) => {
             Err(RegistryError::Unauthenticated { resource: format!("package {package:?}") })
         }
+        (AccessRule::Anonymous, None) => Ok(()),
+        // `$anonymous` admits only unauthenticated callers; a valid
+        // identity falls outside that group, so it's forbidden rather
+        // than unauthenticated.
+        (AccessRule::Anonymous, Some(user)) => Err(RegistryError::Forbidden {
+            user,
+            action: action.label(),
+            resource: format!("package {package:?}"),
+        }),
     }
 }
 

--- a/registry/crates/pnpm-registry/tests/policy.rs
+++ b/registry/crates/pnpm-registry/tests/policy.rs
@@ -1,0 +1,97 @@
+//! Integration tests for the YAML-driven access policy: the
+//! `packages:` `access` / `publish` tokens compile into the runtime
+//! policy and gate requests, including the `$anonymous` rule.
+//! Static-mode (no upstream) to keep the tests hermetic.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use pnpm_registry::{Config, router};
+
+fn listen() -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873))
+}
+
+/// Write a `config.yaml` (with `packages_block` spliced in) into a
+/// fresh tempdir and load it through the real `from_yaml` path, so
+/// the test exercises YAML parsing → policy compilation end to end.
+fn config_from_yaml(packages_block: &str) -> (TempDir, Config) {
+    let dir = TempDir::new().unwrap();
+    let storage = dir.path().join("storage");
+    std::fs::create_dir_all(&storage).unwrap();
+    let yaml = format!("storage: {}\nuplinks: {{}}\n{packages_block}\n", storage.display());
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    let config =
+        Config::from_yaml(&path, listen(), Some("http://example.test".to_string())).unwrap();
+    (dir, config)
+}
+
+fn get(path: &str) -> Request<Body> {
+    Request::get(path).body(Body::empty()).unwrap()
+}
+
+fn get_auth(path: &str, token: &str) -> Request<Body> {
+    Request::get(path)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn status_of(app: axum::Router, req: Request<Body>) -> StatusCode {
+    app.oneshot(req).await.unwrap().status()
+}
+
+async fn add_user_and_get_token(app: &axum::Router, username: &str, password: &str) -> String {
+    let path = format!("/-/user/org.couchdb.user:{username}");
+    let body = json!({
+        "name": username,
+        "password": password,
+        "email": "u@e.test",
+        "type": "user",
+        "roles": [],
+    });
+    let req = Request::put(&path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&bytes).unwrap();
+    payload["token"].as_str().expect("token in response").to_string()
+}
+
+#[tokio::test]
+async fn authenticated_access_token_from_yaml_gates_anonymous_reads() {
+    let (_dir, config) = config_from_yaml(
+        "packages:\n  '@secret/*':\n    access: $authenticated\n  '**':\n    access: $all\n",
+    );
+    let app = router(config);
+
+    // `@secret/*` requires auth: an anonymous read is 401.
+    assert_eq!(status_of(app.clone(), get("/@secret/thing")).await, StatusCode::UNAUTHORIZED);
+    // A `**` ($all) package is readable anonymously — it's just absent
+    // on disk, so 404, which proves the access check passed.
+    assert_eq!(status_of(app, get("/lodash")).await, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn anonymous_rule_admits_anonymous_and_forbids_authenticated() {
+    let (_dir, config) = config_from_yaml(
+        "packages:\n  '@anon/*':\n    access: $anonymous\n  '**':\n    access: $all\n",
+    );
+    let app = router(config);
+
+    // Anonymous read passes the access check (404 = allowed but absent).
+    assert_eq!(status_of(app.clone(), get("/@anon/x")).await, StatusCode::NOT_FOUND);
+
+    // An authenticated caller is outside the `$anonymous` group → 403.
+    let token = add_user_and_get_token(&app, "alice", "secret").await;
+    assert_eq!(status_of(app, get_auth("/@anon/x", &token)).await, StatusCode::FORBIDDEN);
+}


### PR DESCRIPTION
## Summary

Wires `pnpm-registry`'s per-package access policy from the YAML config instead of hard-coding it, and adds the `$anonymous` access rule.

Until now `from_yaml` / `from_default_yaml` ignored each `packages[*].access` / `.publish` token and always installed `PackagePolicies::registry_mock_defaults()`. So a config like:

```yaml
packages:
  '@acme/*':
    access: $authenticated
```

parsed fine but was **silently unenforced** — `@acme/*` stayed world-readable. This closes that gap: configured ACLs now actually gate requests.

## What's in

- **Policy compiled from YAML.** `from_yaml_str` builds `PackagePolicies` from the `packages:` block in declared order (first match wins). Missing `access` defaults to `$all`, missing `publish` to `$authenticated` — the same safe fallback applied to unmatched packages.
- **`$anonymous` rule.** New `AccessRule::Anonymous`: admits only unauthenticated callers. An authenticated caller is outside that group, so it gets **403** (matching verdaccio, where `$anonymous` is absent from a logged-in user's groups).
- **Fail closed on unknown tokens.** A token that isn't `$all` / `$authenticated` / `$anonymous` (e.g. a named group, not modeled yet) now fails config parsing rather than silently mis-enforcing.
- **Programmatic constructors unchanged.** `Config::proxy` / `Config::static_serve` still use `registry_mock_defaults`, so the bundled/test behaviour is identical.

## Notes / scope

- `unpublish` is parsed but still folds into `publish` at enforcement time (separate item).
- Named groups / per-user group membership remain unsupported (separate item in #11973).
- The bundled `config.yaml` already carries the `@private/*` and `@pnpm.e2e/needs-auth` rules, so `from_default_yaml` reproduces the previous protections (covered by a regression test).

## Test plan

- [x] New unit tests: YAML→policy derivation, defaults, first-match-wins, `$anonymous`, unknown-token error, and bundled-config protections preserved; plus `AccessRule` parsing/rejection.
- [x] New integration test (`tests/policy.rs`) drives the real `from_yaml` → router → enforce path: an `$authenticated` scope 401s anonymous reads; an `$anonymous` scope admits anonymous (404) and 403s an authenticated caller.
- [x] Existing auth/integration tests unaffected (they use `static_serve`).
- [x] `cargo test`, `cargo clippy --deny warnings`, `cargo dylint` (perfectionist), `cargo fmt --check`, `cargo doc -D warnings` all clean.

Refs #11973 (Access control → "Wire policy fully from YAML" + "`$anonymous` group").

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package access policies now compile directly from YAML package entries.
  * Anonymous access token supported in access rules.

* **Bug Fixes**
  * Configuration parse errors surface as clear client-facing "Invalid config" responses (400).
  * Authorization behavior updated for anonymous vs. authenticated requests.

* **Documentation**
  * Updated docs describing YAML-driven policy compilation and token semantics.

* **Tests**
  * Added integration and unit tests covering policy derivation and access scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->