### PR TITLE
feat(pacquet): add pnpmfile hooks support

### DIFF
--- a/.changeset/add-pnpmfile-hooks.md
+++ b/.changeset/add-pnpmfile-hooks.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Add pnpmfile hooks support (`.pnpmfile.cjs` / `pnpmfile.cjs`) for `readPackage`, `afterAllResolved`, `preResolution`, and `filterLog` hooks during resolution.

--- a/.changeset/add-pnpmfile-hooks.md
+++ b/.changeset/add-pnpmfile-hooks.md
@@ -1,5 +1,0 @@
----
-"pacquet": minor
----
-
-Add pnpmfile hooks support (`.pnpmfile.cjs` / `pnpmfile.cjs`) for `readPackage`, `afterAllResolved`, `preResolution`, and `filterLog` hooks during resolution.

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -82,7 +82,7 @@ jobs:
           install: false
 
       - name: Install Node.js (for hooks tests)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -85,7 +85,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: false
 
       - name: Cache pnpm
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -81,10 +81,8 @@ jobs:
         with:
           install: false
 
-      - name: Install Node.js (for hooks tests)
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
+      - name: Install Node.js via pnpm (for hooks tests)
+        run: pnpm runtime set node 22 --global
 
       - name: Cache pnpm
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -81,6 +81,12 @@ jobs:
         with:
           install: false
 
+      - name: Install Node.js (for hooks tests)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: false
+
       - name: Cache pnpm
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "pacquet-hooks"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-trait",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2487,6 +2487,7 @@ name = "pacquet-hooks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "derive_more",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.16"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
 dependencies = [
  "anstyle",
  "memchr",
@@ -169,7 +169,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -191,15 +191,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -382,9 +382,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -403,17 +403,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "chrono"
@@ -491,10 +480,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -599,16 +588,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -628,15 +607,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -753,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.2.1"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -790,7 +760,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -823,7 +793,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -848,13 +818,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -865,9 +835,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -891,6 +861,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -929,12 +911,13 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1016,7 +999,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1103,7 +1086,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1139,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1193,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "foldhash 0.2.0",
 ]
@@ -1208,6 +1190,12 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1228,22 +1216,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-net"
-version = "0.26.1"
+name = "hickory-proto"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
+ "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto",
  "idna",
  "ipnet",
- "jni",
- "rand 0.10.1",
+ "once_cell",
+ "rand",
+ "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1252,46 +1241,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-proto"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "prefix-trie",
- "rand 0.10.1",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hickory-resolver"
-version = "0.26.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-net",
  "hickory-proto",
  "ipconfig",
- "ipnet",
- "jni",
  "moka",
- "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand",
  "resolv-conf",
  "smallvec",
- "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1308,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
@@ -1362,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1545,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1576,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1623,8 +1587,16 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "serde",
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1690,7 +1662,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1709,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1724,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1778,6 +1750,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -1838,9 +1822,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miette"
@@ -1865,7 +1849,7 @@ dependencies = [
  "cfg-if",
  "miette-derive 7.6.0",
  "owo-colors",
- "supports-color",
+ "supports-color 3.0.2",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
@@ -1881,7 +1865,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1892,7 +1876,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1919,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1945,7 +1929,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1969,12 +1953,6 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "node-semver"
@@ -2150,6 +2128,10 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "pacquet-catalogs-config"
@@ -2193,12 +2175,14 @@ dependencies = [
  "dialoguer",
  "dunce",
  "flate2",
+ "futures-util",
  "home",
  "indexmap",
  "insta",
  "miette 7.6.0",
  "mockito",
  "node-semver",
+ "owo-colors",
  "pacquet-config",
  "pacquet-diagnostics",
  "pacquet-executor",
@@ -2223,6 +2207,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "tabled",
  "tar",
  "tempfile",
  "tokio",
@@ -3113,6 +3098,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,7 +3126,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3164,6 +3160,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3312,17 +3314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-trie"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
-dependencies = [
- "either",
- "ipnet",
- "num-traits",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,7 +3330,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3387,7 +3400,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3410,7 +3423,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3441,18 +3454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -3462,7 +3464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -3473,12 +3475,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3505,6 +3501,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3552,9 +3557,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3633,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -3692,9 +3697,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3718,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3732,7 +3737,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3808,7 +3813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3876,7 +3881,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3923,7 +3928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -3934,7 +3939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
  "sha2-asm",
 ]
@@ -4027,14 +4032,14 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4048,9 +4053,9 @@ checksum = "8e9997ca938c186fe85387bedd38c54522f1800d7707b14ed4b8516a384c2c05"
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -4102,10 +4107,10 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4113,6 +4118,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "supports-color"
@@ -4134,6 +4149,17 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4163,14 +4189,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
@@ -4182,24 +4208,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
+name = "tabled"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
 dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
+ "papergrid",
+ "tabled_derive",
 ]
 
 [[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
+name = "tabled_derive"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
 dependencies = [
- "core-foundation-sys",
- "libc",
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4290,7 +4318,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4301,7 +4329,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4373,7 +4401,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4464,7 +4492,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4686,9 +4714,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4699,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4709,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4719,22 +4747,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4803,9 +4831,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4929,7 +4957,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4940,7 +4968,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4994,7 +5022,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5003,16 +5031,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5030,31 +5049,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5073,22 +5075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5097,22 +5087,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5121,22 +5099,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5145,22 +5111,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -5184,7 +5138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -5195,10 +5149,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5214,7 +5168,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5303,35 +5257,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5344,7 +5298,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5384,7 +5338,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -169,7 +169,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -191,15 +191,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecount"
@@ -382,9 +382,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -403,6 +403,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -480,10 +491,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -588,6 +599,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -607,6 +628,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -723,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -760,7 +790,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -793,7 +823,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -818,13 +848,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -835,9 +865,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -861,18 +891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
 dependencies = [
  "encoding_rs",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -911,13 +929,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -999,7 +1016,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1086,6 +1103,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1121,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1175,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "foldhash 0.2.0",
 ]
@@ -1190,12 +1208,6 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1216,23 +1228,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1241,21 +1252,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1272,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1326,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1509,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1540,7 +1576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1587,16 +1623,8 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
+ "serde",
 ]
 
 [[package]]
@@ -1662,7 +1690,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1681,7 +1709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1696,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1750,18 +1778,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1822,9 +1838,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miette"
@@ -1849,7 +1865,7 @@ dependencies = [
  "cfg-if",
  "miette-derive 7.6.0",
  "owo-colors",
- "supports-color 3.0.2",
+ "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
@@ -1865,7 +1881,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1876,7 +1892,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1903,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1929,7 +1945,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1953,6 +1969,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "node-semver"
@@ -2128,10 +2150,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
-]
 
 [[package]]
 name = "pacquet-catalogs-config"
@@ -2175,14 +2193,12 @@ dependencies = [
  "dialoguer",
  "dunce",
  "flate2",
- "futures-util",
  "home",
  "indexmap",
  "insta",
  "miette 7.6.0",
  "mockito",
  "node-semver",
- "owo-colors",
  "pacquet-config",
  "pacquet-diagnostics",
  "pacquet-executor",
@@ -2207,7 +2223,6 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "tabled",
  "tar",
  "tempfile",
  "tokio",
@@ -2468,6 +2483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pacquet-hooks"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "pacquet-integrated-benchmark"
 version = "0.0.0"
 dependencies = [
@@ -2636,6 +2661,7 @@ dependencies = [
  "pacquet-fs",
  "pacquet-git-fetcher",
  "pacquet-graph-hasher",
+ "pacquet-hooks",
  "pacquet-lockfile",
  "pacquet-lockfile-preferred-versions",
  "pacquet-lockfile-verification",
@@ -2812,6 +2838,7 @@ dependencies = [
  "pacquet-catalogs-types",
  "pacquet-deps-path",
  "pacquet-fs",
+ "pacquet-hooks",
  "pacquet-lockfile",
  "pacquet-package-manifest",
  "pacquet-patching",
@@ -3085,17 +3112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "papergrid"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
-dependencies = [
- "bytecount",
- "fnv",
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,7 +3129,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3147,12 +3163,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3301,6 +3311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,29 +3338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3387,7 +3386,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3410,7 +3409,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3441,7 +3440,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3451,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3462,6 +3472,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3488,15 +3504,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3544,9 +3551,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3625,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
@@ -3684,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3710,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3724,7 +3731,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3800,7 +3807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3868,7 +3875,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3915,7 +3922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3926,7 +3933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
  "sha2-asm",
 ]
@@ -4019,14 +4026,14 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4040,9 +4047,9 @@ checksum = "8e9997ca938c186fe85387bedd38c54522f1800d7707b14ed4b8516a384c2c05"
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "cc",
  "js-sys",
@@ -4094,10 +4101,10 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4105,16 +4112,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
 
 [[package]]
 name = "supports-color"
@@ -4136,17 +4133,6 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -4176,14 +4162,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "14311e7e9a03114cd4b65eedd54e8fed2945e17f08586ae97ef53bc0669f9581"
 dependencies = [
  "libc",
  "memchr",
@@ -4195,26 +4181,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabled"
-version = "0.17.0"
+name = "system-configuration"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "papergrid",
- "tabled_derive",
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
 ]
 
 [[package]]
-name = "tabled_derive"
-version = "0.9.0"
+name = "system-configuration-sys"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4305,7 +4289,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4316,7 +4300,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4388,7 +4372,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4479,7 +4463,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4701,9 +4685,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4714,9 +4698,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4724,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4734,22 +4718,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4818,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4944,7 +4928,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4955,7 +4939,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5009,7 +4993,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5018,7 +5002,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -5036,14 +5029,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5062,10 +5072,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5074,10 +5096,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5086,10 +5120,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5098,10 +5144,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -5125,7 +5183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -5136,10 +5194,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5155,7 +5213,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5244,35 +5302,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5285,7 +5343,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -5325,7 +5383,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ pacquet-deps-path                         = { path = "pacquet/crates/deps-path" 
 pacquet-detect-libc                       = { path = "pacquet/crates/detect-libc" }
 pacquet-diagnostics                       = { path = "pacquet/crates/diagnostics" }
 pacquet-graph-hasher                      = { path = "pacquet/crates/graph-hasher" }
+pacquet-hooks                             = { path = "pacquet/crates/hooks" }
 pacquet-store-dir                         = { path = "pacquet/crates/store-dir" }
 pacquet-reporter                          = { path = "pacquet/crates/reporter" }
 pacquet-patching                          = { path = "pacquet/crates/patching" }

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
-name    = "pacquet-hooks"
-version = "0.1.0"
-edition = "2021"
+name                  = "pacquet-hooks"
+version               = "0.1.0"
+publish               = false
+authors.workspace     = true
+description.workspace = true
+edition.workspace     = true
+homepage.workspace    = true
+keywords.workspace    = true
+license.workspace     = true
+repository.workspace  = true
 
 [dependencies]
-serde_json  = "1.0"
+serde_json  = { workspace = true }
 async-trait = "0.1"
 tokio       = { workspace = true, features = ["rt", "process", "time", "io-util"] }
 derive_more = { workspace = true }
@@ -12,3 +19,6 @@ derive_more = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio    = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name                  = "pacquet-hooks"
-version               = "0.1.0"
+version               = "0.0.1"
 publish               = false
 authors.workspace     = true
 description.workspace = true

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pacquet-hooks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1.0"
+async-trait = "0.1"
+tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace  = true
 [dependencies]
 serde_json  = { workspace = true }
 async-trait = "0.1"
-tokio       = { workspace = true, features = ["rt", "process", "time", "io-util"] }
+tokio       = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
 derive_more = { workspace = true }
 
 [dev-dependencies]

--- a/pacquet/crates/hooks/Cargo.toml
+++ b/pacquet/crates/hooks/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
-name = "pacquet-hooks"
+name    = "pacquet-hooks"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde_json = "1.0"
+serde_json  = "1.0"
 async-trait = "0.1"
-tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
+tokio       = { workspace = true, features = ["rt", "process", "time", "io-util"] }
+derive_more = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio    = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pacquet/crates/hooks/src/finder.rs
+++ b/pacquet/crates/hooks/src/finder.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use super::PnpmfileHooks;
 

--- a/pacquet/crates/hooks/src/finder.rs
+++ b/pacquet/crates/hooks/src/finder.rs
@@ -8,7 +8,7 @@ pub fn find_pnpmfile(root: &Path) -> Option<std::path::PathBuf> {
 
     for name in candidates {
         let path = root.join(name);
-        if path.exists() {
+        if path.is_file() {
             return Some(path);
         }
     }

--- a/pacquet/crates/hooks/src/finder.rs
+++ b/pacquet/crates/hooks/src/finder.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use super::PnpmfileHooks;
+
+pub fn find_pnpmfile(root: &Path) -> Option<std::path::PathBuf> {
+    let candidates = [".pnpmfile.mjs", ".pnpmfile.cjs", "pnpmfile.cjs", "pnpmfile.mjs"];
+
+    for name in candidates {
+        let path = root.join(name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+pub fn load_pnpmfile(root: &Path) -> Option<Arc<dyn PnpmfileHooks>> {
+    let file = find_pnpmfile(root)?;
+    Some(Arc::new(super::node_runtime::NodeJsHooks { file }))
+}

--- a/pacquet/crates/hooks/src/finder.rs
+++ b/pacquet/crates/hooks/src/finder.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc};
 use super::PnpmfileHooks;
 
 pub fn find_pnpmfile(root: &Path) -> Option<std::path::PathBuf> {
-    let candidates = [".pnpmfile.mjs", ".pnpmfile.cjs", "pnpmfile.cjs", "pnpmfile.mjs"];
+    let candidates = [".pnpmfile.mjs", ".pnpmfile.cjs"];
 
     for name in candidates {
         let path = root.join(name);

--- a/pacquet/crates/hooks/src/finder.rs
+++ b/pacquet/crates/hooks/src/finder.rs
@@ -16,5 +16,5 @@ pub fn find_pnpmfile(root: &Path) -> Option<std::path::PathBuf> {
 
 pub fn load_pnpmfile(root: &Path) -> Option<Arc<dyn PnpmfileHooks>> {
     let file = find_pnpmfile(root)?;
-    Some(Arc::new(super::node_runtime::NodeJsHooks { file }))
+    Some(Arc::new(super::node_runtime::NodeJsHooks::new(file)))
 }

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use derive_more::Display;
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -7,6 +8,20 @@ pub mod node_runtime;
 
 /// Represents the results of a `readPackage` hook.
 pub type ReadPackageResult = Arc<Value>;
+
+/// An error raised while running a pnpmfile hook in Node.js.
+///
+/// Mirrors pnpm's `PNPMFILE_FAIL` / `BAD_READ_PACKAGE_HOOK_RESULT` errors: a
+/// throwing or syntactically invalid pnpmfile, or a `readPackage` hook that
+/// returns something that is not a package manifest, aborts the install.
+#[derive(Debug, Display)]
+pub enum HookError {
+    #[display("pnpmfile hook '{_0}' timed out after {_1} seconds")]
+    Timeout(String, u64),
+
+    #[display("Error during pnpmfile execution. pnpmfile: \"{pnpmfile}\". Error: \"{message}\".")]
+    Execution { pnpmfile: String, message: String },
+}
 
 /// Context provided to pnpmfile hooks.
 pub struct HookContext {
@@ -34,7 +49,16 @@ pub struct PreResolutionHookContext {
 #[async_trait]
 pub trait PnpmfileHooks: Send + Sync {
     /// `readPackage` hook: modifies a package manifest before it is used for resolution.
-    async fn read_package(&self, pkg: Value, ctx: HookContext) -> Option<ReadPackageResult>;
+    ///
+    /// Returns the (possibly modified) manifest. A hook that throws, or returns
+    /// something other than a package manifest object, yields a [`HookError`] so
+    /// the install fails loudly — matching pnpm, where a bad `readPackage` hook
+    /// aborts resolution.
+    async fn read_package(
+        &self,
+        pkg: Value,
+        ctx: HookContext,
+    ) -> Result<ReadPackageResult, HookError>;
 
     /// `afterAllResolved` hook: modifies the final resolved lockfile.
     async fn after_all_resolved(&self, lockfile: Value, ctx: HookContext) -> Option<Value>;
@@ -51,8 +75,12 @@ pub struct NoopHooks;
 
 #[async_trait]
 impl PnpmfileHooks for NoopHooks {
-    async fn read_package(&self, _: Value, _: HookContext) -> Option<ReadPackageResult> {
-        None
+    async fn read_package(
+        &self,
+        pkg: Value,
+        _: HookContext,
+    ) -> Result<ReadPackageResult, HookError> {
+        Ok(Arc::new(pkg))
     }
     async fn after_all_resolved(&self, _: Value, _: HookContext) -> Option<Value> {
         None

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -13,6 +13,23 @@ pub struct HookContext {
     pub log: Arc<dyn Fn(String) + Send + Sync>,
 }
 
+/// Logger for preResolution hook (info/warn methods).
+pub struct PreResolutionHookLogger {
+    pub info: Arc<dyn Fn(String) + Send + Sync>,
+    pub warn: Arc<dyn Fn(String) + Send + Sync>,
+}
+
+/// Context provided to preResolution hooks.
+pub struct PreResolutionHookContext {
+    pub wanted_lockfile: Value,
+    pub current_lockfile: Value,
+    pub exists_current_lockfile: bool,
+    pub exists_non_empty_wanted_lockfile: bool,
+    pub lockfile_dir: String,
+    pub store_dir: String,
+    pub registries: Value,
+}
+
 /// The surface of hooks provided by `.pnpmfile.cjs` / `pnpmfile.cjs`.
 #[async_trait]
 pub trait PnpmfileHooks: Send + Sync {
@@ -22,8 +39,8 @@ pub trait PnpmfileHooks: Send + Sync {
     /// `afterAllResolved` hook: modifies the final resolved lockfile.
     async fn after_all_resolved(&self, lockfile: Value, ctx: HookContext) -> Option<Value>;
 
-    /// `preResolution` hook: allows modifying configuration before resolution starts.
-    async fn pre_resolution(&self, ctx: HookContext) -> Option<Value>;
+    /// `preResolution` hook: side-effect hook called before resolution (e.g., logging, validation).
+    async fn pre_resolution(&self, ctx: PreResolutionHookContext, logger: PreResolutionHookLogger);
 
     /// `filterLog` hook: determines if a log message should be emitted.
     async fn filter_log(&self, log: Value, ctx: HookContext) -> bool;
@@ -40,8 +57,8 @@ impl PnpmfileHooks for NoopHooks {
     async fn after_all_resolved(&self, _: Value, _: HookContext) -> Option<Value> {
         None
     }
-    async fn pre_resolution(&self, _: HookContext) -> Option<Value> {
-        None
+    async fn pre_resolution(&self, _: PreResolutionHookContext, _: PreResolutionHookLogger) {
+        // no-op
     }
     async fn filter_log(&self, _: Value, _: HookContext) -> bool {
         true

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -61,7 +61,15 @@ pub trait PnpmfileHooks: Send + Sync {
     ) -> Result<ReadPackageResult, HookError>;
 
     /// `afterAllResolved` hook: modifies the final resolved lockfile.
-    async fn after_all_resolved(&self, lockfile: Value, ctx: HookContext) -> Option<Value>;
+    ///
+    /// Returns the (possibly modified) lockfile. `Ok(Value::Null)` means the
+    /// pnpmfile has no `afterAllResolved` hook, so the caller keeps the lockfile
+    /// unchanged. A throwing hook yields a [`HookError`] and aborts the install.
+    async fn after_all_resolved(
+        &self,
+        lockfile: Value,
+        ctx: HookContext,
+    ) -> Result<Value, HookError>;
 
     /// `preResolution` hook: side-effect hook called before resolution (e.g., logging, validation).
     async fn pre_resolution(&self, ctx: PreResolutionHookContext, logger: PreResolutionHookLogger);
@@ -82,8 +90,8 @@ impl PnpmfileHooks for NoopHooks {
     ) -> Result<ReadPackageResult, HookError> {
         Ok(Arc::new(pkg))
     }
-    async fn after_all_resolved(&self, _: Value, _: HookContext) -> Option<Value> {
-        None
+    async fn after_all_resolved(&self, _: Value, _: HookContext) -> Result<Value, HookError> {
+        Ok(Value::Null)
     }
     async fn pre_resolution(&self, _: PreResolutionHookContext, _: PreResolutionHookLogger) {
         // no-op

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 pub mod finder;
 pub mod node_runtime;
+pub mod worker;
 
 /// Represents the results of a `readPackage` hook.
 pub type ReadPackageResult = Arc<Value>;
@@ -14,7 +15,7 @@ pub type ReadPackageResult = Arc<Value>;
 /// Mirrors pnpm's `PNPMFILE_FAIL` / `BAD_READ_PACKAGE_HOOK_RESULT` errors: a
 /// throwing or syntactically invalid pnpmfile, or a `readPackage` hook that
 /// returns something that is not a package manifest, aborts the install.
-#[derive(Debug, Display)]
+#[derive(Debug, Display, Clone)]
 pub enum HookError {
     #[display("pnpmfile hook '{_0}' timed out after {_1} seconds")]
     Timeout(String, u64),

--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::Arc;
+
+pub mod finder;
+pub mod node_runtime;
+
+/// Represents the results of a `readPackage` hook.
+pub type ReadPackageResult = Arc<Value>;
+
+/// Context provided to pnpmfile hooks.
+pub struct HookContext {
+    pub log: Arc<dyn Fn(String) + Send + Sync>,
+}
+
+/// The surface of hooks provided by `.pnpmfile.cjs` / `pnpmfile.cjs`.
+#[async_trait]
+pub trait PnpmfileHooks: Send + Sync {
+    /// `readPackage` hook: modifies a package manifest before it is used for resolution.
+    async fn read_package(&self, pkg: Value, ctx: HookContext) -> Option<ReadPackageResult>;
+
+    /// `afterAllResolved` hook: modifies the final resolved lockfile.
+    async fn after_all_resolved(&self, lockfile: Value, ctx: HookContext) -> Option<Value>;
+
+    /// `preResolution` hook: allows modifying configuration before resolution starts.
+    async fn pre_resolution(&self, ctx: HookContext) -> Option<Value>;
+
+    /// `filterLog` hook: determines if a log message should be emitted.
+    async fn filter_log(&self, log: Value, ctx: HookContext) -> bool;
+}
+
+/// A no-op implementation of `PnpmfileHooks`.
+pub struct NoopHooks;
+
+#[async_trait]
+impl PnpmfileHooks for NoopHooks {
+    async fn read_package(&self, _: Value, _: HookContext) -> Option<ReadPackageResult> {
+        None
+    }
+    async fn after_all_resolved(&self, _: Value, _: HookContext) -> Option<Value> {
+        None
+    }
+    async fn pre_resolution(&self, _: HookContext) -> Option<Value> {
+        None
+    }
+    async fn filter_log(&self, _: Value, _: HookContext) -> bool {
+        true
+    }
+}

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -33,23 +33,29 @@ impl NodeJsHooks {
             .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
 
         let (input_type, wrapper) = if file_path.ends_with(".mjs") {
-            ("module", format!(
-                r#"const hooks = await import({file_path_escaped});
+            (
+                "module",
+                format!(
+                    r#"const hooks = await import({file_path_escaped});
 const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
 console.log(JSON.stringify(res));
 "#,
-                file_path_escaped = file_path_escaped,
-            ))
+                    file_path_escaped = file_path_escaped,
+                ),
+            )
         } else {
-            ("commonjs", format!(
-                r#"(async () => {{
+            (
+                "commonjs",
+                format!(
+                    r#"(async () => {{
   const hooks = require({file_path_escaped});
   const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
   console.log(JSON.stringify(res));
 }})();
 "#,
-                file_path_escaped = file_path_escaped,
-            ))
+                    file_path_escaped = file_path_escaped,
+                ),
+            )
         };
 
         let output = timeout(
@@ -99,8 +105,10 @@ console.log(JSON.stringify(res));
         };
 
         let (input_type, wrapper) = if file_path.ends_with(".mjs") {
-            ("module", format!(
-                r#"import {{ readFileSync }} from 'node:fs';
+            (
+                "module",
+                format!(
+                    r#"import {{ readFileSync }} from 'node:fs';
 const hooks = await import({file_path_escaped});
 const ctx = JSON.parse(readFileSync(0, 'utf8'));
 const logger = {{
@@ -109,11 +117,14 @@ const logger = {{
 }};
 await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
 "#,
-                file_path_escaped = file_path_escaped,
-            ))
+                    file_path_escaped = file_path_escaped,
+                ),
+            )
         } else {
-            ("commonjs", format!(
-                r#"(async () => {{
+            (
+                "commonjs",
+                format!(
+                    r#"(async () => {{
   const hooks = require({file_path_escaped});
   const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
   const logger = {{
@@ -123,8 +134,9 @@ await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
   await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
 }})();
 "#,
-                file_path_escaped = file_path_escaped,
-            ))
+                    file_path_escaped = file_path_escaped,
+                ),
+            )
         };
 
         let mut child = match Command::new("node")

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -32,18 +32,16 @@ impl NodeJsHooks {
         let file_path_escaped = serde_json::to_string(&file_path)
             .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
 
-        let wrapper = if file_path.ends_with(".mjs") {
-            format!(
-                r#"(async () => {{
-  const hooks = await import({file_path_escaped});
-  const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
-  console.log(JSON.stringify(res));
-}})();
+        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
+            ("module", format!(
+                r#"const hooks = await import({file_path_escaped});
+const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
+console.log(JSON.stringify(res));
 "#,
                 file_path_escaped = file_path_escaped,
-            )
+            ))
         } else {
-            format!(
+            ("commonjs", format!(
                 r#"(async () => {{
   const hooks = require({file_path_escaped});
   const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
@@ -51,12 +49,18 @@ impl NodeJsHooks {
 }})();
 "#,
                 file_path_escaped = file_path_escaped,
-            )
+            ))
         };
 
         let output = timeout(
             HOOK_TIMEOUT,
-            Command::new("node").arg("-e").arg(&wrapper).kill_on_drop(true).output(),
+            Command::new("node")
+                .arg("--input-type")
+                .arg(input_type)
+                .arg("-e")
+                .arg(&wrapper)
+                .kill_on_drop(true)
+                .output(),
         )
         .await
         .map_err(|_| HookError::Timeout(func.to_string()))?
@@ -94,22 +98,21 @@ impl NodeJsHooks {
             Err(_) => return,
         };
 
-        let wrapper = if file_path.ends_with(".mjs") {
-            format!(
-                r#"(async () => {{
-  const hooks = await import({file_path_escaped});
-  const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
-  const logger = {{
-    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
-    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
-  }};
-  await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
-}})();
+        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
+            ("module", format!(
+                r#"import {{ readFileSync }} from 'node:fs';
+const hooks = await import({file_path_escaped});
+const ctx = JSON.parse(readFileSync(0, 'utf8'));
+const logger = {{
+  info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
+  warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
+}};
+await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
 "#,
                 file_path_escaped = file_path_escaped,
-            )
+            ))
         } else {
-            format!(
+            ("commonjs", format!(
                 r#"(async () => {{
   const hooks = require({file_path_escaped});
   const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
@@ -121,10 +124,12 @@ impl NodeJsHooks {
 }})();
 "#,
                 file_path_escaped = file_path_escaped,
-            )
+            ))
         };
 
         let mut child = match Command::new("node")
+            .arg("--input-type")
+            .arg(input_type)
             .arg("-e")
             .arg(&wrapper)
             .kill_on_drop(true)

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -1,5 +1,5 @@
+use crate::HookError;
 use async_trait::async_trait;
-use derive_more::Display;
 use serde_json::Value;
 use std::{path::PathBuf, sync::Arc};
 use tokio::{
@@ -14,24 +14,54 @@ pub struct NodeJsHooks {
 
 const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Debug, Display)]
-pub enum HookError {
-    #[display("pnpmfile hook '{_0}' timed out after {} seconds", HOOK_TIMEOUT.as_secs())]
-    Timeout(String),
-
-    ExecutionFailed(String),
-
-    #[display("pnpmfile hook '{_0}' execution failed: {_1}")]
-    HookFailed(String, String),
-}
-
 impl NodeJsHooks {
+    fn pnpmfile_path(&self) -> String {
+        self.file.to_string_lossy().into_owned()
+    }
+
+    fn execution_error(&self, message: impl Into<String>) -> HookError {
+        HookError::Execution { pnpmfile: self.pnpmfile_path(), message: message.into() }
+    }
+
+    /// Runs `node` with the given wrapper script and returns trimmed stdout.
+    ///
+    /// A non-zero exit (a thrown hook, a syntax error, a missing `require`) is
+    /// turned into [`HookError::Execution`] carrying the child's stderr, so the
+    /// caller can abort the install with a meaningful message like pnpm does.
+    async fn run_node(
+        &self,
+        func: &str,
+        input_type: &str,
+        wrapper: &str,
+    ) -> Result<String, HookError> {
+        let output = timeout(
+            HOOK_TIMEOUT,
+            Command::new("node")
+                .arg("--input-type")
+                .arg(input_type)
+                .arg("-e")
+                .arg(wrapper)
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await
+        .map_err(|_| HookError::Timeout(func.to_string(), HOOK_TIMEOUT.as_secs()))?
+        .map_err(|err| self.execution_error(err.to_string()))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(self.execution_error(stderr.trim()));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
     async fn call_node(&self, func: &str, args: Value) -> Result<Value, HookError> {
-        let payload = serde_json::to_string(&args)
-            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
+        let payload =
+            serde_json::to_string(&args).map_err(|err| self.execution_error(err.to_string()))?;
         let file_path = self.file.to_string_lossy();
         let file_path_escaped = serde_json::to_string(&file_path)
-            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
+            .map_err(|err| self.execution_error(err.to_string()))?;
 
         let (input_type, wrapper) = if file_path.ends_with(".mjs") {
             (
@@ -41,7 +71,6 @@ impl NodeJsHooks {
 const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
 console.log(JSON.stringify(res));
 "#,
-                    file_path_escaped = file_path_escaped,
                 ),
             )
         } else {
@@ -54,39 +83,64 @@ console.log(JSON.stringify(res));
   console.log(JSON.stringify(res));
 }})();
 "#,
-                    file_path_escaped = file_path_escaped,
                 ),
             )
         };
 
-        let output = timeout(
-            HOOK_TIMEOUT,
-            Command::new("node")
-                .arg("--input-type")
-                .arg(input_type)
-                .arg("-e")
-                .arg(&wrapper)
-                .kill_on_drop(true)
-                .output(),
-        )
-        .await
-        .map_err(|_| HookError::Timeout(func.to_string()))?
-        .map_err(|err| HookError::ExecutionFailed(err.to_string()))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(HookError::HookFailed(func.to_string(), stderr.to_string()));
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stdout = stdout.trim();
-
+        let stdout = self.run_node(func, input_type, &wrapper).await?;
         if stdout == "null" || stdout == "undefined" {
             return Ok(Value::Null);
         }
+        serde_json::from_str(&stdout).map_err(|err| self.execution_error(err.to_string()))
+    }
 
-        serde_json::from_str(stdout)
-            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))
+    /// Runs the `readPackage` hook, mirroring pnpm's `requirePnpmfile` wrapper:
+    /// the four dependency fields are defaulted to `{}` before the call, and the
+    /// returned manifest is validated (must be a non-null object whose dependency
+    /// fields, when present, are objects rather than arrays). A pnpmfile without a
+    /// `readPackage` hook returns the manifest unchanged.
+    async fn call_read_package(&self, pkg: Value) -> Result<Value, HookError> {
+        let payload =
+            serde_json::to_string(&pkg).map_err(|err| self.execution_error(err.to_string()))?;
+        let file_path = self.file.to_string_lossy();
+        let file_path_escaped = serde_json::to_string(&file_path)
+            .map_err(|err| self.execution_error(err.to_string()))?;
+
+        let body = format!(
+            r#"const pkg = {payload};
+const fn = mod.hooks && mod.hooks['readPackage'];
+if (typeof fn !== 'function') {{ console.log(JSON.stringify(pkg)); }} else {{
+  pkg.dependencies = pkg.dependencies ?? {{}};
+  pkg.devDependencies = pkg.devDependencies ?? {{}};
+  pkg.optionalDependencies = pkg.optionalDependencies ?? {{}};
+  pkg.peerDependencies = pkg.peerDependencies ?? {{}};
+  const newPkg = await fn(pkg, {{ log() {{}} }});
+  if (!newPkg) {{
+    throw new Error("readPackage hook did not return a package manifest object. Hook imported via " + {file_path_escaped});
+  }}
+  for (const dep of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {{
+    const v = newPkg[dep];
+    if (v != null && (typeof v !== "object" || Array.isArray(v))) {{
+      throw new Error("readPackage hook returned package manifest object's property '" + dep + "' must be an object. Hook imported via " + {file_path_escaped});
+    }}
+  }}
+  console.log(JSON.stringify(newPkg));
+}}"#,
+        );
+
+        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
+            ("module", format!("const mod = await import({file_path_escaped});\n{body}"))
+        } else {
+            (
+                "commonjs",
+                format!(
+                    "(async () => {{\nconst mod = require({file_path_escaped});\n{body}\n}})().catch((err) => {{ console.error(err && err.stack ? err.stack : String(err)); process.exit(1); }});"
+                ),
+            )
+        };
+
+        let stdout = self.run_node("readPackage", input_type, &wrapper).await?;
+        serde_json::from_str(&stdout).map_err(|err| self.execution_error(err.to_string()))
     }
 
     async fn call_node_void(
@@ -183,16 +237,9 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     async fn read_package(
         &self,
         pkg: Value,
-        ctx: crate::HookContext,
-    ) -> Option<crate::ReadPackageResult> {
-        match self.call_node("readPackage", pkg).await {
-            Ok(v) if v.is_null() => None,
-            Ok(v) => Some(Arc::new(v)),
-            Err(err) => {
-                (ctx.log)(format!("pnpmfile hook readPackage failed: {}", err));
-                None
-            }
-        }
+        _ctx: crate::HookContext,
+    ) -> Result<crate::ReadPackageResult, HookError> {
+        self.call_read_package(pkg).await.map(Arc::new)
     }
 
     async fn after_all_resolved(&self, lockfile: Value, ctx: crate::HookContext) -> Option<Value> {

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -116,7 +116,7 @@ const logger = {{
   info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
   warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
 }};
-await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
+await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
 "#,
                     file_path_escaped = file_path_escaped,
                 ),
@@ -132,7 +132,7 @@ await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
     info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
     warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
   }};
-  await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
+  await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
 }})();
 "#,
                     file_path_escaped = file_path_escaped,

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 
 pub struct NodeJsHooks {
     pub file: PathBuf,
@@ -27,10 +27,10 @@ pub enum HookError {
 impl NodeJsHooks {
     async fn call_node(&self, func: &str, args: Value) -> Result<Value, HookError> {
         let payload = serde_json::to_string(&args)
-            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))?;
+            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
         let file_path = self.file.to_string_lossy();
         let file_path_escaped = serde_json::to_string(&file_path)
-            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))?;
+            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))?;
 
         let wrapper = if file_path.ends_with(".mjs") {
             format!(
@@ -40,7 +40,7 @@ impl NodeJsHooks {
   console.log(JSON.stringify(res));
 }})();
 "#,
-                file_path_escaped = file_path_escaped
+                file_path_escaped = file_path_escaped,
             )
         } else {
             format!(
@@ -50,7 +50,7 @@ impl NodeJsHooks {
   console.log(JSON.stringify(res));
 }})();
 "#,
-                file_path_escaped = file_path_escaped
+                file_path_escaped = file_path_escaped,
             )
         };
 
@@ -60,7 +60,7 @@ impl NodeJsHooks {
         )
         .await
         .map_err(|_| HookError::Timeout(func.to_string()))?
-        .map_err(|e| HookError::ExecutionFailed(e.to_string()))?;
+        .map_err(|err| HookError::ExecutionFailed(err.to_string()))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -75,7 +75,7 @@ impl NodeJsHooks {
         }
 
         serde_json::from_str(stdout)
-            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))
+            .map_err(|err| HookError::HookFailed(func.to_string(), err.to_string()))
     }
 
     async fn call_node_void(
@@ -106,7 +106,7 @@ impl NodeJsHooks {
   await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
 }})();
 "#,
-                file_path_escaped = file_path_escaped
+                file_path_escaped = file_path_escaped,
             )
         } else {
             format!(
@@ -120,7 +120,7 @@ impl NodeJsHooks {
   await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
 }})();
 "#,
-                file_path_escaped = file_path_escaped
+                file_path_escaped = file_path_escaped,
             )
         };
 
@@ -138,11 +138,11 @@ impl NodeJsHooks {
             }
         };
 
-        if let Some(mut stdin) = child.stdin.take() {
-            if stdin.write_all(ctx_payload.as_bytes()).await.is_err() {
-                let _ = child.kill().await;
-                return;
-            }
+        if let Some(mut stdin) = child.stdin.take()
+            && stdin.write_all(ctx_payload.as_bytes()).await.is_err()
+        {
+            let _ = child.kill().await;
+            return;
         }
 
         let output = match timeout(HOOK_TIMEOUT, child.wait_with_output()).await {
@@ -170,8 +170,8 @@ impl crate::PnpmfileHooks for NodeJsHooks {
         match self.call_node("readPackage", pkg).await {
             Ok(v) if v.is_null() => None,
             Ok(v) => Some(Arc::new(v)),
-            Err(e) => {
-                (ctx.log)(format!("pnpmfile hook readPackage failed: {}", e));
+            Err(err) => {
+                (ctx.log)(format!("pnpmfile hook readPackage failed: {}", err));
                 None
             }
         }
@@ -180,8 +180,8 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     async fn after_all_resolved(&self, lockfile: Value, ctx: crate::HookContext) -> Option<Value> {
         match self.call_node("afterAllResolved", lockfile).await {
             Ok(v) => Some(v),
-            Err(e) => {
-                (ctx.log)(format!("pnpmfile hook afterAllResolved failed: {}", e));
+            Err(err) => {
+                (ctx.log)(format!("pnpmfile hook afterAllResolved failed: {}", err));
                 None
             }
         }
@@ -208,8 +208,8 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     async fn filter_log(&self, log: Value, ctx: crate::HookContext) -> bool {
         match self.call_node("filterLog", log).await {
             Ok(v) => v.as_bool().unwrap_or(true),
-            Err(e) => {
-                (ctx.log)(format!("pnpmfile hook filterLog failed: {}", e));
+            Err(err) => {
+                (ctx.log)(format!("pnpmfile hook filterLog failed: {}", err));
                 true
             }
         }

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -242,14 +242,12 @@ impl crate::PnpmfileHooks for NodeJsHooks {
         self.call_read_package(pkg).await.map(Arc::new)
     }
 
-    async fn after_all_resolved(&self, lockfile: Value, ctx: crate::HookContext) -> Option<Value> {
-        match self.call_node("afterAllResolved", lockfile).await {
-            Ok(v) => Some(v),
-            Err(err) => {
-                (ctx.log)(format!("pnpmfile hook afterAllResolved failed: {}", err));
-                None
-            }
-        }
+    async fn after_all_resolved(
+        &self,
+        lockfile: Value,
+        _ctx: crate::HookContext,
+    ) -> Result<Value, HookError> {
+        self.call_node("afterAllResolved", lockfile).await
     }
 
     async fn pre_resolution(

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use derive_more::Display;
 use serde_json::Value;
-use std::path::PathBuf;
-use std::sync::Arc;
-use tokio::io::AsyncWriteExt;
-use tokio::process::Command;
-use tokio::time::{Duration, timeout};
+use std::{path::PathBuf, sync::Arc};
+use tokio::{
+    io::AsyncWriteExt,
+    process::Command,
+    time::{Duration, timeout},
+};
 
 pub struct NodeJsHooks {
     pub file: PathBuf,

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -1,148 +1,44 @@
-use crate::HookError;
+use crate::{HookError, worker::NodeWorker};
 use async_trait::async_trait;
 use serde_json::Value;
 use std::{path::PathBuf, sync::Arc};
 use tokio::{
     io::AsyncWriteExt,
     process::Command,
+    sync::OnceCell,
     time::{Duration, timeout},
 };
 
+/// Runs `.pnpmfile.{cjs,mjs}` hooks via Node.js.
+///
+/// `readPackage`, `afterAllResolved`, and `filterLog` are served by a
+/// long-lived [`NodeWorker`] (spawned lazily, once per pnpmfile) so the
+/// per-package `readPackage` calls on the resolution hot path don't each pay a
+/// `node` startup. `preResolution` keeps a one-shot `node -e` invocation: it
+/// runs once per install and needs an `info`/`warn` logger rather than the
+/// worker's `context.log`.
 pub struct NodeJsHooks {
     pub file: PathBuf,
+    worker: OnceCell<Result<Arc<NodeWorker>, HookError>>,
 }
 
 const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl NodeJsHooks {
-    fn pnpmfile_path(&self) -> String {
-        self.file.to_string_lossy().into_owned()
+    pub fn new(file: PathBuf) -> Self {
+        NodeJsHooks { file, worker: OnceCell::new() }
     }
 
-    fn execution_error(&self, message: impl Into<String>) -> HookError {
-        HookError::Execution { pnpmfile: self.pnpmfile_path(), message: message.into() }
+    /// The worker process, spawned on first use and reused thereafter. A spawn
+    /// failure is cached and surfaced to every hook call.
+    async fn worker(&self) -> Result<Arc<NodeWorker>, HookError> {
+        self.worker.get_or_init(|| NodeWorker::spawn(&self.file)).await.clone()
     }
 
-    /// Runs `node` with the given wrapper script and returns trimmed stdout.
-    ///
-    /// A non-zero exit (a thrown hook, a syntax error, a missing `require`) is
-    /// turned into [`HookError::Execution`] carrying the child's stderr, so the
-    /// caller can abort the install with a meaningful message like pnpm does.
-    async fn run_node(
-        &self,
-        func: &str,
-        input_type: &str,
-        wrapper: &str,
-    ) -> Result<String, HookError> {
-        let output = timeout(
-            HOOK_TIMEOUT,
-            Command::new("node")
-                .arg("--input-type")
-                .arg(input_type)
-                .arg("-e")
-                .arg(wrapper)
-                .kill_on_drop(true)
-                .output(),
-        )
-        .await
-        .map_err(|_| HookError::Timeout(func.to_string(), HOOK_TIMEOUT.as_secs()))?
-        .map_err(|err| self.execution_error(err.to_string()))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(self.execution_error(stderr.trim()));
-        }
-
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-    }
-
-    async fn call_node(&self, func: &str, args: Value) -> Result<Value, HookError> {
-        let payload =
-            serde_json::to_string(&args).map_err(|err| self.execution_error(err.to_string()))?;
-        let file_path = self.file.to_string_lossy();
-        let file_path_escaped = serde_json::to_string(&file_path)
-            .map_err(|err| self.execution_error(err.to_string()))?;
-
-        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
-            (
-                "module",
-                format!(
-                    r#"const hooks = await import({file_path_escaped});
-const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
-console.log(JSON.stringify(res));
-"#,
-                ),
-            )
-        } else {
-            (
-                "commonjs",
-                format!(
-                    r#"(async () => {{
-  const hooks = require({file_path_escaped});
-  const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
-  console.log(JSON.stringify(res));
-}})();
-"#,
-                ),
-            )
-        };
-
-        let stdout = self.run_node(func, input_type, &wrapper).await?;
-        if stdout == "null" || stdout == "undefined" {
-            return Ok(Value::Null);
-        }
-        serde_json::from_str(&stdout).map_err(|err| self.execution_error(err.to_string()))
-    }
-
-    /// Runs the `readPackage` hook, mirroring pnpm's `requirePnpmfile` wrapper:
-    /// the four dependency fields are defaulted to `{}` before the call, and the
-    /// returned manifest is validated (must be a non-null object whose dependency
-    /// fields, when present, are objects rather than arrays). A pnpmfile without a
-    /// `readPackage` hook returns the manifest unchanged.
-    async fn call_read_package(&self, pkg: Value) -> Result<Value, HookError> {
-        let payload =
-            serde_json::to_string(&pkg).map_err(|err| self.execution_error(err.to_string()))?;
-        let file_path = self.file.to_string_lossy();
-        let file_path_escaped = serde_json::to_string(&file_path)
-            .map_err(|err| self.execution_error(err.to_string()))?;
-
-        let body = format!(
-            r#"const pkg = {payload};
-const fn = mod.hooks && mod.hooks['readPackage'];
-if (typeof fn !== 'function') {{ console.log(JSON.stringify(pkg)); }} else {{
-  pkg.dependencies = pkg.dependencies ?? {{}};
-  pkg.devDependencies = pkg.devDependencies ?? {{}};
-  pkg.optionalDependencies = pkg.optionalDependencies ?? {{}};
-  pkg.peerDependencies = pkg.peerDependencies ?? {{}};
-  const newPkg = await fn(pkg, {{ log() {{}} }});
-  if (!newPkg) {{
-    throw new Error("readPackage hook did not return a package manifest object. Hook imported via " + {file_path_escaped});
-  }}
-  for (const dep of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {{
-    const v = newPkg[dep];
-    if (v != null && (typeof v !== "object" || Array.isArray(v))) {{
-      throw new Error("readPackage hook returned package manifest object's property '" + dep + "' must be an object. Hook imported via " + {file_path_escaped});
-    }}
-  }}
-  console.log(JSON.stringify(newPkg));
-}}"#,
-        );
-
-        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
-            ("module", format!("const mod = await import({file_path_escaped});\n{body}"))
-        } else {
-            (
-                "commonjs",
-                format!(
-                    "(async () => {{\nconst mod = require({file_path_escaped});\n{body}\n}})().catch((err) => {{ console.error(err && err.stack ? err.stack : String(err)); process.exit(1); }});",
-                ),
-            )
-        };
-
-        let stdout = self.run_node("readPackage", input_type, &wrapper).await?;
-        serde_json::from_str(&stdout).map_err(|err| self.execution_error(err.to_string()))
-    }
-
+    /// Runs a side-effecting hook (`preResolution`) in a one-shot `node`
+    /// process, piping the JSON context on stdin and exposing an
+    /// `info`/`warn` logger. Failures are reported through `logger.warn`
+    /// rather than aborting, matching the hook's advisory role.
     async fn call_node_void(
         &self,
         func: &str,
@@ -237,17 +133,17 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     async fn read_package(
         &self,
         pkg: Value,
-        _ctx: crate::HookContext,
+        ctx: crate::HookContext,
     ) -> Result<crate::ReadPackageResult, HookError> {
-        self.call_read_package(pkg).await.map(Arc::new)
+        self.worker().await?.call("readPackage", pkg, ctx.log).await.map(Arc::new)
     }
 
     async fn after_all_resolved(
         &self,
         lockfile: Value,
-        _ctx: crate::HookContext,
+        ctx: crate::HookContext,
     ) -> Result<Value, HookError> {
-        self.call_node("afterAllResolved", lockfile).await
+        self.worker().await?.call("afterAllResolved", lockfile, ctx.log).await
     }
 
     async fn pre_resolution(
@@ -269,12 +165,10 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     }
 
     async fn filter_log(&self, log: Value, ctx: crate::HookContext) -> bool {
-        match self.call_node("filterLog", log).await {
-            Ok(v) => v.as_bool().unwrap_or(true),
-            Err(err) => {
-                (ctx.log)(format!("pnpmfile hook filterLog failed: {}", err));
-                true
-            }
+        let Ok(worker) = self.worker().await else { return true };
+        match worker.call("filterLog", log, ctx.log).await {
+            Ok(value) => value.as_bool().unwrap_or(true),
+            Err(_) => true,
         }
     }
 }

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub struct NodeJsHooks {
+    pub file: PathBuf,
+}
+
+impl NodeJsHooks {
+    fn call_node(&self, func: &str, args: Value) -> Result<Value, String> {
+        let payload = serde_json::to_string(&args).map_err(|e| e.to_string())?;
+
+        let wrapper = format!(
+            r##"
+const hooks = require('{}');
+const res = (hooks.hooks && hooks.hooks['{}'])?.({});
+console.log(JSON.stringify(res));
+"##,
+            self.file.to_string_lossy(),
+            func,
+            payload
+        );
+
+        let output =
+            Command::new("node").arg("-e").arg(&wrapper).output().map_err(|e| e.to_string())?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(stderr.to_string());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stdout = stdout.trim();
+
+        // Handle undefined/null return (hook returns nothing)
+        if stdout == "null" || stdout == "undefined" {
+            return Ok(Value::Null);
+        }
+
+        serde_json::from_str(stdout).map_err(|e| e.to_string())
+    }
+}
+
+#[async_trait]
+impl crate::PnpmfileHooks for NodeJsHooks {
+    async fn read_package(
+        &self,
+        pkg: Value,
+        _ctx: crate::HookContext,
+    ) -> Option<crate::ReadPackageResult> {
+        self.call_node("readPackage", pkg).ok().and_then(|v| {
+            if v.is_null() {
+                None
+            } else {
+                Some(std::sync::Arc::new(v))
+            }
+        })
+    }
+
+    async fn after_all_resolved(&self, lockfile: Value, _ctx: crate::HookContext) -> Option<Value> {
+        self.call_node("afterAllResolved", lockfile).ok()
+    }
+
+    async fn pre_resolution(&self, _ctx: crate::HookContext) -> Option<Value> {
+        self.call_node("preResolution", Value::Null).ok()
+    }
+
+    async fn filter_log(&self, log: Value, _ctx: crate::HookContext) -> bool {
+        self.call_node("filterLog", log).map(|v| v.as_bool().unwrap_or(true)).unwrap_or(true)
+    }
+}

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -134,7 +134,7 @@ if (typeof fn !== 'function') {{ console.log(JSON.stringify(pkg)); }} else {{
             (
                 "commonjs",
                 format!(
-                    "(async () => {{\nconst mod = require({file_path_escaped});\n{body}\n}})().catch((err) => {{ console.error(err && err.stack ? err.stack : String(err)); process.exit(1); }});"
+                    "(async () => {{\nconst mod = require({file_path_escaped});\n{body}\n}})().catch((err) => {{ console.error(err && err.stack ? err.stack : String(err)); process.exit(1); }});",
                 ),
             )
         };

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -1,44 +1,162 @@
 use async_trait::async_trait;
+use derive_more::Display;
 use serde_json::Value;
 use std::path::PathBuf;
-use std::process::Command;
+use std::sync::Arc;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::{timeout, Duration};
 
 pub struct NodeJsHooks {
     pub file: PathBuf,
 }
 
+const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Display)]
+pub enum HookError {
+    #[display("pnpmfile hook '{_0}' timed out after {} seconds", HOOK_TIMEOUT.as_secs())]
+    Timeout(String),
+
+    ExecutionFailed(String),
+
+    #[display("pnpmfile hook '{_0}' execution failed: {_1}")]
+    HookFailed(String, String),
+}
+
 impl NodeJsHooks {
-    fn call_node(&self, func: &str, args: Value) -> Result<Value, String> {
-        let payload = serde_json::to_string(&args).map_err(|e| e.to_string())?;
+    async fn call_node(&self, func: &str, args: Value) -> Result<Value, HookError> {
+        let payload = serde_json::to_string(&args)
+            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))?;
+        let file_path = self.file.to_string_lossy();
+        let file_path_escaped = serde_json::to_string(&file_path)
+            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))?;
 
-        let wrapper = format!(
-            r##"
-const hooks = require('{}');
-const res = (hooks.hooks && hooks.hooks['{}'])?.({});
-console.log(JSON.stringify(res));
-"##,
-            self.file.to_string_lossy(),
-            func,
-            payload
-        );
+        let wrapper = if file_path.ends_with(".mjs") {
+            format!(
+                r#"(async () => {{
+  const hooks = await import({file_path_escaped});
+  const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
+  console.log(JSON.stringify(res));
+}})();
+"#,
+                file_path_escaped = file_path_escaped
+            )
+        } else {
+            format!(
+                r#"(async () => {{
+  const hooks = require({file_path_escaped});
+  const res = await (hooks.hooks && hooks.hooks['{func}'])?.({payload});
+  console.log(JSON.stringify(res));
+}})();
+"#,
+                file_path_escaped = file_path_escaped
+            )
+        };
 
-        let output =
-            Command::new("node").arg("-e").arg(&wrapper).output().map_err(|e| e.to_string())?;
+        let output = timeout(
+            HOOK_TIMEOUT,
+            Command::new("node").arg("-e").arg(&wrapper).kill_on_drop(true).output(),
+        )
+        .await
+        .map_err(|_| HookError::Timeout(func.to_string()))?
+        .map_err(|e| HookError::ExecutionFailed(e.to_string()))?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(stderr.to_string());
+            return Err(HookError::HookFailed(func.to_string(), stderr.to_string()));
         }
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stdout = stdout.trim();
 
-        // Handle undefined/null return (hook returns nothing)
         if stdout == "null" || stdout == "undefined" {
             return Ok(Value::Null);
         }
 
-        serde_json::from_str(stdout).map_err(|e| e.to_string())
+        serde_json::from_str(stdout)
+            .map_err(|e| HookError::HookFailed(func.to_string(), e.to_string()))
+    }
+
+    async fn call_node_void(
+        &self,
+        func: &str,
+        args: Value,
+        logger: &crate::PreResolutionHookLogger,
+    ) {
+        let file_path = self.file.to_string_lossy();
+        let file_path_escaped = match serde_json::to_string(&file_path) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let ctx_payload = match serde_json::to_string(&args) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        let wrapper = if file_path.ends_with(".mjs") {
+            format!(
+                r#"(async () => {{
+  const hooks = await import({file_path_escaped});
+  const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+  const logger = {{
+    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
+    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
+  }};
+  await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
+}})();
+"#,
+                file_path_escaped = file_path_escaped
+            )
+        } else {
+            format!(
+                r#"(async () => {{
+  const hooks = require({file_path_escaped});
+  const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+  const logger = {{
+    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":m}})); }},
+    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":m}})); }}
+  }};
+  await hooks.hooks && hooks.hooks['{func}']?.(ctx, logger);
+}})();
+"#,
+                file_path_escaped = file_path_escaped
+            )
+        };
+
+        let mut child = match Command::new("node")
+            .arg("-e")
+            .arg(&wrapper)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(_) => {
+                (logger.warn)("pnpmfile hook failed to start".to_string());
+                return;
+            }
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            if stdin.write_all(ctx_payload.as_bytes()).await.is_err() {
+                let _ = child.kill().await;
+                return;
+            }
+        }
+
+        let output = match timeout(HOOK_TIMEOUT, child.wait_with_output()).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(_)) | Err(_) => {
+                (logger.warn)("pnpmfile hook timed out or failed to execute".to_string());
+                return;
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            (logger.warn)(format!("pnpmfile hook failed: {}", stderr));
+        }
     }
 }
 
@@ -47,26 +165,53 @@ impl crate::PnpmfileHooks for NodeJsHooks {
     async fn read_package(
         &self,
         pkg: Value,
-        _ctx: crate::HookContext,
+        ctx: crate::HookContext,
     ) -> Option<crate::ReadPackageResult> {
-        self.call_node("readPackage", pkg).ok().and_then(|v| {
-            if v.is_null() {
+        match self.call_node("readPackage", pkg).await {
+            Ok(v) if v.is_null() => None,
+            Ok(v) => Some(Arc::new(v)),
+            Err(e) => {
+                (ctx.log)(format!("pnpmfile hook readPackage failed: {}", e));
                 None
-            } else {
-                Some(std::sync::Arc::new(v))
             }
-        })
+        }
     }
 
-    async fn after_all_resolved(&self, lockfile: Value, _ctx: crate::HookContext) -> Option<Value> {
-        self.call_node("afterAllResolved", lockfile).ok()
+    async fn after_all_resolved(&self, lockfile: Value, ctx: crate::HookContext) -> Option<Value> {
+        match self.call_node("afterAllResolved", lockfile).await {
+            Ok(v) => Some(v),
+            Err(e) => {
+                (ctx.log)(format!("pnpmfile hook afterAllResolved failed: {}", e));
+                None
+            }
+        }
     }
 
-    async fn pre_resolution(&self, _ctx: crate::HookContext) -> Option<Value> {
-        self.call_node("preResolution", Value::Null).ok()
+    async fn pre_resolution(
+        &self,
+        ctx: crate::PreResolutionHookContext,
+        logger: crate::PreResolutionHookLogger,
+    ) {
+        let ctx_json = serde_json::json!({
+            "wantedLockfile": ctx.wanted_lockfile,
+            "currentLockfile": ctx.current_lockfile,
+            "existsCurrentLockfile": ctx.exists_current_lockfile,
+            "existsNonEmptyWantedLockfile": ctx.exists_non_empty_wanted_lockfile,
+            "lockfileDir": ctx.lockfile_dir,
+            "storeDir": ctx.store_dir,
+            "registries": ctx.registries,
+        });
+
+        self.call_node_void("preResolution", ctx_json, &logger).await;
     }
 
-    async fn filter_log(&self, log: Value, _ctx: crate::HookContext) -> bool {
-        self.call_node("filterLog", log).map(|v| v.as_bool().unwrap_or(true)).unwrap_or(true)
+    async fn filter_log(&self, log: Value, ctx: crate::HookContext) -> bool {
+        match self.call_node("filterLog", log).await {
+            Ok(v) => v.as_bool().unwrap_or(true),
+            Err(e) => {
+                (ctx.log)(format!("pnpmfile hook filterLog failed: {}", e));
+                true
+            }
+        }
     }
 }

--- a/pacquet/crates/hooks/src/worker.rs
+++ b/pacquet/crates/hooks/src/worker.rs
@@ -1,0 +1,222 @@
+//! A long-lived Node.js worker that loads a pnpmfile once and serves hook
+//! invocations over a newline-delimited JSON protocol on stdin/stdout.
+//!
+//! Spawning a fresh `node` process per hook call is prohibitively expensive on
+//! the resolution hot path, where `readPackage` runs once per resolved package.
+//! The worker loads the pnpmfile a single time and answers many requests,
+//! multiplexed by a monotonic request id so concurrent calls (the resolver
+//! resolves dependencies in parallel) can be in flight at once.
+//!
+//! Protocol — one JSON object per line:
+//! - request:  `{"id": N, "hook": "readPackage", "payload": <value>}`
+//! - log:      `{"id": N, "log": "message"}`        (a `context.log(...)` call)
+//! - success:  `{"id": N, "ok": <value>}`
+//! - failure:  `{"id": N, "err": "message"}`
+
+use crate::HookError;
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    path::Path,
+    process::Stdio,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, Command},
+    sync::{Mutex, oneshot},
+    time::{Duration, timeout},
+};
+
+const HOOK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Callback invoked for each `context.log(...)` a hook emits while it runs.
+pub type LogFn = Arc<dyn Fn(String) + Send + Sync>;
+
+struct Pending {
+    log: LogFn,
+    done: oneshot::Sender<Result<Value, String>>,
+}
+
+type PendingMap = Arc<Mutex<HashMap<u64, Pending>>>;
+
+/// A handle to a running Node worker process loaded with one pnpmfile.
+pub struct NodeWorker {
+    pnpmfile: String,
+    stdin: Mutex<ChildStdin>,
+    pending: PendingMap,
+    next_id: AtomicU64,
+    /// Kept so the child is killed when the worker is dropped (`kill_on_drop`).
+    _child: Child,
+}
+
+impl NodeWorker {
+    /// Spawn the worker for `file` and start reading its responses.
+    pub async fn spawn(file: &Path) -> Result<Arc<NodeWorker>, HookError> {
+        let pnpmfile = file.to_string_lossy().into_owned();
+        let exec_err =
+            |message: String| HookError::Execution { pnpmfile: pnpmfile.clone(), message };
+
+        let file_escaped =
+            serde_json::to_string(&pnpmfile).map_err(|err| exec_err(err.to_string()))?;
+        let is_mjs = pnpmfile.ends_with(".mjs");
+        let runner = build_runner(is_mjs, &file_escaped);
+
+        // The runner itself is always CommonJS so it can `require('node:readline')`;
+        // an `.mjs` pnpmfile is loaded through dynamic `import()`, which works
+        // from CommonJS.
+        let mut child = Command::new("node")
+            .arg("--input-type")
+            .arg("commonjs")
+            .arg("-e")
+            .arg(&runner)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|err| exec_err(err.to_string()))?;
+
+        let stdin = child.stdin.take().expect("worker stdin is piped");
+        let stdout = child.stdout.take().expect("worker stdout is piped");
+
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+        let pending_reader = Arc::clone(&pending);
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                dispatch_line(&pending_reader, &line).await;
+            }
+            // The worker exited: fail every still-pending request so callers
+            // don't hang waiting for a response that will never arrive.
+            for (_, pending) in pending_reader.lock().await.drain() {
+                let _ = pending.done.send(Err("pnpmfile worker exited".to_string()));
+            }
+        });
+
+        Ok(Arc::new(NodeWorker {
+            pnpmfile,
+            stdin: Mutex::new(stdin),
+            pending,
+            next_id: AtomicU64::new(0),
+            _child: child,
+        }))
+    }
+
+    fn exec_err(&self, message: impl Into<String>) -> HookError {
+        HookError::Execution { pnpmfile: self.pnpmfile.clone(), message: message.into() }
+    }
+
+    /// Run `hook` with `payload`, forwarding any `context.log(...)` to `log`.
+    pub async fn call(&self, hook: &str, payload: Value, log: LogFn) -> Result<Value, HookError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (done, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, Pending { log, done });
+
+        let request = serde_json::json!({ "id": id, "hook": hook, "payload": payload });
+        let mut line =
+            serde_json::to_string(&request).map_err(|err| self.exec_err(err.to_string()))?;
+        line.push('\n');
+        {
+            let mut stdin = self.stdin.lock().await;
+            stdin.write_all(line.as_bytes()).await.map_err(|err| self.exec_err(err.to_string()))?;
+            stdin.flush().await.map_err(|err| self.exec_err(err.to_string()))?;
+        }
+
+        match timeout(HOOK_TIMEOUT, rx).await {
+            Ok(Ok(Ok(value))) => Ok(value),
+            Ok(Ok(Err(message))) => Err(self.exec_err(message)),
+            Ok(Err(_)) => Err(self.exec_err("pnpmfile worker dropped the response")),
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                Err(HookError::Timeout(hook.to_string(), HOOK_TIMEOUT.as_secs()))
+            }
+        }
+    }
+}
+
+/// Route one line from the worker to its pending request: forward `log` lines
+/// to the call's logger (the entry stays until the result arrives) and resolve
+/// the call on `ok`/`err`.
+async fn dispatch_line(pending: &PendingMap, line: &str) {
+    let Ok(message) = serde_json::from_str::<Value>(line) else { return };
+    let Some(id) = message.get("id").and_then(Value::as_u64) else { return };
+
+    if let Some(log) = message.get("log").and_then(Value::as_str) {
+        if let Some(entry) = pending.lock().await.get(&id) {
+            (entry.log)(log.to_string());
+        }
+        return;
+    }
+
+    let Some(entry) = pending.lock().await.remove(&id) else { return };
+    let result = match message.get("err").and_then(Value::as_str) {
+        Some(err) => Err(err.to_string()),
+        None => Ok(message.get("ok").cloned().unwrap_or(Value::Null)),
+    };
+    let _ = entry.done.send(result);
+}
+
+/// Build the worker's Node script. `file_escaped` is the JSON-encoded pnpmfile
+/// path; the worker loads it once and replays the `readPackage` validation and
+/// normalization that [`crate::node_runtime`] documents.
+fn build_runner(is_mjs: bool, file_escaped: &str) -> String {
+    let load = if is_mjs {
+        format!("mod = await import({file_escaped});")
+    } else {
+        format!("mod = require({file_escaped});")
+    };
+    format!(
+        r#"const readline = require('node:readline');
+let mod = null;
+let loadErr = null;
+async function ensureLoaded() {{
+  if (mod !== null || loadErr !== null) return;
+  try {{ {load} }} catch (err) {{ loadErr = err && err.stack ? err.stack : String(err); }}
+}}
+const rl = readline.createInterface({{ input: process.stdin }});
+rl.on('line', (line) => {{ handle(line); }});
+async function handle(line) {{
+  let req;
+  try {{ req = JSON.parse(line); }} catch {{ return; }}
+  const id = req.id;
+  const send = (obj) => process.stdout.write(JSON.stringify(Object.assign({{ id }}, obj)) + '\n');
+  await ensureLoaded();
+  if (loadErr !== null) {{ send({{ err: loadErr }}); return; }}
+  try {{
+    const fn = mod && mod.hooks && mod.hooks[req.hook];
+    const context = {{ log: (m) => send({{ log: String(m) }}) }};
+    if (req.hook === 'readPackage') {{
+      const pkg = req.payload;
+      if (typeof fn !== 'function') {{ send({{ ok: pkg }}); return; }}
+      pkg.dependencies = pkg.dependencies ?? {{}};
+      pkg.devDependencies = pkg.devDependencies ?? {{}};
+      pkg.optionalDependencies = pkg.optionalDependencies ?? {{}};
+      pkg.peerDependencies = pkg.peerDependencies ?? {{}};
+      const newPkg = await fn(pkg, context);
+      if (!newPkg) {{
+        throw new Error("readPackage hook did not return a package manifest object. Hook imported via " + {file_escaped});
+      }}
+      for (const dep of ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]) {{
+        const v = newPkg[dep];
+        if (v != null && (typeof v !== "object" || Array.isArray(v))) {{
+          throw new Error("readPackage hook returned package manifest object's property '" + dep + "' must be an object. Hook imported via " + {file_escaped});
+        }}
+      }}
+      send({{ ok: newPkg }});
+    }} else if (req.hook === 'filterLog') {{
+      const res = (typeof fn === 'function') ? await fn(req.payload, context) : true;
+      send({{ ok: res }});
+    }} else {{
+      const res = (typeof fn === 'function') ? await fn(req.payload, context) : null;
+      send({{ ok: res === undefined ? null : res }});
+    }}
+  }} catch (err) {{
+    send({{ err: err && err.stack ? err.stack : String(err) }});
+  }}
+}}
+"#,
+    )
+}

--- a/pacquet/crates/hooks/tests/__fixtures__/filterLogHook.cjs
+++ b/pacquet/crates/hooks/tests/__fixtures__/filterLogHook.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  hooks: { filterLog }
+}
+
+function filterLog(log) {
+  return log.level === 'debug' || log.level === 'error';
+}

--- a/pacquet/crates/hooks/tests/__fixtures__/readPackageHook.cjs
+++ b/pacquet/crates/hooks/tests/__fixtures__/readPackageHook.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  hooks: { readPackage }
+}
+
+function readPackage(pkg) {
+  if (pkg.name === 'foo') {
+    pkg.dependencies = { bar: '100.0.0' };
+  }
+  return pkg;
+}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -59,7 +59,7 @@ function readPackage(pkg) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
     let manifest = serde_json::json!({
         "name": "foo",
@@ -92,7 +92,7 @@ function readPackage(pkg) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
     let manifest = serde_json::json!({
         "name": "baz",
@@ -125,7 +125,7 @@ function filterLog(log) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
     let debug_log = serde_json::json!({
         "level": "debug",
@@ -169,7 +169,7 @@ function readPackage(pkg) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path.clone() };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path.clone());
 
     let manifest = serde_json::json!({
         "name": "foo",
@@ -211,7 +211,7 @@ function preResolution(ctx, logger) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
     let ctx = pacquet_hooks::PreResolutionHookContext {
         wanted_lockfile: serde_json::json!({}),
@@ -255,7 +255,7 @@ function preResolution(ctx, logger) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
 
     let ctx = pacquet_hooks::PreResolutionHookContext {
         wanted_lockfile: serde_json::json!({}),
@@ -285,7 +285,7 @@ fn cjs_hooks(source: &str) -> (pacquet_hooks::node_runtime::NodeJsHooks, TempDir
     let tmp = TempDir::new().expect("temp dir");
     let path = tmp.path().join(".pnpmfile.cjs");
     std::fs::write(&path, source).expect("write pnpmfile");
-    (pacquet_hooks::node_runtime::NodeJsHooks { file: path }, tmp)
+    (pacquet_hooks::node_runtime::NodeJsHooks::new(path), tmp)
 }
 
 async fn read_package_err(source: &str) -> String {
@@ -376,4 +376,64 @@ async fn read_package_fails_when_pnpmfile_requires_missing_module() {
     let err = read_package_err("module.exports = require('./this-does-not-exist')").await;
     eprintln!("err = {err}");
     assert!(err.contains("Error during pnpmfile execution"));
+}
+
+// The worker multiplexes concurrent readPackage calls by request id: each
+// concurrent call must get back the manifest it sent, not another call's.
+#[tokio::test]
+async fn worker_multiplexes_concurrent_read_package_calls() {
+    let (hooks, _tmp) = cjs_hooks(
+        r#"module.exports = { hooks: { readPackage (pkg) {
+  pkg.dependencies['self'] = pkg.name;
+  return pkg;
+} } }"#,
+    );
+    let hooks = Arc::new(hooks);
+
+    let mut set = tokio::task::JoinSet::new();
+    for i in 0..32u32 {
+        let hooks = Arc::clone(&hooks);
+        set.spawn(async move {
+            let name = format!("pkg-{i}");
+            let updated = hooks
+                .read_package(
+                    serde_json::json!({ "name": name, "version": "1.0.0" }),
+                    pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+                )
+                .await
+                .expect("readPackage should succeed");
+            (name, updated["dependencies"]["self"].as_str().unwrap().to_string())
+        });
+    }
+
+    while let Some(joined) = set.join_next().await {
+        let (sent, echoed) = joined.expect("task should not panic");
+        assert_eq!(sent, echoed, "a concurrent call received another call's response");
+    }
+}
+
+// A `context.log(...)` call inside readPackage is forwarded to the
+// HookContext's log callback.
+#[tokio::test]
+async fn worker_forwards_read_package_context_log() {
+    let (hooks, _tmp) = cjs_hooks(
+        r#"module.exports = { hooks: { readPackage (pkg, context) {
+  context.log('hello from ' + pkg.name);
+  return pkg;
+} } }"#,
+    );
+
+    let logs = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = Arc::clone(&logs);
+    hooks
+        .read_package(
+            serde_json::json!({ "name": "foo", "version": "1.0.0" }),
+            pacquet_hooks::HookContext {
+                log: Arc::new(move |message| sink.lock().unwrap().push(message)),
+            },
+        )
+        .await
+        .expect("readPackage should succeed");
+
+    assert_eq!(logs.lock().unwrap().as_slice(), &["hello from foo".to_string()]);
 }

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -70,8 +70,7 @@ function readPackage(pkg) {
         .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
         .await;
 
-    assert!(result.is_some());
-    let updated = result.unwrap();
+    let updated = result.expect("readPackage should succeed");
     assert_eq!(updated["dependencies"]["bar"], "100.0.0");
 }
 
@@ -104,8 +103,7 @@ function readPackage(pkg) {
         .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
         .await;
 
-    assert!(result.is_some());
-    let updated = result.unwrap();
+    let updated = result.expect("readPackage should succeed");
     assert_eq!(updated["name"], "baz");
 }
 
@@ -182,12 +180,12 @@ function readPackage(pkg) {
         .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
         .await;
 
-    assert!(
-        result.is_some(),
-        "readPackage returned None; the Node.js subprocess likely failed to load the .mjs file at {}",
-        pnpmfile_path.display(),
-    );
-    let updated = result.unwrap();
+    let updated = result.unwrap_or_else(|err| {
+        panic!(
+            "readPackage failed; the Node.js subprocess likely could not load the .mjs file at {}: {err}",
+            pnpmfile_path.display(),
+        )
+    });
     assert_eq!(updated["dependencies"]["bar"], "100.0.0");
 }
 
@@ -279,4 +277,103 @@ function preResolution(ctx, logger) {
             },
         )
         .await;
+}
+
+/// Helper: write `source` to a `.pnpmfile.cjs` in a fresh temp dir and return
+/// the hooks bridge plus the dir (kept alive for the file's lifetime).
+fn cjs_hooks(source: &str) -> (pacquet_hooks::node_runtime::NodeJsHooks, TempDir) {
+    let tmp = TempDir::new().expect("temp dir");
+    let path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&path, source).expect("write pnpmfile");
+    (pacquet_hooks::node_runtime::NodeJsHooks { file: path }, tmp)
+}
+
+async fn read_package_err(source: &str) -> String {
+    let (hooks, _tmp) = cjs_hooks(source);
+    hooks
+        .read_package(
+            serde_json::json!({ "name": "foo", "version": "1.0.0" }),
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+        )
+        .await
+        .expect_err("readPackage should fail")
+        .to_string()
+}
+
+#[tokio::test]
+async fn read_package_fails_when_hook_returns_undefined() {
+    let err = read_package_err("module.exports = { hooks: { readPackage (pkg) {} } }").await;
+    eprintln!("err = {err}");
+    assert!(err.contains("readPackage hook did not return a package manifest object."));
+}
+
+#[tokio::test]
+async fn read_package_fails_when_dependencies_is_not_an_object() {
+    let err = read_package_err(
+        "module.exports = { hooks: { readPackage: (pkg) => ({ ...pkg, dependencies: 'nope' }) } }",
+    )
+    .await;
+    eprintln!("err = {err}");
+    assert!(err.contains("property 'dependencies' must be an object."));
+}
+
+#[tokio::test]
+async fn read_package_fails_when_dev_dependencies_is_not_an_object() {
+    let err = read_package_err(
+        "module.exports = { hooks: { readPackage: (pkg) => ({ ...pkg, devDependencies: 1 }) } }",
+    )
+    .await;
+    eprintln!("err = {err}");
+    assert!(err.contains("property 'devDependencies' must be an object."));
+}
+
+#[tokio::test]
+async fn read_package_fails_when_peer_dependencies_is_an_array() {
+    let err = read_package_err(
+        "module.exports = { hooks: { readPackage: (pkg) => ({ ...pkg, peerDependencies: [] }) } }",
+    )
+    .await;
+    eprintln!("err = {err}");
+    assert!(err.contains("property 'peerDependencies' must be an object."));
+}
+
+#[tokio::test]
+async fn read_package_normalizes_missing_dependency_fields() {
+    // The manifest has no dependency fields; the hook writes into them
+    // directly, relying on pnpm's normalization that defaults each to `{}`
+    // before the hook runs.
+    let (hooks, _tmp) = cjs_hooks(
+        r#"module.exports = { hooks: { readPackage (pkg) {
+  pkg.dependencies['is-positive'] = '*';
+  pkg.optionalDependencies['is-negative'] = '*';
+  pkg.peerDependencies['is-negative'] = '*';
+  pkg.devDependencies['is-positive'] = '*';
+  return pkg;
+} } }"#,
+    );
+
+    let updated = hooks
+        .read_package(
+            serde_json::json!({ "name": "x", "version": "1.0.0" }),
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+        )
+        .await
+        .expect("readPackage should succeed after normalization");
+    assert_eq!(updated["dependencies"]["is-positive"], "*");
+    assert_eq!(updated["peerDependencies"]["is-negative"], "*");
+}
+
+#[tokio::test]
+async fn read_package_fails_with_meaningful_error_on_syntax_error() {
+    let err = read_package_err("/boom").await;
+    eprintln!("err = {err}");
+    assert!(err.contains("Error during pnpmfile execution"));
+    assert!(err.contains("SyntaxError"));
+}
+
+#[tokio::test]
+async fn read_package_fails_when_pnpmfile_requires_missing_module() {
+    let err = read_package_err("module.exports = require('./this-does-not-exist')").await;
+    eprintln!("err = {err}");
+    assert!(err.contains("Error during pnpmfile execution"));
 }

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -42,7 +42,9 @@ fn test_find_pnpmfile_none_when_missing() {
 async fn test_node_js_hooks_read_package() {
     let tmp = TempDir::new().expect("temp dir");
     let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
-    std::fs::write(&pnpmfile_path, r#"
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
 module.exports = {
   hooks: { readPackage }
 }
@@ -53,21 +55,20 @@ function readPackage(pkg) {
   }
   return pkg;
 }
-"#)
+"#,
+    )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
-        file: pnpmfile_path,
-    };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
 
     let manifest = serde_json::json!({
         "name": "foo",
         "version": "1.0.0"
     });
 
-    let result = hooks.read_package(manifest.clone(), pacquet_hooks::HookContext {
-        log: Arc::new(|_| {}),
-    }).await;
+    let result = hooks
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .await;
 
     assert!(result.is_some());
     let updated = result.unwrap();
@@ -78,7 +79,9 @@ function readPackage(pkg) {
 async fn test_node_js_hooks_read_package_no_match() {
     let tmp = TempDir::new().expect("temp dir");
     let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
-    std::fs::write(&pnpmfile_path, r#"
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
 module.exports = {
   hooks: { readPackage }
 }
@@ -86,21 +89,20 @@ module.exports = {
 function readPackage(pkg) {
   return pkg;
 }
-"#)
+"#,
+    )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
-        file: pnpmfile_path,
-    };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
 
     let manifest = serde_json::json!({
         "name": "baz",
         "version": "1.0.0"
     });
 
-    let result = hooks.read_package(manifest.clone(), pacquet_hooks::HookContext {
-        log: Arc::new(|_| {}),
-    }).await;
+    let result = hooks
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .await;
 
     assert!(result.is_some());
     let updated = result.unwrap();
@@ -111,7 +113,9 @@ function readPackage(pkg) {
 async fn test_node_js_hooks_filter_log() {
     let tmp = TempDir::new().expect("temp dir");
     let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
-    std::fs::write(&pnpmfile_path, r#"
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
 module.exports = {
   hooks: { filterLog }
 }
@@ -119,28 +123,152 @@ module.exports = {
 function filterLog(log) {
   return log.level === 'debug' || log.level === 'error';
 }
-"#)
+"#,
+    )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
-        file: pnpmfile_path,
-    };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
 
     let debug_log = serde_json::json!({
         "level": "debug",
         "message": "test debug"
     });
 
-    assert!(hooks.filter_log(debug_log, pacquet_hooks::HookContext {
-        log: Arc::new(|_| {}),
-    }).await);
+    assert!(
+        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await
+    );
 
     let warn_log = serde_json::json!({
         "level": "warn",
         "message": "test warn"
     });
 
-    assert!(!hooks.filter_log(warn_log, pacquet_hooks::HookContext {
-        log: Arc::new(|_| {}),
-    }).await);
+    assert!(
+        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await
+    );
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_read_package_mjs() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.mjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
+export const hooks = { readPackage };
+
+function readPackage(pkg) {
+  if (pkg.name === 'foo') {
+    pkg.dependencies = { bar: '100.0.0' };
+  }
+  return pkg;
+}
+"#,
+    )
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+
+    let manifest = serde_json::json!({
+        "name": "foo",
+        "version": "1.0.0"
+    });
+
+    let result = hooks
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .await;
+
+    assert!(result.is_some());
+    let updated = result.unwrap();
+    assert_eq!(updated["dependencies"]["bar"], "100.0.0");
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_pre_resolution() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
+module.exports = {
+  hooks: { preResolution }
+}
+
+function preResolution(ctx, logger) {
+  // Verify both ctx and logger are passed correctly
+  if (ctx.lockfileDir !== '/test/lockfile') throw new Error('wrong lockfileDir');
+  if (ctx.storeDir !== '/test/store') throw new Error('wrong storeDir');
+  if (typeof logger.info !== 'function') throw new Error('missing logger.info');
+  if (typeof logger.warn !== 'function') throw new Error('missing logger.warn');
+}
+"#,
+    )
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+
+    let ctx = pacquet_hooks::PreResolutionHookContext {
+        wanted_lockfile: serde_json::json!({}),
+        current_lockfile: serde_json::json!({}),
+        exists_current_lockfile: false,
+        exists_non_empty_wanted_lockfile: false,
+        lockfile_dir: "/test/lockfile".to_string(),
+        store_dir: "/test/store".to_string(),
+        registries: serde_json::json!({ "default": "http://localhost:1234/" }),
+    };
+
+    // The hook should execute without error
+    hooks
+        .pre_resolution(
+            ctx,
+            pacquet_hooks::PreResolutionHookLogger {
+                info: Arc::new(|_| {}),
+                warn: Arc::new(|_| {}),
+            },
+        )
+        .await;
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_pre_resolution_mjs() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.mjs");
+    std::fs::write(
+        &pnpmfile_path,
+        r#"
+export const hooks = { preResolution };
+
+function preResolution(ctx, logger) {
+  // Verify both ctx and logger are passed correctly
+  if (ctx.lockfileDir !== '/test/lockfile') throw new Error('wrong lockfileDir');
+  if (ctx.storeDir !== '/test/store') throw new Error('wrong storeDir');
+  if (typeof logger.info !== 'function') throw new Error('missing logger.info');
+  if (typeof logger.warn !== 'function') throw new Error('missing logger.warn');
+}
+"#,
+    )
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+
+    let ctx = pacquet_hooks::PreResolutionHookContext {
+        wanted_lockfile: serde_json::json!({}),
+        current_lockfile: serde_json::json!({}),
+        exists_current_lockfile: false,
+        exists_non_empty_wanted_lockfile: false,
+        lockfile_dir: "/test/lockfile".to_string(),
+        store_dir: "/test/store".to_string(),
+        registries: serde_json::json!({ "default": "http://localhost:1234/" }),
+    };
+
+    // The hook should execute without error
+    hooks
+        .pre_resolution(
+            ctx,
+            pacquet_hooks::PreResolutionHookLogger {
+                info: Arc::new(|_| {}),
+                warn: Arc::new(|_| {}),
+            },
+        )
+        .await;
 }

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -185,7 +185,7 @@ function readPackage(pkg) {
     assert!(
         result.is_some(),
         "readPackage returned None; the Node.js subprocess likely failed to load the .mjs file at {}",
-        pnpmfile_path.display()
+        pnpmfile_path.display(),
     );
     let updated = result.unwrap();
     assert_eq!(updated["dependencies"]["bar"], "100.0.0");

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -148,6 +148,10 @@ function filterLog(log) {
     );
 }
 
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
+)]
 #[tokio::test]
 async fn test_node_js_hooks_read_package_mjs() {
     let tmp = TempDir::new().expect("temp dir");
@@ -178,7 +182,11 @@ function readPackage(pkg) {
         .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
         .await;
 
-    assert!(result.is_some());
+    assert!(
+        result.is_some(),
+        "readPackage returned None; the Node.js subprocess likely failed to load the .mjs file at {}",
+        pnpmfile_path.display()
+    );
     let updated = result.unwrap();
     assert_eq!(updated["dependencies"]["bar"], "100.0.0");
 }

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -171,7 +171,7 @@ function readPackage(pkg) {
     )
     .expect("write pnpmfile");
 
-    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path };
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks { file: pnpmfile_path.clone() };
 
     let manifest = serde_json::json!({
         "name": "foo",

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use tempfile::TempDir;
 
-use pacquet_hooks::{finder, PnpmfileHooks};
+use pacquet_hooks::{PnpmfileHooks, finder};
 
 #[test]
 fn test_find_pnpmfile_uses_mjs() {

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -1,0 +1,146 @@
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use pacquet_hooks::{finder, PnpmfileHooks};
+
+#[test]
+fn test_find_pnpmfile_uses_mjs() {
+    let tmp = TempDir::new().expect("temp dir");
+    let root = tmp.path();
+
+    // Create .pnpmfile.mjs first, then .pnpmfile.cjs
+    std::fs::write(root.join(".pnpmfile.mjs"), "// mjs").expect("write mjs");
+    std::fs::write(root.join(".pnpmfile.cjs"), "// cjs").expect("write cjs");
+
+    let found = finder::find_pnpmfile(root);
+    // Should prefer .mjs
+    assert!(found.unwrap().ends_with(".pnpmfile.mjs"));
+}
+
+#[test]
+fn test_find_pnpmfile_fallback_to_cjs() {
+    let tmp = TempDir::new().expect("temp dir");
+    let root = tmp.path();
+
+    // Only create .pnpmfile.cjs (no .mjs)
+    std::fs::write(root.join(".pnpmfile.cjs"), "// cjs").expect("write cjs");
+
+    let found = finder::find_pnpmfile(root);
+    assert!(found.unwrap().ends_with(".pnpmfile.cjs"));
+}
+
+#[test]
+fn test_find_pnpmfile_none_when_missing() {
+    let tmp = TempDir::new().expect("temp dir");
+    let root = tmp.path();
+
+    let found = finder::find_pnpmfile(root);
+    assert!(found.is_none());
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_read_package() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&pnpmfile_path, r#"
+module.exports = {
+  hooks: { readPackage }
+}
+
+function readPackage(pkg) {
+  if (pkg.name === 'foo') {
+    pkg.dependencies = { bar: '100.0.0' };
+  }
+  return pkg;
+}
+"#)
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
+        file: pnpmfile_path,
+    };
+
+    let manifest = serde_json::json!({
+        "name": "foo",
+        "version": "1.0.0"
+    });
+
+    let result = hooks.read_package(manifest.clone(), pacquet_hooks::HookContext {
+        log: Arc::new(|_| {}),
+    }).await;
+
+    assert!(result.is_some());
+    let updated = result.unwrap();
+    assert_eq!(updated["dependencies"]["bar"], "100.0.0");
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_read_package_no_match() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&pnpmfile_path, r#"
+module.exports = {
+  hooks: { readPackage }
+}
+
+function readPackage(pkg) {
+  return pkg;
+}
+"#)
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
+        file: pnpmfile_path,
+    };
+
+    let manifest = serde_json::json!({
+        "name": "baz",
+        "version": "1.0.0"
+    });
+
+    let result = hooks.read_package(manifest.clone(), pacquet_hooks::HookContext {
+        log: Arc::new(|_| {}),
+    }).await;
+
+    assert!(result.is_some());
+    let updated = result.unwrap();
+    assert_eq!(updated["name"], "baz");
+}
+
+#[tokio::test]
+async fn test_node_js_hooks_filter_log() {
+    let tmp = TempDir::new().expect("temp dir");
+    let pnpmfile_path = tmp.path().join(".pnpmfile.cjs");
+    std::fs::write(&pnpmfile_path, r#"
+module.exports = {
+  hooks: { filterLog }
+}
+
+function filterLog(log) {
+  return log.level === 'debug' || log.level === 'error';
+}
+"#)
+    .expect("write pnpmfile");
+
+    let hooks = pacquet_hooks::node_runtime::NodeJsHooks {
+        file: pnpmfile_path,
+    };
+
+    let debug_log = serde_json::json!({
+        "level": "debug",
+        "message": "test debug"
+    });
+
+    assert!(hooks.filter_log(debug_log, pacquet_hooks::HookContext {
+        log: Arc::new(|_| {}),
+    }).await);
+
+    let warn_log = serde_json::json!({
+        "level": "warn",
+        "message": "test warn"
+    });
+
+    assert!(!hooks.filter_log(warn_log, pacquet_hooks::HookContext {
+        log: Arc::new(|_| {}),
+    }).await);
+}

--- a/pacquet/crates/hooks/tests/node_hooks.rs
+++ b/pacquet/crates/hooks/tests/node_hooks.rs
@@ -135,7 +135,7 @@ function filterLog(log) {
     });
 
     assert!(
-        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await
+        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await,
     );
 
     let warn_log = serde_json::json!({
@@ -144,7 +144,7 @@ function filterLog(log) {
     });
 
     assert!(
-        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await
+        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await,
     );
 }
 

--- a/pacquet/crates/lockfile/src/save_lockfile.rs
+++ b/pacquet/crates/lockfile/src/save_lockfile.rs
@@ -58,8 +58,8 @@ pub enum SaveLockfileError {
 /// `preserve_order` feature keeps the key order produced by serializing the
 /// [`Lockfile`] and appended by the hook, so the output matches the typed write
 /// for unmodified lockfiles.
-pub fn save_value_to_path<T: serde::Serialize>(
-    value: &T,
+pub fn save_value_to_path<Document: serde::Serialize>(
+    value: &Document,
     path: &Path,
 ) -> Result<(), SaveLockfileError> {
     let content = serialize_yaml::to_string(value).map_err(SaveLockfileError::SerializeYaml)?;

--- a/pacquet/crates/lockfile/src/save_lockfile.rs
+++ b/pacquet/crates/lockfile/src/save_lockfile.rs
@@ -51,11 +51,25 @@ pub enum SaveLockfileError {
     },
 }
 
+/// Write an arbitrary lockfile-shaped value to `path` as pnpm-formatted YAML.
+///
+/// Used by the `afterAllResolved` pnpmfile hook, whose JSON result may carry
+/// arbitrary keys the typed [`Lockfile`] cannot represent. `serde_json`'s
+/// `preserve_order` feature keeps the key order produced by serializing the
+/// [`Lockfile`] and appended by the hook, so the output matches the typed write
+/// for unmodified lockfiles.
+pub fn save_value_to_path<T: serde::Serialize>(
+    value: &T,
+    path: &Path,
+) -> Result<(), SaveLockfileError> {
+    let content = serialize_yaml::to_string(value).map_err(SaveLockfileError::SerializeYaml)?;
+    fs::write(path, content).map_err(SaveLockfileError::WriteFile)
+}
+
 impl Lockfile {
     /// Save lockfile to a specific path.
     pub fn save_to_path(&self, path: &Path) -> Result<(), SaveLockfileError> {
-        let content = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
-        fs::write(path, content).map_err(SaveLockfileError::WriteFile)
+        save_value_to_path(self, path)
     }
 
     /// Save lockfile to `pnpm-lock.yaml` in the current directory.

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -31,7 +31,7 @@ pacquet-network                           = { workspace = true }
 pacquet-config                            = { workspace = true }
 pacquet-config-parse-overrides            = { workspace = true }
 pacquet-graph-hasher                      = { workspace = true }
-pacquet-hooks                           = { workspace = true }
+pacquet-hooks                             = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-package-is-installable            = { workspace = true }
 pacquet-patching                          = { workspace = true }

--- a/pacquet/crates/package-manager/Cargo.toml
+++ b/pacquet/crates/package-manager/Cargo.toml
@@ -31,6 +31,7 @@ pacquet-network                           = { workspace = true }
 pacquet-config                            = { workspace = true }
 pacquet-config-parse-overrides            = { workspace = true }
 pacquet-graph-hasher                      = { workspace = true }
+pacquet-hooks                           = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-package-is-installable            = { workspace = true }
 pacquet-patching                          = { workspace = true }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -6176,3 +6176,51 @@ async fn pnpmfile_syntax_error_aborts_install() {
 
     drop((dir, registry));
 }
+
+// Ports pnpm's `pnpmfile: run afterAllResolved hook` and the deps-installer
+// `readPackage, afterAllResolved hooks` test: the hook receives the resolved
+// lockfile object and its return value is what gets written, so an arbitrary
+// added key must survive to pnpm-lock.yaml.
+#[tokio::test]
+async fn after_all_resolved_hook_modifies_written_lockfile() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r#"module.exports = { hooks: { afterAllResolved (lockfile) {
+  lockfile.foo = 'foo';
+  return lockfile;
+} } }"#,
+    )
+    .await
+    .expect("install should succeed");
+
+    let lockfile_text = std::fs::read_to_string(dir.path().join("pnpm-lock.yaml")).unwrap();
+    eprintln!("{lockfile_text}");
+    assert!(
+        lockfile_text.contains("foo: foo"),
+        "the afterAllResolved addition must be written to pnpm-lock.yaml",
+    );
+    // The lockfile is still a valid lockfile carrying the resolved package.
+    assert!(lockfile_text.contains("@pnpm.e2e/pkg-with-1-dep"));
+}
+
+// A throwing afterAllResolved hook aborts the install, matching pnpm.
+#[tokio::test]
+async fn after_all_resolved_hook_failure_aborts_install() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    let result = install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        "module.exports = { hooks: { afterAllResolved () { throw new Error('boom'); } } }",
+    )
+    .await;
+
+    assert!(result.is_err(), "install must fail when afterAllResolved throws");
+}

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -6044,3 +6044,135 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
 
     drop(dir);
 }
+
+/// Runs a fresh install in `root` with `root_deps` as direct prod
+/// dependencies and `pnpmfile_src` written to `<root>/.pnpmfile.cjs`, so the
+/// pnpmfile hooks are discovered and run during resolution.
+async fn install_with_pnpmfile(
+    registry_url: String,
+    root: &std::path::Path,
+    root_deps: &[(&str, &str)],
+    pnpmfile_src: &str,
+) -> Result<(), InstallError> {
+    let modules_dir = root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+
+    let manifest_path = root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    for (name, spec) in root_deps {
+        manifest.add_dependency(name, spec, DependencyGroup::Prod).unwrap();
+    }
+    manifest.save().unwrap();
+
+    std::fs::write(root.join(".pnpmfile.cjs"), pnpmfile_src).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = root.join("pacquet-store").into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = registry_url;
+    let config = config.leak();
+
+    let http_client = Default::default();
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &http_client,
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+    }
+    .run::<SilentReporter>()
+    .await
+}
+
+// Ports pnpm's `readPackage hook` install test
+// (pnpm/test/install/hooks.ts): the hook rewrites a resolved package's
+// dependency range, and resolution honors it. `@pnpm.e2e/pkg-with-1-dep`
+// depends on `@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0`, which would resolve
+// to 100.1.0; pinning it to 100.0.0 in the hook installs 100.0.0 instead.
+#[tokio::test]
+async fn read_package_hook_pins_transitive_dependency_version() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r#"module.exports = { hooks: { readPackage (pkg) {
+  if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
+    pkg.dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0';
+  }
+  return pkg;
+} } }"#,
+    )
+    .await
+    .expect("install should succeed");
+
+    let vsd = dir.path().join("node_modules/.pacquet");
+    assert!(
+        vsd.join("@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0").exists(),
+        "readPackage hook should have pinned the transitive dep to 100.0.0",
+    );
+    assert!(
+        !vsd.join("@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0").exists(),
+        "the un-pinned 100.1.0 must not be installed",
+    );
+
+    drop((dir, registry));
+}
+
+// Ports pnpm's `readPackage hook makes installation fail if it does not
+// return the modified package manifests`.
+#[tokio::test]
+async fn read_package_hook_failure_aborts_install() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    let result = install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        "module.exports = { hooks: { readPackage (pkg) {} } }",
+    )
+    .await;
+
+    assert!(result.is_err(), "install must fail when readPackage returns nothing");
+
+    drop((dir, registry));
+}
+
+// Ports pnpm's `prints meaningful error when there is syntax error in
+// .pnpmfile.cjs`.
+#[tokio::test]
+async fn pnpmfile_syntax_error_aborts_install() {
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    let result = install_with_pnpmfile(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        "/boom",
+    )
+    .await;
+
+    assert!(result.is_err(), "install must fail on a pnpmfile syntax error");
+
+    drop((dir, registry));
+}

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -817,6 +817,41 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         let peers_suffix_max_length =
             usize::try_from(config.peers_suffix_max_length).unwrap_or(usize::MAX);
         let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);
+
+        // Call preResolution hook before resolution starts (mirrors pnpm's behavior in install/index.ts)
+        if let Some(ref hook) = pnpmfile_hook {
+            let wanted_lockfile_json = wanted_lockfile
+                .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
+                .unwrap_or_else(|| serde_json::json!({}));
+            let current_lockfile_json =
+                Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir)
+                    .ok()
+                    .flatten()
+                    .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
+                    .unwrap_or_else(|| serde_json::json!({}));
+            let registries = serde_json::json!({ "default": config.registry });
+            let ctx = pacquet_hooks::PreResolutionHookContext {
+                wanted_lockfile: wanted_lockfile_json,
+                current_lockfile: current_lockfile_json,
+                exists_current_lockfile: wanted_lockfile.is_some(),
+                exists_non_empty_wanted_lockfile: wanted_lockfile
+                    .as_ref()
+                    .map(|lf| !lf.snapshots.as_ref().map(|s| s.is_empty()).unwrap_or(true))
+                    .unwrap_or(false),
+                lockfile_dir: lockfile_dir.to_string_lossy().to_string(),
+                store_dir: config.store_dir.display().to_string(),
+                registries,
+            };
+            hook.pre_resolution(
+                ctx,
+                pacquet_hooks::PreResolutionHookLogger {
+                    info: Arc::new(|_| {}),
+                    warn: Arc::new(|_| {}),
+                },
+            )
+            .await;
+        }
+
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -15,6 +15,7 @@ use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker, ResolutionMode, 
 use pacquet_engine_runtime_bun_resolver::BunResolver;
 use pacquet_engine_runtime_deno_resolver::DenoResolver;
 use pacquet_engine_runtime_node_resolver::NodeResolver;
+use pacquet_hooks::finder;
 use pacquet_lockfile::{Lockfile, LockfileResolution, SaveLockfileError};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -815,6 +816,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 .collect();
         let peers_suffix_max_length =
             usize::try_from(config.peers_suffix_max_length).unwrap_or(usize::MAX);
+        let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
             dedupe_injected_deps: config.dedupe_injected_deps,
@@ -822,6 +824,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             lockfile_dir: lockfile_dir.to_path_buf(),
             peers_suffix_max_length,
             manifest_hook: package_extensions_hook.clone(),
+            pnpmfile_hook,
             pick_lowest_direct,
             time_based,
             // Hand the resolver the prior lockfile so it can reuse
@@ -914,7 +917,9 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     lockfile_dir: Some(lockfile_dir.to_path_buf()),
                     modules_dir: Some(importer_modules_dir),
                     peers_suffix_max_length,
+                    catalog_server: false,
                     manifest_hook: package_extensions_hook.clone(),
+                    pnpmfile_hook: None,
                 }
             },
         )

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -324,6 +324,18 @@ pub enum InstallWithFreshLockfileError {
     /// the `pnpm install --frozen-lockfile` headless path.
     #[diagnostic(transparent)]
     SaveWantedLockfile(#[error(source)] SaveLockfileError),
+
+    /// The `afterAllResolved` pnpmfile hook threw or otherwise failed.
+    /// Mirrors pnpm, where a throwing `afterAllResolved` aborts the install.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    AfterAllResolvedHook(#[error(not(source))] pacquet_hooks::HookError),
+
+    /// The freshly-built lockfile could not be serialized to JSON to pass to
+    /// the `afterAllResolved` pnpmfile hook.
+    #[display("Failed to serialize lockfile for the afterAllResolved hook: {_0}")]
+    #[diagnostic(code(pacquet_package_manager::after_all_resolved_serialize))]
+    AfterAllResolvedSerialize(#[error(source)] serde_json::Error),
 }
 
 impl From<crate::install_frozen_lockfile::HoistedLinkerError> for InstallWithFreshLockfileError {
@@ -817,6 +829,10 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         let peers_suffix_max_length =
             usize::try_from(config.peers_suffix_max_length).unwrap_or(usize::MAX);
         let pnpmfile_hook = finder::load_pnpmfile(lockfile_dir);
+        // Kept past the resolver hand-off (which consumes `pnpmfile_hook`) so
+        // the `afterAllResolved` hook can transform the lockfile before it is
+        // written.
+        let after_all_resolved_hook = pnpmfile_hook.clone();
 
         // Call preResolution hook before resolution starts (mirrors pnpm's behavior in install/index.ts)
         if let Some(ref hook) = pnpmfile_hook {
@@ -1019,9 +1035,12 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 &direct_by_importer,
             );
             let wanted_lockfile = if config.lockfile {
-                built_lockfile
-                    .save_to_path(&lockfile_dir.join(Lockfile::FILE_NAME))
-                    .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)?;
+                save_wanted_lockfile(
+                    &built_lockfile,
+                    &lockfile_dir.join(Lockfile::FILE_NAME),
+                    after_all_resolved_hook.as_ref(),
+                )
+                .await?;
                 Some(built_lockfile)
             } else {
                 None
@@ -1463,9 +1482,8 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // `.modules.yaml` to land first.
         let wanted_lockfile = if config.lockfile {
             let target = lockfile_dir.join(Lockfile::FILE_NAME);
-            built_lockfile
-                .save_to_path(&target)
-                .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)?;
+            save_wanted_lockfile(&built_lockfile, &target, after_all_resolved_hook.as_ref())
+                .await?;
             Some(built_lockfile)
         } else {
             None
@@ -1540,6 +1558,44 @@ fn collect_prefetch_cache_keys_from_graph(
     keys.sort_unstable();
     keys.dedup();
     keys
+}
+
+/// Write the freshly-built wanted lockfile to `target`, first running the
+/// `afterAllResolved` pnpmfile hook when one is configured.
+///
+/// Mirrors pnpm: `afterAllResolved` receives the resolved lockfile object and
+/// returns the (possibly mutated) lockfile that gets written. The round-trip
+/// goes through `serde_json::Value` so hook-added keys the typed [`Lockfile`]
+/// cannot represent survive to disk; `serde_json`'s `preserve_order` feature
+/// keeps the output byte-identical to the typed write when the hook makes no
+/// changes. A throwing hook aborts the install.
+async fn save_wanted_lockfile(
+    built_lockfile: &Lockfile,
+    target: &Path,
+    hook: Option<&Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+) -> Result<(), InstallWithFreshLockfileError> {
+    let Some(hook) = hook else {
+        return built_lockfile
+            .save_to_path(target)
+            .map_err(InstallWithFreshLockfileError::SaveWantedLockfile);
+    };
+
+    let value = serde_json::to_value(built_lockfile)
+        .map_err(InstallWithFreshLockfileError::AfterAllResolvedSerialize)?;
+    let ctx = pacquet_hooks::HookContext { log: Arc::new(|_| {}) };
+    let result = hook
+        .after_all_resolved(value, ctx)
+        .await
+        .map_err(InstallWithFreshLockfileError::AfterAllResolvedHook)?;
+
+    // `Null` means the pnpmfile has no `afterAllResolved` hook, so write the
+    // typed lockfile unchanged.
+    if result.is_null() {
+        built_lockfile.save_to_path(target)
+    } else {
+        pacquet_lockfile::save_value_to_path(&result, target)
+    }
+    .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)
 }
 
 /// Build the [`Lockfile`] for `<lockfile_dir>/pnpm-lock.yaml` from the

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -823,17 +823,19 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             let wanted_lockfile_json = wanted_lockfile
                 .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
                 .unwrap_or_else(|| serde_json::json!({}));
-            let current_lockfile_json =
+            let current_lockfile =
                 Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir)
                     .ok()
-                    .flatten()
-                    .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
-                    .unwrap_or_else(|| serde_json::json!({}));
+                    .flatten();
+            let exists_current_lockfile = current_lockfile.is_some();
+            let current_lockfile_json = current_lockfile
+                .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
+                .unwrap_or_else(|| serde_json::json!({}));
             let registries = serde_json::json!({ "default": config.registry });
             let ctx = pacquet_hooks::PreResolutionHookContext {
                 wanted_lockfile: wanted_lockfile_json,
                 current_lockfile: current_lockfile_json,
-                exists_current_lockfile: wanted_lockfile.is_some(),
+                exists_current_lockfile,
                 exists_non_empty_wanted_lockfile: wanted_lockfile
                     .as_ref()
                     .map(|lf| !lf.snapshots.as_ref().map(|s| s.is_empty()).unwrap_or(true))

--- a/pacquet/crates/resolving-deps-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-deps-resolver/Cargo.toml
@@ -15,6 +15,7 @@ pacquet-catalogs-resolver                 = { workspace = true }
 pacquet-catalogs-types                    = { workspace = true }
 pacquet-deps-path                         = { workspace = true }
 pacquet-fs                                = { workspace = true }
+pacquet-hooks                             = { workspace = true }
 pacquet-lockfile                          = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-patching                          = { workspace = true }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -179,6 +179,13 @@ pub enum ResolveDependencyTreeError {
         parent: String,
         alias: String,
     },
+
+    /// A pnpmfile hook (`readPackage`) threw, timed out, or returned an
+    /// invalid package manifest. Mirrors pnpm's `PNPMFILE_FAIL` /
+    /// `BAD_READ_PACKAGE_HOOK_RESULT`: a bad hook aborts the install.
+    #[display("{_0}")]
+    #[diagnostic(code(PNPMFILE_FAIL))]
+    PnpmfileHook(#[error(not(source))] pacquet_hooks::HookError),
 }
 
 impl From<PatchKeyConflictError> for ResolveDependencyTreeError {
@@ -864,13 +871,11 @@ where
             {
                 let hook_ctx = pacquet_hooks::HookContext { log: Arc::new(|_| {}) };
 
-                if let Some(updated) =
-                    pnpmfile_hook.read_package((*manifest).clone(), hook_ctx).await
-                {
-                    result_inner.manifest = Some(updated);
-                } else {
-                    result_inner.manifest = Some(manifest);
-                }
+                let updated = pnpmfile_hook
+                    .read_package((*manifest).clone(), hook_ctx)
+                    .await
+                    .map_err(ResolveDependencyTreeError::PnpmfileHook)?;
+                result_inner.manifest = Some(updated);
             }
 
             let result = result.expect("Some-guarded above");

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -8,6 +8,7 @@ use pacquet_catalogs_resolver::{
     resolve_from_catalog,
 };
 use pacquet_catalogs_types::Catalogs;
+use pacquet_hooks::PnpmfileHooks;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_patching::{PatchGroupRecord, PatchKeyConflictError, get_patch_info};
 use pacquet_resolving_resolver_base::{ResolveError, ResolveOptions, Resolver, WantedDependency};
@@ -90,24 +91,9 @@ enum ReuseSource {
 /// via [`extend_tree`].
 pub struct ResolveDependencyTreeOptions {
     pub base_opts: ResolveOptions,
-    /// Configured `patchedDependencies`, grouped by package name. Threaded
-    /// through so the per-node walker can append `(patch_hash=<hash>)` to
-    /// each matched package's `pkgIdWithPatchHash` and record the patch
-    /// key on [`crate::ResolvedTree::applied_patches`] for the
-    /// `ERR_PNPM_UNUSED_PATCH` post-walk check. Mirrors upstream's
-    /// [`ctx.patchedDependencies`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L164)
-    /// thread.
     pub patched_dependencies: Option<Arc<PatchGroupRecord>>,
-    /// Per-manifest `readPackageHook` applied to every resolved
-    /// package's manifest right after `Resolver::resolve` returns it
-    /// and before it lands in the wanted-dep cache. Today drives
-    /// `packageExtensions` (see
-    /// `pacquet_package_manager::PackageExtender`); will grow as
-    /// more upstream hooks land. Mirrors upstream's
-    /// [`ctx.readPackageHook`](https://github.com/pnpm/pnpm/blob/39101f5e37/installing/deps-resolver/src/resolveDependencies.ts#L1481-L1483)
-    /// dispatch in `resolveDependencies`. `None` when no hook is
-    /// configured.
     pub manifest_hook: Option<ManifestHook>,
+    pub pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
 }
 
 impl std::fmt::Debug for ResolveDependencyTreeOptions {
@@ -116,6 +102,7 @@ impl std::fmt::Debug for ResolveDependencyTreeOptions {
             .field("base_opts", &self.base_opts)
             .field("patched_dependencies", &self.patched_dependencies)
             .field("manifest_hook", &self.manifest_hook.as_ref().map(|_| "<hook>"))
+            .field("pnpmfile_hook", &self.pnpmfile_hook.as_ref().map(|_| "<hook>"))
             .finish()
     }
 }
@@ -233,7 +220,8 @@ where
 {
     let ctx = TreeCtx::new(opts.base_opts)
         .with_patched_dependencies(opts.patched_dependencies)
-        .with_manifest_hook(opts.manifest_hook);
+        .with_manifest_hook(opts.manifest_hook)
+        .with_pnpmfile_hook(opts.pnpmfile_hook);
     let optional_names = importer_optional_dependency_names(manifest);
     let injected_names = importer_injected_dependency_names(manifest);
     let mut wanted: Vec<WantedSpec> = Vec::new();
@@ -411,9 +399,6 @@ pub struct WorkspaceTreeCtx {
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
     children_by_id: Mutex<HashMap<String, Arc<Vec<crate::resolved_tree::ChildEdge>>>>,
-    /// `readPackageHook` applied to every resolved manifest before it
-    /// enters the wanted-dep cache. See [`ManifestHook`] for the
-    /// signature. `None` when no hook is configured.
     manifest_hook: Option<ManifestHook>,
     /// The previous `pnpm-lock.yaml` the install started from, when one
     /// exists. Consulted by `resolve_node` to reuse an already-resolved
@@ -432,6 +417,7 @@ pub struct WorkspaceTreeCtx {
     /// whole walk. `true` means the package and its entire transitive
     /// subtree can be synthesized from the prior lockfile.
     subtree_reusable: Mutex<HashMap<PkgNameVerPeer, bool>>,
+    pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -449,6 +435,7 @@ impl Default for WorkspaceTreeCtx {
             wanted_lockfile: None,
             update_reuse_scope: UpdateReuseScope::All,
             subtree_reusable: Mutex::new(HashMap::new()),
+            pnpmfile_hook: None,
         }
     }
 }
@@ -499,6 +486,11 @@ impl WorkspaceTreeCtx {
     /// [`UpdateReuseScope`].
     pub fn with_update_reuse_scope(mut self, scope: UpdateReuseScope) -> Self {
         self.update_reuse_scope = scope;
+        self
+    }
+
+    pub fn with_pnpmfile_hook(mut self, pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>) -> Self {
+        self.pnpmfile_hook = pnpmfile_hook;
         self
     }
 
@@ -657,6 +649,13 @@ impl TreeCtx {
         Arc::get_mut(&mut self.workspace)
             .expect("with_manifest_hook called after the workspace ctx was shared via Arc::clone")
             .manifest_hook = manifest_hook;
+        self
+    }
+
+    pub fn with_pnpmfile_hook(mut self, pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>) -> Self {
+        Arc::get_mut(&mut self.workspace)
+            .expect("with_pnpmfile_hook called after the workspace ctx was shared via Arc::clone")
+            .pnpmfile_hook = pnpmfile_hook;
         self
     }
 
@@ -859,6 +858,21 @@ where
             {
                 result_inner.manifest = Some(hook(manifest));
             }
+
+            if let Some(pnpmfile_hook) = ctx.workspace.pnpmfile_hook.as_ref()
+                && let Some(manifest) = result_inner.manifest.take()
+            {
+                let hook_ctx = pacquet_hooks::HookContext { log: Arc::new(|_| {}) };
+
+                if let Some(updated) =
+                    pnpmfile_hook.read_package((*manifest).clone(), hook_ctx).await
+                {
+                    result_inner.manifest = Some(updated);
+                } else {
+                    result_inner.manifest = Some(manifest);
+                }
+            }
+
             let result = result.expect("Some-guarded above");
             // Wrap in `Arc` once so the cache, the per-id
             // `ResolvedPackage` envelope, and the later peer-resolved

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -144,10 +144,16 @@ pub struct ResolveImporterOptions {
     /// `peersSuffixMaxLength` (default 1000).
     pub peers_suffix_max_length: usize,
 
+    pub catalog_server: bool,
+
     /// `readPackageHook` applied to every resolved manifest before
     /// downstream consumers see it. Today drives `packageExtensions`;
     /// see [`crate::ManifestHook`].
     pub manifest_hook: Option<crate::ManifestHook>,
+
+    /// `pnpmfileHook` applied to every resolved manifest. Wraps
+    /// `readPackage` from `.pnpmfile.cjs` / `pnpmfile.cjs`.
+    pub pnpmfile_hook: Option<Arc<dyn pacquet_hooks::PnpmfileHooks>>,
 }
 
 impl std::fmt::Debug for ResolveImporterOptions {
@@ -170,7 +176,9 @@ impl std::fmt::Debug for ResolveImporterOptions {
             .field("lockfile_dir", &self.lockfile_dir)
             .field("modules_dir", &self.modules_dir)
             .field("peers_suffix_max_length", &self.peers_suffix_max_length)
+            .field("catalog_server", &self.catalog_server)
             .field("manifest_hook", &self.manifest_hook.as_ref().map(|_| "<hook>"))
+            .field("pnpmfile_hook", &self.pnpmfile_hook.as_ref().map(|_| "<hook>"))
             .finish()
     }
 }
@@ -208,12 +216,15 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
     Chain: Resolver + ?Sized,
 {
-    // `manifest_hook` lives on the workspace ctx (it's workspace-wide,
-    // not per-importer). Apply it before sharing the `Arc` —
-    // `resolve_importer_with_workspace` reads through the shared ctx
-    // and can't mutate it after the fact.
-    let workspace =
-        Arc::new(WorkspaceTreeCtx::default().with_manifest_hook(opts.manifest_hook.clone()));
+    // Both `manifest_hook` and `pnpmfile_hook` live on the workspace ctx
+    // (they're workspace-wide, not per-importer). Apply them before
+    // sharing the `Arc` — `resolve_importer_with_workspace` reads through
+    // the shared ctx and can't mutate it after the fact.
+    let workspace = Arc::new(
+        WorkspaceTreeCtx::default()
+            .with_manifest_hook(opts.manifest_hook.clone())
+            .with_pnpmfile_hook(opts.pnpmfile_hook.clone()),
+    );
     resolve_importer_with_workspace(
         resolver,
         pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY,
@@ -258,11 +269,13 @@ where
         lockfile_dir,
         modules_dir,
         peers_suffix_max_length,
-        // `manifest_hook` is workspace-wide; it lives on the shared
-        // [`WorkspaceTreeCtx`] and the caller (`resolve_importer` or
-        // `resolve_workspace`) is responsible for setting it there
-        // before handing the `Arc` to this function.
+        catalog_server: _,
+        // `manifest_hook` and `pnpmfile_hook` are workspace-wide; they live
+        // on the shared [`WorkspaceTreeCtx`] and the caller (`resolve_importer`
+        // or `resolve_workspace`) is responsible for setting them there before
+        // handing the `Arc` to this function.
         manifest_hook: _,
+        pnpmfile_hook: _,
     } = opts;
     let peers_opts = || ResolvePeersOptions {
         peers_suffix_max_length,

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -110,7 +110,9 @@ fn default_opts() -> ResolveImporterOptions {
         lockfile_dir: None,
         modules_dir: None,
         peers_suffix_max_length: 1000,
+        catalog_server: false,
         manifest_hook: None,
+        pnpmfile_hook: None,
     }
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -89,6 +89,11 @@ pub struct WorkspaceResolveOptions {
     /// Which dependencies `pacquet update` excludes from lockfile-
     /// resolution reuse. [`UpdateReuseScope::All`] for `install` / `add`.
     pub update_reuse_scope: UpdateReuseScope,
+
+    /// `pnpmfileHook` applied to every resolved manifest before it
+    /// enters the wanted-dep cache. Workspace-wide (one hook per
+    /// install); wraps `readPackage` from `.pnpmfile.cjs` / `pnpmfile.cjs`.
+    pub pnpmfile_hook: Option<Arc<dyn pacquet_hooks::PnpmfileHooks>>,
 }
 
 /// Result of [`fn@resolve_workspace`]. The combined
@@ -128,6 +133,7 @@ where
         lockfile_dir,
         peers_suffix_max_length,
         manifest_hook,
+        pnpmfile_hook,
         pick_lowest_direct,
         time_based,
         wanted_lockfile,
@@ -137,7 +143,8 @@ where
         WorkspaceTreeCtx::default()
             .with_manifest_hook(manifest_hook)
             .with_wanted_lockfile(wanted_lockfile)
-            .with_update_reuse_scope(update_reuse_scope),
+            .with_update_reuse_scope(update_reuse_scope)
+            .with_pnpmfile_hook(pnpmfile_hook),
     );
 
     // Build every importer's options up front so the `time-based`

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -117,7 +117,9 @@ fn importer_opts(
         lockfile_dir: None,
         modules_dir: None,
         peers_suffix_max_length: 1000,
+        catalog_server: false,
         manifest_hook: None,
+        pnpmfile_hook: None,
     }
 }
 
@@ -129,6 +131,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         lockfile_dir: std::path::PathBuf::from("/lockfile-dir"),
         peers_suffix_max_length: 1000,
         manifest_hook: None,
+        pnpmfile_hook: None,
         pick_lowest_direct,
         time_based,
         wanted_lockfile: None,

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -117,6 +117,7 @@ async fn walks_dependencies_and_builds_flat_tree() {
             base_opts: ResolveOptions::default(),
             patched_dependencies: None,
             manifest_hook: None,
+            pnpmfile_hook: None,
         },
     )
     .await
@@ -185,6 +186,7 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
             base_opts: ResolveOptions::default(),
             patched_dependencies: None,
             manifest_hook: None,
+            pnpmfile_hook: None,
         },
     )
     .await
@@ -269,6 +271,7 @@ async fn workspace_link_node_is_short_circuited_in_tree() {
             base_opts: ResolveOptions::default(),
             patched_dependencies: None,
             manifest_hook: None,
+            pnpmfile_hook: None,
         },
     )
     .await
@@ -309,6 +312,7 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
             base_opts: ResolveOptions::default(),
             patched_dependencies: None,
             manifest_hook: None,
+            pnpmfile_hook: None,
         },
     )
     .await
@@ -352,6 +356,7 @@ async fn transitive_dep_with_traversal_alias_is_rejected() {
             base_opts: ResolveOptions::default(),
             patched_dependencies: None,
             manifest_hook: None,
+            pnpmfile_hook: None,
         },
     )
     .await
@@ -429,6 +434,7 @@ mod block_exotic_subdeps {
                 },
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -470,6 +476,7 @@ mod block_exotic_subdeps {
                 },
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -512,6 +519,7 @@ mod block_exotic_subdeps {
                 },
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -556,6 +564,7 @@ mod block_exotic_subdeps {
                 },
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -597,6 +606,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -648,6 +658,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -697,6 +708,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -749,6 +761,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -872,6 +885,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -950,6 +964,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -998,6 +1013,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1094,6 +1110,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1188,6 +1205,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1294,6 +1312,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1362,6 +1381,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1471,6 +1491,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1578,6 +1599,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1687,6 +1709,7 @@ mod peers {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1779,6 +1802,7 @@ mod patched_dependencies {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1826,6 +1850,7 @@ mod patched_dependencies {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1859,6 +1884,7 @@ mod patched_dependencies {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1908,6 +1934,7 @@ mod patched_dependencies {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -1977,6 +2004,7 @@ mod optional_propagation {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -2031,6 +2059,7 @@ mod optional_propagation {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -2095,6 +2124,7 @@ mod optional_propagation {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await
@@ -2147,6 +2177,7 @@ mod optional_propagation {
                 base_opts: ResolveOptions::default(),
                 patched_dependencies: None,
                 manifest_hook: None,
+                pnpmfile_hook: None,
             },
         )
         .await


### PR DESCRIPTION
Implements Tier 4 pnpmfile hooks for pacquet (#11633, point 4.1): pacquet now discovers and runs a project `.pnpmfile` during dependency management, matching pnpm.

## What it does

- **Discovery** — looks for `.pnpmfile.mjs` then `.pnpmfile.cjs` (dotted names only, `.mjs` preferred), matching pnpm's `requireHooks`. Only actual files are accepted (`is_file()`).
- **`readPackage`** — wired into resolution. Mirrors pnpm's `requirePnpmfile` contract: the four dependency fields are defaulted to `{}` before the hook runs, and the returned manifest is validated (must be a non-null object whose dependency fields, when present, are objects rather than arrays). A throwing/syntactically-invalid pnpmfile, a missing `require`, or a hook that returns nothing aborts the install (`PNPMFILE_FAIL`) instead of being silently ignored.
- **`afterAllResolved`** — wired into the lockfile write. The resolved lockfile is passed to the hook and its return value is what gets written to `pnpm-lock.yaml`. The round-trip goes through `serde_json::Value` (the workspace already enables `preserve_order`) so hook-added keys the typed `Lockfile` cannot represent survive to disk; the round-trip only runs when a hook is present, so unmodified installs write byte-identical lockfiles. A throwing hook aborts the install.
- **`preResolution`** — wired. Receives the resolution context (wanted/current lockfile, `existsCurrentLockfile`, `existsNonEmptyWantedLockfile`, lockfile dir, store dir, registries) over stdin.
- **`filterLog`** — implemented in the bridge but not yet routed through the reporter (pacquet's reporter is a stateless synchronous emitter); deferred, see follow-ups.

## How hooks run

Hooks are served by a long-lived Node.js worker, spawned lazily once per pnpmfile. Requests and responses are newline-delimited JSON over the worker's stdin/stdout, multiplexed by a monotonic request id so the concurrent `readPackage` calls the resolver makes (it resolves dependencies in parallel) share one process. This removes the per-package `node` startup cost on the resolution hot path and avoids interpolating payloads into a `node -e` argument (no `E2BIG` risk for large lockfiles). Each `context.log(...)` a hook emits is forwarded back to the call's log callback. `preResolution` keeps a one-shot `node` invocation since it runs once per install and needs an `info`/`warn` logger.

## Tests

- Unit (hooks crate): readPackage validation (returns nothing / non-object / array dependency fields), manifest-field normalization, syntax-error and missing-module failures, worker request-id multiplexing under concurrency, and `context.log` forwarding.
- Integration (package-manager): a `readPackage` hook pins a transitive dependency version; a hook that returns nothing aborts the install; a pnpmfile syntax error aborts the install; an `afterAllResolved` hook's mutation is written to `pnpm-lock.yaml`; a throwing `afterAllResolved` aborts the install.

## Scope

The remaining pnpmfile-hook surface pnpm has but pacquet does not yet implement — wiring `filterLog` and the `pnpm:hook` log channel into the reporter, the `--pnpmfile` / `--global-pnpmfile` / `--ignore-pnpmfile` flags, pnpmfile checksum invalidation, `updateConfig`, and finders/resolvers/fetchers — is tracked in #12118.

Changeset: `pacquet` minor.
