### PR TITLE
feat(pacquet): port lockfileOnly setting

### DIFF
--- a/pacquet/crates/cli/src/cli_args/add.rs
+++ b/pacquet/crates/cli/src/cli_args/add.rs
@@ -82,6 +82,11 @@ pub struct AddArgs {
     /// the default semver range operator.
     #[clap(short = 'E', long = "save-exact")]
     pub save_exact: bool,
+    /// Dependencies are not downloaded. The package is added to the
+    /// manifest and only `pnpm-lock.yaml` is updated; no `node_modules`
+    /// is created. Mirrors pnpm's `--lockfile-only`.
+    #[clap(long = "lockfile-only")]
+    pub lockfile_only: bool,
     /// The directory with links to the store (default is node_modules/.pacquet).
     /// All direct and indirect dependencies of the project are linked into this directory
     #[clap(long = "virtual-store-dir", default_value = "node_modules/.pacquet")]
@@ -124,6 +129,7 @@ impl AddArgs {
             save_exact: self.save_exact,
             resolved_packages,
             supported_architectures,
+            lockfile_only: self.lockfile_only,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -80,6 +80,13 @@ pub struct InstallArgs {
     #[clap(long)]
     pub frozen_lockfile: bool,
 
+    /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is
+    /// updated. Resolution still runs, but nothing is fetched into the
+    /// store and no `node_modules` is created. Mirrors pnpm's
+    /// `--lockfile-only`.
+    #[clap(long = "lockfile-only")]
+    pub lockfile_only: bool,
+
     /// Force-enable `preferFrozenLockfile` for this invocation.
     /// Overrides `pnpm-workspace.yaml` / `PNPM_CONFIG_PREFER_FROZEN_LOCKFILE`.
     /// Mirrors pnpm's `--prefer-frozen-lockfile`. Conflicts with
@@ -204,6 +211,7 @@ impl InstallArgs {
             dependency_options,
             supported_architectures,
             frozen_lockfile,
+            lockfile_only,
             prefer_frozen_lockfile,
             no_prefer_frozen_lockfile,
             ignore_manifest_check,
@@ -280,6 +288,7 @@ impl InstallArgs {
             resolved_packages,
             supported_architectures,
             node_linker,
+            lockfile_only,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/cli/tests/lockfile_only.rs
+++ b/pacquet/crates/cli/tests/lockfile_only.rs
@@ -1,0 +1,332 @@
+//! `--lockfile-only` coverage for `pacquet install`.
+//!
+//! Ports pnpm's
+//! [`installing/deps-installer/test/install/lockfileOnly.ts`](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/install/lockfileOnly.ts):
+//! resolving with `lockfileOnly` writes `pnpm-lock.yaml` (direct and
+//! transitive deps) without fetching any tarball into the store or
+//! creating `node_modules`, and a repeat run keeps that property. The
+//! `--frozen-lockfile --lockfile-only` combination still validates the
+//! on-disk lockfile against the manifest and fails when it is stale.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::get_all_files,
+};
+use std::{fs, path::Path, process::Command};
+
+/// A fresh `pacquet` command rooted at `workspace`. `std::process::Command`
+/// isn't `Clone` and each invocation consumes the builder, so tests that
+/// run pacquet more than once rebuild it here.
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+}
+
+/// Content-addressable tarball blobs under the store (`v11/files/...`).
+/// `--lockfile-only` writes none; the empty `v11/index.db` the writer
+/// task always creates is excluded so the assertion targets fetched
+/// package content, not store scaffolding.
+fn cas_blobs(store_dir: &Path) -> Vec<String> {
+    get_all_files(store_dir)
+        .into_iter()
+        .filter(|path| {
+            Path::new(path).components().any(|component| component.as_os_str() == "files")
+        })
+        .collect()
+}
+
+/// `pacquet install --lockfile-only` resolves the graph, writes
+/// `pnpm-lock.yaml` (direct + transitive deps), and stops: no tarball
+/// reaches the store, and no `node_modules` is created. A second
+/// `--lockfile-only` run against the now-present lockfile keeps both
+/// properties.
+#[test]
+fn writes_lockfile_without_downloading_or_linking() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    // `pnpm-lock.yaml` records the direct dep and its transitive dep.
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/pkg-with-1-dep"),
+        "lockfile must record the direct dependency:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("@pnpm.e2e/pkg-with-1-dep@100.0.0"),
+        "lockfile must pin the resolved direct-dep version:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@"),
+        "lockfile must record the transitive dependency:\n{lockfile}",
+    );
+
+    // Nothing materialized: no `node_modules`, no tarball in the store.
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "node_modules must not be created by --lockfile-only",
+    );
+    assert!(
+        cas_blobs(&store_dir).is_empty(),
+        "the store must hold no tarball CAS blob — nothing is fetched by --lockfile-only; got:\n{:#?}",
+        cas_blobs(&store_dir),
+    );
+
+    // Repeat run: still resolve-and-write only, nothing materialized.
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "node_modules must stay absent on a repeat --lockfile-only run",
+    );
+    assert!(
+        cas_blobs(&store_dir).is_empty(),
+        "the store must hold no tarball CAS blob on a repeat --lockfile-only run",
+    );
+
+    // A subsequent ordinary install materializes from the lockfile the
+    // --lockfile-only run produced, proving it left a usable state.
+    pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        workspace.join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0").exists(),
+        "a normal install after --lockfile-only must materialize the virtual store",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `--frozen-lockfile --lockfile-only` keeps frozen semantics: it
+/// validates the on-disk `pnpm-lock.yaml` against the manifest and
+/// fails when the manifest has drifted, never rewriting the lockfile.
+#[test]
+fn frozen_lockfile_only_rejects_a_stale_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({ "dependencies": { "is-positive": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    // Drift the manifest away from the locked specifier.
+    fs::write(
+        &manifest_path,
+        serde_json::json!({ "dependencies": { "is-positive": "2.0.0" } }).to_string(),
+    )
+    .expect("rewrite package.json");
+
+    let output = pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--lockfile-only"])
+        .output()
+        .expect("spawn pacquet install");
+
+    assert!(
+        !output.status.success(),
+        "frozen + lockfile-only must reject a stale lockfile (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // miette wraps the long "is not up to date" sentence across lines,
+    // so assert on the stable diagnostic code instead of the prose.
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("outdated_lockfile"),
+        "stderr must name the outdated-lockfile diagnostic; got:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `--frozen-lockfile --lockfile-only` against an up-to-date lockfile
+/// succeeds via the headless dispatch: the freshness gate passes, the
+/// lockfile is re-persisted, and nothing is materialized. Pins the
+/// explicit-frozen happy path that shares a branch with the auto-frozen
+/// (`preferFrozenLockfile`) repeat run covered above.
+#[test]
+fn frozen_lockfile_only_succeeds_without_materializing_when_fresh() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "is-positive": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    // Seed an up-to-date lockfile with a plain lockfile-only run.
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    assert!(lockfile_path.exists(), "the seeding run must write pnpm-lock.yaml");
+
+    // Headless lockfile-only: lockfile matches the manifest, so the
+    // freshness gate passes and the run returns after re-persisting the
+    // lockfile, without creating node_modules or fetching a tarball.
+    pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--lockfile-only"])
+        .assert()
+        .success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("is-positive@1.0.0"),
+        "the lockfile must still pin is-positive@1.0.0:\n{lockfile}",
+    );
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "node_modules must not be created by --frozen-lockfile --lockfile-only",
+    );
+    assert!(
+        cas_blobs(&store_dir).is_empty(),
+        "the store must hold no tarball CAS blob under --frozen-lockfile --lockfile-only",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `--lockfile-only` together with `lockfile: false` (pnpm's
+/// `useLockfile: false`) is a config conflict — the only output the
+/// flag produces is the lockfile, which `lockfile: false` disables.
+/// Ports pnpm's
+/// [`lockfile.ts` "fail when installing with useLockfile: false and lockfileOnly: true"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/lockfile.ts#L727-L736).
+#[test]
+fn lockfile_false_with_lockfile_only_is_a_config_conflict() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "is-positive": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("lockfile: false\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    let output =
+        pacquet.with_args(["install", "--lockfile-only"]).output().expect("spawn pacquet install");
+
+    assert!(
+        !output.status.success(),
+        "lockfile: false + --lockfile-only must fail (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE"),
+        "stderr must name the upstream config-conflict code; got:\n{stderr}",
+    );
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "no pnpm-lock.yaml must be written on the rejected install",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// In a workspace, a fresh `--lockfile-only` run records every
+/// importer, and a later run after a new project is added updates the
+/// lockfile to include it — all without materializing `node_modules`.
+/// Ports pnpm's
+/// [`lockfile.ts` "update the lockfile when a new project is added to the workspace and lockfile-only installation is used"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/lockfile.ts#L1564-L1610).
+#[test]
+fn lockfile_only_updates_importers_when_a_project_is_added() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/project-1")).expect("mkdir project-1");
+    fs::write(
+        workspace.join("packages/project-1/package.json"),
+        serde_json::json!({
+            "name": "project-1",
+            "version": "1.0.0",
+            "dependencies": { "is-positive": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write project-1 package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("packages/project-1:"),
+        "lockfile must record the project-1 importer:\n{lockfile}",
+    );
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "node_modules must not be created by --lockfile-only",
+    );
+
+    // Add a second project, re-run lockfile-only, and confirm both
+    // importers are recorded. `--no-prefer-frozen-lockfile` forces the
+    // fresh-resolve path: pacquet's auto-frozen freshness gate
+    // (`check_lockfile_freshness`) only validates the root importer
+    // today, so it wouldn't notice a newly-added sibling and would
+    // otherwise short-circuit to the frozen path. Re-resolving is what
+    // pnpm's `mutateModules` does unconditionally in the upstream test.
+    fs::create_dir_all(workspace.join("packages/project-2")).expect("mkdir project-2");
+    fs::write(
+        workspace.join("packages/project-2/package.json"),
+        serde_json::json!({ "name": "project-2", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write project-2 package.json");
+
+    pacquet_at(&workspace)
+        .with_args(["install", "--lockfile-only", "--no-prefer-frozen-lockfile"])
+        .assert()
+        .success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("re-read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("packages/project-1:"),
+        "lockfile must keep the project-1 importer:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("packages/project-2:"),
+        "lockfile must record the newly added project-2 importer:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -32,6 +32,10 @@ where
     /// `Install` run that follows the manifest mutation. See
     /// [`Install::supported_architectures`].
     pub supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
+    /// `--lockfile-only`: add the dependency to the manifest and write
+    /// `pnpm-lock.yaml`, but skip materializing `node_modules`. Forwarded
+    /// to the follow-up `Install` run. See [`Install::lockfile_only`].
+    pub lockfile_only: bool,
 }
 
 /// Error type of [`Add`].
@@ -65,6 +69,7 @@ where
             save_exact,
             resolved_packages,
             supported_architectures,
+            lockfile_only,
         } = self;
 
         let latest_version = PackageVersion::fetch_from_registry(
@@ -110,6 +115,7 @@ where
             resolved_packages,
             supported_architectures,
             node_linker: config.node_linker,
+            lockfile_only,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -137,6 +137,19 @@ where
     /// Used today for the `.modules.yaml.nodeLinker` write and
     /// (in Slice 6) for the install-pipeline branch.
     pub node_linker: pacquet_config::NodeLinker,
+    /// When `true`, resolve dependencies and (re)write `pnpm-lock.yaml`
+    /// but skip every materialization step: no tarball is fetched into
+    /// the store, no `node_modules` is linked, and neither
+    /// `.modules.yaml` nor the current lockfile
+    /// (`<virtual_store_dir>/lock.yaml`) nor the workspace-state file
+    /// is written. Surfaced as `--lockfile-only` on the CLI. A pure
+    /// per-invocation flag (no `pnpm-workspace.yaml` / `config.yaml`
+    /// counterpart — upstream lists `lockfile-only` in `excludedPnpmKeys`),
+    /// so it is threaded straight from the CLI like
+    /// [`Self::frozen_lockfile`]. Mirrors pnpm's
+    /// [`lockfileOnly`](https://github.com/pnpm/pnpm/blob/3b62f9da31/config/reader/src/Config.ts#L170)
+    /// (`like npm's --package-lock-only`).
+    pub lockfile_only: bool,
 }
 
 /// Error type of [`Install`].
@@ -276,6 +289,18 @@ pub enum InstallError {
     /// [`config/parse-overrides`](https://github.com/pnpm/pnpm/blob/4a36b9a110/config/parse-overrides/src/index.ts).
     #[diagnostic(transparent)]
     InvalidOverrides(#[error(source)] pacquet_config_parse_overrides::ParseOverridesError),
+
+    /// `--lockfile-only` was requested together with `lockfile: false`
+    /// (pnpm's `useLockfile: false`). There is nothing left to do — the
+    /// only output `--lockfile-only` produces is the lockfile, and that
+    /// write is disabled — so the combination is a user-config conflict
+    /// rather than a silent no-op. Mirrors pnpm's
+    /// `ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE` thrown
+    /// from
+    /// <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/extendInstallOptions.ts#L410-L415>.
+    #[display("Cannot generate a pnpm-lock.yaml because lockfile is set to false")]
+    #[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE))]
+    ConfigConflictLockfileOnlyWithNoLockfile,
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -302,7 +327,17 @@ where
             update_checksums,
             supported_architectures,
             node_linker,
+            lockfile_only,
         } = self;
+
+        // `--lockfile-only` with `lockfile: false` (pnpm's
+        // `useLockfile: false`) is a config conflict: the only output the
+        // flag produces is the lockfile, and that write is disabled.
+        // Fail fast rather than run a resolve that writes nothing.
+        // Mirrors pnpm's `extendInstallOptions` guard.
+        if lockfile_only && !config.lockfile {
+            return Err(InstallError::ConfigConflictLockfileOnlyWithNoLockfile);
+        }
 
         // Resolve the effective `preferFrozenLockfile` for the
         // dispatch: a per-invocation CLI flag wins over
@@ -674,6 +709,36 @@ where
             false
         };
 
+        // `--lockfile-only`: resolve and (re)write `pnpm-lock.yaml`, then
+        // stop — never materialize `node_modules`, `.modules.yaml`, the
+        // current lockfile, or the workspace-state file. Mirrors pnpm's
+        // lockfileOnly short-circuits: the frozen / up-to-date path writes
+        // the wanted lockfile and returns at
+        // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L979-L986>,
+        // and the fresh-resolve path skips `linkPackages` at
+        // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L1543>.
+        if lockfile_only && take_frozen_path {
+            // Frozen (`--frozen-lockfile`) or auto-frozen
+            // (`preferFrozenLockfile`) + `--lockfile-only`: the freshness
+            // gate folded into `take_frozen_path` already validated the
+            // on-disk lockfile (a stale one surfaced `OutdatedLockfile`).
+            // Re-persist it so a brand-new project still lands a file, then
+            // return without touching `node_modules`.
+            let lockfile = lockfile.expect("frozen dispatch verified lockfile is present");
+            if config.lockfile {
+                lockfile
+                    .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
+                    .map_err(InstallError::SaveWantedLockfile)?;
+            }
+            Reporter::emit(&LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: prefix.clone(),
+                stage: Stage::ImportingDone,
+            }));
+            Reporter::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
+            return Ok(());
+        }
+
         // No-op short-circuit. When the frozen-lockfile dispatch is
         // eligible, the on-disk `.modules.yaml` agrees with the current
         // config, and `<virtual_store_dir>/lock.yaml` is byte-equal to
@@ -768,7 +833,13 @@ where
             //   [`installing/deps-installer/src/install/index.ts:1374-1387`](https://github.com/pnpm/pnpm/blob/94240bc046/installing/deps-installer/src/install/index.ts#L1374-L1387)
             //   filter. Without it, runtime archives get fetched +
             //   materialized despite the opt-out.
-            if skip_runtimes {
+            //
+            // Bypassed under `--lockfile-only`: that path writes only
+            // `pnpm-lock.yaml` and never materializes, so the runtime
+            // filter is irrelevant to its output. Mirrors pnpm gating its
+            // lockfileOnly-specific handling on `!opts.lockfileOnly` at
+            // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L1957>.
+            if !lockfile_only && skip_runtimes {
                 return Err(InstallError::UnsupportedFreshInstallSkipRuntimes);
             }
 
@@ -842,6 +913,7 @@ where
                 wanted_lockfile: lockfile,
                 node_linker,
                 supported_architectures: supported_architectures.as_ref(),
+                lockfile_only,
             }
             .run::<Reporter>()
             .await
@@ -856,6 +928,21 @@ where
         };
 
         tracing::info!(target: "pacquet::install", "Complete all");
+
+        // Fresh-resolve `--lockfile-only` already wrote `pnpm-lock.yaml` and
+        // emitted `importing_done` inside `InstallWithFreshLockfile::run`.
+        // Skip `.modules.yaml`, the current lockfile, and the
+        // workspace-state file: there is no `node_modules` to describe, and
+        // writing the workspace-state file would make the next install's
+        // up-to-date check believe materialization happened. Mirrors pnpm
+        // writing only the wanted lockfile at
+        // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L1784>
+        // and skipping `updateWorkspaceState` when `lockfileOnly` at
+        // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/commands/src/installDeps.ts#L515>.
+        if lockfile_only {
+            Reporter::emit(&LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix }));
+            return Ok(());
+        }
 
         // `Stage::ImportingDone` is emitted inside the install paths
         // (`InstallFrozenLockfile` between symlink and build, and

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -66,6 +66,7 @@ async fn should_install_dependencies() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -135,6 +136,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -179,6 +181,7 @@ async fn should_error_when_frozen_lockfile_and_update_checksums_are_both_set() {
         update_checksums: true,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -252,6 +255,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -318,6 +322,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -401,6 +406,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -469,6 +475,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -557,6 +564,7 @@ async fn install_emits_pnpm_event_sequence() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -702,6 +710,7 @@ async fn install_writes_modules_yaml() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -803,6 +812,7 @@ async fn install_writes_workspace_state() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1004,6 +1014,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1077,6 +1088,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1173,6 +1185,7 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1303,6 +1316,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -1401,6 +1415,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1507,6 +1522,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1557,6 +1573,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1649,6 +1666,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -1744,6 +1762,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -1808,6 +1827,7 @@ async fn ignore_manifest_check_bypasses_manifest_freshness_gate() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -1873,6 +1893,7 @@ async fn frozen_lockfile_errors_when_overrides_drift_from_lockfile() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -1964,6 +1985,7 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2071,6 +2093,7 @@ async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2132,6 +2155,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;
@@ -2220,6 +2244,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await
@@ -2327,6 +2352,7 @@ async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log()
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<RecordingReporter>()
     .await
@@ -2441,6 +2467,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await
@@ -2521,6 +2548,7 @@ async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await
@@ -2720,6 +2748,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -2844,6 +2873,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -2944,6 +2974,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3050,6 +3081,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3141,6 +3173,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3235,6 +3268,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3326,6 +3360,7 @@ async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3414,6 +3449,7 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3509,6 +3545,7 @@ async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
         supported_architectures: None,
         resolved_packages: &Default::default(),
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3601,6 +3638,7 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
         supported_architectures: None,
         resolved_packages: &Default::default(),
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await
@@ -3698,6 +3736,7 @@ async fn install_rejects_invalid_minimum_release_age_exclude_pattern() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3798,6 +3837,7 @@ async fn frozen_lockfile_gate_rejects_under_huge_minimum_release_age() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3884,6 +3924,7 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -3968,6 +4009,7 @@ async fn fresh_install_splits_dev_and_prod_dependency_sections() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4038,6 +4080,7 @@ async fn fresh_install_records_user_written_specifier() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4104,6 +4147,7 @@ async fn fresh_install_lockfile_round_trips_through_load_save_load() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4169,6 +4213,7 @@ async fn fresh_install_with_lockfile_disabled_does_not_write_a_lockfile() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4237,6 +4282,7 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4321,6 +4367,7 @@ async fn fresh_install_with_lockfile_disabled_skips_current_lockfile_too() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4383,6 +4430,7 @@ async fn fresh_install_marks_optional_snapshots_in_pnpm_lock_yaml() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4470,6 +4518,7 @@ async fn fresh_install_hoisted_node_linker_records_modules_yaml() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Hoisted,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4537,6 +4586,7 @@ async fn fresh_install_refuses_skip_runtimes_before_writing_state() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4608,6 +4658,7 @@ async fn prefer_frozen_lockfile_takes_frozen_path_when_lockfile_is_fresh() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4680,6 +4731,7 @@ async fn no_prefer_frozen_lockfile_flag_forces_fresh_resolve() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4746,6 +4798,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -4998,6 +5051,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -5179,6 +5233,7 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -5327,6 +5382,7 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -5476,6 +5532,7 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::Isolated,
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -5554,6 +5611,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -5605,6 +5663,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<RecordingReporter>()
@@ -5712,6 +5771,7 @@ async fn fresh_install_applies_package_extensions_to_dependency_manifest() {
         update_checksums: false,
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
         resolved_packages: &Default::default(),
     }
     .run::<SilentReporter>()
@@ -5808,6 +5868,7 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
         resolved_packages: &Default::default(),
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
     }
     .run::<SilentReporter>()
     .await;

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -157,6 +157,13 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// walker so its installability filter honors user-supplied
     /// accept lists. `None` when no architectures are configured.
     pub supported_architectures: Option<&'a pacquet_package_is_installable::SupportedArchitectures>,
+    /// When `true`, resolve the graph and write `pnpm-lock.yaml`, then
+    /// return — skipping the tarball prefetch, virtual-store
+    /// materialization, symlinks, hoisting, and bin linking. The store
+    /// stays untouched (no tarball is fetched), matching pnpm's
+    /// `dryRun: opts.lockfileOnly` resolve pass. See
+    /// [`crate::Install::lockfile_only`].
+    pub lockfile_only: bool,
 }
 
 /// Error type of [`InstallWithFreshLockfile`].
@@ -365,6 +372,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             meta_cache,
             node_linker,
             supported_architectures,
+            lockfile_only,
         } = self;
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Materialise the caller's iterator into a `Vec` so the same
@@ -542,18 +550,28 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // download's `pnpm:progress` emits route through the same
         // reporter the install pass uses. See
         // `prefetching_resolver.rs` for the full design rationale.
-        let resolver: Box<dyn Resolver> = Box::new(PrefetchingResolver::<Reporter>::new(
-            inner_resolver,
-            PrefetchContext {
-                http_client: &http_client_arc,
-                mem_cache: &tarball_mem_cache,
-                store_index: store_index_ref,
-                store_index_writer: Some(&store_index_writer),
-                verified_files_cache: &verified_files_cache,
-                config,
-                requester,
-            },
-        ));
+        //
+        // Skipped entirely under `--lockfile-only`: that path writes only
+        // `pnpm-lock.yaml` and must not touch the store, so resolution
+        // runs through the bare chain with no background download.
+        // Mirrors pnpm's `dryRun: opts.lockfileOnly` at
+        // <https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L1432>.
+        let resolver: Box<dyn Resolver> = if lockfile_only {
+            inner_resolver
+        } else {
+            Box::new(PrefetchingResolver::<Reporter>::new(
+                inner_resolver,
+                PrefetchContext {
+                    http_client: &http_client_arc,
+                    mem_cache: &tarball_mem_cache,
+                    store_index: store_index_ref,
+                    store_index_writer: Some(&store_index_writer),
+                    verified_files_cache: &verified_files_cache,
+                    config,
+                    requester,
+                },
+            ))
+        };
 
         // Compile `minimumReleaseAge` (and its exclude pattern set)
         // for the resolve pass. Mirrors the verifier wiring in
@@ -747,6 +765,52 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         drop(meta_cache);
         drop(fetch_locker);
         drop(picked_manifest_cache);
+
+        // `--lockfile-only`: the graph is resolved, so build and write
+        // `pnpm-lock.yaml` and return before any materialization. No
+        // tarball was prefetched (the resolver ran without the
+        // `PrefetchingResolver` wrapper), so the store is untouched and
+        // there is no `node_modules`, `.modules.yaml`, or current
+        // lockfile — matching pnpm's lockfileOnly resolve pass.
+        if lockfile_only {
+            let built_lockfile = build_fresh_lockfile(
+                config,
+                &importer_manifests,
+                &merged_graph,
+                &direct_by_importer,
+            );
+            let wanted_lockfile = if config.lockfile {
+                built_lockfile
+                    .save_to_path(&lockfile_dir.join(Lockfile::FILE_NAME))
+                    .map_err(InstallWithFreshLockfileError::SaveWantedLockfile)?;
+                Some(built_lockfile)
+            } else {
+                None
+            };
+
+            // Close the store-index writer cleanly even though no rows
+            // were written, mirroring the drain at the tail of the
+            // materializing path.
+            drop(store_index_writer);
+            if let Err(error) = writer_task.await {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "store-index writer task failed during a lockfile-only install",
+                );
+            }
+
+            Reporter::emit(&LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: requester.to_string(),
+                stage: Stage::ImportingDone,
+            }));
+            return Ok(InstallWithFreshLockfileResult {
+                hoisted_dependencies: HoistedDependencies::new(),
+                hoisted_locations: BTreeMap::new(),
+                wanted_lockfile,
+            });
+        }
 
         // Warm-cache batched prefetch: collect every `(integrity,
         // pkg_id)` pair the resolver produced, run one batched SQL


### PR DESCRIPTION
Ports pnpm's [`lockfileOnly` / `--lockfile-only`](https://pnpm.io/cli/install#--lockfile-only) to pacquet — one of the items tracked in #12042: resolve dependencies and write `pnpm-lock.yaml` **without** fetching any tarball into the store or materializing `node_modules`.

## Design

`lockfile-only` lives in pnpm's `excludedPnpmKeys` (alongside `frozen-lockfile`), so it is a pure per-invocation CLI flag — not a valid `pnpm-workspace.yaml` / `config.yaml` key. It is therefore threaded straight from the CLI through `Install` / `Add`, mirroring the existing `frozen_lockfile` plumbing. **No config-crate changes.**

## What changed

- **CLI:** `--lockfile-only` added to both `install` and `add`.
- **`Install::run`:**
  - `--frozen-lockfile` / auto-frozen (`preferFrozenLockfile`) + `--lockfile-only`: the freshness gate still runs (a stale lockfile surfaces `OutdatedLockfile`, matching pnpm), then the wanted lockfile is re-persisted and the run returns without touching `node_modules`. Mirrors pnpm's [`index.ts#L979-L986`](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/index.ts#L979-L986).
  - Otherwise the fresh-resolve path runs, and `.modules.yaml`, the current lockfile, and the workspace-state file are skipped — there is no `node_modules` to describe, and writing the workspace-state file would make the next install's up-to-date check believe materialization happened (pnpm skips `updateWorkspaceState` under `lockfileOnly`).
  - `--lockfile-only` with `lockfile: false` (pnpm's `useLockfile: false`) fails fast with `ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE`, matching pnpm's [`extendInstallOptions` guard](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/src/install/extendInstallOptions.ts#L410-L415).
- **`InstallWithFreshLockfile::run`:** skips the `PrefetchingResolver` wrapper so **no tarball is fetched** (matching pnpm's `dryRun: opts.lockfileOnly`), then writes `pnpm-lock.yaml` and returns before the prefetch / virtual-store / symlink / hoist / bin steps.

## Tests

New `pacquet/crates/cli/tests/lockfile_only.rs` ports **every** lockfileOnly-focused test from `installing/deps-installer/test/`:

- `writes_lockfile_without_downloading_or_linking` — ports [`install/lockfileOnly.ts` "install with lockfileOnly = true"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/install/lockfileOnly.ts#L17): lockfile written (direct + transitive deps), no `node_modules`, no CAS blob in the store, repeat-run stable, follow-up ordinary install materializes.
- `frozen_lockfile_only_rejects_a_stale_lockfile` — ports [`install/lockfileOnly.ts` "do not update the lockfile when lockfileOnly and frozenLockfile are both used"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/install/lockfileOnly.ts#L52).
- `lockfile_false_with_lockfile_only_is_a_config_conflict` — ports [`lockfile.ts` "fail when installing with useLockfile: false and lockfileOnly: true"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/lockfile.ts#L727).
- `lockfile_only_updates_importers_when_a_project_is_added` — ports [`lockfile.ts` "update the lockfile when a new project is added to the workspace and lockfile-only installation is used"](https://github.com/pnpm/pnpm/blob/a33c4bfcb0/installing/deps-installer/test/lockfile.ts#L1564). The second run uses `--no-prefer-frozen-lockfile` to force re-resolution: pacquet's auto-frozen freshness gate validates only the root importer today, so it wouldn't otherwise notice a newly-added sibling (pre-existing workspace-freshness limitation, independent of this change).

All other `lockfileOnly` references in the upstream test suite (`deepRecursive`, `catalogs`, `peerDependencies`, …) merely use it as setup to generate a lockfile and aren't lockfileOnly behavior tests.

The 61 existing `Install { … }` literals in `install/tests.rs` were updated with `lockfile_only: false`.

`cargo check` / `clippy --deny warnings` / `fmt` clean; the 4 new tests pass, `pacquet-package-manager` 365/365, `pacquet-cli` add+install green.

Pacquet-only change (the pnpm CLI already implements `lockfileOnly`), so no changeset.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--lockfile-only` to `pacquet add` and `pacquet install` to update the lockfile without downloading deps or creating `node_modules`, matching pnpm behavior
  * Validation to prevent using `--lockfile-only` when lockfile writing is disabled

* **Tests**
  * Integration tests covering lockfile-only behavior, frozen-lockfile interactions, workspace importer updates, and error cases when lockfiles are disabled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->