### PR TITLE
feat(registry): per-user access lists (verdaccio-style groups)

### DIFF
--- a/registry/crates/pnpm-registry/src/config.rs
+++ b/registry/crates/pnpm-registry/src/config.rs
@@ -7,7 +7,7 @@ use pacquet_env_replace::{SystemEnv, env_replace_lossy};
 use serde::Deserialize;
 
 use crate::error::RegistryError;
-use crate::policy::{AccessRule, PackagePolicies, PackagePolicy};
+use crate::policy::{AccessList, PackagePolicies, PackagePolicy};
 
 /// The bundled verdaccio-shaped YAML config, mirrored from
 /// `@pnpm/registry-mock`'s `registry/config.yaml`. Other crates can
@@ -230,16 +230,41 @@ pub struct UplinkConfig {
 }
 
 /// Per-package routing and access rules. `access` / `publish` are
-/// verdaccio access tokens (`$all` / `$authenticated` / `$anonymous`)
-/// compiled into the [`PackagePolicies`] that gate reads and writes;
+/// verdaccio permission lists (built-in groups like `$all` /
+/// `$authenticated` / `$anonymous`, plus usernames / group names),
+/// compiled into the [`PackagePolicies`] that gate reads and writes.
 /// `unpublish` is parsed but currently folded into `publish` at
 /// enforcement time. `proxy` selects the [`UplinkConfig`] by name.
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct PackageAccess {
-    pub access: Option<String>,
-    pub publish: Option<String>,
-    pub unpublish: Option<String>,
+    pub access: Option<AccessSpec>,
+    pub publish: Option<AccessSpec>,
+    pub unpublish: Option<AccessSpec>,
     pub proxy: Option<String>,
+}
+
+/// A YAML permission value. Verdaccio accepts either a single
+/// space-separated string (`access: $authenticated admin`) or a
+/// sequence (`access: [$authenticated, admin]`); both normalize to the
+/// same token list.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum AccessSpec {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl AccessSpec {
+    fn to_access_list(&self) -> AccessList {
+        match self {
+            AccessSpec::One(spec) => AccessList::parse(spec),
+            // Each element may itself be space-separated; flatten so
+            // `[a b, c]` and `[a, b, c]` agree.
+            AccessSpec::Many(items) => {
+                AccessList::from_tokens(items.iter().flat_map(|item| item.split_whitespace()))
+            }
+        }
+    }
 }
 
 /// Disk shape of the YAML file. Fields verdaccio supports but
@@ -529,33 +554,28 @@ fn build_log_config(entry: Option<&LogEntryFile>) -> LogConfig {
 /// [`PackagePolicies`], in declared order (first match wins). A
 /// missing `access` defaults to `$all`, a missing `publish` to
 /// `$authenticated` — the same safe fallback [`PackagePolicies`]
-/// applies to packages no rule matches. `unpublish` is parsed but
-/// not yet enforced separately (it folds into `publish`).
+/// applies to packages no rule matches. `unpublish` is parsed for
+/// config compatibility but not yet enforced separately (it folds
+/// into `publish`). Errors only on an invalid glob pattern — any
+/// token string is a valid group/username, as in verdaccio.
 fn build_policies(
     packages: &IndexMap<String, PackageAccess>,
 ) -> Result<PackagePolicies, RegistryError> {
     let rules = packages
         .iter()
         .map(|(pattern, access)| {
-            let access_rule = parse_access_rule(access.access.as_deref(), AccessRule::All)?;
-            let publish_rule =
-                parse_access_rule(access.publish.as_deref(), AccessRule::Authenticated)?;
-            // `unpublish` folds into `publish` at enforcement time, but
-            // validate it here so an unknown token fails fast like the
-            // others instead of slipping through. (Defaults to the
-            // publish rule when absent, matching verdaccio.)
-            parse_access_rule(access.unpublish.as_deref(), publish_rule)?;
-            PackagePolicy::new(pattern, access_rule, publish_rule)
+            let access_list = access
+                .access
+                .as_ref()
+                .map_or_else(|| AccessList::parse("$all"), AccessSpec::to_access_list);
+            let publish_list = access
+                .publish
+                .as_ref()
+                .map_or_else(|| AccessList::parse("$authenticated"), AccessSpec::to_access_list);
+            PackagePolicy::new(pattern, access_list, publish_list)
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(PackagePolicies::new(rules))
-}
-
-fn parse_access_rule(
-    value: Option<&str>,
-    default: AccessRule,
-) -> Result<AccessRule, RegistryError> {
-    value.map_or(Ok(default), str::parse)
 }
 
 /// Join `config.yaml` onto a resolved config directory and keep the
@@ -613,11 +633,16 @@ fn pattern_matches(pattern: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AccessRule, Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, config_file_in,
+        Config, ConfigSource, DEFAULT_CONFIG_YAML, LogFormat, LogLevel, config_file_in,
         pattern_matches, resolve_relative,
     };
+    use crate::policy::Identity;
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::{Path, PathBuf};
+
+    fn user(name: &str) -> Identity {
+        Identity::User { username: name.to_string() }
+    }
 
     fn listen() -> SocketAddr {
         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873))
@@ -1307,11 +1332,11 @@ packages:
 ";
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
         let secret = config.policies.for_package("@secret/thing");
-        assert_eq!(secret.access, AccessRule::Authenticated);
-        assert_eq!(secret.publish, AccessRule::Authenticated);
+        assert!(!secret.access.allows(&Identity::Anonymous));
+        assert!(secret.access.allows(&user("alice")));
         let public = config.policies.for_package("lodash");
-        assert_eq!(public.access, AccessRule::All);
-        assert_eq!(public.publish, AccessRule::Authenticated);
+        assert!(public.access.allows(&Identity::Anonymous));
+        assert!(!public.publish.allows(&Identity::Anonymous));
     }
 
     #[test]
@@ -1328,8 +1353,8 @@ packages:
     access: $all
 ";
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-        assert_eq!(config.policies.for_package("@secret/x").access, AccessRule::Authenticated);
-        assert_eq!(config.policies.for_package("anything").access, AccessRule::All);
+        assert!(!config.policies.for_package("@secret/x").access.allows(&Identity::Anonymous));
+        assert!(config.policies.for_package("anything").access.allows(&Identity::Anonymous));
     }
 
     #[test]
@@ -1342,8 +1367,9 @@ packages:
 ";
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
         let effective = config.policies.for_package("lodash");
-        assert_eq!(effective.access, AccessRule::All);
-        assert_eq!(effective.publish, AccessRule::Authenticated);
+        assert!(effective.access.allows(&Identity::Anonymous));
+        assert!(!effective.publish.allows(&Identity::Anonymous));
+        assert!(effective.publish.allows(&user("alice")));
     }
 
     #[test]
@@ -1356,43 +1382,58 @@ packages:
     access: $anonymous
 ";
         let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
-        assert_eq!(config.policies.for_package("@anon/x").access, AccessRule::Anonymous);
+        let anon = config.policies.for_package("@anon/x");
+        assert!(anon.access.allows(&Identity::Anonymous));
+        assert!(!anon.access.allows(&user("alice")));
     }
 
     #[test]
-    fn policy_unknown_access_token_is_a_config_error() {
-        // Named groups aren't modeled yet — an unrecognized token must
-        // fail the parse rather than silently enforce the wrong rule.
+    fn policy_usernames_grant_per_user_access() {
+        // Bare names are usernames/groups (verdaccio-style), no longer
+        // a config error.
         let yaml = "\
 storage: ./s
 uplinks: {}
 packages:
-  'lodash':
-    access: admin
+  '@team/*':
+    access: alice bob
+    publish: alice
 ";
-        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
-        assert!(
-            matches!(err, super::RegistryError::InvalidAccessRule { .. }),
-            "expected InvalidAccessRule, got {err:?}",
-        );
+        let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+        let team = config.policies.for_package("@team/x");
+        assert!(team.access.allows(&user("alice")));
+        assert!(team.access.allows(&user("bob")));
+        assert!(!team.access.allows(&user("carol")));
+        assert!(!team.access.allows(&Identity::Anonymous));
+        assert!(team.publish.allows(&user("alice")));
+        assert!(!team.publish.allows(&user("bob")));
     }
 
     #[test]
-    fn policy_unknown_unpublish_token_is_a_config_error() {
-        // `unpublish` folds into `publish` at enforcement, but it's
-        // still validated so a typo can't slip through unchecked.
-        let yaml = "\
+    fn policy_access_list_accepts_string_and_sequence_forms() {
+        // verdaccio accepts both a space-separated string and a YAML
+        // sequence; they must compile to the same token list.
+        let as_string = "\
 storage: ./s
 uplinks: {}
 packages:
-  'lodash':
-    unpublish: bogus
+  '@team/*':
+    access: alice bob
 ";
-        let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap_err();
-        assert!(
-            matches!(err, super::RegistryError::InvalidAccessRule { .. }),
-            "expected InvalidAccessRule, got {err:?}",
-        );
+        let as_sequence = "\
+storage: ./s
+uplinks: {}
+packages:
+  '@team/*':
+    access: [alice, bob]
+";
+        for yaml in [as_string, as_sequence] {
+            let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+            let access = config.policies.for_package("@team/x").access;
+            assert!(access.allows(&user("alice")), "{yaml}");
+            assert!(access.allows(&user("bob")), "{yaml}");
+            assert!(!access.allows(&user("carol")), "{yaml}");
+        }
     }
 
     #[test]
@@ -1400,12 +1441,12 @@ packages:
         // Building from the bundled YAML must reproduce the
         // registry-mock protections that used to be hard-coded.
         let config = Config::from_default_yaml(Path::new("/tmp"), listen(), None);
-        assert_eq!(
-            config.policies.for_package("@pnpm.e2e/needs-auth").access,
-            AccessRule::Authenticated,
-        );
-        assert_eq!(config.policies.for_package("@private/foo").access, AccessRule::Authenticated);
-        assert_eq!(config.policies.for_package("lodash").access, AccessRule::All);
-        assert_eq!(config.policies.for_package("lodash").publish, AccessRule::Authenticated);
+        let needs_auth = config.policies.for_package("@pnpm.e2e/needs-auth");
+        assert!(!needs_auth.access.allows(&Identity::Anonymous));
+        assert!(needs_auth.access.allows(&user("alice")));
+        assert!(!config.policies.for_package("@private/foo").access.allows(&Identity::Anonymous));
+        let public = config.policies.for_package("lodash");
+        assert!(public.access.allows(&Identity::Anonymous));
+        assert!(!public.publish.allows(&Identity::Anonymous));
     }
 }

--- a/registry/crates/pnpm-registry/src/error.rs
+++ b/registry/crates/pnpm-registry/src/error.rs
@@ -32,15 +32,6 @@ pub enum RegistryError {
         filename: String,
     },
 
-    #[display(
-        "Access rule {value:?} is not recognized (expected $all, $authenticated, or $anonymous)"
-    )]
-    #[from(skip)]
-    InvalidAccessRule {
-        #[error(not(source))]
-        value: String,
-    },
-
     #[display("Package policy pattern {pattern:?} is invalid: {reason}")]
     #[from(skip)]
     InvalidPolicyPattern {
@@ -171,7 +162,6 @@ impl RegistryError {
             RegistryError::UpstreamStatus { .. } => StatusCode::BAD_GATEWAY,
             RegistryError::InvalidPackageName { .. }
             | RegistryError::InvalidTarballName { .. }
-            | RegistryError::InvalidAccessRule { .. }
             | RegistryError::InvalidPolicyPattern { .. }
             | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }

--- a/registry/crates/pnpm-registry/src/lib.rs
+++ b/registry/crates/pnpm-registry/src/lib.rs
@@ -25,5 +25,5 @@ pub use config::{
     LogLevel, MaxUsers, PackageAccess, TokensConfig, UplinkConfig,
 };
 pub use error::{RegistryError, Result};
-pub use policy::{AccessRule, PackagePolicies, PackagePolicy};
+pub use policy::{AccessList, AccessToken, Identity, PackagePolicies, PackagePolicy};
 pub use server::{router, router_with_auth, serve};

--- a/registry/crates/pnpm-registry/src/policy.rs
+++ b/registry/crates/pnpm-registry/src/policy.rs
@@ -1,41 +1,103 @@
-//! Per-package access and publish rules. Mirrors the subset of
-//! verdaccio's `packages:` config that `@pnpm/registry-mock` relies
-//! on: a list of glob patterns, each with `access` and `publish`
-//! permissions. The first matching pattern wins, with sensible
-//! defaults applied when nothing matches.
-
-use std::str::FromStr;
+//! Per-package access rules. Mirrors verdaccio's `packages:` config:
+//! a list of glob patterns, each with `access` / `publish` permission
+//! lists. The first matching pattern wins.
+//!
+//! Each permission is a list of tokens (verdaccio's space-separated
+//! groups); a request is allowed when the caller's identity satisfies
+//! any token in the list. Tokens are the built-in pseudo-groups
+//! (`$all`, `$authenticated`, `$anonymous`, plus their `@`/bare
+//! aliases) or a *name*. With htpasswd auth a caller's only group is
+//! their own username, so a name token matches an authenticated caller
+//! whose username equals it — group names supplied by other auth
+//! backends would match here too once such a backend lands. This is
+//! verdaccio's model, where the auth plugin owns group membership and
+//! the htpasswd plugin contributes only the username.
 
 use wax::{Glob, Program};
 
 use crate::error::RegistryError;
 
-/// What identities are allowed to perform an action on a package.
-/// Mirrors verdaccio's built-in access tokens. Named groups and
-/// per-user membership are not modeled yet — only the three special
-/// groups every caller's identity is derived from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AccessRule {
-    /// `$all` — anyone, authenticated or not.
+/// A single token in an access list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessToken {
+    /// `$all` / `@all` / `all` — anyone, authenticated or not.
     All,
-    /// `$authenticated` — any caller carrying a valid Bearer token
-    /// or Basic auth header.
+    /// `$authenticated` / `@authenticated` — any caller carrying valid
+    /// Bearer or Basic credentials.
     Authenticated,
-    /// `$anonymous` — only callers *without* valid credentials.
-    /// Authenticated callers are not in this group, so a rule of
-    /// `$anonymous` denies them (matching verdaccio, where the
-    /// `$anonymous` group is absent from a logged-in user's groups).
+    /// `$anonymous` / `@anonymous` — only callers *without* valid
+    /// credentials.
     Anonymous,
+    /// A username or group name. Matches an authenticated caller whose
+    /// username (or, eventually, auth-provided group) equals it.
+    Named(String),
 }
 
-impl FromStr for AccessRule {
-    type Err = RegistryError;
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "$all" | "all" => Ok(AccessRule::All),
-            "$authenticated" | "authenticated" => Ok(AccessRule::Authenticated),
-            "$anonymous" | "anonymous" => Ok(AccessRule::Anonymous),
-            other => Err(RegistryError::InvalidAccessRule { value: other.to_string() }),
+impl From<&str> for AccessToken {
+    fn from(token: &str) -> Self {
+        match token {
+            "$all" | "@all" | "all" => AccessToken::All,
+            "$authenticated" | "@authenticated" | "authenticated" => AccessToken::Authenticated,
+            "$anonymous" | "@anonymous" | "anonymous" => AccessToken::Anonymous,
+            name => AccessToken::Named(name.to_string()),
+        }
+    }
+}
+
+/// One `access` / `publish` permission: the set of tokens that satisfy
+/// it. An empty list admits no one (verdaccio's empty `unpublish:`).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct AccessList(Vec<AccessToken>);
+
+impl AccessList {
+    /// Build from a verdaccio space-separated permission string
+    /// (e.g. `"$authenticated admin"`).
+    pub fn parse(spec: &str) -> Self {
+        Self::from_tokens(spec.split_whitespace())
+    }
+
+    /// Build from already-separated tokens (e.g. a YAML sequence).
+    pub fn from_tokens<Tokens, Token>(tokens: Tokens) -> Self
+    where
+        Tokens: IntoIterator<Item = Token>,
+        Token: AsRef<str>,
+    {
+        Self(tokens.into_iter().map(|token| AccessToken::from(token.as_ref())).collect())
+    }
+
+    /// Whether `identity` satisfies any token in the list.
+    pub fn allows(&self, identity: &Identity) -> bool {
+        self.0.iter().any(|token| identity.satisfies(token))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// The resolved caller identity an [`AccessList`] is evaluated against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Identity {
+    /// No valid credentials were presented.
+    Anonymous,
+    /// Authenticated as `username`. (With htpasswd that's the caller's
+    /// only group beyond the built-ins; a group-providing auth backend
+    /// would widen this.)
+    User { username: String },
+}
+
+impl Identity {
+    pub fn is_authenticated(&self) -> bool {
+        matches!(self, Identity::User { .. })
+    }
+
+    fn satisfies(&self, token: &AccessToken) -> bool {
+        match (token, self) {
+            (AccessToken::All, _) => true,
+            (AccessToken::Authenticated, Identity::User { .. }) => true,
+            (AccessToken::Anonymous, Identity::Anonymous) => true,
+            (AccessToken::Named(name), Identity::User { username }) => name == username,
+            _ => false,
         }
     }
 }
@@ -48,15 +110,15 @@ impl FromStr for AccessRule {
 #[derive(Debug, Clone)]
 pub struct PackagePolicy {
     pattern: Glob<'static>,
-    pub access: AccessRule,
-    pub publish: AccessRule,
+    pub access: AccessList,
+    pub publish: AccessList,
 }
 
 impl PackagePolicy {
     pub fn new(
         pattern: &str,
-        access: AccessRule,
-        publish: AccessRule,
+        access: AccessList,
+        publish: AccessList,
     ) -> Result<Self, RegistryError> {
         let glob = Glob::new(pattern)
             .map_err(|err| RegistryError::InvalidPolicyPattern {
@@ -75,24 +137,37 @@ impl PackagePolicy {
 /// Ordered list of [`PackagePolicy`] rules. First match wins,
 /// matching verdaccio's evaluation order — order in the config is
 /// significant, since the catch-all `**` is almost always last.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct PackagePolicies {
     rules: Vec<PackagePolicy>,
+    /// Applied to packages no rule matches: reads open, writes require
+    /// auth. Owned here so [`Self::for_package`] can hand back a
+    /// borrow.
+    default_access: AccessList,
+    default_publish: AccessList,
 }
 
-/// Effective permissions for one package. Returned by
-/// [`PackagePolicies::for_package`] with the catch-all defaults
-/// applied when no rule matches: anonymous reads allowed,
-/// authenticated writes required.
+impl Default for PackagePolicies {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+/// Effective permissions for one package, borrowed from the matched
+/// rule (or the defaults when none matched).
 #[derive(Debug, Clone, Copy)]
-pub struct Effective {
-    pub access: AccessRule,
-    pub publish: AccessRule,
+pub struct Effective<'a> {
+    pub access: &'a AccessList,
+    pub publish: &'a AccessList,
 }
 
 impl PackagePolicies {
     pub fn new(rules: Vec<PackagePolicy>) -> Self {
-        Self { rules }
+        Self {
+            rules,
+            default_access: AccessList::parse("$all"),
+            default_publish: AccessList::parse("$authenticated"),
+        }
     }
 
     /// `@pnpm/registry-mock`'s defaults, hard-coded so an out-of-the
@@ -104,93 +179,129 @@ impl PackagePolicies {
     /// * everything else — $all access, $authenticated publish
     pub fn registry_mock_defaults() -> Self {
         let rules = [
-            ("@private/*", AccessRule::Authenticated, AccessRule::Authenticated),
-            ("@pnpm.e2e/needs-auth", AccessRule::Authenticated, AccessRule::Authenticated),
-            ("**", AccessRule::All, AccessRule::Authenticated),
+            ("@private/*", "$authenticated", "$authenticated"),
+            ("@pnpm.e2e/needs-auth", "$authenticated", "$authenticated"),
+            ("**", "$all", "$authenticated"),
         ];
         let rules = rules
             .into_iter()
             .map(|(pattern, access, publish)| {
-                PackagePolicy::new(pattern, access, publish)
+                PackagePolicy::new(pattern, AccessList::parse(access), AccessList::parse(publish))
                     .expect("registry-mock defaults compile")
             })
             .collect();
         Self::new(rules)
     }
 
-    pub fn for_package(&self, package: &str) -> Effective {
+    pub fn for_package(&self, package: &str) -> Effective<'_> {
         for rule in &self.rules {
             if rule.matches(package) {
-                return Effective { access: rule.access, publish: rule.publish };
+                return Effective { access: &rule.access, publish: &rule.publish };
             }
         }
-        // Fallback when no `**` catch-all is configured: reads open,
-        // writes require auth. Same shape as the registry-mock default.
-        Effective { access: AccessRule::All, publish: AccessRule::Authenticated }
+        Effective { access: &self.default_access, publish: &self.default_publish }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AccessRule, PackagePolicies};
+    use super::{AccessList, AccessToken, Identity, PackagePolicies};
+
+    fn user(name: &str) -> Identity {
+        Identity::User { username: name.to_string() }
+    }
+
+    #[test]
+    fn token_parsing_maps_builtins_and_names() {
+        assert_eq!(AccessToken::from("$all"), AccessToken::All);
+        assert_eq!(AccessToken::from("@all"), AccessToken::All);
+        assert_eq!(AccessToken::from("all"), AccessToken::All);
+        assert_eq!(AccessToken::from("$authenticated"), AccessToken::Authenticated);
+        assert_eq!(AccessToken::from("$anonymous"), AccessToken::Anonymous);
+        assert_eq!(AccessToken::from("@anonymous"), AccessToken::Anonymous);
+        // Anything else is a username / group name (no longer an error).
+        assert_eq!(AccessToken::from("admin"), AccessToken::Named("admin".to_string()));
+    }
+
+    #[test]
+    fn all_admits_everyone() {
+        let list = AccessList::parse("$all");
+        assert!(list.allows(&Identity::Anonymous));
+        assert!(list.allows(&user("alice")));
+    }
+
+    #[test]
+    fn authenticated_admits_only_logged_in() {
+        let list = AccessList::parse("$authenticated");
+        assert!(!list.allows(&Identity::Anonymous));
+        assert!(list.allows(&user("alice")));
+    }
+
+    #[test]
+    fn anonymous_admits_only_logged_out() {
+        let list = AccessList::parse("$anonymous");
+        assert!(list.allows(&Identity::Anonymous));
+        assert!(!list.allows(&user("alice")));
+    }
+
+    #[test]
+    fn usernames_grant_per_user_access() {
+        // verdaccio's per-user access: list the usernames directly.
+        let list = AccessList::parse("alice bob");
+        assert!(list.allows(&user("alice")));
+        assert!(list.allows(&user("bob")));
+        assert!(!list.allows(&user("carol")));
+        assert!(!list.allows(&Identity::Anonymous));
+    }
+
+    #[test]
+    fn mixed_token_list_is_a_union() {
+        // `$authenticated admin` — any logged-in user OR (redundantly)
+        // the `admin` name; satisfied by any authenticated caller.
+        let list = AccessList::parse("$authenticated admin");
+        assert!(list.allows(&user("carol")));
+        assert!(!list.allows(&Identity::Anonymous));
+    }
+
+    #[test]
+    fn empty_list_admits_no_one() {
+        let list = AccessList::parse("");
+        assert!(list.is_empty());
+        assert!(!list.allows(&Identity::Anonymous));
+        assert!(!list.allows(&user("alice")));
+    }
 
     #[test]
     fn defaults_match_registry_mock_config() {
         let policies = PackagePolicies::registry_mock_defaults();
 
         let needs_auth = policies.for_package("@pnpm.e2e/needs-auth");
-        assert_eq!(needs_auth.access, AccessRule::Authenticated);
-        assert_eq!(needs_auth.publish, AccessRule::Authenticated);
+        assert!(!needs_auth.access.allows(&Identity::Anonymous));
+        assert!(needs_auth.access.allows(&user("alice")));
 
         let private = policies.for_package("@private/foo");
-        assert_eq!(private.access, AccessRule::Authenticated);
+        assert!(!private.access.allows(&Identity::Anonymous));
 
         let public = policies.for_package("@pnpm.e2e/no-deps");
-        assert_eq!(public.access, AccessRule::All);
-        assert_eq!(public.publish, AccessRule::Authenticated);
-
-        let unscoped = policies.for_package("lodash");
-        assert_eq!(unscoped.access, AccessRule::All);
-        assert_eq!(unscoped.publish, AccessRule::Authenticated);
+        assert!(public.access.allows(&Identity::Anonymous));
+        assert!(!public.publish.allows(&Identity::Anonymous));
+        assert!(public.publish.allows(&user("alice")));
     }
 
     #[test]
     fn first_matching_rule_wins() {
         let policies = PackagePolicies::registry_mock_defaults();
         // `@private/foo` matches `@private/*` first, not the `**`
-        // catch-all. The first rule's $authenticated access wins
-        // over the catch-all's $all.
-        assert_eq!(policies.for_package("@private/foo").access, AccessRule::Authenticated);
+        // catch-all: anonymous reads are denied.
+        assert!(!policies.for_package("@private/foo").access.allows(&Identity::Anonymous));
     }
 
     #[test]
     fn falls_back_to_safe_defaults_when_no_rules_match() {
         let policies = PackagePolicies::new(vec![]);
         let effective = policies.for_package("anything");
-        assert_eq!(effective.access, AccessRule::All);
-        assert_eq!(effective.publish, AccessRule::Authenticated);
-    }
-
-    #[test]
-    fn access_rule_parses_special_tokens_with_and_without_sigil() {
-        use super::AccessRule::{All, Anonymous, Authenticated};
-        for (token, expected) in [
-            ("$all", All),
-            ("all", All),
-            ("$authenticated", Authenticated),
-            ("authenticated", Authenticated),
-            ("$anonymous", Anonymous),
-            ("anonymous", Anonymous),
-        ] {
-            assert_eq!(token.parse::<AccessRule>().unwrap(), expected, "{token}");
-        }
-    }
-
-    #[test]
-    fn access_rule_rejects_unknown_token() {
-        // Named groups aren't modeled yet, so a group name (or typo)
-        // is a hard error rather than silently enforcing the wrong rule.
-        assert!("admin".parse::<AccessRule>().is_err());
-        assert!("$all $authenticated".parse::<AccessRule>().is_err());
+        assert!(effective.access.allows(&Identity::Anonymous));
+        assert!(!effective.publish.allows(&Identity::Anonymous));
+        assert!(effective.publish.allows(&user("alice")));
     }
 }

--- a/registry/crates/pnpm-registry/src/policy.rs
+++ b/registry/crates/pnpm-registry/src/policy.rs
@@ -22,11 +22,11 @@ use crate::error::RegistryError;
 pub enum AccessToken {
     /// `$all` / `@all` / `all` — anyone, authenticated or not.
     All,
-    /// `$authenticated` / `@authenticated` — any caller carrying valid
-    /// Bearer or Basic credentials.
+    /// `$authenticated` / `@authenticated` / `authenticated` — any
+    /// caller carrying valid Bearer or Basic credentials.
     Authenticated,
-    /// `$anonymous` / `@anonymous` — only callers *without* valid
-    /// credentials.
+    /// `$anonymous` / `@anonymous` / `anonymous` — only callers
+    /// *without* valid credentials.
     Anonymous,
     /// A username or group name. Matches an authenticated caller whose
     /// username (or, eventually, auth-provided group) equals it.

--- a/registry/crates/pnpm-registry/src/server.rs
+++ b/registry/crates/pnpm-registry/src/server.rs
@@ -17,7 +17,7 @@ use crate::cache::Cache;
 use crate::config::Config;
 use crate::error::RegistryError;
 use crate::package_name::PackageName;
-use crate::policy::{AccessRule, PackagePolicies};
+use crate::policy::Identity;
 use crate::publish::{
     PendingAttachment, extract_attachments, iso_from_unix_millis, merge_manifest, now_iso,
     stream_decode_verify_and_write,
@@ -1313,29 +1313,30 @@ fn enforce_access(
     package: &str,
     action: Action,
 ) -> Result<(), RegistryError> {
-    let policies: &PackagePolicies = &state.inner.config.policies;
-    let effective = policies.for_package(package);
-    let rule = match action {
+    let effective = state.inner.config.policies.for_package(package);
+    let list = match action {
         Action::Access => effective.access,
         Action::Publish => effective.publish,
     };
-    let authenticated = identify(
+    let identity = match identify(
         headers.get(header::AUTHORIZATION).and_then(|value| value.to_str().ok()),
         &state.inner.auth.users,
         &state.inner.auth.tokens,
-    );
-    match (rule, authenticated) {
-        (AccessRule::All, _) => Ok(()),
-        (AccessRule::Authenticated, Some(_)) => Ok(()),
-        (AccessRule::Authenticated, None) => {
+    ) {
+        Some(username) => Identity::User { username },
+        None => Identity::Anonymous,
+    };
+    if list.allows(&identity) {
+        return Ok(());
+    }
+    // Denied: an anonymous caller gets a chance to authenticate (401);
+    // an authenticated caller simply isn't in the allowed set (403).
+    match identity {
+        Identity::Anonymous => {
             Err(RegistryError::Unauthenticated { resource: format!("package {package:?}") })
         }
-        (AccessRule::Anonymous, None) => Ok(()),
-        // `$anonymous` admits only unauthenticated callers; a valid
-        // identity falls outside that group, so it's forbidden rather
-        // than unauthenticated.
-        (AccessRule::Anonymous, Some(user)) => Err(RegistryError::Forbidden {
-            user,
+        Identity::User { username } => Err(RegistryError::Forbidden {
+            user: username,
             action: action.label(),
             resource: format!("package {package:?}"),
         }),

--- a/registry/crates/pnpm-registry/tests/policy.rs
+++ b/registry/crates/pnpm-registry/tests/policy.rs
@@ -95,3 +95,22 @@ async fn anonymous_rule_admits_anonymous_and_forbids_authenticated() {
     let token = add_user_and_get_token(&app, "alice", "secret").await;
     assert_eq!(status_of(app, get_auth("/@anon/x", &token)).await, StatusCode::FORBIDDEN);
 }
+
+#[tokio::test]
+async fn username_in_access_list_grants_only_that_user() {
+    // verdaccio per-user access: `@team/*` is restricted to `alice`.
+    let (_dir, config) =
+        config_from_yaml("packages:\n  '@team/*':\n    access: alice\n  '**':\n    access: $all\n");
+    let app = router(config);
+
+    // Anonymous: no creds for a name-gated package → 401.
+    assert_eq!(status_of(app.clone(), get("/@team/x")).await, StatusCode::UNAUTHORIZED);
+
+    // A different authenticated user is not `alice` → 403.
+    let bob = add_user_and_get_token(&app, "bob", "secret").await;
+    assert_eq!(status_of(app.clone(), get_auth("/@team/x", &bob)).await, StatusCode::FORBIDDEN);
+
+    // `alice` is on the list → access granted (404 = allowed but absent).
+    let alice = add_user_and_get_token(&app, "alice", "secret").await;
+    assert_eq!(status_of(app, get_auth("/@team/x", &alice)).await, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Models each package's `access` / `publish` permission as a **list of tokens** (verdaccio's space-separated groups) matched against the caller's identity, instead of a single rule. This adds **per-user access** (list usernames directly) and lays the matching groundwork for named groups.

```yaml
packages:
  '@team/*':
    access:  alice bob        # only these users (+ they can read)
    publish: alice            # only alice can publish
  '@public/*':
    access:  $all
    publish: $authenticated
```

## How verdaccio does it (and what we mirror)

verdaccio's `access`/`publish`/`unpublish` are space-separated lists; a request is allowed when the caller's group set intersects the list. A logged-in user's groups are the built-ins **plus their username**, **plus whatever the auth plugin returns** — and the default **htpasswd plugin contributes only the username**. Named groups beyond that come from other auth backends (LDAP/GitLab/…).

So there is intentionally **no new `groups:` config key**: that's not how verdaccio works with htpasswd. Usernames give per-user access today; group names will resolve here for free once a group-providing auth backend lands (the separate "pluggable auth" item in #11973).

## What's in

- `AccessRule` (single enum) → **`AccessList`** (`Vec<AccessToken>`) + **`Identity`**. A permission is satisfied if the identity matches any token (union).
- **Tokens:** `$all` / `@all` / `all`, `$authenticated` / `@authenticated`, `$anonymous` / `@anonymous`, or a **name**. A name matches an authenticated caller whose username equals it.
- Each permission accepts **both** a space-separated string (`access: alice bob`) and a YAML sequence (`access: [alice, bob]`), like verdaccio.
- `enforce_access`: a denied **anonymous** caller gets `401` (can authenticate); a denied **authenticated** caller gets `403`.

## Behavior change to note

This **reverses the `InvalidAccessRule` stopgap from #12043**, which rejected bare names because groups weren't modeled yet. Bare names are now valid tokens (usernames/groups) — verdaccio's actual behavior. The error variant and its two "unknown token is a config error" tests are removed, replaced by per-user / list tests.

## Scope

- Completes the *mechanism* for "Named groups, per-user group membership": usernames work fully today; group names beyond usernames await a group-providing auth backend (verdaccio is identical with htpasswd).
- `unpublish` is still parsed for config compatibility but folds into `publish` at enforcement (unchanged; separate item).

## Test plan

- [x] Unit tests: token parsing (built-ins + names), `$all`/`$authenticated`/`$anonymous`/username/empty-list semantics, mixed-list union, YAML string-vs-sequence equivalence, defaults, first-match-wins, and bundled-config protections preserved.
- [x] Integration (`tests/policy.rs`): `$authenticated` gating, `$anonymous` admit/forbid, and a new `username_in_access_list_grants_only_that_user` (anon → 401, wrong user → 403, listed user → allowed).
- [x] `cargo test`, `cargo clippy --deny warnings`, `cargo dylint` (perfectionist), `cargo fmt --check`, `cargo doc -D warnings`, `typos` all clean.

Refs #11973 (Access control → "Named groups, per-user group membership").

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-token permission lists for package access, accepting both string and sequence YAML formats.
  * Username-specific access rules supported and enforced.

* **Improvements**
  * Clearer handling of unauthenticated vs forbidden authorization responses.

* **Tests**
  * Added integration tests covering username-based rules and token-list parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->