### PR TITLE
fix(ci): inject release version into PACQUET_VERSION constant

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -82,17 +82,17 @@ jobs:
             exit 1
           fi
 
-      - name: Inject version into pacquet/crates/cli/src/cli_args.rs
-        # The version reported by `pacquet --version` is a hardcoded clap
-        # attribute. Patch it here so the binary built for the matrix leg
-        # reports the version we're about to publish.
+      - name: Inject version into pacquet/crates/config/src/defaults.rs
+        # `pacquet --version` and the default User-Agent both read the
+        # PACQUET_VERSION constant. Patch it here so the binary built for the
+        # matrix leg reports the version we're about to publish.
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          file=pacquet/crates/cli/src/cli_args.rs
-          perl -i -pe 's/#\[clap\(version = "[^"]*"\)\]/#[clap(version = "'"$VERSION"'")]/' "$file"
-          grep -F "version = \"$VERSION\"" "$file"
+          file=pacquet/crates/config/src/defaults.rs
+          perl -i -pe 's/(pub const PACQUET_VERSION: &str = )"[^"]*";/${1}"'"$VERSION"'";/' "$file"
+          grep -F "PACQUET_VERSION: &str = \"$VERSION\"" "$file"
 
       - name: Build with cross
         run: cross build -p pacquet-cli --bin pacquet --release --target=${{ matrix.target }}

--- a/pacquet/crates/config/src/defaults.rs
+++ b/pacquet/crates/config/src/defaults.rs
@@ -269,13 +269,14 @@ pub fn default_fetch_timeout() -> u64 {
 /// Default `User-Agent`, mirroring pnpm v11's
 /// [`config/reader/src/index.ts:293`](https://github.com/pnpm/pnpm/blob/1819226b51/config/reader/src/index.ts#L293)
 /// format `${name}/${version} npm/? node/${nodeVersion} ${platform} ${arch}`.
-/// pacquet has no embedded Node runtime, so the `node/` segment is the
-/// `?` placeholder pnpm already uses for `npm/`. Platform and arch use
-/// Node's naming via [`pacquet_detect_libc::host_platform`] /
-/// [`pacquet_detect_libc::host_arch`].
+/// The `name/version` segment is `pnpm/pacquet-<version>` so registries can
+/// tell pacquet's traffic apart from the TypeScript pnpm CLI. pacquet has no
+/// embedded Node runtime, so the `node/` segment is the `?` placeholder pnpm
+/// already uses for `npm/`. Platform and arch use Node's naming via
+/// [`pacquet_detect_libc::host_platform`] / [`pacquet_detect_libc::host_arch`].
 pub fn default_user_agent() -> String {
     format!(
-        "pnpm/{PACQUET_VERSION} npm/? node/? {} {}",
+        "pnpm/pacquet-{PACQUET_VERSION} npm/? node/? {} {}",
         pacquet_detect_libc::host_platform(),
         pacquet_detect_libc::host_arch(),
     )

--- a/pacquet/crates/config/src/defaults/tests.rs
+++ b/pacquet/crates/config/src/defaults/tests.rs
@@ -438,14 +438,14 @@ fn fetch_timeout_default_matches_pnpm() {
 }
 
 /// The default `User-Agent` mirrors pnpm's
-/// `pnpm/<version> npm/? node/? <platform> <arch>` format. The exact
+/// `pnpm/pacquet-<version> npm/? node/? <platform> <arch>` format. The exact
 /// platform / arch depend on where the test runs, so assert the
-/// `pnpm/<version> npm/? node/? ` prefix and the two trailing
+/// `pnpm/pacquet-<version> npm/? node/? ` prefix and the two trailing
 /// space-separated tokens.
 #[test]
 fn user_agent_default_matches_pnpm_format() {
     let ua = default_user_agent();
-    let prefix = format!("pnpm/{PACQUET_VERSION} npm/? node/? ");
+    let prefix = format!("pnpm/pacquet-{PACQUET_VERSION} npm/? node/? ");
     assert!(ua.starts_with(&prefix), "user-agent {ua:?} must start with {prefix:?}");
     let tail: Vec<&str> = ua[prefix.len()..].split(' ').collect();
     assert_eq!(tail.len(), 2, "expected `<platform> <arch>` tail, got {ua:?}");

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -857,7 +857,7 @@ pub struct Config {
 
     /// Value of the `User-Agent` header sent on every registry request.
     /// Mirrors pnpm's `userAgent`; the default is pnpm's
-    /// `pnpm/<version> npm/? node/? <platform> <arch>` format (built by
+    /// `pnpm/pacquet-<version> npm/? node/? <platform> <arch>` format (built by
     /// `default_user_agent`).
     #[default(_code = "default_user_agent()")]
     pub user_agent: String,

--- a/pacquet/crates/network/src/lib.rs
+++ b/pacquet/crates/network/src/lib.rs
@@ -24,7 +24,7 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 ///
 /// Production installs override this with the value resolved by
 /// `pacquet-config` (`userAgent`, defaulting to pnpm's
-/// `pnpm/<version> npm/? node/? <platform> <arch>` format — see
+/// `pnpm/pacquet-<version> npm/? node/? <platform> <arch>` format — see
 /// `config/reader/src/index.ts`). The `pnpm` token is preserved in
 /// that default so any UA-keyed allow / rate-limit rule that lets pnpm
 /// through also lets pacquet through.


### PR DESCRIPTION
## Why

The [pacquet release run](https://github.com/pnpm/pnpm/actions/runs/26630058695/job/78476361365) failed at the **Inject version into `pacquet/crates/cli/src/cli_args.rs`** step (exit 1), which — with `fail-fast` — cancelled every platform leg.

The step patched the clap `version` attribute, expecting a string literal:

```rust
#[clap(version = "0.2.2")]
```

Since #12047 that attribute references a constant:

```rust
#[clap(version = pacquet_config::PACQUET_VERSION)]
```

So the perl substitution matched nothing, the file was left unchanged, and the verifying `grep "version = \"$VERSION\""` failed.

## What

- **Workflow:** patch the `PACQUET_VERSION` constant in `pacquet/crates/config/src/defaults.rs` instead of the clap attribute. That single constant feeds both `pacquet --version` and the default User-Agent, so both now report the published version (the old step only fixed `--version`).
- **User-Agent:** tag the default UA as `pnpm/pacquet-<version> npm/? node/? <platform> <arch>` so registries can distinguish pacquet's traffic from the TypeScript pnpm CLI, while keeping the leading `pnpm` token so UA-keyed allow / rate-limit rules that pass pnpm also pass pacquet.
- Updated the UA-format test and the two doc comments describing the old format.

## Verification

- Confirmed the new perl substitution + grep succeed under bash with a sample version (`0.2.2-14`).
- `cargo nextest run -p pacquet-config user_agent` passes.
- `cargo clippy -p pacquet-config -p pacquet-network --all-targets -- --deny warnings` clean.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * User-agent identification in HTTP requests to package registries now uses an updated format for better clarity and distinction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->