### PR TITLE
fix(package-manager): record configDependencies in workspace state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "pacquet-patching",
  "pacquet-store-dir",
  "pacquet-testing-utils",
+ "pacquet-workspace-state",
  "pipe-trait",
  "pretty_assertions",
  "serde",

--- a/pacquet/crates/config/Cargo.toml
+++ b/pacquet/crates/config/Cargo.toml
@@ -18,6 +18,7 @@ pacquet-network                = { workspace = true }
 pacquet-package-is-installable = { workspace = true }
 pacquet-patching               = { workspace = true }
 pacquet-store-dir              = { workspace = true }
+pacquet-workspace-state        = { workspace = true }
 
 derive_more   = { workspace = true }
 home          = { workspace = true }

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -895,6 +895,15 @@ pub struct Config {
     /// [`addSettingsFromWorkspaceManifestToConfig`](https://github.com/pnpm/pnpm/blob/b4f8f47ac2/config/reader/src/index.ts#L803-L831).
     pub patched_dependencies: Option<IndexMap<String, String>>,
 
+    /// Raw `configDependencies` from `pnpm-workspace.yaml`: package
+    /// name → version-with-integrity spec. Recorded verbatim in the
+    /// workspace-state file so pnpm's `checkDepsStatus` sees the same
+    /// value it holds in the live config and doesn't treat the install
+    /// as stale. See [`WorkspaceSettings::config_dependencies`].
+    ///
+    /// [`WorkspaceSettings::config_dependencies`]: crate::workspace_yaml::WorkspaceSettings::config_dependencies
+    pub config_dependencies: Option<BTreeMap<String, String>>,
+
     /// `pnpm.allowBuilds` from `pnpm-workspace.yaml`: package names
     /// (or `name@version` keys) that are allowed to run lifecycle
     /// scripts. pnpm 11 denies scripts by default; the allow-list is

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -12,6 +12,7 @@ pub use crate::api::{EnvVar, EnvVarOs, GetCurrentDir, GetHomeDir, Host, LinkProb
 use indexmap::IndexMap;
 use pacquet_patching::{PatchGroupRecord, ResolvePatchedDependenciesError, resolve_and_group};
 use pacquet_store_dir::StoreDir;
+use pacquet_workspace_state::ConfigDependency;
 use pipe_trait::Pipe;
 use serde::Deserialize;
 use smart_default::SmartDefault;
@@ -902,7 +903,7 @@ pub struct Config {
     /// as stale. See [`WorkspaceSettings::config_dependencies`].
     ///
     /// [`WorkspaceSettings::config_dependencies`]: crate::workspace_yaml::WorkspaceSettings::config_dependencies
-    pub config_dependencies: Option<BTreeMap<String, String>>,
+    pub config_dependencies: Option<BTreeMap<String, ConfigDependency>>,
 
     /// `pnpm.allowBuilds` from `pnpm-workspace.yaml`: package names
     /// (or `name@version` keys) that are allowed to run lifecycle

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -8,6 +8,7 @@ use miette::Diagnostic;
 use pacquet_env_replace::env_replace_lossy;
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_store_dir::StoreDir;
+use pacquet_workspace_state::ConfigDependency;
 use pipe_trait::Pipe;
 use serde::{Deserialize, Deserializer};
 use std::{
@@ -214,10 +215,7 @@ pub struct WorkspaceSettings {
     /// otherwise pnpm reads a missing `configDependencies` on the next
     /// `pnpm run` / `pnpm node`, compares it against the live config,
     /// and reinstalls on every invocation.
-    ///
-    /// Only the `VersionWithIntegrity` string form is modeled; pnpm's
-    /// `{ tarball?, integrity }` object form is not yet supported.
-    pub config_dependencies: Option<BTreeMap<String, String>>,
+    pub config_dependencies: Option<BTreeMap<String, ConfigDependency>>,
 
     /// Map of `name[@version]` → `true` / `false`. Drives pnpm 11's
     /// default-deny build policy: a package's lifecycle scripts only

--- a/pacquet/crates/config/src/workspace_yaml.rs
+++ b/pacquet/crates/config/src/workspace_yaml.rs
@@ -205,6 +205,20 @@ pub struct WorkspaceSettings {
     /// [`BTreeMap`]: std::collections::BTreeMap
     pub patched_dependencies: Option<IndexMap<String, String>>,
 
+    /// `configDependencies` from `pnpm-workspace.yaml`: package name →
+    /// version-with-integrity spec. pnpm records this verbatim in the
+    /// workspace-state file so that `checkDepsStatus` can detect when a
+    /// config dependency changed and force a reinstall. Pacquet must
+    /// write the same value back (see
+    /// [`build_workspace_state`](../../package-manager/src/install.rs)),
+    /// otherwise pnpm reads a missing `configDependencies` on the next
+    /// `pnpm run` / `pnpm node`, compares it against the live config,
+    /// and reinstalls on every invocation.
+    ///
+    /// Only the `VersionWithIntegrity` string form is modeled; pnpm's
+    /// `{ tarball?, integrity }` object form is not yet supported.
+    pub config_dependencies: Option<BTreeMap<String, String>>,
+
     /// Map of `name[@version]` → `true` / `false`. Drives pnpm 11's
     /// default-deny build policy: a package's lifecycle scripts only
     /// run when an entry here resolves to `true`. Mirrors upstream's
@@ -550,6 +564,7 @@ impl WorkspaceSettings {
         self.hoisting_limits = None;
         self.external_dependencies = None;
         self.patched_dependencies = None;
+        self.config_dependencies = None;
         self.allow_builds = None;
         self.supported_architectures = None;
         self.ignored_optional_dependencies = None;
@@ -715,6 +730,9 @@ impl WorkspaceSettings {
         config.workspace_dir = Some(base_dir.to_path_buf());
         if let Some(v) = self.patched_dependencies {
             config.patched_dependencies = Some(v);
+        }
+        if let Some(v) = self.config_dependencies {
+            config.config_dependencies = Some(v);
         }
         if let Some(v) = self.allow_builds {
             config.allow_builds = v;

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -4,6 +4,7 @@ use crate::{
     ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
 };
 use pacquet_store_dir::StoreDir;
+use pacquet_workspace_state::{ConfigDependency, ConfigDependencyDetail};
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use std::{fs, path::Path};
@@ -338,15 +339,37 @@ configDependencies:
   "@pnpm/pacquet": 0.2.2-14
 "#;
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
-    let map = settings.config_dependencies.clone().expect("field present");
-    assert_eq!(map.get("@pnpm/pacquet").map(String::as_str), Some("0.2.2-14"));
+    let expected = settings.config_dependencies.clone();
+    assert_eq!(
+        expected.as_ref().and_then(|m| m.get("@pnpm/pacquet")),
+        Some(&ConfigDependency::VersionWithIntegrity("0.2.2-14".to_string())),
+    );
 
     let mut config = Config::new();
     assert!(config.config_dependencies.is_none(), "default is None");
     settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.config_dependencies, expected);
+}
+
+/// pnpm's `configDependencies` value can also be the `{ tarball?, integrity }`
+/// object form. It must parse (not error) and round-trip, otherwise an
+/// upstream-supported manifest becomes a hard config-load failure.
+#[test]
+fn parses_object_form_config_dependencies() {
+    let yaml = r#"
+configDependencies:
+  "@scope/dep":
+    integrity: sha512-abc
+    tarball: https://example.test/dep.tgz
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let map = settings.config_dependencies.expect("field present");
     assert_eq!(
-        config.config_dependencies.expect("present").get("@pnpm/pacquet").map(String::as_str),
-        Some("0.2.2-14")
+        map.get("@scope/dep"),
+        Some(&ConfigDependency::Detailed(ConfigDependencyDetail {
+            integrity: "sha512-abc".to_string(),
+            tarball: Some("https://example.test/dep.tgz".to_string()),
+        })),
     );
 }
 

--- a/pacquet/crates/config/src/workspace_yaml/tests.rs
+++ b/pacquet/crates/config/src/workspace_yaml/tests.rs
@@ -326,6 +326,43 @@ patchedDependencies:
     assert_eq!(map.get("lodash@4.17.21").map(String::as_str), Some("patches/lodash@4.17.21.patch"));
 }
 
+/// `configDependencies` is a map of package name → version-with-integrity
+/// spec. pacquet records it into the workspace-state file so pnpm's
+/// `checkDepsStatus` doesn't treat the install as stale on the next
+/// `pnpm run` / `pnpm node`. Guards the camelCase rename, optionality,
+/// and `apply_to` wiring.
+#[test]
+fn parses_config_dependencies_from_yaml_and_applies() {
+    let yaml = r#"
+configDependencies:
+  "@pnpm/pacquet": 0.2.2-14
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let map = settings.config_dependencies.clone().expect("field present");
+    assert_eq!(map.get("@pnpm/pacquet").map(String::as_str), Some("0.2.2-14"));
+
+    let mut config = Config::new();
+    assert!(config.config_dependencies.is_none(), "default is None");
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(
+        config.config_dependencies.expect("present").get("@pnpm/pacquet").map(String::as_str),
+        Some("0.2.2-14")
+    );
+}
+
+/// `configDependencies` is workspace-only: it must not be honored from
+/// the global `config.yaml`, matching pnpm's `isConfigFileKey` filter.
+#[test]
+fn config_dependencies_cleared_as_workspace_only_field() {
+    let yaml = r#"
+configDependencies:
+  "@pnpm/pacquet": 0.2.2-14
+"#;
+    let mut settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    settings.clear_workspace_only_fields();
+    assert!(settings.config_dependencies.is_none());
+}
+
 /// `allowBuilds` is a map of `name[@version]` → bool. Same camelCase
 /// rename + `apply_to` wiring as the other yaml-sourced settings.
 /// pnpm 10+ moved this out of `package.json#pnpm` (matches

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1597,10 +1597,6 @@ fn build_workspace_state(
         // `false` so pnpm doesn't treat the install as partial and
         // skip the cache.
         filtered_install: false,
-        // Mirror pnpm's `createWorkspaceState`, which records
-        // `configDependencies` verbatim. Omitting it makes pnpm's
-        // `checkDepsStatus` see a missing value, compare it against the
-        // live config, and reinstall on every `pnpm run` / `pnpm node`.
         config_dependencies: config.config_dependencies.clone(),
         // Settings construction is shared with
         // `optimistic_repeat_install::current_settings` so the

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1597,7 +1597,11 @@ fn build_workspace_state(
         // `false` so pnpm doesn't treat the install as partial and
         // skip the cache.
         filtered_install: false,
-        config_dependencies: None,
+        // Mirror pnpm's `createWorkspaceState`, which records
+        // `configDependencies` verbatim. Omitting it makes pnpm's
+        // `checkDepsStatus` see a missing value, compare it against the
+        // live config, and reinstall on every `pnpm run` / `pnpm node`.
+        config_dependencies: config.config_dependencies.clone(),
         // Settings construction is shared with
         // `optimistic_repeat_install::current_settings` so the
         // freshness check sees the same byte shape this writer

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -900,6 +900,7 @@ mod build_workspace_state_tests {
     use pacquet_config::Config;
     use pacquet_modules_yaml::IncludedDependencies;
     use pacquet_package_manifest::PackageManifest;
+    use pacquet_workspace_state::ConfigDependency;
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use tempfile::tempdir;
@@ -976,8 +977,10 @@ mod build_workspace_state_tests {
     #[test]
     fn records_config_dependencies_from_config() {
         let mut config = Config::new();
-        config.config_dependencies =
-            Some(BTreeMap::from([("@pnpm/pacquet".to_string(), "0.2.2-14".to_string())]));
+        config.config_dependencies = Some(BTreeMap::from([(
+            "@pnpm/pacquet".to_string(),
+            ConfigDependency::VersionWithIntegrity("0.2.2-14".to_string()),
+        )]));
         let state = build_workspace_state(
             &config,
             pacquet_config::NodeLinker::default(),

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -900,6 +900,7 @@ mod build_workspace_state_tests {
     use pacquet_config::Config;
     use pacquet_modules_yaml::IncludedDependencies;
     use pacquet_package_manifest::PackageManifest;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -964,6 +965,26 @@ mod build_workspace_state_tests {
             assert_eq!(entry.version.as_deref(), Some("1.0.0"));
             assert!(packages.contains(&entry.name.as_deref().unwrap_or_default(),));
         }
+    }
+
+    /// pnpm's `createWorkspaceState` records `configDependencies`
+    /// verbatim. When pacquet is the install engine for a project that
+    /// declares one (the `@pnpm/pacquet` configDependency itself), the
+    /// written state must carry the same map — otherwise pnpm's
+    /// `checkDepsStatus` reads a missing value, treats the install as
+    /// stale, and reinstalls on every `pnpm run` / `pnpm node`.
+    #[test]
+    fn records_config_dependencies_from_config() {
+        let mut config = Config::new();
+        config.config_dependencies =
+            Some(BTreeMap::from([("@pnpm/pacquet".to_string(), "0.2.2-14".to_string())]));
+        let state = build_workspace_state(
+            &config,
+            pacquet_config::NodeLinker::default(),
+            IncludedDependencies::default(),
+            &[],
+        );
+        assert_eq!(state.config_dependencies, config.config_dependencies);
     }
 }
 

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -74,6 +74,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         npmrc_auth_file: None,
         workspace_dir: None,
         patched_dependencies: None,
+        config_dependencies: None,
         allow_builds: Default::default(),
         dangerously_allow_all_builds: false,
         scripts_prepend_node_path: Default::default(),

--- a/pacquet/crates/workspace-state/src/lib.rs
+++ b/pacquet/crates/workspace-state/src/lib.rs
@@ -45,6 +45,27 @@ pub struct ProjectEntry {
     pub version: Option<String>,
 }
 
+/// A single `configDependencies` value. Mirrors pnpm's
+/// `VersionWithIntegrity | { tarball?, integrity }` at
+/// <https://github.com/pnpm/pnpm/blob/7ff112bac6/core/types/src/package.ts>.
+/// Untagged so it round-trips both shapes verbatim; pnpm compares the
+/// recorded value against the live config with a deep, order-independent
+/// equality check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ConfigDependency {
+    VersionWithIntegrity(String),
+    Detailed(ConfigDependencyDetail),
+}
+
+/// The `{ tarball?, integrity }` form of a [`ConfigDependency`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigDependencyDetail {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tarball: Option<String>,
+    pub integrity: String,
+}
+
 /// Typed view of `.pnpm-workspace-state-v1.json`.
 ///
 /// Mirrors upstream's [`WorkspaceState`](https://github.com/pnpm/pnpm/blob/7ff112bac6/workspace/state/src/types.ts).
@@ -59,7 +80,7 @@ pub struct WorkspaceState {
     pub pnpmfiles: Vec<String>,
     pub filtered_install: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub config_dependencies: Option<BTreeMap<String, String>>,
+    pub config_dependencies: Option<BTreeMap<String, ConfigDependency>>,
     pub settings: WorkspaceStateSettings,
 }
 


### PR DESCRIPTION
## Problem

When pacquet is the install engine (declared via `configDependencies['@pnpm/pacquet']`), a freshly installed workspace is reported as **out of sync** by pnpm on the very next `pnpm run` / `pnpm node` / `pnpm exec`, triggering an unwanted reinstall every time.

Root cause: `build_workspace_state` hard-coded `config_dependencies: None`, so pacquet wrote `node_modules/.pnpm-workspace-state-v1.json` **without** the `configDependencies` map. pnpm's `checkDepsStatus` then compares the live config's `configDependencies` (e.g. `{"@pnpm/pacquet":"0.2.2-14"}`) against the missing recorded value:

```ts
if ((opts.configDependencies != null || workspaceState.configDependencies != null) &&
    !equals(opts.configDependencies ?? {}, workspaceState.configDependencies ?? {})) {
  return { upToDate: false, issue: 'Configuration dependencies are not up to date', ... }
}
```

→ always unequal → reinstall on every invocation. With `verifyDepsBeforeRun: install` and a `devEngines.runtime` pin using `onFail: download`, that reinstall also re-provisions the runtime — e.g. `pnpm node -v` ends up running a different Node version than the one the environment set up.

## Fix

Mirror pnpm's `createWorkspaceState`, which records `configDependencies` verbatim:

- Parse `configDependencies` from `pnpm-workspace.yaml` into `Config` (workspace-only, cleared from the global `config.yaml` like `patchedDependencies`, matching pnpm's `isConfigFileKey`).
- Write it through `build_workspace_state` instead of hard-coding `None`.

Only the `VersionWithIntegrity` string form is modeled; pnpm's `{ tarball?, integrity }` object form is a separate follow-up.

## Verification

- Unit tests: parse + `apply_to`, workspace-only clearing, and `build_workspace_state` records the map.
- `cargo nextest` for `pacquet-config` + `pacquet-package-manager`: 618 passed.
- End-to-end with the built binary: `pacquet install` in a project declaring `configDependencies` now writes `configDependencies = {"@pnpm/pacquet":"0.2.2-14"}` into the state file (previously `null`), so pnpm's `checkDepsStatus` no longer treats the install as stale.

Pacquet-only parity fix (the pnpm TypeScript side already records this), so no changeset.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read and preserve workspace "configDependencies" from pnpm workspace config, supporting both string and object forms and recording them in workspace state so dependency checks observe the same values.
* **Tests**
  * Added tests for deserialization (both forms), propagation into workspace state, round‑tripping, and clearing for non‑workspace/global configs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->