### PR TITLE
test(exe): fix EXDEV when seeding the Windows setup sandbox

### DIFF
--- a/pnpm/artifacts/exe/test/setup.test.ts
+++ b/pnpm/artifacts/exe/test/setup.test.ts
@@ -166,10 +166,21 @@ function buildWinSetupSandbox (): string {
   fs.writeFileSync(path.join(platformDir, 'package.json'), JSON.stringify({
     name: platformPkgName, version: '0.0.0',
   }))
-  // Hardlink the test's own node.exe as the platform binary. setup.js then
+  // Seed the platform binary with the test's own node.exe. setup.js then
   // hardlinks it again into the sandbox @pnpm/exe dir; downstream tests can
   // invoke the resulting `pnpx.exe` (etc.) and assert the alias actually ran.
-  fs.linkSync(process.execPath, path.join(platformDir, 'pnpm.exe'))
+  // A hardlink is enough and avoids copying ~80MB, but it can't span volumes
+  // — on GitHub's Windows runners the workspace (and node) sit on `D:` while
+  // `os.tmpdir()` is on `C:`, so fall back to a copy when the link is
+  // cross-device. The seed's identity doesn't matter here; the assertions
+  // exercise setup.js's own intra-sandbox hardlinking.
+  const seedTarget = path.join(platformDir, 'pnpm.exe')
+  try {
+    fs.linkSync(process.execPath, seedTarget)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err
+    fs.copyFileSync(process.execPath, seedTarget)
+  }
   // platform-pkg-name.js calls into detect-libc; make the package resolvable
   // from the sandbox. On Windows, use a junction — non-junction directory
   // symlinks require Developer Mode or admin privileges, which Windows CI and


### PR DESCRIPTION
## Problem

The `@pnpm/exe` Windows setup tests (`pnpm/artifacts/exe/test/setup.test.ts`, regression coverage for #11486) fail on GitHub's Windows runners:

```
EXDEV: cross-device link not permitted, link
'D:\a\pnpm\pnpm\node_modules\.bin\node.exe' ->
'C:\Users\RUNNER~1\AppData\Local\Temp\pnpm-exe-fix11486-*\node_modules\@pnpm\win-x64\pnpm.exe'
```

The runner places the workspace (and the pnpm-managed node) on `D:`, while `os.tmpdir()` is on `C:`. `fs.linkSync` (a hardlink) can't span volumes, so seeding the sandbox's platform binary throws `EXDEV`.

## Fix

Fall back to `fs.copyFileSync` when the hardlink would cross devices. The seed binary's identity is irrelevant to the assertions — they exercise `setup.js`'s own *intra-sandbox* hardlinking (all on one volume), which is unaffected.

Surfaced on the CI run for #12069 but pre-existing on `main`.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox setup reliability for cross-device filesystem operations. The initialization process now intelligently handles device boundary limitations with automatic fallback mechanisms, ensuring smooth setup completion across diverse storage and system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->