### PR TITLE
fix(pnpr): drop version floor on pnpr workspace deps so releases resolve

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ pacquet-workspace-state                   = { path = "pacquet/crates/workspace-s
 pacquet-registry-mock = { path = "pacquet/tasks/registry-mock" }
 
 # Registry (sibling project — pnpm-compatible registry server)
-pnpr          = { path = "pnpr/crates/pnpr", version = "0.0.1" }
-pnpr-fixtures = { path = "pnpr/crates/pnpr-fixtures", version = "0.0.1" }
+pnpr          = { path = "pnpr/crates/pnpr" }
+pnpr-fixtures = { path = "pnpr/crates/pnpr-fixtures" }
 
 # Dependencies
 async-recursion = { version = "1.1.1" }


### PR DESCRIPTION
## Problem

The [`@pnpm/pnpr` release run](https://github.com/pnpm/pnpm/actions/runs/26653794175) failed on every platform leg with:

```
error: failed to select a version for the requirement `pnpr = "^0.0.1"`
candidate versions found which didn't match: 0.0.0-26052901
required by package `pacquet-testing-utils`
```

The release workflow's *"Inject version into `pnpr/crates/pnpr/Cargo.toml`"* step rewrites the crate's `version` field to the dispatched input (here `0.0.0-26052901`), then runs `cross build -p pnpr`. Cargo resolves the whole workspace graph during that build, and `pacquet-testing-utils` depends on `pnpr` via the workspace dep. The root `Cargo.toml` declared that dep with a version floor:

```toml
pnpr          = { path = "pnpr/crates/pnpr", version = "0.0.1" }
pnpr-fixtures = { path = "pnpr/crates/pnpr-fixtures", version = "0.0.1" }
```

`0.0.0-26052901` is both below `0.0.1` and a prerelease, so resolution failed, and `fail-fast` cancelled the other legs.

The sibling `pacquet` release never hits this because every pacquet workspace path dep is declared with **no** `version =` requirement. The two `pnpr` deps were the only path deps in the workspace carrying a version floor.

## Fix

Drop the `version` requirement from the two `pnpr` workspace path deps, matching every pacquet crate. None of `pnpr`, `pnpr-fixtures`, or `testing-utils` is published to crates.io (the binary ships to npm), so the floor served no purpose and only broke releases whose version wasn't `≥0.0.1` stable.

## Verification

Reproduced the workflow's exact injection locally (`version = "0.0.0-26052901"`) and ran `cargo build -p pnpr --bin pnpr`. Before the change it failed at resolution; after, it compiles `pnpr v0.0.0-26052901` cleanly.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workspace dependency configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->