### PR TITLE
fix(deps-resolver): preserve locked optional peer candidates

### DIFF
--- a/.changeset/steady-optional-peers.md
+++ b/.changeset/steady-optional-peers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Preserve compatible optional peer versions already present in the lockfile when resolving dependencies.

--- a/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { expect, test } from '@jest/globals'
 import { assertProject } from '@pnpm/assert-project'
 import { createPeerDepGraphHash } from '@pnpm/deps.path'
-import { addDependenciesToPackage, install, mutateModules, mutateModulesInSingleProject, type PackageManifest } from '@pnpm/installing.deps-installer'
+import { addDependenciesToPackage, install, type MutatedProject, mutateModules, mutateModulesInSingleProject, type PackageManifest } from '@pnpm/installing.deps-installer'
 import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { ProjectRootDir } from '@pnpm/types'
@@ -706,5 +706,55 @@ test('override narrows auto-installed peer dep range on subsequent install', asy
     // peer-c should now be 1.0.0, not the stale 1.0.1 from the previous lockfile
     expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/peer-c@1.0.0'])
     expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/peer-c@1.0.1'])
+  }
+})
+
+test('a locked optional peer version is not rewritten when a sibling workspace package declares a lower version', async () => {
+  // Regression test for https://github.com/pnpm/pnpm/pull/12075
+  // The optional peer is locked at the higher 1.0.1. A sibling workspace
+  // package then declares the lower 1.0.0 directly. The locked 1.0.1 is seeded
+  // into the preferred versions as a weighted selector, which optional peer
+  // hoisting must still consider — otherwise the only candidate left is the
+  // sibling's 1.0.0 and the lockfile is needlessly rewritten.
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+
+  const mutations: MutatedProject[] = [
+    { mutation: 'install', rootDir: path.resolve('project1') as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('project2') as ProjectRootDir },
+  ]
+  const allProjects = (peerCVersion: string) => [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project1',
+        dependencies: { '@pnpm.e2e/abc-optional-peers': '1.0.0' },
+      },
+      rootDir: path.resolve('project1') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project2',
+        dependencies: { '@pnpm.e2e/peer-c': peerCVersion },
+      },
+      rootDir: path.resolve('project2') as ProjectRootDir,
+    },
+  ]
+
+  // Lock the optional peer at the higher 1.0.1 brought in by the sibling.
+  await mutateModules(mutations, testDefaults({ autoInstallPeers: true, allProjects: allProjects('1.0.1') }))
+  {
+    const lockfile = project.readLockfile()
+    expect(lockfile.importers.project1.dependencies?.['@pnpm.e2e/abc-optional-peers']?.version).toContain('(@pnpm.e2e/peer-c@1.0.1)')
+  }
+
+  // The sibling now declares the lower 1.0.0, but the optional peer stays at 1.0.1.
+  await mutateModules(mutations, testDefaults({ autoInstallPeers: true, allProjects: allProjects('1.0.0') }))
+  {
+    const lockfile = project.readLockfile()
+    const optionalPeerVersion = lockfile.importers.project1.dependencies?.['@pnpm.e2e/abc-optional-peers']?.version
+    expect(optionalPeerVersion).toContain('(@pnpm.e2e/peer-c@1.0.1)')
+    expect(optionalPeerVersion).not.toContain('(@pnpm.e2e/peer-c@1.0.0)')
   }
 })

--- a/installing/deps-resolver/src/hoistPeers.ts
+++ b/installing/deps-resolver/src/hoistPeers.ts
@@ -73,7 +73,8 @@ export function getHoistableOptionalPeers (
     if (!allPreferredVersions[missingOptionalPeerName]) continue
 
     let maxSatisfyingVersion: string | undefined
-    for (const [version, specType] of Object.entries(allPreferredVersions[missingOptionalPeerName])) {
+    for (const [version, selector] of Object.entries(allPreferredVersions[missingOptionalPeerName])) {
+      const specType = typeof selector === 'string' ? selector : selector.selectorType
       if (
         specType === 'version' &&
         ranges.every(range => semver.satisfies(version, range)) &&

--- a/installing/deps-resolver/test/hoistPeers.test.ts
+++ b/installing/deps-resolver/test/hoistPeers.test.ts
@@ -155,3 +155,16 @@ test('getHoistableOptionalPeers picks the highest version that satisfies all the
     foo: '2.1.1',
   })
 })
+
+test('getHoistableOptionalPeers handles version selector with weight', () => {
+  expect(getHoistableOptionalPeers({
+    jsdom: ['*'],
+  }, {
+    jsdom: {
+      '26.1.0': 'version',
+      '27.4.0': { selectorType: 'version', weight: 1 },
+    },
+  })).toStrictEqual({
+    jsdom: '27.4.0',
+  })
+})

--- a/pacquet/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -140,18 +140,12 @@ pub fn hoist_peers(
 
 /// Pick an installable version for each missing optional peer, but only
 /// when at least one preferred version satisfies *every* recorded range.
-/// Returns `peer_name → version`. Mirrors upstream's
-/// [`getHoistableOptionalPeers`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/hoistPeers.ts#L67-L90).
+/// Returns `peer_name → version`. Mirrors pnpm's
+/// `getHoistableOptionalPeers`.
 ///
-/// Upstream's loop checks `specType === 'version'` against the raw map
-/// value, which is true only for the *string* selector form (`'version'`)
-/// produced by the resolver as packages are walked
-/// ([`resolveDependencies.ts:1440`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1440)),
-/// **not** the weighted form
-/// `getPreferredVersionsFromLockfileAndManifests` produces. Pacquet
-/// mirrors that filter exactly — weighted entries are skipped — so
-/// optional peer hoisting only sees versions added to the preferred
-/// map during the in-flight walk, matching upstream behavior.
+/// Version selectors may be plain entries produced while resolving or
+/// weighted entries seeded from the wanted lockfile. Both are eligible
+/// so an already locked optional peer is not discarded during re-resolution.
 pub fn get_hoistable_optional_peers(
     all_missing_optional_peers: &BTreeMap<String, Vec<String>>,
     all_preferred_versions: &PreferredVersions,
@@ -161,9 +155,11 @@ pub fn get_hoistable_optional_peers(
         let Some(selectors) = all_preferred_versions.get(peer_name) else { continue };
         let mut max_satisfying_version: Option<Version> = None;
         for (version_str, entry) in selectors {
-            let is_plain_version =
-                matches!(entry, VersionSelectorEntry::Plain(VersionSelectorType::Version));
-            if !is_plain_version {
+            let selector_type = match entry {
+                VersionSelectorEntry::Plain(selector_type) => *selector_type,
+                VersionSelectorEntry::Weighted(weighted) => weighted.selector_type,
+            };
+            if selector_type != VersionSelectorType::Version {
                 continue;
             }
             let Ok(version) = version_str.parse::<Version>() else { continue };

--- a/pacquet/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -141,11 +141,14 @@ pub fn hoist_peers(
 /// Pick an installable version for each missing optional peer, but only
 /// when at least one preferred version satisfies *every* recorded range.
 /// Returns `peer_name → version`. Mirrors pnpm's
-/// `getHoistableOptionalPeers`.
+/// [`getHoistableOptionalPeers`](https://github.com/pnpm/pnpm/blob/a1bda24c4f/installing/deps-resolver/src/hoistPeers.ts#L67-L91).
 ///
-/// Version selectors may be plain entries produced while resolving or
-/// weighted entries seeded from the wanted lockfile. Both are eligible
-/// so an already locked optional peer is not discarded during re-resolution.
+/// Version selectors may be plain entries
+/// [produced while resolving](https://github.com/pnpm/pnpm/blob/a1bda24c4f/installing/deps-resolver/src/resolveDependencies.ts#L1439-L1444)
+/// or weighted entries
+/// [seeded from the wanted lockfile](https://github.com/pnpm/pnpm/blob/a1bda24c4f/lockfile/preferred-versions/src/index.ts#L35-L55).
+/// Both are eligible so an already locked optional peer is not discarded
+/// during re-resolution.
 pub fn get_hoistable_optional_peers(
     all_missing_optional_peers: &BTreeMap<String, Vec<String>>,
     all_preferred_versions: &PreferredVersions,

--- a/pacquet/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -170,6 +170,29 @@ fn get_hoistable_optional_peers_picks_the_highest_satisfying_version() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn get_hoistable_optional_peers_handles_version_selector_with_weight() {
+    let preferred = preferred(&[(
+        "jsdom",
+        &[
+            ("26.1.0", plain(VersionSelectorType::Version)),
+            (
+                "27.4.0",
+                VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+                    selector_type: VersionSelectorType::Version,
+                    weight: 1,
+                }),
+            ),
+        ],
+    )]);
+    let mut missing = BTreeMap::new();
+    missing.insert("jsdom".to_string(), vec!["*".to_string()]);
+    let result = get_hoistable_optional_peers(&missing, &preferred);
+    let mut expected = BTreeMap::new();
+    expected.insert("jsdom".to_string(), "27.4.0".to_string());
+    assert_eq!(result, expected);
+}
+
 /// Mirrors upstream's `{ includePrerelease: true }` arg to
 /// `semver.maxSatisfying`: a `^18.0.0`-style range must accept an
 /// `18.0.0-rc.1` candidate from the preferred-versions table. The

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -2,8 +2,9 @@ use std::{collections::HashMap, str::FromStr, sync::Mutex};
 
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, PreferredVersions, ResolveError, ResolveFuture, ResolveLatestFuture,
-    ResolveOptions, ResolveResult, Resolver, WantedDependency,
+    EXISTING_VERSION_SELECTOR_WEIGHT, LatestQuery, PreferredVersions, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, VersionSelectorEntry,
+    VersionSelectorType, VersionSelectorWithWeight, VersionSelectors, WantedDependency,
 };
 use pretty_assertions::assert_eq;
 
@@ -342,6 +343,87 @@ async fn auto_install_skips_optional_peers_without_preferred_versions() {
     assert!(
         !direct.contains(&"peer-c"),
         "optional peer must stay missing without a preferred version",
+    );
+}
+
+/// A locked optional peer version is preserved on re-resolution. The
+/// optional peer `peer-c` is recorded in the preferred versions twice: a
+/// plain entry for the lower `1.0.0` a sibling workspace package declares
+/// directly, and a weighted entry for the already-locked higher `1.0.1`
+/// seeded from the wanted lockfile. Optional peer hoisting must consider
+/// the weighted entry too — otherwise the locked `1.0.1` is discarded and
+/// the lockfile is rewritten to the sibling's `1.0.0`. Regression test for
+/// <https://github.com/pnpm/pnpm/pull/12075>; the end-to-end equivalent
+/// lives in pnpm's `autoInstallPeers.ts`.
+#[tokio::test]
+async fn keeps_locked_optional_peer_over_lower_sibling_version() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("abc".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "abc",
+            "1.0.0",
+            serde_json::json!({
+                "name": "abc",
+                "version": "1.0.0",
+                "peerDependencies": {
+                    "peer-a": "^1.0.0",
+                    "peer-c": "^1.0.0",
+                },
+                "peerDependenciesMeta": {
+                    "peer-c": { "optional": true },
+                },
+            }),
+        ),
+    );
+    table.insert(
+        ("peer-a".to_string(), "^1.0.0".to_string()),
+        fake_result("peer-a", "1.0.0", serde_json::json!({ "name": "peer-a", "version": "1.0.0" })),
+    );
+    for version in ["1.0.0", "1.0.1"] {
+        table.insert(
+            ("peer-c".to_string(), version.to_string()),
+            fake_result(
+                "peer-c",
+                version,
+                serde_json::json!({ "name": "peer-c", "version": version }),
+            ),
+        );
+    }
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "abc": "1.0.0" }));
+
+    let mut opts = default_opts();
+    let mut peer_c_selectors = VersionSelectors::new();
+    peer_c_selectors
+        .insert("1.0.0".to_string(), VersionSelectorEntry::Plain(VersionSelectorType::Version));
+    peer_c_selectors.insert(
+        "1.0.1".to_string(),
+        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+            selector_type: VersionSelectorType::Version,
+            weight: EXISTING_VERSION_SELECTOR_WEIGHT,
+        }),
+    );
+    opts.all_preferred_versions.insert("peer-c".to_string(), peer_c_selectors);
+
+    let result =
+        resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], opts).await.unwrap();
+
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("peer-c"),
+        Some(&DepPath::from("peer-c@1.0.1".to_string())),
+        "the already-locked optional peer 1.0.1 must win over the sibling's 1.0.0",
+    );
+    let abc = result
+        .peers_result
+        .direct_dependencies_by_alias
+        .get("abc")
+        .expect("abc resolved")
+        .to_string();
+    assert!(abc.contains("(peer-c@1.0.1)"), "abc should keep the locked optional peer: {abc}");
+    assert!(
+        !abc.contains("(peer-c@1.0.0)"),
+        "abc must not adopt the sibling's lower version: {abc}",
     );
 }
 


### PR DESCRIPTION
## Summary

Preserve compatible optional-peer versions already recorded in the lockfile
when pnpm re-resolves a workspace.

## Reproduction

Public reproduction:
<https://github.com/sharmila-oai/pnpm-optional-peer-lockfile-repro>

The workspace contains:

```text
packages/uses-vitest -> vitest@3.2.4
packages/older       -> jsdom@26.1.0
```

Vitest declares `jsdom` as an optional peer dependency.

The committed lockfile was generated when another workspace package also
depended on `jsdom@27.4.0`. At that time, pnpm selected the higher compatible
version for Vitest:

```text
vitest@3.2.4(jsdom@27.4.0)
```

That additional direct dependency was then removed from its `package.json`,
without regenerating the lockfile. This simulates a normal manifest edit.

Running:

```sh
pnpm install --lockfile-only --no-frozen-lockfile
```

unnecessarily rewrites Vitest's still-valid optional-peer context:

```diff
-        version: 3.2.4(jsdom@27.4.0)
+        version: 3.2.4(jsdom@26.1.0)
```

Both versions satisfy Vitest's optional peer range. The existing `27.4.0`
resolution remains valid and should not be discarded while pnpm updates the
lockfile.

## Cause

Preferred versions loaded from the wanted lockfile are stored as weighted
selectors:

```ts
{ selectorType: 'version', weight: EXISTING_VERSION_SELECTOR_WEIGHT }
```

`getHoistableOptionalPeers()` only recognized the plain string form:

```ts
specType === 'version'
```

As a result, it ignored the compatible locked `27.4.0` candidate. It only saw
`26.1.0`, which was rediscovered from `packages/older/package.json`, and
rewrote the peer context.

## Fix

Normalize the selector before checking its type, matching the handling already
used by `hoistPeers()` for required peers:

```ts
const specType = typeof selector === 'string'
  ? selector
  : selector.selectorType
```

This restores lockfile-seeded versions to the candidate set. It does not add a
new preference rule or force pnpm to keep every locked version. Optional-peer
auto-installation continues to choose the highest version satisfying every
recorded peer range.

The equivalent fix is included in pacquet, pnpm's Rust port.

## Validation

- Added matching TypeScript and Rust regression tests.
- Verified the public reproduction against `pnpm@11.4.0` and the patched CLI.
- Ran the focused TypeScript resolver checks and pacquet test, clippy, format,
  and `cargo nextest` checks.

---
Written by an agent (Codex, GPT-5).

Sent by Codex
