### PR TITLE
feat(tarball): support remote https-tarball direct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,9 +2850,14 @@ dependencies = [
  "mockito",
  "pacquet-lockfile",
  "pacquet-network",
+ "pacquet-reporter",
  "pacquet-resolving-resolver-base",
+ "pacquet-store-dir",
+ "pacquet-tarball",
  "pretty_assertions",
  "reqwest",
+ "serde_json",
+ "ssri",
  "tokio",
 ]
 

--- a/pacquet/crates/cli/tests/tarball_url_dependency.rs
+++ b/pacquet/crates/cli/tests/tarball_url_dependency.rs
@@ -1,48 +1,49 @@
-//! Integrity preservation for remote https-tarball dependencies.
+//! Remote (non-registry) https-tarball *direct* dependencies install
+//! end to end, recording the computed integrity in the lockfile.
 //!
-//! URL/tarball resolvers carry no `integrity` at resolve time — it is
-//! only known after the tarball is downloaded and hashed. The risk
-//! (pnpm issue [#12001](https://github.com/pnpm/pnpm/issues/12001),
-//! fixed upstream in [#12040](https://github.com/pnpm/pnpm/pull/12040))
-//! is that installing an *unrelated* package later rewrites the
-//! lockfile while the tarball dependency is reused without being
-//! re-fetched, dropping its recorded integrity — which then makes the
-//! next `--frozen-lockfile` install fail closed.
+//! URL/tarball resolvers carry no `name@version`/`integrity` at resolve
+//! time — those live in the tarball's `package.json`. pacquet builds
+//! the lockfile before the install pass, so the [`TarballResolver`]
+//! downloads the tarball during resolution to compute its sha512
+//! integrity and read its manifest (see <https://github.com/pnpm/pnpm/issues/12053>).
 //!
-//! Reproducing that in pacquet requires resolving a dependency through
-//! the [`TarballResolver`], which only claims a bare specifier whose
-//! URL does *not* start with the configured registry. A registry-host
+//! The scenario also guards pnpm issue
+//! [#12001](https://github.com/pnpm/pnpm/issues/12001) (fixed upstream
+//! in [#12040](https://github.com/pnpm/pnpm/pull/12040)): installing an
+//! *unrelated* package rewrites the lockfile while the tarball
+//! dependency is re-resolved, and its integrity must survive so the next
+//! `--frozen-lockfile` install doesn't fail closed.
+//!
+//! Reaching the [`TarballResolver`] requires a bare specifier whose URL
+//! does *not* start with the configured registry — a registry-host
 //! tarball URL is parsed by the npm resolver instead (see
-//! `parse_bare_specifier`), so it carries the registry's integrity from
-//! metadata and never exercises the reuse path [#12001] is about.
-//!
-//! Pacquet doesn't support remote (non-registry) https-tarball *direct
-//! dependencies* end to end yet, so the scenario below is a
-//! [`known_failures`] entry. See that module for the exact gap.
-//!
-//! [#12001]: https://github.com/pnpm/pnpm/issues/12001
+//! `parse_bare_specifier`) and carries the registry's integrity from
+//! metadata. The test points at the loopback registry via `localhost`
+//! while it's configured as `127.0.0.1` so the URL prefix doesn't match.
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use known_failures::external_tarball_dependency_unsupported;
-use pacquet_testing_utils::{
-    allow_known_failure,
-    bin::{AddMockedRegistry, CommandTempCwd},
-};
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
-/// The `integrity:` recorded for a `packages:` entry, e.g.
-/// `is-positive@1.0.0`. `None` when the entry is absent or carries no
-/// integrity (the [#12001](https://github.com/pnpm/pnpm/issues/12001) regression).
+/// The `integrity:` recorded for a `packages:` entry keyed by
+/// `package_key` (e.g. `is-positive@<tarball-url>`). `None` when the
+/// entry is absent or carries no integrity (the #12001 regression).
 fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
-    let header = format!("{package_key}:");
+    // The `packages:` key for a tarball-URL dep contains `://` and a
+    // `:port`, which the YAML emitter wraps in double quotes; the lookup
+    // tolerates either the quoted or bare form.
+    let is_header = |line: &str| {
+        let trimmed = line.trim().trim_end_matches(':');
+        trimmed == package_key || trimmed.trim_matches('"') == package_key
+    };
     lockfile
         .lines()
-        .skip_while(|line| line.trim() != header)
+        .skip_while(|line| !is_header(line))
         .take_while(|line| !line.trim_start().starts_with("snapshots:"))
         .find_map(|line| line.trim().strip_prefix("integrity:").map(|rest| rest.trim().to_string()))
 }
@@ -52,20 +53,24 @@ fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
 /// `--frozen-lockfile` install still succeeds.
 #[test]
 fn remote_tarball_integrity_survives_unrelated_install() {
-    allow_known_failure!(external_tarball_dependency_unsupported());
-
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
-    // The registry is `http://localhost:PORT/`; pointing at the same
-    // loopback server via `127.0.0.1` keeps the URL from matching the
-    // registry prefix, so the TarballResolver — not the npm resolver —
-    // claims it. The tarball is still downloadable from that server.
+    // The mocked registry is `http://127.0.0.1:PORT/`; pointing at the
+    // same loopback server via `localhost` keeps the URL from matching
+    // the registry prefix, so the TarballResolver — not the npm resolver
+    // — claims it. `localhost` resolves to 127.0.0.1, so the tarball is
+    // still downloadable from that server.
     let tarball = format!(
         "{}is-positive/-/is-positive-1.0.0.tgz",
-        mock_instance.url().replace("localhost", "127.0.0.1"),
+        mock_instance.url().replace("127.0.0.1", "localhost"),
     );
+    // A non-registry tarball is keyed by `name@<url>` (the version lives
+    // in `resolution.tarball` + the `version:` field), not `name@1.0.0`.
+    // Mirrors pnpm — see `installing/deps-installer/test/lockfile.ts`
+    // ("packages installed via tarball URL ... are normalized").
+    let package_key = format!("is-positive@{tarball}");
     let manifest_path = workspace.join("package.json");
     let lockfile_path = workspace.join("pnpm-lock.yaml");
 
@@ -77,12 +82,12 @@ fn remote_tarball_integrity_survives_unrelated_install() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
-    let integrity = package_integrity(&lockfile, "is-positive@1.0.0").unwrap_or_else(|| {
+    let integrity = package_integrity(&lockfile, &package_key).unwrap_or_else(|| {
         panic!("the fresh install must record an integrity for the tarball dep:\n{lockfile}")
     });
 
     // Install an unrelated package. This rewrites the lockfile while the
-    // tarball dependency is reused — the exact <https://github.com/pnpm/pnpm/issues/12001> trigger.
+    // tarball dependency is re-resolved — the exact #12001 trigger.
     fs::write(
         &manifest_path,
         serde_json::json!({
@@ -99,41 +104,14 @@ fn remote_tarball_integrity_survives_unrelated_install() {
         "the unrelated dependency must be recorded:\n{lockfile}",
     );
     assert_eq!(
-        package_integrity(&lockfile, "is-positive@1.0.0").as_deref(),
+        package_integrity(&lockfile, &package_key).as_deref(),
         Some(integrity.as_str()),
         "the tarball dependency's integrity must be preserved verbatim:\n{lockfile}",
     );
 
-    // The frozen install is the symptom <https://github.com/pnpm/pnpm/issues/12001> reports: it fails closed
+    // The frozen install is the symptom #12001 reports: it fails closed
     // when the tarball entry has lost its integrity.
     pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, mock_instance));
-}
-
-mod known_failures {
-    //! Subject-under-test not built yet, stubbed through
-    //! [`pacquet_testing_utils::allow_known_failure`] so the port exits
-    //! early instead of masking a real bug.
-
-    use pacquet_testing_utils::known_failure::{KnownFailure, KnownResult};
-
-    /// A remote, non-registry https-tarball *direct dependency* (e.g.
-    /// `https://cdn.example.com/foo-1.0.0.tgz`) cannot be installed yet:
-    /// `TarballResolver` returns no `name_ver` (the name/version live in
-    /// the tarball's manifest, which pacquet doesn't fetch during
-    /// resolution), so `dependencies_graph_to_lockfile` panics with
-    /// `MissingSuffix` building the importer dep path. Until the
-    /// resolve-time tarball-manifest fetch (and the integrity it
-    /// computes) lands, pnpm [#12001]'s integrity-preservation-on-reuse
-    /// isn't reachable here. Registry-host tarball URLs take the npm
-    /// resolver path instead and already carry integrity from metadata.
-    /// Tracked in <https://github.com/pnpm/pnpm/issues/12053>.
-    ///
-    /// [#12001]: https://github.com/pnpm/pnpm/issues/12001
-    pub fn external_tarball_dependency_unsupported() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "remote non-registry https-tarball direct dependencies are unsupported",
-        ))
-    }
 }

--- a/pacquet/crates/cli/tests/tarball_url_dependency.rs
+++ b/pacquet/crates/cli/tests/tarball_url_dependency.rs
@@ -42,10 +42,20 @@ fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
         let trimmed = line.trim().trim_end_matches(':');
         trimmed == package_key || trimmed.trim_matches('"') == package_key
     };
-    lockfile
-        .lines()
-        .skip_while(|line| !is_header(line))
-        .take_while(|line| !line.trim_start().starts_with("snapshots:"))
+    let mut lines = lockfile.lines().skip_while(|line| !is_header(line));
+    let header = lines.next()?;
+    let header_indent = header.len() - header.trim_start().len();
+
+    // Stop at the next sibling entry (a key at the header's indent or
+    // shallower, e.g. the next `packages:` member or `snapshots:`) so a
+    // tarball entry that lost its own `integrity:` can't borrow another
+    // package's.
+    lines
+        .take_while(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with("snapshots:")
+                && (!trimmed.ends_with(':') || (line.len() - trimmed.len()) > header_indent)
+        })
         .find_map(|line| line.trim().strip_prefix("integrity:").map(|rest| rest.trim().to_string()))
 }
 

--- a/pacquet/crates/cli/tests/tarball_url_dependency.rs
+++ b/pacquet/crates/cli/tests/tarball_url_dependency.rs
@@ -32,7 +32,8 @@ fn pacquet_at(workspace: &Path) -> Command {
 
 /// The `integrity:` recorded for a `packages:` entry keyed by
 /// `package_key` (e.g. `is-positive@<tarball-url>`). `None` when the
-/// entry is absent or carries no integrity (the #12001 regression).
+/// entry is absent or carries no integrity (the
+/// <https://github.com/pnpm/pnpm/issues/12001> regression).
 fn package_integrity(lockfile: &str, package_key: &str) -> Option<String> {
     // The `packages:` key for a tarball-URL dep contains `://` and a
     // `:port`, which the YAML emitter wraps in double quotes; the lookup
@@ -87,7 +88,8 @@ fn remote_tarball_integrity_survives_unrelated_install() {
     });
 
     // Install an unrelated package. This rewrites the lockfile while the
-    // tarball dependency is re-resolved — the exact #12001 trigger.
+    // tarball dependency is re-resolved — the exact
+    // <https://github.com/pnpm/pnpm/issues/12001> trigger.
     fs::write(
         &manifest_path,
         serde_json::json!({
@@ -109,8 +111,9 @@ fn remote_tarball_integrity_survives_unrelated_install() {
         "the tarball dependency's integrity must be preserved verbatim:\n{lockfile}",
     );
 
-    // The frozen install is the symptom #12001 reports: it fails closed
-    // when the tarball entry has lost its integrity.
+    // The frozen install is the symptom
+    // <https://github.com/pnpm/pnpm/issues/12001> reports: it fails
+    // closed when the tarball entry has lost its integrity.
     pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, mock_instance));

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -344,7 +344,8 @@ fn real_name(result: &ResolveResult) -> Option<String> {
     // matching pnpm's `depPathToRef`. Other manifest-only resolutions
     // (`file:` / git) are deliberately left to the `None` path so their
     // importer entries keep pacquet's current prefixed shape — bringing
-    // those in line with `depPathToRef` is separate from #12053.
+    // those in line with `depPathToRef` is separate from
+    // <https://github.com/pnpm/pnpm/issues/12053>.
     let LockfileResolution::Tarball(tarball) = &result.resolution else {
         return None;
     };
@@ -355,8 +356,9 @@ fn real_name(result: &ResolveResult) -> Option<String> {
 }
 
 /// `true` for an `http(s)://` tarball URL — the remote tarball deps
-/// #12053 covers. Excludes `file:` tarballs and registry-reconstructed
-/// resolutions that carry no URL.
+/// covered by <https://github.com/pnpm/pnpm/issues/12053>. Excludes
+/// `file:` tarballs and registry-reconstructed resolutions that carry
+/// no URL.
 fn is_remote_http_tarball(tarball: &str) -> bool {
     tarball.starts_with("http:") || tarball.starts_with("https:")
 }

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -14,9 +14,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use pacquet_lockfile::{
-    ComVer, ImporterDepVersion, Lockfile, LockfileSettings, LockfileVersion, PackageKey,
-    PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
-    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
+    ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings, LockfileVersion,
+    PackageKey, PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer,
+    ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -334,7 +334,31 @@ fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDe
 /// uses in the resolve-peers walker — and the same shape the
 /// `name_ver` field carries upstream.
 fn real_name(result: &ResolveResult) -> Option<String> {
-    Some(result.name_ver.as_ref()?.name.to_string())
+    if let Some(name_ver) = result.name_ver.as_ref() {
+        return Some(name_ver.name.to_string());
+    }
+    // A remote (non-registry, non-git) http(s) tarball direct dep leaves
+    // `name_ver` unset and carries its name in the fetched manifest.
+    // Reading it lets `importer_dep_version` strip the `name@` prefix off
+    // the depPath so the importer records just the URL (`version: <url>`),
+    // matching pnpm's `depPathToRef`. Other manifest-only resolutions
+    // (`file:` / git) are deliberately left to the `None` path so their
+    // importer entries keep pacquet's current prefixed shape — bringing
+    // those in line with `depPathToRef` is separate from #12053.
+    let LockfileResolution::Tarball(tarball) = &result.resolution else {
+        return None;
+    };
+    if tarball.git_hosted == Some(true) || !is_remote_http_tarball(&tarball.tarball) {
+        return None;
+    }
+    result.manifest.as_ref()?.get("name")?.as_str().map(str::to_string)
+}
+
+/// `true` for an `http(s)://` tarball URL — the remote tarball deps
+/// #12053 covers. Excludes `file:` tarballs and registry-reconstructed
+/// resolutions that carry no URL.
+fn is_remote_http_tarball(tarball: &str) -> bool {
+    tarball.starts_with("http:") || tarball.starts_with("https:")
 }
 
 /// Walk the depPath-keyed [`DependenciesGraph`] and emit the matching

--- a/pacquet/crates/package-manager/src/install_package_from_registry.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry.rs
@@ -125,17 +125,15 @@ impl<'a> InstallPackageFromRegistry<'a> {
             first_visit,
         } = self;
 
-        let name_ver = resolution.name_ver.as_ref().ok_or_else(|| {
+        let (real_name, version) = real_name_version(resolution).ok_or_else(|| {
             InstallPackageFromRegistryError::UnsupportedResolution {
                 detail: format!(
                     "resolver {resolved_via} produced a resolution without a structured \
-                     name@version; the npm install path needs both (alias={alias})",
+                     name@version and no manifest name/version to fall back to (alias={alias})",
                     resolved_via = resolution.resolved_via,
                 ),
             }
         })?;
-        let real_name = name_ver.name.to_string();
-        let version = name_ver.suffix.to_string();
         let package_id = format!("{real_name}@{version}");
 
         // The exposed symlink under `node_modules/` uses the manifest
@@ -221,6 +219,23 @@ impl<'a> InstallPackageFromRegistry<'a> {
 
         Ok(())
     }
+}
+
+/// The package's canonical `(name, version)`. Prefers the resolver's
+/// structured `name_ver` (npm registry); falls back to the name/version
+/// read from the fetched manifest for resolvers that learn them only
+/// after the fetch — remote (non-registry) tarball, git, and file deps,
+/// whose name/version live in `package.json`. Mirrors pnpm's
+/// [`getManifestFromResponse`](https://github.com/pnpm/pnpm/blob/df990fdb51/installing/deps-resolver/src/resolveDependencies.ts)
+/// fallback.
+fn real_name_version(resolution: &ResolveResult) -> Option<(String, String)> {
+    if let Some(name_ver) = resolution.name_ver.as_ref() {
+        return Some((name_ver.name.to_string(), name_ver.suffix.to_string()));
+    }
+    let manifest = resolution.manifest.as_deref()?;
+    let name = manifest.get("name")?.as_str()?.to_string();
+    let version = manifest.get("version")?.as_str()?.to_string();
+    Some((name, version))
 }
 
 /// Pull the tarball URL + integrity hash out of the resolver-produced

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -860,12 +860,18 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             // were written, mirroring the drain at the tail of the
             // materializing path.
             drop(store_index_writer);
-            if let Err(error) = writer_task.await {
-                tracing::warn!(
+            match writer_task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => tracing::warn!(
                     target: "pacquet::install",
                     ?error,
-                    "store-index writer task failed during a lockfile-only install",
-                );
+                    "store-index writer task returned an error during a lockfile-only install",
+                ),
+                Err(error) => tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "store-index writer task panicked during a lockfile-only install",
+                ),
             }
 
             Reporter::emit(&LogEvent::Stage(StageLog {

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -34,7 +34,7 @@ use pacquet_resolving_npm_resolver::{
 use pacquet_resolving_resolver_base::{
     LatestQuery, ResolveFuture, ResolveLatestFuture, ResolveOptions, Resolver, WantedDependency,
 };
-use pacquet_resolving_tarball_resolver::TarballResolver;
+use pacquet_resolving_tarball_resolver::{TarballFetchContext, TarballResolver};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
 use pacquet_tarball::MemCache;
 use std::{
@@ -451,6 +451,36 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // every occurrence of a shared dep in the tree.
         let picked_manifest_cache = shared_picked_manifest_cache();
 
+        // Open the read-only SQLite index, spawn the batched writer, and
+        // allocate the install-scoped `verifiedFilesCache` *before* the
+        // resolver chain is built. Both the `TarballResolver` (which
+        // fetches a remote tarball direct dep during resolution to learn
+        // its name/version/integrity) and the [`PrefetchingResolver`]
+        // need these at construction time so the store-index / writer /
+        // verify cache they touch is the same one the install pass uses
+        // once resolution is done. Mirrors pnpm's `packageRequester`
+        // shape: the fetch begins as soon as the resolver returns,
+        // before any further tree walk.
+        let store_index =
+            match tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
+                .await
+            {
+                Ok(store_index) => store_index,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        ?error,
+                        "store-index open task failed; continuing without a shared cache index",
+                    );
+                    None
+                }
+            };
+        let store_index_ref = store_index.as_ref();
+
+        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
+
+        let verified_files_cache = SharedVerifiedFilesCache::default();
+
         let npm_resolver: Arc<dyn Resolver> = Arc::new(NpmResolver {
             registries,
             named_registries: merged_named_registries.clone(),
@@ -476,7 +506,25 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
             Arc::new(RealGitRunner::new()),
         );
-        let tarball_resolver = TarballResolver { http_client: Arc::clone(&http_client_arc) };
+        // A remote (non-registry) tarball *direct* dependency carries no
+        // name/version/integrity at resolve time — they live in the
+        // tarball's `package.json`. The resolver downloads + extracts it
+        // here (warming `tarball_mem_cache` keyed by URL) so the lockfile
+        // builder gets the manifest + integrity and the install pass
+        // reuses the extraction without a second download. Wired in both
+        // the materializing and `--lockfile-only` paths: the lockfile
+        // needs the integrity regardless of whether `node_modules` is
+        // built.
+        let tarball_resolver = TarballResolver {
+            http_client: Arc::clone(&http_client_arc),
+            fetch_context: Some(TarballFetchContext {
+                store_dir,
+                store_index_writer: Some(Arc::clone(&store_index_writer)),
+                mem_cache: Some(Arc::clone(&tarball_mem_cache)),
+                auth_headers: Arc::clone(&config.auth_headers),
+                retry_opts: crate::retry_config::retry_opts_from_config(config),
+            }),
+        };
         // `preserveAbsolutePaths` is wired through `Config`; thread the
         // current value into the local-resolver context so absolute
         // `file:` / `link:` specs round-trip the same shape upstream
@@ -528,36 +576,6 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             Box::new(named_registry_resolver),
             Box::new(local_path_resolver),
         ]));
-
-        // Open the read-only SQLite index, spawn the batched writer,
-        // and allocate the install-scoped `verifiedFilesCache` *before*
-        // the resolver chain runs. These were originally opened after
-        // `resolve_importer` returned, but the
-        // [`PrefetchingResolver`] needs them at construction time so
-        // the per-resolve `tokio::spawn`ed [`DownloadTarballToStore`]
-        // shares the same store-index / writer / verify cache as the
-        // install pass that runs once resolution is done. Mirrors
-        // pnpm's `packageRequester` shape: the fetch begins as soon as
-        // the resolver returns, before any further tree walk.
-        let store_index =
-            match tokio::task::spawn_blocking(move || StoreIndex::shared_readonly_in(store_dir))
-                .await
-            {
-                Ok(store_index) => store_index,
-                Err(error) => {
-                    tracing::warn!(
-                        target: "pacquet::install",
-                        ?error,
-                        "store-index open task failed; continuing without a shared cache index",
-                    );
-                    None
-                }
-            };
-        let store_index_ref = store_index.as_ref();
-
-        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(store_dir);
-
-        let verified_files_cache = SharedVerifiedFilesCache::default();
 
         // Wrap the resolver chain so each tarball-shaped result fires a
         // background download into `tarball_mem_cache` while the
@@ -1304,12 +1322,13 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
 /// batch hits the same rows pnpm or pacquet wrote on the prior
 /// install.
 ///
-/// Skips nodes whose resolver result isn't a tarball with both
-/// `integrity` and a structured `name@version`: git-hosted tarballs
-/// and directory / git / binary resolutions use a different key
-/// shape (`pkg_id`-only) and route through the cold path. Today's
-/// `install_subtree` only handles tarball+integrity anyway, so the
-/// skipped entries can't be served from the prefetch either way.
+/// Skips nodes whose resolver result isn't a non-git-hosted tarball
+/// with an `integrity` and a resolvable `name@version` (from `name_ver`
+/// or, for remote-tarball direct deps, the fetched manifest):
+/// git-hosted tarballs and directory / git / binary resolutions use a
+/// different key shape (`pkg_id`-only) and route through the cold path.
+/// Today's `install_subtree` only handles tarball+integrity anyway, so
+/// the skipped entries can't be served from the prefetch either way.
 fn collect_prefetch_cache_keys_from_graph(
     graph: &pacquet_resolving_deps_resolver::DependenciesGraph,
 ) -> Vec<String> {
@@ -1325,8 +1344,19 @@ fn collect_prefetch_cache_keys_from_graph(
                 return None;
             }
             let integrity = tarball.integrity.as_ref()?.to_string();
-            let name_ver = node.resolve_result.name_ver.as_ref()?;
-            let pkg_id = format!("{}@{}", name_ver.name, name_ver.suffix);
+            // `name_ver` when the resolver produced one (npm registry);
+            // otherwise the manifest's `name@version` — remote-tarball
+            // direct deps learn both from `package.json`, and the
+            // resolve-time fetch keyed the store-index row the same way.
+            let pkg_id = match node.resolve_result.name_ver.as_ref() {
+                Some(name_ver) => format!("{}@{}", name_ver.name, name_ver.suffix),
+                None => {
+                    let manifest = node.resolve_result.manifest.as_deref()?;
+                    let name = manifest.get("name")?.as_str()?;
+                    let version = manifest.get("version")?.as_str()?;
+                    format!("{name}@{version}")
+                }
+            };
             Some(pacquet_store_dir::store_index_key(&integrity, &pkg_id))
         })
         .collect();

--- a/pacquet/crates/resolving-tarball-resolver/Cargo.toml
+++ b/pacquet/crates/resolving-tarball-resolver/Cargo.toml
@@ -13,9 +13,14 @@ repository.workspace  = true
 [dependencies]
 pacquet-lockfile                = { workspace = true }
 pacquet-network                 = { workspace = true }
+pacquet-reporter                = { workspace = true }
 pacquet-resolving-resolver-base = { workspace = true }
+pacquet-store-dir               = { workspace = true }
+pacquet-tarball                 = { workspace = true }
 
-reqwest = { workspace = true }
+reqwest    = { workspace = true }
+serde_json = { workspace = true }
+ssri       = { workspace = true }
 
 [dev-dependencies]
 mockito           = { workspace = true }

--- a/pacquet/crates/resolving-tarball-resolver/src/lib.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/lib.rs
@@ -16,11 +16,18 @@
 //!   keep the original URL so subsequent installs revalidate the
 //!   moving target.
 //!
-//! The resolver doesn't compute or stamp `integrity` — that work
-//! happens later in the package-requester after the tarball is
-//! downloaded. See pnpm's
+//! Unlike pnpm — which defers the tarball download (and thus the
+//! manifest read + integrity computation) to the package-requester
+//! after resolution — pacquet builds the lockfile *before* the
+//! install/fetch pass, so for a remote (non-registry) tarball *direct*
+//! dependency the resolver must learn name/version/integrity here.
+//! When a [`TarballFetchContext`] is supplied, the resolver downloads
+//! the tarball, computes its sha512 integrity, extracts it to the
+//! store, and reads its bundled manifest, warming the shared mem cache
+//! so the install pass reuses the extraction without re-downloading.
+//! See pnpm's
 //! [`packageRequester.ts`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/installing/package-requester/src/packageRequester.ts).
 
 mod tarball_resolver;
 
-pub use tarball_resolver::TarballResolver;
+pub use tarball_resolver::{TarballFetchContext, TarballResolver};

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -6,19 +6,48 @@
 use std::sync::Arc;
 
 use pacquet_lockfile::{LockfileResolution, TarballResolution};
-use pacquet_network::ThrottledClient;
+use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_reporter::SilentReporter;
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, PkgResolutionId, ResolveError, ResolveFuture, ResolveLatestFuture,
     ResolveOptions, ResolveResult, Resolver, WantedDependency,
 };
+use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+use pacquet_tarball::{FetchTarballForResolution, MemCache, RetryOpts};
+use ssri::Integrity;
+
+/// Store/network handles the [`TarballResolver`] needs to fetch a
+/// remote tarball during resolution — download it, compute its sha512
+/// integrity, extract it to the store, and read its bundled manifest.
+///
+/// The install orchestrator owns these and hands the resolver a clone;
+/// `mem_cache` (when present) is warmed keyed by URL so the install
+/// pass reuses the extraction without re-downloading. Absent only in
+/// unit tests that exercise the HEAD/normalize/redirect logic in
+/// isolation — see [`TarballResolver`].
+pub struct TarballFetchContext {
+    pub store_dir: &'static StoreDir,
+    pub store_index_writer: Option<Arc<StoreIndexWriter>>,
+    pub mem_cache: Option<Arc<MemCache>>,
+    pub auth_headers: Arc<AuthHeaders>,
+    pub retry_opts: RetryOpts,
+}
 
 /// Resolves `http://...` / `https://...` tarball URLs from a project's
 /// manifest. One instance per install — the throttled HTTP client is
 /// shared with the rest of the install pipeline so the HEAD
 /// pre-flight respects the same concurrency cap as metadata fetches
 /// and tarball downloads.
+///
+/// When `fetch_context` is `Some`, the resolver downloads the tarball
+/// during resolution to fill `manifest` + `integrity` into its
+/// [`ResolveResult`] — name/version/integrity for a remote tarball live
+/// in the tarball's `package.json`, and pacquet builds the lockfile
+/// before the install/fetch pass. `None` (unit tests only) keeps the
+/// HEAD-only shape with no manifest/integrity.
 pub struct TarballResolver {
     pub http_client: Arc<ThrottledClient>,
+    pub fetch_context: Option<TarballFetchContext>,
 }
 
 impl Resolver for TarballResolver {
@@ -80,19 +109,69 @@ impl TarballResolver {
             normalized_bare_specifier.clone()
         };
 
-        Ok(Some(ResolveResult {
+        // No store context (unit tests): keep the HEAD-only shape. The
+        // download below is what fills `manifest` + `integrity`; without
+        // a store to extract into there's nothing to fetch, so leave
+        // them unset.
+        let Some(ctx) = self.fetch_context.as_ref() else {
+            return Ok(Some(self.head_only_result(
+                wanted_dependency,
+                normalized_bare_specifier,
+                resolved_url,
+                None,
+                None,
+            )));
+        };
+
+        // Download the tarball, compute its sha512 integrity, extract it
+        // to the store, and read its bundled manifest. Warms `mem_cache`
+        // (keyed by `resolved_url`) so the install pass reuses the
+        // extraction. Silent reporter: the install pass owns the
+        // `resolved → found_in_store → imported` event ordering (see
+        // `prefetching_resolver.rs`).
+        let resolved = FetchTarballForResolution {
+            http_client: &self.http_client,
+            store_dir: ctx.store_dir,
+            store_index_writer: ctx.store_index_writer.clone(),
+            package_url: &resolved_url,
+            auth_headers: &ctx.auth_headers,
+            retry_opts: ctx.retry_opts,
+        }
+        .run::<SilentReporter>(ctx.mem_cache.as_deref())
+        .await
+        .map_err(|err| Box::new(err) as ResolveError)?;
+
+        Ok(Some(self.head_only_result(
+            wanted_dependency,
+            normalized_bare_specifier,
+            resolved_url,
+            Some(resolved.integrity),
+            resolved.manifest.map(Arc::new),
+        )))
+    }
+
+    /// Build the `ResolveResult` for a claimed http(s) tarball.
+    /// `name_ver` stays `None` (URL-id semantics: the depPath is
+    /// `name@<url>`, derived downstream from the manifest name);
+    /// `integrity` and `manifest` are filled once the tarball is
+    /// fetched.
+    fn head_only_result(
+        &self,
+        wanted_dependency: &WantedDependency,
+        normalized_bare_specifier: String,
+        resolved_url: String,
+        integrity: Option<Integrity>,
+        manifest: Option<Arc<serde_json::Value>>,
+    ) -> ResolveResult {
+        ResolveResult {
             id: PkgResolutionId::from(normalized_bare_specifier.clone()),
-            // Tarball URLs carry no `name@version` at resolve time —
-            // the canonical name/version come from the manifest after
-            // the tarball is fetched. Downstream consumers fall back
-            // to reading the manifest when `name_ver` is `None`.
             name_ver: None,
             latest: None,
             published_at: None,
-            manifest: None,
+            manifest,
             resolution: LockfileResolution::Tarball(TarballResolution {
                 tarball: resolved_url,
-                integrity: None,
+                integrity,
                 git_hosted: None,
                 path: None,
             }),
@@ -100,7 +179,7 @@ impl TarballResolver {
             normalized_bare_specifier: Some(normalized_bare_specifier),
             alias: wanted_dependency.alias.clone(),
             policy_violation: None,
-        }))
+        }
     }
 }
 

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -87,11 +87,18 @@ impl TarballResolver {
             reqwest::Url::parse(bare).map_err(|err| Box::new(err) as ResolveError)?.to_string();
 
         let client = self.http_client.acquire_for_url(&normalized_bare_specifier).await;
-        let response = client
-            .head(&normalized_bare_specifier)
-            .send()
-            .await
-            .map_err(|err| Box::new(err) as ResolveError)?;
+        let mut request = client.head(&normalized_bare_specifier);
+        // Authenticate the preflight the same way the resolve-time GET
+        // does (`auth_headers.for_url`), so a private tarball host isn't
+        // rejected here before `FetchTarballForResolution` runs.
+        if let Some(value) = self
+            .fetch_context
+            .as_ref()
+            .and_then(|ctx| ctx.auth_headers.for_url(&normalized_bare_specifier))
+        {
+            request = request.header("authorization", value);
+        }
+        let response = request.send().await.map_err(|err| Box::new(err) as ResolveError)?;
 
         // If the upstream marks the response immutable, store the
         // *post-redirect* URL so subsequent installs hit the

--- a/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver/tests.rs
+++ b/pacquet/crates/resolving-tarball-resolver/src/tarball_resolver/tests.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use crate::TarballResolver;
 
 fn build_resolver() -> TarballResolver {
-    TarballResolver { http_client: Arc::new(ThrottledClient::default()) }
+    TarballResolver { http_client: Arc::new(ThrottledClient::default()), fetch_context: None }
 }
 
 fn tarball_url(resolution: &LockfileResolution) -> &str {

--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -22,7 +22,7 @@ use pacquet_store_dir::{
 use pipe_trait::Pipe;
 use rayon::prelude::*;
 use smart_default::SmartDefault;
-use ssri::Integrity;
+use ssri::{Algorithm, Integrity, IntegrityOpts};
 use tar::Archive;
 use tokio::sync::{Notify, RwLock, Semaphore};
 use tracing::instrument;
@@ -1428,14 +1428,14 @@ fn is_transient_error(err: &TarballError) -> bool {
 async fn fetch_and_extract_once<Reporter: self::Reporter>(
     http_client: &ThrottledClient,
     package_url: &str,
-    package_integrity: &Integrity,
+    expected_integrity: Option<&Integrity>,
     package_unpacked_size: Option<usize>,
     package_id: &str,
     attempt: u32,
     store_dir: &'static StoreDir,
     auth_headers: &AuthHeaders,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
-) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
 
@@ -1625,13 +1625,29 @@ async fn fetch_and_extract_once<Reporter: self::Reporter>(
     // each tarball — on a 2-core runner only two tarballs could make
     // progress at a time. The post-download semaphore caps concurrency
     // here.
-    let package_integrity = package_integrity.clone();
+    let expected_integrity = expected_integrity.cloned();
     let package_url_owned = package_url.to_string();
     let result = tokio::task::spawn_blocking(
-        move || -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
-            package_integrity.check(&buffer).map_err(|error| {
-                TarballError::Checksum(VerifyChecksumError { url: package_url_owned, error })
-            })?;
+        move || -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+            // Verify a known integrity, or compute one when the hash
+            // isn't known until after download — remote (non-registry)
+            // https-tarball direct deps, where the resolver learns the
+            // integrity here. Mirrors pnpm's worker
+            // `integrity ?? calcIntegrity(buffer)`
+            // ([worker/src/start.ts](https://github.com/pnpm/pnpm/blob/086c5e91e8/worker/src/start.ts#L232)).
+            let integrity = match expected_integrity {
+                Some(expected) => {
+                    expected.check(&buffer).map_err(|error| {
+                        TarballError::Checksum(VerifyChecksumError { url: package_url_owned, error })
+                    })?;
+                    expected
+                }
+                None => {
+                    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha512);
+                    opts.input(&buffer);
+                    opts.result()
+                }
+            };
 
             // Extract in a scope so the decompressed buffer + `tar::Archive`
             // are released before we return — a large package's inflated
@@ -1642,7 +1658,7 @@ async fn fetch_and_extract_once<Reporter: self::Reporter>(
                     .pipe(Archive::new);
                 extract_tarball_entries(&mut archive, store_dir, ignore_file_pattern.as_deref())?
             };
-            Ok((cas_paths, pkg_files_idx))
+            Ok((integrity, cas_paths, pkg_files_idx))
         },
     )
     .await
@@ -1689,7 +1705,7 @@ fn emit_progress_found_in_store<Reporter: self::Reporter>(package_id: &str, requ
 async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
     http_client: &ThrottledClient,
     package_url: &str,
-    package_integrity: &Integrity,
+    expected_integrity: Option<&Integrity>,
     package_unpacked_size: Option<usize>,
     package_id: &str,
     requester: &str,
@@ -1697,13 +1713,13 @@ async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
     retry_opts: RetryOpts,
     auth_headers: &AuthHeaders,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
-) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let mut attempt: u32 = 0;
     loop {
         let result = fetch_and_extract_once::<Reporter>(
             http_client,
             package_url,
-            package_integrity,
+            expected_integrity,
             package_unpacked_size,
             package_id,
             attempt,
@@ -2076,19 +2092,20 @@ impl<'a> DownloadTarballToStore<'a> {
         // parsing recovers via re-fetch instead of aborting the install
         // (<https://github.com/pnpm/pacquet/issues/259>). Only HTTP 401 / 403 / 404 fail fast — see
         // [`is_transient_error`].
-        let (cas_paths, pkg_files_idx) = fetch_and_extract_with_retry::<Reporter>(
-            http_client,
-            package_url,
-            package_integrity,
-            package_unpacked_size,
-            package_id,
-            requester,
-            store_dir,
-            retry_opts,
-            auth_headers,
-            ignore_file_pattern,
-        )
-        .await?;
+        let (_computed_integrity, cas_paths, pkg_files_idx) =
+            fetch_and_extract_with_retry::<Reporter>(
+                http_client,
+                package_url,
+                Some(package_integrity),
+                package_unpacked_size,
+                package_id,
+                requester,
+                store_dir,
+                retry_opts,
+                auth_headers,
+                ignore_file_pattern,
+            )
+            .await?;
 
         // Hand the per-tarball files index off to the shared writer task
         // from <https://github.com/pnpm/pacquet/pull/265> *after* the retry loop returns, so transient failures
@@ -2112,6 +2129,108 @@ impl<'a> DownloadTarballToStore<'a> {
 
         Ok(cas_paths)
     }
+}
+
+/// Outcome of [`FetchTarballForResolution::run`]: the sha512 integrity
+/// computed from the downloaded tarball and the bundled manifest read
+/// from its `package.json`. The extracted CAFS paths are not returned —
+/// they are stashed in the shared [`MemCache`] keyed by URL so the
+/// install pass reuses them without re-downloading.
+#[derive(Debug)]
+pub struct ResolvedTarball {
+    pub integrity: Integrity,
+    pub manifest: Option<serde_json::Value>,
+}
+
+/// Download a remote tarball during *resolution*, compute its sha512
+/// integrity, extract it to the store, and read its bundled manifest.
+///
+/// Remote (non-registry) https-tarball direct dependencies carry no
+/// name/version/integrity at resolve time — those live in the tarball's
+/// `package.json`. pnpm learns them in `packageRequester` after the
+/// fetch; pacquet builds the lockfile before the install pass, so the
+/// `TarballResolver` must fetch here to fill `manifest` + `integrity`
+/// into its `ResolveResult`. Passing a `mem_cache` warms it (keyed by
+/// URL) so the install pass's
+/// [`DownloadTarballToStore::run_with_mem_cache`] reuses the extraction
+/// without a second download.
+pub struct FetchTarballForResolution<'a> {
+    pub http_client: &'a ThrottledClient,
+    pub store_dir: &'static StoreDir,
+    pub store_index_writer: Option<Arc<StoreIndexWriter>>,
+    pub package_url: &'a str,
+    pub auth_headers: &'a AuthHeaders,
+    pub retry_opts: RetryOpts,
+}
+
+impl FetchTarballForResolution<'_> {
+    pub async fn run<Reporter: self::Reporter>(
+        self,
+        mem_cache: Option<&MemCache>,
+    ) -> Result<ResolvedTarball, TarballError> {
+        let FetchTarballForResolution {
+            http_client,
+            store_dir,
+            store_index_writer,
+            package_url,
+            auth_headers,
+            retry_opts,
+        } = self;
+
+        // `None` expected-integrity → compute it from the bytes. The
+        // package_id / requester are the post-redirect URL: the real
+        // `name@version` is only known once the manifest is read below,
+        // and the resolve-time fetch is silent (the install pass owns
+        // the reporter ordering), so the placeholder never surfaces.
+        let (integrity, cas_paths, pkg_files_idx) = fetch_and_extract_with_retry::<Reporter>(
+            http_client,
+            package_url,
+            None,
+            None,
+            package_url,
+            package_url,
+            store_dir,
+            retry_opts,
+            auth_headers,
+            None,
+        )
+        .await?;
+
+        let manifest = pkg_files_idx.manifest.clone();
+        // Scope the store-index row by the package's canonical
+        // `name@version`, matching what the install pass derives from
+        // the same manifest. Fall back to the URL when the tarball has
+        // no usable `package.json` name (degraded, but keeps the row
+        // addressable).
+        let package_id =
+            manifest_package_id(manifest.as_ref()).unwrap_or_else(|| package_url.to_string());
+
+        let index_key = store_index_key(&integrity.to_string(), &package_id);
+        if let Some(writer) = store_index_writer {
+            writer.queue(index_key, pkg_files_idx);
+        } else {
+            tracing::warn!(
+                target: "pacquet::download",
+                ?index_key,
+                "no shared store-index writer; skipping index row for this resolve-time tarball",
+            );
+        }
+
+        if let Some(mem_cache) = mem_cache {
+            let cache_lock = Arc::new(RwLock::new(CacheValue::Available(Arc::new(cas_paths))));
+            mem_cache.insert(package_url.to_string(), cache_lock);
+        }
+
+        Ok(ResolvedTarball { integrity, manifest })
+    }
+}
+
+/// `name@version` from a bundled manifest, when both fields are present.
+fn manifest_package_id(manifest: Option<&serde_json::Value>) -> Option<String> {
+    let manifest = manifest?;
+    let name = manifest.get("name")?.as_str()?;
+    let version = manifest.get("version")?.as_str()?;
+    Some(format!("{name}@{version}"))
 }
 
 /// Run one full zip-archive fetch attempt: hit the network, drain the

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -1063,10 +1063,10 @@ async fn retries_then_succeeds_on_transient_5xx() {
     let client = ThrottledClient::default();
     let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
 
-    let (cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
+    let (_integrity, cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1114,7 +1114,7 @@ async fn retries_integrity_mismatch_until_exhausted() {
     let err = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1146,7 +1146,7 @@ async fn fails_fast_on_404() {
     let err = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1187,7 +1187,7 @@ async fn retries_other_4xx_codes() {
     let err = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1222,7 +1222,7 @@ async fn retry_exhaustion_returns_last_error() {
     let err = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1416,7 +1416,7 @@ async fn zero_retries_makes_a_single_attempt() {
     fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1458,10 +1458,10 @@ async fn fetch_attaches_authorization_header_when_creds_match_tarball_url() {
         None,
     );
 
-    let (cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
+    let (_integrity, cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1512,10 +1512,10 @@ async fn retry_re_attaches_authorization_header_on_each_attempt() {
         None,
     );
 
-    let (cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
+    let (_integrity, cas_paths, _idx) = fetch_and_extract_with_retry::<SilentReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",
@@ -1828,7 +1828,7 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
     fetch_and_extract_with_retry::<RecordingReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "@fastify/error@3.3.0",
         "",
@@ -1918,7 +1918,7 @@ async fn started_fires_for_connection_level_failures() {
     let _ = fetch_and_extract_with_retry::<RecordingReporter>(
         &client,
         "http://127.0.0.1:1/pkg.tgz", // port 1 is reserved → connect-refused
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "/proj",
@@ -2125,7 +2125,7 @@ async fn request_retry_event_fires_per_retried_attempt() {
     fetch_and_extract_with_retry::<RecordingReporter>(
         &client,
         &url,
-        &pkg_integrity,
+        Some(&pkg_integrity),
         None,
         "test-pkg",
         "",


### PR DESCRIPTION
## What

Implements end-to-end support in **pacquet** for remote (non-registry) `http(s)`-tarball **direct** dependencies — e.g. `"foo": "https://cdn.example.com/foo-1.0.0.tgz"`. Fixes #12053.

### The bug

A direct dependency whose specifier is a non-registry tarball URL panicked while building the lockfile:

```
dep paths produced by the resolver always parse as PkgNameVerPeer: MissingSuffix
  at pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
```

`TarballResolver` returned no `name`/`version`/`integrity` (those live in the tarball's `package.json`), so the dep path was just the URL (no `@`) and the importer-dep-path parse hit `MissingSuffix`. (A registry-host tarball URL is claimed by the npm resolver instead and was already fine.)

### The fix

pnpm learns name/version/integrity in the package-requester *after* the fetch, but pacquet builds the lockfile *before* the install pass. So the `TarballResolver` now fetches the tarball **during resolution**: it downloads, computes the sha512 integrity, extracts to the store, and reads the bundled manifest, warming the shared `MemCache` (keyed by URL) so the install pass reuses the extraction without a second download (one download total).

`name_ver` stays `None` so the depPath is `name@<url>` — matching pnpm (see `installing/deps-installer/test/lockfile.ts`, "packages installed via tarball URL … are normalized"). The `name_ver`-dependent call sites fall back to the manifest (mirroring pnpm's `getManifestFromResponse`).

### Changes (pacquet-only)

- **`crates/tarball`** — new public `FetchTarballForResolution` entry point that downloads + **computes** integrity (refactored the integrity step of `fetch_and_extract_once` to verify-or-compute), extracts to the store, reads the manifest, queues the store-index row, and warms `MemCache`.
- **`TarballResolver`** — fetches during resolution when given a `TarballFetchContext`; legacy HEAD-only shape when none (unit tests).
- **`install_with_fresh_lockfile.rs`** — store handles opened before resolver construction; context wired in.
- **Manifest fallbacks** where `name_ver` was required (`install_package_from_registry`, prefetch-key collector, and — scoped to remote http tarballs only — `real_name` in the lockfile builder, leaving `file:`/git deps untouched).
- **Flipped the gated regression test** `remote_tarball_integrity_survives_unrelated_install`. Its original premise was inverted: the test registry binds to `127.0.0.1`, so its `.replace("localhost", "127.0.0.1")` was a no-op and routed through the npm resolver — corrected so the tarball host is `localhost` (registry stays `127.0.0.1`) and `TarballResolver` is actually exercised.

### Verification

- The un-gated regression test passes end to end (fresh install records integrity under the `name@<url>` key → unrelated `add` preserves it verbatim → `--frozen-lockfile` succeeds). Confirmed it fails when the integrity is dropped.
- Full `pacquet-cli` (152) and `pacquet-package-manager` (370) suites pass.
- `cargo check` / `clippy -D warnings` / `fmt` / `taplo` / `cargo doc -D warnings` / `typos` / `dylint` all clean.

### Notes / out of scope

- **Issue item 3 (#12001/#12040 integrity-carry-over-on-reuse) is moot here:** pacquet re-resolves every dependency on every install (no lockfile-reuse fast path), so the tarball is re-fetched and its integrity recomputed each time — the unrelated-add + frozen steps pass on that basis. The carry-over guard becomes necessary only if/when a resolve-time reuse fast path lands.
- **Pre-existing, cross-cutting lockfile-emitter parity gaps** surfaced (not introduced here; they affect all url/git/file keys): pacquet omits the `version:` field on URL-keyed `packages:` entries, and its YAML emitter quotes keys containing `://`+`:port` (pnpm leaves them bare). Worth a follow-up.
- Under `--lockfile-only`, a remote tarball direct dep now writes CAS files to the store (the lockfile needs the integrity, which requires the download). Minor; possible follow-up.
- No changeset (pacquet-only, per repo convention).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote HTTPS tarball dependencies are fetched during resolution, compute integrity, and read bundled manifests.

* **Bug Fixes**
  * Integrity values for direct tarball URL dependencies are preserved verbatim in the lockfile across re-resolves.

* **Improvements**
  * Better frozen-lockfile install behavior and reuse of tarball fetch/cache across resolution and install for more reliable installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->