### PR TITLE
[wontfix] fix: allow dry-run to be read from .npmrc files

### DIFF
--- a/.changeset/dry-run-npmrc-read.md
+++ b/.changeset/dry-run-npmrc-read.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Allow `dry-run` to be read from `.npmrc` files so that `pnpm pack --dry-run` works when configured via project or user configuration [#12054](https://github.com/pnpm/pnpm/issues/12054).

--- a/config/reader/src/Config.ts
+++ b/config/reader/src/Config.ts
@@ -75,7 +75,7 @@ export interface Config extends OptionsFromRootManifest {
   filter: string[]
   filterProd: string[]
   authConfig: Record<string, any>, // eslint-disable-line
-  dryRun?: boolean // This option might be not supported ever
+  dryRun?: boolean // Supported for pack/publish and serve commands
   global?: boolean
   dir: string
   bin: string

--- a/config/reader/src/localConfig.ts
+++ b/config/reader/src/localConfig.ts
@@ -23,6 +23,18 @@ const NETWORK_INI_KEYS = [
   'strict-ssl',
 ]
 
+/**
+ * Feature-flag / behavioral keys that are safe to read from .npmrc.
+ * These are neither auth nor network — they change *how* a command runs
+ * without altering *where* packages come from or whether the operation
+ * succeeds. Keeping them behind `isNpmrcReadableKey` prevents accidental
+ * clobbering of CLI-only flags while still letting users set them in
+ * project-level or user-level .npmrc.
+ */
+const NPM_BEHAVIOR_INI_KEYS = [
+  'dry-run',
+]
+
 const RAW_AUTH_CFG_KEY_SUFFIXES = [
   ':ca',
   ':cafile',
@@ -195,7 +207,7 @@ export const isIniConfigKey = (key: string): boolean =>
  * for easier migration from npm, but are written to YAML config files).
  */
 export const isNpmrcReadableKey = (key: string): boolean =>
-  isIniConfigKey(key) || NETWORK_INI_KEYS.includes(key)
+  isIniConfigKey(key) || NETWORK_INI_KEYS.includes(key) || NPM_BEHAVIOR_INI_KEYS.includes(key)
 
 /**
  * Filter keys that are allowed to be read from an INI config file.


### PR DESCRIPTION
Allow `dry-run` to be read from `.npmrc` files so that `pnpm pack --dry-run` works when configured via project or user configuration.

Add `dry-run` to the `NPM_BEHAVIOR_INI_KEYS` allowlist in `localConfig.ts`, which already gates auth, registry, and network keys. A new array is introduced for behavioral/feature-flag keys that are neither auth nor network.

Fix the comment on `Config.dryRun` to reflect that the option is actually supported for `pack`/`publish` commands, not "not supported ever".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `dry-run` configuration can now be read from `.npmrc` files, enabling `pnpm pack --dry-run` to function correctly when configured via project or user `.npmrc` settings.

* **Documentation**
  * Updated configuration documentation to reflect `dry-run` support for pack, publish, and serve commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/pnpm/pull/12080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->