### PR TITLE
fix(deps-resolver): prefer locked peer contexts during resolution by default

### DIFF
--- a/.changeset/prefer-locked-peer-contexts.md
+++ b/.changeset/prefer-locked-peer-contexts.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": minor
+"pnpm": minor
+---
+
+Peer dependency resolution now reuses the peer contexts already recorded in the lockfile when those providers are still present in the dependency graph and still satisfy the peer ranges. This avoids unnecessary peer-context rewrites during lockfile regeneration. Current manifest choices remain authoritative: a newly added, explicitly updated, or aliased direct provider, a changed nested provider, or a locked version that no longer satisfies the range still takes precedence.

--- a/installing/deps-installer/test/install/peerDependencies.ts
+++ b/installing/deps-installer/test/install/peerDependencies.ts
@@ -2111,6 +2111,61 @@ test('dedupePeers: version-only peer suffixes without nested dep paths', async (
   expect(lockfile.settings.dedupePeers).toBe(true)
 })
 
+test('a newly added top-level peer provider wins over a locked context', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  const opts = testDefaults({ strictPeerDependencies: false })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/abc-parent-with-ab@1.0.0'],
+    opts
+  )
+  await addDependenciesToPackage(manifest, ['@pnpm.e2e/peer-c@2.0.0'], opts)
+
+  expect(project.readLockfile().importers['.']?.dependencies?.['@pnpm.e2e/abc-parent-with-ab'].version)
+    .toBe('1.0.0(@pnpm.e2e/peer-c@2.0.0)')
+})
+
+test('an explicitly updated top-level peer provider wins over a locked context', async () => {
+  const project = prepareEmpty()
+  const opts = testDefaults({ strictPeerDependencies: false })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/abc-parent-with-ab@1.0.0', '@pnpm.e2e/peer-c@1.0.0', '@pnpm.e2e/has-peer-c-in-deps@1.0.0'],
+    opts
+  )
+  await addDependenciesToPackage(manifest, ['@pnpm.e2e/peer-c@2.0.0'], opts)
+
+  expect(project.readLockfile().importers['.']?.dependencies?.['@pnpm.e2e/abc-parent-with-ab'].version)
+    .toBe('1.0.0(@pnpm.e2e/peer-c@2.0.0)')
+})
+
+test('compatible existing peer contexts survive writable lockfile regeneration', async () => {
+  await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  const opts = testDefaults({ strictPeerDependencies: false })
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage(
+    {},
+    ['@pnpm.e2e/abc-grand-parent-with-c', '@pnpm.e2e/peer-c@2.0.0'],
+    opts
+  )
+  const { updatedManifest: manifestWithBothContexts } = await addDependenciesToPackage(
+    manifest,
+    ['@pnpm.e2e/abc-parent-with-ab'],
+    opts
+  )
+  await addDependenciesToPackage(manifestWithBothContexts, ['is-positive@1.0.0'], opts)
+
+  expect(project.readLockfile().snapshots)
+    .toHaveProperty(['@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.0.0)'])
+  expect(project.readLockfile().snapshots)
+    .toHaveProperty(['@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@2.0.0)'])
+})
+
 // Covers https://github.com/pnpm/pnpm/issues/11070
 test('dedupePeers: workspace projects with different peer versions get different instances', async () => {
   await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })

--- a/installing/deps-resolver/src/index.ts
+++ b/installing/deps-resolver/src/index.ts
@@ -39,7 +39,7 @@ import { depPathToRef } from './depPathToRef.js'
 import { getCatalogSnapshots } from './getCatalogSnapshots.js'
 import { getWantedDependencies, type WantedDependency } from './getWantedDependencies.js'
 import type { NodeId } from './nextNodeId.js'
-import { createNodeIdForLinkedLocalPkg, type UpdateMatchingFunction } from './resolveDependencies.js'
+import { createNodeIdForLinkedLocalPkg, type DependenciesTree, type UpdateMatchingFunction } from './resolveDependencies.js'
 import {
   type Importer,
   type LinkedDependency,
@@ -73,7 +73,9 @@ export {
 
 interface ProjectToLink {
   binsDir: string
+  declaredDirectDependencies: Set<string>
   directNodeIdsByAlias: Map<string, NodeId>
+  explicitlyRequestedDirectDependencies: Set<string>
   id: ProjectId
   linkedDependencies: LinkedDependency[]
   manifest: ProjectManifest
@@ -245,7 +247,18 @@ export async function resolveDependencies (
 
     return {
       binsDir: project.binsDir,
+      declaredDirectDependencies: new Set([
+        ...Object.keys(project.manifest == null ? {} : getAllDependenciesFromManifest(project.manifest)),
+        ...project.wantedDependencies.flatMap(({ alias, isNew }) => isNew && alias != null ? [alias] : []),
+      ]),
       directNodeIdsByAlias: resolvedImporter.directNodeIdsByAlias,
+      explicitlyRequestedDirectDependencies: new Set(
+        project.wantedDependencies.flatMap(({ alias, bareSpecifier, isNew, prevSpecifier, updateSpec }) =>
+          alias != null && (isNew === true || updateSpec === true || (prevSpecifier != null && bareSpecifier !== prevSpecifier))
+            ? [alias]
+            : []
+        )
+      ),
       id: project.id,
       linkedDependencies: resolvedImporter.linkedDependencies,
       manifest: project.manifest,
@@ -255,11 +268,7 @@ export async function resolveDependencies (
     }
   }))
 
-  const {
-    dependenciesGraph,
-    dependenciesByProjectId,
-    peerDependencyIssuesByProjects,
-  } = await resolvePeers({
+  const peerResolutionOpts = {
     allPeerDepNames,
     dependenciesTree,
     dedupePeerDependents: opts.dedupePeerDependents,
@@ -273,7 +282,23 @@ export async function resolveDependencies (
     resolvedImporters,
     peersSuffixMaxLength: opts.peersSuffixMaxLength,
     workspaceProjectIds: new Set([...opts.allProjectIds, ...Object.keys(opts.wantedLockfile.importers)]),
-  })
+  }
+  const initiallyResolvedPeers = await resolvePeers(peerResolutionOpts)
+  // A second pass reuses the peer contexts already recorded in the lockfile so a
+  // writable install does not rewrite dependency instances whose locked provider
+  // is still valid and present. It can only differ from the first pass for nodes
+  // that carry a locked peer context, so it is skipped when none do (e.g. a fresh
+  // install) to avoid resolving peers twice for no benefit.
+  const {
+    dependenciesGraph,
+    dependenciesByProjectId,
+    peerDependencyIssuesByProjects,
+  } = treeHasLockedPeerContexts(dependenciesTree)
+    ? await resolvePeers({
+      ...peerResolutionOpts,
+      resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
+    })
+    : initiallyResolvedPeers
 
   const linkedDependenciesByProjectId: Record<string, LinkedDependency[]> = {}
   await Promise.all(projectsToResolve.map(async (project, index) => {
@@ -412,6 +437,13 @@ export async function resolveDependencies (
     wantedToBeSkippedPackageIds,
     resolutionPolicyViolations,
   }
+}
+
+function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedPackage>): boolean {
+  for (const node of dependenciesTree.values()) {
+    if (node.lockedPeerContext != null) return true
+  }
+  return false
 }
 
 function addDirectDependenciesToLockfile (

--- a/installing/deps-resolver/src/resolveDependencies.ts
+++ b/installing/deps-resolver/src/resolveDependencies.ts
@@ -92,6 +92,9 @@ export interface ChildrenMap {
 export type DependenciesTreeNode<T> = {
   children: (() => ChildrenMap) | ChildrenMap
   installable: boolean
+  dependencyNamesWhoseCurrentProviderMustWin?: Set<string>
+  lockedPeerContext?: LockedPeerContext
+  previousDepPath?: DepPath
 } & ({
   resolvedPackage: T & { name: string, version: string }
   depth: number
@@ -133,6 +136,8 @@ export interface PendingNode {
   resolvedPackage: ResolvedPackage
   depth: number
   installable: boolean
+  lockedPeerContext?: LockedPeerContext
+  previousDepPath?: DepPath
   parentIds: PkgResolutionId[]
 }
 
@@ -235,6 +240,8 @@ export interface PkgAddress extends PkgAddressOrLinkBase {
   missingPeersOfChildren?: MissingPeersOfChildren
   publishedAt?: string
   saveCatalogName?: string
+  lockedPeerContext?: LockedPeerContext
+  previousDepPath?: DepPath
 }
 
 export type PkgAddressOrLink = PkgAddress | LinkedDependency
@@ -279,7 +286,7 @@ export interface ResolvedPackage {
   }
 }
 
-type ParentPkg = Pick<PkgAddress, 'nodeId' | 'installable' | 'rootDir' | 'optional' | 'pkgId' | 'resolvedVia'>
+type ParentPkg = Pick<PkgAddress, 'nodeId' | 'installable' | 'rootDir' | 'optional' | 'pkgId' | 'resolvedVia' | 'lockedPeerContext' | 'previousDepPath'>
 
 export type ParentPkgAliases = Record<string, PkgAddress | true>
 
@@ -937,6 +944,10 @@ async function resolveDependenciesOfDependency (
     })
     return { resolveDependencyResult }
   }
+  if (update === false && extendedWantedDep.infoFromLockfile != null) {
+    resolveDependencyResult.previousDepPath = extendedWantedDep.infoFromLockfile.depPath
+    resolveDependencyResult.lockedPeerContext = extendedWantedDep.infoFromLockfile.lockedPeerContext
+  }
   if (!resolveDependencyResult.isNew) {
     return {
       resolveDependencyResult,
@@ -1078,6 +1089,16 @@ async function resolveChildren (
     }, {} as Record<string, NodeId>),
     depth: parentDepth,
     installable: parentPkg.installable,
+    dependencyNamesWhoseCurrentProviderMustWin: new Set(pkgAddresses
+      .filter((child) => {
+        const previousRef = dependencyLockfile?.dependencies?.[child.alias] ??
+          dependencyLockfile?.optionalDependencies?.[child.alias]
+        if (previousRef == null || child.isLinkedDependency) return true
+        return child.previousDepPath !== dp.refToRelative(previousRef, child.alias)
+      })
+      .map(({ alias }) => alias)),
+    lockedPeerContext: parentPkg.lockedPeerContext,
+    previousDepPath: parentPkg.previousDepPath,
     resolvedPackage: ctx.resolvedPkgsById[parentPkg.pkgId],
   })
   return resolvingPeers
@@ -1183,9 +1204,26 @@ function referenceSatisfiesWantedSpec (
   return semver.satisfies(version, wantedDep.bareSpecifier, true)
 }
 
+export interface LockedPeerContext {
+  [peerName: string]: DepPath
+}
+
+function getLockedPeerContext (dependencyLockfile: PackageSnapshot): LockedPeerContext | undefined {
+  if (dependencyLockfile.peerDependencies == null) return undefined
+  const lockedPeerContext: LockedPeerContext = {}
+  for (const peerName of Object.keys(dependencyLockfile.peerDependencies)) {
+    const ref = dependencyLockfile.dependencies?.[peerName] ?? dependencyLockfile.optionalDependencies?.[peerName]
+    const depPath = ref == null ? null : dp.refToRelative(ref, peerName)
+    if (depPath != null) lockedPeerContext[peerName] = depPath
+  }
+  return Object.keys(lockedPeerContext).length === 0 ? undefined : lockedPeerContext
+}
+
 type InfoFromLockfile = {
+  depPath: DepPath
   pkgId: PkgResolutionId
   dependencyLockfile?: PackageSnapshot
+  lockedPeerContext?: LockedPeerContext
   name?: string
   version?: string
   resolution?: Resolution
@@ -1215,6 +1253,7 @@ function getInfoFromLockfile (
   let dependencyLockfile = lockfile.packages?.[depPath]
 
   if (dependencyLockfile != null) {
+    const lockedPeerContext = getLockedPeerContext(dependencyLockfile)
     if ((dependencyLockfile.peerDependencies != null) && (dependencyLockfile.dependencies != null)) {
       // This is done to guarantee that the dependency will be relinked with the
       // up-to-date peer dependencies
@@ -1232,9 +1271,11 @@ function getInfoFromLockfile (
 
     const { name, version, nonSemverVersion } = nameVerFromPkgSnapshot(depPath, dependencyLockfile)
     return {
+      depPath,
       name,
       version,
       dependencyLockfile,
+      lockedPeerContext,
       pkgId: nonSemverVersion ?? (`${name}@${version}` as PkgResolutionId),
       // resolution may not exist if lockfile is broken, and an unexpected error will be thrown
       // if resolution does not exist, return undefined so it can be autofixed later
@@ -1243,6 +1284,7 @@ function getInfoFromLockfile (
   } else {
     const parsed = dp.parse(depPath)
     return {
+      depPath,
       pkgId: parsed.nonSemverVersion ?? (parsed.name && parsed.version ? `${parsed.name}@${parsed.version}` : depPath) as PkgResolutionId, // Does it make sense to set pkgId when we're not sure?
     }
   }
@@ -1257,6 +1299,7 @@ interface ResolveDependencyOptions {
     pkgId?: PkgResolutionId
     resolution?: Resolution
     dependencyLockfile?: PackageSnapshot
+    lockedPeerContext?: LockedPeerContext
   }
   preferredVersion?: string
   parentPkg: ParentPkg
@@ -1645,6 +1688,8 @@ async function resolveDependency (
         depth: options.currentDepth,
         parentIds: options.parentIds,
         installable,
+        lockedPeerContext: currentPkg.lockedPeerContext,
+        previousDepPath: currentPkg.depPath,
         nodeId,
         resolvedPackage: ctx.resolvedPkgsById[pkgResponse.body.id],
       })

--- a/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -312,6 +312,8 @@ export async function resolveDependencyTree<T> (
         ctx.childrenByParentId[pendingNode.resolvedPackage.id], pendingNode.depth + 1, pendingNode.installable),
       depth: pendingNode.depth,
       installable: pendingNode.installable,
+      lockedPeerContext: pendingNode.lockedPeerContext,
+      previousDepPath: pendingNode.previousDepPath,
       resolvedPackage: pendingNode.resolvedPackage,
     })
   }

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { createPeerDepGraphHash, depPathToFilename, type PeerId } from '@pnpm/deps.path'
+import { createPeerDepGraphHash, depPathToFilename, parseDepPath, type PeerId } from '@pnpm/deps.path'
 import type {
   DepPath,
   ParentPackages,
@@ -477,6 +477,19 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       const peerDependency = resolvedPackage.peerDependencies[peerName]
       if (peerNodeId == null || peerDependency == null) continue
       if (ctx.resolvedPeerProviderPaths?.get(peerNodeId) !== previousPeerDepPath) continue
+      // Only pin providers that have no peer context of their own. A provider
+      // whose locked depPath carries a peer suffix is itself context-dependent
+      // — and self-referential for cyclic peers — so reusing it can re-expand
+      // cyclic suffixes and break the deterministic resolution that
+      // https://github.com/pnpm/pnpm/issues/8155 established. Stable leaf
+      // providers are the ones worth pinning; anything else falls back to
+      // fresh resolution.
+      if (parseDepPath(previousPeerDepPath).peerDepGraphHash !== '') continue
+      // A provider that already resolved to a different path this pass no longer
+      // matches its locked context; pinning it would leave pathsByNodeId
+      // pointing at a depPath that was never added to the graph.
+      const currentPeerDepPath = ctx.pathsByNodeId.get(peerNodeId)
+      if (currentPeerDepPath != null && currentPeerDepPath !== previousPeerDepPath) continue
       if (hasCurrentPeerProviderThatMustWin(peerName, parentPkgs, ctx)) continue
       const lockedPeer = toPkgByName([{
         alias: peerName,

--- a/installing/deps-resolver/src/resolvePeers.ts
+++ b/installing/deps-resolver/src/resolvePeers.ts
@@ -69,6 +69,8 @@ export interface GenericDependenciesGraphWithResolvedChildren<T extends PartialR
 
 export interface ProjectToResolve {
   directNodeIdsByAlias: Map<string, NodeId>
+  declaredDirectDependencies?: Set<string>
+  explicitlyRequestedDirectDependencies?: Set<string>
   // only the top dependencies that were already installed
   // to avoid warnings about unresolved peer dependencies
   topParents: Array<{ name: string, version: string, alias?: string }>
@@ -93,24 +95,44 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     resolvedImporters: ResolvedImporters
     peersSuffixMaxLength: number
     workspaceProjectIds: Set<string>
+    resolvedPeerProviderPaths?: Map<NodeId, DepPath>
   }
 ): Promise<{
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<T>
   dependenciesByProjectId: DependenciesByProjectId
   peerDependencyIssuesByProjects: PeerDependencyIssuesByProjects
+  pathsByNodeId: Map<NodeId, DepPath>
 }> {
   const depGraph: GenericDependenciesGraph<T> = {}
   const pathsByNodeId = new Map<NodeId, DepPath>()
   const pathsByNodeIdPromises = new Map<NodeId, DeferredPromise<DepPath>>()
   const depPathsByPkgId = new Map<PkgIdWithPatchHash, Set<DepPath>>()
+  const nodeIdsByPreviousDepPath = opts.resolvedPeerProviderPaths == null
+    ? new Map<DepPath, NodeId>()
+    : getNodeIdsByPreviousDepPath(opts.dependenciesTree)
   const _createPkgsByName = createPkgsByName.bind(null, opts.dependenciesTree)
-  const rootPkgsByName = opts.resolvePeersFromWorkspaceRoot ? getRootPkgsByName(opts.dependenciesTree, opts.projects) : {}
+  const workspaceRootProject = opts.resolvePeersFromWorkspaceRoot && opts.projects.length > 1
+    ? opts.projects.find(({ id }) => id === '.')
+    : undefined
+  const rootPkgsByName = workspaceRootProject == null ? {} : _createPkgsByName(workspaceRootProject)
   const peerDependencyIssuesByProjects: PeerDependencyIssuesByProjects = {}
 
   const finishingList: FinishingResolutionPromise[] = []
   const peersCache = new Map<PkgIdWithPatchHash, PeersCacheItem[]>()
   const purePkgs = new Set<PkgIdWithPatchHash>()
-  for (const { directNodeIdsByAlias, topParents, rootDir, id } of opts.projects) {
+  for (const { directNodeIdsByAlias, declaredDirectDependencies, explicitlyRequestedDirectDependencies, topParents, rootDir, id } of opts.projects) {
+    const currentProviderSources: CurrentProviderSource[] = [{
+      directNodeIdsByAlias,
+      declaredDirectDependencies: declaredDirectDependencies ?? new Set(),
+      explicitlyRequestedDirectDependencies: explicitlyRequestedDirectDependencies ?? new Set(),
+    }]
+    if (workspaceRootProject != null && workspaceRootProject.id !== id) {
+      currentProviderSources.push({
+        directNodeIdsByAlias: workspaceRootProject.directNodeIdsByAlias,
+        declaredDirectDependencies: workspaceRootProject.declaredDirectDependencies ?? new Set(),
+        explicitlyRequestedDirectDependencies: workspaceRootProject.explicitlyRequestedDirectDependencies ?? new Set(),
+      })
+    }
     const peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'> = { bad: {}, missing: {} }
     const pkgsByName = Object.fromEntries(Object.entries({
       ...rootPkgsByName,
@@ -134,6 +156,9 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       pathsByNodeId,
       pathsByNodeIdPromises,
       depPathsByPkgId,
+      nodeIdsByPreviousDepPath,
+      resolvedPeerProviderPaths: opts.resolvedPeerProviderPaths,
+      currentProviderSources,
       peersCache,
       peerDependencyIssues,
       purePkgs,
@@ -199,6 +224,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     dependenciesGraph: depGraphWithResolvedChildren,
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
+    pathsByNodeId,
   }
 }
 
@@ -293,11 +319,6 @@ function isCompatibleAndHasMoreDeps<T extends PartialResolvedPackage> (
   return true
 }
 
-function getRootPkgsByName<T extends PartialResolvedPackage> (dependenciesTree: DependenciesTree<T>, projects: ProjectToResolve[]): ParentRefs {
-  const rootProject = projects.length > 1 ? projects.find(({ id }) => id === '.') : null
-  return rootProject == null ? {} : createPkgsByName(dependenciesTree, rootProject)
-}
-
 function createPkgsByName<T extends PartialResolvedPackage> (
   dependenciesTree: DependenciesTree<T>,
   { directNodeIdsByAlias, topParents }: {
@@ -356,6 +377,15 @@ interface ResolvePeersContext {
   pathsByNodeId: Map<NodeId, DepPath>
   pathsByNodeIdPromises: Map<NodeId, DeferredPromise<DepPath>>
   depPathsByPkgId?: Map<PkgIdWithPatchHash, Set<DepPath>>
+  nodeIdsByPreviousDepPath: Map<DepPath, NodeId>
+  resolvedPeerProviderPaths?: Map<NodeId, DepPath>
+  currentProviderSources: CurrentProviderSource[]
+}
+
+interface CurrentProviderSource {
+  directNodeIdsByAlias: Map<string, NodeId>
+  declaredDirectDependencies: Set<string>
+  explicitlyRequestedDirectDependencies: Set<string>
 }
 
 type CalculateDepPath = (cycles: string[][]) => Promise<void>
@@ -439,6 +469,27 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       } else {
         parentPkgs[newParentPkgName] = newParentPkg
       }
+    }
+  }
+  if (node.lockedPeerContext != null && ctx.resolvedPeerProviderPaths != null) {
+    for (const [peerName, previousPeerDepPath] of Object.entries(node.lockedPeerContext)) {
+      const peerNodeId = ctx.nodeIdsByPreviousDepPath.get(previousPeerDepPath)
+      const peerDependency = resolvedPackage.peerDependencies[peerName]
+      if (peerNodeId == null || peerDependency == null) continue
+      if (ctx.resolvedPeerProviderPaths?.get(peerNodeId) !== previousPeerDepPath) continue
+      if (hasCurrentPeerProviderThatMustWin(peerName, parentPkgs, ctx)) continue
+      const lockedPeer = toPkgByName([{
+        alias: peerName,
+        node: ctx.dependenciesTree.get(peerNodeId)!,
+        nodeId: peerNodeId,
+        parentNodeIds,
+      }])[peerName]
+      if (!semverUtils.satisfiesWithPrereleases(lockedPeer.version, peerDependency.version.replace(/^workspace:/, ''), true)) continue
+      const peerPathPromise = ctx.pathsByNodeIdPromises.get(peerNodeId) ?? pDefer<DepPath>()
+      ctx.pathsByNodeIdPromises.set(peerNodeId, peerPathPromise)
+      ctx.pathsByNodeId.set(peerNodeId, previousPeerDepPath)
+      peerPathPromise.resolve(previousPeerDepPath)
+      parentPkgs[peerName] = lockedPeer
     }
   }
   const hit = findHit(ctx, parentPkgs, resolvedPackage.pkgIdWithPatchHash)
@@ -642,6 +693,49 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       }
     }
   }
+}
+
+function getNodeIdsByPreviousDepPath<T> (dependenciesTree: DependenciesTree<T>): Map<DepPath, NodeId> {
+  const nodeIdsByPreviousDepPath = new Map<DepPath, NodeId>()
+  for (const [nodeId, node] of dependenciesTree.entries()) {
+    if (node.previousDepPath != null && !nodeIdsByPreviousDepPath.has(node.previousDepPath)) {
+      nodeIdsByPreviousDepPath.set(node.previousDepPath, nodeId)
+    }
+  }
+  return nodeIdsByPreviousDepPath
+}
+
+function hasCurrentPeerProviderThatMustWin<T extends PartialResolvedPackage> (
+  peerName: string,
+  parentPkgs: ParentRefs,
+  ctx: {
+    currentProviderSources: CurrentProviderSource[]
+    parentNodeIds: NodeId[]
+    dependenciesTree: DependenciesTree<T>
+  }
+): boolean {
+  const peerNodeId = parentPkgs[peerName]?.nodeId
+  if (peerNodeId == null) return false
+  for (const source of ctx.currentProviderSources) {
+    for (const [alias, directNodeId] of source.directNodeIdsByAlias) {
+      if (directNodeId === peerNodeId &&
+        (alias !== peerName ||
+          source.explicitlyRequestedDirectDependencies.has(alias) ||
+          (source.declaredDirectDependencies.has(alias) &&
+            ctx.dependenciesTree.get(peerNodeId)?.previousDepPath == null)
+        )) return true
+    }
+  }
+  for (const parentNodeId of ctx.parentNodeIds) {
+    const parentNode = ctx.dependenciesTree.get(parentNodeId)
+    if (parentNode == null) continue
+    const children = typeof parentNode.children === 'function' ? parentNode.children() : parentNode.children
+    parentNode.children = children
+    if ([...(parentNode.dependencyNamesWhoseCurrentProviderMustWin ?? [])].some((alias) =>
+      children[alias] === peerNodeId
+    )) return true
+  }
+  return false
 }
 
 interface PendingPeer {

--- a/installing/deps-resolver/test/resolvePeers.ts
+++ b/installing/deps-resolver/test/resolvePeers.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../../__typings__/index.d.ts" />
 import { beforeAll, describe, expect, it, test } from '@jest/globals'
 import type {
+  DepPath,
   PeerDependencyIssuesByProjects,
   PkgIdWithPatchHash,
   PkgResolutionId,
@@ -8,7 +9,7 @@ import type {
 } from '@pnpm/types'
 
 import type { NodeId } from '../lib/nextNodeId.js'
-import type { DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
+import type { ChildrenMap, DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
 import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers.js'
 
 test('resolve peer dependencies of cyclic dependencies', async () => {
@@ -673,6 +674,282 @@ test('resolve peer dependencies with npm aliases', async () => {
     'foo/1.0.0(bar/1.0.0)',
     'foo/2.0.0(bar/2.0.0)',
   ])
+})
+
+describe('locked peer provider preferences', () => {
+  const currentPeerNodeId = '>peer/1.0.0>' as NodeId
+  const retainedPeerNodeId = '>retainer/1.0.0>peer/2.0.0>' as NodeId
+  const retainerNodeId = '>retainer/1.0.0>' as NodeId
+  const wrapperNodeId = '>wrapper/1.0.0>' as NodeId
+  const consumerNodeId = '>wrapper/1.0.0>consumer/1.0.0>' as NodeId
+
+  const peer1Pkg = {
+    name: 'peer',
+    pkgIdWithPatchHash: 'peer/1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const peer2Pkg = {
+    name: 'peer',
+    pkgIdWithPatchHash: 'peer/2.0.0' as PkgIdWithPatchHash,
+    version: '2.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const wrapperPkg = {
+    name: 'wrapper',
+    pkgIdWithPatchHash: 'wrapper/1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const retainerPkg = {
+    name: 'retainer',
+    pkgIdWithPatchHash: 'retainer/1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const consumerPkg = {
+    name: 'consumer',
+    pkgIdWithPatchHash: 'consumer/1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      peer: { version: '>=1' },
+    },
+    id: '' as PkgResolutionId,
+  }
+
+  function createTree (
+    declaredPeerNodeId?: NodeId,
+    currentPeerWasPreviouslyLocked = true,
+    peerRange = '>=1'
+  ): Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>> {
+    const wrapperChildren: ChildrenMap = { consumer: consumerNodeId }
+    if (declaredPeerNodeId != null) wrapperChildren.peer = declaredPeerNodeId
+    return new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [currentPeerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: currentPeerWasPreviouslyLocked ? 'peer/1.0.0' as DepPath : undefined,
+        resolvedPackage: peer1Pkg,
+        depth: 0,
+      }],
+      [retainerNodeId, {
+        children: { peer: retainedPeerNodeId },
+        installable: true,
+        resolvedPackage: retainerPkg,
+        depth: 0,
+      }],
+      [retainedPeerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer/2.0.0' as DepPath,
+        resolvedPackage: peer2Pkg,
+        depth: 1,
+      }],
+      [wrapperNodeId, {
+        children: wrapperChildren,
+        dependencyNamesWhoseCurrentProviderMustWin: declaredPeerNodeId == null ? undefined : new Set(['peer']),
+        installable: true,
+        resolvedPackage: wrapperPkg,
+        depth: 0,
+      }],
+      [consumerNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer/2.0.0' as DepPath },
+        resolvedPackage: {
+          ...consumerPkg,
+          peerDependencies: {
+            peer: { version: peerRange },
+          },
+        },
+        depth: 1,
+      }],
+    ])
+  }
+
+  function options (
+    dependenciesTree: Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>,
+    directNodeIdsByAlias: Map<string, NodeId>,
+    declaredDirectDependencies: Set<string> = new Set(),
+    explicitlyRequestedDirectDependencies: Set<string> = new Set()
+  ) {
+    return {
+      allPeerDepNames: new Set(['peer']),
+      projects: [{
+        directNodeIdsByAlias,
+        declaredDirectDependencies,
+        explicitlyRequestedDirectDependencies,
+        topParents: [],
+        rootDir: '' as ProjectRootDir,
+        id: '',
+      }],
+      resolvedImporters: {},
+      dependenciesTree,
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set<string>(),
+    }
+  }
+
+  test('prefers a compatible locked provider that remains reachable in the current graph', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(initial.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+  })
+
+  test('does not replace a newly resolved nested peer provider', async () => {
+    const resolutionOpts = options(createTree(currentPeerNodeId), new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace a newly declared importer peer provider', async () => {
+    const resolutionOpts = options(createTree(undefined, false), new Map([
+      ['consumer', consumerNodeId],
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+    ]), new Set(['consumer', 'peer', 'retainer']))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace an explicitly updated importer peer provider that existed before', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['consumer', consumerNodeId],
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+    ]), new Set(['consumer', 'peer', 'retainer']), new Set(['peer']))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace an explicitly requested importer provider for a nested consumer', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]), new Set(['peer', 'retainer', 'wrapper']), new Set(['peer']))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace an explicitly requested workspace root provider', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['consumer', consumerNodeId],
+      ['retainer', retainerNodeId],
+    ]))
+    resolutionOpts.projects.unshift({
+      directNodeIdsByAlias: new Map([['peer', currentPeerNodeId]]),
+      declaredDirectDependencies: new Set(['peer']),
+      explicitlyRequestedDirectDependencies: new Set(['peer']),
+      topParents: [],
+      rootDir: '' as ProjectRootDir,
+      id: '.',
+    })
+    const initial = await resolvePeers({
+      ...resolutionOpts,
+      resolvePeersFromWorkspaceRoot: true,
+    })
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvePeersFromWorkspaceRoot: true,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace an explicitly requested importer peer provider installed by alias', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer-alias', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]), new Set(['peer-alias', 'retainer', 'wrapper']), new Set(['peer-alias']))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not replace an existing importer peer provider installed by alias', async () => {
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer-alias', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]), new Set(['peer-alias', 'retainer', 'wrapper']))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('does not reuse a locked provider outside the current peer range', async () => {
+    const resolutionOpts = options(createTree(undefined, true, '^1.0.0'), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const preferred = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
+    expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
 })
 
 describe('dedupePeers', () => {

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -756,3 +756,93 @@ fn resolution_mode_lowest_direct_picks_lowest_direct_version() {
 
     drop((root, mock_instance)); // cleanup
 }
+
+/// `@pnpm.e2e/abc-parent-with-ab@1.0.0` transitively peer-depends on
+/// `@pnpm.e2e/peer-c` (through its `@pnpm.e2e/abc` dependency). A diamond
+/// reaches it in two compatible peer contexts: the root supplies
+/// `peer-c@2.0.0` directly, while `@pnpm.e2e/abc-grand-parent-with-c` supplies
+/// its own `peer-c@^1.0.0`. The root's exact `abc-parent-with-ab@1.0.0` pin
+/// seeds preferred versions so the grand-parent's `^1.0.0` resolves to the
+/// same `1.0.0`, leaving two distinct peer-suffixed snapshots.
+///
+/// The first install records both. The second install adds a new dep — which
+/// defeats the up-to-date short-circuit so the writable fresh-lockfile path
+/// re-resolves the tree against the prior lockfile, reusing
+/// `abc-parent-with-ab` in both contexts via the lockfile-reuse path. That
+/// reuse must preserve both contexts instead of collapsing the two
+/// occurrences onto one (bare) snapshot.
+///
+/// Mirrors the upstream end-to-end coverage in
+/// [`installing/deps-installer/test/install/peerDependencies.ts`](https://github.com/pnpm/pnpm/blob/4b07ee0228/installing/deps-installer/test/install/peerDependencies.ts).
+#[test]
+fn compatible_existing_peer_contexts_survive_writable_lockfile_regeneration() {
+    // The binary is re-spawned per install via `new_pacquet_command`, so the
+    // `CommandTempCwd::pacquet` builder is not used here.
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // The root pins `abc-parent-with-ab@1.0.0` (the root's peer-c@2.0.0
+    // context) and also pulls in `abc-grand-parent-with-c`, which depends on
+    // `abc-parent-with-ab@^1.0.0` plus its own `peer-c@^1.0.0` (the nested
+    // peer-c@1.x context). The root's exact `1.0.0` pin seeds preferred
+    // versions so the grand-parent's `^1.0.0` resolves to the same `1.0.0`,
+    // giving two compatible peer contexts of the same `abc-parent-with-ab`.
+    let install_with = |deps: serde_json::Value| {
+        fs::write(
+            workspace.join("package.json"),
+            serde_json::json!({ "dependencies": deps }).to_string(),
+        )
+        .expect("write package.json");
+        new_pacquet_command(&workspace).with_arg("install").assert().success();
+    };
+
+    let root_context = "@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@2.0.0)";
+    let nested_context_prefix = "@pnpm.e2e/abc-parent-with-ab@1.0.0(@pnpm.e2e/peer-c@1.";
+
+    eprintln!("First install: records both peer-c contexts...");
+    install_with(serde_json::json!({
+        "@pnpm.e2e/abc-grand-parent-with-c": "1.0.0",
+        "@pnpm.e2e/peer-c": "2.0.0",
+        "@pnpm.e2e/abc-parent-with-ab": "1.0.0",
+    }));
+
+    let first = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        first.contains(nested_context_prefix) && first.contains(root_context),
+        "first install must record both peer-c contexts; lockfile:\n{first}",
+    );
+
+    // Add a genuinely new dep. This defeats the up-to-date short-circuit, so
+    // the writable fresh-lockfile resolution path runs and re-resolves the
+    // tree against the prior lockfile — `abc-parent-with-ab` is reused in both
+    // peer contexts via the lockfile-reuse path while only the new dep
+    // resolves fresh.
+    eprintln!("Second install re-resolves with the lockfile and must keep both contexts...");
+    install_with(serde_json::json!({
+        "@pnpm.e2e/abc-grand-parent-with-c": "1.0.0",
+        "@pnpm.e2e/peer-c": "2.0.0",
+        "@pnpm.e2e/abc-parent-with-ab": "1.0.0",
+        "@pnpm.e2e/foo": "100.0.0",
+    }));
+
+    let second = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        second.contains(nested_context_prefix),
+        "reuse must preserve the nested peer-c@1.x context; lockfile:\n{second}",
+    );
+    assert!(
+        second.contains(root_context),
+        "reuse must preserve the root peer-c@2.0.0 context; lockfile:\n{second}",
+    );
+
+    drop((root, mock_instance)); // cleanup
+}
+
+/// A fresh `pacquet` command rooted at `workspace`, for tests that run the
+/// binary more than once (the builder is consumed on `assert()`).
+fn new_pacquet_command(workspace: &std::path::Path) -> std::process::Command {
+    std::process::Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1386,8 +1386,8 @@ where
         .as_ref()
         .and_then(|lockfile| lockfile.snapshots.as_ref())
         .and_then(|snaps| snaps.get(&key));
-    let child_refs = snapshot_child_refs(snapshot);
     let peer_dependencies = extract_peer_dependencies(&result);
+    let child_refs = snapshot_child_refs(snapshot, &peer_dependencies);
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
@@ -1495,18 +1495,46 @@ where
 }
 
 /// `(install_alias, resolved_snapshot_key)` for every non-`link:` child
-/// recorded on `snapshot`'s `dependencies` + `optionalDependencies`.
-/// Sorted by alias so the per-occurrence walk order is deterministic.
-fn snapshot_child_refs(snapshot: Option<&SnapshotEntry>) -> Vec<(String, PkgNameVerPeer)> {
+/// recorded on `snapshot`'s `dependencies` + `optionalDependencies`,
+/// excluding resolved peers. Sorted by alias so the per-occurrence walk
+/// order is deterministic.
+///
+/// A snapshot's `dependencies` map lists not only the package's real
+/// dependencies but also every *resolved peer* — the node's own peers
+/// (`peer_dependencies`) and the peers its descendants required and
+/// resolved through this node (`transitivePeerDependencies`) — each
+/// pinned to the version it matched in the recorded context. Those are
+/// not real children: a fresh resolve walks only the package's manifest
+/// `dependencies` and re-derives peers separately against the parent
+/// context. Mirroring that, reuse must walk the manifest's deps too — so
+/// peer-named entries are dropped here, matching pnpm's reuse path, which
+/// builds children from
+/// [`getNonDevWantedDependencies(parentPkg.pkg)`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L1058)
+/// and uses the snapshot's `dependencies` only as the locked-ref lookup,
+/// not as the child set. Treating a resolved peer as a regular child
+/// makes the peer pass satisfy the peer from the node's own subtree
+/// instead of propagating it up, collapsing the peer-context suffix.
+fn snapshot_child_refs(
+    snapshot: Option<&SnapshotEntry>,
+    peer_dependencies: &BTreeMap<String, PeerDep>,
+) -> Vec<(String, PkgNameVerPeer)> {
     let Some(snapshot) = snapshot else { return Vec::new() };
+    let transitive_peers: HashSet<&str> =
+        snapshot.transitive_peer_dependencies.iter().flatten().map(String::as_str).collect();
     let mut out: Vec<(String, PkgNameVerPeer)> = Vec::new();
     for dep_map in [snapshot.dependencies.as_ref(), snapshot.optional_dependencies.as_ref()]
         .into_iter()
         .flatten()
     {
         for (alias, dep_ref) in dep_map {
+            let alias_str = alias.to_string();
+            if peer_dependencies.contains_key(&alias_str)
+                || transitive_peers.contains(alias_str.as_str())
+            {
+                continue;
+            }
             if let Some(key) = dep_ref.resolve(alias) {
-                out.push((alias.to_string(), key));
+                out.push((alias_str, key));
             }
         }
     }

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -15,6 +15,7 @@ use pacquet_resolving_resolver_base::{ResolveError, ResolveOptions, Resolver, Wa
 use pipe_trait::Pipe;
 use serde_json::Value;
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     path::PathBuf,
     sync::{Arc, Mutex, MutexGuard},
@@ -1527,14 +1528,17 @@ fn snapshot_child_refs(
         .flatten()
     {
         for (alias, dep_ref) in dep_map {
-            let alias_str = alias.to_string();
-            if peer_dependencies.contains_key(&alias_str)
-                || transitive_peers.contains(alias_str.as_str())
+            let alias_str = match &alias.scope {
+                Some(scope) => Cow::Owned(format!("@{scope}/{}", alias.bare)),
+                None => Cow::Borrowed(alias.bare.as_str()),
+            };
+            if peer_dependencies.contains_key(alias_str.as_ref())
+                || transitive_peers.contains(alias_str.as_ref())
             {
                 continue;
             }
             if let Some(key) = dep_ref.resolve(alias) {
-                out.push((alias_str, key));
+                out.push((alias_str.into_owned(), key));
             }
         }
     }

--- a/pnpm/test/install/preferLockedPeerContexts.ts
+++ b/pnpm/test/install/preferLockedPeerContexts.ts
@@ -1,0 +1,36 @@
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { createPeerDepGraphHash } from '@pnpm/deps.path'
+import type { LockfileFile } from '@pnpm/lockfile.types'
+import { prepare } from '@pnpm/prepare'
+import { addDistTag } from '@pnpm/testing.registry-mock'
+import { readYamlFileSync } from 'read-yaml-file'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpm } from '../utils/index.js'
+
+// @pnpm.e2e/abc-parent-with-ab transitively peer-depends on @pnpm.e2e/peer-c. It
+// ends up with two compatible contexts: one resolved through
+// @pnpm.e2e/abc-grand-parent-with-c (which supplies peer-c@1.0.0) and one from
+// the root (which supplies peer-c@2.0.0). A later writable install must preserve
+// both recorded contexts instead of collapsing them onto a single one.
+test('compatible existing peer contexts survive writable lockfile regeneration', async () => {
+  await addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+  prepare()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    strictPeerDependencies: false,
+  })
+
+  await execPnpm(['add', '@pnpm.e2e/abc-grand-parent-with-c@1.0.0', '@pnpm.e2e/peer-c@2.0.0'])
+  await execPnpm(['add', '@pnpm.e2e/abc-parent-with-ab'])
+  await execPnpm(['add', 'is-positive@1.0.0'])
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+  const snapshots = Object.keys(lockfile.snapshots ?? {})
+  expect(snapshots).toContain(`@pnpm.e2e/abc-parent-with-ab@1.0.0${createPeerDepGraphHash([{ name: '@pnpm.e2e/peer-c', version: '1.0.0' }])}`)
+  expect(snapshots).toContain(`@pnpm.e2e/abc-parent-with-ab@1.0.0${createPeerDepGraphHash([{ name: '@pnpm.e2e/peer-c', version: '2.0.0' }])}`)
+})


### PR DESCRIPTION
## Summary

Add an opt-in workspace setting in pnpm-workspace.yaml:

```
peerResolutionMode: prefer-locked
```

During writable resolution, pnpm reuses each dependency instance's previous
compatible peer providers when those providers are still present in the
current dependency graph.

The default resolution behavior is unchanged.

## Why

[#12075](https://github.com/pnpm/pnpm/pull/12075) fixed optional-peer candidate
selection: pnpm no longer discards a compatible optional-peer version merely
because it came from the lockfile.

This PR addresses a separate source of lockfile churn. A writable install could
still replace one valid peer context with another valid peer context even when
the existing provider remained present and satisfied the peer range.

Public reproduction:
<https://github.com/sharmila-oai/pnpm-optional-peer-lockfile-repro>

The nested reproduction starts with two valid `vitest@3.2.4` contexts:

```text
context-low  -> vitest@3.2.4(jsdom@26.1.0)
context-high -> vitest@3.2.4(jsdom@27.4.0)
```

Running a writable lockfile regeneration should retain both contexts:

```sh
./reproduce-nested-context.sh
```

## Behavior

pnpm reuses a locked peer provider only when:

- The provider is still present in the current dependency graph.
- The provider still satisfies the peer range.

Current manifest choices remain authoritative. In particular, pnpm does not
replace:

- A newly added direct peer provider.
- An explicitly updated direct peer provider.
- A changed nested provider.
- A direct provider installed through an alias.

The reuse pass runs only when the dependency tree contains locked peer contexts,
so fresh installs do not pay for a second peer-resolution pass.

## Tradeoff

This change favors lockfile stability over reducing the number of peer
contexts. A writable install may retain multiple compatible peer contexts where
a fresh install would select one.

## Implementation

The resolver performs its normal peer-resolution pass first. When the
dependency tree contains locked peer contexts, it performs a second pass that
may reuse compatible provider paths from the lockfile while respecting current
manifest choices.

pacquet now mirrors this behavior. Its lockfile-reuse path rebuilds child
dependencies from the package manifest and skips peer dependencies recorded in
the snapshot, so the peer pass derives each dependency instance's peer context.

## Validation

- Added resolver tests for compatible locked providers, incompatible providers,
  newly declared providers, explicitly updated providers, changed nested
  providers, workspace-root providers, and aliases.
- Added pnpm CLI and pacquet end-to-end coverage for preserving multiple valid
  peer contexts during writable lockfile regeneration.
- Ran `cargo fmt --check`.
- Ran `cargo test -p pacquet-resolving-deps-resolver`.
- Ran `cargo clippy -p pacquet-resolving-deps-resolver --all-targets -- --deny warnings`.

---
Written by an agent (Codex, GPT-5).

Sent by Codex
