### PR TITLE
pnpr: avoid concurrent adduser overwrite

### DIFF
--- a/pnpr/crates/pnpr/src/auth.rs
+++ b/pnpr/crates/pnpr/src/auth.rs
@@ -160,23 +160,45 @@ impl UserStore {
         }
 
         let hash = hash_bcrypt(password.to_string(), self.bcrypt_cost).await?;
-        let snapshot = {
+        enum NextStep {
+            Persist(String),
+            VerifyExisting(String),
+        }
+        let next_step = {
             let mut users = self.users.lock().expect("UserStore mutex poisoned");
-            // Re-check the cap under the lock to make the limit hold
-            // under concurrent adduser bursts. A second writer that
-            // raced in while we were hashing could otherwise push
-            // past the cap.
-            if let MaxUsers::Limited(max) = self.max_users
-                && (users.len() as u64) >= max
-                && !users.contains_key(username)
-            {
-                return Err(RegistryError::TooManyUsers { max });
+            if let Some(stored) = users.get(username).cloned() {
+                NextStep::VerifyExisting(stored)
+            } else {
+                // Re-check the cap under the lock to make the limit hold
+                // under concurrent adduser bursts. A second writer that
+                // raced in while we were hashing could otherwise push
+                // past the cap.
+                if let MaxUsers::Limited(max) = self.max_users
+                    && (users.len() as u64) >= max
+                {
+                    return Err(RegistryError::TooManyUsers { max });
+                }
+                users.insert(username.to_string(), hash);
+                NextStep::Persist(serialize_htpasswd(&users))
             }
-            users.insert(username.to_string(), hash);
-            serialize_htpasswd(&users)
         };
-        self.persist(snapshot).await?;
-        Ok(UpsertOutcome::Created)
+        match next_step {
+            NextStep::Persist(snapshot) => {
+                self.persist(snapshot).await?;
+                Ok(UpsertOutcome::Created)
+            }
+            NextStep::VerifyExisting(stored) => {
+                verify_bcrypt(password.to_string(), stored).await.and_then(|ok| {
+                    if ok {
+                        Ok(UpsertOutcome::LoggedIn)
+                    } else {
+                        Err(RegistryError::Unauthenticated {
+                            resource: format!("user {username:?}"),
+                        })
+                    }
+                })
+            }
+        }
     }
 
     /// Verify a username+password pair against the store. Returns

--- a/pnpr/crates/pnpr/src/auth.rs
+++ b/pnpr/crates/pnpr/src/auth.rs
@@ -137,13 +137,7 @@ impl UserStore {
             users.get(username).cloned()
         };
         if let Some(stored) = existing_hash {
-            return verify_bcrypt(password.to_string(), stored).await.and_then(|ok| {
-                if ok {
-                    Ok(UpsertOutcome::LoggedIn)
-                } else {
-                    Err(RegistryError::Unauthenticated { resource: format!("user {username:?}") })
-                }
-            });
+            return verify_returning_user(username, password, stored).await;
         }
 
         // Brand-new user — check the registration cap before doing
@@ -188,15 +182,7 @@ impl UserStore {
                 Ok(UpsertOutcome::Created)
             }
             NextStep::VerifyExisting(stored) => {
-                verify_bcrypt(password.to_string(), stored).await.and_then(|ok| {
-                    if ok {
-                        Ok(UpsertOutcome::LoggedIn)
-                    } else {
-                        Err(RegistryError::Unauthenticated {
-                            resource: format!("user {username:?}"),
-                        })
-                    }
-                })
+                verify_returning_user(username, password, stored).await
             }
         }
     }
@@ -551,6 +537,21 @@ async fn verify_bcrypt(password: String, hash: String) -> Result<bool> {
         bcrypt::verify(&password, &hash).map_err(RegistryError::from)
     })
     .await?
+}
+
+/// Verify `password` against an existing user's `stored` hash,
+/// mapping the result to the login outcome a returning user expects:
+/// `LoggedIn` on a match, `Unauthenticated` otherwise.
+async fn verify_returning_user(
+    username: &str,
+    password: &str,
+    stored: String,
+) -> Result<UpsertOutcome> {
+    if verify_bcrypt(password.to_string(), stored).await? {
+        Ok(UpsertOutcome::LoggedIn)
+    } else {
+        Err(RegistryError::Unauthenticated { resource: format!("user {username:?}") })
+    }
 }
 
 // ---------------------------------------------------------------

--- a/pnpr/crates/pnpr/src/auth/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/tests.rs
@@ -45,6 +45,9 @@ async fn adduser_rejects_same_username_concurrent_registration_with_different_pa
         users: std::sync::Mutex::new(std::collections::HashMap::new()),
         path: None,
         max_users: MaxUsers::Unlimited,
+        // Higher than TEST_COST so hashing lasts long enough for both
+        // tasks to clear the initial missing-user check before either
+        // takes the lock — i.e. to actually exercise the race window.
         bcrypt_cost: 8,
     });
     let barrier = Arc::new(Barrier::new(3));

--- a/pnpr/crates/pnpr/src/auth/tests.rs
+++ b/pnpr/crates/pnpr/src/auth/tests.rs
@@ -1,5 +1,7 @@
 use super::{TokenStore, UpsertOutcome, UserStore, identify, parse_htpasswd};
 use crate::config::MaxUsers;
+use std::sync::Arc;
+use tokio::sync::Barrier;
 
 /// Tests run with cost 4 (the bcrypt crate's minimum sane value)
 /// so per-test wall-clock stays in the single-digit ms range.
@@ -35,6 +37,50 @@ async fn adduser_rejects_existing_user_with_wrong_password() {
     store.add_or_login("alice", "secret").await.unwrap();
     let err = store.add_or_login("alice", "different").await.unwrap_err();
     assert_eq!(err.status_code(), axum::http::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn adduser_rejects_same_username_concurrent_registration_with_different_password() {
+    let store = Arc::new(UserStore {
+        users: std::sync::Mutex::new(std::collections::HashMap::new()),
+        path: None,
+        max_users: MaxUsers::Unlimited,
+        bcrypt_cost: 8,
+    });
+    let barrier = Arc::new(Barrier::new(3));
+
+    let spawn_adduser = |password: &'static str| {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store.add_or_login("alice", password).await
+        })
+    };
+
+    let add_a = spawn_adduser("pw-a");
+    let add_b = spawn_adduser("pw-b");
+    barrier.wait().await;
+
+    let result_a = add_a.await.unwrap();
+    let result_b = add_b.await.unwrap();
+    let created = [result_a.as_ref(), result_b.as_ref()]
+        .into_iter()
+        .filter(|result| matches!(result, Ok(UpsertOutcome::Created)))
+        .count();
+    let unauthorized = [&result_a, &result_b]
+        .into_iter()
+        .filter(|result| {
+            result
+                .as_ref()
+                .err()
+                .is_some_and(|err| err.status_code() == axum::http::StatusCode::UNAUTHORIZED)
+        })
+        .count();
+
+    assert_eq!(created, 1, "exactly one concurrent adduser should create the account");
+    assert_eq!(unauthorized, 1, "the losing registration must be rejected");
+    assert_ne!(store.verify("alice", "pw-a").is_some(), store.verify("alice", "pw-b").is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- re-check the username under the lock after bcrypt finishes
- verify against the stored hash if another request created the user while we were hashing
- add a concurrent regression test for same-username registration with different passwords

## Why
Two concurrent `adduser` requests for the same username could both pass the initial missing-user check. The later insert would then overwrite the password written by the earlier one.

## Testing
- `cargo test -p pnpr adduser_`
- `cargo test -p pnpr max_users_caps_new_registrations`

Fixes #12084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents race conditions during concurrent sign-up/login so only one account is created and others correctly fail authentication.
* **Tests**
  * Adds a concurrency test to validate simultaneous login/signup behavior and ensure credential consistency.
* **Chores**
  * Internal improvements to authentication handling for reliability and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->