### PR TITLE
fix(audit): prune path traversal

### DIFF
--- a/.changeset/audit-path-traversal-performance.md
+++ b/.changeset/audit-path-traversal-performance.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.audit": patch
+"pnpm": patch
+---
+
+Improve `pnpm audit` performance by pruning non-vulnerable lockfile subtrees and stopping path enumeration once vulnerable findings reach the path cap.

--- a/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -189,12 +189,15 @@ function walkForPaths (ctx: WalkForPathsCtx): void {
   const includeDevDeps = include?.devDependencies !== false
   const includeOptDeps = include?.optionalDependencies !== false
   const packages = lockfile.packages ?? {}
+  const reachableVulnerabilities = createReachableVulnerabilitiesGetter(lockfile, vulnerableNames, includeOptDeps)
 
   // Reused across every root to avoid per-node Set cloning. visit adds the
   // current depPath before recursing and removes it on the way back, so the
   // set always reflects the current trail.
   const inTrail = new Set<DepPath>()
   const visit = (edge: { name: string, depPath: DepPath }, trail: string[]): void => {
+    const reachable = reachableVulnerabilities(edge)
+    if (reachable.size === 0 || allReachableVulnerabilitiesSaturated(paths, reachable, depTypes, optionalOnly)) return
     if (inTrail.has(edge.depPath)) return
     const pkgSnapshot = packages[edge.depPath]
     if (pkgSnapshot == null) return
@@ -206,6 +209,7 @@ function walkForPaths (ctx: WalkForPathsCtx): void {
         depTypes[edge.depPath] === DepType.DevOnly,
         optionalOnly.has(edge.depPath))
     }
+    if (allReachableVulnerabilitiesSaturated(paths, reachable, depTypes, optionalOnly)) return
     inTrail.add(edge.depPath)
     try {
       for (const child of resolvedDepsToNamedDepPaths(pkgSnapshot.dependencies ?? {})) {
@@ -230,6 +234,74 @@ function walkForPaths (ctx: WalkForPathsCtx): void {
     for (const root of roots) {
       visit(root, trail)
     }
+  }
+}
+
+function createReachableVulnerabilitiesGetter (
+  lockfile: LockfileObject,
+  vulnerableNames: Set<string>,
+  includeOptDeps: boolean
+): (edge: { name: string, depPath: DepPath }) => Set<string> {
+  const packages = lockfile.packages ?? {}
+  const memo = new Map<DepPath, Set<string>>()
+  const inTrail = new Set<DepPath>()
+  const get = (edge: { name: string, depPath: DepPath }): Set<string> => {
+    const cached = memo.get(edge.depPath)
+    if (cached) return cached
+    if (inTrail.has(edge.depPath)) return new Set()
+    const pkgSnapshot = packages[edge.depPath]
+    if (pkgSnapshot == null) return new Set()
+
+    inTrail.add(edge.depPath)
+    const result = new Set<string>()
+    const { name, version } = nameVerFromPkgSnapshot(edge.depPath, pkgSnapshot)
+    const resolvedName = name ?? edge.name
+    if (version && vulnerableNames.has(resolvedName)) {
+      result.add(vulnerabilityKey(resolvedName, version, edge.depPath))
+    }
+    for (const child of resolvedDepsToNamedDepPaths(pkgSnapshot.dependencies ?? {})) {
+      addAll(result, get(child))
+    }
+    if (includeOptDeps) {
+      for (const child of resolvedDepsToNamedDepPaths(pkgSnapshot.optionalDependencies ?? {})) {
+        addAll(result, get(child))
+      }
+    }
+    inTrail.delete(edge.depPath)
+    memo.set(edge.depPath, result)
+    return result
+  }
+  return get
+}
+
+function allReachableVulnerabilitiesSaturated (
+  paths: AuditPathIndex,
+  reachable: Set<string>,
+  depTypes: DepTypes,
+  optionalOnly: Set<DepPath>
+): boolean {
+  for (const key of reachable) {
+    const { name, version, depPath } = parseVulnerabilityKey(key)
+    const info = paths[name]?.get(version)
+    if (!info || info.paths.length < MAX_PATHS_PER_FINDING) return false
+    if (depTypes[depPath] !== DepType.DevOnly && info.dev) return false
+    if (!optionalOnly.has(depPath) && info.optional) return false
+  }
+  return true
+}
+
+function vulnerabilityKey (name: string, version: string, depPath: DepPath): string {
+  return `${name}\0${version}\0${depPath}`
+}
+
+function parseVulnerabilityKey (key: string): { name: string, version: string, depPath: DepPath } {
+  const [name, version, depPath] = key.split('\0')
+  return { name, version, depPath: depPath as DepPath }
+}
+
+function addAll<T> (target: Set<T>, source: Set<T>): void {
+  for (const value of source) {
+    target.add(value)
   }
 }
 

--- a/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -244,16 +244,14 @@ function createReachableVulnerabilitiesGetter (
 ): (edge: { name: string, depPath: DepPath }) => Set<string> {
   const packages = lockfile.packages ?? {}
   const memo = new Map<DepPath, Set<string>>()
-  const inTrail = new Set<DepPath>()
   const get = (edge: { name: string, depPath: DepPath }): Set<string> => {
     const cached = memo.get(edge.depPath)
     if (cached) return cached
-    if (inTrail.has(edge.depPath)) return new Set()
     const pkgSnapshot = packages[edge.depPath]
     if (pkgSnapshot == null) return new Set()
 
-    inTrail.add(edge.depPath)
     const result = new Set<string>()
+    memo.set(edge.depPath, result)
     const { name, version } = nameVerFromPkgSnapshot(edge.depPath, pkgSnapshot)
     const resolvedName = name ?? edge.name
     if (version && vulnerableNames.has(resolvedName)) {
@@ -267,8 +265,6 @@ function createReachableVulnerabilitiesGetter (
         addAll(result, get(child))
       }
     }
-    inTrail.delete(edge.depPath)
-    memo.set(edge.depPath, result)
     return result
   }
   return get

--- a/deps/compliance/audit/src/lockfileToAuditIndex.ts
+++ b/deps/compliance/audit/src/lockfileToAuditIndex.ts
@@ -243,31 +243,47 @@ function createReachableVulnerabilitiesGetter (
   includeOptDeps: boolean
 ): (edge: { name: string, depPath: DepPath }) => Set<string> {
   const packages = lockfile.packages ?? {}
+  // Only fully-resolved (acyclic) subtrees are memoized. A node whose reachable
+  // set still depends on a back-edge to an ancestor is incomplete until the
+  // enclosing cycle is left, so caching it would under-report reachable
+  // vulnerabilities and let the walker prune valid audit paths. Such nodes are
+  // recomputed on each top-level query, which is cheap because cycles in a
+  // lockfile are rare and small.
   const memo = new Map<DepPath, Set<string>>()
-  const get = (edge: { name: string, depPath: DepPath }): Set<string> => {
+  const onStack = new Set<DepPath>()
+  const compute = (edge: { name: string, depPath: DepPath }): { result: Set<string>, complete: boolean } => {
     const cached = memo.get(edge.depPath)
-    if (cached) return cached
+    if (cached) return { result: cached, complete: true }
+    if (onStack.has(edge.depPath)) return { result: new Set(), complete: false }
     const pkgSnapshot = packages[edge.depPath]
-    if (pkgSnapshot == null) return new Set()
+    if (pkgSnapshot == null) return { result: new Set(), complete: true }
 
+    onStack.add(edge.depPath)
     const result = new Set<string>()
-    memo.set(edge.depPath, result)
+    let complete = true
     const { name, version } = nameVerFromPkgSnapshot(edge.depPath, pkgSnapshot)
     const resolvedName = name ?? edge.name
     if (version && vulnerableNames.has(resolvedName)) {
       result.add(vulnerabilityKey(resolvedName, version, edge.depPath))
     }
+    const collect = (child: { name: string, depPath: DepPath }): void => {
+      const childResult = compute(child)
+      addAll(result, childResult.result)
+      if (!childResult.complete) complete = false
+    }
     for (const child of resolvedDepsToNamedDepPaths(pkgSnapshot.dependencies ?? {})) {
-      addAll(result, get(child))
+      collect(child)
     }
     if (includeOptDeps) {
       for (const child of resolvedDepsToNamedDepPaths(pkgSnapshot.optionalDependencies ?? {})) {
-        addAll(result, get(child))
+        collect(child)
       }
     }
-    return result
+    onStack.delete(edge.depPath)
+    if (complete) memo.set(edge.depPath, result)
+    return { result, complete }
   }
-  return get
+  return (edge) => compute(edge).result
 }
 
 function allReachableVulnerabilitiesSaturated (

--- a/deps/compliance/audit/test/index.ts
+++ b/deps/compliance/audit/test/index.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 import { LOCKFILE_VERSION } from '@pnpm/constants'
 import { audit, buildAuditPathIndex, lockfileToAuditRequest } from '@pnpm/deps.compliance.audit'
 import type { PnpmError } from '@pnpm/error'
+import type { PackageSnapshots } from '@pnpm/lockfile.types'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 import type { DepPath, ProjectId } from '@pnpm/types'
 
@@ -81,6 +82,68 @@ describe('audit', () => {
     const info = result['lodash']!.get('4.0.0')!
     expect(info.paths).toHaveLength(2)
     expect(info.paths).toEqual(expect.arrayContaining(['.>a>lodash', '.>b>lodash']))
+  })
+
+  test('buildAuditPathIndex() prunes non-vulnerable subtrees while enumerating paths', () => {
+    let coldReads = 0
+    const importers: Record<ProjectId, { dependencies: Record<string, string>, specifiers: Record<string, string> }> = {}
+    const packages: PackageSnapshots = {
+      ['vuln@1.0.0' as DepPath]: { resolution: { integrity: 'vuln-integrity' } },
+    }
+    Object.defineProperty(packages, 'cold@1.0.0', {
+      enumerable: true,
+      get: () => {
+        coldReads++
+        return { dependencies: { 'cold-leaf': '1.0.0' }, resolution: { integrity: 'cold-integrity' } }
+      },
+    })
+    packages['cold-leaf@1.0.0' as DepPath] = { resolution: { integrity: 'cold-leaf-integrity' } }
+    for (let i = 0; i < 50; i++) {
+      const parentName = `parent-${i}`
+      importers[`.${i}` as ProjectId] = {
+        dependencies: { [parentName]: '1.0.0' },
+        specifiers: { [parentName]: '1.0.0' },
+      }
+      packages[`${parentName}@1.0.0` as DepPath] = {
+        dependencies: { cold: '1.0.0', vuln: '1.0.0' },
+        resolution: { integrity: `${parentName}-integrity` },
+      }
+    }
+    const result = buildAuditPathIndex({
+      importers,
+      lockfileVersion: LOCKFILE_VERSION,
+      packages,
+    }, new Set(['vuln']), { depTypes: {}, optionalOnly: new Set() })
+
+    expect(result['vuln']!.get('1.0.0')!.paths).toHaveLength(50)
+    expect(coldReads).toBe(1)
+  })
+
+  test('buildAuditPathIndex() stops reading saturated vulnerable nodes', () => {
+    let vulnReads = 0
+    const importers: Record<ProjectId, { dependencies: Record<string, string>, specifiers: Record<string, string> }> = {}
+    const packages: PackageSnapshots = {}
+    Object.defineProperty(packages, 'vuln@1.0.0', {
+      enumerable: true,
+      get: () => {
+        vulnReads++
+        return { resolution: { integrity: 'vuln-integrity' } }
+      },
+    })
+    for (let i = 0; i < 150; i++) {
+      importers[`.${i}` as ProjectId] = {
+        dependencies: { vuln: '1.0.0' },
+        specifiers: { vuln: '1.0.0' },
+      }
+    }
+    const result = buildAuditPathIndex({
+      importers,
+      lockfileVersion: LOCKFILE_VERSION,
+      packages,
+    }, new Set(['vuln']), { depTypes: {}, optionalOnly: new Set() })
+
+    expect(result['vuln']!.get('1.0.0')!.paths).toHaveLength(100)
+    expect(vulnReads).toBe(101)
   })
 
   test('buildAuditPathIndex() classifies as optional when the only non-optional path runs through an excluded devDependency', () => {

--- a/deps/compliance/audit/test/index.ts
+++ b/deps/compliance/audit/test/index.ts
@@ -210,6 +210,73 @@ describe('audit', () => {
     })
   })
 
+  test('buildAuditPathIndex() preserves reachability across cyclic dependencies', () => {
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { a: '1.0.0' },
+          specifiers: { a: '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['a@1.0.0' as DepPath]: {
+          dependencies: { b: '1.0.0' },
+          resolution: { integrity: 'a-integrity' },
+        },
+        ['b@1.0.0' as DepPath]: {
+          dependencies: { a: '1.0.0' },
+          resolution: { integrity: 'b-integrity' },
+        },
+      } as PackageSnapshots,
+    }
+    const result = buildAuditPathIndex(lockfile, new Set(['a', 'b']), {})
+
+    expect(result['a']!.get('1.0.0')).toEqual({
+      paths: ['.>a'],
+      dev: false,
+      optional: false,
+    })
+    expect(result['b']!.get('1.0.0')).toEqual({
+      paths: ['.>a>b'],
+      dev: false,
+      optional: false,
+    })
+  })
+
+  test('buildAuditPathIndex() preserves vulnerability reachability when cycle root is queried second', () => {
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { root: '1.0.0' },
+          specifiers: { root: '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['root@1.0.0' as DepPath]: {
+          dependencies: { b: '1.0.0' },
+          resolution: { integrity: 'root-integrity' },
+        },
+        ['a@1.0.0' as DepPath]: {
+          dependencies: { b: '1.0.0' },
+          resolution: { integrity: 'a-integrity' },
+        },
+        ['b@1.0.0' as DepPath]: {
+          dependencies: { a: '1.0.0' },
+          resolution: { integrity: 'b-integrity' },
+        },
+      } as PackageSnapshots,
+    }
+    const result = buildAuditPathIndex(lockfile, new Set(['a']), {})
+
+    expect(result['a']!.get('1.0.0')).toEqual({
+      paths: ['.>root>b>a'],
+      dev: false,
+      optional: false,
+    })
+  })
+
   test('buildAuditPathIndex() replaces slashes in workspace importer ids', () => {
     const lockfile = {
       importers: {

--- a/deps/compliance/audit/test/index.ts
+++ b/deps/compliance/audit/test/index.ts
@@ -277,6 +277,37 @@ describe('audit', () => {
     })
   })
 
+  test('buildAuditPathIndex() keeps paths reached through a non-entry cycle member', () => {
+    // The importer reaches the b<->c cycle through both c and b. Visiting c
+    // first must not memoize an under-approximated reachable set for b that
+    // would prune the still-valid `.>b>c>x` path to the vulnerable package.
+    const lockfile = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: { c: '1.0.0', b: '1.0.0' },
+          specifiers: { c: '^1.0.0', b: '^1.0.0' },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['b@1.0.0' as DepPath]: {
+          dependencies: { c: '1.0.0' },
+          resolution: { integrity: 'b-integrity' },
+        },
+        ['c@1.0.0' as DepPath]: {
+          dependencies: { b: '1.0.0', x: '1.0.0' },
+          resolution: { integrity: 'c-integrity' },
+        },
+        ['x@1.0.0' as DepPath]: {
+          resolution: { integrity: 'x-integrity' },
+        },
+      } as PackageSnapshots,
+    }
+    const result = buildAuditPathIndex(lockfile, new Set(['x']), {})
+
+    expect(result['x']!.get('1.0.0')!.paths.sort()).toEqual(['.>b>c>x', '.>c>x'])
+  })
+
   test('buildAuditPathIndex() replaces slashes in workspace importer ids', () => {
     const lockfile = {
       importers: {


### PR DESCRIPTION
## Summary

- Prune lockfile subtrees that cannot reach vulnerable packages while building audit findings paths.
- Stop descending into subtrees once every reachable vulnerable package/version has hit the existing path cap.
- Add focused coverage for non-vulnerable subtree pruning and saturated finding short-circuiting.

## Benchmark

In our large monorepo (`/Users/aqeelat/fathom/frontend/fathom-frontend`), `pnpm audit` went from 4+ minutes to less than 2 seconds with this change:

```text
Before: pnpm audit  251.46s user 2.22s system 93% cpu 4:30.94 total
After:  real 1.44s, user 0.59s, sys 0.04s
```

## Validation

- `pnpm --filter @pnpm/deps.compliance.audit test`
- `git diff --check`
- Push hook: typecheck, pnpm bundle compile, spellcheck, meta lint, TS lint

Fixes #12086

---
Written by an agent (OpenCode, gpt-5.5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved audit performance: non-vulnerable lockfile subtrees are pruned and path enumeration stops once per‑vulnerability path limits are reached, reducing work and speeding up audits.
* **Tests**
  * Added tests verifying traversal pruning, saturation/capping behavior, and correct handling of cycles to ensure audit accuracy and reliability.
* **Chores**
  * Updated release metadata and added a note describing the audit performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->