### PR TITLE
fix: set user agent in headless lifecycle scripts

### DIFF
--- a/.changeset/lucky-user-agent.md
+++ b/.changeset/lucky-user-agent.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+Set `npm_config_user_agent` for root lifecycle scripts during headless installs.

--- a/installing/deps-restorer/src/index.ts
+++ b/installing/deps-restorer/src/index.ts
@@ -247,6 +247,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     stdio: opts.ownLifecycleHooksStdio ?? 'inherit',
     storeController: opts.storeController,
     unsafePerm: opts.unsafePerm || false,
+    userAgent: opts.userAgent,
   }
 
   if (opts.virtualStoreOnly && opts.enableModulesDir === false && !opts.enableGlobalVirtualStore) {

--- a/pnpm/test/install/lifecycleScripts.ts
+++ b/pnpm/test/install/lifecycleScripts.ts
@@ -40,6 +40,27 @@ test('lifecycle script runs with the correct user agent', () => {
   expect(result.stdout.toString()).toContain(expectedUserAgentPrefix)
 })
 
+test('lifecycle script runs with the correct user agent during headless install', () => {
+  prepare({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+    scripts: {
+      preinstall: 'node --eval "console.log(process.env.npm_config_user_agent)"',
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    optimisticRepeatInstall: true,
+  })
+
+  execPnpmSync(['install', '--lockfile-only'], { expectSuccess: true })
+  const result = execPnpmSync(['install'])
+
+  expect(result.status).toBe(0)
+  const expectedUserAgentPrefix = `${pnpmPkg.name}/${pnpmPkg.version} `
+  expect(result.stdout.toString()).toContain(expectedUserAgentPrefix)
+})
+
 test('preinstall is executed before general installation', () => {
   prepare({
     scripts: {


### PR DESCRIPTION
Fixes #12003.

## What changed
- Pass the configured user agent into root lifecycle scripts during headless installs.
- Add a regression test for the lockfile-only then install path from the issue.
- Add a patch changeset for `@pnpm/installing.deps-restorer` and `pnpm`.

This is in the TypeScript headless lifecycle options path. I did not make a pacquet change because pacquet is not assembling these root lifecycle script options.

## Validation
- `pnpm install` completed; optional `fuse-native` native build printed `spawn node-gyp ENOENT`, but install exited 0.
- `cargo build -p pnpr-fixtures --bin pnpr-prepare`
- `env PATH=/tmp/pnpm-codex-bin:$PATH pnpm --filter pnpm test test/install/lifecycleScripts.ts -t "correct user agent"`
- `env PATH=/tmp/pnpm-codex-bin:$PATH git push -u origin codex/fix-lifecycle-user-agent` ran the repo pre-push checks successfully.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `npm_config_user_agent` environment variable was not being properly passed to lifecycle scripts during headless installations, ensuring scripts have proper context about the package manager being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->