### PR TITLE
feat(sbom): per-package SBOM generation with --out and --split

### DIFF
--- a/.changeset/sbom-workspace-root-component.md
+++ b/.changeset/sbom-workspace-root-component.md
@@ -4,4 +4,4 @@
 "pnpm": minor
 ---
 
-Added per-package SBOM generation with `--out` and `--split` flags. Use `--out sboms/%s.cdx.json` to write one SBOM per workspace package to individual files, or `--split` for NDJSON output to stdout. When `--filter` selects a single package, the SBOM root component now uses that package's metadata. Workspace inter-dependencies (`workspace:` protocol) and their transitive dependencies are included. Author, repository, and license fall back to the root manifest when the package doesn't define them.
+Added per-package SBOM generation with `--out` and `--split` flags. Use `--out out/%s.cdx.json` to write one SBOM per workspace package to individual files, or `--split` for NDJSON output to stdout. When `--filter` selects a single package, the SBOM root component now uses that package's metadata. Workspace inter-dependencies (`workspace:` protocol) and their transitive dependencies are included. Author, repository, and license fall back to the root manifest when the package doesn't define them.

--- a/.changeset/sbom-workspace-root-component.md
+++ b/.changeset/sbom-workspace-root-component.md
@@ -4,4 +4,4 @@
 "pnpm": minor
 ---
 
-Improved monorepo SBOM generation. When `--filter` selects a single workspace, the root component now uses that workspace's metadata instead of the workspace root's. Workspace inter-dependencies (`workspace:` protocol) and their transitive dependencies are now included in the SBOM output. Author, repository, and license fall back to the root manifest when the workspace package doesn't define them.
+Added per-package SBOM generation with `--out` and `--split` flags. Use `--out sboms/%s.cdx.json` to write one SBOM per workspace package to individual files, or `--split` for NDJSON output to stdout. When `--filter` selects a single package, the SBOM root component now uses that package's metadata. Workspace inter-dependencies (`workspace:` protocol) and their transitive dependencies are included. Author, repository, and license fall back to the root manifest when the package doesn't define them.

--- a/.changeset/sbom-workspace-root-component.md
+++ b/.changeset/sbom-workspace-root-component.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.commands": minor
+"@pnpm/deps.compliance.sbom": minor
+"pnpm": minor
+---
+
+Improved monorepo SBOM generation. When `--filter` selects a single workspace, the root component now uses that workspace's metadata instead of the workspace root's. Workspace inter-dependencies (`workspace:` protocol) and their transitive dependencies are now included in the SBOM output. Author, repository, and license fall back to the root manifest when the workspace package doesn't define them.

--- a/deps/compliance/commands/package.json
+++ b/deps/compliance/commands/package.json
@@ -63,6 +63,7 @@
     "@zkochan/table": "catalog:",
     "chalk": "catalog:",
     "memoize": "catalog:",
+    "p-limit": "catalog:",
     "ramda": "catalog:",
     "render-help": "catalog:",
     "semver": "catalog:"

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { FILTERING } from '@pnpm/cli.common-cli-options-help'
 import { packageManager } from '@pnpm/cli.meta'
 import { docsUrl, readProjectManifestOnly } from '@pnpm/cli.utils'
@@ -6,14 +8,17 @@ import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { isSpdxLicenseExpression, resolveLicenseFromDir } from '@pnpm/deps.compliance.license-resolver'
 import {
   collectSbomComponents,
+  resolveWorkspaceDeps,
   type SbomComponentType,
   type SbomFormat,
   serializeCycloneDx,
   serializeSpdx,
+  type WorkspacePackageInfo,
 } from '@pnpm/deps.compliance.sbom'
 import { PnpmError } from '@pnpm/error'
 import { getLockfileImporterId, readWantedLockfile } from '@pnpm/lockfile.fs'
 import { getStorePath } from '@pnpm/store.path'
+import type { ProjectId } from '@pnpm/types'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 
@@ -124,6 +129,7 @@ export function help (): string {
       'pnpm sbom --sbom-format spdx',
       'pnpm sbom --sbom-format cyclonedx --lockfile-only',
       'pnpm sbom --sbom-format spdx --prod',
+      'pnpm sbom --sbom-format cyclonedx --filter ./apps/my-app',
     ],
   })
 }
@@ -168,27 +174,49 @@ export async function handler (
     optionalDependencies: opts.optional !== false,
   }
 
-  const manifest = await readProjectManifestOnly(opts.dir)
+  const selectedEntries = opts.selectedProjectsGraph
+    ? Object.entries(opts.selectedProjectsGraph)
+    : undefined
+  const singleProject = selectedEntries?.length === 1
+    ? selectedEntries[0]
+    : undefined
+
+  const rootManifest = await readProjectManifestOnly(opts.dir)
+  const manifest = singleProject
+    ? singleProject[1].package.manifest
+    : rootManifest
+  const projectDir = singleProject
+    ? singleProject[0]
+    : opts.dir
+
   const rootName = manifest.name ?? 'unknown'
   const rootVersion = manifest.version ?? '0.0.0'
-  // Keep the root in sync with transitive deps: consult manifest `license` /
-  // legacy `licenses` first, then fall back to an on-disk LICENSE file. Drop
-  // file-scanned values that aren't SPDX-valid to avoid non-compliant output.
-  const rootLicenseInfo = await resolveLicenseFromDir({ manifest, dir: opts.dir })
-  const rootLicense = rootLicenseInfo && rootLicenseInfo.name !== 'Unknown' &&
-    (!rootLicenseInfo.licenseFile || isSpdxLicenseExpression(rootLicenseInfo.name))
-    ? rootLicenseInfo.name
-    : undefined
-  const rootAuthor = typeof manifest.author === 'string'
-    ? manifest.author
-    : (manifest.author as { name?: string } | undefined)?.name
-  const rootRepository = typeof manifest.repository === 'string'
-    ? manifest.repository
-    : (manifest.repository as { url?: string } | undefined)?.url
+  const rootLicense = await resolveRootLicense(manifest, projectDir)
+    ?? (singleProject ? await resolveRootLicense(rootManifest, opts.dir) : undefined)
+  const rootAuthor = extractAuthor(manifest)
+    ?? (singleProject ? extractAuthor(rootManifest) : undefined)
+  const rootRepository = extractRepository(manifest)
+    ?? (singleProject ? extractRepository(rootManifest) : undefined)
 
+  const lockfileDir = opts.lockfileDir ?? opts.dir
   const includedImporterIds = opts.selectedProjectsGraph
     ? Object.keys(opts.selectedProjectsGraph)
-      .map((p) => getLockfileImporterId(opts.lockfileDir ?? opts.dir, p))
+      .map((p) => getLockfileImporterId(lockfileDir, p))
+    : undefined
+
+  const resolvedWorkspaceDeps = opts.lockfileOnly
+    ? undefined
+    : resolveWorkspaceDeps(
+      lockfile,
+      includedImporterIds ?? Object.keys(lockfile.importers) as ProjectId[],
+      include
+    )
+  const workspacePackages = resolvedWorkspaceDeps
+    ? await buildWorkspacePackagesMap(
+      resolvedWorkspaceDeps.additionalImporterIds,
+      lockfileDir,
+      opts.selectedProjectsGraph
+    )
     : undefined
 
   let storeDir: string | undefined
@@ -211,11 +239,13 @@ export async function handler (
     sbomType,
     include,
     registries: opts.registries,
-    lockfileDir: opts.lockfileDir ?? opts.dir,
+    lockfileDir,
     includedImporterIds,
     lockfileOnly: opts.lockfileOnly,
     storeDir,
     virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+    workspacePackages,
+    resolvedWorkspaceDeps,
   })
 
   const output = format === 'cyclonedx'
@@ -240,8 +270,6 @@ function validateSbomType (value: string | undefined): SbomComponentType {
   )
 }
 
-// Versions whose schema is fully covered by what we currently emit
-// (e.g. metadata.lifecycles requires CycloneDX 1.5+).
 const SUPPORTED_CYCLONEDX_SPEC_VERSIONS = ['1.5', '1.6', '1.7']
 
 function validateSbomSpecVersion (value: string | undefined, format: SbomFormat): string | undefined {
@@ -260,4 +288,67 @@ function validateSbomSpecVersion (value: string | undefined, format: SbomFormat)
     )
   }
   return normalized
+}
+
+async function resolveRootLicense (manifest: Parameters<typeof resolveLicenseFromDir>[0]['manifest'], dir: string): Promise<string | undefined> {
+  const info = await resolveLicenseFromDir({ manifest, dir })
+  if (info && info.name !== 'Unknown' && (!info.licenseFile || isSpdxLicenseExpression(info.name))) {
+    return info.name
+  }
+  return undefined
+}
+
+function extractAuthor (manifest: { author?: string | { name?: string } }): string | undefined {
+  if (typeof manifest.author === 'string') return manifest.author
+  return manifest.author?.name
+}
+
+function extractRepository (manifest: { repository?: string | { url?: string } }): string | undefined {
+  if (typeof manifest.repository === 'string') return manifest.repository
+  return manifest.repository?.url
+}
+
+async function buildWorkspacePackagesMap (
+  reachableImporterIds: ProjectId[],
+  lockfileDir: string,
+  selectedProjectsGraph?: SbomCommandOptions['selectedProjectsGraph']
+): Promise<Record<ProjectId, WorkspacePackageInfo>> {
+  if (reachableImporterIds.length === 0) return {} as Record<ProjectId, WorkspacePackageInfo>
+
+  const selectedEntriesMap = new Map<string, { manifest: { name?: string, version?: string, license?: string, description?: string, author?: string | { name?: string }, repository?: string | { url?: string } } }>()
+  if (selectedProjectsGraph) {
+    for (const [dir, entry] of Object.entries(selectedProjectsGraph)) {
+      selectedEntriesMap.set(getLockfileImporterId(lockfileDir, dir), entry.package)
+    }
+  }
+
+  const entries = await Promise.all(
+    reachableImporterIds.map(async (importerId): Promise<[ProjectId, WorkspacePackageInfo] | null> => {
+      const selected = selectedEntriesMap.get(importerId)
+      const manifest = selected
+        ? selected.manifest
+        : await readManifestSafe(path.join(lockfileDir, importerId))
+
+      if (!manifest?.name || !manifest.version) return null
+
+      return [importerId, {
+        name: manifest.name,
+        version: manifest.version,
+        license: typeof manifest.license === 'string' ? manifest.license : undefined,
+        description: manifest.description,
+        author: extractAuthor(manifest),
+        repository: extractRepository(manifest),
+      }]
+    })
+  )
+
+  return Object.fromEntries(entries.filter((e) => e !== null)) as Record<ProjectId, WorkspacePackageInfo>
+}
+
+async function readManifestSafe (dir: string): Promise<{ name?: string, version?: string, license?: string, description?: string, author?: string | { name?: string }, repository?: string | { url?: string } } | undefined> {
+  try {
+    return await readProjectManifestOnly(dir)
+  } catch {
+    return undefined
+  }
 }

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -146,7 +146,7 @@ export function help (): string {
       'pnpm sbom --sbom-format cyclonedx --lockfile-only',
       'pnpm sbom --sbom-format spdx --prod',
       'pnpm sbom --sbom-format cyclonedx --filter ./apps/my-app',
-      'pnpm sbom --sbom-format cyclonedx --out sboms/%s.cdx.json',
+      'pnpm sbom --sbom-format cyclonedx --out out/%s.cdx.json',
       'pnpm sbom --sbom-format cyclonedx --split',
     ],
   })

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -227,6 +227,7 @@ async function handleSplit (
   const entries = Object.entries(projectsGraph)
   const ndjsonLines: string[] = []
   const files: string[] = []
+  const writtenPaths = new Set<string>()
   const compact = !opts.out
   const createdDirs = new Set<string>()
 
@@ -251,12 +252,13 @@ async function handleSplit (
       // Sanitizing package names is lossy (e.g. "@a/b" and "a-b" both map to "a-b"),
       // so two packages can resolve to the same path. Fail loudly instead of letting
       // one SBOM silently overwrite another.
-      if (files.includes(filePath)) {
+      if (writtenPaths.has(filePath)) {
         throw new PnpmError(
           'SBOM_OUT_PATH_COLLISION',
           `Multiple workspace packages resolve to the same output path "${filePath}". Include %v in the --out pattern to disambiguate.`
         )
       }
+      writtenPaths.add(filePath)
       const fileDir = path.dirname(filePath)
       if (!createdDirs.has(fileDir)) {
         fs.mkdirSync(fileDir, { recursive: true })
@@ -279,11 +281,16 @@ async function handleSplit (
   return { output: ndjsonLines.join('\n'), exitCode: 0 }
 }
 
+type ManifestLike = { name?: string, version?: string, license?: string, description?: string, author?: string | { name?: string }, repository?: string | { url?: string } }
+
 interface SharedContext {
   lockfile: Exclude<Awaited<ReturnType<typeof readWantedLockfile>>, null>
   rootManifest: Awaited<ReturnType<typeof readProjectManifestOnly>>
   rootManifestDir: string
   storeDir: string | undefined
+  /** Workspace package manifests keyed by lockfile importer id, read once from the
+   * project graph so split mode does not re-read them for every emitted SBOM. */
+  workspaceManifestsByImporterId: Map<string, ManifestLike>
 }
 
 async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedContext> {
@@ -310,7 +317,16 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
     })
   }
 
-  return { lockfile, rootManifest, rootManifestDir, storeDir }
+  const lockfileDir = opts.lockfileDir ?? opts.dir
+  const workspaceManifestsByImporterId = new Map<string, ManifestLike>()
+  for (const graph of [opts.allProjectsGraph, opts.selectedProjectsGraph]) {
+    if (!graph) continue
+    for (const [dir, entry] of Object.entries(graph)) {
+      workspaceManifestsByImporterId.set(getLockfileImporterId(lockfileDir, dir), entry.package.manifest)
+    }
+  }
+
+  return { lockfile, rootManifest, rootManifestDir, storeDir, workspaceManifestsByImporterId }
 }
 
 async function generateSbomForProject (
@@ -369,7 +385,7 @@ async function generateSbomForProject (
     ? await buildWorkspacePackagesMap(
       resolvedWorkspaceDeps.additionalImporterIds,
       lockfileDir,
-      opts.selectedProjectsGraph
+      ctx.workspaceManifestsByImporterId
     )
     : undefined
 
@@ -459,23 +475,16 @@ const WORKSPACE_MANIFEST_READ_CONCURRENCY = 8
 async function buildWorkspacePackagesMap (
   reachableImporterIds: ProjectId[],
   lockfileDir: string,
-  selectedProjectsGraph?: SbomCommandOptions['selectedProjectsGraph']
+  manifestsByImporterId: Map<string, ManifestLike>
 ): Promise<Record<ProjectId, WorkspacePackageInfo>> {
   if (reachableImporterIds.length === 0) return {} as Record<ProjectId, WorkspacePackageInfo>
-
-  const selectedEntriesMap = new Map<string, { manifest: { name?: string, version?: string, license?: string, description?: string, author?: string | { name?: string }, repository?: string | { url?: string } } }>()
-  if (selectedProjectsGraph) {
-    for (const [dir, entry] of Object.entries(selectedProjectsGraph)) {
-      selectedEntriesMap.set(getLockfileImporterId(lockfileDir, dir), entry.package)
-    }
-  }
 
   const readManifest = pLimit(WORKSPACE_MANIFEST_READ_CONCURRENCY)
   const entries = await Promise.all(
     reachableImporterIds.map((importerId) => readManifest(async (): Promise<[ProjectId, WorkspacePackageInfo] | null> => {
-      const selected = selectedEntriesMap.get(importerId)
-      const manifest = selected
-        ? selected.manifest
+      const known = manifestsByImporterId.get(importerId)
+      const manifest = known
+        ? known
         : isInsideDir(lockfileDir, importerId)
           ? await readManifestSafe(path.join(lockfileDir, importerId))
           : undefined
@@ -496,7 +505,7 @@ async function buildWorkspacePackagesMap (
   return Object.fromEntries(entries.filter((e) => e !== null)) as Record<ProjectId, WorkspacePackageInfo>
 }
 
-async function readManifestSafe (dir: string): Promise<{ name?: string, version?: string, license?: string, description?: string, author?: string | { name?: string }, repository?: string | { url?: string } } | undefined> {
+async function readManifestSafe (dir: string): Promise<ManifestLike | undefined> {
   try {
     return await readProjectManifestOnly(dir)
   } catch {

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -248,6 +248,15 @@ async function handleSplit (
       const filePath = opts.out
         .replaceAll('%s', sanitizePathSegment(sanitizePackageName(manifest.name)))
         .replaceAll('%v', sanitizePathSegment(manifest.version ?? '0.0.0'))
+      // Sanitizing package names is lossy (e.g. "@a/b" and "a-b" both map to "a-b"),
+      // so two packages can resolve to the same path. Fail loudly instead of letting
+      // one SBOM silently overwrite another.
+      if (files.includes(filePath)) {
+        throw new PnpmError(
+          'SBOM_OUT_PATH_COLLISION',
+          `Multiple workspace packages resolve to the same output path "${filePath}". Include %v in the --out pattern to disambiguate.`
+        )
+      }
       const fileDir = path.dirname(filePath)
       if (!createdDirs.has(fileDir)) {
         fs.mkdirSync(fileDir, { recursive: true })

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -178,7 +178,11 @@ export async function handler (
 
   const ctx = await buildSharedContext(opts)
   const serialOpts = { format, sbomType, sbomSpecVersion }
-  const shouldSplit = opts.split || (opts.out != null && opts.out.includes('%s'))
+  // `%s` in --out only implies per-package output inside a workspace; in a
+  // single-project repo it is interpolated from the root component on the
+  // single-output path below.
+  const hasWorkspaceGraph = opts.selectedProjectsGraph != null || opts.allProjectsGraph != null
+  const shouldSplit = opts.split || (opts.out != null && opts.out.includes('%s') && hasWorkspaceGraph)
 
   if (shouldSplit) {
     return handleSplit(opts, serialOpts, ctx)
@@ -287,6 +291,9 @@ interface SharedContext {
   lockfile: Exclude<Awaited<ReturnType<typeof readWantedLockfile>>, null>
   rootManifest: Awaited<ReturnType<typeof readProjectManifestOnly>>
   rootManifestDir: string
+  /** Workspace-root license, resolved once so split mode does not re-probe the
+   * root directory as the fallback for every emitted SBOM. */
+  rootLicense: string | undefined
   storeDir: string | undefined
   /** Workspace package manifests keyed by lockfile importer id, read once from the
    * project graph so split mode does not re-read them for every emitted SBOM. */
@@ -326,7 +333,9 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
     }
   }
 
-  return { lockfile, rootManifest, rootManifestDir, storeDir, workspaceManifestsByImporterId }
+  const rootLicense = await resolveRootLicense(rootManifest, rootManifestDir)
+
+  return { lockfile, rootManifest, rootManifestDir, rootLicense, storeDir, workspaceManifestsByImporterId }
 }
 
 async function generateSbomForProject (
@@ -335,7 +344,7 @@ async function generateSbomForProject (
   ctx: SharedContext,
   compact?: boolean
 ): Promise<{ output: string, exitCode: number, rootName: string, rootVersion: string }> {
-  const { lockfile, rootManifest, rootManifestDir } = ctx
+  const { lockfile, rootManifest, rootManifestDir, rootLicense: cachedRootLicense } = ctx
 
   const include = {
     dependencies: opts.production !== false,
@@ -359,8 +368,9 @@ async function generateSbomForProject (
 
   const rootName = manifest.name ?? 'unknown'
   const rootVersion = manifest.version ?? '0.0.0'
-  const rootLicense = await resolveRootLicense(manifest, projectDir)
-    ?? (singleProject ? await resolveRootLicense(rootManifest, rootManifestDir) : undefined)
+  const rootLicense = singleProject
+    ? (await resolveRootLicense(manifest, projectDir) ?? cachedRootLicense)
+    : cachedRootLicense
   const rootAuthor = extractAuthor(manifest)
     ?? (singleProject ? extractAuthor(rootManifest) : undefined)
   const rootRepository = extractRepository(manifest)
@@ -453,6 +463,11 @@ function validateSbomSpecVersion (value: string | undefined, format: SbomFormat)
 }
 
 async function resolveRootLicense (manifest: Parameters<typeof resolveLicenseFromDir>[0]['manifest'], dir: string): Promise<string | undefined> {
+  // Skip the on-disk LICENSE probing when the manifest already declares a usable
+  // SPDX license; resolveLicenseFromDir would return the same value after the scan.
+  if (typeof manifest.license === 'string' && isSpdxLicenseExpression(manifest.license)) {
+    return manifest.license
+  }
   const info = await resolveLicenseFromDir({ manifest, dir })
   if (info && info.name !== 'Unknown' && (!info.licenseFile || isSpdxLicenseExpression(info.name))) {
     return info.name

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -272,6 +272,7 @@ async function handleSplit (
 interface SharedContext {
   lockfile: Exclude<Awaited<ReturnType<typeof readWantedLockfile>>, null>
   rootManifest: Awaited<ReturnType<typeof readProjectManifestOnly>>
+  rootManifestDir: string
   storeDir: string | undefined
 }
 
@@ -287,7 +288,8 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
     )
   }
 
-  const rootManifest = await readProjectManifestOnly(opts.dir)
+  const rootManifestDir = opts.rootProjectManifestDir ?? opts.dir
+  const rootManifest = opts.rootProjectManifest ?? await readProjectManifestOnly(rootManifestDir)
 
   let storeDir: string | undefined
   if (!opts.lockfileOnly) {
@@ -298,7 +300,7 @@ async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedCont
     })
   }
 
-  return { lockfile, rootManifest, storeDir }
+  return { lockfile, rootManifest, rootManifestDir, storeDir }
 }
 
 async function generateSbomForProject (
@@ -307,7 +309,7 @@ async function generateSbomForProject (
   ctx: SharedContext,
   compact?: boolean
 ): Promise<{ output: string, exitCode: number, rootName: string, rootVersion: string }> {
-  const { lockfile, rootManifest } = ctx
+  const { lockfile, rootManifest, rootManifestDir } = ctx
 
   const include = {
     dependencies: opts.production !== false,
@@ -327,16 +329,18 @@ async function generateSbomForProject (
     : rootManifest
   const projectDir = singleProject
     ? singleProject[0]
-    : opts.dir
+    : rootManifestDir
 
   const rootName = manifest.name ?? 'unknown'
   const rootVersion = manifest.version ?? '0.0.0'
   const rootLicense = await resolveRootLicense(manifest, projectDir)
-    ?? (singleProject ? await resolveRootLicense(rootManifest, opts.dir) : undefined)
+    ?? (singleProject ? await resolveRootLicense(rootManifest, rootManifestDir) : undefined)
   const rootAuthor = extractAuthor(manifest)
     ?? (singleProject ? extractAuthor(rootManifest) : undefined)
   const rootRepository = extractRepository(manifest)
     ?? (singleProject ? extractRepository(rootManifest) : undefined)
+  const rootDescription = manifest.description
+    ?? (singleProject ? rootManifest.description : undefined)
 
   const lockfileDir = opts.lockfileDir ?? opts.dir
   const includedImporterIds = opts.selectedProjectsGraph
@@ -364,7 +368,7 @@ async function generateSbomForProject (
     rootName,
     rootVersion,
     rootLicense,
-    rootDescription: manifest.description,
+    rootDescription,
     rootAuthor,
     rootRepository,
     sbomType: serialOpts.sbomType,

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { FILTERING } from '@pnpm/cli.common-cli-options-help'
@@ -29,6 +30,8 @@ export type SbomCommandOptions = {
   lockfileOnly?: boolean
   sbomAuthors?: string
   sbomSupplier?: string
+  out?: string
+  split?: boolean
 } & Pick<
   Config,
   | 'dev'
@@ -43,6 +46,7 @@ export type SbomCommandOptions = {
   | 'pnpmHomeDir'
   | 'virtualStoreDirMaxLength'
 > & Pick<ConfigContext,
+| 'allProjectsGraph'
 | 'selectedProjectsGraph'
 | 'rootProjectManifest'
 | 'rootProjectManifestDir'
@@ -65,6 +69,8 @@ export const cliOptionsTypes = (): Record<string, unknown> => ({
   'sbom-authors': String,
   'sbom-supplier': String,
   'lockfile-only': Boolean,
+  out: String,
+  split: Boolean,
 })
 
 export const shorthands: Record<string, string> = {
@@ -121,6 +127,14 @@ export function help (): string {
             description: 'Don\'t include "optionalDependencies"',
             name: '--no-optional',
           },
+          {
+            description: 'Write SBOM to a file instead of stdout. Use %s for the package name and %v for the version.',
+            name: '--out <path>',
+          },
+          {
+            description: 'Generate a separate SBOM for each matched workspace package. Outputs NDJSON to stdout, or files when combined with --out.',
+            name: '--split',
+          },
         ],
       },
       FILTERING,
@@ -132,6 +146,8 @@ export function help (): string {
       'pnpm sbom --sbom-format cyclonedx --lockfile-only',
       'pnpm sbom --sbom-format spdx --prod',
       'pnpm sbom --sbom-format cyclonedx --filter ./apps/my-app',
+      'pnpm sbom --sbom-format cyclonedx --out sboms/%s.cdx.json',
+      'pnpm sbom --sbom-format cyclonedx --split',
     ],
   })
 }
@@ -159,6 +175,105 @@ export async function handler (
   const sbomType = validateSbomType(opts.sbomType)
   const sbomSpecVersion = validateSbomSpecVersion(opts.sbomSpecVersion, format)
 
+  const ctx = await buildSharedContext(opts)
+  const serialOpts = { format, sbomType, sbomSpecVersion }
+  const shouldSplit = opts.split || (opts.out != null && opts.out.includes('%s'))
+
+  if (shouldSplit) {
+    return handleSplit(opts, serialOpts, ctx)
+  }
+
+  const { output } = await generateSbomForProject(opts, serialOpts, ctx)
+
+  if (opts.out) {
+    const filePath = opts.out
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, output)
+    return { output: filePath, exitCode: 0 }
+  }
+
+  return { output, exitCode: 0 }
+}
+
+interface SerializeOptions {
+  format: SbomFormat
+  sbomType: SbomComponentType
+  sbomSpecVersion: string | undefined
+}
+
+async function handleSplit (
+  opts: SbomCommandOptions,
+  serialOpts: SerializeOptions,
+  ctx: SharedContext
+): Promise<{ output: string, exitCode: number }> {
+  const projectsGraph = opts.selectedProjectsGraph ?? opts.allProjectsGraph
+  if (!projectsGraph) {
+    throw new PnpmError(
+      'SBOM_NO_PROJECTS',
+      'No workspace projects found. --split requires a workspace.'
+    )
+  }
+
+  if (opts.out && !opts.out.includes('%s')) {
+    throw new PnpmError(
+      'SBOM_OUT_MISSING_PLACEHOLDER',
+      'When using --split with --out, the path must contain %s as a placeholder for the package name.'
+    )
+  }
+
+  const entries = Object.entries(projectsGraph)
+  const ndjsonLines: string[] = []
+  const files: string[] = []
+  const compact = !opts.out
+  const createdDirs = new Set<string>()
+
+  for (const [dir, entry] of entries) {
+    const manifest = entry.package.manifest
+    if (!manifest.name) continue
+
+    const singleProjectGraph = { [dir as keyof typeof projectsGraph]: entry }
+
+    // eslint-disable-next-line no-await-in-loop
+    const { output } = await generateSbomForProject(
+      { ...opts, selectedProjectsGraph: singleProjectGraph as typeof projectsGraph, allProjectsGraph: undefined, split: false, out: undefined },
+      serialOpts,
+      ctx,
+      compact
+    )
+
+    if (opts.out) {
+      const filePath = opts.out
+        .replaceAll('%s', sanitizePathSegment(sanitizePackageName(manifest.name)))
+        .replaceAll('%v', sanitizePathSegment(manifest.version ?? '0.0.0'))
+      const fileDir = path.dirname(filePath)
+      if (!createdDirs.has(fileDir)) {
+        fs.mkdirSync(fileDir, { recursive: true })
+        createdDirs.add(fileDir)
+      }
+      fs.writeFileSync(filePath, output)
+      files.push(filePath)
+    } else {
+      ndjsonLines.push(output)
+    }
+  }
+
+  if (opts.out) {
+    return {
+      output: `Generated ${files.length} SBOMs:\n${files.map((f) => `  ${f}`).join('\n')}`,
+      exitCode: 0,
+    }
+  }
+
+  return { output: ndjsonLines.join('\n'), exitCode: 0 }
+}
+
+interface SharedContext {
+  lockfile: Exclude<Awaited<ReturnType<typeof readWantedLockfile>>, null>
+  rootManifest: Awaited<ReturnType<typeof readProjectManifestOnly>>
+  storeDir: string | undefined
+}
+
+async function buildSharedContext (opts: SbomCommandOptions): Promise<SharedContext> {
   const lockfile = await readWantedLockfile(opts.lockfileDir ?? opts.dir, {
     ignoreIncompatible: true,
   })
@@ -169,6 +284,28 @@ export async function handler (
       `No ${WANTED_LOCKFILE} found: Cannot generate SBOM without a lockfile`
     )
   }
+
+  const rootManifest = await readProjectManifestOnly(opts.dir)
+
+  let storeDir: string | undefined
+  if (!opts.lockfileOnly) {
+    storeDir = await getStorePath({
+      pkgRoot: opts.dir,
+      storePath: opts.storeDir,
+      pnpmHomeDir: opts.pnpmHomeDir,
+    })
+  }
+
+  return { lockfile, rootManifest, storeDir }
+}
+
+async function generateSbomForProject (
+  opts: SbomCommandOptions,
+  serialOpts: SerializeOptions,
+  ctx: SharedContext,
+  compact?: boolean
+): Promise<{ output: string, exitCode: number }> {
+  const { lockfile, rootManifest } = ctx
 
   const include = {
     dependencies: opts.production !== false,
@@ -183,7 +320,6 @@ export async function handler (
     ? selectedEntries[0]
     : undefined
 
-  const rootManifest = await readProjectManifestOnly(opts.dir)
   const manifest = singleProject
     ? singleProject[1].package.manifest
     : rootManifest
@@ -221,15 +357,6 @@ export async function handler (
     )
     : undefined
 
-  let storeDir: string | undefined
-  if (!opts.lockfileOnly) {
-    storeDir = await getStorePath({
-      pkgRoot: opts.dir,
-      storePath: opts.storeDir,
-      pnpmHomeDir: opts.pnpmHomeDir,
-    })
-  }
-
   const result = await collectSbomComponents({
     lockfile,
     rootName,
@@ -238,27 +365,28 @@ export async function handler (
     rootDescription: manifest.description,
     rootAuthor,
     rootRepository,
-    sbomType,
+    sbomType: serialOpts.sbomType,
     include,
     registries: opts.registries,
     lockfileDir,
     includedImporterIds,
     lockfileOnly: opts.lockfileOnly,
-    storeDir,
+    storeDir: ctx.storeDir,
     virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
     workspacePackages,
     resolvedWorkspaceDeps,
   })
 
-  const output = format === 'cyclonedx'
+  const output = serialOpts.format === 'cyclonedx'
     ? serializeCycloneDx(result, {
       pnpmVersion: packageManager.version,
       lockfileOnly: opts.lockfileOnly,
       sbomAuthors: opts.sbomAuthors?.split(',').map((s) => s.trim()).filter(Boolean),
       sbomSupplier: opts.sbomSupplier,
-      specVersion: sbomSpecVersion,
+      specVersion: serialOpts.sbomSpecVersion,
+      compact,
     })
-    : serializeSpdx(result)
+    : serializeSpdx(result, { compact })
 
   return { output, exitCode: 0 }
 }
@@ -353,4 +481,12 @@ async function readManifestSafe (dir: string): Promise<{ name?: string, version?
   } catch {
     return undefined
   }
+}
+
+function sanitizePackageName (name: string): string {
+  return name.replace(/^@/, '').replace(/\//g, '-')
+}
+
+function sanitizePathSegment (value: string): string {
+  return value.replace(/[/\\:*?"<>|]/g, '-')
 }

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -183,10 +183,12 @@ export async function handler (
     return handleSplit(opts, serialOpts, ctx)
   }
 
-  const { output } = await generateSbomForProject(opts, serialOpts, ctx)
+  const { output, rootName, rootVersion } = await generateSbomForProject(opts, serialOpts, ctx)
 
   if (opts.out) {
     const filePath = opts.out
+      .replaceAll('%s', sanitizePathSegment(sanitizePackageName(rootName)))
+      .replaceAll('%v', sanitizePathSegment(rootVersion))
     fs.mkdirSync(path.dirname(filePath), { recursive: true })
     fs.writeFileSync(filePath, output)
     return { output: filePath, exitCode: 0 }
@@ -304,7 +306,7 @@ async function generateSbomForProject (
   serialOpts: SerializeOptions,
   ctx: SharedContext,
   compact?: boolean
-): Promise<{ output: string, exitCode: number }> {
+): Promise<{ output: string, exitCode: number, rootName: string, rootVersion: string }> {
   const { lockfile, rootManifest } = ctx
 
   const include = {
@@ -388,7 +390,7 @@ async function generateSbomForProject (
     })
     : serializeSpdx(result, { compact })
 
-  return { output, exitCode: 0 }
+  return { output, exitCode: 0, rootName, rootVersion }
 }
 
 function validateSbomType (value: string | undefined): SbomComponentType {

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -20,6 +20,7 @@ import { PnpmError } from '@pnpm/error'
 import { getLockfileImporterId, readWantedLockfile } from '@pnpm/lockfile.fs'
 import { getStorePath } from '@pnpm/store.path'
 import type { ProjectId } from '@pnpm/types'
+import pLimit from 'p-limit'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 
@@ -444,6 +445,8 @@ function extractRepository (manifest: { repository?: string | { url?: string } }
   return manifest.repository?.url
 }
 
+const WORKSPACE_MANIFEST_READ_CONCURRENCY = 8
+
 async function buildWorkspacePackagesMap (
   reachableImporterIds: ProjectId[],
   lockfileDir: string,
@@ -458,24 +461,27 @@ async function buildWorkspacePackagesMap (
     }
   }
 
+  const readManifest = pLimit(WORKSPACE_MANIFEST_READ_CONCURRENCY)
   const entries = await Promise.all(
-    reachableImporterIds.map(async (importerId): Promise<[ProjectId, WorkspacePackageInfo] | null> => {
+    reachableImporterIds.map((importerId) => readManifest(async (): Promise<[ProjectId, WorkspacePackageInfo] | null> => {
       const selected = selectedEntriesMap.get(importerId)
       const manifest = selected
         ? selected.manifest
-        : await readManifestSafe(path.join(lockfileDir, importerId))
+        : isInsideDir(lockfileDir, importerId)
+          ? await readManifestSafe(path.join(lockfileDir, importerId))
+          : undefined
 
-      if (!manifest?.name || !manifest.version) return null
+      if (!manifest?.name) return null
 
       return [importerId, {
         name: manifest.name,
-        version: manifest.version,
+        version: manifest.version ?? '0.0.0',
         license: typeof manifest.license === 'string' ? manifest.license : undefined,
         description: manifest.description,
         author: extractAuthor(manifest),
         repository: extractRepository(manifest),
       }]
-    })
+    }))
   )
 
   return Object.fromEntries(entries.filter((e) => e !== null)) as Record<ProjectId, WorkspacePackageInfo>
@@ -494,5 +500,13 @@ function sanitizePackageName (name: string): string {
 }
 
 function sanitizePathSegment (value: string): string {
-  return value.replace(/[/\\:*?"<>|]/g, '-')
+  const sanitized = value.replace(/[/\\:*?"<>|]/g, '-')
+  // `.`, `..`, or a blank value would let a crafted name/version escape or replace
+  // the intended output directory once interpolated into an `--out` template.
+  return sanitized === '.' || sanitized === '..' || sanitized.trim() === '' ? '-' : sanitized
+}
+
+function isInsideDir (parentDir: string, childRelativePath: string): boolean {
+  const rel = path.relative(parentDir, path.resolve(parentDir, childRelativePath))
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))
 }

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -74,6 +74,8 @@ export const shorthands: Record<string, string> = {
 
 export const commandNames = ['sbom']
 
+export const recursiveByDefault = true
+
 export function help (): string {
   return renderHelp({
     description: 'Generate a Software Bill of Materials (SBOM) for the project.',

--- a/deps/compliance/commands/src/sbom/sbom.ts
+++ b/deps/compliance/commands/src/sbom/sbom.ts
@@ -509,7 +509,11 @@ function sanitizePackageName (name: string): string {
 }
 
 function sanitizePathSegment (value: string): string {
-  const sanitized = value.replace(/[/\\:*?"<>|]/g, '-')
+  // Control characters (e.g. newlines) would produce confusing filenames and could
+  // inject extra lines into the printed `--split --out` summary; filesystem
+  // metacharacters are replaced so the value stays a single path segment.
+  // eslint-disable-next-line no-control-regex
+  const sanitized = value.replace(/[/\\:*?"<>|\x00-\x1F\x7F]/g, '-')
   // `.`, `..`, or a blank value would let a crafted name/version escape or replace
   // the intended output directory once interpolated into an `--out` template.
   return sanitized === '.' || sanitized === '..' || sanitized.trim() === '' ? '-' : sanitized

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/app/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-positive": "3.1.0"
+  },
+  "devDependencies": {
+    "dev-tool": "workspace:*"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/dev-tool/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/dev-tool/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dev-tool",
+  "version": "0.5.0",
+  "dependencies": {
+    "is-negative": "2.1.0"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-sbom-dev-root",
+  "version": "0.0.0",
+  "private": true
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/pnpm-workspace.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom-dev/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - app
+  - dev-tool

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-a/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app-a",
+  "version": "1.0.0",
+  "description": "First workspace app",
+  "dependencies": {
+    "is-positive": "3.1.0",
+    "shared-lib": "workspace:*"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-a/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app-a",
+  "name": "@test/app-a",
   "version": "1.0.0",
   "description": "First workspace app",
   "dependencies": {

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-b/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/app-b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "app-b",
+  "version": "2.0.0",
+  "description": "Second workspace app",
+  "dependencies": {
+    "is-negative": "2.1.0"
+  }
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-sbom-root",
+  "version": "0.0.0",
+  "private": true
+}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/pnpm-lock.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/pnpm-workspace.yaml
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - app-a
+  - app-b
+  - shared-lib

--- a/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/shared-lib/package.json
+++ b/deps/compliance/commands/test/sbom/fixtures/workspace-sbom/shared-lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "shared-lib",
+  "version": "0.1.0",
+  "description": "Shared workspace library",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -344,7 +344,8 @@ test('pnpm sbom --filter uses workspace manifest for root component', async () =
   expect(exitCode).toBe(0)
 
   const parsed = JSON.parse(output)
-  expect(parsed.metadata.component.name).toBe('@test/app-a')
+  expect(parsed.metadata.component.name).toBe('app-a')
+  expect(parsed.metadata.component.group).toBe('@test')
   expect(parsed.metadata.component.version).toBe('1.0.0')
 
   const componentNames = parsed.components.map((c: { name: string }) => c.name)
@@ -549,7 +550,8 @@ test('pnpm sbom --lockfile-only skips workspace dep resolution', async () => {
   expect(exitCode).toBe(0)
 
   const parsed = JSON.parse(output)
-  expect(parsed.metadata.component.name).toBe('@test/app-a')
+  expect(parsed.metadata.component.name).toBe('app-a')
+  expect(parsed.metadata.component.group).toBe('@test')
 
   const componentNames = parsed.components.map((c: { name: string }) => c.name)
   // lockfile-only mode: workspace deps are not resolved (no manifest reads)
@@ -634,7 +636,8 @@ test('pnpm sbom --out with %s writes per-package files', async () => {
   expect(files).toContain('shared-lib.cdx.json')
 
   const appA = JSON.parse(fs.readFileSync(path.join(outDir, 'test-app-a.cdx.json'), 'utf8'))
-  expect(appA.metadata.component.name).toBe('@test/app-a')
+  expect(appA.metadata.component.name).toBe('app-a')
+  expect(appA.metadata.component.group).toBe('@test')
   expect(appA.metadata.component.version).toBe('1.0.0')
 
   const appB = JSON.parse(fs.readFileSync(path.join(outDir, 'app-b.cdx.json'), 'utf8'))
@@ -678,7 +681,10 @@ test('pnpm sbom --split outputs NDJSON to stdout', async () => {
   const lines = output.trim().split('\n')
   expect(lines).toHaveLength(4)
 
-  const names = lines.map((line) => JSON.parse(line).metadata.component.name).sort()
+  const names = lines.map((line) => {
+    const component = JSON.parse(line).metadata.component
+    return component.group ? `${component.group}/${component.name}` : component.name
+  }).sort()
   expect(names).toContain('@test/app-a')
   expect(names).toContain('app-b')
   expect(names).toContain('shared-lib')

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -611,7 +611,7 @@ test('pnpm sbom --out with %s writes per-package files', async () => {
     selectedProjectsGraph,
   })
 
-  const outDir = path.join(workspaceDir, 'sboms')
+  const outDir = path.join(workspaceDir, 'sbom-out')
   const outPattern = path.join(outDir, '%s.cdx.json')
 
   const { exitCode } = await sbom.handler({
@@ -710,7 +710,7 @@ test('pnpm sbom --out with %s and %v uses name and version in filename', async (
     selectedProjectsGraph,
   })
 
-  const outDir = path.join(workspaceDir, 'sboms')
+  const outDir = path.join(workspaceDir, 'sbom-out')
   const outPattern = path.join(outDir, '%s-%v.cdx.json')
 
   const appADir = path.join(workspaceDir, 'app-a')

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../../../__typings__/index.d.ts" />
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
@@ -343,7 +344,7 @@ test('pnpm sbom --filter uses workspace manifest for root component', async () =
   expect(exitCode).toBe(0)
 
   const parsed = JSON.parse(output)
-  expect(parsed.metadata.component.name).toBe('app-a')
+  expect(parsed.metadata.component.name).toBe('@test/app-a')
   expect(parsed.metadata.component.version).toBe('1.0.0')
 
   const componentNames = parsed.components.map((c: { name: string }) => c.name)
@@ -548,11 +549,230 @@ test('pnpm sbom --lockfile-only skips workspace dep resolution', async () => {
   expect(exitCode).toBe(0)
 
   const parsed = JSON.parse(output)
-  expect(parsed.metadata.component.name).toBe('app-a')
+  expect(parsed.metadata.component.name).toBe('@test/app-a')
 
   const componentNames = parsed.components.map((c: { name: string }) => c.name)
   // lockfile-only mode: workspace deps are not resolved (no manifest reads)
   expect(componentNames).not.toContain('shared-lib')
   // External deps from the selected importer are still present
   expect(componentNames).toContain('is-positive')
+})
+
+test('pnpm sbom --out writes single file', async () => {
+  const workspaceDir = tempDir()
+  f.copy('simple-sbom', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  const outFile = path.join(workspaceDir, 'output', 'sbom.cdx.json')
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    out: outFile,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toBe(outFile)
+  expect(fs.existsSync(outFile)).toBe(true)
+
+  const parsed = JSON.parse(fs.readFileSync(outFile, 'utf8'))
+  expect(parsed.bomFormat).toBe('CycloneDX')
+  expect(parsed.metadata.component.name).toBe('simple-sbom-test')
+})
+
+test('pnpm sbom --out with %s writes per-package files', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const outDir = path.join(workspaceDir, 'sboms')
+  const outPattern = path.join(outDir, '%s.cdx.json')
+
+  const { exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    out: outPattern,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const files = fs.readdirSync(outDir).sort()
+  expect(files).toContain('test-app-a.cdx.json')
+  expect(files).toContain('app-b.cdx.json')
+  expect(files).toContain('shared-lib.cdx.json')
+
+  const appA = JSON.parse(fs.readFileSync(path.join(outDir, 'test-app-a.cdx.json'), 'utf8'))
+  expect(appA.metadata.component.name).toBe('@test/app-a')
+  expect(appA.metadata.component.version).toBe('1.0.0')
+
+  const appB = JSON.parse(fs.readFileSync(path.join(outDir, 'app-b.cdx.json'), 'utf8'))
+  expect(appB.metadata.component.name).toBe('app-b')
+})
+
+test('pnpm sbom --split outputs NDJSON to stdout', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    split: true,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const lines = output.trim().split('\n')
+  expect(lines).toHaveLength(4)
+
+  const names = lines.map((line) => JSON.parse(line).metadata.component.name).sort()
+  expect(names).toContain('@test/app-a')
+  expect(names).toContain('app-b')
+  expect(names).toContain('shared-lib')
+
+  for (const line of lines) {
+    expect(line).toBe(line.trim())
+    expect(line.startsWith('{')).toBe(true)
+    JSON.parse(line)
+  }
+})
+
+test('pnpm sbom --out with %s and %v uses name and version in filename', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const outDir = path.join(workspaceDir, 'sboms')
+  const outPattern = path.join(outDir, '%s-%v.cdx.json')
+
+  const appADir = path.join(workspaceDir, 'app-a')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appADir
+    )
+  )
+
+  const { exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    out: outPattern,
+    selectedProjectsGraph: filteredGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const files = fs.readdirSync(outDir)
+  expect(files).toContain('test-app-a-1.0.0.cdx.json')
+})
+
+test('pnpm sbom --split without workspace throws', async () => {
+  const workspaceDir = tempDir()
+  f.copy('simple-sbom', workspaceDir)
+
+  await expect(
+    sbom.handler({
+      ...DEFAULT_OPTS,
+      dir: workspaceDir,
+      lockfileDir: workspaceDir,
+      pnpmHomeDir: '',
+      sbomFormat: 'cyclonedx',
+      split: true,
+      lockfileOnly: true,
+    })
+  ).rejects.toThrow('requires a workspace')
+})
+
+test('pnpm sbom --split --out without %s throws', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  await expect(
+    sbom.handler({
+      ...DEFAULT_OPTS,
+      dir: workspaceDir,
+      lockfileDir: workspaceDir,
+      pnpmHomeDir: '',
+      sbomFormat: 'cyclonedx',
+      split: true,
+      out: 'sbom.cdx.json',
+      allProjectsGraph,
+      selectedProjectsGraph,
+      lockfileOnly: true,
+    })
+  ).rejects.toThrow('must contain %s')
 })

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -595,6 +595,36 @@ test('pnpm sbom --out writes single file', async () => {
   expect(parsed.metadata.component.name).toBe('simple-sbom-test')
 })
 
+test('pnpm sbom --out with %s in a single-project repo writes one file', async () => {
+  const workspaceDir = tempDir()
+  f.copy('simple-sbom', workspaceDir)
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+  })
+
+  const outFile = path.join(workspaceDir, 'sbom-out', '%s.cdx.json')
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    out: outFile,
+  })
+
+  expect(exitCode).toBe(0)
+  const expectedFile = path.join(workspaceDir, 'sbom-out', 'simple-sbom-test.cdx.json')
+  expect(output).toBe(expectedFile)
+  expect(fs.existsSync(expectedFile)).toBe(true)
+})
+
 test('pnpm sbom --out with %s writes per-package files', async () => {
   const workspaceDir = tempDir()
   f.copy('workspace-sbom', workspaceDir)

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -7,6 +7,7 @@ import { sbom } from '@pnpm/deps.compliance.commands'
 import { install } from '@pnpm/installing.commands'
 import { tempDir } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
+import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
 
 import { DEFAULT_OPTS } from './utils/index.js'
 
@@ -300,4 +301,258 @@ test('pnpm sbom --sbom-type application', async () => {
 
   const parsed = JSON.parse(output)
   expect(parsed.metadata.component.type).toBe('application')
+})
+
+test('pnpm sbom --filter uses workspace manifest for root component', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appADir = path.join(workspaceDir, 'app-a')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appADir
+    )
+  )
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appADir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    selectedProjectsGraph: filteredGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  expect(parsed.metadata.component.name).toBe('app-a')
+  expect(parsed.metadata.component.version).toBe('1.0.0')
+
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  expect(componentNames).not.toContain('is-negative')
+
+  // Workspace dep shared-lib and its transitive dep is-odd should be included
+  expect(componentNames).toContain('shared-lib')
+  expect(componentNames).toContain('is-odd')
+
+  const sharedLib = parsed.components.find(
+    (c: { name: string }) => c.name === 'shared-lib'
+  )
+  expect(sharedLib.version).toBe('0.1.0')
+  expect(sharedLib.purl).toBe('pkg:npm/shared-lib@0.1.0')
+})
+
+test('pnpm sbom --filter with spdx uses workspace manifest for root component', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appBDir = path.join(workspaceDir, 'app-b')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appBDir
+    )
+  )
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appBDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'spdx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    selectedProjectsGraph: filteredGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const rootPkg = parsed.packages.find(
+    (p: { name: string }) => p.name === 'app-b'
+  )
+  expect(rootPkg).toBeDefined()
+  expect(rootPkg.versionInfo).toBe('2.0.0')
+
+  const componentNames = parsed.packages.map((p: { name: string }) => p.name)
+  expect(componentNames).toContain('is-negative')
+  expect(componentNames).not.toContain('is-positive')
+})
+
+test('pnpm sbom --prod excludes dev-only workspace dependencies', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom-dev', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appDir = path.join(workspaceDir, 'app')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appDir
+    )
+  )
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    selectedProjectsGraph: filteredGraph,
+    production: true,
+    dev: false,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  // dev-tool is a devDependency workspace dep; excluded with --prod
+  expect(componentNames).not.toContain('dev-tool')
+  // is-negative is a transitive dep of dev-tool; also excluded
+  expect(componentNames).not.toContain('is-negative')
+})
+
+test('pnpm sbom --filter includes dev workspace deps without --prod', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom-dev', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appDir = path.join(workspaceDir, 'app')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appDir
+    )
+  )
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    storeDir: path.resolve(storeDir, STORE_VERSION),
+    selectedProjectsGraph: filteredGraph,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  expect(componentNames).toContain('is-positive')
+  expect(componentNames).toContain('dev-tool')
+  expect(componentNames).toContain('is-negative')
+})
+
+test('pnpm sbom --lockfile-only skips workspace dep resolution', async () => {
+  const workspaceDir = tempDir()
+  f.copy('workspace-sbom', workspaceDir)
+
+  const { allProjects, allProjectsGraph, selectedProjectsGraph } =
+    await filterProjectsBySelectorObjectsFromDir(workspaceDir, [])
+
+  const storeDir = path.join(workspaceDir, 'store')
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    storeDir,
+    allProjects,
+    allProjectsGraph,
+    selectedProjectsGraph,
+  })
+
+  const appADir = path.join(workspaceDir, 'app-a')
+  const filteredGraph = Object.fromEntries(
+    Object.entries(selectedProjectsGraph).filter(([p]) =>
+      p === appADir
+    )
+  )
+
+  const { output, exitCode } = await sbom.handler({
+    ...DEFAULT_OPTS,
+    dir: appADir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    sbomFormat: 'cyclonedx',
+    selectedProjectsGraph: filteredGraph,
+    lockfileOnly: true,
+  })
+
+  expect(exitCode).toBe(0)
+
+  const parsed = JSON.parse(output)
+  expect(parsed.metadata.component.name).toBe('app-a')
+
+  const componentNames = parsed.components.map((c: { name: string }) => c.name)
+  // lockfile-only mode: workspace deps are not resolved (no manifest reads)
+  expect(componentNames).not.toContain('shared-lib')
+  // External deps from the selected importer are still present
+  expect(componentNames).toContain('is-positive')
 })

--- a/deps/compliance/commands/test/sbom/index.ts
+++ b/deps/compliance/commands/test/sbom/index.ts
@@ -556,6 +556,8 @@ test('pnpm sbom --lockfile-only skips workspace dep resolution', async () => {
   const componentNames = parsed.components.map((c: { name: string }) => c.name)
   // lockfile-only mode: workspace deps are not resolved (no manifest reads)
   expect(componentNames).not.toContain('shared-lib')
+  // Transitive deps reachable only through workspace links are not traversed either
+  expect(componentNames).not.toContain('is-odd')
   // External deps from the selected importer are still present
   expect(componentNames).toContain('is-positive')
 })

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -10,6 +10,7 @@ import {
 import type { Resolution } from '@pnpm/resolving.resolver-base'
 import { StoreIndex } from '@pnpm/store.index'
 import type { DependenciesField, ProjectId, Registries } from '@pnpm/types'
+import pLimit from 'p-limit'
 
 import { getPkgMetadata, type GetPkgMetadataOptions } from './getPkgMetadata.js'
 import { buildPurl, encodePurlName } from './purl.js'
@@ -43,6 +44,8 @@ export interface CollectSbomComponentsOptions {
   workspacePackages?: Record<ProjectId, WorkspacePackageInfo>
   resolvedWorkspaceDeps?: ReturnType<typeof resolveWorkspaceDeps>
 }
+
+const IMPORTER_WALK_CONCURRENCY = 8
 
 export async function collectSbomComponents (opts: CollectSbomComponentsOptions): Promise<SbomResult> {
   const depTypes = detectDepTypes(opts.lockfile)
@@ -126,14 +129,17 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
     }
     : undefined
 
+  const walkImporter = pLimit(IMPORTER_WALK_CONCURRENCY)
   await Promise.all(
-    importerWalkers.map(async ({ importerId, step }) => {
+    importerWalkers.map(({ importerId, step }) => walkImporter(async () => {
       let parentPurl = rootPurl
       if (!importerIdSet.has(importerId as ProjectId)) {
         const info = opts.workspacePackages?.[importerId as ProjectId]
-        if (info) {
-          parentPurl = buildPurl({ name: info.name, version: info.version })
-        }
+        // A reachable workspace importer with no resolved package info (e.g. its
+        // manifest could not be read) is skipped entirely; walking it would
+        // misattribute its dependencies to the root component.
+        if (!info) return
+        parentPurl = buildPurl({ name: info.name, version: info.version })
       }
       await walkStep(
         step,
@@ -144,7 +150,7 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
         opts,
         metadataOpts
       )
-    })
+    }))
   )
   storeIndex?.close()
 

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -52,7 +52,10 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
   const relationships: SbomRelationship[] = []
   const rootPurl = `pkg:npm/${encodePurlName(opts.rootName)}@${opts.rootVersion}`
 
-  const workspaceDeps = opts.resolvedWorkspaceDeps ?? resolveWorkspaceDeps(opts.lockfile, importerIds, opts.include)
+  const workspaceDeps = opts.resolvedWorkspaceDeps
+    ?? (opts.lockfileOnly
+      ? { links: [], additionalImporterIds: [] }
+      : resolveWorkspaceDeps(opts.lockfile, importerIds, opts.include))
   const allImporterIds = [...importerIds, ...workspaceDeps.additionalImporterIds]
 
   const importerWalkers = lockfileWalkerGroupImporterSteps(
@@ -256,6 +259,10 @@ export function resolveWorkspaceDeps (
       const targetId = path.posix.normalize(
         importerId === ('.' as ProjectId) ? linkPath : path.posix.join(importerId, linkPath)
       ) as ProjectId
+
+      // A crafted lockfile can point a `link:` target outside the workspace root;
+      // such importer IDs must never be followed, as they later become filesystem reads.
+      if (path.posix.isAbsolute(targetId) || targetId === '..' || targetId.startsWith('../')) continue
 
       if (!(targetId in lockfile.importers)) continue
 

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -270,7 +270,9 @@ export function resolveWorkspaceDeps (
       // such importer IDs must never be followed, as they later become filesystem reads.
       if (path.posix.isAbsolute(targetId) || targetId === '..' || targetId.startsWith('../')) continue
 
-      if (!(targetId in lockfile.importers)) continue
+      // `in` would also match inherited keys (e.g. "toString"); a crafted lockfile
+      // must not be able to enqueue importer IDs that are not actually present.
+      if (!Object.prototype.hasOwnProperty.call(lockfile.importers, targetId)) continue
 
       const devOnly = devDepNames.has(depName) && !(depName in prodDeps)
       links.push({ sourceImporterId: importerId, targetImporterId: targetId, depName, devOnly })

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -237,8 +237,8 @@ export function resolveWorkspaceDeps (
   const queue = [...importerIds]
   const additionalImporterIds: ProjectId[] = []
 
-  while (queue.length > 0) {
-    const importerId = queue.shift()!
+  for (let head = 0; head < queue.length; head++) {
+    const importerId = queue[head]
     const snapshot = lockfile.importers[importerId]
     if (!snapshot) continue
 

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -61,8 +61,9 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
     { include: opts.include }
   )
 
+  const importerIdSet = new Set<string>(importerIds)
+
   if (opts.workspacePackages) {
-    const importerIdSet = new Set<string>(importerIds)
 
     const workspaceDepTypes = new Map<string, DepType>()
     for (const dep of workspaceDeps.links) {
@@ -123,10 +124,17 @@ export async function collectSbomComponents (opts: CollectSbomComponentsOptions)
     : undefined
 
   await Promise.all(
-    importerWalkers.map(async ({ step }) => {
+    importerWalkers.map(async ({ importerId, step }) => {
+      let parentPurl = rootPurl
+      if (!importerIdSet.has(importerId as ProjectId)) {
+        const info = opts.workspacePackages?.[importerId as ProjectId]
+        if (info) {
+          parentPurl = buildPurl({ name: info.name, version: info.version })
+        }
+      }
       await walkStep(
         step,
-        rootPurl,
+        parentPurl,
         depTypes,
         componentsMap,
         relationships,

--- a/deps/compliance/sbom/src/collectComponents.ts
+++ b/deps/compliance/sbom/src/collectComponents.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { DepType, type DepTypes, detectDepTypes } from '@pnpm/lockfile.detect-dep-types'
 import type { LockfileObject, TarballResolution } from '@pnpm/lockfile.types'
 import { nameVerFromPkgSnapshot, pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
@@ -12,6 +14,15 @@ import type { DependenciesField, ProjectId, Registries } from '@pnpm/types'
 import { getPkgMetadata, type GetPkgMetadataOptions } from './getPkgMetadata.js'
 import { buildPurl, encodePurlName } from './purl.js'
 import type { SbomComponent, SbomComponentType, SbomRelationship, SbomResult } from './types.js'
+
+export interface WorkspacePackageInfo {
+  name: string
+  version: string
+  license?: string
+  description?: string
+  author?: string
+  repository?: string
+}
 
 export interface CollectSbomComponentsOptions {
   lockfile: LockfileObject
@@ -29,21 +40,75 @@ export interface CollectSbomComponentsOptions {
   lockfileOnly?: boolean
   storeDir?: string
   virtualStoreDirMaxLength?: number
+  workspacePackages?: Record<ProjectId, WorkspacePackageInfo>
+  resolvedWorkspaceDeps?: ReturnType<typeof resolveWorkspaceDeps>
 }
 
 export async function collectSbomComponents (opts: CollectSbomComponentsOptions): Promise<SbomResult> {
   const depTypes = detectDepTypes(opts.lockfile)
   const importerIds = opts.includedImporterIds ?? Object.keys(opts.lockfile.importers) as ProjectId[]
 
-  const importerWalkers = lockfileWalkerGroupImporterSteps(
-    opts.lockfile,
-    importerIds,
-    { include: opts.include }
-  )
-
   const componentsMap = new Map<string, SbomComponent>()
   const relationships: SbomRelationship[] = []
   const rootPurl = `pkg:npm/${encodePurlName(opts.rootName)}@${opts.rootVersion}`
+
+  const workspaceDeps = opts.resolvedWorkspaceDeps ?? resolveWorkspaceDeps(opts.lockfile, importerIds, opts.include)
+  const allImporterIds = [...importerIds, ...workspaceDeps.additionalImporterIds]
+
+  const importerWalkers = lockfileWalkerGroupImporterSteps(
+    opts.lockfile,
+    allImporterIds,
+    { include: opts.include }
+  )
+
+  if (opts.workspacePackages) {
+    const importerIdSet = new Set<string>(importerIds)
+
+    const workspaceDepTypes = new Map<string, DepType>()
+    for (const dep of workspaceDeps.links) {
+      const info = opts.workspacePackages[dep.targetImporterId]
+      if (!info) continue
+      const purl = buildPurl({ name: info.name, version: info.version })
+      const current = workspaceDepTypes.get(purl)
+      if (!dep.devOnly) {
+        workspaceDepTypes.set(purl, DepType.ProdOnly)
+      } else if (current === undefined) {
+        workspaceDepTypes.set(purl, DepType.DevOnly)
+      }
+    }
+
+    for (const dep of workspaceDeps.links) {
+      const info = opts.workspacePackages[dep.targetImporterId]
+      if (!info) continue
+
+      const purl = buildPurl({ name: info.name, version: info.version })
+
+      let parentPurl: string
+      if (importerIdSet.has(dep.sourceImporterId)) {
+        parentPurl = rootPurl
+      } else {
+        const sourceInfo = opts.workspacePackages[dep.sourceImporterId]
+        parentPurl = sourceInfo
+          ? buildPurl({ name: sourceInfo.name, version: sourceInfo.version })
+          : rootPurl
+      }
+      relationships.push({ from: parentPurl, to: purl })
+
+      if (!componentsMap.has(purl)) {
+        componentsMap.set(purl, {
+          name: info.name,
+          version: info.version,
+          purl,
+          depPath: `link:${dep.targetImporterId}`,
+          depType: workspaceDepTypes.get(purl) ?? DepType.ProdOnly,
+          license: info.license,
+          description: info.description,
+          author: info.author,
+          repository: info.repository,
+        })
+      }
+    }
+  }
 
   const storeIndex = (!opts.lockfileOnly && opts.storeDir)
     ? new StoreIndex(opts.storeDir)
@@ -142,4 +207,60 @@ export function gitDownloadUrl (resolution: Resolution): string | undefined {
   const needsGitPlusPrefix = resolution.repo.includes('://') && !resolution.repo.startsWith('git+')
   const prefix = needsGitPlusPrefix ? 'git+' : ''
   return `${prefix}${resolution.repo}#${resolution.commit}`
+}
+
+interface WorkspaceLink {
+  sourceImporterId: ProjectId
+  targetImporterId: ProjectId
+  depName: string
+  devOnly: boolean
+}
+
+export function resolveWorkspaceDeps (
+  lockfile: LockfileObject,
+  importerIds: ProjectId[],
+  include?: { [dependenciesField in DependenciesField]: boolean }
+): { links: WorkspaceLink[], additionalImporterIds: ProjectId[] } {
+  const links: WorkspaceLink[] = []
+  const visited = new Set<string>(importerIds)
+  const queue = [...importerIds]
+  const additionalImporterIds: ProjectId[] = []
+
+  while (queue.length > 0) {
+    const importerId = queue.shift()!
+    const snapshot = lockfile.importers[importerId]
+    if (!snapshot) continue
+
+    const devDepNames = new Set(Object.keys(snapshot.devDependencies ?? {}))
+    const prodDeps = {
+      ...(include?.dependencies !== false ? snapshot.dependencies : {}),
+      ...(include?.optionalDependencies !== false ? snapshot.optionalDependencies : {}),
+    }
+    const allDeps: Record<string, string> = {
+      ...prodDeps,
+      ...(include?.devDependencies !== false ? snapshot.devDependencies : {}),
+    }
+
+    for (const [depName, reference] of Object.entries(allDeps)) {
+      if (!reference.startsWith('link:')) continue
+
+      const linkPath = reference.slice(5)
+      const targetId = path.posix.normalize(
+        importerId === ('.' as ProjectId) ? linkPath : path.posix.join(importerId, linkPath)
+      ) as ProjectId
+
+      if (!(targetId in lockfile.importers)) continue
+
+      const devOnly = devDepNames.has(depName) && !(depName in prodDeps)
+      links.push({ sourceImporterId: importerId, targetImporterId: targetId, depName, devOnly })
+
+      if (!visited.has(targetId)) {
+        visited.add(targetId)
+        additionalImporterIds.push(targetId)
+        queue.push(targetId)
+      }
+    }
+  }
+
+  return { links, additionalImporterIds }
 }

--- a/deps/compliance/sbom/src/index.ts
+++ b/deps/compliance/sbom/src/index.ts
@@ -1,4 +1,4 @@
-export { collectSbomComponents, type CollectSbomComponentsOptions, gitDownloadUrl } from './collectComponents.js'
+export { collectSbomComponents, type CollectSbomComponentsOptions, gitDownloadUrl, resolveWorkspaceDeps, type WorkspacePackageInfo } from './collectComponents.js'
 export { integrityToHashes } from './integrity.js'
 export { buildPurl, encodePurlName } from './purl.js'
 export { type CycloneDxOptions, serializeCycloneDx } from './serializeCycloneDx.js'

--- a/deps/compliance/sbom/src/serializeCycloneDx.ts
+++ b/deps/compliance/sbom/src/serializeCycloneDx.ts
@@ -13,6 +13,7 @@ export interface CycloneDxOptions {
   sbomAuthors?: string[]
   sbomSupplier?: string
   specVersion?: string
+  compact?: boolean
 }
 
 export function serializeCycloneDx (result: SbomResult, opts?: CycloneDxOptions): string {
@@ -185,7 +186,7 @@ export function serializeCycloneDx (result: SbomResult, opts?: CycloneDxOptions)
     dependencies: bomDependencies,
   }
 
-  return JSON.stringify(bom, null, 2)
+  return JSON.stringify(bom, null, opts?.compact ? undefined : 2)
 }
 
 function splitScopedName (fullName: string): { group: string | undefined, name: string } {

--- a/deps/compliance/sbom/src/serializeSpdx.ts
+++ b/deps/compliance/sbom/src/serializeSpdx.ts
@@ -4,7 +4,11 @@ import { integrityToHashes } from './integrity.js'
 import { encodePurlName } from './purl.js'
 import type { SbomResult } from './types.js'
 
-export function serializeSpdx (result: SbomResult): string {
+export interface SpdxOptions {
+  compact?: boolean
+}
+
+export function serializeSpdx (result: SbomResult, opts?: SpdxOptions): string {
   const { rootComponent, components, relationships } = result
 
   const rootSpdxId = 'SPDXRef-RootPackage'
@@ -145,7 +149,7 @@ export function serializeSpdx (result: SbomResult): string {
     relationships: spdxRelationships,
   }
 
-  return JSON.stringify(doc, null, 2)
+  return JSON.stringify(doc, null, opts?.compact ? undefined : 2)
 }
 
 function sanitizeSpdxId (value: string): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3060,6 +3060,9 @@ importers:
       memoize:
         specifier: 'catalog:'
         version: 11.0.0
+      p-limit:
+        specifier: 'catalog:'
+        version: 7.3.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'


### PR DESCRIPTION
Per-package SBOM generation for workspaces. Each package gets its own SBOM with the correct root component and full transitive dependency tree, including workspace inter-dependencies.

## New flags

**`--out <path>`** writes SBOM to a file instead of stdout. Supports `%s` (package name) and `%v` (version) placeholders. When `%s` is present, generates one SBOM per workspace package:

    pnpm sbom --sbom-format cyclonedx --out out/%s.cdx.json
    pnpm sbom --sbom-format cyclonedx --out out/%s-%v.cdx.json
    pnpm sbom --sbom-format cyclonedx --filter @scope/my-app --out my-app.cdx.json

**`--split`** outputs one compact JSON per line (NDJSON) to stdout, for piping into tools that process multiple SBOMs:

    pnpm sbom --sbom-format cyclonedx --split
    pnpm sbom --sbom-format cyclonedx --split --filter "./apps/*"

## Per-package correctness

When `--filter` selects a single package, the SBOM root component uses that package's name, version, description, license, and author. Fields the package doesn't define fall back to the workspace root manifest.

Workspace inter-dependencies (`workspace:` protocol) and their transitive external dependencies are now included in the SBOM. Dev-only workspace deps are excluded with `--prod`. `--lockfile-only` skips workspace dep resolution to avoid disk reads beyond the lockfile.

## Changes

- `--out` and `--split` flags with `%s`/`%v` placeholder support
- `compact` option on CycloneDX and SPDX serializers for NDJSON output
- `resolveWorkspaceDeps` BFS finds workspace link deps and tracks source importer and dep type
- `SharedContext` reads lockfile, root manifest, and store path once (shared across all packages in split mode)
- Path segments sanitized to prevent traversal via crafted version strings
- `recursiveByDefault` so `--filter` works in workspaces (bug in released pnpm, separate fix in #12187)

Depends on #12187.

@ultrox this should cover the per-workspace SBOM use case you described. Would be great to hear if it fits your Turborepo setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SBOM generation now supports `--out` (writes to disk using `%s`/version placeholders) and `--split` (generates per-workspace-package SBOMs; otherwise a single SBOM is produced).
  * Workspace filtering is reflected in the SBOM “root” metadata when a single package is selected.

* **Improvements**
  * Workspace `link:` dependencies and their transitive workspace impacts are included in SBOM components/relationships.
  * SBOM outputs can be generated in more compact JSON formats; author metadata is normalized.

* **Documentation**
  * Release metadata and SBOM behavior are documented, including workspace inter-dependency handling.

* **Tests**
  * Expanded end-to-end coverage for workspace filtering, `--prod`, `--lockfile-only`, and output modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->