### PR TITLE
feat(pacquet): implement the `update` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,19 @@ checksum = "b1b4fe32ea3f2a8d975b6c5cdd3f02ac358f471ca24dbb18d7a4ca58b3193d2d"
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -749,6 +762,17 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console 0.15.11",
+ "shell-words",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1530,7 +1554,7 @@ version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
- "console",
+ "console 0.16.3",
  "globset",
  "once_cell",
  "serde",
@@ -2127,11 +2151,13 @@ dependencies = [
  "clap",
  "command-extra",
  "derive_more",
+ "dialoguer",
  "dunce",
  "home",
  "indexmap",
  "insta",
  "miette 7.6.0",
+ "node-semver",
  "pacquet-config",
  "pacquet-diagnostics",
  "pacquet-executor",
@@ -3864,6 +3890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4872,6 +4904,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ bytes = { version = "1.11.0" }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 dashmap = { version = "6.1.0" }
 derive_more = { version = "2.1.1", features = ["full"] }
+dialoguer = { version = "0.11.0", default-features = false }
 diffy = { version = "0.5.0" }
 dunce = { version = "1.0.5" }
 home = { version = "0.5.12" }

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -33,9 +33,11 @@ pacquet-workspace-projects-graph = { workspace = true }
 
 clap        = { workspace = true }
 derive_more = { workspace = true }
+dialoguer   = { workspace = true }
 dunce       = { workspace = true }
 home        = { workspace = true }
 indexmap    = { workspace = true }
+node-semver = { workspace = true }
 miette      = { workspace = true }
 pipe-trait  = { workspace = true }
 rayon       = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -3,6 +3,8 @@ pub mod install;
 pub mod run;
 pub mod store;
 pub mod supported_architectures;
+pub mod update;
+pub mod update_interactive;
 
 use crate::{State, config_overrides::ConfigOverrides};
 use add::AddArgs;
@@ -16,6 +18,7 @@ use pacquet_reporter::{NdjsonReporter, SilentReporter};
 use run::RunArgs;
 use std::path::PathBuf;
 use store::StoreCommand;
+use update::UpdateArgs;
 
 /// Experimental package manager for node.js written in rust.
 #[derive(Debug, Parser)]
@@ -99,6 +102,9 @@ pub enum CliCommand {
     Add(AddArgs),
     /// Install packages
     Install(InstallArgs),
+    /// Update packages to their newest version based on the specified range
+    #[clap(visible_aliases = ["up", "upgrade"])]
+    Update(UpdateArgs),
     /// Runs a package's "test" script, if one was provided.
     Test,
     /// Runs a defined package script.
@@ -183,6 +189,10 @@ impl CliArgs {
                 PackageManifest::init(&manifest_path()).wrap_err("initialize package.json")?;
             }
             CliCommand::Add(args) => match reporter {
+                ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
+                ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
+            },
+            CliCommand::Update(args) => match reporter {
                 ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
                 ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
             },

--- a/pacquet/crates/cli/src/cli_args/install.rs
+++ b/pacquet/crates/cli/src/cli_args/install.rs
@@ -3,7 +3,7 @@ use clap::{Args, ValueEnum};
 use miette::Context;
 use pacquet_config::{NodeLinker, TrustPolicy};
 use pacquet_lockfile::Lockfile;
-use pacquet_package_manager::Install;
+use pacquet_package_manager::{Install, UpdateSeedPolicy};
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_pnpr_client::{InstallOptions, PnprClient};
 use pacquet_reporter::Reporter;
@@ -352,6 +352,7 @@ impl InstallArgs {
             supported_architectures,
             node_linker,
             lockfile_only,
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
         }
         .run::<Reporter>()
         .await
@@ -474,6 +475,7 @@ async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         supported_architectures: link.supported_architectures,
         node_linker: link.node_linker,
         lockfile_only: false,
+        update_seed_policy: UpdateSeedPolicy::KeepAll,
     }
     .run::<Reporter>()
     .await

--- a/pacquet/crates/cli/src/cli_args/update.rs
+++ b/pacquet/crates/cli/src/cli_args/update.rs
@@ -1,0 +1,183 @@
+use crate::{State, cli_args::supported_architectures::SupportedArchitecturesArgs};
+use clap::Args;
+use miette::Context;
+use pacquet_package_manager::Update;
+use pacquet_package_manifest::DependencyGroup;
+use pacquet_reporter::Reporter;
+
+/// `--prod` / `--dev` / `--no-optional` for `pacquet update`.
+///
+/// Ports pnpm's
+/// [`makeIncludeDependenciesFromCLI`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/update/index.ts#L330-L340),
+/// which reads the *raw* CLI flags (not the rc-merged config) so an
+/// absent flag is `undefined` rather than a default. The quirk that
+/// `--no-optional` only excludes `optionalDependencies` when combined
+/// with `--prod` or `--dev` is preserved verbatim.
+#[derive(Debug, Args)]
+pub struct UpdateDependencyOptions {
+    /// Update packages only in "dependencies" and "optionalDependencies".
+    #[clap(short = 'P', long)]
+    prod: bool,
+    /// Update packages only in "devDependencies".
+    #[clap(short = 'D', long)]
+    dev: bool,
+    /// Don't update packages in "optionalDependencies".
+    #[clap(long)]
+    no_optional: bool,
+}
+
+impl UpdateDependencyOptions {
+    /// The dependency groups whose direct dependencies the update may
+    /// match (pnpm's `includeDirect`). Returns the groups for which the
+    /// corresponding inclusion bit is set.
+    fn include_direct(&self) -> Vec<DependencyGroup> {
+        // `Some(true)` only when the flag was explicitly passed, mirroring
+        // pnpm reading `opts.cliOptions` rather than the merged config.
+        let production = self.prod.then_some(true);
+        let dev = self.dev.then_some(true);
+        // pnpm has no positive `--optional` flag for update; `--no-optional`
+        // sets it to `false`, otherwise it stays unset.
+        let optional = self.no_optional.then_some(false);
+
+        let ne_true = |flag: Option<bool>| flag != Some(true);
+        let dependencies = production == Some(true) || (ne_true(dev) && ne_true(optional));
+        let dev_dependencies = dev == Some(true) || (ne_true(production) && ne_true(optional));
+        let optional_dependencies = optional == Some(true) || (ne_true(production) && ne_true(dev));
+
+        std::iter::empty()
+            .chain(dependencies.then_some(DependencyGroup::Prod))
+            .chain(dev_dependencies.then_some(DependencyGroup::Dev))
+            .chain(optional_dependencies.then_some(DependencyGroup::Optional))
+            .collect()
+    }
+}
+
+/// `pacquet update` (alias `up` / `upgrade`).
+#[derive(Debug, Args)]
+pub struct UpdateArgs {
+    /// Packages to update. Bare names (`foo`, `@scope/bar`), glob
+    /// patterns (`@scope/bar-*`), and versioned selectors (`foo@2`) are
+    /// accepted. With no arguments, every direct dependency in the
+    /// included groups is updated.
+    pub packages: Vec<String>,
+
+    /// --prod, --dev, and --no-optional.
+    #[clap(flatten)]
+    pub dependency_options: UpdateDependencyOptions,
+
+    /// `--cpu` / `--os` / `--libc` overrides for the optional-dep
+    /// platform filter.
+    #[clap(flatten)]
+    pub supported_architectures: SupportedArchitecturesArgs,
+
+    /// Ignore version ranges in package.json: bump the matched packages
+    /// to their latest version and rewrite the manifest ranges.
+    #[clap(short = 'L', long)]
+    pub latest: bool,
+
+    /// Write the resolved version without a range operator when
+    /// rewriting the manifest under `--latest`.
+    #[clap(short = 'E', long = "save-exact")]
+    pub save_exact: bool,
+
+    /// How deep to inspect dependencies. `0` means top-level
+    /// dependencies only. Defaults to unlimited.
+    #[clap(long)]
+    pub depth: Option<usize>,
+
+    /// Dependencies are not downloaded; only `pnpm-lock.yaml` is updated.
+    #[clap(long = "lockfile-only")]
+    pub lockfile_only: bool,
+
+    /// Show outdated dependencies and select which ones to update.
+    #[clap(short = 'i', long)]
+    pub interactive: bool,
+
+    /// Update globally installed packages.
+    #[clap(short = 'g', long)]
+    pub global: bool,
+
+    /// Tries to link all packages from the workspace, updating versions
+    /// to match the workspace packages.
+    #[clap(long)]
+    pub workspace: bool,
+}
+
+impl UpdateArgs {
+    /// Execute the subcommand.
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+    ) -> miette::Result<()> {
+        // Global and workspace-link updates depend on subsystems pacquet
+        // hasn't ported yet (global-dir / `@pnpm/global.commands`, and
+        // workspace version linking). Refuse rather than silently doing
+        // a plain update.
+        if self.global {
+            return Err(miette::miette!(
+                "`pacquet update --global` is not supported yet; global package management has not been ported to pacquet."
+            ));
+        }
+        if self.workspace {
+            return Err(miette::miette!(
+                "`pacquet update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pacquet."
+            ));
+        }
+
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &mut state;
+
+        let supported_architectures =
+            self.supported_architectures.apply_to(config.supported_architectures.clone());
+
+        let lockfile_path = manifest
+            .path()
+            .parent()
+            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+
+        let packages = if self.interactive {
+            match crate::cli_args::update_interactive::select_packages(
+                manifest,
+                lockfile.as_ref(),
+                config,
+                http_client,
+                self.latest,
+                &self.dependency_options.include_direct(),
+            )
+            .await?
+            {
+                Some(selected) => selected,
+                // Nothing outdated, or the user picked nothing — there
+                // is nothing to update, so don't fall through to a
+                // full update (which an empty selector list would mean).
+                None => return Ok(()),
+            }
+        } else {
+            self.packages.clone()
+        };
+
+        Update {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            resolved_packages,
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile: lockfile.as_ref(),
+            lockfile_path: lockfile_path.as_deref(),
+            packages: &packages,
+            latest: self.latest,
+            save_exact: self.save_exact,
+            include_direct: self.dependency_options.include_direct(),
+            depth: self.depth.unwrap_or(usize::MAX),
+            supported_architectures,
+            lockfile_only: self.lockfile_only,
+        }
+        .run::<Reporter>()
+        .await
+        .wrap_err("updating dependencies")
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/update.rs
+++ b/pacquet/crates/cli/src/cli_args/update.rs
@@ -80,6 +80,11 @@ pub struct UpdateArgs {
     #[clap(short = 'E', long = "save-exact")]
     pub save_exact: bool,
 
+    /// Do not write the updated ranges back to package.json. The
+    /// lockfile is still updated. Mirrors pnpm's `--no-save`.
+    #[clap(long = "no-save")]
+    pub no_save: bool,
+
     /// How deep to inspect dependencies. `0` means top-level
     /// dependencies only. Defaults to unlimited.
     #[clap(long)]
@@ -168,6 +173,7 @@ impl UpdateArgs {
             packages: &packages,
             latest: self.latest,
             save_exact: self.save_exact,
+            save: !self.no_save,
             include_direct: self.dependency_options.include_direct(),
             depth: self.depth.unwrap_or(usize::MAX),
             supported_architectures,

--- a/pacquet/crates/cli/src/cli_args/update/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/update/tests.rs
@@ -1,0 +1,47 @@
+use super::UpdateDependencyOptions;
+use pacquet_package_manifest::DependencyGroup;
+
+fn options(prod: bool, dev: bool, no_optional: bool) -> UpdateDependencyOptions {
+    UpdateDependencyOptions { prod, dev, no_optional }
+}
+
+#[test]
+fn no_flags_includes_all_groups() {
+    let groups = options(false, false, false).include_direct();
+    assert_eq!(
+        groups,
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}
+
+#[test]
+fn prod_includes_only_dependencies() {
+    // Mirrors pnpm's `makeIncludeDependenciesFromCLI` with
+    // `production === true`: dependencies only.
+    let groups = options(true, false, false).include_direct();
+    assert_eq!(groups, vec![DependencyGroup::Prod]);
+}
+
+#[test]
+fn dev_includes_only_dev_dependencies() {
+    let groups = options(false, true, false).include_direct();
+    assert_eq!(groups, vec![DependencyGroup::Dev]);
+}
+
+#[test]
+fn no_optional_alone_does_not_drop_optional() {
+    // Faithful to pnpm's quirk: `--no-optional` only excludes
+    // optionalDependencies when combined with `--prod` or `--dev`,
+    // because the inclusion formula reads the raw CLI flags.
+    let groups = options(false, false, true).include_direct();
+    assert_eq!(
+        groups,
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}
+
+#[test]
+fn prod_with_no_optional_drops_optional() {
+    let groups = options(true, false, true).include_direct();
+    assert_eq!(groups, vec![DependencyGroup::Prod]);
+}

--- a/pacquet/crates/cli/src/cli_args/update_interactive.rs
+++ b/pacquet/crates/cli/src/cli_args/update_interactive.rs
@@ -1,0 +1,151 @@
+//! Interactive selection for `pacquet update --interactive`.
+//!
+//! Ports the data-gathering half of pnpm's
+//! [`interactiveUpdate`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/update/index.ts#L195-L280):
+//! find the direct dependencies that have a newer version available
+//! (within the current range, or the `latest` tag under `--latest`),
+//! show them in a checkbox prompt, and return the names the user picked
+//! so the regular update path can run with them as selectors.
+//!
+//! Unlike pnpm — which fans out through `@pnpm/deps.inspection.outdated`
+//! — pacquet computes "outdated" inline: the current version comes from
+//! the wanted lockfile and the target from a single packument fetch per
+//! dependency. The choice list is intentionally flat (pnpm groups by
+//! dependency type); the prompt is a `dialoguer` multi-select.
+
+use dialoguer::MultiSelect;
+use miette::{IntoDiagnostic, miette};
+use node_semver::Version;
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use pacquet_network::ThrottledClient;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::Package;
+
+/// One outdated direct dependency offered in the prompt.
+struct OutdatedChoice {
+    name: String,
+    current: Version,
+    target: Version,
+}
+
+/// Gather outdated direct dependencies, prompt the user, and return the
+/// selected package names. `Ok(None)` means "nothing to do" — either no
+/// dependency has an update available or the prompt was answered with an
+/// empty selection — and the caller should not run an update.
+pub async fn select_packages(
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    latest: bool,
+    include_direct: &[DependencyGroup],
+) -> miette::Result<Option<Vec<String>>> {
+    let choices =
+        collect_outdated(manifest, lockfile, config, http_client, latest, include_direct).await?;
+
+    if choices.is_empty() {
+        let message = if latest {
+            "All of your dependencies are already up to date"
+        } else {
+            "All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json"
+        };
+        println!("{message}");
+        return Ok(None);
+    }
+
+    let labels: Vec<String> = choices
+        .iter()
+        .map(|choice| format!("{} {} ❯ {}", choice.name, choice.current, choice.target))
+        .collect();
+
+    let selected_indices = MultiSelect::new()
+        .with_prompt("Choose which packages to update (space to select, enter to confirm)")
+        .items(&labels)
+        .interact()
+        .into_diagnostic()
+        .map_err(|err| miette!("interactive update selection failed: {err}"))?;
+
+    let selected: Vec<String> =
+        selected_indices.into_iter().map(|index| choices[index].name.clone()).collect();
+
+    if selected.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(selected))
+}
+
+/// Build the outdated-direct-dependency list. A dependency is outdated
+/// when its registry target (highest version satisfying the manifest
+/// range, or the `latest` tag under `--latest`) is strictly newer than
+/// the version currently pinned in the lockfile. Dependencies without a
+/// lockfile pin, without a registry target, or whose specifier is not a
+/// plain semver range are skipped — they can't be diffed.
+async fn collect_outdated(
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    latest: bool,
+    include_direct: &[DependencyGroup],
+) -> miette::Result<Vec<OutdatedChoice>> {
+    let current_versions = current_versions_from_lockfile(lockfile, include_direct);
+
+    let mut direct: Vec<(String, String)> = Vec::new();
+    for &group in include_direct {
+        for (name, range) in manifest.dependencies([group]) {
+            direct.push((name.to_string(), range.to_string()));
+        }
+    }
+
+    let mut choices = Vec::new();
+    for (name, range) in direct {
+        let Some(current) = current_versions.get(&name).cloned() else { continue };
+        let package = match Package::fetch_from_registry(
+            &name,
+            http_client,
+            &config.registry,
+            &config.auth_headers,
+        )
+        .await
+        {
+            Ok(package) => package,
+            // A dependency the registry can't serve (private, renamed,
+            // network blip) is simply not offered for update rather than
+            // failing the whole prompt.
+            Err(_) => continue,
+        };
+
+        let target_raw = if latest {
+            package.dist_tag("latest").map(ToString::to_string)
+        } else {
+            package.pinned_version(&range).map(|version| version.serialize(true).replace('^', ""))
+        };
+        let Some(target_raw) = target_raw else { continue };
+        let Ok(target) = target_raw.parse::<Version>() else { continue };
+
+        if target > current {
+            choices.push(OutdatedChoice { name, current, target });
+        }
+    }
+
+    Ok(choices)
+}
+
+/// Map each direct dependency name to its lockfile-pinned semver
+/// version. Only the root importer is consulted (pacquet's single-project
+/// scope); entries whose resolved version isn't a plain semver (`link:`,
+/// `file:`, non-semver runtimes) are omitted.
+fn current_versions_from_lockfile(
+    lockfile: Option<&Lockfile>,
+    include_direct: &[DependencyGroup],
+) -> std::collections::HashMap<String, Version> {
+    let mut map = std::collections::HashMap::new();
+    let Some(importer) = lockfile.and_then(Lockfile::root_project) else { return map };
+    for (name, spec) in importer.dependencies_by_groups(include_direct.iter().copied()) {
+        if let Some(version) = spec.version.ver_peer().and_then(|ver| ver.version_semver()) {
+            map.insert(name.to_string(), version.clone());
+        }
+    }
+    map
+}

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -1,0 +1,163 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pretty_assertions::assert_eq;
+use std::{ffi::OsStr, fs, path::Path, process::Command};
+use tempfile::TempDir;
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const FOO: &str = "@pnpm.e2e/foo";
+
+/// Spin up a temp workspace with the mocked registry and return the
+/// pieces a multi-step update test needs.
+fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    (root, workspace, npmrc_info)
+}
+
+/// Build a fresh `pacquet` command bound to `workspace`. The
+/// `assert_cmd` `Command` is single-shot, so each install/update step
+/// needs its own.
+fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
+    Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+        .with_args(args)
+}
+
+fn write_manifest(workspace: &Path, dependencies: &str) {
+    let manifest = format!(
+        r#"{{ "name": "test-update", "version": "1.0.0", "dependencies": {dependencies} }}"#,
+    );
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+}
+
+fn dep_spec(workspace: &Path, name: &str) -> Option<String> {
+    let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
+    manifest
+        .dependencies([DependencyGroup::Prod])
+        .find(|(key, _)| *key == name)
+        .map(|(_, spec)| spec.to_string())
+}
+
+fn virtual_store_has(workspace: &Path, name_at_version: &str) -> bool {
+    workspace.join("node_modules").join(".pnpm").join(name_at_version).exists()
+}
+
+/// `pacquet update` re-resolves a dependency to the highest version
+/// inside its range, even when the lockfile pins an older one — the
+/// behaviour that distinguishes it from a plain `install` (which keeps
+/// the pin because it still satisfies the range).
+#[test]
+fn update_bumps_within_range() {
+    let (root, workspace, anchor) = setup();
+
+    // Pin 100.0.0 exactly, then widen the range to `^100.0.0`. A plain
+    // install would keep 100.0.0 (it satisfies `^100.0.0`); update must
+    // bump to 100.1.0 (101.0.0 is outside the range).
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["update"]).assert().success();
+
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "update should have bumped the dependency to the highest version in range",
+    );
+    // Compatible updates do not rewrite the manifest range.
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `pacquet update --latest` ignores the manifest range, bumps to the
+/// `latest` dist-tag, and rewrites `package.json`.
+#[test]
+fn update_latest_rewrites_manifest() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    // latest tag is the max published version, 101.0.0.
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--save-exact` writes the bumped version without a range operator.
+#[test]
+fn update_latest_save_exact() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest", "--save-exact"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// A package selector only updates the matched dependency; others keep
+/// their manifest ranges.
+#[test]
+fn update_latest_with_selector_is_scoped() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest", FOO]).assert().success();
+
+    // foo's latest is 100.1.0; dep-of-pkg-with-1-dep is untouched.
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.1.0"));
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `up` and `upgrade` are accepted as aliases of `update`.
+#[test]
+fn update_aliases_work() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["up", "--latest"]).assert().success();
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--latest` combined with a versioned selector is rejected, matching
+/// pnpm's `ERR_PNPM_LATEST_WITH_SPEC`.
+#[test]
+fn update_latest_with_spec_is_rejected() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["update", "--latest", &format!("{DEP}@2")])
+        .output()
+        .expect("run pacquet update");
+    assert!(!output.status.success(), "update --latest with a spec should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Specs are not allowed to be used with --latest"),
+        "stderr did not mention the LATEST_WITH_SPEC error: {stderr}",
+    );
+
+    drop((root, anchor));
+}

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -126,6 +126,67 @@ fn update_latest_with_selector_is_scoped() {
     drop((root, anchor));
 }
 
+/// A negation selector (`!@scope/*`) updates everything *except* the
+/// matched packages — ports pnpm's "update with negation pattern" test.
+#[test]
+fn update_latest_with_negation_selector() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    // Update everything except dep-of-pkg-with-1-dep.
+    pacquet(&workspace, ["update", "--latest", &format!("!{DEP}")]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.1.0"));
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--no-save` bumps the lockfile but leaves `package.json` untouched —
+/// ports pnpm's "update --no-save should not update package.json" test.
+#[test]
+fn update_latest_no_save_keeps_manifest() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+
+    pacquet(&workspace, ["update", "--latest", "--no-save"]).assert().success();
+
+    // package.json range is unchanged...
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+    // ...but the lockfile/store was re-resolved (101.0.0 is latest; the
+    // in-memory `^101.0.0` drove resolution even though it wasn't saved).
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `update <pkg> --depth 0` where the package is not a direct dependency
+/// fails with `ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES`.
+#[test]
+fn update_depth_zero_unknown_package_errors() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["update", "--depth", "0", "@pnpm.e2e/not-a-dependency"])
+        .output()
+        .expect("run pacquet update");
+    assert!(!output.status.success(), "depth-0 update of a non-dependency should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("None of the specified packages were found in the dependencies"),
+        "stderr did not mention NO_PACKAGE_IN_DEPENDENCIES: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
 /// `up` and `upgrade` are accepted as aliases of `update`.
 #[test]
 fn update_aliases_work() {

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -1,4 +1,4 @@
-use crate::{Install, InstallError, ResolvedPackages};
+use crate::{Install, InstallError, ResolvedPackages, UpdateSeedPolicy};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_config::Config;
@@ -120,6 +120,10 @@ where
             supported_architectures,
             node_linker: config.node_linker,
             lockfile_only,
+            // `add` keeps every lockfile pin; the freshly-added range
+            // is the only thing that re-resolves. `update`'s bump is a
+            // separate operation.
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
         }
         .run::<Reporter>()
         .await

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1,6 +1,6 @@
 use crate::{
     BuildVerifiersError, HoistedDependencies, InstallFrozenLockfile, InstallFrozenLockfileError,
-    InstallWithFreshLockfile, InstallWithFreshLockfileError, ResolvedPackages,
+    InstallWithFreshLockfile, InstallWithFreshLockfileError, ResolvedPackages, UpdateSeedPolicy,
     build_resolution_verifiers, check_optimistic_repeat_install,
     optimistic_repeat_install::Decision as OptimisticRepeatInstallDecision,
 };
@@ -167,6 +167,16 @@ where
     /// [`lockfileOnly`](https://github.com/pnpm/pnpm/blob/3b62f9da31/config/reader/src/Config.ts#L170)
     /// (`like npm's --package-lock-only`).
     pub lockfile_only: bool,
+    /// Which lockfile pins to withhold from the preferred-versions seed.
+    /// [`UpdateSeedPolicy::KeepAll`] for `install` / `add`; the `DropAll`
+    /// / `DropOnly` variants drive `pacquet update`'s compatible bump by
+    /// forcing the affected names to re-resolve to highest-in-range.
+    /// Forwarded to [`InstallWithFreshLockfile`]; ignored on the frozen
+    /// path (`update` always takes the fresh-resolve path). When set to
+    /// anything other than `KeepAll` the optimistic repeat-install
+    /// short-circuit is also bypassed so an `update` that finds newer
+    /// in-range versions isn't skipped as "already up to date".
+    pub update_seed_policy: UpdateSeedPolicy,
 }
 
 /// Error type of [`Install`].
@@ -354,6 +364,7 @@ where
             supported_architectures,
             node_linker,
             lockfile_only,
+            update_seed_policy,
         } = self;
 
         // `--lockfile-only` with `lockfile: false` (pnpm's
@@ -450,7 +461,14 @@ where
         // forcing the frozen path.
         let project_manifests =
             build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
-        if !frozen_lockfile
+        // `pacquet update` must always re-resolve, so it bypasses the
+        // optimistic short-circuit: a compatible bump leaves the
+        // manifest byte-identical, which the repeat-install check would
+        // otherwise read as "nothing changed → already up to date" and
+        // skip the registry re-resolution entirely. Gating on
+        // `KeepAll` keeps `install` / `add` on the fast path.
+        if matches!(update_seed_policy, UpdateSeedPolicy::KeepAll)
+            && !frozen_lockfile
             && let OptimisticRepeatInstallDecision::UpToDate = check_optimistic_repeat_install(
                 &workspace_root,
                 config,
@@ -942,6 +960,7 @@ where
                 node_linker,
                 supported_architectures: supported_architectures.as_ref(),
                 lockfile_only,
+                update_seed_policy,
             }
             .run::<Reporter>()
             .await

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -71,6 +71,7 @@ async fn should_install_dependencies() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -142,6 +143,7 @@ async fn should_error_when_frozen_lockfile_is_requested_but_none_exists() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -188,6 +190,7 @@ async fn should_error_when_frozen_lockfile_and_update_checksums_are_both_set() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -263,6 +266,7 @@ async fn frozen_lockfile_flag_overrides_config_lockfile_false() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -331,6 +335,7 @@ async fn npm_alias_dependency_installs_under_alias_key() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -418,6 +423,7 @@ async fn unversioned_npm_alias_defaults_to_latest() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -488,6 +494,7 @@ async fn frozen_lockfile_flag_with_no_lockfile_errors() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -578,6 +585,7 @@ async fn install_emits_pnpm_event_sequence() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -725,6 +733,7 @@ async fn install_writes_modules_yaml() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -828,6 +837,7 @@ async fn install_writes_workspace_state() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -1054,6 +1064,7 @@ async fn install_optional_failing_postinstall_dep_via_registry_mock_succeeds() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -1129,6 +1140,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -1227,6 +1239,7 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -1361,6 +1374,7 @@ async fn warm_reinstall_skips_snapshot_when_current_lockfile_matches() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -1461,6 +1475,7 @@ async fn warm_reinstall_emits_broken_modules_when_dir_is_missing() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await;
@@ -1569,6 +1584,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -1621,6 +1637,7 @@ async fn context_log_reflects_current_lockfile_after_first_install() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -1715,6 +1732,7 @@ async fn warm_reinstall_reports_added_zero_and_emits_no_imported_events() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -1813,6 +1831,7 @@ async fn frozen_lockfile_errors_when_manifest_drifts_from_lockfile() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -1879,6 +1898,7 @@ async fn ignore_manifest_check_bypasses_manifest_freshness_gate() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -1946,6 +1966,7 @@ async fn frozen_lockfile_errors_when_overrides_drift_from_lockfile() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -2039,6 +2060,7 @@ async fn frozen_lockfile_applies_overrides_to_manifest_before_freshness_check() 
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -2148,6 +2170,7 @@ async fn frozen_lockfile_resolves_catalog_protocol_in_overrides_before_freshness
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -2211,6 +2234,7 @@ async fn frozen_lockfile_errors_when_lockfile_has_no_root_importer() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -2301,6 +2325,7 @@ async fn frozen_lockfile_under_gvs_registers_project_and_runs_clean() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -2410,6 +2435,7 @@ async fn gvs_persists_global_virtual_store_dir_in_modules_yaml_and_context_log()
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -2526,6 +2552,7 @@ async fn frozen_lockfile_with_gvs_off_skips_project_registry() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -2608,6 +2635,7 @@ async fn frozen_lockfile_under_gvs_registers_workspace_root_only() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -2810,6 +2838,7 @@ async fn frozen_install_preserves_seeded_skipped_across_reinstall() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -2936,6 +2965,7 @@ async fn frozen_install_silently_swallows_unreachable_optional_tarball() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3038,6 +3068,7 @@ async fn frozen_install_propagates_non_optional_fetch_failure() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -3146,6 +3177,7 @@ async fn frozen_install_no_optional_drops_optional_only_snapshots() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3239,6 +3271,7 @@ async fn frozen_install_optional_included_surfaces_missing_metadata() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -3335,6 +3368,7 @@ async fn frozen_install_no_optional_keeps_shared_non_optional_snapshot() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -3430,6 +3464,7 @@ async fn hoisted_node_linker_empty_lockfile_writes_modules_yaml() {
         node_linker: pacquet_config::NodeLinker::Hoisted,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3520,6 +3555,7 @@ async fn hoisted_node_linker_does_not_create_virtual_store_root() {
         node_linker: pacquet_config::NodeLinker::Hoisted,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3618,6 +3654,7 @@ async fn frozen_lockfile_install_errors_when_no_variant_matches_host() {
         resolved_packages: &Default::default(),
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3714,6 +3751,7 @@ async fn frozen_lockfile_install_skips_runtime_when_skip_runtimes_set() {
         resolved_packages: &Default::default(),
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -3814,6 +3852,7 @@ async fn install_rejects_invalid_minimum_release_age_exclude_pattern() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -3916,6 +3955,7 @@ async fn frozen_lockfile_gate_rejects_under_huge_minimum_release_age() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -4004,6 +4044,7 @@ async fn fresh_install_writes_pnpm_lock_yaml_with_expected_shape() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4090,6 +4131,7 @@ async fn fresh_install_splits_dev_and_prod_dependency_sections() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4162,6 +4204,7 @@ async fn fresh_install_records_user_written_specifier() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4230,6 +4273,7 @@ async fn fresh_install_lockfile_round_trips_through_load_save_load() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4297,6 +4341,7 @@ async fn fresh_install_with_lockfile_disabled_does_not_write_a_lockfile() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4367,6 +4412,7 @@ async fn fresh_install_also_writes_current_lockfile_under_virtual_store() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4453,6 +4499,7 @@ async fn fresh_install_with_lockfile_disabled_skips_current_lockfile_too() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4517,6 +4564,7 @@ async fn fresh_install_marks_optional_snapshots_in_pnpm_lock_yaml() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4606,6 +4654,7 @@ async fn fresh_install_hoisted_node_linker_records_modules_yaml() {
         node_linker: pacquet_config::NodeLinker::Hoisted,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4675,6 +4724,7 @@ async fn fresh_install_refuses_skip_runtimes_before_writing_state() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -4748,6 +4798,7 @@ async fn prefer_frozen_lockfile_takes_frozen_path_when_lockfile_is_fresh() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -4822,6 +4873,7 @@ async fn no_prefer_frozen_lockfile_flag_forces_fresh_resolve() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -4890,6 +4942,7 @@ async fn stale_lockfile_under_no_flag_falls_through_to_fresh_resolve() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;
@@ -5144,6 +5197,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         node_linker: pacquet_config::NodeLinker::Isolated,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -5327,6 +5381,7 @@ async fn optimistic_repeat_install_skips_entire_pipeline_when_state_is_fresh() {
         node_linker: pacquet_config::NodeLinker::Isolated,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -5477,6 +5532,7 @@ async fn frozen_lockfile_disables_optimistic_short_circuit() {
         node_linker: pacquet_config::NodeLinker::Isolated,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -5628,6 +5684,7 @@ async fn optimistic_repeat_install_does_not_short_circuit_when_lockfile_missing(
         node_linker: pacquet_config::NodeLinker::Isolated,
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await;
@@ -5708,6 +5765,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -5761,6 +5819,7 @@ async fn optimistic_repeat_install_round_trips_on_single_project_install() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<RecordingReporter>()
     .await
@@ -5870,6 +5929,7 @@ async fn fresh_install_applies_package_extensions_to_dependency_manifest() {
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
         resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await
@@ -5967,6 +6027,7 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
         supported_architectures: None,
         node_linker: pacquet_config::NodeLinker::default(),
         lockfile_only: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await;

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -709,9 +709,18 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             UpdateSeedPolicy::DropOnly(names) => match lockfile_snapshots {
                 None => None,
                 Some(snapshots) => {
+                    // The update-target set is small (CLI selectors / direct
+                    // deps); the snapshot map is large. Parse the targets to
+                    // `PkgName` once so the per-snapshot filter compares
+                    // against `key.name` directly instead of allocating a
+                    // `String` per key.
+                    let drop: std::collections::HashSet<pacquet_lockfile::PkgName> = names
+                        .iter()
+                        .filter_map(|name| pacquet_lockfile::PkgName::parse(name.as_str()).ok())
+                        .collect();
                     filtered_snapshots = snapshots
                         .iter()
-                        .filter(|(key, _)| !names.contains(&key.name.to_string()))
+                        .filter(|(key, _)| !drop.contains(&key.name))
                         .map(|(key, entry)| (key.clone(), entry.clone()))
                         .collect::<HashMap<_, _>>();
                     Some(&filtered_snapshots)

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -164,6 +164,39 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// `dryRun: opts.lockfileOnly` resolve pass. See
     /// [`crate::Install::lockfile_only`].
     pub lockfile_only: bool,
+    /// Which lockfile pins to withhold from the preferred-versions seed
+    /// so the affected names re-resolve to the highest version
+    /// satisfying their manifest range. Drives `pacquet update`'s
+    /// compatible bump; see [`UpdateSeedPolicy`].
+    pub update_seed_policy: UpdateSeedPolicy,
+}
+
+/// Which lockfile-pinned `(name, version)` pairs to *withhold* from the
+/// preferred-versions tie-break seed [`InstallWithFreshLockfile`] builds
+/// via `get_preferred_versions_from_lockfile_and_manifests`.
+///
+/// A name whose pin is withheld no longer carries its previously-locked
+/// version at the existing-version weight, so the resolver falls back to
+/// picking the highest version satisfying the manifest range — the
+/// compatible re-resolution `pacquet update` performs. Mirrors pnpm's
+/// `update: 'compatible'` resolver mode, which ignores the lockfile
+/// version for the dependency being updated
+/// (<https://github.com/pnpm/pnpm/blob/097983fbca/installing/deps-resolver/src/resolveDependencies.ts#L823-L827>).
+///
+/// `KeepAll` is the install/add default (every pin seeds the table, so
+/// unrelated entries keep their resolutions on a rewrite).
+#[derive(Debug, Default, Clone)]
+pub enum UpdateSeedPolicy {
+    /// Seed every lockfile pin. `pacquet install` / `pacquet add`.
+    #[default]
+    KeepAll,
+    /// Withhold every lockfile pin. `pacquet update` with no package
+    /// selectors — the whole graph re-resolves to highest-in-range.
+    DropAll,
+    /// Withhold only the named packages' pins. `pacquet update <pattern>`
+    /// — matched names (at any depth) re-resolve while everything else
+    /// keeps its pin. Keyed by package name (scope included).
+    DropOnly(std::collections::HashSet<String>),
 }
 
 /// Error type of [`InstallWithFreshLockfile`].
@@ -379,6 +412,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             node_linker,
             supported_architectures,
             lockfile_only,
+            update_seed_policy,
         } = self;
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
         // Materialise the caller's iterator into a `Vec` so the same
@@ -662,9 +696,31 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // recorded pins; see <https://pnpm.io/settings#preferfrozenlockfile>.
         let manifests_for_preferred: Vec<&PackageManifest> =
             importer_manifests.values().copied().collect();
+        // `pacquet update` withholds the lockfile pins for the names it
+        // is bumping so they re-resolve to highest-in-range; everything
+        // else keeps its pin. `DropOnly` builds a filtered snapshot map
+        // (owned, so it outlives the seed build) excluding the matched
+        // names; `DropAll` passes `None` so no pin seeds the table.
+        let lockfile_snapshots = wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref());
+        let filtered_snapshots;
+        let seed_snapshots = match &update_seed_policy {
+            UpdateSeedPolicy::KeepAll => lockfile_snapshots,
+            UpdateSeedPolicy::DropAll => None,
+            UpdateSeedPolicy::DropOnly(names) => match lockfile_snapshots {
+                None => None,
+                Some(snapshots) => {
+                    filtered_snapshots = snapshots
+                        .iter()
+                        .filter(|(key, _)| !names.contains(&key.name.to_string()))
+                        .map(|(key, entry)| (key.clone(), entry.clone()))
+                        .collect::<HashMap<_, _>>();
+                    Some(&filtered_snapshots)
+                }
+            },
+        };
         let all_preferred_versions =
             pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
-                wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()),
+                seed_snapshots,
                 manifests_for_preferred.as_slice(),
             );
 

--- a/pacquet/crates/package-manager/src/lib.rs
+++ b/pacquet/crates/package-manager/src/lib.rs
@@ -31,6 +31,7 @@ mod retry_config;
 mod store_init;
 mod symlink_direct_dependencies;
 mod symlink_package;
+mod update;
 mod version_policy;
 mod virtual_store_layout;
 
@@ -65,5 +66,6 @@ pub use package_extender::*;
 pub use prefetching_resolver::*;
 pub use symlink_direct_dependencies::*;
 pub use symlink_package::*;
+pub use update::*;
 pub use version_policy::*;
 pub use virtual_store_layout::*;

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -64,6 +64,12 @@ pub struct Update<'a> {
     /// `--save-exact` / `-E`: write the resolved version without a range
     /// operator when rewriting the manifest under `--latest`.
     pub save_exact: bool,
+    /// `--save` (default) / `--no-save`. When `false`, the manifest is
+    /// not persisted: the `--latest` / versioned-selector range rewrites
+    /// still drive resolution (so `pnpm-lock.yaml` updates) but
+    /// `package.json` on disk is left untouched. Mirrors pnpm's
+    /// `updatePackageManifest: opts.save !== false`.
+    pub save: bool,
     /// Dependency groups the update considers when choosing which direct
     /// dependencies to match. Mirrors pnpm's `includeDirect` derived from
     /// `--prod` / `--dev` / `--no-optional`. Note: the *materialized*
@@ -91,6 +97,13 @@ pub enum UpdateError {
     #[diagnostic(code(ERR_PNPM_LATEST_WITH_SPEC))]
     LatestWithSpec(#[error(not(source))] String),
 
+    /// Package selectors were given (with `--depth 0` and without
+    /// `--latest`) but none matched a direct dependency. Mirrors pnpm's
+    /// `ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES`.
+    #[display("None of the specified packages were found in the dependencies.")]
+    #[diagnostic(code(ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES))]
+    NoPackageInDependencies,
+
     /// Fetching a package's `latest` tag from the registry failed while
     /// computing the new manifest range for `--latest`.
     #[display("Failed to resolve the latest version of {name}: {error}")]
@@ -113,21 +126,27 @@ pub enum UpdateError {
 
 /// A CLI selector split into its name pattern and optional version part.
 /// Ports pnpm's
-/// [`parseUpdateParam`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/recursive.ts)
-/// — `lastIndexOf('@')` with `index >= 1` so a leading scope `@` is not
-/// mistaken for a version separator.
+/// [`parseUpdateParam`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/recursive.ts#L582-L595):
+/// the version separator is the **first** `@` at or after index `1`
+/// (`2` for a `!`-negated pattern), so neither a leading scope `@` nor
+/// the `!@scope/...` negation form is mistaken for a version.
 struct ParsedSelector {
     pattern: String,
     version: Option<String>,
 }
 
 fn parse_update_param(input: &str) -> ParsedSelector {
-    match input.rfind('@') {
-        Some(idx) if idx >= 1 => ParsedSelector {
+    let search_start = if input.starts_with('!') { 2 } else { 1 };
+    let at_index = input
+        .get(search_start..)
+        .and_then(|rest| rest.find('@'))
+        .map(|offset| offset + search_start);
+    match at_index {
+        Some(idx) => ParsedSelector {
             pattern: input[..idx].to_string(),
             version: Some(input[idx + 1..].to_string()),
         },
-        _ => ParsedSelector { pattern: input.to_string(), version: None },
+        None => ParsedSelector { pattern: input.to_string(), version: None },
     }
 }
 
@@ -145,6 +164,7 @@ impl Update<'_> {
             packages,
             latest,
             save_exact,
+            save,
             include_direct,
             depth,
             supported_architectures,
@@ -243,29 +263,60 @@ impl Update<'_> {
             // manifest, mirroring pnpm's `matchDependencies` + `updateSpec`.
             let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
             let matcher = create_matcher(&patterns);
-            for (name, group, _) in &direct {
-                if !matcher.matches(name) {
-                    continue;
-                }
-                drop_names.insert(name.clone());
+            let matched_direct: Vec<(String, DependencyGroup)> = direct
+                .iter()
+                .filter(|(name, _, _)| matcher.matches(name))
+                .map(|(name, group, _)| (name.clone(), *group))
+                .collect();
+
+            if matched_direct.is_empty() {
+                // No direct dependency matched the selectors. Mirrors
+                // pnpm's `matchDependencies` returning empty:
+                // <https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/installDeps.ts#L353-L366>.
                 if latest {
-                    let version = fetch_latest(name, http_client, config).await?;
-                    rewrites.push((name.clone(), *group, version.serialize(save_exact)));
-                } else if let Some(spec) = selectors
-                    .iter()
-                    .find(|sel| matcher_one(&sel.pattern).matches(name))
-                    .and_then(|sel| sel.version.clone())
-                {
-                    rewrites.push((name.clone(), *group, spec));
+                    // `--latest` with an unmatched selector is a no-op.
+                    return Ok(());
                 }
+                if depth == 0 {
+                    return Err(UpdateError::NoPackageInDependencies);
+                }
+                // `depth > 0`: update only the matching *indirect*
+                // dependencies (no manifest rewrite). Reached here only
+                // for versioned selectors — bare-name selectors with
+                // `depth > 0` take the name-matcher branch above.
+                if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
+                    for key in snapshots.keys() {
+                        let name = key.name.to_string();
+                        if matcher.matches(&name) {
+                            drop_names.insert(name);
+                        }
+                    }
+                }
+                UpdateSeedPolicy::DropOnly(drop_names)
+            } else {
+                for (name, group) in &matched_direct {
+                    drop_names.insert(name.clone());
+                    if latest {
+                        let version = fetch_latest(name, http_client, config).await?;
+                        rewrites.push((name.clone(), *group, version.serialize(save_exact)));
+                    } else if let Some(spec) = selectors
+                        .iter()
+                        .find(|sel| matcher_one(&sel.pattern).matches(name))
+                        .and_then(|sel| sel.version.clone())
+                    {
+                        rewrites.push((name.clone(), *group, spec));
+                    }
+                }
+                UpdateSeedPolicy::DropOnly(drop_names)
             }
-            UpdateSeedPolicy::DropOnly(drop_names)
         };
 
         // Apply the manifest rewrites in memory before resolving so the
-        // install picks the new ranges. The save happens after the
-        // install succeeds, matching pnpm's manifest-write ordering.
-        let manifest_changed = !rewrites.is_empty();
+        // install picks the new ranges. Under `--no-save` the in-memory
+        // mutation still drives resolution (so `pnpm-lock.yaml` updates)
+        // but the manifest is not persisted below — matching pnpm's
+        // `updatePackageManifest: opts.save !== false`.
+        let persist_manifest = save && !rewrites.is_empty();
         for (name, group, spec) in &rewrites {
             manifest.add_dependency(name, spec, *group).map_err(UpdateError::UpdateManifest)?;
         }
@@ -304,7 +355,7 @@ impl Update<'_> {
         .await
         .map_err(UpdateError::Install)?;
 
-        if manifest_changed {
+        if persist_manifest {
             manifest.save().map_err(UpdateError::SaveManifest)?;
 
             let prefix = manifest

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -1,0 +1,355 @@
+use crate::{Install, InstallError, ResolvedPackages, UpdateSeedPolicy};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_config::{Config, matcher::create_matcher};
+use pacquet_lockfile::Lockfile;
+use pacquet_network::ThrottledClient;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
+use pacquet_registry::{PackageTag, PackageVersion};
+use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
+use pacquet_tarball::MemCache;
+use std::{collections::HashSet, sync::Arc};
+
+/// The three dependency groups `pacquet update` considers as "direct"
+/// targets, in the order pnpm's `updateProjectManifest` walks them.
+const DIRECT_GROUPS: [DependencyGroup; 3] =
+    [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+
+/// Everything `pacquet update` (alias `up` / `upgrade`) does.
+///
+/// Ports pnpm's
+/// [`update` command](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/update/index.ts)
+/// onto pacquet's always-fresh-resolve install path. The two halves of
+/// pnpm's behavior map as follows:
+///
+/// * **Compatible bump** (no `--latest`): the matched names have their
+///   lockfile pins withheld from the preferred-versions seed
+///   ([`UpdateSeedPolicy`]) so the resolver re-picks the highest version
+///   satisfying the manifest range. `package.json` is left untouched —
+///   pnpm only rewrites the manifest for deps marked `updateSpec`, which
+///   compatible updates are not.
+/// * **`--latest`**: each matched *direct* dependency's `latest` tag is
+///   fetched and written into `package.json` (`^<version>`, or the exact
+///   version under `--save-exact`), exactly as `pacquet add` records a
+///   freshly-added range. The follow-up install then resolves the new
+///   range. Mirrors pnpm's `updateToLatest` + `updateSpec` path.
+///
+/// Selector handling mirrors pnpm's
+/// [`update`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/update/index.ts#L282-L328):
+/// bare-name selectors (`foo`, `@scope/bar-*`) with `depth > 0` and no
+/// `--latest` match every package of that name **at any depth** (the
+/// match is applied against the lockfile's package names, like pnpm's
+/// `updateMatching(infoFromLockfile.name, ...)`); selectors carrying a
+/// version (`foo@2`) or any selector under `--latest` match only direct
+/// dependencies, and the version (or fetched latest) is written into the
+/// manifest before resolving.
+#[must_use]
+pub struct Update<'a> {
+    pub tarball_mem_cache: Arc<MemCache>,
+    pub resolved_packages: &'a ResolvedPackages,
+    pub http_client: &'a ThrottledClient,
+    pub http_client_arc: Arc<ThrottledClient>,
+    pub config: &'static Config,
+    pub manifest: &'a mut PackageManifest,
+    pub lockfile: Option<&'a Lockfile>,
+    pub lockfile_path: Option<&'a std::path::Path>,
+    /// Package selectors from the CLI (`foo`, `@scope/bar-*`, `foo@2`).
+    /// Empty means "update every direct dependency in the included
+    /// groups", matching `pnpm update` with no arguments.
+    pub packages: &'a [String],
+    /// `--latest` / `-L`: ignore the manifest range and bump matched
+    /// direct dependencies to their `latest` dist-tag, rewriting
+    /// `package.json`.
+    pub latest: bool,
+    /// `--save-exact` / `-E`: write the resolved version without a range
+    /// operator when rewriting the manifest under `--latest`.
+    pub save_exact: bool,
+    /// Dependency groups the update considers when choosing which direct
+    /// dependencies to match. Mirrors pnpm's `includeDirect` derived from
+    /// `--prod` / `--dev` / `--no-optional`. Note: the *materialized*
+    /// dependency set is always all three groups (pnpm's `include` is
+    /// all-true for updates so the `node_modules` layout is unchanged);
+    /// this only narrows the update scope.
+    pub include_direct: Vec<DependencyGroup>,
+    /// `--depth`. Only its `> 0` predicate is consulted (matching pnpm's
+    /// `depth > 0` gate on the name matcher); `usize::MAX` stands in for
+    /// pnpm's `Infinity` default.
+    pub depth: usize,
+    /// CLI-merged `supportedArchitectures`, forwarded to the install.
+    pub supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
+    /// `--lockfile-only`: re-resolve and rewrite `pnpm-lock.yaml` without
+    /// materializing `node_modules`. Forwarded to the install.
+    pub lockfile_only: bool,
+}
+
+/// Error type of [`Update`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum UpdateError {
+    /// `--latest` was combined with a versioned selector (`foo@2`).
+    /// Mirrors pnpm's `ERR_PNPM_LATEST_WITH_SPEC`.
+    #[display("Specs are not allowed to be used with --latest ({_0})")]
+    #[diagnostic(code(ERR_PNPM_LATEST_WITH_SPEC))]
+    LatestWithSpec(#[error(not(source))] String),
+
+    /// Fetching a package's `latest` tag from the registry failed while
+    /// computing the new manifest range for `--latest`.
+    #[display("Failed to resolve the latest version of {name}: {error}")]
+    #[diagnostic(code(pacquet_package_manager::update_resolve_latest))]
+    ResolveLatest {
+        name: String,
+        #[error(source)]
+        error: pacquet_registry::RegistryError,
+    },
+
+    #[display("Failed to update the manifest: {_0}")]
+    UpdateManifest(#[error(source)] PackageManifestError),
+
+    #[display("Failed to save the manifest file: {_0}")]
+    SaveManifest(#[error(source)] PackageManifestError),
+
+    #[diagnostic(transparent)]
+    Install(#[error(source)] InstallError),
+}
+
+/// A CLI selector split into its name pattern and optional version part.
+/// Ports pnpm's
+/// [`parseUpdateParam`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/recursive.ts)
+/// — `lastIndexOf('@')` with `index >= 1` so a leading scope `@` is not
+/// mistaken for a version separator.
+struct ParsedSelector {
+    pattern: String,
+    version: Option<String>,
+}
+
+fn parse_update_param(input: &str) -> ParsedSelector {
+    match input.rfind('@') {
+        Some(idx) if idx >= 1 => ParsedSelector {
+            pattern: input[..idx].to_string(),
+            version: Some(input[idx + 1..].to_string()),
+        },
+        _ => ParsedSelector { pattern: input.to_string(), version: None },
+    }
+}
+
+impl Update<'_> {
+    pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), UpdateError> {
+        let Update {
+            tarball_mem_cache,
+            resolved_packages,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            lockfile,
+            lockfile_path,
+            packages,
+            latest,
+            save_exact,
+            include_direct,
+            depth,
+            supported_architectures,
+            lockfile_only,
+        } = self;
+
+        let selectors: Vec<ParsedSelector> =
+            packages.iter().map(|p| parse_update_param(p)).collect();
+
+        // `--latest` forbids versioned selectors, matching pnpm's
+        // `LATEST_WITH_SPEC` guard.
+        if latest {
+            let with_spec: Vec<&str> = packages
+                .iter()
+                .zip(&selectors)
+                .filter(|(_, sel)| sel.version.is_some())
+                .map(|(raw, _)| raw.as_str())
+                .collect();
+            if !with_spec.is_empty() {
+                return Err(UpdateError::LatestWithSpec(with_spec.join(", ")));
+            }
+        }
+
+        // Snapshot the direct dependencies in the included groups before
+        // any manifest mutation, so the matcher and the `--latest`
+        // rewrite both see the pre-update shape.
+        let direct: Vec<(String, DependencyGroup, String)> = include_direct
+            .iter()
+            .flat_map(|&group| {
+                manifest
+                    .dependencies([group])
+                    .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let updates_all_groups = DIRECT_GROUPS.iter().all(|group| include_direct.contains(group));
+
+        // Names whose lockfile pins to withhold so they re-resolve, and
+        // the per-direct-dep manifest rewrites (`--latest` / versioned
+        // selector only).
+        let mut drop_names: HashSet<String> = HashSet::new();
+        let mut rewrites: Vec<(String, DependencyGroup, String)> = Vec::new();
+
+        // Mirror pnpm's gate for the name matcher: bare-name selectors,
+        // `depth > 0`, and no `--latest` use `updateMatching`, applied to
+        // every package name at any depth.
+        let use_name_matcher = !selectors.is_empty()
+            && selectors.iter().all(|sel| sel.version.is_none())
+            && depth > 0
+            && !latest;
+
+        let seed_policy = if selectors.is_empty() {
+            if latest {
+                for (name, group, _) in &direct {
+                    let version = fetch_latest(name, http_client, config).await?;
+                    rewrites.push((name.clone(), *group, version.serialize(save_exact)));
+                }
+            }
+            for (name, _, _) in &direct {
+                drop_names.insert(name.clone());
+            }
+            // `pnpm update` (no selectors, no group narrowing) re-resolves
+            // the whole graph to highest-in-range. Once the groups are
+            // narrowed (`--prod` / `--dev` / `--no-optional`) only the
+            // included direct deps (and their same-named transitive
+            // occurrences) re-resolve.
+            if updates_all_groups {
+                UpdateSeedPolicy::DropAll
+            } else {
+                UpdateSeedPolicy::DropOnly(drop_names)
+            }
+        } else if use_name_matcher {
+            let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
+            let matcher = create_matcher(&patterns);
+            for (name, _, _) in &direct {
+                if matcher.matches(name) {
+                    drop_names.insert(name.clone());
+                }
+            }
+            // Match against every locked package name too, so a selector
+            // that names a transitive-only dependency still bumps it —
+            // pnpm applies `updateMatching` to `infoFromLockfile.name`.
+            if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
+                for key in snapshots.keys() {
+                    let name = key.name.to_string();
+                    if matcher.matches(&name) {
+                        drop_names.insert(name);
+                    }
+                }
+            }
+            UpdateSeedPolicy::DropOnly(drop_names)
+        } else {
+            // Versioned selectors and/or `--latest`: match direct
+            // dependencies only and write the new range into the
+            // manifest, mirroring pnpm's `matchDependencies` + `updateSpec`.
+            let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
+            let matcher = create_matcher(&patterns);
+            for (name, group, _) in &direct {
+                if !matcher.matches(name) {
+                    continue;
+                }
+                drop_names.insert(name.clone());
+                if latest {
+                    let version = fetch_latest(name, http_client, config).await?;
+                    rewrites.push((name.clone(), *group, version.serialize(save_exact)));
+                } else if let Some(spec) = selectors
+                    .iter()
+                    .find(|sel| matcher_one(&sel.pattern).matches(name))
+                    .and_then(|sel| sel.version.clone())
+                {
+                    rewrites.push((name.clone(), *group, spec));
+                }
+            }
+            UpdateSeedPolicy::DropOnly(drop_names)
+        };
+
+        // Apply the manifest rewrites in memory before resolving so the
+        // install picks the new ranges. The save happens after the
+        // install succeeds, matching pnpm's manifest-write ordering.
+        let manifest_changed = !rewrites.is_empty();
+        for (name, group, spec) in &rewrites {
+            manifest.add_dependency(name, spec, *group).map_err(UpdateError::UpdateManifest)?;
+        }
+
+        Install {
+            tarball_mem_cache,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            lockfile,
+            lockfile_path,
+            // `include` is always all-true for updates: the materialized
+            // `node_modules` layout must not change just because the
+            // update scope was narrowed. Mirrors pnpm's update `include`.
+            dependency_groups: DIRECT_GROUPS,
+            frozen_lockfile: false,
+            // `update` always re-resolves against the registry, so the
+            // auto-frozen / repeat-install fast paths must not fire.
+            prefer_frozen_lockfile: Some(false),
+            ignore_manifest_check: false,
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
+            update_checksums: false,
+            // A targeted `pacquet update <pkg>` is a partial install
+            // (pnpm's `installSome`); a bare `pacquet update` is a full
+            // install that runs the project's own lifecycle scripts.
+            is_full_install: packages.is_empty(),
+            resolved_packages,
+            supported_architectures,
+            node_linker: config.node_linker,
+            lockfile_only,
+            update_seed_policy: seed_policy,
+        }
+        .run::<Reporter>()
+        .await
+        .map_err(UpdateError::Install)?;
+
+        if manifest_changed {
+            manifest.save().map_err(UpdateError::SaveManifest)?;
+
+            let prefix = manifest
+                .path()
+                .parent()
+                .unwrap_or_else(|| manifest.path())
+                .to_string_lossy()
+                .into_owned();
+            Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
+                level: LogLevel::Debug,
+                message: PackageManifestMessage::Updated {
+                    prefix,
+                    updated: manifest.value().clone(),
+                },
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+/// Compile a single pattern into a matcher. Used to map a matched direct
+/// dependency back to the selector that claimed it (so a versioned
+/// selector's version is applied to the right dep).
+fn matcher_one(pattern: &str) -> pacquet_config::matcher::Matcher {
+    create_matcher(std::slice::from_ref(&pattern.to_string()))
+}
+
+/// Fetch a package's `latest` dist-tag from the registry. Shares the
+/// shape `pacquet add` uses for a freshly-added dependency.
+async fn fetch_latest(
+    name: &str,
+    http_client: &ThrottledClient,
+    config: &Config,
+) -> Result<PackageVersion, UpdateError> {
+    PackageVersion::fetch_from_registry(
+        name,
+        PackageTag::Latest,
+        http_client,
+        &config.registry,
+        &config.auth_headers,
+    )
+    .await
+    .map_err(|error| UpdateError::ResolveLatest { name: name.to_string(), error })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/package-manager/src/update/tests.rs
+++ b/pacquet/crates/package-manager/src/update/tests.rs
@@ -1,0 +1,36 @@
+use super::parse_update_param;
+
+#[test]
+fn parses_bare_name_without_version() {
+    let parsed = parse_update_param("foo");
+    assert_eq!(parsed.pattern, "foo");
+    assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn parses_name_with_version() {
+    let parsed = parse_update_param("foo@2");
+    assert_eq!(parsed.pattern, "foo");
+    assert_eq!(parsed.version.as_deref(), Some("2"));
+}
+
+#[test]
+fn leading_scope_at_is_not_a_version_separator() {
+    let parsed = parse_update_param("@scope/foo");
+    assert_eq!(parsed.pattern, "@scope/foo");
+    assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn scoped_name_with_version_splits_on_last_at() {
+    let parsed = parse_update_param("@scope/foo@^1.2.3");
+    assert_eq!(parsed.pattern, "@scope/foo");
+    assert_eq!(parsed.version.as_deref(), Some("^1.2.3"));
+}
+
+#[test]
+fn wildcard_pattern_without_version() {
+    let parsed = parse_update_param("@pnpm.e2e/peer-*");
+    assert_eq!(parsed.pattern, "@pnpm.e2e/peer-*");
+    assert_eq!(parsed.version, None);
+}

--- a/pacquet/crates/package-manager/src/update/tests.rs
+++ b/pacquet/crates/package-manager/src/update/tests.rs
@@ -34,3 +34,19 @@ fn wildcard_pattern_without_version() {
     assert_eq!(parsed.pattern, "@pnpm.e2e/peer-*");
     assert_eq!(parsed.version, None);
 }
+
+#[test]
+fn negated_scoped_pattern_is_not_split_on_scope_at() {
+    // The `@` after `!` is the scope marker, not a version separator —
+    // pnpm searches for `@` starting at index 2 for `!`-negated params.
+    let parsed = parse_update_param("!@pnpm.e2e/peer-*");
+    assert_eq!(parsed.pattern, "!@pnpm.e2e/peer-*");
+    assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn negated_unscoped_pattern_without_version() {
+    let parsed = parse_update_param("!foo");
+    assert_eq!(parsed.pattern, "!foo");
+    assert_eq!(parsed.version, None);
+}

--- a/pnpr/crates/pnpr/src/install_accelerator/resolve.rs
+++ b/pnpr/crates/pnpr/src/install_accelerator/resolve.rs
@@ -111,6 +111,7 @@ pub async fn resolve(
         supported_architectures: None,
         node_linker: NodeLinker::Isolated,
         lockfile_only: true,
+        update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAll,
     }
     .run::<SilentReporter>()
     .await


### PR DESCRIPTION
Ports pnpm's `update` (aliases `up` / `upgrade`) to pacquet, onto its always-fresh-resolve install path.

## Behavior
- **Compatible bump** (no `--latest`): the matched names have their lockfile pins withheld from the preferred-versions seed (new `UpdateSeedPolicy`), so the resolver re-picks the highest version satisfying the manifest range. `package.json` is left untouched — this is exactly what distinguishes `update` from `install` (which keeps the pin because it still satisfies the range). Mirrors pnpm's `update: 'compatible'`.
- **`--latest`**: each matched *direct* dependency's `latest` dist-tag is fetched and written into `package.json` (`^<version>`, or exact under `--save-exact`), then the install resolves the new range. Mirrors pnpm's `updateToLatest` + `updateSpec`.
- **Selectors**: bare-name / glob patterns (`@scope/bar-*`) with `depth > 0` and no `--latest` match every locked package name at any depth (like pnpm's `updateMatching(infoFromLockfile.name, …)`); versioned (`foo@2`) or `--latest` selectors match direct deps only; `--latest` combined with a spec is rejected (`ERR_PNPM_LATEST_WITH_SPEC`).
- **Flags**: `-L/--latest`, `-E/--save-exact`, `-P/-D/--no-optional` (faithful `makeIncludeDependenciesFromCLI`, including the quirk that `--no-optional` only drops optionals alongside `--prod`/`--dev`), `--depth`, `--lockfile-only`, `-i/--interactive`.
- **Interactive** uses `dialoguer` (added to `[workspace.dependencies]`) plus an inline outdated check (current from the lockfile, target from one packument fetch).

The resolver's `UpdateBehavior` tri-state and the npm resolver's `include_latest_tag` already existed — this PR drives them from a new CLI command and `pacquet_package_manager::Update` operation.

## Deferred (error out rather than misbehave) → tracked in #12101
- `--global` / `-g` (global-dir + `@pnpm/global.commands` not ported)
- `--workspace` (workspace-protocol version linking not ported)
- Known gap: under recursive `-r`, sibling-importer `package.json` files aren't rewritten on `--latest` (only the root manifest is); resolution still spans all importers.

## Tests
New e2e suite `pacquet/crates/cli/tests/update.rs`: compatible bump within range, `--latest` manifest rewrite, `--save-exact`, scoped selector, `up` alias, and `LATEST_WITH_SPEC` rejection. Full Rust suite green; `cargo check` / `clippy -D warnings` / `cargo doc -D warnings` / dylint (perfectionist) / `fmt --check` / `typos` all clean.

No changeset (pacquet-only change). This is the pnpm → pacquet porting direction, so no TypeScript-side mirror is needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pacquet update` (aliases: `up`, `upgrade`) with flags: `--interactive`, `--latest`, `--save-exact`, `--no-save`, `--prod`, `--dev`, `--no-optional`, `--depth`
  * `--interactive` prompts to select outdated direct deps
  * `add`/`install` now preserve existing lockfile pins by default during updates

* **Tests**
  * New unit and integration tests covering update parsing, selection, and CLI behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->