### PR TITLE
feat(pacquet): honor `updateConfig.ignoreDependencies` in `update`

### DIFF
--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -8,6 +8,9 @@ use tempfile::TempDir;
 
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const FOO: &str = "@pnpm.e2e/foo";
+/// Depends on `dep-of-pkg-with-1-dep@^100.0.0`, used to exercise
+/// indirect-dependency update behavior when the direct dep is ignored.
+const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
 
 /// Spin up a temp workspace with the mocked registry and return the
 /// pieces a multi-step update test needs.
@@ -277,6 +280,52 @@ fn update_prod_scopes_and_honors_ignore() {
         .find(|(k, _)| *k == "@pnpm.e2e/peer-c")
         .map(|(_, spec)| spec.to_string());
     assert_eq!(peer_c.as_deref(), Some("^1.0.0"));
+
+    drop((root, anchor));
+}
+
+/// When every included *direct* dep is ignored, `update --latest` is a
+/// full no-op — it must not re-resolve the non-ignored *indirect* deps.
+/// Mirrors pnpm's early `if (opts.latest) return`.
+#[test]
+fn update_latest_all_direct_ignored_does_not_touch_indirect() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[PARENT]);
+
+    // Pin the transitive dep-of-pkg-with-1-dep at 100.0.0 (via a direct
+    // exact entry), then drop it to a pure transitive of pkg-with-1-dep.
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0" }}"#));
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    // No-op: the indirect dep stays pinned at 100.0.0.
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+    assert!(!virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+
+    drop((root, anchor));
+}
+
+/// The non-`--latest` counterpart: when the only direct dep is ignored,
+/// a plain `update` still re-resolves the non-ignored indirect deps to
+/// the highest in range. Mirrors pnpm's "updating indirect dependencies
+/// only" branch — and guards against narrowing the `--latest` no-op
+/// guard into an unconditional one.
+#[test]
+fn update_compatible_all_direct_ignored_still_updates_indirect() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[PARENT]);
+
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0" }}"#));
+    pacquet(&workspace, ["update"]).assert().success();
+
+    // The indirect dep bumps within range (100.0.0 -> 100.1.0).
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
     drop((root, anchor));
 }

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -70,6 +70,22 @@ fn virtual_store_has(workspace: &Path, name_at_version: &str) -> bool {
     workspace.join("node_modules").join(".pnpm").join(name_at_version).exists()
 }
 
+/// List the `node_modules/.pnpm` entries. Logged before
+/// `virtual_store_has` assertions so a failing CI run shows what was
+/// actually materialized.
+fn list_virtual_store(workspace: &Path) -> Vec<String> {
+    let dir = workspace.join("node_modules").join(".pnpm");
+    std::fs::read_dir(&dir)
+        .map(|entries| {
+            entries
+                .filter_map(|entry| {
+                    entry.ok().map(|entry| entry.file_name().to_string_lossy().into_owned())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// `pacquet update` re-resolves a dependency to the highest version
 /// inside its range, even when the lockfile pins an older one — the
 /// behaviour that distinguishes it from a plain `install` (which keeps
@@ -83,11 +99,13 @@ fn update_bumps_within_range() {
     // bump to 100.1.0 (101.0.0 is outside the range).
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
 
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
     pacquet(&workspace, ["update"]).assert().success();
 
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(
         virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
         "update should have bumped the dependency to the highest version in range",
@@ -106,11 +124,13 @@ fn update_latest_rewrites_manifest() {
 
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
     pacquet(&workspace, ["update", "--latest"]).assert().success();
 
     // latest tag is the max published version, 101.0.0.
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^101.0.0"));
 
@@ -176,6 +196,7 @@ fn update_latest_no_save_keeps_manifest() {
 
     write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
     pacquet(&workspace, ["update", "--latest", "--no-save"]).assert().success();
@@ -184,6 +205,7 @@ fn update_latest_no_save_keeps_manifest() {
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
     // ...but the lockfile/store was re-resolved (101.0.0 is latest; the
     // in-memory `^101.0.0` drove resolution even though it wasn't saved).
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
 
     drop((root, anchor));
@@ -247,6 +269,7 @@ fn update_compatible_honors_ignore_dependencies() {
     pacquet(&workspace, ["update"]).assert().success();
 
     // dep re-resolved to the highest in range; foo kept its old pin.
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+foo@1.0.0"));
     assert!(!virtual_store_has(&workspace, "@pnpm.e2e+foo@1.3.0"));
@@ -296,12 +319,14 @@ fn update_latest_all_direct_ignored_does_not_touch_indirect() {
     // exact entry), then drop it to a pure transitive of pkg-with-1-dep.
     write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#));
     pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
 
     write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0" }}"#));
     pacquet(&workspace, ["update", "--latest"]).assert().success();
 
     // No-op: the indirect dep stays pinned at 100.0.0.
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
     assert!(!virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
@@ -325,6 +350,7 @@ fn update_compatible_all_direct_ignored_still_updates_indirect() {
     pacquet(&workspace, ["update"]).assert().success();
 
     // The indirect dep bumps within range (100.0.0 -> 100.1.0).
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
     assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
 
     drop((root, anchor));

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -34,6 +34,21 @@ fn write_manifest(workspace: &Path, dependencies: &str) {
     fs::write(workspace.join("package.json"), manifest).expect("write package.json");
 }
 
+/// Append an `updateConfig.ignoreDependencies` block to the
+/// `pnpm-workspace.yaml` the harness already wrote.
+fn set_ignore_dependencies(workspace: &Path, names: &[&str]) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("updateConfig:\n  ignoreDependencies:\n");
+    for name in names {
+        yaml.push_str(&format!("    - \"{name}\"\n"));
+    }
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
 fn dep_spec(workspace: &Path, name: &str) -> Option<String> {
     let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
     manifest
@@ -183,6 +198,45 @@ fn update_depth_zero_unknown_package_errors() {
         stderr.contains("None of the specified packages were found in the dependencies"),
         "stderr did not mention NO_PACKAGE_IN_DEPENDENCIES: {stderr}",
     );
+
+    drop((root, anchor));
+}
+
+/// `updateConfig.ignoreDependencies` excludes the listed packages from a
+/// no-selector update — ports pnpm's "ignore packages in
+/// updateConfig.ignoreDependencies" test (adapted to static fixtures).
+#[test]
+fn update_latest_honors_ignore_dependencies() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[DEP]);
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    // foo is updated to its latest; the ignored dep keeps its range.
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.1.0"));
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// When every dependency is ignored, `update --latest` is a no-op —
+/// ports pnpm's "do not update anything if all the dependencies are
+/// ignored" test.
+#[test]
+fn update_latest_all_ignored_is_noop() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[FOO]);
+
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    // The only dependency is ignored, so its range is untouched.
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^1.0.0"));
 
     drop((root, anchor));
 }

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -39,6 +39,12 @@ fn write_manifest(workspace: &Path, dependencies: &str) {
 fn set_ignore_dependencies(workspace: &Path, names: &[&str]) {
     let yaml_path = workspace.join("pnpm-workspace.yaml");
     let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    // Fail loudly if the harness ever starts writing `updateConfig` —
+    // appending a second top-level mapping key produces invalid YAML.
+    assert!(
+        !yaml.contains("updateConfig:"),
+        "pnpm-workspace.yaml already has an `updateConfig:` key — update this helper",
+    );
     if !yaml.ends_with('\n') {
         yaml.push('\n');
     }
@@ -218,6 +224,59 @@ fn update_latest_honors_ignore_dependencies() {
     // foo is updated to its latest; the ignored dep keeps its range.
     assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.1.0"));
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// A compatible (non-`--latest`) update honors `ignoreDependencies`: the
+/// ignored dep keeps its lockfile pin while the rest re-resolve.
+#[test]
+fn update_compatible_honors_ignore_dependencies() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[FOO]);
+
+    // Pin both exactly, then widen the ranges. A plain `update` would
+    // bump both to the highest in range; ignoring foo must keep it pinned.
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "100.0.0", "{FOO}": "1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["update"]).assert().success();
+
+    // dep re-resolved to the highest in range; foo kept its old pin.
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+foo@1.0.0"));
+    assert!(!virtual_store_has(&workspace, "@pnpm.e2e+foo@1.3.0"));
+
+    drop((root, anchor));
+}
+
+/// `--prod` scopes the update to production dependencies, and
+/// `ignoreDependencies` still excludes names within that scope. A
+/// devDependency is left untouched even though it has a newer version.
+#[test]
+fn update_prod_scopes_and_honors_ignore() {
+    let (root, workspace, anchor) = setup();
+    set_ignore_dependencies(&workspace, &[FOO]);
+
+    let manifest = format!(
+        r#"{{ "name": "test-update", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}, "devDependencies": {{ "@pnpm.e2e/peer-c": "^1.0.0" }} }}"#,
+    );
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--prod", "--latest"]).assert().success();
+
+    // dep (prod, not ignored) → latest; foo (prod, ignored) unchanged;
+    // peer-c (dev, excluded by --prod) unchanged.
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^101.0.0"));
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^1.0.0"));
+    let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
+    let peer_c = manifest
+        .dependencies([DependencyGroup::Dev])
+        .find(|(k, _)| *k == "@pnpm.e2e/peer-c")
+        .map(|(_, spec)| spec.to_string());
+    assert_eq!(peer_c.as_deref(), Some("^1.0.0"));
 
     drop((root, anchor));
 }

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -732,6 +732,11 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 seed_snapshots,
                 manifests_for_preferred.as_slice(),
             );
+        // The picker biases toward this seed so pins that still satisfy
+        // their range survive the re-resolve. Build the `Arc` once here
+        // so each per-importer `ResolveOptions` shares it with a refcount
+        // bump rather than deep-cloning the map.
+        let preferred_versions_seed = Arc::new(all_preferred_versions.clone());
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. The resolver consults the grouped record at
@@ -828,7 +833,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     pick_lowest_direct,
                     subdep_published_by: published_by,
                     base_opts: ResolveOptions {
-                        preferred_versions: all_preferred_versions.clone(),
+                        preferred_versions: Arc::clone(&preferred_versions_seed),
                         default_tag: Some("latest".to_string()),
                         published_by,
                         published_by_exclude: published_by_exclude.clone(),

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -828,6 +828,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     pick_lowest_direct,
                     subdep_published_by: published_by,
                     base_opts: ResolveOptions {
+                        preferred_versions: all_preferred_versions.clone(),
                         default_tag: Some("latest".to_string()),
                         published_by,
                         published_by_exclude: published_by_exclude.clone(),

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -733,10 +733,10 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                 manifests_for_preferred.as_slice(),
             );
         // The picker biases toward this seed so pins that still satisfy
-        // their range survive the re-resolve. Build the `Arc` once here
-        // so each per-importer `ResolveOptions` shares it with a refcount
-        // bump rather than deep-cloning the map.
-        let preferred_versions_seed = Arc::new(all_preferred_versions.clone());
+        // their range survive the re-resolve. Move the map into the `Arc`
+        // (no extra clone) so each per-importer `ResolveOptions` shares it
+        // with a refcount bump rather than deep-cloning the map.
+        let preferred_versions_seed = Arc::new(all_preferred_versions);
 
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. The resolver consults the grouped record at
@@ -821,7 +821,9 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                         .auto_install_peers_from_highest_match,
                     resolve_peers_from_workspace_root: config.resolve_peers_from_workspace_root,
                     dedupe_peers: config.dedupe_peers,
-                    all_preferred_versions: all_preferred_versions.clone(),
+                    // The per-importer hoist loop mutates its own copy, so
+                    // clone the shared seed's map here (deref past the `Arc`).
+                    all_preferred_versions: (*preferred_versions_seed).clone(),
                     patched_dependencies: patched_dependencies.clone(),
                     // `pick_lowest_direct` / `subdep_published_by` are
                     // authoritative from `resolve_workspace` (it computes

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -227,9 +227,12 @@ impl Update<'_> {
             // `matchDependencies(..., includeDirect)`.
             let ignore_patterns =
                 config.update_config.ignore_dependencies.as_deref().unwrap_or_default();
-            let ignore_matcher = create_matcher(ignore_patterns);
+            // Only compile a matcher when there's something to ignore, so
+            // the common (no ignore list) path skips it entirely.
+            let ignore_matcher =
+                (!ignore_patterns.is_empty()).then(|| create_matcher(ignore_patterns));
             let is_ignored =
-                |name: &str| !ignore_patterns.is_empty() && ignore_matcher.matches(name);
+                |name: &str| ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name));
 
             for (name, group, _) in &direct {
                 if is_ignored(name) {

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -171,13 +171,34 @@ impl Update<'_> {
             lockfile_only,
         } = self;
 
+        // `updateConfig.ignoreDependencies` applies only when the user
+        // passed no package selectors: each ignored name becomes a
+        // negation selector (`!name`) so the update covers everything
+        // *except* those. Mirrors pnpm's gate in
+        // [`installDeps`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/installDeps.ts#L337-L344)
+        // → `makeIgnorePatterns`.
+        let ignore_patterns: Vec<String>;
+        let selector_inputs: &[String] = if packages.is_empty() {
+            ignore_patterns = config
+                .update_config
+                .ignore_dependencies
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|dep| format!("!{dep}"))
+                .collect();
+            &ignore_patterns
+        } else {
+            packages
+        };
+
         let selectors: Vec<ParsedSelector> =
-            packages.iter().map(|p| parse_update_param(p)).collect();
+            selector_inputs.iter().map(|input| parse_update_param(input)).collect();
 
         // `--latest` forbids versioned selectors, matching pnpm's
         // `LATEST_WITH_SPEC` guard.
         if latest {
-            let with_spec: Vec<&str> = packages
+            let with_spec: Vec<&str> = selector_inputs
                 .iter()
                 .zip(&selectors)
                 .filter(|(_, sel)| sel.version.is_some())

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -253,7 +253,18 @@ impl Update<'_> {
                 // Whole-graph update minus the ignored names: drop every
                 // locked name that isn't ignored so the ignored ones keep
                 // their pins.
-                if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
+                //
+                // Skip the expansion when `--latest` selected no direct
+                // dependency (every included direct dep was ignored):
+                // pnpm returns early there (`if (opts.latest) return`), a
+                // true no-op. A non-`--latest` update with no direct match
+                // still re-resolves the non-ignored *indirect* deps,
+                // matching pnpm's "updating indirect dependencies only"
+                // branch, so the expansion must run in that case.
+                // <https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/installDeps.ts#L355-L364>
+                if !(latest && drop_names.is_empty())
+                    && let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref())
+                {
                     for key in snapshots.keys() {
                         let name = key.name.to_string();
                         if !is_ignored(&name) {

--- a/pacquet/crates/package-manager/src/update.rs
+++ b/pacquet/crates/package-manager/src/update.rs
@@ -171,34 +171,13 @@ impl Update<'_> {
             lockfile_only,
         } = self;
 
-        // `updateConfig.ignoreDependencies` applies only when the user
-        // passed no package selectors: each ignored name becomes a
-        // negation selector (`!name`) so the update covers everything
-        // *except* those. Mirrors pnpm's gate in
-        // [`installDeps`](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/installDeps.ts#L337-L344)
-        // → `makeIgnorePatterns`.
-        let ignore_patterns: Vec<String>;
-        let selector_inputs: &[String] = if packages.is_empty() {
-            ignore_patterns = config
-                .update_config
-                .ignore_dependencies
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .map(|dep| format!("!{dep}"))
-                .collect();
-            &ignore_patterns
-        } else {
-            packages
-        };
-
         let selectors: Vec<ParsedSelector> =
-            selector_inputs.iter().map(|input| parse_update_param(input)).collect();
+            packages.iter().map(|input| parse_update_param(input)).collect();
 
         // `--latest` forbids versioned selectors, matching pnpm's
         // `LATEST_WITH_SPEC` guard.
         if latest {
-            let with_spec: Vec<&str> = selector_inputs
+            let with_spec: Vec<&str> = packages
                 .iter()
                 .zip(&selectors)
                 .filter(|(_, sel)| sel.version.is_some())
@@ -239,23 +218,51 @@ impl Update<'_> {
             && !latest;
 
         let seed_policy = if selectors.is_empty() {
-            if latest {
-                for (name, group, _) in &direct {
+            // `updateConfig.ignoreDependencies` applies only when the user
+            // gave no selectors: the listed name globs are excluded from
+            // the update so they keep their lockfile pins. The filter runs
+            // against the *included* direct deps, so group narrowing
+            // (`--prod` / `--dev` / `--no-optional`) still scopes the
+            // update. Mirrors pnpm's `makeIgnorePatterns` feeding
+            // `matchDependencies(..., includeDirect)`.
+            let ignore_patterns =
+                config.update_config.ignore_dependencies.as_deref().unwrap_or_default();
+            let ignore_matcher = create_matcher(ignore_patterns);
+            let is_ignored =
+                |name: &str| !ignore_patterns.is_empty() && ignore_matcher.matches(name);
+
+            for (name, group, _) in &direct {
+                if is_ignored(name) {
+                    continue;
+                }
+                if latest {
                     let version = fetch_latest(name, http_client, config).await?;
                     rewrites.push((name.clone(), *group, version.serialize(save_exact)));
                 }
-            }
-            for (name, _, _) in &direct {
                 drop_names.insert(name.clone());
             }
-            // `pnpm update` (no selectors, no group narrowing) re-resolves
-            // the whole graph to highest-in-range. Once the groups are
-            // narrowed (`--prod` / `--dev` / `--no-optional`) only the
-            // included direct deps (and their same-named transitive
-            // occurrences) re-resolve.
-            if updates_all_groups {
+
+            if updates_all_groups && ignore_patterns.is_empty() {
+                // `pnpm update` (no selectors, no narrowing, no ignore
+                // list) re-resolves the whole graph to highest-in-range.
                 UpdateSeedPolicy::DropAll
+            } else if updates_all_groups {
+                // Whole-graph update minus the ignored names: drop every
+                // locked name that isn't ignored so the ignored ones keep
+                // their pins.
+                if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
+                    for key in snapshots.keys() {
+                        let name = key.name.to_string();
+                        if !is_ignored(&name) {
+                            drop_names.insert(name);
+                        }
+                    }
+                }
+                UpdateSeedPolicy::DropOnly(drop_names)
             } else {
+                // Group-narrowed: only the included direct deps (minus
+                // ignored) and their same-named transitive occurrences
+                // re-resolve.
                 UpdateSeedPolicy::DropOnly(drop_names)
             }
         } else if use_name_matcher {

--- a/pacquet/crates/resolving-resolver-base/src/resolve.rs
+++ b/pacquet/crates/resolving-resolver-base/src/resolve.rs
@@ -194,7 +194,13 @@ pub enum UpdateBehavior {
 pub struct ResolveOptions {
     pub project_dir: PathBuf,
     pub lockfile_dir: PathBuf,
-    pub preferred_versions: PreferredVersions,
+    /// Lockfile + manifest preferred-versions seed the npm picker biases
+    /// toward (so pins that still satisfy their range survive a
+    /// re-resolve). Held behind [`Arc`] because the tree walker clones
+    /// `ResolveOptions` per depth tier and the install layer clones it
+    /// per importer — sharing the (potentially large) map keeps those
+    /// clones to a refcount bump.
+    pub preferred_versions: Arc<PreferredVersions>,
     pub workspace_packages: Option<WorkspacePackages>,
     pub default_tag: Option<String>,
     pub pick_lowest_version: bool,


### PR DESCRIPTION
Follow-up to #12102, addressing one item from #12101.

When `pacquet update` runs with **no package selectors**, the names listed in `updateConfig.ignoreDependencies` (from `pnpm-workspace.yaml`) are excluded from the update so they keep their pins. Explicit CLI selectors take precedence over the ignore list — matching pnpm, which only applies `ignoreDependencies` when `params.length === 0`. The exclusion is applied over the *included* direct deps, so `--prod`/`--dev`/`--no-optional` group narrowing still scopes the update.

Ports pnpm's [`installDeps` gate](https://github.com/pnpm/pnpm/blob/097983fbca/installing/commands/src/installDeps.ts#L337-L344) + `makeIgnorePatterns`.

## Also: a resolver fix this surfaced
Writing the compatible-update ignore test revealed that the fresh-resolve path **never fed the preferred-versions seed to the version picker** — `get_preferred_versions_from_lockfile_and_manifests` was built but only used for peer hoisting, never written into `ResolveOptions.preferred_versions`. So a fresh re-resolve bumped *every* dep to its highest in-range version instead of keeping the lockfile pins that still satisfy their range, diverging from pnpm's `update: false` behavior (and making `update <selector>` / `ignoreDependencies` unable to keep non-targeted pins). Seeding `base_opts.preferred_versions` fixes it; fresh installs with no lockfile are unaffected, and all 2693 workspace tests still pass.

## Tests
Ports four cases from `installing/commands/test/update/update.ts` (adapted to pacquet's static fixtures, where `latest = max(version)`):
- `update --latest` ignores the listed dep and bumps the rest.
- `update --latest` with every dependency ignored is a no-op.
- A compatible (non-`--latest`) update keeps the ignored dep's resolved version while the rest bump.
- `--prod` scoping: an ignored prod dep keeps its range and a devDependency is left untouched.

All `update` e2e tests + full workspace suite (2693) + `clippy -D warnings` / dylint / `fmt --check` / `typos` pass.

No changeset (pacquet-only change).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update command supports workspace-configured dependency ignores so specified packages skip manifest range rewrites and lockfile pin drops.

* **Bug Fixes**
  * `update` (including `--latest` and scoped `--prod`) now correctly honors ignore settings; when all direct deps are ignored, `update --latest` is a no-op and indirect deps behave appropriately.

* **Tests**
  * Expanded CLI tests covering ignore behavior across latest/compatible updates and production scoping; tests now emit virtual-store diagnostics for clearer failure context.

* **Refactor**
  * Resolver/installer now share a preferred-versions seed to reduce copying and improve resolution consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->