### PR TITLE
fix(update): handle mixed direct and transitive selectors

### DIFF
--- a/.changeset/fix-recursive-update-mixed-selectors.md
+++ b/.changeset/fix-recursive-update-mixed-selectors.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fix recursive updates of transitive dependencies when the update command mixes transitive dependency patterns with direct dependency selectors. For example, `pnpm up -r "@babel/core" uuid` now updates matching transitive `@babel/core` dependencies even when `uuid` is a direct dependency selector [#12103](https://github.com/pnpm/pnpm/issues/12103).

--- a/installing/commands/test/update/update.ts
+++ b/installing/commands/test/update/update.ts
@@ -105,6 +105,31 @@ test('update with negation pattern', async () => {
   expect(lockfile.packages['@pnpm.e2e/foo@2.0.0']).toBeTruthy()
 })
 
+test('update transitive dependency when mixed with a direct dependency selector', async () => {
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '1.0.0',
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  }, ['@pnpm.e2e/dep-of-pkg-with-1-dep', '@pnpm.e2e/foo'])
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0']).toBeTruthy()
+})
+
 test('update: fail when both "latest" and "workspace" are true', async () => {
   preparePackages([
     {

--- a/installing/commands/test/update/update.ts
+++ b/installing/commands/test/update/update.ts
@@ -106,6 +106,10 @@ test('update with negation pattern', async () => {
 })
 
 test('update transitive dependency when mixed with a direct dependency selector', async () => {
+  // Pin the transitive @pnpm.e2e/dep-of-pkg-with-1-dep to 100.0.0 at install
+  // time, so the later update has an older version to bump from.
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' })
+
   const project = prepare({
     dependencies: {
       '@pnpm.e2e/foo': '1.0.0',
@@ -118,8 +122,13 @@ test('update transitive dependency when mixed with a direct dependency selector'
     dir: process.cwd(),
   })
 
+  expect(project.readLockfile().packages['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0']).toBeTruthy()
+
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
 
+  // @pnpm.e2e/dep-of-pkg-with-1-dep is a transitive selector (matched via
+  // updateMatching); @pnpm.e2e/foo is a direct dependency selector. The
+  // presence of the direct selector must not block the transitive update.
   await update.handler({
     ...DEFAULT_OPTS,
     dir: process.cwd(),

--- a/installing/deps-resolver/src/toResolveImporter.ts
+++ b/installing/deps-resolver/src/toResolveImporter.ts
@@ -77,7 +77,7 @@ export async function toResolveImporter (
           ? updateLocalTarballs
           : (dep) => ({ ...dep, updateDepth: defaultUpdateDepth })),
       ...existingDeps.map(
-        opts.noDependencySelectors && project.updateMatching != null
+        project.updateMatching != null
           ? updateLocalTarballs
           : (dep) => ({ ...dep, updateDepth: -1 })
       ),

--- a/pacquet/crates/cli/tests/update.rs
+++ b/pacquet/crates/cli/tests/update.rs
@@ -116,6 +116,75 @@ fn update_bumps_within_range() {
     drop((root, anchor));
 }
 
+/// Mixing a transitive selector with a direct dependency selector must
+/// still update the matching transitive package. Ports pnpm's regression
+/// test for <https://github.com/pnpm/pnpm/issues/12103>, where a direct
+/// selector wrongly suppressed recursive transitive updates. pacquet
+/// matches every bare-name selector against direct deps and locked
+/// package names alike, so the direct selector never gates the
+/// transitive one.
+#[test]
+fn update_transitive_mixed_with_direct_selector() {
+    let (root, workspace, anchor) = setup();
+
+    // Pin the transitive dep-of-pkg-with-1-dep at 100.0.0 (via a direct
+    // exact entry), then drop it to a pure transitive of pkg-with-1-dep.
+    write_manifest(
+        &workspace,
+        &format!(r#"{{ "{FOO}": "1.0.0", "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#),
+    );
+    pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "1.0.0", "{PARENT}": "100.0.0" }}"#));
+
+    // DEP is a transitive selector; FOO is a direct dependency selector.
+    pacquet(&workspace, ["update", DEP, FOO]).assert().success();
+
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "the transitive selector should bump even alongside a direct selector",
+    );
+
+    drop((root, anchor));
+}
+
+/// The glob form of the mixed-selector case — the shape from
+/// <https://github.com/pnpm/pnpm/issues/12103> (`pnpm up "@babel/*" uuid`).
+/// A glob that names only a transitive
+/// dependency must still bump it when a direct selector rides alongside.
+/// The glob is matched against locked package names through the same
+/// `create_matcher` path as a bare name, so the direct selector cannot
+/// gate it.
+#[test]
+fn update_transitive_glob_mixed_with_direct_selector() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(
+        &workspace,
+        &format!(r#"{{ "{FOO}": "1.0.0", "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#),
+    );
+    pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "1.0.0", "{PARENT}": "100.0.0" }}"#));
+
+    // "@pnpm.e2e/dep-of-*" matches the transitive dep-of-pkg-with-1-dep
+    // only; FOO is a direct dependency selector.
+    pacquet(&workspace, ["update", "@pnpm.e2e/dep-of-*", FOO]).assert().success();
+
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "the transitive glob selector should bump even alongside a direct selector",
+    );
+
+    drop((root, anchor));
+}
+
 /// `pacquet update --latest` ignores the manifest range, bumps to the
 /// `latest` dist-tag, and rewrites `package.json`.
 #[test]


### PR DESCRIPTION
## Summary

Fixes recursive transitive updates when the update command mixes a transitive dependency pattern with a direct dependency selector.

For example, `pnpm up -r "@babel/core" uuid` now updates matching transitive `@babel/core` dependencies even when `uuid` is a direct dependency selector.

Fixes #12103.

## Root Cause

`noDependencySelectors` was computed globally. If any importer had a direct selector, existing transitive dependencies were assigned `updateDepth: -1`, so `updateMatching` could match the package name but still fail to request an update.

## Changes

- Apply `defaultUpdateDepth` to existing deps whenever `project.updateMatching` is present.
- Add a regression test for mixing a transitive selector with a direct dependency selector.
- Add a patch changeset for `@pnpm/installing.deps-resolver` and `pnpm`.

## Validation

- `pnpm --filter @pnpm/installing.deps-resolver run compile`
- `pnpm --filter @pnpm/installing.commands test test/update/update.ts -t "mixed with a direct"`
- Verified in `~/fathom/frontend/fathom-frontend-bench1` with local pnpm bundle:
  - `pnpm up -r "@babel/core" uuid` now adds `@babel/core@7.29.7`
  - The original long command now adds `@babel/core@7.29.7`

Push hooks also passed TypeScript build, pnpm compile, spellcheck, metadata lint, eslint, cargo fmt/doc, and taplo format. Existing skipped-test warnings were reported; `cargo-dylint` was not installed and was skipped by the hook.

---

Written by an agent (opencode, gpt-5.5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where recursive updates could fail when a single update command mixed transitive dependency selectors with direct dependency selectors.
  * Improved update handling for local tarball dependencies to ensure matching updates apply as expected.

* **Tests**
  * Added coverage for updating a transitive dependency when combined with a direct dependency selector in the same update command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->