### PR TITLE
fix(exec): scope verifyDepsBeforeRun auto-install to filtered packages

### DIFF
--- a/.changeset/fix-verify-deps-filter-install.md
+++ b/.changeset/fix-verify-deps-filter-install.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+---
+
+Fixed `verifyDepsBeforeRun` triggering a full workspace install when using `--filter`. The auto-triggered install now respects the filter, so only the filtered package's dependencies are installed.

--- a/exec/commands/src/exec.ts
+++ b/exec/commands/src/exec.ts
@@ -151,6 +151,7 @@ export type ExecOpts = Required<Pick<ConfigContext, 'selectedProjectsGraph'>> & 
 | 'dir'
 | 'extraBinPaths'
 | 'extraEnv'
+| 'filter'
 | 'lockfileDir'
 | 'modulesDir'
 | 'nodeOptions'

--- a/exec/commands/src/run.ts
+++ b/exec/commands/src/run.ts
@@ -167,6 +167,7 @@ export type RunOpts =
   | 'engineStrict'
   | 'extraBinPaths'
   | 'extraEnv'
+  | 'filter'
   | 'nodeOptions'
   | 'pnpmHomeDir'
   | 'reporter'

--- a/exec/commands/src/runDepsStatusCheck.ts
+++ b/exec/commands/src/runDepsStatusCheck.ts
@@ -7,6 +7,7 @@ import { globalWarn } from '@pnpm/logger'
 
 export interface RunDepsStatusCheckOptions extends CheckDepsStatusOptions {
   dir: string
+  filter?: Config['filter']
   reporter?: Config['reporter']
   verifyDepsBeforeRun?: VerifyDepsBeforeRun
 }
@@ -20,7 +21,8 @@ export async function runDepsStatusCheck (opts: RunDepsStatusCheckOptions): Prom
   const { upToDate, issue, workspaceState } = await checkDepsStatus(opts)
   if (upToDate) return
 
-  const command = ['install', ...createInstallArgs(workspaceState?.settings)]
+  const filterArgs = (opts.filter ?? []).map(f => `--filter=${f}`)
+  const command = ['install', ...filterArgs, ...createInstallArgs(workspaceState?.settings)]
   const install = runPnpmCli.bind(null, command, { cwd: opts.dir, reporter: opts.reporter })
 
   switch (opts.verifyDepsBeforeRun) {

--- a/exec/commands/test/runDepsStatusCheck.test.ts
+++ b/exec/commands/test/runDepsStatusCheck.test.ts
@@ -1,6 +1,8 @@
 import { expect, jest, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
 
+import { DEFAULT_OPTS } from './utils/index.js'
+
 jest.unstable_mockModule('@pnpm/deps.status', () => ({
   checkDepsStatus: jest.fn(async () => ({ upToDate: false, workspaceState: undefined })),
 }))
@@ -13,10 +15,9 @@ jest.unstable_mockModule('@pnpm/exec.pnpm-cli-runner', () => ({
 const { runDepsStatusCheck } = await import('../src/runDepsStatusCheck.js')
 
 const baseOpts = {
+  ...DEFAULT_OPTS,
   dir: process.cwd(),
   verifyDepsBeforeRun: 'install' as const,
-  pnpmfile: [],
-  linkWorkspacePackages: false,
   rootProjectManifestDir: process.cwd(),
 }
 
@@ -27,6 +28,8 @@ test('includes --filter args in the install command when filter is set', async (
 
   await runDepsStatusCheck({
     ...baseOpts,
+    dir: process.cwd(),
+    rootProjectManifestDir: process.cwd(),
     filter: ['foo', 'bar'],
   })
 
@@ -39,10 +42,13 @@ test('includes --filter args in the install command when filter is set', async (
 test('does not add --filter args when filter is empty', async () => {
   prepare({ name: 'root', private: true })
 
+  mockRunPnpmCli.mockClear()
   mockRunPnpmCli.mockReturnValue(undefined)
 
   await runDepsStatusCheck({
     ...baseOpts,
+    dir: process.cwd(),
+    rootProjectManifestDir: process.cwd(),
     filter: [],
   })
 
@@ -54,9 +60,15 @@ test('does not add --filter args when filter is empty', async () => {
 test('does not add --filter args when filter is undefined', async () => {
   prepare({ name: 'root', private: true })
 
+  mockRunPnpmCli.mockClear()
   mockRunPnpmCli.mockReturnValue(undefined)
 
-  await runDepsStatusCheck(baseOpts)
+  await runDepsStatusCheck({
+    ...baseOpts,
+    dir: process.cwd(),
+    rootProjectManifestDir: process.cwd(),
+    filter: undefined,
+  })
 
   const calledCommand = mockRunPnpmCli.mock.calls[0]?.[0] as string[]
   expect(calledCommand).not.toEqual(expect.arrayContaining([expect.stringContaining('--filter=')]))

--- a/exec/commands/test/runDepsStatusCheck.test.ts
+++ b/exec/commands/test/runDepsStatusCheck.test.ts
@@ -1,0 +1,64 @@
+import { expect, jest, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+jest.unstable_mockModule('@pnpm/deps.status', () => ({
+  checkDepsStatus: jest.fn(async () => ({ upToDate: false, workspaceState: undefined })),
+}))
+
+const mockRunPnpmCli = jest.fn()
+jest.unstable_mockModule('@pnpm/exec.pnpm-cli-runner', () => ({
+  runPnpmCli: mockRunPnpmCli,
+}))
+
+const { runDepsStatusCheck } = await import('../src/runDepsStatusCheck.js')
+
+const baseOpts = {
+  dir: process.cwd(),
+  verifyDepsBeforeRun: 'install' as const,
+  pnpmfile: [],
+  linkWorkspacePackages: false,
+  rootProjectManifestDir: process.cwd(),
+}
+
+test('includes --filter args in the install command when filter is set', async () => {
+  prepare({ name: 'root', private: true })
+
+  mockRunPnpmCli.mockReturnValue(undefined)
+
+  await runDepsStatusCheck({
+    ...baseOpts,
+    filter: ['foo', 'bar'],
+  })
+
+  expect(mockRunPnpmCli).toHaveBeenCalledWith(
+    expect.arrayContaining(['install', '--filter=foo', '--filter=bar']),
+    expect.any(Object)
+  )
+})
+
+test('does not add --filter args when filter is empty', async () => {
+  prepare({ name: 'root', private: true })
+
+  mockRunPnpmCli.mockReturnValue(undefined)
+
+  await runDepsStatusCheck({
+    ...baseOpts,
+    filter: [],
+  })
+
+  const calledCommand = mockRunPnpmCli.mock.calls[0]?.[0] as string[]
+  expect(calledCommand).not.toContain('--filter=foo')
+  expect(calledCommand[0]).toBe('install')
+})
+
+test('does not add --filter args when filter is undefined', async () => {
+  prepare({ name: 'root', private: true })
+
+  mockRunPnpmCli.mockReturnValue(undefined)
+
+  await runDepsStatusCheck(baseOpts)
+
+  const calledCommand = mockRunPnpmCli.mock.calls[0]?.[0] as string[]
+  expect(calledCommand).not.toEqual(expect.arrayContaining([expect.stringContaining('--filter=')]))
+  expect(calledCommand[0]).toBe('install')
+})

--- a/pnpm/test/verifyDepsBeforeRun/exec.ts
+++ b/pnpm/test/verifyDepsBeforeRun/exec.ts
@@ -345,3 +345,70 @@ test('multi-project workspace', async () => {
   // should set env.pnpm_config_verify_deps_before_run to false for all the scripts (to skip check for nested script)
   await execPnpm([...CONFIG, 'exec', 'node', '--eval', 'assert.strictEqual(process.env.pnpm_config_verify_deps_before_run, "false")'])
 })
+
+test('filtered exec with verifyDepsBeforeRun=install auto-installs only filtered packages', async () => {
+  const manifests: Record<string, ProjectManifest> = {
+    root: {
+      name: 'root',
+      private: true,
+      dependencies: {
+        '@pnpm.e2e/foo': '=100.0.0',
+      },
+    },
+    foo: {
+      name: 'foo',
+      private: true,
+      dependencies: {
+        '@pnpm.e2e/foo': '=100.0.0',
+      },
+    },
+    bar: {
+      name: 'bar',
+      private: true,
+      dependencies: {
+        '@pnpm.e2e/foo': '=100.0.0',
+      },
+    },
+  }
+
+  const projects = preparePackages([
+    {
+      location: '.',
+      package: manifests.root,
+    },
+    manifests.foo,
+    manifests.bar,
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['**', '!store/**'] })
+
+  const INSTALL_CONFIG = ['--config.verify-deps-before-run=install'] as const
+  const EXEC = ['exec', 'node', '--print', '"hello from exec: " + process.cwd()'] as const
+
+  await execPnpm([...INSTALL_CONFIG, 'install'])
+
+  {
+    const workspaceState = loadWorkspaceState(process.cwd())
+    expect(workspaceState?.filteredInstall).toBe(false)
+  }
+
+  // update foo's dependencies to make it out of sync
+  projects.foo.writePackageJson({
+    ...manifests.foo,
+    dependencies: {
+      '@pnpm.e2e/foo': '=100.1.0',
+    },
+  })
+
+  // exec with --filter=foo and verifyDepsBeforeRun=install should auto-install only foo and succeed
+  {
+    const { stdout } = execPnpmSync([...INSTALL_CONFIG, '--filter=foo', ...EXEC], { expectSuccess: true })
+    expect(stdout.toString()).toContain(`hello from exec: ${path.resolve('foo')}`)
+  }
+
+  // the auto-triggered install should have been a filtered install, not a full workspace install
+  {
+    const workspaceState = loadWorkspaceState(process.cwd())
+    expect(workspaceState?.filteredInstall).toBe(true)
+  }
+})


### PR DESCRIPTION
## Summary

When `verifyDepsBeforeRun` is set to `install` (or `prompt`) and a user runs `pnpm --filter <pkg> exec` or `pnpm --filter <pkg> run`, the triggered install now includes the same `--filter` args, so only the selected packages' dependencies are installed instead of the full workspace.

**Root cause:** `runDepsStatusCheck` constructed the install command as `['install', ...installArgs]` without considering any active `--filter` flags. The `filter` option from `Config` was not threaded through `ExecOpts` or `RunOpts`, so it was never available to `runDepsStatusCheck`.

**Fix:**
- Added `filter` to the `Pick<Config, ...>` in both `ExecOpts` (`exec.ts`) and `RunOpts` (`run.ts`) so the filter patterns flow through to the deps check.
- Added `filter?: Config['filter']` to `RunDepsStatusCheckOptions` and prepended `--filter=<pattern>` args to the install command for each active filter.

## Test plan

- New unit tests in `exec/commands/test/runDepsStatusCheck.test.ts` that mock `@pnpm/deps.status` and `@pnpm/exec.pnpm-cli-runner`, and assert that `runPnpmCli` receives the correct `--filter=` args.
- New e2e test in `pnpm/test/verifyDepsBeforeRun/exec.ts` that runs `pnpm --filter=foo exec` with `verifyDepsBeforeRun=install`, verifies the command succeeds, and checks that `workspaceState.filteredInstall` is `true` (proving a filtered install ran, not a full one).

Fixes #11865

---
Written by an agent (Claude Code, claude-sonnet-4-6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed auto-triggered dependency installation behavior when using `--filter` to install only the filtered package's dependencies instead of performing a full workspace install.

* **Tests**
  * Added comprehensive tests to verify correct dependency verification behavior with filtered package execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->