### PR TITLE
fix(publish): normalize string `repository` field to object form

### DIFF
--- a/.changeset/publish-normalize-repository.md
+++ b/.changeset/publish-normalize-repository.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.exportable-manifest": patch
+"pnpm": patch
+---
+
+Normalize a string `repository` field into the `{ type, url }` object form when creating the publish manifest, matching npm's behavior. Some registries (e.g. Gitea/Codeberg) reject a string `repository` with a 500 Internal Server Error during `pnpm publish` [#12099](https://github.com/pnpm/pnpm/issues/12099).

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "certfile",
     "clonedeep",
     "cmds",
+    "Codeberg",
     "codeload",
     "codenames",
     "codesign",

--- a/releasing/exportable-manifest/src/transform/index.ts
+++ b/releasing/exportable-manifest/src/transform/index.ts
@@ -4,6 +4,7 @@ import { pipe } from 'ramda'
 
 import { transformBin } from './bin.js'
 import { transformPeerDependenciesMeta } from './peerDependenciesMeta.js'
+import { transformRepository } from './repository.js'
 import { transformRequiredFields } from './requiredFields.js'
 
 export { type ExportedManifest }
@@ -12,5 +13,6 @@ export type Transform = (manifest: ProjectManifest) => ExportedManifest
 export const transform: Transform = pipe(
   transformRequiredFields,
   transformBin,
-  transformPeerDependenciesMeta
+  transformPeerDependenciesMeta,
+  transformRepository
 ) as Transform

--- a/releasing/exportable-manifest/src/transform/repository.ts
+++ b/releasing/exportable-manifest/src/transform/repository.ts
@@ -1,0 +1,26 @@
+import type { ProjectManifest } from '@pnpm/types'
+
+import type { ExportedManifest } from './index.js'
+
+type Input = Pick<ProjectManifest, 'repository'>
+type Output<Manifest extends Input> = Omit<Manifest, 'repository'> & Pick<ExportedManifest, 'repository'>
+
+/**
+ * Normalizes a string `repository` into the object form `{ type: 'git', url }`.
+ *
+ * npm's `normalize-package-data` performs this conversion before publishing, so a
+ * package whose `repository` is a bare URL string still reaches the registry as an
+ * object. Some registries (e.g. Gitea) reject a string `repository` with a 500
+ * because they decode it into an object-typed struct. Matching npm keeps
+ * `pnpm publish` compatible with them. See https://github.com/pnpm/pnpm/issues/12099.
+ */
+export function transformRepository<Manifest extends Input> (manifest: Manifest): Output<Manifest> {
+  if (typeof manifest.repository !== 'string') return manifest as Output<Manifest>
+  return {
+    ...manifest,
+    repository: {
+      type: 'git',
+      url: manifest.repository,
+    },
+  }
+}

--- a/releasing/exportable-manifest/test/transformRepository.test.ts
+++ b/releasing/exportable-manifest/test/transformRepository.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@jest/globals'
+import type { ProjectManifest } from '@pnpm/types'
+
+import { transformRepository } from '../lib/transform/repository.js'
+
+test('returns manifest as-is when repository is absent', () => {
+  const manifest: ProjectManifest = {
+    name: 'foo',
+    version: '1.0.0',
+  }
+  expect(transformRepository(manifest)).toStrictEqual(manifest)
+})
+
+test('normalizes a string repository into the git object form', () => {
+  const manifest: ProjectManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    repository: 'https://codeberg.org/tao-cumplido/binary-tools',
+  }
+  expect(transformRepository(manifest)).toStrictEqual({
+    name: 'foo',
+    version: '1.0.0',
+    repository: {
+      type: 'git',
+      url: 'https://codeberg.org/tao-cumplido/binary-tools',
+    },
+  })
+})
+
+test('preserves an object repository as-is', () => {
+  const manifest: ProjectManifest = {
+    name: 'foo',
+    version: '1.0.0',
+    repository: {
+      url: 'https://codeberg.org/tao-cumplido/binary-tools',
+    },
+  }
+  expect(transformRepository(manifest)).toStrictEqual(manifest)
+})


### PR DESCRIPTION
## Problem

`pnpm publish` fails with a `500 Internal Server Error` when publishing to registries such as [Gitea](https://docs.gitea.com/usage/packages/npm)/Codeberg, while `npm publish` of the same package succeeds. Reported in #12099.

## Root cause

These registries decode the published package metadata into a typed struct where `repository` is an **object** (`{ type, url, directory }`) — see [Gitea's `creator.go`](https://github.com/go-gitea/gitea/blob/main/modules/packages/npm/creator.go). When `repository` arrives as a **string** (e.g. `"https://codeberg.org/tao-cumplido/binary-tools"`), JSON decoding into that struct fails and the server returns a 500.

npm avoids this because `normalize-package-data` rewrites a string `repository` into `{ type: 'git', url }` before publishing. pnpm's exportable manifest did not apply that normalization, so it sent the bare string and tripped the registry. This is also why the documented workaround `pnpm pack && npm publish *.tgz` works — npm normalizes the manifest it reads from the tarball.

## Fix

Add a `transformRepository` step to the exportable-manifest pipeline that converts a string `repository` into `{ type: 'git', url }`, matching npm. Object-form `repository` values are left untouched.

## Test

Added unit tests for the new transform (absent / string / object cases).

Close #12099

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository field in publish manifests is now normalized from string format to object format containing `type` and `url` properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->