### PR TITLE
feat(pacquet): implement the `outdated` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -180,7 +180,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -480,10 +480,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -824,7 +824,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -869,10 +869,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -999,7 +999,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1190,6 +1190,12 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1583,6 +1589,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,7 +1662,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1664,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1832,7 +1849,7 @@ dependencies = [
  "cfg-if",
  "miette-derive 7.6.0",
  "owo-colors",
- "supports-color",
+ "supports-color 3.0.2",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
@@ -1848,7 +1865,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1859,7 +1876,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2111,6 +2128,10 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "pacquet-catalogs-config"
@@ -2154,12 +2175,14 @@ dependencies = [
  "dialoguer",
  "dunce",
  "flate2",
+ "futures-util",
  "home",
  "indexmap",
  "insta",
  "miette 7.6.0",
  "mockito",
  "node-semver",
+ "owo-colors",
  "pacquet-config",
  "pacquet-diagnostics",
  "pacquet-executor",
@@ -2184,6 +2207,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "tabled",
  "tar",
  "tempfile",
  "tokio",
@@ -3061,6 +3085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,7 +3317,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3353,7 +3410,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3811,7 +3868,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3962,7 +4019,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4037,10 +4094,10 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4048,6 +4105,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "supports-color"
@@ -4069,6 +4136,17 @@ name = "supports-unicode"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4098,7 +4176,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4114,6 +4192,29 @@ dependencies = [
  "objc2-io-kit",
  "objc2-open-directory",
  "windows",
+]
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4204,7 +4305,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4215,7 +4316,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4287,7 +4388,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4378,7 +4479,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4640,7 +4741,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4843,7 +4944,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4854,7 +4955,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5024,7 +5125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -5035,10 +5136,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5054,7 +5155,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5143,7 +5244,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5164,7 +5265,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5184,7 +5285,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5224,7 +5325,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ getrandom = { version = "0.4.2" }
 miette = { version = "7.6.0", features = ["fancy"] }
 num_cpus = { version = "1.17.0" }
 os_display = { version = "0.1.4" }
+owo-colors = { version = "4", features = ["supports-colors"] }
 reflink-copy = { version = "0.1.29" }
 junction = { version = "2.0.0" }
 libc = { version = "0.2.186" }
@@ -135,6 +136,7 @@ split-first-char   = { version = "2.0.1" }
 ssri               = { version = "9.2.0" }
 strum              = { version = "0.28.0", features = ["derive"] }
 sysinfo            = { version = "0.39.2" }
+tabled             = { version = "0.17" }
 tar                = { version = "0.4.46" }
 text-block-macros  = { version = "0.2.0" }
 tower              = { version = "0.5.3" }

--- a/pacquet/crates/cli/Cargo.toml
+++ b/pacquet/crates/cli/Cargo.toml
@@ -31,19 +31,22 @@ pacquet-diagnostics              = { workspace = true }
 pacquet-workspace                = { workspace = true }
 pacquet-workspace-projects-graph = { workspace = true }
 
-clap        = { workspace = true }
-derive_more = { workspace = true }
-dialoguer   = { workspace = true }
-dunce       = { workspace = true }
-home        = { workspace = true }
-indexmap    = { workspace = true }
-node-semver = { workspace = true }
-miette      = { workspace = true }
-pipe-trait  = { workspace = true }
-rayon       = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tokio       = { workspace = true }
+clap         = { workspace = true }
+derive_more  = { workspace = true }
+dialoguer    = { workspace = true }
+dunce        = { workspace = true }
+futures-util = { workspace = true }
+home         = { workspace = true }
+indexmap     = { workspace = true }
+node-semver  = { workspace = true }
+miette       = { workspace = true }
+owo-colors   = { workspace = true }
+pipe-trait   = { workspace = true }
+rayon        = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+tabled       = { workspace = true }
+tokio        = { workspace = true }
 
 [dev-dependencies]
 pacquet-store-dir     = { workspace = true }

--- a/pacquet/crates/cli/src/cli_args.rs
+++ b/pacquet/crates/cli/src/cli_args.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod install;
+pub mod outdated;
 pub mod remove;
 pub mod run;
 pub mod store;
@@ -12,6 +13,7 @@ use add::AddArgs;
 use clap::{Parser, Subcommand, ValueEnum};
 use install::InstallArgs;
 use miette::{Context, IntoDiagnostic};
+use outdated::{OutdatedArgs, OutdatedOutcome};
 use pacquet_config::{Config, Host};
 use pacquet_executor::execute_shell;
 use pacquet_package_manifest::PackageManifest;
@@ -107,6 +109,8 @@ pub enum CliCommand {
     /// Update packages to their newest version based on the specified range
     #[clap(visible_aliases = ["up", "upgrade"])]
     Update(UpdateArgs),
+    /// Check for outdated packages
+    Outdated(OutdatedArgs),
     /// Removes packages from `node_modules` and from the project's `package.json`.
     // Unlike npm, pnpm does not treat "r" as an alias of "remove" to avoid
     // confusion with "run" and "recursive". Mirrors pnpm's `commandNames`.
@@ -203,6 +207,16 @@ impl CliArgs {
                 ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
                 ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,
             },
+            // `outdated` is a read-only query: it prints a report to
+            // stdout and never installs, so it has no reporter-typed
+            // install pipeline to dispatch on. It reports back whether any
+            // dependency was outdated; process termination stays here, at
+            // the top-level harness, rather than inside the command.
+            CliCommand::Outdated(args) => {
+                if args.run(state(false)?).await? == OutdatedOutcome::Outdated {
+                    std::process::exit(1);
+                }
+            }
             CliCommand::Remove(args) => match reporter {
                 ReporterType::Ndjson => args.run::<NdjsonReporter>(state(false)?).await?,
                 ReporterType::Silent => args.run::<SilentReporter>(state(false)?).await?,

--- a/pacquet/crates/cli/src/cli_args/outdated.rs
+++ b/pacquet/crates/cli/src/cli_args/outdated.rs
@@ -1,0 +1,629 @@
+//! `pacquet outdated` — report direct dependencies that have a newer
+//! version available.
+//!
+//! Ports pnpm's
+//! [`outdated` command](https://github.com/pnpm/pnpm/blob/6f382f42ee/deps/inspection/commands/src/outdated/outdated.ts)
+//! and the detection core in
+//! [`@pnpm/deps.inspection.outdated`](https://github.com/pnpm/pnpm/blob/6f382f42ee/deps/inspection/outdated/src/outdated.ts).
+//!
+//! The detection half — [`collect_outdated`] — is shared with
+//! `update --interactive`, which gathers the same "what has a newer
+//! version" list before prompting. The two callers differ only in which
+//! registry version counts as the comparison [`TargetVersion`]: `outdated`
+//! compares against the absolute newest (`latest` tag, or the highest
+//! in-range version under `--compatible`), while `update` compares against
+//! the version a bump would move to.
+//!
+//! Scope vs. pnpm: pacquet loads a single lockfile (the *wanted*
+//! lockfile), so there is no separate *current* lockfile to diff against —
+//! a dependency's `current` and `wanted` versions are always equal, and
+//! the "missing (wanted X)" state pnpm shows for a resolved-but-not-
+//! installed dependency does not arise. Recursive (`-r`) and global
+//! (`-g`) runs are rejected, matching `pacquet update`.
+
+use crate::State;
+use clap::{Args, ValueEnum};
+use node_semver::Version;
+use owo_colors::{OwoColorize, Stream};
+use pacquet_config::{
+    Config,
+    matcher::{Matcher, create_matcher},
+};
+use pacquet_lockfile::Lockfile;
+use pacquet_network::ThrottledClient;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_registry::{Package, PackageVersion};
+use std::{collections::HashMap, io::Write};
+
+/// Which registry version a dependency is compared against to decide
+/// whether it is outdated.
+#[derive(Debug, Clone, Copy)]
+pub enum TargetVersion {
+    /// The `latest` dist-tag — the absolute newest published version.
+    /// pnpm's default for `outdated`.
+    Latest,
+    /// The highest version satisfying the manifest range. pnpm's
+    /// `outdated --compatible`, and the version an in-range `update`
+    /// would move to.
+    WithinRange,
+}
+
+/// A direct dependency with a newer (or deprecated) registry version.
+///
+/// `current` is the lockfile-pinned version; `target` is the resolved
+/// [`TargetVersion`]. Both are always present — dependencies without a
+/// lockfile pin, without a registry target, or whose specifier is not a
+/// plain semver range are dropped during collection because they cannot
+/// be diffed.
+pub struct OutdatedPackage {
+    /// The `package.json` key (and `node_modules` directory name). Equals
+    /// `package_name` except for npm-alias entries (`"foo": "npm:bar@^1"`).
+    pub alias: String,
+    /// The registry package name actually queried.
+    pub package_name: String,
+    pub belongs_to: DependencyGroup,
+    pub current: Version,
+    pub target: Version,
+    /// Deprecation reason of the `target` version, when the registry
+    /// marked it deprecated.
+    pub deprecated: Option<String>,
+    /// `homepage` of the package, shown in the `--long` details column
+    /// when the registry serves it.
+    pub homepage: Option<String>,
+}
+
+/// What counts as outdated for a [`collect_outdated`] run.
+pub struct OutdatedQuery<'a> {
+    /// The registry version each dependency is compared against.
+    pub target_version: TargetVersion,
+    /// Dependency groups to inspect.
+    pub include_direct: &'a [DependencyGroup],
+    /// When present, restricts the walk to dependency keys the matcher
+    /// accepts (pnpm's `outdated <pattern>` arguments).
+    pub match_names: Option<&'a Matcher>,
+    /// Also report a dependency whose `target` is deprecated even when it
+    /// is not strictly newer than `current`. `outdated` sets this;
+    /// `update` does not (a deprecated-but-current dependency has no
+    /// newer version to move to).
+    pub include_deprecated: bool,
+}
+
+/// Gather the direct dependencies whose `target` version is newer than
+/// the lockfile-pinned `current` version (or, per
+/// [`OutdatedQuery::include_deprecated`], whose `target` is deprecated).
+///
+/// A dependency the registry cannot serve (private, renamed, offline) is
+/// skipped rather than failing the whole run.
+pub async fn collect_outdated(
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    query: &OutdatedQuery<'_>,
+) -> miette::Result<Vec<OutdatedPackage>> {
+    let current_versions = current_versions_from_lockfile(lockfile, query.include_direct);
+    let current_versions = &current_versions;
+
+    // Gather the lockfile-pinned direct dependencies to inspect, then
+    // fetch their packuments concurrently — mirroring pnpm's
+    // `Promise.all` fan-out. Concurrency is bounded by the HTTP client's
+    // per-registry limit (`network_concurrency`), so this does not flood
+    // the registry. Dependencies without a lockfile pin are dropped here;
+    // those the registry cannot serve are dropped after the fetch.
+    let fetches = query
+        .include_direct
+        .iter()
+        .flat_map(move |&group| {
+            manifest.dependencies([group]).filter_map(move |(alias, bare_specifier)| {
+                if query.match_names.is_some_and(|matcher| !matcher.matches(alias)) {
+                    return None;
+                }
+                let current = current_versions.get(alias).cloned()?;
+                Some((alias, group, bare_specifier, current))
+            })
+        })
+        .map(|(alias, group, bare_specifier, current)| async move {
+            let (package_name, range) =
+                PackageManifest::resolve_registry_dependency(alias, bare_specifier);
+            let package = Package::fetch_from_registry(
+                package_name,
+                http_client,
+                &config.registry,
+                &config.auth_headers,
+            )
+            .await
+            .ok()?;
+            let target = resolve_target(&package, range, query.target_version)?;
+            let deprecated = target.deprecated.clone();
+            let is_newer = target.version > current;
+            if !(is_newer || (query.include_deprecated && deprecated.is_some())) {
+                return None;
+            }
+            Some(OutdatedPackage {
+                alias: alias.to_string(),
+                package_name: package_name.to_string(),
+                belongs_to: group,
+                current,
+                target: target.version.clone(),
+                deprecated,
+                homepage: package.homepage.clone(),
+            })
+        });
+
+    Ok(futures_util::future::join_all(fetches).await.into_iter().flatten().collect())
+}
+
+/// Resolve the [`TargetVersion`] to a concrete published version, or
+/// `None` when the registry has no matching version (no `latest` tag, no
+/// in-range version, or a non-semver range).
+fn resolve_target<'a>(
+    package: &'a Package,
+    range: &str,
+    target_version: TargetVersion,
+) -> Option<&'a PackageVersion> {
+    match target_version {
+        TargetVersion::Latest => {
+            let tag = package.dist_tag("latest")?;
+            package.versions.get(tag)
+        }
+        TargetVersion::WithinRange => {
+            // `pinned_version` parses the range with `.unwrap()`, so guard
+            // non-semver specifiers (`workspace:`, `link:`, git URLs) that
+            // a lockfile-pinned semver `current` would not have screened
+            // out on its own.
+            range.parse::<node_semver::Range>().ok()?;
+            package.pinned_version(range)
+        }
+    }
+}
+
+/// Map each direct dependency key to its lockfile-pinned semver version.
+/// Only the root importer is consulted (pacquet's single-project scope);
+/// entries whose resolved version is not a plain semver (`link:`,
+/// `file:`, non-semver runtimes) are omitted.
+fn current_versions_from_lockfile(
+    lockfile: Option<&Lockfile>,
+    include_direct: &[DependencyGroup],
+) -> HashMap<String, Version> {
+    let mut map = HashMap::new();
+    let Some(importer) = lockfile.and_then(Lockfile::root_project) else { return map };
+    for (name, spec) in importer.dependencies_by_groups(include_direct.iter().copied()) {
+        if let Some(version) = spec.version.ver_peer().and_then(|ver| ver.version_semver()) {
+            map.insert(name.to_string(), version.clone());
+        }
+    }
+    map
+}
+
+/// Output format for `pacquet outdated`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutdatedFormat {
+    Table,
+    List,
+    Json,
+}
+
+/// `--prod` / `--dev` / `--no-optional` for `pacquet outdated`.
+///
+/// Ports pnpm's config normalization
+/// ([`config/reader`](https://github.com/pnpm/pnpm/blob/6f382f42ee/config/reader/src/index.ts#L640-L650))
+/// followed by the `include` map the `outdated` handler builds
+/// ([`outdated.ts`](https://github.com/pnpm/pnpm/blob/6f382f42ee/deps/inspection/commands/src/outdated/outdated.ts#L182-L186)):
+/// `--prod` keeps `dependencies` + `optionalDependencies`, `--dev` keeps
+/// only `devDependencies`, and `--no-optional` drops
+/// `optionalDependencies`. Note this differs from `update`'s include
+/// formula.
+#[derive(Debug, Args)]
+pub struct OutdatedDependencyOptions {
+    /// Check only "dependencies" and "optionalDependencies".
+    #[clap(short = 'P', long, visible_alias = "production")]
+    prod: bool,
+    /// Check only "devDependencies".
+    #[clap(short = 'D', long)]
+    dev: bool,
+    /// Don't check "optionalDependencies".
+    #[clap(long)]
+    no_optional: bool,
+}
+
+impl OutdatedDependencyOptions {
+    fn include(&self) -> Vec<DependencyGroup> {
+        let mut optional = !self.no_optional;
+        let (production, dev) = if self.prod {
+            (true, false)
+        } else if self.dev {
+            optional = false;
+            (false, true)
+        } else {
+            (true, true)
+        };
+        std::iter::empty()
+            .chain(production.then_some(DependencyGroup::Prod))
+            .chain(dev.then_some(DependencyGroup::Dev))
+            .chain(optional.then_some(DependencyGroup::Optional))
+            .collect()
+    }
+}
+
+/// `pacquet outdated [<pkg> ...]`.
+#[derive(Debug, Args)]
+pub struct OutdatedArgs {
+    /// Restrict the check to dependencies whose name matches one of these
+    /// patterns (`*` wildcard, leading `!` to negate). With no arguments,
+    /// every direct dependency in the included groups is checked.
+    pub packages: Vec<String>,
+
+    /// --prod, --dev, and --no-optional.
+    #[clap(flatten)]
+    pub dependency_options: OutdatedDependencyOptions,
+
+    /// Print only versions that satisfy the ranges in package.json.
+    #[clap(long)]
+    pub compatible: bool,
+
+    /// Print details about the outdated packages (homepage, deprecation
+    /// notice).
+    #[clap(long)]
+    pub long: bool,
+
+    /// Output format.
+    #[clap(long, value_enum, default_value_t = OutdatedFormat::Table)]
+    pub format: OutdatedFormat,
+
+    /// Shorthand for `--format list`. Good for small consoles.
+    #[clap(long = "no-table")]
+    pub no_table: bool,
+
+    /// Shorthand for `--format json`.
+    #[clap(long)]
+    pub json: bool,
+
+    /// Sorting method. Currently only `name` is supported; the default
+    /// sorts by the size of the version change, then by name.
+    #[clap(long, value_enum)]
+    pub sort_by: Option<SortBy>,
+
+    /// Check globally installed packages.
+    #[clap(short = 'g', long)]
+    pub global: bool,
+}
+
+/// `--sort-by` value. pnpm currently documents only `name`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SortBy {
+    Name,
+}
+
+/// Whether `outdated` found any outdated dependency. The CLI harness maps
+/// [`OutdatedOutcome::Outdated`] to a process exit code of `1`, matching
+/// pnpm; returning the outcome (rather than terminating here) keeps
+/// [`OutdatedArgs::run`] composable and process termination in one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutdatedOutcome {
+    UpToDate,
+    Outdated,
+}
+
+impl OutdatedArgs {
+    /// Run the check and print the report to stdout. Returns whether any
+    /// dependency was outdated; the caller decides the process exit code.
+    pub async fn run(self, state: State) -> miette::Result<OutdatedOutcome> {
+        if self.global {
+            return Err(miette::miette!(
+                "`pacquet outdated --global` is not supported yet; global package management has not been ported to pacquet."
+            ));
+        }
+        if state.config.recursive {
+            return Err(miette::miette!(
+                "`pacquet outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pacquet."
+            ));
+        }
+
+        let config = state.config;
+        let manifest = &state.manifest;
+        let lockfile = &state.lockfile;
+        let http_client = &state.http_client;
+
+        // A manifest with no dependencies at all is reported as up to date
+        // (empty, exit 0) *before* the no-lockfile check — matching pnpm's
+        // `packageHasNoDeps` short-circuit, so an empty project doesn't
+        // error just because it was never installed.
+        let has_any_dependency = manifest
+            .dependencies([DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional])
+            .next()
+            .is_some();
+        if !has_any_dependency {
+            return Ok(OutdatedOutcome::UpToDate);
+        }
+
+        if lockfile.is_none() {
+            let dir = manifest.path().parent().unwrap_or_else(|| manifest.path()).display();
+            return Err(miette::miette!(
+                code = "ERR_PNPM_OUTDATED_NO_LOCKFILE",
+                "No lockfile in directory \"{dir}\". Run `pacquet install` to generate one."
+            ));
+        }
+
+        let include = self.dependency_options.include();
+        let target_version =
+            if self.compatible { TargetVersion::WithinRange } else { TargetVersion::Latest };
+        let matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+
+        let query = OutdatedQuery {
+            target_version,
+            include_direct: &include,
+            match_names: matcher.as_ref(),
+            include_deprecated: true,
+        };
+        let mut outdated =
+            collect_outdated(manifest, lockfile.as_ref(), config, http_client, &query).await?;
+
+        sort_outdated(&mut outdated, self.sort_by);
+
+        let output = match self.resolve_format() {
+            OutdatedFormat::Table => render_table(&outdated, self.long),
+            OutdatedFormat::List => render_list(&outdated, self.long),
+            OutdatedFormat::Json => render_json(&outdated, self.long),
+        };
+
+        let mut stdout = std::io::stdout();
+        let _ = writeln!(stdout, "{output}");
+        let _ = stdout.flush();
+
+        Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
+    }
+
+    /// Collapse the `--format` flag and its `--no-table` / `--json`
+    /// shorthands into one format. The shorthands win over an explicit
+    /// `--format`, with `--json` taking precedence over `--no-table`,
+    /// mirroring pnpm's shorthand expansion order.
+    fn resolve_format(&self) -> OutdatedFormat {
+        if self.json {
+            OutdatedFormat::Json
+        } else if self.no_table {
+            OutdatedFormat::List
+        } else {
+            self.format
+        }
+    }
+}
+
+/// The kind of semver bump from `current` to `target`. Drives the default
+/// sort order and the colorized highlight in the `Latest` column.
+///
+/// Ports pnpm's [`@pnpm/semver-diff`](https://www.npmjs.com/package/@pnpm/semver-diff)
+/// change classification: `None` for exactly-equal versions (pnpm's
+/// `change: null`), `Fix` / `Feature` / `Breaking` for a patch / minor /
+/// major difference, and `Unknown` when the versions differ only beyond
+/// the major.minor.patch core (e.g. a prerelease-only bump), matching
+/// pnpm's `change: 'unknown'`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Change {
+    None,
+    Fix,
+    Feature,
+    Breaking,
+    Unknown,
+}
+
+fn classify(current: &Version, target: &Version) -> Change {
+    if current == target {
+        Change::None
+    } else if target.major != current.major {
+        Change::Breaking
+    } else if target.minor != current.minor {
+        Change::Feature
+    } else if target.patch != current.patch {
+        Change::Fix
+    } else {
+        // Same major.minor.patch but not equal: a prerelease/build-only
+        // difference. pnpm classifies this as `unknown`.
+        Change::Unknown
+    }
+}
+
+/// Ascending sort priority for the default (non-`--sort-by name`) order:
+/// no-change, fix, feature, breaking, then unknown last. Mirrors pnpm's
+/// `pkgPriority`.
+fn change_priority(change: Change) -> u8 {
+    match change {
+        Change::None => 0,
+        Change::Fix => 1,
+        Change::Feature => 2,
+        Change::Breaking => 3,
+        Change::Unknown => 4,
+    }
+}
+
+fn sort_outdated(outdated: &mut [OutdatedPackage], sort_by: Option<SortBy>) {
+    match sort_by {
+        Some(SortBy::Name) => {
+            outdated.sort_by(|left, right| left.package_name.cmp(&right.package_name))
+        }
+        None => outdated.sort_by(|left, right| {
+            let by_change = change_priority(classify(&left.current, &left.target))
+                .cmp(&change_priority(classify(&right.current, &right.target)));
+            by_change
+                .then_with(|| left.package_name.cmp(&right.package_name))
+                .then_with(|| left.current.to_string().cmp(&right.current.to_string()))
+        }),
+    }
+}
+
+fn render_table(outdated: &[OutdatedPackage], long: bool) -> String {
+    if outdated.is_empty() {
+        return String::new();
+    }
+    use tabled::builder::Builder;
+    use tabled::settings::Style;
+
+    let mut header: Vec<String> =
+        ["Package", "Current", "Latest"].iter().map(|h| bright_blue(h)).collect();
+    if long {
+        header.push(bright_blue("Details"));
+    }
+
+    let mut builder = Builder::default();
+    builder.push_record(header);
+    for pkg in outdated {
+        let mut row = vec![render_package_name(pkg), pkg.current.to_string(), render_latest(pkg)];
+        if long {
+            row.push(render_details(pkg));
+        }
+        builder.push_record(row);
+    }
+    let mut table = builder.build();
+    table.with(Style::modern());
+    table.to_string()
+}
+
+fn render_list(outdated: &[OutdatedPackage], long: bool) -> String {
+    outdated
+        .iter()
+        .map(|pkg| {
+            let mut info = format!(
+                "{}\n{} {} {}",
+                bold(&render_package_name(pkg)),
+                pkg.current,
+                grey("=>"),
+                render_latest(pkg),
+            );
+            if long {
+                let details = render_details(pkg);
+                if !details.is_empty() {
+                    info.push('\n');
+                    info.push_str(&details);
+                }
+            }
+            info
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn render_json(outdated: &[OutdatedPackage], long: bool) -> String {
+    let mut map = serde_json::Map::new();
+    for pkg in outdated {
+        let dependency_type: &'static str = pkg.belongs_to.into();
+        let mut entry = serde_json::json!({
+            "current": pkg.current.to_string(),
+            "latest": pkg.target.to_string(),
+            "wanted": pkg.current.to_string(),
+            "isDeprecated": pkg.deprecated.is_some(),
+            "dependencyType": dependency_type,
+        });
+        if long {
+            entry["latestManifest"] = serde_json::json!({
+                "name": pkg.package_name,
+                "version": pkg.target.to_string(),
+                "deprecated": pkg.deprecated,
+                "homepage": pkg.homepage,
+            });
+        }
+        map.insert(pkg.package_name.clone(), entry);
+    }
+    serde_json::to_string_pretty(&serde_json::Value::Object(map))
+        .expect("serialize outdated report to JSON")
+}
+
+fn render_package_name(pkg: &OutdatedPackage) -> String {
+    match pkg.belongs_to {
+        DependencyGroup::Dev => format!("{} {}", pkg.package_name, dimmed("(dev)")),
+        DependencyGroup::Optional => format!("{} {}", pkg.package_name, dimmed("(optional)")),
+        _ => pkg.package_name.clone(),
+    }
+}
+
+fn render_latest(pkg: &OutdatedPackage) -> String {
+    let change = classify(&pkg.current, &pkg.target);
+    if change == Change::None {
+        return if pkg.deprecated.is_some() {
+            red_bold("Deprecated")
+        } else {
+            pkg.target.to_string()
+        };
+    }
+    let colored = colorize_version(&pkg.target, change);
+    if pkg.deprecated.is_some() { format!("{colored} {}", red("(deprecated)")) } else { colored }
+}
+
+/// Highlight the version segment that changed: the whole string for a
+/// breaking bump, from the minor field for a feature bump, from the patch
+/// field for a fix. Mirrors pnpm's `colorizeSemverDiff`.
+fn colorize_version(version: &Version, change: Change) -> String {
+    let text = version.to_string();
+    let split = match change {
+        Change::Breaking => 0,
+        Change::Feature => text.find('.').map_or(0, |i| i + 1),
+        Change::Fix => {
+            text.find('.').and_then(|i| text[i + 1..].find('.').map(|j| i + 1 + j + 1)).unwrap_or(0)
+        }
+        // pnpm's `colorizeSemverDiff` highlights nothing for an `unknown`
+        // (or `null`) change, so the version renders plain.
+        Change::None | Change::Unknown => return text,
+    };
+    let (head, tail) = text.split_at(split);
+    let painted = match change {
+        Change::Breaking => red(tail),
+        Change::Feature => yellow(tail),
+        Change::Fix => green(tail),
+        Change::None | Change::Unknown => tail.to_string(),
+    };
+    format!("{head}{painted}")
+}
+
+fn render_details(pkg: &OutdatedPackage) -> String {
+    let mut outputs = Vec::new();
+    if let Some(reason) = &pkg.deprecated
+        && !reason.is_empty()
+    {
+        outputs.push(red(reason));
+    }
+    if let Some(homepage) = &pkg.homepage {
+        outputs.push(underline(homepage));
+    }
+    outputs.join("\n")
+}
+
+// Color helpers. Each is a no-op when stdout is not a terminal (piped or
+// captured output), matching chalk's auto-disable so machine-readable
+// output stays free of escape codes.
+fn bright_blue(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.bright_blue()).to_string()
+}
+
+fn red(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.red()).to_string()
+}
+
+fn red_bold(text: &str) -> String {
+    let style = owo_colors::Style::new().red().bold();
+    text.if_supports_color(Stream::Stdout, |t| t.style(style)).to_string()
+}
+
+fn green(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.green()).to_string()
+}
+
+fn yellow(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.yellow()).to_string()
+}
+
+fn grey(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.bright_black()).to_string()
+}
+
+fn bold(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+fn dimmed(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
+}
+
+fn underline(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.underline()).to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pacquet/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pacquet/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,0 +1,122 @@
+use super::{
+    Change, OutdatedDependencyOptions, OutdatedPackage, classify, render_json, render_latest,
+    sort_outdated,
+};
+use node_semver::Version;
+use pacquet_package_manifest::DependencyGroup;
+
+fn v(text: &str) -> Version {
+    text.parse().expect("parse semver")
+}
+
+fn pkg(name: &str, current: &str, target: &str, group: DependencyGroup) -> OutdatedPackage {
+    OutdatedPackage {
+        alias: name.to_string(),
+        package_name: name.to_string(),
+        belongs_to: group,
+        current: v(current),
+        target: v(target),
+        deprecated: None,
+        homepage: None,
+    }
+}
+
+#[test]
+fn classify_detects_each_bump_kind() {
+    assert_eq!(classify(&v("1.0.0"), &v("2.0.0")), Change::Breaking);
+    assert_eq!(classify(&v("1.0.0"), &v("1.1.0")), Change::Feature);
+    assert_eq!(classify(&v("1.0.0"), &v("1.0.1")), Change::Fix);
+    // Exactly equal -> no change; a prerelease-only difference with the
+    // same major.minor.patch is `Unknown` (pnpm's `change: 'unknown'`),
+    // not `None`.
+    assert_eq!(classify(&v("1.0.0"), &v("1.0.0")), Change::None);
+    assert_eq!(classify(&v("1.0.0-alpha.1"), &v("1.0.0")), Change::Unknown);
+}
+
+#[test]
+fn include_default_covers_all_three_groups() {
+    let opts = OutdatedDependencyOptions { prod: false, dev: false, no_optional: false };
+    assert_eq!(
+        opts.include(),
+        vec![DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+    );
+}
+
+#[test]
+fn include_prod_keeps_dependencies_and_optional() {
+    let opts = OutdatedDependencyOptions { prod: true, dev: false, no_optional: false };
+    assert_eq!(opts.include(), vec![DependencyGroup::Prod, DependencyGroup::Optional]);
+}
+
+#[test]
+fn include_dev_keeps_only_dev() {
+    let opts = OutdatedDependencyOptions { prod: false, dev: true, no_optional: false };
+    assert_eq!(opts.include(), vec![DependencyGroup::Dev]);
+}
+
+#[test]
+fn include_no_optional_drops_optional() {
+    let opts = OutdatedDependencyOptions { prod: false, dev: false, no_optional: true };
+    assert_eq!(opts.include(), vec![DependencyGroup::Prod, DependencyGroup::Dev]);
+}
+
+#[test]
+fn default_sort_orders_by_change_then_name() {
+    let mut outdated = vec![
+        pkg("breaking-z", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("fix-a", "1.0.0", "1.0.1", DependencyGroup::Prod),
+        pkg("fix-b", "1.0.0", "1.0.1", DependencyGroup::Prod),
+        pkg("feature-a", "1.0.0", "1.1.0", DependencyGroup::Prod),
+    ];
+    sort_outdated(&mut outdated, None);
+    let order: Vec<&str> = outdated.iter().map(|item| item.package_name.as_str()).collect();
+    assert_eq!(order, vec!["fix-a", "fix-b", "feature-a", "breaking-z"]);
+}
+
+#[test]
+fn json_report_has_expected_shape() {
+    let outdated = vec![pkg("foo", "1.0.0", "2.0.0", DependencyGroup::Dev)];
+    let value: serde_json::Value =
+        serde_json::from_str(&render_json(&outdated, false)).expect("valid JSON");
+    let entry = &value["foo"];
+    assert_eq!(entry["current"], "1.0.0");
+    assert_eq!(entry["latest"], "2.0.0");
+    assert_eq!(entry["wanted"], "1.0.0");
+    assert_eq!(entry["isDeprecated"], false);
+    assert_eq!(entry["dependencyType"], "devDependencies");
+    assert!(entry.get("latestManifest").is_none(), "latestManifest is --long only");
+}
+
+// Ports `deps/inspection/commands/test/outdated/renderLatest.test.ts`.
+// Colors are emitted only on a TTY, so the captured (non-TTY) output is
+// plain text here.
+#[test]
+fn render_latest_outdated_and_deprecated() {
+    let mut item = pkg("foo", "0.0.1", "1.0.0", DependencyGroup::Prod);
+    item.deprecated = Some("This package is deprecated".to_string());
+    let output = render_latest(&item);
+    assert!(output.contains("1.0.0"), "shows the latest version: {output}");
+    assert!(output.contains("(deprecated)"), "flags the deprecation: {output}");
+}
+
+#[test]
+fn render_latest_outdated_and_not_deprecated() {
+    let item = pkg("foo", "0.0.1", "1.0.0", DependencyGroup::Prod);
+    let output = render_latest(&item);
+    assert!(output.contains("1.0.0"), "shows the latest version: {output}");
+    assert!(!output.contains("(deprecated)"), "no deprecation marker: {output}");
+}
+
+#[test]
+fn json_report_long_includes_latest_manifest() {
+    let mut item = pkg("foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    item.deprecated = Some("do not use".to_string());
+    item.homepage = Some("https://example.com".to_string());
+    let value: serde_json::Value =
+        serde_json::from_str(&render_json(&[item], true)).expect("valid JSON");
+    let manifest = &value["foo"]["latestManifest"];
+    assert_eq!(manifest["version"], "2.0.0");
+    assert_eq!(manifest["deprecated"], "do not use");
+    assert_eq!(manifest["homepage"], "https://example.com");
+    assert_eq!(value["foo"]["isDeprecated"], true);
+}

--- a/pacquet/crates/cli/src/cli_args/update_interactive.rs
+++ b/pacquet/crates/cli/src/cli_args/update_interactive.rs
@@ -7,27 +7,22 @@
 //! show them in a checkbox prompt, and return the names the user picked
 //! so the regular update path can run with them as selectors.
 //!
-//! Unlike pnpm — which fans out through `@pnpm/deps.inspection.outdated`
-//! — pacquet computes "outdated" inline: the current version comes from
-//! the wanted lockfile and the target from a single packument fetch per
-//! dependency. The choice list is intentionally flat (pnpm groups by
-//! dependency type); the prompt is a `dialoguer` multi-select.
+//! The outdated set is computed by the shared
+//! [`collect_outdated`], which also backs `pacquet outdated`. The two
+//! callers differ only in
+//! the [`TargetVersion`] they compare against: `update` targets the
+//! version a bump would move to (the `latest` tag under `--latest`,
+//! otherwise the highest in-range version). The choice list is
+//! intentionally flat (pnpm groups by dependency type); the prompt is a
+//! `dialoguer` multi-select.
 
+use crate::cli_args::outdated::{OutdatedQuery, TargetVersion, collect_outdated};
 use dialoguer::MultiSelect;
 use miette::{IntoDiagnostic, miette};
-use node_semver::Version;
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_registry::Package;
-
-/// One outdated direct dependency offered in the prompt.
-struct OutdatedChoice {
-    name: String,
-    current: Version,
-    target: Version,
-}
 
 /// Gather outdated direct dependencies, prompt the user, and return the
 /// selected package names. `Ok(None)` means "nothing to do" — either no
@@ -41,8 +36,14 @@ pub async fn select_packages(
     latest: bool,
     include_direct: &[DependencyGroup],
 ) -> miette::Result<Option<Vec<String>>> {
-    let choices =
-        collect_outdated(manifest, lockfile, config, http_client, latest, include_direct).await?;
+    let target_version = if latest { TargetVersion::Latest } else { TargetVersion::WithinRange };
+    let query = OutdatedQuery {
+        target_version,
+        include_direct,
+        match_names: None,
+        include_deprecated: false,
+    };
+    let choices = collect_outdated(manifest, lockfile, config, http_client, &query).await?;
 
     if choices.is_empty() {
         let message = if latest {
@@ -56,7 +57,7 @@ pub async fn select_packages(
 
     let labels: Vec<String> = choices
         .iter()
-        .map(|choice| format!("{} {} ❯ {}", choice.name, choice.current, choice.target))
+        .map(|choice| format!("{} {} ❯ {}", choice.alias, choice.current, choice.target))
         .collect();
 
     let selected_indices = MultiSelect::new()
@@ -67,85 +68,10 @@ pub async fn select_packages(
         .map_err(|err| miette!("interactive update selection failed: {err}"))?;
 
     let selected: Vec<String> =
-        selected_indices.into_iter().map(|index| choices[index].name.clone()).collect();
+        selected_indices.into_iter().map(|index| choices[index].alias.clone()).collect();
 
     if selected.is_empty() {
         return Ok(None);
     }
     Ok(Some(selected))
-}
-
-/// Build the outdated-direct-dependency list. A dependency is outdated
-/// when its registry target (highest version satisfying the manifest
-/// range, or the `latest` tag under `--latest`) is strictly newer than
-/// the version currently pinned in the lockfile. Dependencies without a
-/// lockfile pin, without a registry target, or whose specifier is not a
-/// plain semver range are skipped — they can't be diffed.
-async fn collect_outdated(
-    manifest: &PackageManifest,
-    lockfile: Option<&Lockfile>,
-    config: &Config,
-    http_client: &ThrottledClient,
-    latest: bool,
-    include_direct: &[DependencyGroup],
-) -> miette::Result<Vec<OutdatedChoice>> {
-    let current_versions = current_versions_from_lockfile(lockfile, include_direct);
-
-    let mut direct: Vec<(String, String)> = Vec::new();
-    for &group in include_direct {
-        for (name, range) in manifest.dependencies([group]) {
-            direct.push((name.to_string(), range.to_string()));
-        }
-    }
-
-    let mut choices = Vec::new();
-    for (name, range) in direct {
-        let Some(current) = current_versions.get(&name).cloned() else { continue };
-        let package = match Package::fetch_from_registry(
-            &name,
-            http_client,
-            &config.registry,
-            &config.auth_headers,
-        )
-        .await
-        {
-            Ok(package) => package,
-            // A dependency the registry can't serve (private, renamed,
-            // network blip) is simply not offered for update rather than
-            // failing the whole prompt.
-            Err(_) => continue,
-        };
-
-        let target_raw = if latest {
-            package.dist_tag("latest").map(ToString::to_string)
-        } else {
-            package.pinned_version(&range).map(|version| version.serialize(true).replace('^', ""))
-        };
-        let Some(target_raw) = target_raw else { continue };
-        let Ok(target) = target_raw.parse::<Version>() else { continue };
-
-        if target > current {
-            choices.push(OutdatedChoice { name, current, target });
-        }
-    }
-
-    Ok(choices)
-}
-
-/// Map each direct dependency name to its lockfile-pinned semver
-/// version. Only the root importer is consulted (pacquet's single-project
-/// scope); entries whose resolved version isn't a plain semver (`link:`,
-/// `file:`, non-semver runtimes) are omitted.
-fn current_versions_from_lockfile(
-    lockfile: Option<&Lockfile>,
-    include_direct: &[DependencyGroup],
-) -> std::collections::HashMap<String, Version> {
-    let mut map = std::collections::HashMap::new();
-    let Some(importer) = lockfile.and_then(Lockfile::root_project) else { return map };
-    for (name, spec) in importer.dependencies_by_groups(include_direct.iter().copied()) {
-        if let Some(version) = spec.version.ver_peer().and_then(|ver| ver.version_semver()) {
-            map.insert(name.to_string(), version.clone());
-        }
-    }
-    map
 }

--- a/pacquet/crates/cli/tests/outdated.rs
+++ b/pacquet/crates/cli/tests/outdated.rs
@@ -1,0 +1,308 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{ffi::OsStr, fs, path::Path, process::Command};
+use tempfile::TempDir;
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const FOO: &str = "@pnpm.e2e/foo";
+const DEPRECATED: &str = "@pnpm.e2e/deprecated";
+
+fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    (root, workspace, npmrc_info)
+}
+
+fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
+    Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+        .with_args(args)
+}
+
+fn write_manifest(workspace: &Path, dependencies: &str) {
+    let manifest = format!(
+        r#"{{ "name": "test-outdated", "version": "1.0.0", "dependencies": {dependencies} }}"#,
+    );
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+}
+
+/// `outdated` reports a dependency whose `latest` tag is newer than the
+/// installed (in-range) version, and exits non-zero.
+#[test]
+fn outdated_reports_newer_version() {
+    let (root, workspace, anchor) = setup();
+
+    // `^100.0.0` installs the highest in-range version (100.1.0); the
+    // `latest` tag is 101.0.0, so the dependency is outdated.
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1), "outdated deps present should exit 1");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(DEP), "report should mention the package: {stdout}");
+    assert!(stdout.contains("100.1.0"), "report should show the current version: {stdout}");
+    assert!(stdout.contains("101.0.0"), "report should show the latest version: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// `--compatible` compares against the highest in-range version, so a
+/// dependency already at the top of its range is not reported even when a
+/// newer major exists.
+#[test]
+fn outdated_compatible_ignores_out_of_range_releases() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    // Default run is outdated (101.0.0 latest)...
+    assert_eq!(
+        pacquet(&workspace, ["outdated"]).output().unwrap().status.code(),
+        Some(1),
+        "default outdated should flag the out-of-range 101.0.0",
+    );
+
+    // ...but --compatible only considers in-range versions; 100.1.0 is
+    // already the highest in `^100.0.0`, so nothing is outdated.
+    let output =
+        pacquet(&workspace, ["outdated", "--compatible"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(0), "compatible run should be up to date");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains(DEP), "compatible run should report nothing: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// `--format json` emits a parseable object keyed by package name.
+#[test]
+fn outdated_json_format() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated", "--format", "json"])
+        .output()
+        .expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("outdated --format json should emit valid JSON");
+    let entry = &value[DEP];
+    assert_eq!(entry["current"], "100.1.0");
+    assert_eq!(entry["latest"], "101.0.0");
+    assert_eq!(entry["dependencyType"], "dependencies");
+
+    drop((root, anchor));
+}
+
+/// A dependency pinned to its `latest` tag is not outdated; the report is
+/// empty and the exit code is zero.
+#[test]
+fn outdated_up_to_date_exits_zero() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "101.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(0), "up-to-date deps should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains(DEP), "no outdated dep should be reported: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// A package selector restricts the report to matching dependencies.
+#[test]
+fn outdated_pattern_filters_dependencies() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0", "{FOO}": "^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated", FOO]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(FOO), "selected package should be reported: {stdout}");
+    assert!(!stdout.contains(DEP), "unselected package should be excluded: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// A package at its newest version but marked deprecated is still
+/// reported as outdated.
+#[test]
+fn outdated_reports_deprecated_package() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEPRECATED}": "1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1), "deprecated dep should be flagged");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(DEPRECATED), "deprecated package should be reported: {stdout}");
+    assert!(stdout.contains("Deprecated"), "should mark the version deprecated: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// Without a lockfile, `outdated` fails with
+/// `ERR_PNPM_OUTDATED_NO_LOCKFILE` rather than silently reporting nothing.
+#[test]
+fn outdated_without_lockfile_errors() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert!(!output.status.success(), "outdated without a lockfile should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No lockfile in directory"), "stderr should explain why: {stderr}");
+
+    drop((root, anchor));
+}
+
+/// `--recursive` is rejected until workspace-wide inspection is ported.
+#[test]
+fn outdated_recursive_is_rejected() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output =
+        pacquet(&workspace, ["outdated", "--recursive"]).output().expect("run pacquet outdated");
+    assert!(!output.status.success(), "recursive outdated should be rejected");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not supported yet"), "stderr should say it is unsupported: {stderr}");
+
+    drop((root, anchor));
+}
+
+/// A dependency-free manifest is reported as up to date (exit 0) even
+/// when there is no lockfile — the no-lockfile error only fires for a
+/// manifest that actually declares dependencies. Ports pnpm's "should
+/// return empty when there is no lockfile and no dependencies".
+#[test]
+fn outdated_no_dependencies_no_lockfile_is_empty() {
+    let (root, workspace, anchor) = setup();
+
+    fs::write(workspace.join("package.json"), r#"{ "name": "test-outdated", "version": "1.0.0" }"#)
+        .expect("write package.json");
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(0), "no dependencies should exit 0");
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty(), "report should be empty");
+
+    drop((root, anchor));
+}
+
+/// `--format json` emits `{}` (exit 0) when nothing is outdated. Ports
+/// pnpm's "format json when there are no outdated dependencies".
+#[test]
+fn outdated_json_empty_when_up_to_date() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "101.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated", "--format", "json"])
+        .output()
+        .expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "{}");
+
+    drop((root, anchor));
+}
+
+/// `--no-table` (list format) prints names and `=>` arrows instead of a
+/// box-drawing table. Ports pnpm's "no table".
+#[test]
+fn outdated_list_format() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output =
+        pacquet(&workspace, ["outdated", "--no-table"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(DEP), "list should mention the package: {stdout}");
+    assert!(stdout.contains("=>"), "list uses the `=>` arrow: {stdout}");
+    assert!(!stdout.contains('┌'), "list format must not draw a table: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// `--long` adds the deprecation reason to the report. Ports pnpm's
+/// "--long with only deprecated packages".
+#[test]
+fn outdated_long_shows_deprecation_details() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "{DEPRECATED}": "1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output =
+        pacquet(&workspace, ["outdated", "--long"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("This package is deprecated"),
+        "--long should print the deprecation reason: {stdout}",
+    );
+
+    drop((root, anchor));
+}
+
+/// An npm-aliased dependency is reported under its real registry name,
+/// not the alias. Ports pnpm's "outdated() aliased dependency".
+#[test]
+fn outdated_npm_alias_reports_real_name() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "positive": "npm:{FOO}@^1.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated"]).output().expect("run pacquet outdated");
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(FOO), "report should use the real package name: {stdout}");
+
+    drop((root, anchor));
+}
+
+/// `--prod` and `--dev` restrict the report to the matching dependency
+/// group. Ports pnpm's "showing only prod or dev dependencies".
+#[test]
+fn outdated_prod_dev_filtering() {
+    let (root, workspace, anchor) = setup();
+
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "test-outdated", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0" }}, "devDependencies": {{ "{FOO}": "^1.0.0" }} }}"#,
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let prod = pacquet(&workspace, ["outdated", "--prod"]).output().expect("run pacquet outdated");
+    let prod_out = String::from_utf8_lossy(&prod.stdout);
+    assert!(prod_out.contains(DEP), "--prod includes the prod dep: {prod_out}");
+    assert!(!prod_out.contains(FOO), "--prod excludes the dev dep: {prod_out}");
+
+    let dev = pacquet(&workspace, ["outdated", "--dev"]).output().expect("run pacquet outdated");
+    let dev_out = String::from_utf8_lossy(&dev.stdout);
+    assert!(dev_out.contains(FOO), "--dev includes the dev dep: {dev_out}");
+    assert!(!dev_out.contains(DEP), "--dev excludes the prod dep: {dev_out}");
+
+    drop((root, anchor));
+}

--- a/pacquet/crates/registry/src/package.rs
+++ b/pacquet/crates/registry/src/package.rs
@@ -55,6 +55,17 @@ pub struct Package {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub etag: Option<String>,
 
+    /// Package-level `homepage` URL, shown in the `Details` column of
+    /// `pacquet outdated --long`. Mirrors pnpm's
+    /// [`PackageManifest.homepage`](https://github.com/pnpm/pnpm/blob/2a9bd897bf/packages/types/src/package.ts).
+    ///
+    /// Only the full-metadata endpoint (`application/json`) carries this
+    /// field; the abbreviated install metadata pacquet fetches by default
+    /// (`application/vnd.npm.install-v1+json`) omits it, so it is `None`
+    /// unless the registry serves it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub homepage: Option<String>,
+
     #[serde(skip_serializing, skip_deserializing)]
     pub mutex: Arc<Mutex<u8>>,
 }

--- a/pacquet/crates/registry/src/package/tests.rs
+++ b/pacquet/crates/registry/src/package/tests.rs
@@ -116,6 +116,7 @@ fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package
         time: None,
         modified: None,
         etag: None,
+        homepage: None,
         mutex: Default::default(),
     }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -863,6 +863,10 @@ fn project_trust_meta(meta: &Package) -> Package {
         time: meta.time.clone(),
         modified: meta.modified.clone(),
         etag: meta.etag.clone(),
+        // `homepage` is only read by `outdated --long`, never by trust
+        // verification, so it is dropped here to keep the trust-meta cache
+        // bounded by the trust-evidence footprint (see the fn doc).
+        homepage: None,
         mutex: std::sync::Arc::new(std::sync::Mutex::new(0)),
     }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -440,6 +440,7 @@ pub fn filter_pkg_metadata_by_publish_date(
         time: meta.time.clone(),
         modified: meta.modified.clone(),
         etag: meta.etag.clone(),
+        homepage: meta.homepage.clone(),
         mutex: std::sync::Arc::clone(&meta.mutex),
     }
 }

--- a/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -54,6 +54,7 @@ fn make_package(
         time: None,
         modified: None,
         etag: None,
+        homepage: None,
         mutex: Default::default(),
     }
 }


### PR DESCRIPTION
## What

Ports pnpm's `outdated` command to pacquet. It reports the direct dependencies whose newest published version (or highest in-range version under `--compatible`) is newer than the lockfile-pinned version, and exits with code `1` when any outdated dependency is found.

This widens pacquet's command surface beyond `install`/`add`/`update`/`remove`.

## How

- **Detection core** — `collect_outdated` / `OutdatedQuery` / `TargetVersion` in `pacquet/crates/cli/src/cli_args/outdated.rs`. This is shared with `update --interactive`, which already computed the same "what has a newer version" list inline; that code now calls the shared collector. The two callers differ only in the `TargetVersion` they compare against (`outdated` → `latest` tag / highest in-range under `--compatible`; `update` → the version a bump moves to). Packument fetches fan out concurrently via `futures::join_all`, mirroring pnpm's `Promise.all` (bounded by the HTTP client's per-registry concurrency limit).
- **Flags** — `--compatible`, `--long`, `--format table|list|json` (plus `--no-table` / `--json` shorthands), `-P/--prod` (`--production`), `-D/--dev`, `--no-optional` (following pnpm's `only`-normalization include-set), `--sort-by name` (default sort is by semver-change size then name), and positional name patterns (`@pnpm/config.matcher`).
- **Exit code** — `OutdatedArgs::run` returns an `OutdatedOutcome`; the single `process::exit(1)` lives in the top-level CLI dispatch, keeping the command composable.
- **`--global` and `--recursive` are rejected** with a "not supported yet" message, matching `pacquet update` (single-project scope).
- **Empty-manifest short-circuit** — a dependency-free manifest reports empty (exit 0) *before* the no-lockfile check, matching pnpm's `packageHasNoDeps` behavior so an empty, never-installed project doesn't error.
- **Rendering** — adds `tabled` (`Style::modern()` reproduces pnpm's `@zkochan/table` full-grid borders) and `owo-colors` (auto-disables on non-TTY, like chalk, so piped/JSON output is escape-free). Both are MIT (allowed by `deny.toml`). JSON output is keyed by package name with `current` / `latest` / `wanted` / `isDeprecated` / `dependencyType` (+ `latestManifest` under `--long`), matching pnpm's `renderOutdatedJSON`.
- Adds an optional `homepage` field to the registry `Package` for the `--long` details column.

## Parity notes / scope

pacquet loads a single (wanted) lockfile, so `current == wanted` and pnpm's "missing (wanted X)" state does not arise. `OUTDATED_NO_LOCKFILE` is raised when a manifest declares dependencies but no lockfile exists. Deprecated-but-current packages are still reported.

Deferred with their surrounding features (not yet ported to pacquet), each tracked by an upstream test that does not yet translate:
- `--long` **homepage** needs full registry metadata; the abbreviated fetch omits it, so it appears only when the registry serves it (deprecation details work fully).
- `minimumReleaseAge` / `minimumReleaseAgeExclude`, `pnpm.updateConfig.ignoreDependencies`, `catalog:` protocol replacement, `-g`/global packages, recursive workspace listing, and `runtime:` (node/deno/bun) dependencies.

## Tests

Ported the translatable pnpm `outdated` tests (`deps/inspection/outdated/test/*` and `deps/inspection/commands/test/outdated/*`):

- **10 unit tests** — semver-change classification, include-set normalization (default / `--prod` / `--dev` / `--no-optional`), default sort order, `renderLatest` (deprecated / not), and JSON shape (with/without `--long`).
- **14 integration tests** against the mocked registry — newer-version report, `--compatible` discrimination, JSON, JSON-empty `{}`, list (`--no-table`) format, up-to-date → exit 0, name-pattern filter, prod/dev filtering, npm-alias real-name reporting, deprecated package, `--long` deprecation details, no-deps/no-lockfile → empty exit 0, no-lockfile-with-deps error, and `--recursive` rejection.

No changeset (pacquet-only change).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pacquet outdated` (table, list, or JSON) with semver-diff colorization and deprecation/homepage details in long mode.
  * `pacquet update --interactive` can source outdated candidates for selection; supports name filtering and prod/dev scopes.
* **Behavior Changes / Bug Fixes**
  * Command exits non‑zero when outdated packages exist; rejects unsupported flags and errors when a lockfile is required; disables ANSI styling when stdout is not a TTY.
* **Tests**
  * Integration and unit tests added for reporting, formatting, filtering, and deprecated-package handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->