### PR TITLE
fix(lockfile): emit pacquet lockfile maps in canonical key order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ name = "pacquet-lockfile"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "indexmap",
  "node-semver",
  "pacquet-crypto-hash",
  "pacquet-diagnostics",

--- a/pacquet/crates/cli/tests/inject_workspace_packages.rs
+++ b/pacquet/crates/cli/tests/inject_workspace_packages.rs
@@ -138,11 +138,9 @@ fn inject_workspace_packages_writes_file_resolutions_and_lockfile_setting() {
     // recorded dep on project-1 reads `project-1@file:project-1(...)`
     // even though project-2 lives a directory away.
     //
-    // The lockfile's `importers` map is unordered upstream (the JSON
-    // wire shape preserves whatever order serde emits), so pacquet's
-    // `HashMap`-backed writer may interleave importer blocks in any
-    // order. Parse the YAML and inspect the consumer importer's
-    // recorded version directly through pacquet's own lockfile model.
+    // Parse the YAML and inspect the consumer importer's recorded
+    // version directly through pacquet's own lockfile model, rather than
+    // string-slicing importer blocks out of the serialized file.
     let parsed: pacquet_lockfile::Lockfile = serde_saphyr::from_str(&lockfile)
         .map_err(|err| {
             format!(

--- a/pacquet/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pacquet/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -109,7 +109,7 @@ fn reuses_unchanged_subtree_without_re_resolving_from_the_registry() {
     drop((root, mock_instance));
 }
 
-/// A lockfile produced via the reuse path is structurally identical to
+/// A lockfile produced via the reuse path is byte-for-byte identical to
 /// one produced by resolving the same manifest entirely from scratch.
 ///
 /// The discriminating test above proves reuse *fires*; this proves it's
@@ -120,13 +120,13 @@ fn reuses_unchanged_subtree_without_re_resolving_from_the_registry() {
 ///      reuses `pkg-with-1-dep`'s subtree and resolves only `foo`;
 ///   B. install both from scratch — no prior lockfile, nothing reused.
 ///
-/// Compared as parsed [`pacquet_lockfile::Lockfile`] values rather than
-/// raw bytes: the two are content-identical (same packages, versions,
-/// integrities, snapshots, importer specifiers), but the writer emits the
-/// `packages` / `snapshots` / importer-`dependencies` maps in build-
-/// insertion order, which differs between the incremental and the fresh
-/// build. That byte-level ordering is a separate lockfile-determinism
-/// concern (tracked as a follow-up), orthogonal to reuse correctness.
+/// Compared **byte-for-byte**: the writer sorts every lockfile map by its
+/// rendered key (matching pnpm's
+/// [`sortLockfileKeys`](https://github.com/pnpm/pnpm/blob/39101f5e37/lockfile/fs/src/sortLockfileKeys.ts)),
+/// so build-insertion order no longer leaks into the file. A reuse build and
+/// a fresh build of the same manifest therefore emit identical bytes — this
+/// is the byte-stability guarantee from
+/// [#12117](https://github.com/pnpm/pnpm/issues/12117).
 #[test]
 fn a_reused_tree_is_structurally_identical_to_a_fresh_resolve() {
     let both = serde_json::json!({
@@ -156,14 +156,49 @@ fn a_reused_tree_is_structurally_identical_to_a_fresh_resolve() {
     let fresh_lockfile =
         fs::read_to_string(fresh.workspace.join("pnpm-lock.yaml")).expect("read fresh lockfile");
 
-    let parse = |yaml: &str| {
-        serde_saphyr::from_str::<pacquet_lockfile::Lockfile>(yaml).expect("parse pnpm-lock.yaml")
-    };
     pretty_assertions::assert_eq!(
-        parse(&reused_lockfile),
-        parse(&fresh_lockfile),
-        "a tree built via subtree reuse must be structurally identical to a fresh resolve",
+        reused_lockfile,
+        fresh_lockfile,
+        "a tree built via subtree reuse must serialize byte-for-byte identically to a fresh resolve",
     );
 
     drop((reused, fresh));
+}
+
+/// Re-installing an unchanged manifest must leave `pnpm-lock.yaml`
+/// byte-identical. Before the lockfile maps were sorted at emit time, the
+/// `importers` / `packages` / `snapshots` / dependency maps serialized in
+/// `HashMap` iteration order — a per-instance random seed — so a no-op
+/// re-install could reorder the file and produce a spurious git diff
+/// ([#12117](https://github.com/pnpm/pnpm/issues/12117)). The manifest
+/// carries several dependencies so at least one map holds multiple keys,
+/// giving order a chance to differ.
+#[test]
+fn reinstalling_an_unchanged_manifest_keeps_the_lockfile_byte_identical() {
+    let manifest = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/foo": "100.0.0",
+            "@pnpm.e2e/bar": "100.0.0",
+            "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+        }
+    })
+    .to_string();
+
+    let project = CommandTempCwd::init().add_mocked_registry();
+    fs::write(project.workspace.join("package.json"), &manifest).expect("write manifest");
+
+    pacquet_at(&project.workspace).with_arg("install").assert().success();
+    let lockfile_path = project.workspace.join("pnpm-lock.yaml");
+    let first = fs::read_to_string(&lockfile_path).expect("read lockfile after first install");
+
+    pacquet_at(&project.workspace).with_arg("install").assert().success();
+    let second = fs::read_to_string(&lockfile_path).expect("read lockfile after second install");
+
+    pretty_assertions::assert_eq!(
+        first,
+        second,
+        "a no-op re-install must not reorder the lockfile",
+    );
+
+    drop(project);
 }

--- a/pacquet/crates/lockfile/Cargo.toml
+++ b/pacquet/crates/lockfile/Cargo.toml
@@ -16,6 +16,7 @@ pacquet-diagnostics      = { workspace = true }
 pacquet-package-manifest = { workspace = true }
 
 derive_more      = { workspace = true }
+indexmap         = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
 serde            = { workspace = true }

--- a/pacquet/crates/lockfile/src/lib.rs
+++ b/pacquet/crates/lockfile/src/lib.rs
@@ -37,6 +37,7 @@ pub use snapshot_dep_ref::*;
 pub use snapshot_entry::*;
 pub use yaml_documents::*;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -98,8 +99,15 @@ pub struct Lockfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<LockfileSettings>,
 
+    /// `overrides` recorded by the install that wrote this lockfile.
+    /// Kept in an [`IndexMap`] so the entries serialize in the order
+    /// the user declared them — pnpm does **not** sort this map (it is
+    /// the one lockfile map left out of
+    /// [`sortLockfileKeys`](https://github.com/pnpm/pnpm/blob/39101f5e37/lockfile/fs/src/sortLockfileKeys.ts)),
+    /// so preserving insertion order is what keeps pacquet byte-stable
+    /// *and* faithful to pnpm.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub overrides: Option<HashMap<String, String>>,
+    pub overrides: Option<IndexMap<String, String>>,
 
     /// `packageExtensionsChecksum` recorded by the install that wrote
     /// this lockfile. Top-level in the v9 wire shape, mirroring
@@ -130,13 +138,23 @@ pub struct Lockfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignored_optional_dependencies: Option<Vec<String>>,
 
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        serialize_with = "crate::serialize_yaml::sorted_map"
+    )]
     pub importers: HashMap<String, ProjectSnapshot>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub packages: Option<HashMap<PackageKey, PackageMetadata>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub snapshots: Option<HashMap<PackageKey, SnapshotEntry>>,
 }
 

--- a/pacquet/crates/lockfile/src/package_metadata.rs
+++ b/pacquet/crates/lockfile/src/package_metadata.rs
@@ -13,7 +13,10 @@ use std::collections::HashMap;
 pub struct PackageMetadata {
     pub resolution: LockfileResolution,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub engines: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu: Option<Vec<String>>,
@@ -34,9 +37,15 @@ pub struct PackageMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bundled_dependencies: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub peer_dependencies: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>,
 }
 

--- a/pacquet/crates/lockfile/src/project_snapshot.rs
+++ b/pacquet/crates/lockfile/src/project_snapshot.rs
@@ -7,13 +7,25 @@ use std::collections::HashMap;
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectSnapshot {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub specifiers: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub dependencies: Option<ResolvedDependencyMap>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub optional_dependencies: Option<ResolvedDependencyMap>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub dev_dependencies: Option<ResolvedDependencyMap>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies_meta: Option<serde_json::Value>, // TODO: DependenciesMeta

--- a/pacquet/crates/lockfile/src/serialize_yaml.rs
+++ b/pacquet/crates/lockfile/src/serialize_yaml.rs
@@ -6,8 +6,12 @@
 //! into block style (`>-`), so we explicitly disable that to preserve byte-
 //! level parity with what pnpm produces.
 
-use serde::Serialize;
+use serde::{
+    Serialize,
+    ser::{SerializeMap, Serializer},
+};
 use serde_saphyr::{SerializerOptions, ser, ser_options, to_string_with_options};
+use std::{collections::HashMap, fmt::Display};
 
 /// Serializer options matching pnpm's lockfile output.
 fn options() -> SerializerOptions {
@@ -20,4 +24,54 @@ fn options() -> SerializerOptions {
 /// formatting.
 pub(crate) fn to_string<Value: Serialize>(value: &Value) -> Result<String, ser::Error> {
     to_string_with_options(value, options())
+}
+
+/// Serialize a [`HashMap`] with its entries emitted in canonical key order.
+///
+/// pnpm orders every lockfile map by its *rendered* key string via
+/// [`lexCompare`](https://github.com/pnpm/pnpm/blob/39101f5e37/lockfile/fs/src/sortLockfileKeys.ts)
+/// (a plain code-unit comparison). Sorting by the rendered string — rather
+/// than by the key type's structural `Ord` — is load-bearing: the `@`
+/// separating `name` from `version` in a `packages:`/`snapshots:` key, and
+/// the leading `@` of a scoped `name`, both order differently under a
+/// field-wise comparison than under a comparison of the concatenated string
+/// (`react-dom@1.0.0` sorts before `react@17.0.2`; `@types/node` sorts before
+/// `node`). [`Display`] renders each key exactly as it is serialized, so
+/// sorting by it reproduces pnpm's byte order.
+pub(crate) fn sorted_map<Key, Value, Ser>(
+    map: &HashMap<Key, Value>,
+    serializer: Ser,
+) -> Result<Ser::Ok, Ser::Error>
+where
+    Key: Serialize + Display,
+    Value: Serialize,
+    Ser: Serializer,
+{
+    let mut entries: Vec<(String, &Key, &Value)> =
+        map.iter().map(|(key, value)| (key.to_string(), key, value)).collect();
+    entries.sort_unstable_by(|(left, ..), (right, ..)| left.cmp(right));
+    let mut map_serializer = serializer.serialize_map(Some(entries.len()))?;
+    for (_, key, value) in &entries {
+        map_serializer.serialize_entry(key, value)?;
+    }
+    map_serializer.end()
+}
+
+/// [`sorted_map`] for an `Option<HashMap<…>>` field. The `None` arm is
+/// unreachable in practice — every call site pairs this with
+/// `skip_serializing_if = "Option::is_none"` — but is handled so the helper
+/// is a drop-in `serialize_with` for optional maps.
+pub(crate) fn sorted_map_opt<Key, Value, Ser>(
+    map: &Option<HashMap<Key, Value>>,
+    serializer: Ser,
+) -> Result<Ser::Ok, Ser::Error>
+where
+    Key: Serialize + Display,
+    Value: Serialize,
+    Ser: Serializer,
+{
+    match map {
+        Some(map) => sorted_map(map, serializer),
+        None => serializer.serialize_none(),
+    }
 }

--- a/pacquet/crates/lockfile/src/snapshot_entry.rs
+++ b/pacquet/crates/lockfile/src/snapshot_entry.rs
@@ -18,9 +18,15 @@ pub struct SnapshotEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub dependencies: Option<HashMap<PkgName, SnapshotDepRef>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::serialize_yaml::sorted_map_opt"
+    )]
     pub optional_dependencies: Option<HashMap<PkgName, SnapshotDepRef>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -13,6 +13,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use indexmap::IndexMap;
 use pacquet_lockfile::{
     ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings, LockfileVersion,
     PackageKey, PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer,
@@ -84,7 +85,9 @@ pub struct GraphToLockfileOptions<'a> {
     pub peers_suffix_max_length: Option<u64>,
     /// `overrides` recorded into the lockfile so a later install can
     /// detect drift. Mirrors upstream's `lockfile.overrides` field.
-    pub overrides: Option<HashMap<String, String>>,
+    /// An [`IndexMap`] so the user's declaration order is preserved on
+    /// serialization, matching pnpm (which leaves this map unsorted).
+    pub overrides: Option<IndexMap<String, String>>,
     /// `ignoredOptionalDependencies` recorded the same way.
     pub ignored_optional_dependencies: Option<Vec<String>>,
     /// `packageExtensionsChecksum` recorded the same way. Mirrors

--- a/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pacquet/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1,4 +1,5 @@
 use super::{GraphToLockfileOptions, ImporterLockfileInput, dependencies_graph_to_lockfile};
+use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
     DirectoryResolution, ImporterDepVersion, LockfileResolution, PackageKey, PkgName, PkgNameVer,
@@ -10,7 +11,7 @@ use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use serde_json::json;
 use ssri::Integrity;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     str::FromStr,
 };
 use tempfile::TempDir;
@@ -24,7 +25,7 @@ fn single_importer_opts<'a>(
     direct: BTreeMap<String, DepPath>,
     auto_install_peers: bool,
     exclude_links_from_lockfile: bool,
-    overrides: Option<HashMap<String, String>>,
+    overrides: Option<IndexMap<String, String>>,
     ignored_optional_dependencies: Option<Vec<String>>,
 ) -> GraphToLockfileOptions<'a> {
     let mut importers = BTreeMap::new();

--- a/pacquet/plans/LOCKFILE_RESOLUTION_REUSE.md
+++ b/pacquet/plans/LOCKFILE_RESOLUTION_REUSE.md
@@ -96,14 +96,13 @@ pass and the `updated`-propagation boundary are the subtlest parts.
 
 ## Known follow-ups (before un-drafting)
 
-- **Lockfile byte-ordering is build-order-dependent** ([#12117](https://github.com/pnpm/pnpm/issues/12117)). Surfaced by the
-  structural-equivalence test: reuse and fresh resolves produce
-  *content-identical* lockfiles, but the writer emits the
-  `packages` / `snapshots` / importer-`dependencies` maps in
-  build-insertion order, so a re-install can reorder the lockfile (spurious
-  git diff) even though nothing changed. pnpm emits these canonically
-  sorted. Likely a pre-existing writer gap that reuse makes user-visible;
-  fix by sorting those maps at emit time so lockfiles are byte-stable.
+- ~~**Lockfile byte-ordering is build-order-dependent**~~ ([#12117](https://github.com/pnpm/pnpm/issues/12117)) — **fixed.**
+  The writer now sorts every lockfile map by its rendered key at emit time
+  (`serialize_yaml::sorted_map`), matching pnpm's `sortLockfileKeys`, so
+  reuse and fresh resolves emit byte-identical lockfiles and a no-op
+  re-install no longer reorders the file. The reuse-equivalence test now
+  asserts byte-parity, and `reinstalling_an_unchanged_manifest_keeps_the_lockfile_byte_identical`
+  guards re-install stability.
 - **`overrides` drift** isn't yet guarded for transitive reuse (only
   `packageExtensions` is). An `overrides` change that rewrites a transitive
   dep's version should invalidate that subtree's reuse.


### PR DESCRIPTION
## What

Makes pacquet's `pnpm-lock.yaml` serialization byte-stable by emitting every lockfile map in canonical key order, matching pnpm. Fixes #12117.

## Why

pacquet serialized the `importers`, `packages`, `snapshots`, and per-importer/per-snapshot dependency maps in `std::HashMap` iteration order — a per-instance random seed — so two installs of the *same* resolution could emit byte-different lockfiles, producing spurious git diffs on no-op re-installs. pnpm's lockfile is canonically ordered ([`sortLockfileKeys`](https://github.com/pnpm/pnpm/blob/39101f5e37/lockfile/fs/src/sortLockfileKeys.ts)).

## How

- Two `serialize_with` helpers in `serialize_yaml` (`sorted_map` / `sorted_map_opt`) sort each map by its **rendered key string** at emit time, wired onto every map field across `lib.rs`, `project_snapshot.rs`, `snapshot_entry.rs`, and `package_metadata.rs`. The in-memory maps stay `HashMap` (no iteration-order ripple elsewhere).
- Sorting by the rendered key (not a field-wise `Ord`) is load-bearing and matches pnpm's `lexCompare`: the `@` separating `name@version` and the leading `@` of a scoped name both order differently as struct fields than as the concatenated string pnpm compares (`react-dom@1.0.0` before `react@17.0.2`; `@types/node` before `node`).
- `overrides` is the one map pnpm deliberately leaves out of `sortLockfileKeys` (it keeps declaration order). Rather than sort it, the lockfile's `overrides` field moves from `HashMap` to `IndexMap` so the user's declaration order is preserved — deterministic *and* faithful to pnpm.

## Tests

- The reuse-vs-fresh equivalence test (surfaced this in #12113) now asserts **byte-for-byte** parity, replacing the parsed-struct comparison that worked around the old non-determinism.
- New `reinstalling_an_unchanged_manifest_keeps_the_lockfile_byte_identical` guards that a no-op re-install leaves the lockfile bytes unchanged.

## Verification

`cargo check --workspace --all-targets`, clippy (`-D warnings`), `cargo dylint`, `typos`, and `cargo fmt`/`taplo` all clean. `pacquet-lockfile` (183), `pacquet-package-manager` (381), and the reuse + inject CLI tests pass.

pacquet-only (pnpm already orders canonically), so no TypeScript change and no changeset.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lockfile byte-ordering to be deterministic and not affected by build order, ensuring consistent output across fresh and reused lockfile generation.

* **Tests**
  * Enhanced tests to verify byte-for-byte lockfile correctness and added validation that re-installing unchanged manifests produces identical lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->