### PR TITLE
fix(cli): avoid Windows crash after network requests

### DIFF
--- a/.changeset/destroy-windows-dispatchers.md
+++ b/.changeset/destroy-windows-dispatchers.md
@@ -1,4 +1,5 @@
 ---
+"@pnpm/network.fetch": patch
 "pnpm": patch
 ---
 

--- a/.changeset/destroy-windows-dispatchers.md
+++ b/.changeset/destroy-windows-dispatchers.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/network.fetch": patch
+"@pnpm/network.fetch": minor
 "pnpm": patch
 ---
 

--- a/.changeset/slow-windows-exits.md
+++ b/.changeset/slow-windows-exits.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Avoided a Node.js crash when pnpm exits after network requests on Windows.

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -20,14 +20,16 @@ const KEEP_ALIVE_MAX_TIMEOUT = 600_000 // 10 minutes
 // With HTTP/2, undici multiplexes many streams over 1-2 TCP connections sharing a single
 // congestion window. In benchmarks this was slower than opening ~50 independent HTTP/1.1
 // connections that each get their own congestion window and can saturate bandwidth in parallel.
-setGlobalDispatcher(new Agent({
+const GLOBAL_DISPATCHER = new Agent({
   connections: DEFAULT_MAX_SOCKETS,
   keepAliveTimeout: KEEP_ALIVE_TIMEOUT,
   keepAliveMaxTimeout: KEEP_ALIVE_MAX_TIMEOUT,
   connect: {
     autoSelectFamily: true,
   },
-}).compose(stripSecFetchHeaders))
+}).compose(stripSecFetchHeaders)
+
+setGlobalDispatcher(GLOBAL_DISPATCHER)
 
 // undici's fetch() automatically adds sec-fetch-* headers (e.g. sec-fetch-mode: cors)
 // per the Fetch spec. Some registries like Azure DevOps Artifacts interpret these as
@@ -96,6 +98,13 @@ export interface DispatcherOptions {
  */
 export function clearDispatcherCache (): void {
   DISPATCHER_CACHE.clear()
+}
+
+export async function destroyDispatchers (): Promise<void> {
+  await Promise.allSettled([
+    GLOBAL_DISPATCHER.destroy(),
+    ...Array.from(DISPATCHER_CACHE.values(), dispatcher => dispatcher.destroy()),
+  ])
 }
 
 /**

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -7,7 +7,7 @@ import { PnpmError } from '@pnpm/error'
 import type { TlsConfig } from '@pnpm/types'
 import { LRUCache } from 'lru-cache'
 import { SocksClient } from 'socks'
-import { Agent, type Dispatcher, ProxyAgent, setGlobalDispatcher } from 'undici'
+import { Agent, type Dispatcher, getGlobalDispatcher, ProxyAgent, setGlobalDispatcher } from 'undici'
 
 const DEFAULT_MAX_SOCKETS = 50
 const KEEP_ALIVE_TIMEOUT = 30_000 // 30 seconds
@@ -108,10 +108,14 @@ export function clearDispatcherCache (): void {
  * (https://github.com/nodejs/node/issues/56645).
  */
 export async function destroyDispatchers (): Promise<void> {
-  await Promise.allSettled([
-    GLOBAL_DISPATCHER.destroy(),
-    ...Array.from(DISPATCHER_CACHE.values(), dispatcher => dispatcher.destroy()),
+  // getGlobalDispatcher() is included in case something replaced GLOBAL_DISPATCHER
+  // via setGlobalDispatcher(); the Set removes the duplicate when it is still our own instance.
+  const dispatchers = new Set<Dispatcher>([
+    GLOBAL_DISPATCHER,
+    getGlobalDispatcher(),
+    ...DISPATCHER_CACHE.values(),
   ])
+  await Promise.allSettled(Array.from(dispatchers, dispatcher => dispatcher.destroy()))
 }
 
 /**

--- a/network/fetch/src/dispatcher.ts
+++ b/network/fetch/src/dispatcher.ts
@@ -100,6 +100,13 @@ export function clearDispatcherCache (): void {
   DISPATCHER_CACHE.clear()
 }
 
+/**
+ * Destroy the global dispatcher and every cached dispatcher, closing their open
+ * sockets. Intended for process shutdown only: once called, the module can no
+ * longer perform network requests. This is used to work around a Windows crash
+ * that happens when the process exits while sockets are still open
+ * (https://github.com/nodejs/node/issues/56645).
+ */
 export async function destroyDispatchers (): Promise<void> {
   await Promise.allSettled([
     GLOBAL_DISPATCHER.destroy(),

--- a/network/fetch/src/index.ts
+++ b/network/fetch/src/index.ts
@@ -1,4 +1,4 @@
-export { clearDispatcherCache, getDispatcher } from './dispatcher.js'
+export { clearDispatcherCache, destroyDispatchers, getDispatcher } from './dispatcher.js'
 export { fetch, isRedirect, type RetryTimeoutOptions } from './fetch.js'
 export { createDispatchedFetch, type CreateDispatchedFetchOptions, createFetchFromRegistry, type CreateFetchFromRegistryOptions, type DispatcherOptions, fetchWithDispatcher } from './fetchFromRegistry.js'
 export type { FetchFromRegistry } from '@pnpm/fetching.types'

--- a/network/fetch/test/dispatcher.test.ts
+++ b/network/fetch/test/dispatcher.test.ts
@@ -1,9 +1,9 @@
 /// <reference path="../../../__typings__/index.d.ts"/>
 import net from 'node:net'
 
-import { afterEach, describe, expect, test } from '@jest/globals'
-import { clearDispatcherCache, type DispatcherOptions, getDispatcher } from '@pnpm/network.fetch'
-import { Agent, ProxyAgent } from 'undici'
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
+import { clearDispatcherCache, destroyDispatchers, type DispatcherOptions, getDispatcher } from '@pnpm/network.fetch'
+import { Agent, getGlobalDispatcher, ProxyAgent } from 'undici'
 
 afterEach(() => {
   clearDispatcherCache()
@@ -268,5 +268,22 @@ describe('client certificates', () => {
     const d1 = getDispatcher('https://registry.example.com/foo', opts)
     const d2 = getDispatcher('https://other.example.com/foo', opts)
     expect(d1).not.toBe(d2) // different certs → different dispatchers
+  })
+})
+
+describe('destroyDispatchers', () => {
+  // The destroy() calls are mocked so the live global dispatcher survives the test run.
+  test('destroys the global dispatcher and every cached dispatcher without throwing', async () => {
+    const globalDestroySpy = jest.spyOn(getGlobalDispatcher(), 'destroy').mockResolvedValue()
+    const cached = getDispatcher('https://registry.npmjs.org/foo', { strictSsl: false })!
+    const cachedDestroySpy = jest.spyOn(cached, 'destroy').mockResolvedValue()
+    try {
+      await expect(destroyDispatchers()).resolves.toBeUndefined()
+      expect(globalDestroySpy).toHaveBeenCalled()
+      expect(cachedDestroySpy).toHaveBeenCalled()
+    } finally {
+      globalDestroySpy.mockRestore()
+      cachedDestroySpy.mockRestore()
+    }
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7811,6 +7811,9 @@ importers:
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../core/logger
+      '@pnpm/network.fetch':
+        specifier: workspace:*
+        version: link:../network/fetch
       '@pnpm/nopt':
         specifier: 'catalog:'
         version: 0.3.1

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -111,6 +111,7 @@
     "@pnpm/lockfile.fs": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*",
     "@pnpm/logger": "workspace:*",
+    "@pnpm/network.fetch": "workspace:*",
     "@pnpm/nopt": "catalog:",
     "@pnpm/patching.commands": "workspace:*",
     "@pnpm/pkg-manifest.commands": "workspace:*",

--- a/pnpm/src/errorHandler.ts
+++ b/pnpm/src/errorHandler.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util'
 import { logger } from '@pnpm/logger'
 import pidTree from 'pidtree'
 
+import { exit } from './exit.js'
 import { type Global, REPORTER_INITIALIZED } from './main.js'
 
 declare const global: Global
@@ -59,9 +60,5 @@ async function killProcesses (status: number): Promise<void> {
   } catch {
     // ignore error here
   }
-  if (process.platform === 'win32') {
-    // Work around https://github.com/nodejs/node/issues/56645.
-    await new Promise<void>((resolve) => setTimeout(resolve, 100))
-  }
-  process.exit(status)
+  await exit(status)
 }

--- a/pnpm/src/errorHandler.ts
+++ b/pnpm/src/errorHandler.ts
@@ -59,5 +59,9 @@ async function killProcesses (status: number): Promise<void> {
   } catch {
     // ignore error here
   }
+  if (process.platform === 'win32') {
+    // Work around https://github.com/nodejs/node/issues/56645.
+    await new Promise<void>((resolve) => setTimeout(resolve, 100))
+  }
   process.exit(status)
 }

--- a/pnpm/src/exit.ts
+++ b/pnpm/src/exit.ts
@@ -1,0 +1,12 @@
+export async function exit (status: number): Promise<never> {
+  if (process.platform === 'win32') {
+    try {
+      // Work around https://github.com/nodejs/node/issues/56645.
+      const { destroyDispatchers } = await import('@pnpm/network.fetch')
+      await destroyDispatchers()
+    } catch {
+      // ignore error here
+    }
+  }
+  process.exit(status)
+}

--- a/pnpm/src/switchCliVersion.ts
+++ b/pnpm/src/switchCliVersion.ts
@@ -12,6 +12,7 @@ import { createStoreController } from '@pnpm/store.connection-manager'
 import spawn from 'cross-spawn'
 import semver from 'semver'
 
+import { exit } from './exit.js'
 import { shouldPersistLockfile } from './shouldPersistLockfile.js'
 
 export async function switchCliVersion (config: Config, context: ConfigContext): Promise<void> {
@@ -129,7 +130,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
     return
   }
 
-  process.exit(status ?? 0)
+  await exit(status ?? 0)
 }
 
 class VersionSwitchFail extends PnpmError {

--- a/pnpm/test/install/global.ts
+++ b/pnpm/test/install/global.ts
@@ -408,9 +408,9 @@ test('global add in strict minimumReleaseAge mode reports the user-facing error'
   })
   const output = `${result.stdout.toString()}\n${result.stderr.toString()}`
 
-  expect(result.status).toBe(1)
   expect(output).toContain('ERR_PNPM_NO_MATURE_MATCHING_VERSION')
   expect(output).not.toContain('ERR_PNPM_RESOLUTION_POLICY_VIOLATIONS_UNHANDLED')
+  expect(result.status).toBe(1)
 })
 
 test('global update in loose minimumReleaseAge mode persists immature picks', () => {

--- a/pnpm/test/install/minimumReleaseAge.ts
+++ b/pnpm/test/install/minimumReleaseAge.ts
@@ -182,10 +182,10 @@ describe('lockfile minimumReleaseAge verification', () => {
       [PUBLIC_REGISTRY, 'install', '--frozen-lockfile'],
       omitMinReleaseAgeEnv
     )
-    expect(result.status).toBe(1)
     const output = `${result.stdout.toString()}\n${result.stderr.toString()}`
     expect(output).toContain('ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION')
     expect(output).toMatch(/is-odd@0\.1\.2/)
+    expect(result.status).toBe(1)
   })
 
   test('loose mode auto-adds fresh immature picks to minimumReleaseAgeExclude', () => {

--- a/pnpm/tsconfig.json
+++ b/pnpm/tsconfig.json
@@ -126,6 +126,9 @@
       "path": "../lockfile/types"
     },
     {
+      "path": "../network/fetch"
+    },
+    {
       "path": "../patching/commands"
     },
     {


### PR DESCRIPTION
## Summary

- destroy pnpm's Undici dispatchers before forced exits on Windows
- route registry-backed error exits and pnpm version-switch exits through the same helper
- report minimum-release-age validation output before asserting exit codes
- add patch changesets for `@pnpm/network.fetch` and `pnpm`

## Why

Windows CI intermittently exits with `3221226505` (`0xC0000409`) instead of pnpm's expected exit code after registry requests. The same crash appeared in:

- [PR #12075's Windows Node.js 22 job](https://github.com/pnpm/pnpm/actions/runs/26787835034/job/78970540782)
- [`main`'s Windows Node.js 24 job](https://github.com/pnpm/pnpm/actions/runs/26787569329/job/78970758777)
- [`main`'s Windows Node.js 26 job](https://github.com/pnpm/pnpm/actions/runs/26787569329/job/78970758819)
- [this PR's first Windows Node.js 22 job](https://github.com/pnpm/pnpm/actions/runs/26794713920/job/78989781301)

The first run of this PR reproduced the crash in the strict global-add regression:

```text
FAIL test/install/global.ts
  global add in strict minimumReleaseAge mode reports the user-facing error

  Expected: 1
  Received: 3221226505
```

[nodejs/node#56645](https://github.com/nodejs/node/issues/56645) reports the same Windows failure when `process.exit()` runs after network requests. [nodejs/node#61999](https://github.com/nodejs/node/pull/61999) is the open upstream fix.

`@pnpm/network.fetch` now retains the optimized global dispatcher and exposes `destroyDispatchers()`. On Windows, pnpm awaits dispatcher destruction before calling `process.exit()`. The forced exit remains in place because pnpm needs it for errors such as `pnpm install --silent` with unsatisfied dependencies.

## Validation

- `./node_modules/.bin/eslint pnpm/src/exit.ts pnpm/src/errorHandler.ts pnpm/src/switchCliVersion.ts network/fetch/src/dispatcher.ts network/fetch/src/index.ts pnpm/test/install/global.ts pnpm/test/install/minimumReleaseAge.ts`
- `./node_modules/.bin/tsgo --build network/fetch pnpm --pretty false`
- `npm_package_name=pnpm npm_package_version=11.5.0 node bundle.ts`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../../node_modules/.bin/jest test/dispatcher.test.ts --runInBand`
- `DISABLE_SFW=1 NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../node_modules/.bin/jest test/install/minimumReleaseAge.ts --runInBand`
- `DISABLE_SFW=1 NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../node_modules/.bin/jest test/install/global.ts --runInBand -t "global add in strict minimumReleaseAge mode reports the user-facing error"`
- `DISABLE_SFW=1 NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../node_modules/.bin/jest test/switchingVersions.test.ts --runInBand -t "switch to the pnpm version specified in the packageManager field of package.json"`
- `git diff --check upstream/main..HEAD`

Windows Actions is required to exercise the Windows-only dispatcher shutdown.

---
Written by an agent (Codex, GPT-5).

Sent by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents Node.js crashes on Windows by ensuring network dispatchers are cleaned up during shutdown; exit now performs orderly asynchronous cleanup.

* **Tests**
  * Added tests for dispatcher cleanup and reordered assertions to check user-facing output before exit status.

* **Chores**
  * Added the network-fetch package to dev dependencies and updated TypeScript project references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->