### PR TITLE
[pnpm] kill timed-out test child processes

### DIFF
--- a/pnpm/test/dlx.ts
+++ b/pnpm/test/dlx.ts
@@ -320,7 +320,7 @@ test('dlx creates cache and store prune cleans cache', async () => {
 
   const commands = {
     shx: ['echo', 'hello from shx'],
-    'shelljs/shx#61aca968cd7afc712ca61a4fc4ec3201e3770dc7': ['echo', 'hello from shx.git'],
+    'shx@0.3.3': ['echo', 'hello from shx@0.3.3'],
     '@pnpm.e2e/touch-file-good-bin-name': [],
     '@pnpm.e2e/touch-file-one-bin': [],
   } satisfies Record<string, string[]>

--- a/pnpm/test/execPnpm.test.ts
+++ b/pnpm/test/execPnpm.test.ts
@@ -1,0 +1,65 @@
+import type { ChildProcess } from 'node:child_process'
+
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+import { registerProcessTimeout } from './utils/execPnpm.js'
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('kills a process that does not exit gracefully after timing out', () => {
+  jest.useFakeTimers()
+  const proc = {
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: jest.fn((_signal?: NodeJS.Signals | number) => true),
+  }
+  const onTimeout = jest.fn()
+
+  registerProcessTimeout(proc as unknown as ChildProcess, 100, onTimeout)
+
+  jest.advanceTimersByTime(100)
+  expect(onTimeout).toHaveBeenCalledWith(new Error('Command timed out after 100ms'))
+  expect(proc.kill).toHaveBeenCalledWith('SIGINT')
+
+  jest.advanceTimersByTime(10_000)
+  expect(proc.kill).toHaveBeenCalledTimes(2)
+  expect(proc.kill).toHaveBeenLastCalledWith()
+})
+
+test('does not kill a process again if it exits gracefully after timing out', () => {
+  jest.useFakeTimers()
+  const proc = {
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    kill: jest.fn((_signal?: NodeJS.Signals | number) => true),
+  }
+
+  registerProcessTimeout(proc as unknown as ChildProcess, 100, jest.fn())
+
+  jest.advanceTimersByTime(100)
+  proc.exitCode = 0
+  jest.advanceTimersByTime(10_000)
+  expect(proc.kill).toHaveBeenCalledTimes(1)
+})
+
+test('does not kill a process again if it receives a signal after timing out', () => {
+  jest.useFakeTimers()
+  const proc = {
+    exitCode: null as number | null,
+    kill: jest.fn((_signal?: NodeJS.Signals | number) => true),
+    signalCode: null as NodeJS.Signals | null,
+  }
+  const onTimeout = jest.fn()
+
+  registerProcessTimeout(proc as unknown as ChildProcess, 100, onTimeout)
+
+  jest.advanceTimersByTime(100)
+  expect(onTimeout).toHaveBeenCalledWith(new Error('Command timed out after 100ms'))
+  expect(proc.kill).toHaveBeenCalledWith('SIGINT')
+
+  proc.signalCode = 'SIGINT'
+  jest.advanceTimersByTime(10_000)
+  expect(proc.kill).toHaveBeenCalledTimes(1)
+})

--- a/pnpm/test/utils/execPnpm.ts
+++ b/pnpm/test/utils/execPnpm.ts
@@ -224,7 +224,7 @@ function createEnv (opts?: { storeDir?: string, omitEnvDefaults?: PnpmEnvDefault
   return env
 }
 
-function registerProcessTimeout (proc: NodeChildProcess, timeout: number, onTimeout: (reason: Error) => void) {
+export function registerProcessTimeout (proc: NodeChildProcess, timeout: number, onTimeout: (reason: Error) => void): ReturnType<typeof setTimeout> {
   return setTimeout(() => {
     onTimeout(new Error(`Command timed out after ${timeout}ms`))
 
@@ -234,7 +234,7 @@ function registerProcessTimeout (proc: NodeChildProcess, timeout: number, onTime
     proc.kill('SIGINT')
 
     setTimeout(() => {
-      if (proc.exitCode != null) {
+      if (proc.exitCode == null && proc.signalCode == null) {
         proc.kill()
       }
     }, TIMEOUT_FOR_GRACEFUL_EXIT)


### PR DESCRIPTION
## Summary

- force-kill test child processes that remain alive after the graceful timeout
- avoid sending the fallback kill after a child exits normally or from a signal
- remove an unnecessary GitHub git fetch from the `dlx` cache-prune regression
- add fake-timer coverage for all three outcomes

## Why

Windows CI has recurring `dlx creates cache and store prune cleans cache` timeouts:

- [`main` Windows Node.js 24 job](https://github.com/pnpm/pnpm/actions/runs/26766645530/job/78902890506)
- [PR #12121 Windows Node.js 22 job](https://github.com/pnpm/pnpm/actions/runs/26794713920/job/78989781301)

Both jobs report:

```text
dlx creates cache and store prune cleans cache
Command timed out after 180000ms
    at Timeout._onTimeout (test/utils/execPnpm.ts:229:15)
```

This timeout is independent of [PR #12121](https://github.com/pnpm/pnpm/pull/12121): it reproduced on `main` before the Windows dispatcher-shutdown change.

`registerProcessTimeout()` sends `SIGINT`, waits 10 seconds, and then tries to kill a child that did not exit gracefully. The fallback condition was inverted: it killed children with an exit code and left children that were still running alone. The fallback now runs only while both `exitCode` and `signalCode` remain unset.

The cache-prune regression also installed a git-backed `shelljs/shx` revision even though git resolution is unrelated to cache pruning and is covered separately by `exec/commands/test/dlx.e2e.ts`. It now installs `shx@0.3.3` from the registry instead.

## Validation

- `./node_modules/.bin/eslint pnpm/test/utils/execPnpm.ts pnpm/test/execPnpm.test.ts`
- `./node_modules/.bin/tsgo --build pnpm --pretty false`
- `NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../node_modules/.bin/jest test/execPnpm.test.ts --runInBand --preset @pnpm/jest-config`
- `DISABLE_SFW=1 PNPR_PREPARE_BIN="$PWD/../target/debug/pnpr-prepare" PNPR_BIN="$PWD/../target/debug/pnpr" NODE_OPTIONS="--experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169" ../node_modules/.bin/jest test/dlx.ts --runInBand -t "dlx creates cache and store prune cleans cache"`
- `git diff --check upstream/main..HEAD`
- `printf 'test: kill lingering pnpm processes after timeout\n' | ./node_modules/.bin/commitlint --verbose`

The timeout-helper unit tests passed locally: 3 tests. The exact cache-prune regression passed locally: 1 test.

---
Written by an agent (Codex, GPT-5).

Sent by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for process timeout behavior, including comprehensive validation of graceful command termination, proper error handling, and signal delivery to child processes.
  * Enhanced test utilities for cache and store operations with improved process lifecycle management and more rigorous reliability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->