### PR TITLE
feat(pacquet): wire pnpmfile context.log to the pnpm:hook channel

### DIFF
--- a/pacquet/crates/hooks/src/lib.rs
+++ b/pacquet/crates/hooks/src/lib.rs
@@ -7,6 +7,8 @@ pub mod finder;
 pub mod node_runtime;
 pub mod worker;
 
+pub use worker::LogFn;
+
 /// Represents the results of a `readPackage` hook.
 pub type ReadPackageResult = Arc<Value>;
 
@@ -77,6 +79,13 @@ pub trait PnpmfileHooks: Send + Sync {
 
     /// `filterLog` hook: determines if a log message should be emitted.
     async fn filter_log(&self, log: Value, ctx: HookContext) -> bool;
+
+    /// Path of the pnpmfile that defines these hooks, used as the `from`
+    /// field of `pnpm:hook` log events. `None` for hook sets not backed by
+    /// a file (e.g. the no-op).
+    fn source_path(&self) -> Option<&std::path::Path> {
+        None
+    }
 }
 
 /// A no-op implementation of `PnpmfileHooks`.

--- a/pacquet/crates/hooks/src/node_runtime.rs
+++ b/pacquet/crates/hooks/src/node_runtime.rs
@@ -171,4 +171,8 @@ impl crate::PnpmfileHooks for NodeJsHooks {
             Err(_) => true,
         }
     }
+
+    fn source_path(&self) -> Option<&std::path::Path> {
+        Some(&self.file)
+    }
 }

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -7,7 +7,7 @@ use pacquet_modules_yaml::{
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
-    BrokenModulesLog, ContextLog, IgnoredScriptsLog, LogEvent, PackageManifestLog,
+    BrokenModulesLog, ContextLog, HookLog, IgnoredScriptsLog, LogEvent, PackageManifestLog,
     PackageManifestMessage, ProgressLog, ProgressMessage, Reporter, SilentReporter, Stage,
     StageLog, StatsLog, StatsMessage, SummaryLog,
 };
@@ -6054,6 +6054,19 @@ async fn install_with_pnpmfile(
     root_deps: &[(&str, &str)],
     pnpmfile_src: &str,
 ) -> Result<(), InstallError> {
+    install_with_pnpmfile_reporter::<SilentReporter>(registry_url, root, root_deps, pnpmfile_src)
+        .await
+}
+
+/// Same as [`install_with_pnpmfile`] but routes install events through the
+/// given reporter, so a recording reporter can assert on the `pnpm:hook`
+/// log channel.
+async fn install_with_pnpmfile_reporter<Reporter: self::Reporter + 'static>(
+    registry_url: String,
+    root: &std::path::Path,
+    root_deps: &[(&str, &str)],
+    pnpmfile_src: &str,
+) -> Result<(), InstallError> {
     let modules_dir = root.join("node_modules");
     let virtual_store_dir = modules_dir.join(".pacquet");
 
@@ -6096,7 +6109,7 @@ async fn install_with_pnpmfile(
         resolved_packages: &Default::default(),
         update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
     }
-    .run::<SilentReporter>()
+    .run::<Reporter>()
     .await
 }
 
@@ -6223,4 +6236,135 @@ async fn after_all_resolved_hook_failure_aborts_install() {
     .await;
 
     assert!(result.is_err(), "install must fail when afterAllResolved throws");
+}
+
+/// The first `pnpm:hook` event in `events`, or panic.
+fn first_hook_log(events: &[LogEvent]) -> &HookLog {
+    events
+        .iter()
+        .find_map(|event| match event {
+            LogEvent::Hook(log) => Some(log),
+            _ => None,
+        })
+        .expect("a pnpm:hook event must be emitted")
+}
+
+// Ports pnpm's `pnpmfile: pass log function to readPackage hook`
+// (pnpm/test/install/hooks.ts): a `readPackage` hook's `context.log(...)`
+// surfaces on the `pnpm:hook` channel with the pnpmfile path (`from`), the
+// project (`prefix`), the hook name, and the message.
+#[tokio::test]
+async fn read_package_hook_log_is_forwarded_to_pnpm_hook_channel() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile_reporter::<RecordingReporter>(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r#"module.exports = { hooks: { readPackage (pkg, context) {
+  if (pkg.name === '@pnpm.e2e/pkg-with-1-dep') {
+    pkg.dependencies['@pnpm.e2e/dep-of-pkg-with-1-dep'] = '100.0.0';
+    context.log('@pnpm.e2e/dep-of-pkg-with-1-dep pinned to 100.0.0');
+  }
+  return pkg;
+} } }"#,
+    )
+    .await
+    .expect("install should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+    let hook_log = first_hook_log(&captured);
+    assert_eq!(hook_log.hook, "readPackage");
+    assert_eq!(hook_log.message, "@pnpm.e2e/dep-of-pkg-with-1-dep pinned to 100.0.0");
+    assert!(!hook_log.from.is_empty(), "from must be the pnpmfile path");
+    assert!(!hook_log.prefix.is_empty(), "prefix must be the project dir");
+
+    drop((dir, registry));
+}
+
+// Ports pnpm's `pnpmfile: run afterAllResolved hook`: an `afterAllResolved`
+// hook's `context.log(...)` surfaces on the `pnpm:hook` channel.
+#[tokio::test]
+async fn after_all_resolved_hook_log_is_forwarded_to_pnpm_hook_channel() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile_reporter::<RecordingReporter>(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r#"module.exports = { hooks: { afterAllResolved (lockfile, context) {
+  context.log('All resolved');
+  return lockfile;
+} } }"#,
+    )
+    .await
+    .expect("install should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+    let hook_log = first_hook_log(&captured);
+    assert_eq!(hook_log.hook, "afterAllResolved");
+    assert_eq!(hook_log.message, "All resolved");
+    assert!(!hook_log.from.is_empty(), "from must be the pnpmfile path");
+    assert!(!hook_log.prefix.is_empty(), "prefix must be the project dir");
+
+    drop((dir, registry));
+}
+
+// Ports pnpm's `pnpmfile: run async afterAllResolved hook`: an async
+// `afterAllResolved` hook's `context.log(...)` also surfaces on `pnpm:hook`.
+#[tokio::test]
+async fn async_after_all_resolved_hook_log_is_forwarded_to_pnpm_hook_channel() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let registry = TestRegistry::start();
+    let dir = tempdir().unwrap();
+
+    install_with_pnpmfile_reporter::<RecordingReporter>(
+        registry.url(),
+        dir.path(),
+        &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")],
+        r#"module.exports = { hooks: { async afterAllResolved (lockfile, context) {
+  context.log('All resolved');
+  return lockfile;
+} } }"#,
+    )
+    .await
+    .expect("install should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+    let hook_log = first_hook_log(&captured);
+    assert_eq!(hook_log.hook, "afterAllResolved");
+    assert_eq!(hook_log.message, "All resolved");
+
+    drop((dir, registry));
 }

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -19,7 +19,7 @@ use pacquet_hooks::finder;
 use pacquet_lockfile::{Lockfile, LockfileResolution, SaveLockfileError};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_reporter::{LogEvent, LogLevel, Reporter, Stage, StageLog};
+use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter, Stage, StageLog};
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
     ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
@@ -833,6 +833,18 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // the `afterAllResolved` hook can transform the lockfile before it is
         // written.
         let after_all_resolved_hook = pnpmfile_hook.clone();
+        // Pre-bind the reporter, project prefix, and pnpmfile path into the
+        // `context.log(...)` sinks so the resolver and lockfile writer stay
+        // reporter-agnostic. Mirrors pnpm's `createReadPackageHookContext`,
+        // which forwards each hook's `context.log` to the `pnpm:hook` channel.
+        let pnpmfile_path =
+            pnpmfile_hook.as_ref().and_then(|hook| hook.source_path()).map(Path::to_path_buf);
+        let read_package_log = pnpmfile_path
+            .as_ref()
+            .map(|from| hook_log_fn::<Reporter>(lockfile_dir, from, "readPackage"));
+        let after_all_resolved_log = pnpmfile_path
+            .as_ref()
+            .map(|from| hook_log_fn::<Reporter>(lockfile_dir, from, "afterAllResolved"));
 
         // Call preResolution hook before resolution starts (mirrors pnpm's behavior in install/index.ts)
         if let Some(ref hook) = pnpmfile_hook {
@@ -878,6 +890,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             peers_suffix_max_length,
             manifest_hook: package_extensions_hook.clone(),
             pnpmfile_hook,
+            read_package_log,
             pick_lowest_direct,
             time_based,
             // Hand the resolver the prior lockfile so it can reuse
@@ -1039,6 +1052,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
                     &built_lockfile,
                     &lockfile_dir.join(Lockfile::FILE_NAME),
                     after_all_resolved_hook.as_ref(),
+                    after_all_resolved_log.clone(),
                 )
                 .await?;
                 Some(built_lockfile)
@@ -1482,8 +1496,13 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // `.modules.yaml` to land first.
         let wanted_lockfile = if config.lockfile {
             let target = lockfile_dir.join(Lockfile::FILE_NAME);
-            save_wanted_lockfile(&built_lockfile, &target, after_all_resolved_hook.as_ref())
-                .await?;
+            save_wanted_lockfile(
+                &built_lockfile,
+                &target,
+                after_all_resolved_hook.as_ref(),
+                after_all_resolved_log.clone(),
+            )
+            .await?;
             Some(built_lockfile)
         } else {
             None
@@ -1560,6 +1579,29 @@ fn collect_prefetch_cache_keys_from_graph(
     keys
 }
 
+/// Build the `context.log(...)` sink a pnpmfile hook forwards to: each
+/// `context.log(message)` call emits a `pnpm:hook` event through the
+/// install's reporter, carrying the project `prefix`, the pnpmfile path
+/// (`from`), and the hook name. Mirrors pnpm's `createReadPackageHookContext`,
+/// which routes `context.log` to `hookLogger.debug({ from, hook, message, prefix })`.
+fn hook_log_fn<Reporter: self::Reporter>(
+    prefix: &Path,
+    from: &Path,
+    hook: &'static str,
+) -> pacquet_hooks::LogFn {
+    let prefix = prefix.to_string_lossy().into_owned();
+    let from = from.to_string_lossy().into_owned();
+    Arc::new(move |message: String| {
+        Reporter::emit(&LogEvent::Hook(HookLog {
+            level: LogLevel::Debug,
+            from: from.clone(),
+            hook: hook.to_string(),
+            message,
+            prefix: prefix.clone(),
+        }));
+    })
+}
+
 /// Write the freshly-built wanted lockfile to `target`, first running the
 /// `afterAllResolved` pnpmfile hook when one is configured.
 ///
@@ -1573,6 +1615,7 @@ async fn save_wanted_lockfile(
     built_lockfile: &Lockfile,
     target: &Path,
     hook: Option<&Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+    log: Option<pacquet_hooks::LogFn>,
 ) -> Result<(), InstallWithFreshLockfileError> {
     let Some(hook) = hook else {
         return built_lockfile
@@ -1582,7 +1625,7 @@ async fn save_wanted_lockfile(
 
     let value = serde_json::to_value(built_lockfile)
         .map_err(InstallWithFreshLockfileError::AfterAllResolvedSerialize)?;
-    let ctx = pacquet_hooks::HookContext { log: Arc::new(|_| {}) };
+    let ctx = pacquet_hooks::HookContext { log: log.unwrap_or_else(|| Arc::new(|_| {})) };
     let result = hook
         .after_all_resolved(value, ctx)
         .await

--- a/pacquet/crates/reporter/src/lib.rs
+++ b/pacquet/crates/reporter/src/lib.rs
@@ -200,6 +200,17 @@ pub enum LogEvent {
     /// [`cli/default-reporter/src/index.ts:222`](https://github.com/pnpm/pnpm/blob/a456dc78fb/cli/default-reporter/src/index.ts#L222).
     #[serde(rename = "pnpm")]
     Pnpm(PnpmLog),
+
+    /// One per `context.log(...)` call a pnpmfile hook makes while it
+    /// runs (`pnpm:hook`). `readPackage` and `afterAllResolved` hooks
+    /// receive a `context` whose `log` forwards here, so a pnpmfile can
+    /// surface why it rewrote a manifest or lockfile. `@pnpm/cli.default-reporter`
+    /// routes these into the "other" log stream.
+    ///
+    /// Upstream: <https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/hookLogger.ts>.
+    /// Emit site: <https://github.com/pnpm/pnpm/blob/3b12eb27de/hooks/pnpmfile/src/requireHooks.ts#L244-L249>.
+    #[serde(rename = "pnpm:hook")]
+    Hook(HookLog),
 }
 
 /// `pnpm:context` payload.
@@ -724,6 +735,21 @@ pub enum LockfileVerificationMessage {
 #[derive(Debug, Clone, Serialize)]
 pub struct PnpmLog {
     pub level: LogLevel,
+    pub message: String,
+    pub prefix: String,
+}
+
+/// `pnpm:hook` payload. Field names match pnpm's `HookMessage` so
+/// `@pnpm/cli.default-reporter` accepts the record unchanged. `from`
+/// is the pnpmfile that defined the hook, `hook` is the hook name
+/// (`readPackage` / `afterAllResolved`), `prefix` is the project the
+/// hook ran for, and `message` is the string passed to `context.log`.
+/// The hook context logger emits at `debug`.
+#[derive(Debug, Clone, Serialize)]
+pub struct HookLog {
+    pub level: LogLevel,
+    pub from: String,
+    pub hook: String,
     pub message: String,
     pub prefix: String,
 }

--- a/pacquet/crates/reporter/src/tests.rs
+++ b/pacquet/crates/reporter/src/tests.rs
@@ -6,13 +6,13 @@ use serde_json::Value;
 
 use crate::{
     AddedRoot, BrokenModulesLog, ContextLog, DependencyType, Envelope, FetchingProgressLog,
-    FetchingProgressMessage, GetHostName, Host, IgnoredScriptsLog, LifecycleLog, LifecycleMessage,
-    LifecycleStdio, LockfileVerificationLog, LockfileVerificationMessage, LogEvent, LogLevel,
-    PackageImportMethod, PackageImportMethodLog, PackageManifestLog, PackageManifestMessage,
-    PnpmLog, ProgressLog, ProgressMessage, RemovedRoot, Reporter, RequestRetryError,
-    RequestRetryLog, RootLog, RootMessage, SilentReporter, SkippedOptionalDependencyLog,
-    SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
-    SummaryLog,
+    FetchingProgressMessage, GetHostName, HookLog, Host, IgnoredScriptsLog, LifecycleLog,
+    LifecycleMessage, LifecycleStdio, LockfileVerificationLog, LockfileVerificationMessage,
+    LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
+    PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage, RemovedRoot, Reporter,
+    RequestRetryError, RequestRetryLog, RootLog, RootMessage, SilentReporter,
+    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalReason, Stage, StageLog,
+    StatsLog, StatsMessage, SummaryLog,
 };
 
 /// Context log serializes with the camelCase field names
@@ -118,6 +118,35 @@ fn pnpm_event_matches_pnpm_wire_shape() {
     assert_eq!(json["name"], "pnpm");
     assert_eq!(json["level"], "info");
     assert_eq!(json["message"], "Lockfile is up to date, resolution step is skipped");
+    assert_eq!(json["prefix"], "/some/project");
+}
+
+/// Hook log (`name: "pnpm:hook"`) carries the `from` / `hook` /
+/// `message` / `prefix` fields pnpm's `hookLogger` emits, at the
+/// `debug` level the hook-context logger uses. `@pnpm/cli.default-reporter`
+/// dispatches on these to attribute the message to its pnpmfile.
+#[test]
+fn hook_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Hook(HookLog {
+        level: LogLevel::Debug,
+        from: "/some/project/.pnpmfile.cjs".to_string(),
+        hook: "readPackage".to_string(),
+        message: "is-positive pinned to 1.0.0".to_string(),
+        prefix: "/some/project".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm:hook");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["from"], "/some/project/.pnpmfile.cjs");
+    assert_eq!(json["hook"], "readPackage");
+    assert_eq!(json["message"], "is-positive pinned to 1.0.0");
     assert_eq!(json["prefix"], "/some/project");
 }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -425,6 +425,11 @@ pub struct WorkspaceTreeCtx {
     /// subtree can be synthesized from the prior lockfile.
     subtree_reusable: Mutex<HashMap<PkgNameVerPeer, bool>>,
     pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
+    /// `context.log(...)` sink for the `pnpmfile_hook`'s `readPackage`
+    /// calls, pre-bound to the install's reporter, project prefix, and
+    /// pnpmfile path. `None` leaves hook logging a no-op. See
+    /// [`WorkspaceTreeCtx::with_read_package_log`].
+    read_package_log: Option<pacquet_hooks::LogFn>,
 }
 
 impl Default for WorkspaceTreeCtx {
@@ -443,6 +448,7 @@ impl Default for WorkspaceTreeCtx {
             update_reuse_scope: UpdateReuseScope::All,
             subtree_reusable: Mutex::new(HashMap::new()),
             pnpmfile_hook: None,
+            read_package_log: None,
         }
     }
 }
@@ -498,6 +504,15 @@ impl WorkspaceTreeCtx {
 
     pub fn with_pnpmfile_hook(mut self, pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>) -> Self {
         self.pnpmfile_hook = pnpmfile_hook;
+        self
+    }
+
+    /// Attach the `context.log(...)` sink the `pnpmfile_hook`'s
+    /// `readPackage` calls forward to. The install layer pre-binds the
+    /// reporter, project prefix, and pnpmfile path into the closure so the
+    /// resolver stays reporter-agnostic.
+    pub fn with_read_package_log(mut self, read_package_log: Option<pacquet_hooks::LogFn>) -> Self {
+        self.read_package_log = read_package_log;
         self
     }
 
@@ -869,7 +884,9 @@ where
             if let Some(pnpmfile_hook) = ctx.workspace.pnpmfile_hook.as_ref()
                 && let Some(manifest) = result_inner.manifest.take()
             {
-                let hook_ctx = pacquet_hooks::HookContext { log: Arc::new(|_| {}) };
+                let log =
+                    ctx.workspace.read_package_log.clone().unwrap_or_else(|| Arc::new(|_| {}));
+                let hook_ctx = pacquet_hooks::HookContext { log };
 
                 let updated = pnpmfile_hook
                     .read_package((*manifest).clone(), hook_ctx)

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -94,6 +94,10 @@ pub struct ResolveDependencyTreeOptions {
     pub patched_dependencies: Option<Arc<PatchGroupRecord>>,
     pub manifest_hook: Option<ManifestHook>,
     pub pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
+    /// `context.log(...)` sink for the `pnpmfile_hook`'s `readPackage`
+    /// calls. `None` leaves hook logging a no-op. See
+    /// [`WorkspaceTreeCtx::with_read_package_log`].
+    pub read_package_log: Option<pacquet_hooks::LogFn>,
 }
 
 impl std::fmt::Debug for ResolveDependencyTreeOptions {
@@ -103,6 +107,7 @@ impl std::fmt::Debug for ResolveDependencyTreeOptions {
             .field("patched_dependencies", &self.patched_dependencies)
             .field("manifest_hook", &self.manifest_hook.as_ref().map(|_| "<hook>"))
             .field("pnpmfile_hook", &self.pnpmfile_hook.as_ref().map(|_| "<hook>"))
+            .field("read_package_log", &self.read_package_log.as_ref().map(|_| "<log>"))
             .finish()
     }
 }
@@ -228,7 +233,8 @@ where
     let ctx = TreeCtx::new(opts.base_opts)
         .with_patched_dependencies(opts.patched_dependencies)
         .with_manifest_hook(opts.manifest_hook)
-        .with_pnpmfile_hook(opts.pnpmfile_hook);
+        .with_pnpmfile_hook(opts.pnpmfile_hook)
+        .with_read_package_log(opts.read_package_log);
     let optional_names = importer_optional_dependency_names(manifest);
     let injected_names = importer_injected_dependency_names(manifest);
     let mut wanted: Vec<WantedSpec> = Vec::new();
@@ -678,6 +684,19 @@ impl TreeCtx {
         Arc::get_mut(&mut self.workspace)
             .expect("with_pnpmfile_hook called after the workspace ctx was shared via Arc::clone")
             .pnpmfile_hook = pnpmfile_hook;
+        self
+    }
+
+    /// Attach the `context.log(...)` sink the `pnpmfile_hook`'s
+    /// `readPackage` calls forward to. Like [`Self::with_pnpmfile_hook`],
+    /// this targets the underlying [`WorkspaceTreeCtx`] and panics if it
+    /// has already been shared via `Arc::clone`.
+    pub fn with_read_package_log(mut self, read_package_log: Option<pacquet_hooks::LogFn>) -> Self {
+        Arc::get_mut(&mut self.workspace)
+            .expect(
+                "with_read_package_log called after the workspace ctx was shared via Arc::clone",
+            )
+            .read_package_log = read_package_log;
         self
     }
 

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -94,6 +94,11 @@ pub struct WorkspaceResolveOptions {
     /// enters the wanted-dep cache. Workspace-wide (one hook per
     /// install); wraps `readPackage` from `.pnpmfile.cjs` / `pnpmfile.cjs`.
     pub pnpmfile_hook: Option<Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+
+    /// `context.log(...)` sink for the `pnpmfile_hook`'s `readPackage`
+    /// calls, pre-bound to the install's reporter. `None` leaves hook
+    /// logging a no-op.
+    pub read_package_log: Option<pacquet_hooks::LogFn>,
 }
 
 /// Result of [`fn@resolve_workspace`]. The combined
@@ -134,6 +139,7 @@ where
         peers_suffix_max_length,
         manifest_hook,
         pnpmfile_hook,
+        read_package_log,
         pick_lowest_direct,
         time_based,
         wanted_lockfile,
@@ -144,7 +150,8 @@ where
             .with_manifest_hook(manifest_hook)
             .with_wanted_lockfile(wanted_lockfile)
             .with_update_reuse_scope(update_reuse_scope)
-            .with_pnpmfile_hook(pnpmfile_hook),
+            .with_pnpmfile_hook(pnpmfile_hook)
+            .with_read_package_log(read_package_log),
     );
 
     // Build every importer's options up front so the `time-based`

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -132,6 +132,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         peers_suffix_max_length: 1000,
         manifest_hook: None,
         pnpmfile_hook: None,
+        read_package_log: None,
         pick_lowest_direct,
         time_based,
         wanted_lockfile: None,

--- a/pacquet/crates/resolving-deps-resolver/src/tests.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/tests.rs
@@ -118,6 +118,7 @@ async fn walks_dependencies_and_builds_flat_tree() {
             patched_dependencies: None,
             manifest_hook: None,
             pnpmfile_hook: None,
+            read_package_log: None,
         },
     )
     .await
@@ -187,6 +188,7 @@ async fn dedupes_when_the_same_package_appears_in_two_subtrees() {
             patched_dependencies: None,
             manifest_hook: None,
             pnpmfile_hook: None,
+            read_package_log: None,
         },
     )
     .await
@@ -272,6 +274,7 @@ async fn workspace_link_node_is_short_circuited_in_tree() {
             patched_dependencies: None,
             manifest_hook: None,
             pnpmfile_hook: None,
+            read_package_log: None,
         },
     )
     .await
@@ -313,6 +316,7 @@ async fn declined_specifier_surfaces_spec_not_supported_error() {
             patched_dependencies: None,
             manifest_hook: None,
             pnpmfile_hook: None,
+            read_package_log: None,
         },
     )
     .await
@@ -357,6 +361,7 @@ async fn transitive_dep_with_traversal_alias_is_rejected() {
             patched_dependencies: None,
             manifest_hook: None,
             pnpmfile_hook: None,
+            read_package_log: None,
         },
     )
     .await
@@ -435,6 +440,7 @@ mod block_exotic_subdeps {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -477,6 +483,7 @@ mod block_exotic_subdeps {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -520,6 +527,7 @@ mod block_exotic_subdeps {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -565,6 +573,7 @@ mod block_exotic_subdeps {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -607,6 +616,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -659,6 +669,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -709,6 +720,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -762,6 +774,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -886,6 +899,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -965,6 +979,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1014,6 +1029,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1111,6 +1127,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1206,6 +1223,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1313,6 +1331,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1382,6 +1401,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1492,6 +1512,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1600,6 +1621,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1710,6 +1732,7 @@ mod peers {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1803,6 +1826,7 @@ mod patched_dependencies {
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1851,6 +1875,7 @@ mod patched_dependencies {
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1885,6 +1910,7 @@ mod patched_dependencies {
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -1935,6 +1961,7 @@ mod patched_dependencies {
                 patched_dependencies: Some(Arc::new(groups)),
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -2005,6 +2032,7 @@ mod optional_propagation {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -2060,6 +2088,7 @@ mod optional_propagation {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -2125,6 +2154,7 @@ mod optional_propagation {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await
@@ -2178,6 +2208,7 @@ mod optional_propagation {
                 patched_dependencies: None,
                 manifest_hook: None,
                 pnpmfile_hook: None,
+                read_package_log: None,
             },
         )
         .await


### PR DESCRIPTION
## What

Wires each pnpmfile hook's `context.log(...)` call to a new `pnpm:hook`
reporter channel, so a `readPackage` or `afterAllResolved` hook can surface
*why* it rewrote a manifest or lockfile. Before this change the log closure at
both call sites was a no-op.

This is **item 1** of the pnpmfile-hooks tracking issue #12118.

## How

- **`reporter`**: new `LogEvent::Hook` variant (`name: "pnpm:hook"`) with a
  `HookLog` payload — `from` / `hook` / `message` / `prefix`, at `debug`
  level — mirroring pnpm's [`hookLogger`](https://github.com/pnpm/pnpm/blob/3b12eb27de/core/core-loggers/src/hookLogger.ts).
  Added a wire-shape unit test.
- **`hooks`**: re-exported `LogFn`; added `PnpmfileHooks::source_path()`
  (the hook's `from`), overridden by `NodeJsHooks`.
- **`resolving-deps-resolver`**: threaded a pre-bound
  `read_package_log: Option<LogFn>` through `WorkspaceResolveOptions` into the
  shared `WorkspaceTreeCtx`, consumed at the `readPackage` call site.
- **`package-manager`**: a `hook_log_fn::<R>()` helper builds the
  `context.log` sink, capturing `R::emit`, the project prefix, and the
  pnpmfile path; wired into both the `readPackage` path and the
  `afterAllResolved` (`save_wanted_lockfile`) path.

### Design note

The issue suggested making `resolve_dependency_tree` generic over `Reporter`.
Instead, the install layer pre-binds the reporter into a `LogFn` closure and
threads it as a plain `Arc<dyn Fn(String)>`. This keeps the resolver
reporter-agnostic and avoids monomorphizing the entire tree walker over `R` —
matching how the resolver already takes the `dyn PnpmfileHooks` boundary.

## Tests

Ports from `pnpm/test/install/hooks.ts`:
- `pnpmfile: pass log function to readPackage hook`
- `pnpmfile: run afterAllResolved hook`
- `pnpmfile: run async afterAllResolved hook`

Each was verified to fail when the wiring is reverted. The
*"...of global and local pnpmfile"* log test is deferred to items (3)
`--global-pnpmfile` and (4) multiple pnpmfiles, which it depends on.

`cargo fmt`, full-workspace `check` + `clippy --deny warnings`,
`cargo doc -D warnings`, `typos`, and all touched test suites pass.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * pnpmfile hooks now emit structured "pnpm:hook" log events that include hook source path, hook name, message, level, and project prefix; these are surfaced through the normal reporter so hook logs are visible during installs.

* **Tests**
  * Added tests verifying hook logs for readPackage and afterAllResolved (sync and async) are emitted with expected fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->