### PR TITLE
chore(release): 11.5.1

### DIFF
--- a/.changeset-released/release-11-5-1.txt
+++ b/.changeset-released/release-11-5-1.txt
@@ -1,0 +1,8 @@
+audit-path-traversal-performance
+fix-workspace-state-race
+lucky-user-agent
+pnpm-agent-shield-license
+preserve-tarball-integrity-on-reresolution
+publish-normalize-repository
+steady-optional-peers
+twelve-peers-diamond

--- a/.changeset/audit-path-traversal-performance.md
+++ b/.changeset/audit-path-traversal-performance.md
@@ -1,6 +1,0 @@
----
-"@pnpm/deps.compliance.audit": patch
-"pnpm": patch
----
-
-Improve `pnpm audit` performance by pruning non-vulnerable lockfile subtrees and stopping path enumeration once vulnerable findings reach the path cap.

--- a/.changeset/fix-workspace-state-race.md
+++ b/.changeset/fix-workspace-state-race.md
@@ -1,6 +1,0 @@
----
-"@pnpm/workspace.state": patch
-"pnpm": patch
----
-
-Avoid crashing when the workspace state cache is partially written or malformed.

--- a/.changeset/lucky-user-agent.md
+++ b/.changeset/lucky-user-agent.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-restorer": patch
-"pnpm": patch
----
-
-Set `npm_config_user_agent` for root lifecycle scripts during headless installs.

--- a/.changeset/pnpm-agent-shield-license.md
+++ b/.changeset/pnpm-agent-shield-license.md
@@ -1,5 +1,0 @@
----
-"pnpm-agent": patch
----
-
-`pnpm-agent` is now source-available under the [PolyForm Shield License 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) instead of MIT. It may be run, modified, and self-hosted for any purpose except providing a product that competes with it.

--- a/.changeset/preserve-tarball-integrity-on-reresolution.md
+++ b/.changeset/preserve-tarball-integrity-on-reresolution.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Preserve the `integrity` field of a remote (non-registry) tarball dependency when its lockfile entry is rebuilt. Re-resolving such a dependency without re-fetching it (for example via `pnpm update`, or when another dependency changes) produced a resolution with no integrity — URL/tarball resolvers only learn the integrity after the tarball is downloaded — so the previously recorded integrity was dropped, making later installs fail with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#12067](https://github.com/pnpm/pnpm/issues/12067).

--- a/.changeset/publish-normalize-repository.md
+++ b/.changeset/publish-normalize-repository.md
@@ -1,6 +1,0 @@
----
-"@pnpm/releasing.exportable-manifest": patch
-"pnpm": patch
----
-
-Normalize a string `repository` field into the `{ type, url }` object form when creating the publish manifest, matching npm's behavior. Some registries (e.g. Gitea/Codeberg) reject a string `repository` with a 500 Internal Server Error during `pnpm publish` [#12099](https://github.com/pnpm/pnpm/issues/12099).

--- a/.changeset/steady-optional-peers.md
+++ b/.changeset/steady-optional-peers.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Preserve compatible optional peer versions already present in the lockfile when resolving dependencies.

--- a/.changeset/twelve-peers-diamond.md
+++ b/.changeset/twelve-peers-diamond.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Fixed inconsistent resolution of a peer dependency that is shared through a diamond. When a package peer-depends on both another package and one of that package's own peer dependencies (for example `@typescript-eslint/eslint-plugin` peer-depends on both `@typescript-eslint/parser` and `typescript`, and `@typescript-eslint/parser` peer-depends on `typescript`), pnpm no longer reuses a hoisted instance of the shared peer that was resolved against a different version [#12079](https://github.com/pnpm/pnpm/issues/12079).

--- a/agent/server/CHANGELOG.md
+++ b/agent/server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # pnpm-agent
 
+## 0.0.21
+
+### Patch Changes
+
+- d99b725: `pnpm-agent` is now source-available under the [PolyForm Shield License 1.0.0](https://polyformproject.org/licenses/shield/1.0.0) instead of MIT. It may be run, modified, and self-hosted for any purpose except providing a product that competes with it.
+  - @pnpm/installing.deps-installer@1101.6.1
+
 ## 0.0.20
 
 ### Patch Changes

--- a/agent/server/package.json
+++ b/agent/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-agent",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "pnpm agent server for server-side resolution and store-aware downloads",
   "keywords": [
     "pnpm",

--- a/building/commands/CHANGELOG.md
+++ b/building/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/building.commands
 
+## 1100.1.1
+
+### Patch Changes
+
+- @pnpm/installing.commands@1100.7.1
+
 ## 1100.1.0
 
 ### Minor Changes

--- a/building/commands/package.json
+++ b/building/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.commands",
-  "version": "1100.1.0",
+  "version": "1100.1.1",
   "description": "Commands for rebuilding and managing dependency builds",
   "keywords": [
     "pnpm",

--- a/deps/compliance/audit/CHANGELOG.md
+++ b/deps/compliance/audit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/audit
 
+## 1101.0.12
+
+### Patch Changes
+
+- 719cc21: Improve `pnpm audit` performance by pruning non-vulnerable lockfile subtrees and stopping path enumeration once vulnerable findings reach the path cap.
+
 ## 1101.0.11
 
 ### Patch Changes

--- a/deps/compliance/audit/package.json
+++ b/deps/compliance/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.audit",
-  "version": "1101.0.11",
+  "version": "1101.0.12",
   "description": "Audit a lockfile",
   "keywords": [
     "pnpm",

--- a/deps/compliance/commands/CHANGELOG.md
+++ b/deps/compliance/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/deps.compliance.commands
 
+## 1101.3.1
+
+### Patch Changes
+
+- Updated dependencies [719cc21]
+  - @pnpm/deps.compliance.audit@1101.0.12
+  - @pnpm/installing.commands@1100.7.1
+
 ## 1101.3.0
 
 ### Minor Changes

--- a/deps/compliance/commands/package.json
+++ b/deps/compliance/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.commands",
-  "version": "1101.3.0",
+  "version": "1101.3.1",
   "description": "pnpm commands for audit, licenses, and sbom",
   "keywords": [
     "pnpm",

--- a/deps/inspection/commands/CHANGELOG.md
+++ b/deps/inspection/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/deps.inspection.commands
 
+## 1100.3.3
+
+### Patch Changes
+
+- @pnpm/global.commands@1100.0.24
+
 ## 1100.3.2
 
 ### Patch Changes

--- a/deps/inspection/commands/package.json
+++ b/deps/inspection/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.commands",
-  "version": "1100.3.2",
+  "version": "1100.3.3",
   "description": "The list, ll, why, and outdated commands of pnpm",
   "keywords": [
     "pnpm",

--- a/deps/status/CHANGELOG.md
+++ b/deps/status/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/deps.status
 
+## 1100.0.21
+
+### Patch Changes
+
+- Updated dependencies [37669c2]
+  - @pnpm/workspace.state@1100.0.18
+
 ## 1100.0.20
 
 ### Patch Changes

--- a/deps/status/package.json
+++ b/deps/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.status",
-  "version": "1100.0.20",
+  "version": "1100.0.21",
   "description": "Check dependencies status",
   "keywords": [
     "pnpm",

--- a/engine/pm/commands/CHANGELOG.md
+++ b/engine/pm/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/engine.pm.commands
 
+## 1101.1.19
+
+### Patch Changes
+
+- Updated dependencies [118e9be]
+  - @pnpm/installing.deps-restorer@1101.1.8
+  - @pnpm/installing.env-installer@1101.1.5
+  - @pnpm/global.commands@1100.0.24
+
 ## 1101.1.18
 
 ### Patch Changes

--- a/engine/pm/commands/package.json
+++ b/engine/pm/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.pm.commands",
-  "version": "1101.1.18",
+  "version": "1101.1.19",
   "description": "pnpm commands for self-updating and setting up pnpm",
   "keywords": [
     "pnpm",

--- a/exec/commands/CHANGELOG.md
+++ b/exec/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/plugin-commands-script-runners
 
+## 1100.2.1
+
+### Patch Changes
+
+- @pnpm/deps.status@1100.0.21
+- @pnpm/installing.commands@1100.7.1
+- @pnpm/building.commands@1100.1.1
+
 ## 1100.2.0
 
 ### Minor Changes

--- a/exec/commands/package.json
+++ b/exec/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.commands",
-  "version": "1100.2.0",
+  "version": "1100.2.1",
   "description": "Commands for running scripts",
   "keywords": [
     "pnpm",

--- a/global/commands/CHANGELOG.md
+++ b/global/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/global.commands
 
+## 1100.0.24
+
+### Patch Changes
+
+- @pnpm/installing.deps-installer@1101.6.1
+
 ## 1100.0.23
 
 ### Patch Changes

--- a/global/commands/package.json
+++ b/global/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/global.commands",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Global package command handlers for pnpm",
   "keywords": [
     "pnpm",

--- a/installing/commands/CHANGELOG.md
+++ b/installing/commands/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pnpm/plugin-commands-installation
 
+## 1100.7.1
+
+### Patch Changes
+
+- Updated dependencies [37669c2]
+  - @pnpm/workspace.state@1100.0.18
+  - @pnpm/deps.status@1100.0.21
+  - @pnpm/installing.deps-installer@1101.6.1
+  - @pnpm/installing.env-installer@1101.1.5
+  - @pnpm/global.commands@1100.0.24
+
 ## 1100.7.0
 
 ### Minor Changes

--- a/installing/commands/package.json
+++ b/installing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.commands",
-  "version": "1100.7.0",
+  "version": "1100.7.1",
   "description": "Commands for installation",
   "keywords": [
     "pnpm",

--- a/installing/deps-installer/CHANGELOG.md
+++ b/installing/deps-installer/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pnpm/core
 
+## 1101.6.1
+
+### Patch Changes
+
+- Updated dependencies [118e9be]
+- Updated dependencies [6f382f4]
+- Updated dependencies [122ab0a]
+- Updated dependencies [1db05c6]
+  - @pnpm/installing.deps-restorer@1101.1.8
+  - @pnpm/installing.deps-resolver@1100.1.6
+
 ## 1101.6.0
 
 ### Minor Changes

--- a/installing/deps-installer/package.json
+++ b/installing/deps-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-installer",
-  "version": "1101.6.0",
+  "version": "1101.6.1",
   "description": "Fast, disk space efficient installation engine",
   "keywords": [
     "pnpm",

--- a/installing/deps-resolver/CHANGELOG.md
+++ b/installing/deps-resolver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/resolve-dependencies
 
+## 1100.1.6
+
+### Patch Changes
+
+- 6f382f4: Preserve the `integrity` field of a remote (non-registry) tarball dependency when its lockfile entry is rebuilt. Re-resolving such a dependency without re-fetching it (for example via `pnpm update`, or when another dependency changes) produced a resolution with no integrity — URL/tarball resolvers only learn the integrity after the tarball is downloaded — so the previously recorded integrity was dropped, making later installs fail with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#12067](https://github.com/pnpm/pnpm/issues/12067).
+- 122ab0a: Preserve compatible optional peer versions already present in the lockfile when resolving dependencies.
+- 1db05c6: Fixed inconsistent resolution of a peer dependency that is shared through a diamond. When a package peer-depends on both another package and one of that package's own peer dependencies (for example `@typescript-eslint/eslint-plugin` peer-depends on both `@typescript-eslint/parser` and `typescript`, and `@typescript-eslint/parser` peer-depends on `typescript`), pnpm no longer reuses a hoisted instance of the shared peer that was resolved against a different version [#12079](https://github.com/pnpm/pnpm/issues/12079).
+
 ## 1100.1.5
 
 ### Patch Changes

--- a/installing/deps-resolver/package.json
+++ b/installing/deps-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-resolver",
-  "version": "1100.1.5",
+  "version": "1100.1.6",
   "description": "Resolves dependency graph of a package",
   "keywords": [
     "pnpm",

--- a/installing/deps-restorer/CHANGELOG.md
+++ b/installing/deps-restorer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/headless
 
+## 1101.1.8
+
+### Patch Changes
+
+- 118e9be: Set `npm_config_user_agent` for root lifecycle scripts during headless installs.
+
 ## 1101.1.7
 
 ### Patch Changes

--- a/installing/deps-restorer/package.json
+++ b/installing/deps-restorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-restorer",
-  "version": "1101.1.7",
+  "version": "1101.1.8",
   "description": "Fast installation using only pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/installing/env-installer/CHANGELOG.md
+++ b/installing/env-installer/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/config.deps-installer
 
+## 1101.1.5
+
+### Patch Changes
+
+- Updated dependencies [6f382f4]
+- Updated dependencies [122ab0a]
+- Updated dependencies [1db05c6]
+  - @pnpm/installing.deps-resolver@1100.1.6
+
 ## 1101.1.4
 
 ### Patch Changes

--- a/installing/env-installer/package.json
+++ b/installing/env-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.env-installer",
-  "version": "1101.1.4",
+  "version": "1101.1.5",
   "description": "Installer for configurational dependencies",
   "keywords": [
     "pnpm",

--- a/lockfile/make-dedicated-lockfile/CHANGELOG.md
+++ b/lockfile/make-dedicated-lockfile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/make-dedicated-lockfile
 
+## 1100.0.15
+
+### Patch Changes
+
+- Updated dependencies [33921c8]
+  - @pnpm/releasing.exportable-manifest@1100.1.2
+
 ## 1100.0.14
 
 ### Patch Changes

--- a/lockfile/make-dedicated-lockfile/package.json
+++ b/lockfile/make-dedicated-lockfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.make-dedicated-lockfile",
-  "version": "1100.0.14",
+  "version": "1100.0.15",
   "description": "Creates a dedicated lockfile for a subset of workspace projects",
   "keywords": [
     "pnpm",

--- a/patching/commands/CHANGELOG.md
+++ b/patching/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/plugin-commands-patching
 
+## 1100.1.1
+
+### Patch Changes
+
+- @pnpm/installing.commands@1100.7.1
+
 ## 1100.1.0
 
 ### Minor Changes

--- a/patching/commands/package.json
+++ b/patching/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.commands",
-  "version": "1100.1.0",
+  "version": "1100.1.1",
   "description": "Commands for creating patches",
   "keywords": [
     "pnpm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -827,8 +827,8 @@ catalogs:
       specifier: ^9.3.0
       version: 9.3.0
     promise-share:
-      specifier: ^2.0.0
-      version: 2.0.0
+      specifier: ^2.0.1
+      version: 2.0.1
     proxyquire:
       specifier: ^2.1.3
       version: 2.1.3
@@ -6029,7 +6029,7 @@ importers:
         version: 5.0.0
       promise-share:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -6598,7 +6598,7 @@ importers:
         version: 9.3.0
       promise-share:
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -15947,8 +15947,8 @@ packages:
     resolution: {integrity: sha512-lpABypysb42MdCZjMJAdapxt+uTU9F0BZW0YeYVlPD/Gv390c43CdFwBSC9YM3siAgyAjLV94WDuDnwHIJjxiw==}
     engines: {node: '>=8'}
 
-  promise-share@2.0.0:
-    resolution: {integrity: sha512-aJ7A/uh5IqCR9nyD4d8k0bp2xbR3NA2vp9FijCfiQmqmHDAUjf1OqZsBaUAe2RFnb3gQFuxJzjImL0TNeuUXQQ==}
+  promise-share@2.0.1:
+    resolution: {integrity: sha512-FBa/tM0QQhNaCaUA9UnAgaa5VHh1qm5sUvsl+KZtf6B9Y/8AUow2uIbAoQd+bFKSDl5/418FW0sfVzfEdAEsBg==}
     engines: {node: '>=22.13'}
 
   propagate@2.0.1:
@@ -24321,7 +24321,7 @@ snapshots:
     dependencies:
       p-reflect: 2.1.0
 
-  promise-share@2.0.0:
+  promise-share@2.0.1:
     dependencies:
       p-reflect: 3.1.0
 
@@ -24662,7 +24662,7 @@ snapshots:
 
   safe-promise-defer@2.0.0:
     dependencies:
-      promise-share: 2.0.0
+      promise-share: 2.0.1
 
   safe-push-apply@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -259,7 +259,7 @@ catalog:
   preferred-pm: ^5.0.0
   pretty-bytes: ^7.1.0
   pretty-ms: ^9.3.0
-  promise-share: ^2.0.0
+  promise-share: ^2.0.1
   proxyquire: ^2.1.3
   ps-list: ^9.0.0
   qrcode-terminal: ^0.12.0

--- a/pnpm/CHANGELOG.md
+++ b/pnpm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # pnpm
 
+## 11.5.1
+
+### Patch Changes
+
+- Improve `pnpm audit` performance by pruning non-vulnerable lockfile subtrees and stopping path enumeration once vulnerable findings reach the path cap.
+- Avoid crashing when the workspace state cache is partially written or malformed.
+- Set `npm_config_user_agent` for root lifecycle scripts during headless installs.
+- Preserve the `integrity` field of a remote (non-registry) tarball dependency when its lockfile entry is rebuilt. Re-resolving such a dependency without re-fetching it (for example via `pnpm update`, or when another dependency changes) produced a resolution with no integrity — URL/tarball resolvers only learn the integrity after the tarball is downloaded — so the previously recorded integrity was dropped, making later installs fail with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` [#12067](https://github.com/pnpm/pnpm/issues/12067).
+- Normalize a string `repository` field into the `{ type, url }` object form when creating the publish manifest, matching npm's behavior. Some registries (e.g. Gitea/Codeberg) reject a string `repository` with a 500 Internal Server Error during `pnpm publish` [#12099](https://github.com/pnpm/pnpm/issues/12099).
+- Preserve compatible optional peer versions already present in the lockfile when resolving dependencies.
+- Fixed inconsistent resolution of a peer dependency that is shared through a diamond. When a package peer-depends on both another package and one of that package's own peer dependencies (for example `@typescript-eslint/eslint-plugin` peer-depends on both `@typescript-eslint/parser` and `typescript`, and `@typescript-eslint/parser` peer-depends on `typescript`), pnpm no longer reuses a hoisted instance of the shared peer that was resolved against a different version [#12079](https://github.com/pnpm/pnpm/issues/12079).
+
 ## 11.5.0
 
 ### Minor Changes

--- a/pnpm/artifacts/darwin-arm64/package.json
+++ b/pnpm/artifacts/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/macos-arm64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/exe/package.json
+++ b/pnpm/artifacts/exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exe",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm/artifacts/linux-arm64-musl/package.json
+++ b/pnpm/artifacts/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-arm64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-arm64/package.json
+++ b/pnpm/artifacts/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-arm64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-x64-musl/package.json
+++ b/pnpm/artifacts/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-x64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/linux-x64/package.json
+++ b/pnpm/artifacts/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-x64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/win32-arm64/package.json
+++ b/pnpm/artifacts/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-arm64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/artifacts/win32-x64/package.json
+++ b/pnpm/artifacts/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-x64",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm/package.json
+++ b/pnpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/releasing/commands/CHANGELOG.md
+++ b/releasing/commands/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/releasing.commands
 
+## 1100.4.1
+
+### Patch Changes
+
+- Updated dependencies [33921c8]
+  - @pnpm/releasing.exportable-manifest@1100.1.2
+  - @pnpm/installing.commands@1100.7.1
+
 ## 1100.4.0
 
 ### Minor Changes

--- a/releasing/commands/package.json
+++ b/releasing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.commands",
-  "version": "1100.4.0",
+  "version": "1100.4.1",
   "description": "Commands for deploy, pack, and publish",
   "keywords": [
     "pnpm",

--- a/releasing/exportable-manifest/CHANGELOG.md
+++ b/releasing/exportable-manifest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/exportable-manifest
 
+## 1100.1.2
+
+### Patch Changes
+
+- 33921c8: Normalize a string `repository` field into the `{ type, url }` object form when creating the publish manifest, matching npm's behavior. Some registries (e.g. Gitea/Codeberg) reject a string `repository` with a 500 Internal Server Error during `pnpm publish` [#12099](https://github.com/pnpm/pnpm/issues/12099).
+
 ## 1100.1.1
 
 ### Patch Changes

--- a/releasing/exportable-manifest/package.json
+++ b/releasing/exportable-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.exportable-manifest",
-  "version": "1100.1.1",
+  "version": "1100.1.2",
   "description": "Creates an exportable manifest",
   "keywords": [
     "pnpm",

--- a/workspace/state/CHANGELOG.md
+++ b/workspace/state/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/workspace.state
 
+## 1100.0.18
+
+### Patch Changes
+
+- 37669c2: Avoid crashing when the workspace state cache is partially written or malformed.
+
 ## 1100.0.17
 
 ### Patch Changes

--- a/workspace/state/package.json
+++ b/workspace/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.state",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Track the list of actual paths of workspace packages in a cache",
   "keywords": [
     "pnpm",


### PR DESCRIPTION
Release of pnpm 11.5.1.

### Shipped in this release (pnpm CLI)

- **Improve `pnpm audit` performance** — prune non-vulnerable lockfile subtrees and stop path enumeration once vulnerable findings reach the path cap. [#12087](https://github.com/pnpm/pnpm/pull/12087)
- **Avoid crashing when the workspace state cache is partially written or malformed.** [#12094](https://github.com/pnpm/pnpm/pull/12094)
- **Set `npm_config_user_agent` for root lifecycle scripts during headless installs.** [#12092](https://github.com/pnpm/pnpm/pull/12092)
- **Preserve the `integrity` field of a remote (non-registry) tarball dependency on re-resolution** — fixes later installs failing with `ERR_PNPM_MISSING_TARBALL_INTEGRITY`. [#12096](https://github.com/pnpm/pnpm/pull/12096) (closes [#12067](https://github.com/pnpm/pnpm/issues/12067))
- **Normalize a string `repository` field into the `{ type, url }` object form in the publish manifest** — fixes registries such as Gitea/Codeberg rejecting `pnpm publish` with a 500 error. [#12109](https://github.com/pnpm/pnpm/pull/12109) (closes [#12099](https://github.com/pnpm/pnpm/issues/12099))
- **Preserve compatible optional peer versions already present in the lockfile when resolving dependencies.** [#12075](https://github.com/pnpm/pnpm/pull/12075)
- **Fix inconsistent resolution of a peer dependency shared through a diamond** — no longer reuses a hoisted instance of the shared peer resolved against a different version. [#12081](https://github.com/pnpm/pnpm/pull/12081) (closes [#12079](https://github.com/pnpm/pnpm/issues/12079))

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm audit` performance with optimized lockfile pruning
  * Fixed crashes from corrupted workspace cache state
  * Fixed peer dependency resolution inconsistencies
  * Preserved dependency integrity during lockfile re-resolution
  * Improved handling of optional peer versions

* **Changes**
  * Root lifecycle scripts now receive user agent information in headless installs
  * Repository fields automatically normalized during publish

* **Chores**
  * pnpm-agent license updated to PolyForm Shield License 1.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->