### PR TITLE
fix(pacquet): dedupeDirectDeps default + per-importer workspace link resolution, with defaults contract test

### DIFF
--- a/pacquet/crates/cli/tests/dedupe_direct_deps.rs
+++ b/pacquet/crates/cli/tests/dedupe_direct_deps.rs
@@ -6,8 +6,16 @@
 //! a non-root project depends on, the dep must not appear under
 //! that project's `node_modules/`, and a project whose direct deps
 //! are entirely deduped must not have a `node_modules/` created at
-//! all. Setting `dedupeDirectDeps: false` must restore the
-//! per-project symlinks.
+//! all.
+//!
+//! `dedupeDirectDeps` is **off by default** (pnpm's config-reader
+//! default at
+//! [`config/reader/src/index.ts:139`](https://github.com/pnpm/pnpm/blob/a23956e3ab/config/reader/src/index.ts#L139)),
+//! so the dedupe-on tests below set `dedupeDirectDeps: true` in the
+//! workspace yaml explicitly, mirroring upstream's
+//! `testDefaults({ ..., dedupeDirectDeps: true })`. The default-off
+//! behavior — every importer keeps its own per-project symlink — is
+//! covered by [`dedupe_off_by_default_keeps_shared_workspace_link`].
 
 pub mod _utils;
 
@@ -19,11 +27,11 @@ use pacquet_testing_utils::{
 };
 use std::{fs, path::Path, process::Command};
 
-/// With `dedupeDirectDeps` left at its default (`true`), a sibling
-/// project whose only direct dep is also a direct dep of the
-/// workspace root must not get a `node_modules/` of its own.
+/// With `dedupeDirectDeps: true`, a sibling project whose only
+/// direct dep is also a direct dep of the workspace root must not
+/// get a `node_modules/` of its own.
 #[test]
-fn dedupes_direct_deps_against_workspace_root_by_default() {
+fn dedupes_direct_deps_against_workspace_root() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -46,7 +54,7 @@ fn dedupes_direct_deps_against_workspace_root_by_default() {
     if !workspace_yaml.ends_with('\n') {
         workspace_yaml.push('\n');
     }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::create_dir_all(workspace.join("packages/dup")).expect("mkdir packages/dup");
@@ -173,7 +181,7 @@ fn dedupes_direct_deps_with_frozen_lockfile() {
     if !workspace_yaml.ends_with('\n') {
         workspace_yaml.push('\n');
     }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::create_dir_all(workspace.join("packages/dup")).expect("mkdir packages/dup");
@@ -215,6 +223,127 @@ fn dedupes_direct_deps_with_frozen_lockfile() {
     assert!(
         !dup_modules_exists_after_frozen,
         "frozen-lockfile install should keep packages/dup/node_modules absent",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Regression for the v11.5.1 release failure
+/// ([.github#214](https://github.com/pnpm/pnpm/actions/runs/26801861393)):
+/// `dedupeDirectDeps` defaults to **off**, so a workspace package that
+/// both the root and a non-root importer depend on must stay symlinked
+/// under the non-root importer's own `node_modules/`.
+///
+/// The release installs through the frozen-lockfile path and then runs
+/// `pnpm publish` on `@pnpm/exe`, which rewrites the `workspace:*`
+/// devDependency on `@pnpm/jest-config` by reading
+/// `exe/node_modules/@pnpm/jest-config/package.json`. The root also
+/// depends on `@pnpm/jest-config`; when pacquet defaulted
+/// `dedupeDirectDeps` to `true` it dropped the per-importer symlink, so
+/// publish failed with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`.
+/// This fixture reproduces that shape: shared `link:` workspace dep,
+/// non-root importer, frozen-lockfile replay.
+#[test]
+fn dedupe_off_by_default_keeps_shared_workspace_link() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // Root depends on the shared workspace package, exactly like the
+    // monorepo root depends on `@pnpm/jest-config`.
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { "@scope/shared": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    // No `dedupeDirectDeps` key — exercise the default.
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/shared")).expect("mkdir packages/shared");
+    fs::write(
+        workspace.join("packages/shared/package.json"),
+        serde_json::json!({ "name": "@scope/shared", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/shared/package.json");
+
+    // Non-root importer that also depends on the shared package — the
+    // `@pnpm/exe` analogue.
+    fs::create_dir_all(workspace.join("packages/app")).expect("mkdir packages/app");
+    fs::write(
+        workspace.join("packages/app/package.json"),
+        serde_json::json!({
+            "name": "@scope/app",
+            "version": "1.0.0",
+            "dependencies": { "@scope/shared": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/app/package.json");
+
+    // A pnpm-written lockfile (importer-relative `link:` targets), the
+    // same shape the release checks out before installing — so this
+    // test isolates the dedupe behavior rather than pacquet's own
+    // lockfile-writing path.
+    fs::write(
+        workspace.join("pnpm-lock.yaml"),
+        r#"lockfileVersion: "9.0"
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+importers:
+  .:
+    specifiers:
+      "@scope/shared": workspace:*
+    dependencies:
+      "@scope/shared":
+        specifier: workspace:*
+        version: link:packages/shared
+  packages/app:
+    specifiers:
+      "@scope/shared": workspace:*
+    dependencies:
+      "@scope/shared":
+        specifier: workspace:*
+        version: link:../shared
+  packages/shared: {}
+"#,
+    )
+    .expect("write pnpm-lock.yaml");
+
+    // Replay the lockfile through the frozen-lockfile path — the
+    // codepath the release workflow runs.
+    pacquet.with_arg("install").with_arg("--frozen-lockfile").assert().success();
+
+    // The non-root importer must keep its own symlink, and it must
+    // resolve to the shared package's manifest — that read is what
+    // `pnpm publish`'s `workspace:*` rewrite performs.
+    let app_link = workspace.join("packages/app/node_modules/@scope/shared");
+    let app_link_linked = is_symlink_or_junction(&app_link).expect("query app symlink");
+    eprintln!("app_link={app_link:?} linked={app_link_linked}");
+    assert!(
+        app_link_linked,
+        "shared workspace dep must stay symlinked under packages/app/node_modules when \
+         dedupeDirectDeps is at its default (off)",
+    );
+    let app_manifest = app_link.join("package.json");
+    assert!(
+        app_manifest.exists(),
+        "packages/app/node_modules/@scope/shared must resolve to the package manifest at \
+         {app_manifest:?} so `workspace:*` publish resolution succeeds",
     );
 
     drop((root, mock_instance));
@@ -262,7 +391,7 @@ fn dedupes_only_overlapping_direct_deps() {
     if !workspace_yaml.ends_with('\n') {
         workspace_yaml.push('\n');
     }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::create_dir_all(workspace.join("packages/mixed")).expect("mkdir packages/mixed");
@@ -330,7 +459,7 @@ fn dedupes_link_deps_resolving_to_the_same_dir_via_different_segments() {
     if !workspace_yaml.ends_with('\n') {
         workspace_yaml.push('\n');
     }
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::create_dir_all(workspace.join("packages/shared")).expect("mkdir packages/shared");
@@ -411,7 +540,7 @@ fn dedupes_direct_dep_against_publicly_hoisted_root_dep() {
         workspace_yaml.push('\n');
     }
     let base_yaml = workspace_yaml.clone();
-    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\ndedupeDirectDeps: true\n");
     fs::write(&workspace_yaml_path, &workspace_yaml).expect("write pnpm-workspace.yaml");
 
     fs::create_dir_all(workspace.join("packages/dup")).expect("mkdir packages/dup");
@@ -435,7 +564,7 @@ fn dedupes_direct_dep_against_publicly_hoisted_root_dep() {
     // frozen-install path is a pure replay.
     let mut workspace_yaml = base_yaml;
     workspace_yaml.push_str(
-        "packages:\n  - 'packages/*'\npublicHoistPattern:\n  - '@pnpm.e2e/dep-of-pkg-with-1-dep'\n",
+        "packages:\n  - 'packages/*'\ndedupeDirectDeps: true\npublicHoistPattern:\n  - '@pnpm.e2e/dep-of-pkg-with-1-dep'\n",
     );
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
     fs_remove_dir_all(&workspace.join("node_modules"));
@@ -506,6 +635,7 @@ fn dedupe_under_shamefully_hoist() {
     }
     workspace_yaml.push_str(
         "packages:\n  - 'packages/*'\n\
+         dedupeDirectDeps: true\n\
          shamefullyHoist: true\n\
          hoistPattern: []\n\
          publicHoistPattern:\n  - '*'\n",

--- a/pacquet/crates/cli/tests/workspace_install.rs
+++ b/pacquet/crates/cli/tests/workspace_install.rs
@@ -134,3 +134,101 @@ fn fresh_resolve_walks_every_workspace_importer() {
 
     drop((root, mock_instance));
 }
+
+/// When the workspace root and a non-root importer both depend on the
+/// same workspace package via `workspace:*`, each importer's resolved
+/// `link:` target is relative to *its own* directory — pnpm writes
+/// `link:packages/lib` for the root and `link:../lib` for
+/// `packages/app`. A prior bug seeded pacquet's workspace-wide
+/// resolution cache with the first importer's relative path and reused
+/// it for every other importer, so `packages/app` got the root's
+/// `link:packages/lib` and its symlink dangled at
+/// `packages/app/packages/lib`.
+#[test]
+fn shared_workspace_dep_link_is_relative_to_each_importer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    // Root depends on the shared workspace package, so it resolves the
+    // `workspace:*` edge first and would otherwise poison the cache.
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "ws-root",
+            "version": "0.0.0",
+            "private": true,
+            "dependencies": { "@scope/lib": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    fs::create_dir_all(workspace.join("packages/lib")).expect("mkdir packages/lib");
+    fs::write(
+        workspace.join("packages/lib/package.json"),
+        serde_json::json!({ "name": "@scope/lib", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/lib/package.json");
+
+    fs::create_dir_all(workspace.join("packages/app")).expect("mkdir packages/app");
+    fs::write(
+        workspace.join("packages/app/package.json"),
+        serde_json::json!({
+            "name": "@scope/app",
+            "version": "1.0.0",
+            "dependencies": { "@scope/lib": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/app/package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    // The lockfile records importer-relative `link:` targets.
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let parsed: pacquet_lockfile::Lockfile = serde_saphyr::from_str(&lockfile)
+        .unwrap_or_else(|err| panic!("re-parse pnpm-lock.yaml: {err}\n{lockfile}"));
+    let lib_name: pacquet_lockfile::PkgName = "@scope/lib".parse().unwrap();
+    let importer_link = |importer_id: &str| -> String {
+        parsed
+            .importers
+            .get(importer_id)
+            .and_then(|importer| importer.dependencies.as_ref())
+            .and_then(|deps| deps.get(&lib_name))
+            .unwrap_or_else(|| panic!("missing @scope/lib in {importer_id:?}:\n{lockfile}"))
+            .version
+            .to_string()
+    };
+    let root_link = importer_link(".");
+    let app_link = importer_link("packages/app");
+    eprintln!("root_link={root_link:?} app_link={app_link:?}");
+    assert_eq!(root_link, "link:packages/lib", "root importer link must be relative to root");
+    assert_eq!(
+        app_link, "link:../lib",
+        "packages/app link must be relative to packages/app, not reused from the root importer",
+    );
+
+    // The on-disk symlink resolves to the shared package's manifest.
+    let app_link_path = workspace.join("packages/app/node_modules/@scope/lib");
+    assert!(
+        is_symlink_or_junction(&app_link_path).expect("query packages/app link"),
+        "packages/app/node_modules/@scope/lib symlink missing",
+    );
+    assert!(
+        app_link_path.join("package.json").exists(),
+        "packages/app/node_modules/@scope/lib must resolve to @scope/lib's manifest, not dangle",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -725,11 +725,11 @@ pub struct Config {
     /// per-importer symlink) and bin linking (the deduped dep won't
     /// reappear under the project's `node_modules/.bin`).
     ///
-    /// Default `true`. Mirrors pnpm's
-    /// [`dedupeDirectDeps`](https://github.com/pnpm/pnpm/blob/39101f5e37/config/reader/src/Config.ts#L243)
-    /// and the linker call site at
-    /// [`installing/deps-installer/src/install/link.ts:303`](https://github.com/pnpm/pnpm/blob/39101f5e37/installing/deps-installer/src/install/link.ts#L303).
-    #[default = true]
+    /// Default `false`, matching pnpm's config-reader default at
+    /// [`config/reader/src/index.ts:139`](https://github.com/pnpm/pnpm/blob/a23956e3ab/config/reader/src/index.ts#L139)
+    /// (`'dedupe-direct-deps': false`). The linker call site is at
+    /// [`installing/deps-restorer/src/index.ts:777`](https://github.com/pnpm/pnpm/blob/a23956e3ab/installing/deps-restorer/src/index.ts#L777).
+    #[default = false]
     pub dedupe_direct_deps: bool,
 
     /// When `true`, injected workspace dependencies whose materialised

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -1828,4 +1828,6 @@ fn read_npm_env<Sys: EnvVar>(lower: &str, upper: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+mod pnpm_default_parity;
+#[cfg(test)]
 mod tests;

--- a/pacquet/crates/config/src/pnpm_default_parity.rs
+++ b/pacquet/crates/config/src/pnpm_default_parity.rs
@@ -1,0 +1,371 @@
+//! Contract test: every pacquet default that maps to a pnpm CLI
+//! setting must equal pnpm's own default.
+//!
+//! pnpm is the source of truth (see
+//! [`pacquet/AGENTS.md`](../../AGENTS.md#the-cardinal-rule)). Its CLI
+//! defaults live in one object literal, `defaultOptions`, in
+//! [`config/reader/src/index.ts`](https://github.com/pnpm/pnpm/blob/a23956e3ab/config/reader/src/index.ts).
+//! This test reads that literal from source at test time and compares
+//! each value against [`Config::default()`], so a drift on either side
+//! (pnpm changing a default, or pacquet hard-coding the wrong one — the
+//! `dedupeDirectDeps` regression that broke the v11.5.1 release) fails
+//! here instead of in a release pipeline.
+//!
+//! Three buckets classify every key in `defaultOptions`:
+//!
+//! - **mapped** — pacquet implements the setting with a directly
+//!   comparable literal default; the value is asserted equal.
+//! - **non-literal** — pacquet implements it, but pnpm's default is an
+//!   environment / platform / CPU expression (`registry`,
+//!   `workspace-concurrency`, ...) with no source literal to compare.
+//! - **not ported** — pacquet has no `Config` field for it yet.
+//!
+//! The completeness guard asserts the three buckets exactly partition
+//! pnpm's key set, so a *new* pnpm setting (neither mapped nor skipped)
+//! fails the test until someone classifies it — which is how this test
+//! keeps catching the next default that needs porting.
+
+use crate::{Config, LinkWorkspacePackages, NodeLinker, ResolutionMode, ScriptsPrependNodePath};
+use std::collections::BTreeSet;
+
+/// A pnpm default value reduced to the shapes this test compares.
+#[derive(Debug, PartialEq, Eq)]
+enum Scalar {
+    Bool(bool),
+    Int(i64),
+    Str(String),
+    /// Order-insensitive list of strings (pnpm's array defaults carry
+    /// no meaningful order).
+    Set(BTreeSet<String>),
+}
+
+fn s(value: &str) -> Scalar {
+    Scalar::Str(value.to_string())
+}
+
+/// pnpm keys whose default is an environment / platform / CPU
+/// expression, not a source literal. pacquet implements each, but there
+/// is nothing to string-compare against, so they are exercised by the
+/// dedicated `current::<Host>()` config-loading tests instead.
+const NON_LITERAL: &[&str] = &[
+    "registry",                     // npmDefaults.registry
+    "unsafe-perm",                  // npmDefaults['unsafe-perm']
+    "userconfig",                   // npmDefaults.userconfig (home-derived path)
+    "virtual-store-dir-max-length", // isWindows() ? 60 : 120
+    "workspace-concurrency",        // derived from CPU count
+];
+
+/// pnpm settings pacquet has no `Config` field for yet. Porting one
+/// means moving its key from here into a `mapped` row.
+const NOT_PORTED: &[&str] = &[
+    "bail",
+    "catalog-mode",
+    "ci",
+    "color",
+    "deploy-all-files",
+    "disallow-workspace-cycles",
+    "dlx-cache-max-age",
+    "embed-readme",
+    "enable-modules-dir",
+    "enable-pre-post-scripts",
+    "extend-node-path",
+    "fail-if-no-match",
+    "fetch-min-speed-ki-bps",
+    "fetch-warn-timeout-ms",
+    "force-legacy-deploy",
+    "git-branch-lockfile",
+    "ignore-workspace-cycles",
+    "ignore-workspace-root-check",
+    "init-package-manager",
+    "init-type",
+    "optional",
+    "package-lock",
+    "pending",
+    "recursive-install",
+    "reverse",
+    "save-catalog-name",
+    "save-peer",
+    "save-workspace-protocol",
+    "shared-workspace-lockfile",
+    "shell-emulator",
+    "skip-manifest-obfuscation",
+    "sort",
+    "strict-dep-builds",
+    "strict-store-pkg-content-check",
+    "use-beta-cli",
+    "verify-deps-before-run",
+    "virtual-store-only",
+    "workspace-prefix",
+];
+
+/// `(pnpm key, pacquet default rendered as a [`Scalar`])` for every
+/// setting pacquet implements with a comparable literal default. The
+/// test asserts each pacquet value equals the value pnpm's source
+/// records under the same key.
+fn mapped_rows(cfg: &Config) -> Vec<(&'static str, Scalar)> {
+    use Scalar::{Bool, Int};
+    vec![
+        ("auto-install-peers", Bool(cfg.auto_install_peers)),
+        ("block-exotic-subdeps", Bool(cfg.block_exotic_subdeps)),
+        ("dangerously-allow-all-builds", Bool(cfg.dangerously_allow_all_builds)),
+        ("dedupe-direct-deps", Bool(cfg.dedupe_direct_deps)),
+        ("dedupe-injected-deps", Bool(cfg.dedupe_injected_deps)),
+        ("dedupe-peer-dependents", Bool(cfg.dedupe_peer_dependents)),
+        ("dedupe-peers", Bool(cfg.dedupe_peers)),
+        ("exclude-links-from-lockfile", Bool(cfg.exclude_links_from_lockfile)),
+        ("hoist", Bool(cfg.hoist)),
+        ("hoist-workspace-packages", Bool(cfg.hoist_workspace_packages)),
+        ("inject-workspace-packages", Bool(cfg.inject_workspace_packages)),
+        ("lockfile-include-tarball-url", Bool(cfg.lockfile_include_tarball_url)),
+        (
+            "minimum-release-age-ignore-missing-time",
+            Bool(cfg.minimum_release_age_ignore_missing_time),
+        ),
+        ("optimistic-repeat-install", Bool(cfg.optimistic_repeat_install)),
+        ("prefer-workspace-packages", Bool(cfg.prefer_workspace_packages)),
+        ("registry-supports-time-field", Bool(cfg.registry_supports_time_field)),
+        ("resolve-peers-from-workspace-root", Bool(cfg.resolve_peers_from_workspace_root)),
+        ("side-effects-cache", Bool(cfg.side_effects_cache)),
+        ("strict-peer-dependencies", Bool(cfg.strict_peer_dependencies)),
+        ("symlink", Bool(cfg.symlink)),
+        ("verify-store-integrity", Bool(cfg.verify_store_integrity)),
+        // `boolean | 'deep'` upstream; the default is `false`.
+        ("link-workspace-packages", link_workspace_packages_scalar(cfg.link_workspace_packages)),
+        // `boolean | 'warn-only'` upstream; the default is `false`.
+        (
+            "scripts-prepend-node-path",
+            scripts_prepend_node_path_scalar(cfg.scripts_prepend_node_path),
+        ),
+        ("node-linker", node_linker_scalar(cfg.node_linker)),
+        ("resolution-mode", resolution_mode_scalar(cfg.resolution_mode)),
+        ("fetch-retries", Int(i64::from(cfg.fetch_retries))),
+        ("fetch-retry-factor", Int(i64::from(cfg.fetch_retry_factor))),
+        ("fetch-retry-maxtimeout", Int(cfg.fetch_retry_maxtimeout as i64)),
+        ("fetch-retry-mintimeout", Int(cfg.fetch_retry_mintimeout as i64)),
+        ("fetch-timeout", Int(cfg.fetch_timeout as i64)),
+        (
+            "minimum-release-age",
+            Int(cfg.minimum_release_age.expect("pacquet defaults minimum-release-age to Some")
+                as i64),
+        ),
+        ("modules-cache-max-age", Int(cfg.modules_cache_max_age as i64)),
+        ("peers-suffix-max-length", Int(cfg.peers_suffix_max_length as i64)),
+        (
+            "hoist-pattern",
+            Scalar::Set(cfg.hoist_pattern.clone().unwrap_or_default().into_iter().collect()),
+        ),
+        (
+            "public-hoist-pattern",
+            Scalar::Set(cfg.public_hoist_pattern.clone().unwrap_or_default().into_iter().collect()),
+        ),
+        ("git-shallow-hosts", Scalar::Set(cfg.git_shallow_hosts.iter().cloned().collect())),
+    ]
+}
+
+fn node_linker_scalar(value: NodeLinker) -> Scalar {
+    match value {
+        NodeLinker::Isolated => s("isolated"),
+        NodeLinker::Hoisted => s("hoisted"),
+        NodeLinker::Pnp => s("pnp"),
+    }
+}
+
+fn resolution_mode_scalar(value: ResolutionMode) -> Scalar {
+    match value {
+        ResolutionMode::Highest => s("highest"),
+        ResolutionMode::TimeBased => s("time-based"),
+        ResolutionMode::LowestDirect => s("lowest-direct"),
+    }
+}
+
+fn link_workspace_packages_scalar(value: LinkWorkspacePackages) -> Scalar {
+    match value {
+        LinkWorkspacePackages::Off => Scalar::Bool(false),
+        LinkWorkspacePackages::DirectOnly => Scalar::Bool(true),
+        LinkWorkspacePackages::Deep => s("deep"),
+    }
+}
+
+fn scripts_prepend_node_path_scalar(value: ScriptsPrependNodePath) -> Scalar {
+    match value {
+        ScriptsPrependNodePath::Never => Scalar::Bool(false),
+        ScriptsPrependNodePath::Always => Scalar::Bool(true),
+        ScriptsPrependNodePath::WarnOnly => s("warn-only"),
+    }
+}
+
+/// The `defaultOptions` object literal, sliced out of pnpm's
+/// config-reader source. Read live so the test tracks pnpm rather than
+/// a checked-in copy that could silently drift.
+fn read_pnpm_default_options() -> String {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../config/reader/src/index.ts");
+    let src = std::fs::read_to_string(path).unwrap_or_else(|err| {
+        panic!(
+            "read pnpm config-reader source at {path}: {err}. \
+             This contract test reads pnpm's `defaultOptions` from the TypeScript \
+             tree; if config/reader moved, update the path.",
+        )
+    });
+    let marker = "const defaultOptions: Partial<KebabCaseConfig> = {";
+    let start = src
+        .find(marker)
+        .unwrap_or_else(|| panic!("`{marker}` not found in config/reader/src/index.ts"));
+    let body = &src[start + marker.len()..];
+    // The block ends at the first line that is exactly the closing brace
+    // at the object's indentation (`\n  }`).
+    let end = body
+        .find("\n  }")
+        .expect("unterminated `defaultOptions` object literal in config/reader/src/index.ts");
+    body[..end].to_string()
+}
+
+/// Every top-level key declared in the `defaultOptions` literal.
+fn pnpm_keys(block: &str) -> BTreeSet<String> {
+    block
+        .lines()
+        .filter_map(|line| {
+            let line = strip_line_comment(line).trim();
+            // A top-level entry is `key:` / `'key':` at the start of a
+            // line. Array elements (`'github.com',`) have no `:` and are
+            // skipped.
+            let (key, _) = line.split_once(':')?;
+            let key = key.trim().trim_matches('\'');
+            // Keys are kebab-case identifiers; anything with a space or
+            // quote left over is a value fragment from a multi-line
+            // literal, not a key.
+            (!key.is_empty() && key.chars().all(|ch| ch.is_ascii_lowercase() || ch == '-'))
+                .then(|| key.to_string())
+        })
+        .collect()
+}
+
+/// The raw value text pnpm assigns to `key`, with surrounding
+/// whitespace, the trailing comma, and any `// ...` comment stripped.
+/// Handles single-line values and `[ ... ]` arrays that span lines.
+fn pnpm_raw_value<'a>(block: &'a str, key: &str) -> Option<&'a str> {
+    let quoted = format!("'{key}':");
+    let bare = format!("{key}:");
+    let key_pos = block
+        .match_indices(&quoted)
+        .map(|(idx, mat)| (idx, mat.len()))
+        .chain(block.match_indices(&bare).map(|(idx, mat)| (idx, mat.len())))
+        // Only accept a match that sits at the start of a line (after
+        // indentation) so a substring of a longer key can't match.
+        .find(|&(idx, _)| {
+            block[..idx].chars().rev().take_while(|&ch| ch != '\n').all(char::is_whitespace)
+        })?;
+    let after = block[key_pos.0 + key_pos.1..].trim_start();
+    if after.starts_with('[') {
+        let close = after.find(']').expect("unterminated array literal in defaultOptions");
+        Some(&after[..=close])
+    } else {
+        let line_end = after.find('\n').unwrap_or(after.len());
+        Some(strip_line_comment(&after[..line_end]).trim().trim_end_matches(','))
+    }
+}
+
+fn strip_line_comment(line: &str) -> &str {
+    match line.find("//") {
+        Some(idx) => &line[..idx],
+        None => line,
+    }
+}
+
+/// Parse a raw pnpm value into a [`Scalar`]. Panics on a shape this
+/// test doesn't model (which only happens if a mapped key's value type
+/// changed — exactly the drift worth failing on).
+fn parse_scalar(raw: &str, key: &str) -> Scalar {
+    let raw = raw.trim();
+    if raw == "true" || raw == "false" {
+        return Scalar::Bool(raw == "true");
+    }
+    if let Some(inner) = raw.strip_prefix('\'').and_then(|rest| rest.strip_suffix('\'')) {
+        return Scalar::Str(inner.to_string());
+    }
+    if let Some(inner) = raw.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')) {
+        // Strip comments per line *before* splitting on commas — a
+        // comment line inside the array (e.g. the `git-shallow-hosts`
+        // provenance note) shares no comma with the element below it.
+        let items = inner
+            .lines()
+            .map(strip_line_comment)
+            .flat_map(|line| line.split(','))
+            .map(|item| item.trim().trim_matches('\''))
+            .filter(|item| !item.is_empty())
+            .map(str::to_string)
+            .collect();
+        return Scalar::Set(items);
+    }
+    // Integer, possibly with `_` digit separators and `*` products
+    // (`24 * 60`, `7 * 24 * 60`).
+    let product: Option<i64> = raw
+        .split('*')
+        .map(|factor| factor.trim().replace('_', "").parse::<i64>().ok())
+        .try_fold(1_i64, |acc, factor| Some(acc * factor?));
+    match product {
+        Some(value) => Scalar::Int(value),
+        None => panic!("pnpm default for {key:?} has an unsupported value shape: {raw:?}"),
+    }
+}
+
+#[test]
+fn pacquet_defaults_match_pnpm_cli_defaults() {
+    let block = read_pnpm_default_options();
+    let cfg = Config::default();
+
+    for (key, pacquet_value) in mapped_rows(&cfg) {
+        let raw = pnpm_raw_value(&block, key)
+            .unwrap_or_else(|| panic!("pnpm `defaultOptions` has no entry for mapped key {key:?}"));
+        let pnpm_value = parse_scalar(raw, key);
+        assert_eq!(
+            pacquet_value, pnpm_value,
+            "default for {key:?} diverges from pnpm: pacquet={pacquet_value:?}, pnpm={pnpm_value:?} \
+             (pnpm source: config/reader/src/index.ts)",
+        );
+    }
+}
+
+#[test]
+fn every_pnpm_default_is_classified() {
+    let block = read_pnpm_default_options();
+    let pnpm_keys = pnpm_keys(&block);
+    let cfg = Config::default();
+
+    let mapped: BTreeSet<String> =
+        mapped_rows(&cfg).into_iter().map(|(key, _)| key.to_string()).collect();
+    let non_literal: BTreeSet<String> = NON_LITERAL.iter().map(|key| key.to_string()).collect();
+    let not_ported: BTreeSet<String> = NOT_PORTED.iter().map(|key| key.to_string()).collect();
+
+    // The three buckets must be disjoint — a key can't be both mapped
+    // and skipped.
+    for (a, b, label) in [
+        (&mapped, &non_literal, "mapped ∩ non-literal"),
+        (&mapped, &not_ported, "mapped ∩ not-ported"),
+        (&non_literal, &not_ported, "non-literal ∩ not-ported"),
+    ] {
+        let overlap: Vec<_> = a.intersection(b).collect();
+        assert!(overlap.is_empty(), "keys classified twice ({label}): {overlap:?}");
+    }
+
+    let classified: BTreeSet<String> = mapped
+        .union(&non_literal)
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .union(&not_ported)
+        .cloned()
+        .collect();
+
+    let unclassified: Vec<_> = pnpm_keys.difference(&classified).collect();
+    assert!(
+        unclassified.is_empty(),
+        "pnpm added settings pacquet hasn't classified: {unclassified:?}. \
+         Port each (add a mapped row) or record it in NON_LITERAL / NOT_PORTED.",
+    );
+
+    let stale: Vec<_> = classified.difference(&pnpm_keys).collect();
+    assert!(
+        stale.is_empty(),
+        "these keys are classified here but no longer in pnpm's `defaultOptions`: {stale:?}. \
+         pnpm renamed or removed them; update the rows / skip lists.",
+    );
+}

--- a/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pacquet/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -16,6 +16,7 @@ use pipe_trait::Pipe;
 use serde_json::Value;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    path::PathBuf,
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -361,8 +362,43 @@ where
 /// the two occurrences must take different cache slots. In `highest`
 /// mode (the default) every occurrence shares the same pair, so the
 /// dedup is unchanged.
-type WantedKey =
-    (Option<String>, Option<String>, Option<bool>, Option<bool>, bool, Option<DateTime<Utc>>);
+///
+/// `project_dir` is part of the key only for project-relative
+/// specifiers (`link:` / `file:` / `workspace:`). A non-injected
+/// workspace dep resolves through
+/// [`resolve_from_local_package`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L908-L951)
+/// to a `link:<path>` whose `<path>` is computed *relative to the
+/// consuming importer's directory*. Without `project_dir` in the key,
+/// the first importer to resolve `(@scope/lib, workspace:*)` would
+/// seed the workspace-wide cache with its own relative path and every
+/// other importer would reuse it verbatim — e.g. a root resolving to
+/// `link:packages/lib` would hand `packages/app` the same string,
+/// which from `packages/app` points at the non-existent
+/// `packages/app/packages/lib`. Registry specifiers are
+/// importer-independent, so they keep `None` and stay shared across
+/// importers (the cross-importer dedup the cache exists for).
+type WantedKey = (
+    Option<String>,
+    Option<String>,
+    Option<bool>,
+    Option<bool>,
+    bool,
+    Option<DateTime<Utc>>,
+    Option<PathBuf>,
+);
+
+/// Whether a wanted dep's resolution is computed relative to the
+/// consuming importer's directory rather than being
+/// importer-independent. True for the `link:` / `file:` / `workspace:`
+/// protocols, whose resolved path
+/// [`resolve_from_local_package`](https://github.com/pnpm/pnpm/blob/ef87f3ccff/resolving/npm-resolver/src/index.ts#L908-L951)
+/// derives from `project_dir`. Such resolutions must not be shared
+/// across importers in [`WantedKey`].
+fn is_project_relative_specifier(bare_specifier: Option<&str>) -> bool {
+    bare_specifier.is_some_and(|spec| {
+        spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
+    })
+}
 
 /// One spec carried through [`extend_tree`] and the importer-side
 /// orchestrator: `(alias, range, optional, injected)`. `injected`
@@ -831,6 +867,11 @@ where
     // a direct (`depth == 0`) or transitive dep, so the cache key and
     // the resolver call both key off the depth-specific options.
     let opts = ctx.opts_for_depth(depth);
+    // Project-relative resolutions (`link:`/`file:`/`workspace:`) are
+    // keyed by the consuming importer so one importer's relative path
+    // is never reused by another. See [`WantedKey`].
+    let project_scope = is_project_relative_specifier(wanted.bare_specifier.as_deref())
+        .then(|| ctx.base_opts.project_dir.clone());
     let cache_key: WantedKey = (
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
@@ -838,6 +879,7 @@ where
         wanted.injected,
         opts.pick_lowest_version,
         opts.published_by,
+        project_scope,
     );
     let cached =
         lock_recoverable(&ctx.workspace.resolved_by_wanted).get(&cache_key).map(Arc::clone);
@@ -1264,7 +1306,13 @@ where
     // A reused node carries the synthesized registry resolution into the
     // same per-wanted cache a fresh resolve would populate, so a later
     // fresh-resolve of the identical wanted dep short-circuits to it.
+    // `try_reuse_node` only reproduces registry resolutions, which are
+    // importer-independent, so the project scope is always `None` here —
+    // computed through the same helper to stay in lockstep with the
+    // fresh-resolve key shape.
     let opts = ctx.opts_for_depth(depth);
+    let project_scope = is_project_relative_specifier(wanted.bare_specifier.as_deref())
+        .then(|| ctx.base_opts.project_dir.clone());
     let cache_key: WantedKey = (
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
@@ -1272,6 +1320,7 @@ where
         wanted.injected,
         opts.pick_lowest_version,
         opts.published_by,
+        project_scope,
     );
     lock_recoverable(&ctx.workspace.resolved_by_wanted)
         .entry(cache_key)


### PR DESCRIPTION
## What

Two pacquet fixes for workspace `link:` handling, both surfaced by the v11.5.1 release failure, plus a contract test that prevents the class of bug from recurring.

### 1. `dedupeDirectDeps` default `true` → `false` (the release cause)

pnpm's config-reader default is `false` ([`config/reader/src/index.ts:139`](https://github.com/pnpm/pnpm/blob/a23956e3ab/config/reader/src/index.ts#L139), `'dedupe-direct-deps': false`); pacquet defaulted to `true`.

The v11.5.1 [release run](https://github.com/pnpm/pnpm/actions/runs/26801861393/job/79010091042) failed at **Publish @pnpm/exe** with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL` for `@pnpm/jest-config`:

- v11.5.1 bumped the `@pnpm/pacquet` configDependency (`0.2.8` → `0.2.2-15`, a newer build despite the lower semver), engaging pacquet as the install engine for the first time (v11.5.0's release log mentions pacquet zero times).
- The release installs via pacquet (frozen), then `pnpm publish @pnpm/exe` rewrites its `workspace:*` devDependency on `@pnpm/jest-config` by reading `exe/node_modules/@pnpm/jest-config/package.json`.
- The workspace root *also* depends on `@pnpm/jest-config`, so the erroneous dedupe removed the per-importer symlink and publish aborted.

Verified on the repo: a pacquet `0.2.2-15` frozen install leaves `pnpm/artifacts/exe/node_modules/@pnpm/jest-config` missing; the JS engine keeps it.

### 2. Per-importer workspace `link:` resolution

A non-injected workspace dep resolves to a `link:<path>` computed relative to the *consuming importer's* directory. pacquet's workspace-wide `resolved_by_wanted` cache omitted `project_dir` from its key, so the first importer to resolve a shared workspace dep seeded the cache with its own relative path and every other importer reused it verbatim — a root resolving `link:packages/lib` handed `packages/app` the same string (dangling `packages/app/packages/lib`; pnpm writes `link:../lib`). The fix adds `project_dir` to the key only for project-relative specifiers (`link:`/`file:`/`workspace:`); registry specifiers stay importer-independent and keep sharing one cache slot.

### 3. Contract test: pacquet defaults == pnpm CLI defaults

`crates/config/src/pnpm_default_parity.rs` reads pnpm's `defaultOptions` literal from `config/reader/src/index.ts` at test time and asserts every pacquet default that maps to a pnpm setting equals pnpm's value — the `dedupeDirectDeps` divergence would have failed here instead of in the release pipeline. A second test partitions all 80 pnpm settings into mapped / non-literal (env·platform·CPU) / not-ported, so a *new* pnpm setting that's neither mapped nor skipped fails the test until someone classifies it.

## Tests

- The dedupe-on integration tests now set `dedupeDirectDeps: true` explicitly (mirroring upstream's `testDefaults({ ..., dedupeDirectDeps: true })`).
- `dedupe_off_by_default_keeps_shared_workspace_link` pins the default-off behavior against a pnpm-written frozen lockfile (reproduces the release scenario).
- `shared_workspace_dep_link_is_relative_to_each_importer` pins per-importer `link:` paths on a fresh resolve.
- `pacquet_defaults_match_pnpm_cli_defaults` + `every_pnpm_default_is_classified` — the contract tests above.

Each new behavioral test was confirmed to fail before its fix. `just`-level checks run: fmt, clippy `--deny warnings`, `cargo doc -D warnings`, dylint (pre-push), typos, and the resolver + config + workspace/dedupe/lockfile-reuse suites.

## Note for the release

The configDependency `@pnpm/pacquet@0.2.2-15` is the published binary; these source fixes only take effect once a new pacquet build is published and `configDependencies['@pnpm/pacquet']` in `pnpm-workspace.yaml` is bumped to it.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-root workspace packages now retain their own workspace symlink when direct-dep deduplication is off, preventing release/publish failures.

* **Documentation**
  * Workspace config docs updated: direct dependency deduplication now defaults to off.

* **Tests**
  * Added and expanded tests covering dedupe-direct-deps behavior, workspace linking, frozen-lockfile scenarios, and parity of default config values with upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->