### PR TITLE
perf(pacquet): avoid per-entry tarball allocations

### DIFF
--- a/pacquet/crates/tarball/src/lib.rs
+++ b/pacquet/crates/tarball/src/lib.rs
@@ -484,10 +484,10 @@ fn normalize_bundled_manifest(value: &serde_json::Value) -> Option<serde_json::V
     if picked.is_empty() { None } else { Some(serde_json::Value::Object(picked)) }
 }
 
-/// Walk a decompressed tar archive, writing each regular-file entry
-/// into the CAFS and returning the `{in-tarball path → CAFS path}` map
-/// plus the per-tarball [`PackageFilesIndex`] row to hand off to the
-/// shared store-index writer.
+/// Walk decompressed tar bytes, writing each regular-file entry into
+/// the CAFS and returning the `{in-tarball path → CAFS path}` map plus
+/// the per-tarball [`PackageFilesIndex`] row to hand off to the shared
+/// store-index writer.
 ///
 /// Non-regular-file entries (symlinks, hardlinks, character / block
 /// devices, fifos, GNU / PAX extension headers, directories) are
@@ -496,21 +496,28 @@ fn normalize_bundled_manifest(value: &serde_json::Value) -> Option<serde_json::V
 /// do, and silently reading a symlink's 0-byte body into the CAFS as
 /// if it were a file would just corrupt the store.
 ///
+/// The archive is already fully buffered in memory by the download
+/// pipeline. Use `entries_with_seek` + `raw_file_position` to borrow
+/// each file payload as a slice of that buffer instead of allocating a
+/// fresh `Vec<u8>` and `read_to_end`-ing every entry.
+///
 /// Every tar-side failure — a corrupt entries iterator, a mangled
-/// header (bad mode, bad size), a short body read, a path decode error,
-/// a path whose components would escape the CAFS root — comes back as
-/// [`TarballError::ReadTarballEntries`] instead of panicking. Non-UTF-8
-/// entry paths are coerced via [`std::path::Path::to_string_lossy`],
-/// matching pnpm's string-based handling so a mixed install against the
-/// shared `index.db` stays consistent; real-world npm tarballs are
-/// UTF-8 so the coercion is almost never hit in practice.
+/// header (bad mode, bad size), an invalid file offset, a path decode
+/// error, a path whose components would escape the CAFS root — comes
+/// back as [`TarballError::ReadTarballEntries`] instead of panicking.
+/// Non-UTF-8 entry paths are coerced via
+/// [`std::path::Path::to_string_lossy`], matching pnpm's string-based
+/// handling so a mixed install against the shared `index.db` stays
+/// consistent; real-world npm tarballs are UTF-8 so the coercion is
+/// almost never hit in practice.
 fn extract_tarball_entries(
-    archive: &mut Archive<Cursor<Vec<u8>>>,
+    tar_data: &[u8],
     store_dir: &StoreDir,
     ignore_file_pattern: Option<&IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let mut archive = Archive::new(Cursor::new(tar_data));
     let entries = archive
-        .entries()
+        .entries_with_seek()
         .map_err(TarballError::ReadTarballEntries)?
         // Keep only regular-file `Ok` entries; anything else in the
         // `Ok` arm (directories, symlinks, hardlinks, pax/gnu
@@ -534,32 +541,35 @@ fn extract_tarball_entries(
     };
 
     for entry in entries {
-        let mut entry = entry.map_err(TarballError::ReadTarballEntries)?;
+        let entry = entry.map_err(TarballError::ReadTarballEntries)?;
 
         let file_mode = entry.header().mode().map_err(TarballError::ReadTarballEntries)?;
         let file_is_executable = file_mode::is_executable(file_mode);
-
-        // Read the contents of the entry. `entry.size()` is the size
-        // from the tar header — untrusted input from the tarball, not
-        // from any disk-side signal we've verified. Clamp the
-        // pre-allocation hint so a corrupt or malicious tarball that
-        // claims gigabytes can't turn `Vec::with_capacity` into an OOM
-        // abort before `read_to_end` has a chance to surface the real
-        // error. The claimed size beyond the clamp is still read
-        // through `Vec`'s geometric growth. `try_reserve` propagates
-        // an allocation failure as an I/O error rather than aborting.
-        // 64 MiB is generous for any legitimate single-file entry in
-        // an npm tarball — typical entries are well under 1 MiB.
-        const MAX_ENTRY_PREALLOC_BYTES: u64 = 64 * 1024 * 1024;
-        let prealloc_hint = entry.size().min(MAX_ENTRY_PREALLOC_BYTES) as usize;
-        let mut buffer = Vec::new();
-        buffer.try_reserve(prealloc_hint).map_err(|err| {
+        let file_size = entry.header().size().map_err(TarballError::ReadTarballEntries)?;
+        let data_offset = usize::try_from(entry.raw_file_position()).map_err(|_| {
             TarballError::ReadTarballEntries(std::io::Error::new(
-                std::io::ErrorKind::OutOfMemory,
-                format!("failed to reserve {prealloc_hint} bytes for tar entry: {err}"),
+                std::io::ErrorKind::InvalidData,
+                "tar entry file offset does not fit in usize",
             ))
         })?;
-        entry.read_to_end(&mut buffer).map_err(TarballError::ReadTarballEntries)?;
+        let size = usize::try_from(file_size).map_err(|_| {
+            TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "tar entry file size does not fit in usize",
+            ))
+        })?;
+        let end = data_offset.checked_add(size).ok_or_else(|| {
+            TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "tar entry file offset plus size overflows usize",
+            ))
+        })?;
+        let entry_data = tar_data.get(data_offset..end).ok_or_else(|| {
+            TarballError::ReadTarballEntries(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "tar entry payload extends beyond archive",
+            ))
+        })?;
 
         let entry_path = entry.path().map_err(TarballError::ReadTarballEntries)?;
         // `components().skip(1)` drops the top-level package
@@ -616,7 +626,7 @@ fn extract_tarball_entries(
             continue;
         }
         let (file_path, file_hash) = store_dir
-            .write_cas_file(&buffer, file_is_executable)
+            .write_cas_file(entry_data, file_is_executable)
             .map_err(TarballError::WriteCasFile)?;
 
         if let Some(previous) = cas_paths.insert(cleaned_entry_path.clone(), file_path) {
@@ -649,7 +659,7 @@ fn extract_tarball_entries(
         // [pnpm/pnpm@4750fd370c]: <https://github.com/pnpm/pnpm/blob/4750fd370c/worker/src/start.ts#L218>
         // [`addFilesFromTarball`]: <https://github.com/pnpm/pnpm/blob/4750fd370c/store/cafs/src/addFilesFromTarball.ts#L41-L43>
         if cleaned_entry_path == "package.json" {
-            match serde_json::from_slice::<serde_json::Value>(&buffer) {
+            match serde_json::from_slice::<serde_json::Value>(entry_data) {
                 Ok(parsed) => pkg_files_idx.manifest = normalize_bundled_manifest(&parsed),
                 Err(error) => {
                     tracing::debug!(
@@ -671,7 +681,6 @@ fn extract_tarball_entries(
         // is optional and pnpm tolerates `None`.
         let checked_at =
             UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
-        let file_size = entry.header().size().map_err(TarballError::ReadTarballEntries)?;
         let file_attrs = CafsFileInfo {
             digest: format!("{file_hash:x}"),
             mode: file_mode,
@@ -1653,10 +1662,8 @@ async fn fetch_and_extract_once<Reporter: self::Reporter>(
             // are released before we return — a large package's inflated
             // bytes can be many MB.
             let (cas_paths, pkg_files_idx) = {
-                let mut archive = decompress_gzip(&buffer, package_unpacked_size)?
-                    .pipe(Cursor::new)
-                    .pipe(Archive::new);
-                extract_tarball_entries(&mut archive, store_dir, ignore_file_pattern.as_deref())?
+                let tar_data = decompress_gzip(&buffer, package_unpacked_size)?;
+                extract_tarball_entries(&tar_data, store_dir, ignore_file_pattern.as_deref())?
             };
             Ok((integrity, cas_paths, pkg_files_idx))
         },

--- a/pacquet/crates/tarball/src/tests.rs
+++ b/pacquet/crates/tarball/src/tests.rs
@@ -14,7 +14,6 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 use ssri::Integrity;
 use std::{collections::HashMap, io::Cursor, path::PathBuf, sync::Arc, time::Duration};
-use tar::Archive;
 use tempfile::{TempDir, tempdir};
 
 fn integrity(integrity_str: &str) -> Integrity {
@@ -831,9 +830,7 @@ fn extract_propagates_malformed_tar_instead_of_panicking() {
     // way the filter+map_err plumbing must surface the failure as
     // `TarballError::ReadTarballEntries`.
     let bogus: Vec<u8> = vec![0xFF; 1024];
-    let mut archive = Archive::new(Cursor::new(bogus));
-
-    let err = extract_tarball_entries(&mut archive, store_path, None)
+    let err = extract_tarball_entries(&bogus, store_path, None)
         .expect_err("malformed tar must surface a TarballError, not panic");
 
     assert!(
@@ -883,8 +880,7 @@ fn extract_rejects_parent_dir_component_in_entry_path() {
         builder.finish().expect("finalize tar");
     }
 
-    let mut archive = Archive::new(Cursor::new(tar_bytes));
-    let err = extract_tarball_entries(&mut archive, store_path, None)
+    let err = extract_tarball_entries(&tar_bytes, store_path, None)
         .expect_err("parent-dir component must be rejected, not normalized");
 
     match err {
@@ -926,14 +922,13 @@ fn extract_tarball_applies_ignore_filter_dropping_entries_from_both_maps() {
         }
         builder.finish().expect("finalize tar");
     }
-    let mut archive = Archive::new(Cursor::new(tar_bytes));
 
     fn drop_npm(path: &str) -> bool {
         path.starts_with("lib/node_modules/npm/")
     }
 
     let (cas_paths, pkg_files_idx) =
-        extract_tarball_entries(&mut archive, store_path, Some(&drop_npm))
+        extract_tarball_entries(&tar_bytes, store_path, Some(&drop_npm))
             .expect("tarball extraction with ignore filter");
 
     dbg!(&cas_paths);


### PR DESCRIPTION
This updates pacquet's tarball extraction path to avoid allocating and filling a fresh `Vec<u8>` for every regular-file entry in a tar archive.

The download pipeline already buffers and decompresses the full tarball in memory. Instead of calling `read_to_end` per entry, extraction now uses `entries_with_seek` + `raw_file_position` to borrow each file payload as a slice of the decompressed tar buffer, then writes that slice directly into CAFS.

The change keeps the existing safety checks around archive parsing and path validation, and adds explicit handling for invalid entry offsets/sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tarball extraction to reduce memory usage by eliminating per-entry buffering during decompression and processing.

* **Tests**
  * Updated tarball extraction tests to align with refactored implementation, including validation of malformed-tar handling and parent-directory traversal checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->