### PR TITLE
fix(pacquet): support scoped registries from npmrc

### DIFF
--- a/pacquet/crates/cli/src/config_overrides.rs
+++ b/pacquet/crates/cli/src/config_overrides.rs
@@ -1,5 +1,8 @@
 use pacquet_config::Config;
-use std::ffi::{OsStr, OsString};
+use std::{
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
+};
 
 /// CLI overrides parsed from pnpm's `--config.<key>=<value>` dotted-key
 /// syntax. Upstream pnpm uses [`npm-conf`](https://github.com/npm/npm-conf)
@@ -18,6 +21,7 @@ use std::ffi::{OsStr, OsString};
 #[derive(Debug, Default)]
 pub struct ConfigOverrides {
     registry: Option<String>,
+    scoped_registries: BTreeMap<String, String>,
 }
 
 impl ConfigOverrides {
@@ -46,7 +50,13 @@ impl ConfigOverrides {
 
     fn set(&mut self, key: &str, value: &str) {
         if key == "registry" {
-            self.registry = Some(value.to_owned());
+            self.registry = Some(ensure_trailing_slash(value));
+            return;
+        }
+        if let Some(scope) = key.strip_suffix(":registry")
+            && scope.starts_with('@')
+        {
+            self.scoped_registries.insert(scope.to_owned(), ensure_trailing_slash(value));
         }
     }
 
@@ -57,7 +67,12 @@ impl ConfigOverrides {
         if let Some(registry) = &self.registry {
             config.registry = registry.clone();
         }
+        config.scoped_registries.extend(self.scoped_registries.clone());
     }
+}
+
+fn ensure_trailing_slash(value: &str) -> String {
+    if value.ends_with('/') { value.to_owned() } else { format!("{value}/") }
 }
 
 enum ConfigToken<'a> {

--- a/pacquet/crates/cli/src/config_overrides/tests.rs
+++ b/pacquet/crates/cli/src/config_overrides/tests.rs
@@ -22,6 +22,26 @@ fn extract_separates_config_tokens_from_argv() {
 }
 
 #[test]
+fn scoped_registry_overrides_are_applied() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--config.@private-scope:registry=https://registry.example.test/node",
+        "install",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(
+        config.scoped_registries.get("@private-scope").map(String::as_str),
+        Some("https://registry.example.test/node/"),
+    );
+    assert_eq!(
+        config.registry_for_package_name("@private-scope/address"),
+        "https://registry.example.test/node/",
+    );
+}
+
+#[test]
 fn unknown_keys_are_dropped_silently() {
     let (overrides, remaining) =
         ConfigOverrides::extract(argv(["pacquet", "--config.unknown-key=whatever", "install"]));
@@ -48,6 +68,20 @@ fn last_value_wins_for_repeated_keys() {
     let mut config = Config::default();
     overrides.apply(&mut config);
     assert_eq!(config.registry, "https://second.test/");
+}
+
+#[test]
+fn last_value_wins_for_repeated_scoped_registry_keys() {
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "--config.@private-scope:registry=https://first.test/",
+        "--config.@private-scope:registry=https://second.test/",
+    ]));
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(
+        config.scoped_registries.get("@private-scope").map(String::as_str),
+        Some("https://second.test/"),
+    );
 }
 
 #[test]

--- a/pacquet/crates/cli/tests/install.rs
+++ b/pacquet/crates/cli/tests/install.rs
@@ -7,6 +7,7 @@ use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fixtures::{BIG_LOCKFILE, BIG_MANIFEST},
     fs::{get_all_files, get_all_folders, is_symlink_or_junction},
+    registry::TestRegistry,
 };
 #[cfg(unix)]
 use pipe_trait::Pipe;
@@ -308,6 +309,47 @@ fn install_resolves_env_var_in_npmrc_registry() {
     let installed = is_symlink_or_junction(&symlink_path).unwrap();
     eprintln!("symlink_path={symlink_path:?} installed={installed}");
     assert!(installed, "expected installed symlink/junction at {symlink_path:?}");
+
+    drop((root, mock_instance)); // cleanup
+}
+
+/// Regression for pnpm/pnpm#11849: a project `.npmrc` with local
+/// settings must not hide user-level scoped registries. The default
+/// registry intentionally stays unset here, so the install can only
+/// resolve `@pnpm.e2e/*` if the user config's `@pnpm.e2e:registry`
+/// entry is merged and used by the resolver.
+#[test]
+fn install_uses_user_scoped_registry_when_project_npmrc_exists() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let mock_instance = TestRegistry::start();
+
+    fs::write(workspace.join(".npmrc"), "public-hoist-pattern[]=@types/*\n")
+        .expect("write project .npmrc");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "storeDir: ../pacquet-store\ncacheDir: ../pacquet-cache\nenableGlobalVirtualStore: false\n",
+    )
+    .expect("write workspace manifest");
+
+    let user_npmrc = root.path().join("user-npmrc");
+    fs::write(&user_npmrc, format!("@pnpm.e2e:registry={}\n", mock_instance.url()))
+        .expect("write user .npmrc");
+
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write package.json");
+
+    pacquet.with_env("PNPM_CONFIG_USERCONFIG", &user_npmrc).with_arg("install").assert().success();
+
+    let symlink_path = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin-parent");
+    assert!(
+        is_symlink_or_junction(&symlink_path).unwrap(),
+        "expected installed symlink/junction at {symlink_path:?}",
+    );
 
     drop((root, mock_instance)); // cleanup
 }

--- a/pacquet/crates/config/src/lib.rs
+++ b/pacquet/crates/config/src/lib.rs
@@ -572,6 +572,13 @@ pub struct Config {
     #[default(_code = "default_registry()")]
     pub registry: String, // TODO: use Url type (compatible with reqwest)
 
+    /// Per-scope registry URLs from `.npmrc` entries like
+    /// `@scope:registry=https://registry.example/`. The `default`
+    /// registry is stored separately in [`Self::registry`]; use
+    /// [`Self::registry_map`] when handing the full pnpm-style
+    /// `Registries` map to resolver or lockfile code.
+    pub scoped_registries: BTreeMap<String, String>,
+
     /// User-defined named-registry aliases from
     /// `pnpm-workspace.yaml#namedRegistries`. Maps each alias name
     /// (`gh`, `work`, ...) to the registry URL its `<alias>:` specifiers
@@ -1428,6 +1435,24 @@ impl Config {
         }
     }
 
+    pub fn registry_map(&self) -> BTreeMap<String, String> {
+        let mut registries = BTreeMap::new();
+        registries.insert("default".to_string(), self.registry.clone());
+        registries
+            .extend(self.scoped_registries.iter().map(|(scope, url)| (scope.clone(), url.clone())));
+        registries
+    }
+
+    pub fn registry_for_package_name(&self, name: &str) -> String {
+        if let Some(sep) = name.strip_prefix('@').and_then(|rest| rest.find('/')) {
+            let scope = &name[..sep + 1];
+            if let Some(registry) = self.scoped_registries.get(scope) {
+                return registry.clone();
+            }
+        }
+        self.registry.clone()
+    }
+
     pub fn resolved_patched_dependencies(
         &self,
     ) -> Result<Option<PatchGroupRecord>, ResolvePatchedDependenciesError> {
@@ -1444,17 +1469,14 @@ impl Config {
     ///    (cwd, falling back to home), then
     /// 3. the nearest `pnpm-workspace.yaml` walking up from cwd.
     ///
-    /// Pacquet currently applies `registry`, npm-auth credentials, the
-    /// proxy keys (`https-proxy`, `http-proxy`, `proxy`, `no-proxy` /
-    /// `noproxy`), and the TLS + local-address keys (`ca`, `cafile`,
-    /// `cert`, `key`, `strict-ssl`, `local-address`) from `.npmrc`.
-    /// Other `.npmrc` entries — pnpm's scoped-registry keys and
-    /// per-registry TLS overrides (`//host:cafile=`, `//host:ca=`,
-    /// `//host:cert=`, `//host:key=`), plus project-structural
-    /// settings like `storeDir`, `lockfile` and `hoist-pattern` — are
-    /// silently ignored here. The first group is tracked for future
-    /// per-registry-TLS work; the second must come from
-    /// `pnpm-workspace.yaml` or CLI flags, matching pnpm 11.
+    /// Pacquet currently applies `registry`, scoped registry entries
+    /// (`@scope:registry`), npm-auth credentials, the proxy keys
+    /// (`https-proxy`, `http-proxy`, `proxy`, `no-proxy` / `noproxy`),
+    /// and the TLS + local-address keys (`ca`, `cafile`, `cert`, `key`,
+    /// `strict-ssl`, `local-address`) from `.npmrc`. Other `.npmrc`
+    /// entries — project-structural settings like `storeDir`, `lockfile`
+    /// and `hoist-pattern` — are silently ignored here. Those must come
+    /// from `pnpm-workspace.yaml` or CLI flags, matching pnpm 11.
     ///
     /// The yaml wins over `.npmrc` on any key it sets.
     ///
@@ -1483,10 +1505,6 @@ impl Config {
         self.modules_dir = start_dir.join("node_modules");
         self.virtual_store_dir = start_dir.join("node_modules/.pnpm");
 
-        // Read the nearest .npmrc (start_dir first, home second) and apply
-        // only the auth/network subset. Everything else is intentionally
-        // ignored.
-        //
         // pnpm reads several `.npmrc` sources and merges them
         // (`user < auth.ini < workspace`), pinning each file's *unscoped*
         // credentials to that file's own registry *before* the merge so

--- a/pacquet/crates/config/src/npmrc_auth.rs
+++ b/pacquet/crates/config/src/npmrc_auth.rs
@@ -11,6 +11,7 @@ use std::{
 ///
 /// The parser pulls out:
 /// * the top-level `registry=` URL (already supported pre-[#336]),
+/// * scoped registry URLs (`@scope:registry=...`),
 /// * default-registry credentials (`_auth`, `_authToken`,
 ///   `username` + `_password`),
 /// * per-registry credentials keyed on a nerf-darted URI prefix
@@ -32,9 +33,8 @@ use std::{
 /// never reaches downstream auth code (critical for OIDC trusted publishing
 /// — see <https://github.com/pnpm/pnpm/issues/11513>), again matching pnpm.
 ///
-/// Other `.npmrc` knobs (scoped `@scope:registry`, per-registry TLS
-/// like `//host:cafile=`, etc.) remain unparsed for now. See the
-/// upstream
+/// Other `.npmrc` knobs beyond auth, scoped registries, proxy, and TLS
+/// remain unparsed for now. See the upstream
 /// [`isIniConfigKey`](https://github.com/pnpm/pnpm/blob/601317e7a3/config/reader/src/localConfig.ts#L160-L161)
 /// list. They will land here as the matching feature work picks them
 /// up.
@@ -43,6 +43,7 @@ use std::{
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct NpmrcAuth {
     pub registry: Option<String>,
+    pub scoped_registries: HashMap<String, String>,
     /// Default-registry creds (i.e. `_auth=…`, `_authToken=…`,
     /// `username=…` / `_password=…` without a leading `//host/`).
     /// Applied to whichever URI the resolved `registry` points at.
@@ -193,6 +194,12 @@ impl NpmrcAuth {
 
             if key == "registry" {
                 auth.registry = Some(value);
+                continue;
+            }
+            if let Some(scope) = key.strip_suffix(":registry")
+                && scope.starts_with('@')
+            {
+                auth.scoped_registries.insert(scope.to_string(), ensure_trailing_slash(value));
                 continue;
             }
 
@@ -370,9 +377,9 @@ impl NpmrcAuth {
     /// creds end up keyed at the final URL.
     pub fn apply_registry_and_warn(&mut self, config: &mut Config) {
         if let Some(registry) = self.registry.take() {
-            config.registry =
-                if registry.ends_with('/') { registry } else { format!("{registry}/") };
+            config.registry = ensure_trailing_slash(registry);
         }
+        config.scoped_registries.extend(std::mem::take(&mut self.scoped_registries));
         for message in std::mem::take(&mut self.warnings) {
             tracing::warn!(target: "pacquet::npmrc", "{message}");
         }
@@ -501,6 +508,9 @@ impl NpmrcAuth {
     /// pinned to the right registry before they are combined.
     pub fn merge_under(&mut self, lower: NpmrcAuth) {
         self.registry = self.registry.take().or(lower.registry);
+        for (scope, registry) in lower.scoped_registries {
+            self.scoped_registries.entry(scope).or_insert(registry);
+        }
         self.https_proxy = self.https_proxy.take().or(lower.https_proxy);
         self.http_proxy = self.http_proxy.take().or(lower.http_proxy);
         self.legacy_proxy = self.legacy_proxy.take().or(lower.legacy_proxy);
@@ -561,6 +571,10 @@ fn normalize_registry_url(registry: &str) -> String {
 /// `.npmrc` that declared it. Empty and absolute values pass through
 /// unchanged; relative values are joined onto `npmrc_dir`. Mirrors
 /// pnpm/pnpm#11726.
+fn ensure_trailing_slash(value: String) -> String {
+    if value.ends_with('/') { value } else { format!("{value}/") }
+}
+
 fn resolve_cafile(value: String, npmrc_dir: &Path) -> String {
     if value.is_empty() || Path::new(&value).is_absolute() {
         return value;

--- a/pacquet/crates/config/src/tests.rs
+++ b/pacquet/crates/config/src/tests.rs
@@ -350,6 +350,24 @@ fn load_with_project_and_user(project_npmrc: &str, user_file: PathBuf) -> Config
         .expect("load config")
 }
 
+#[test]
+pub fn project_npmrc_keeps_user_scoped_registries() {
+    let auth = tempdir().expect("auth tempdir");
+    let user_file = auth.path().join("user-npmrc");
+    write_file(&user_file, "@private-scope:registry=https://registry.example.test/node/\n");
+
+    let config = load_with_project_and_user("public-hoist-pattern[]=@types/*\n", user_file);
+
+    assert_eq!(
+        config.scoped_registries.get("@private-scope").map(String::as_str),
+        Some("https://registry.example.test/node/"),
+    );
+    assert_eq!(
+        config.registry_for_package_name("@private-scope/address"),
+        "https://registry.example.test/node/",
+    );
+}
+
 /// An unscoped `_authToken` in the user-level file pins to *that
 /// file's* registry, never the workspace registry — even when the
 /// project `.npmrc` overrides the default registry to something else.

--- a/pacquet/crates/package-manager/src/add.rs
+++ b/pacquet/crates/package-manager/src/add.rs
@@ -71,11 +71,12 @@ where
             lockfile_only,
         } = self;
 
+        let registry = config.registry_for_package_name(package_name);
         let latest_version = PackageVersion::fetch_from_registry(
             package_name,
             PackageTag::Latest, // TODO: add support for specifying tags
             http_client,
-            &config.registry,
+            &registry,
             &config.auth_headers,
         )
         .await

--- a/pacquet/crates/package-manager/src/build_resolution_verifiers.rs
+++ b/pacquet/crates/package-manager/src/build_resolution_verifiers.rs
@@ -81,12 +81,7 @@ pub fn build_resolution_verifiers(
         BuildVerifiersError::invalid_trust_policy_exclude,
     )?;
 
-    // Pacquet's `Config` carries a single registry URL; multi-scope
-    // routing lives in `.npmrc` parsing pacquet doesn't surface here
-    // yet. Build the minimal `{"default": registry}` map the verifier
-    // expects, so scope routing degrades to "always default".
-    let mut registries = HashMap::with_capacity(1);
-    registries.insert("default".to_string(), config.registry.clone());
+    let registries: HashMap<String, String> = config.registry_map().into_iter().collect();
 
     let opts = CreateNpmResolutionVerifierOptions {
         minimum_release_age: config.resolved_minimum_release_age(),

--- a/pacquet/crates/package-manager/src/install.rs
+++ b/pacquet/crates/package-manager/src/install.rs
@@ -1341,6 +1341,7 @@ fn is_modules_yaml_consistent(
         && modules.included == included
         && modules.hoist_pattern == config.hoist_pattern
         && modules.public_hoist_pattern == config.public_hoist_pattern
+        && modules.registries == Some(config.registry_map())
         && modules.virtual_store_dir_max_length == config.virtual_store_dir_max_length
         && modules.store_dir == config.store_dir.display().to_string()
         && modules.virtual_store_dir
@@ -1411,7 +1412,7 @@ fn build_modules_manifest(
         // RFC 1123 / `toUTCString()` format, matching upstream's
         // `new Date().toUTCString()` at line 1622.
         pruned_at: httpdate::fmt_http_date(SystemTime::now()),
-        registries: Some(BTreeMap::from([("default".to_string(), config.registry.clone())])),
+        registries: Some(config.registry_map()),
         // `iter_installability` excludes fetch-failure entries so they
         // don't get persisted across installs — matches upstream's
         // silent swallow of optional fetch failures at

--- a/pacquet/crates/package-manager/src/install/tests.rs
+++ b/pacquet/crates/package-manager/src/install/tests.rs
@@ -20,7 +20,7 @@ use pacquet_workspace_state::{
     self as workspace_state, NodeLinker as WorkspaceStateNodeLinker, load_workspace_state,
 };
 use pipe_trait::Pipe;
-use std::sync::Mutex;
+use std::{collections::BTreeMap, sync::Mutex};
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -5005,6 +5005,7 @@ fn is_modules_yaml_consistent_returns_true_when_settings_match() {
         included,
         hoist_pattern: config.hoist_pattern.clone(),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
+        registries: Some(config.registry_map()),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
@@ -5017,6 +5018,44 @@ fn is_modules_yaml_consistent_returns_true_when_settings_match() {
         config,
         pacquet_config::NodeLinker::default(),
         included,
+    ));
+}
+
+/// Registry-map drift between `.modules.yaml.registries` and the
+/// current config disqualifies the up-to-date short-circuit. A
+/// changed scoped registry must rewrite `.modules.yaml` so pnpm and
+/// future pacquet installs see the same registry metadata that
+/// resolution used.
+#[test]
+fn is_modules_yaml_consistent_returns_false_when_registries_drift() {
+    let dir = tempdir().unwrap();
+    let modules_dir = dir.path().join("node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    config.scoped_registries.insert("@scope".to_string(), "https://registry.example/".to_string());
+    let config = config.leak();
+
+    let seed = Modules {
+        layout_version: Some(LayoutVersion),
+        node_linker: Some(NodeLinker::Isolated),
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+        registries: Some(BTreeMap::from([("default".to_string(), config.registry.clone())])),
+        store_dir: config.store_dir.display().to_string(),
+        virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
+        virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        ..Default::default()
+    };
+    write_modules_manifest::<Host>(&modules_dir, seed).expect("seed .modules.yaml");
+
+    assert!(!super::is_modules_yaml_consistent(
+        &modules_dir,
+        config,
+        pacquet_config::NodeLinker::Isolated,
+        pacquet_modules_yaml::IncludedDependencies::default(),
     ));
 }
 
@@ -5040,6 +5079,7 @@ fn is_modules_yaml_consistent_returns_false_when_node_linker_drifts() {
         node_linker: Some(NodeLinker::Hoisted),
         hoist_pattern: config.hoist_pattern.clone(),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
+        registries: Some(config.registry_map()),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
@@ -5087,6 +5127,7 @@ fn is_modules_yaml_consistent_returns_false_when_included_drifts() {
         included: prod_only,
         hoist_pattern: config.hoist_pattern.clone(),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
+        registries: Some(config.registry_map()),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
@@ -5169,6 +5210,7 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
         included,
         hoist_pattern: config.hoist_pattern.clone(),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
+        registries: Some(config.registry_map()),
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
@@ -6098,6 +6140,72 @@ async fn install_with_pnpmfile(
     }
     .run::<SilentReporter>()
     .await
+}
+
+#[tokio::test]
+async fn pre_resolution_hook_receives_scoped_registries() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    let modules_dir = root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+    let captured_path = root.join("registries.json");
+    let captured_path_json = serde_json::to_string(&captured_path.to_string_lossy()).unwrap();
+
+    let manifest_path = root.join("package.json");
+    let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    std::fs::write(
+        root.join(".pnpmfile.cjs"),
+        format!(
+            r#"module.exports = {{ hooks: {{ preResolution (ctx) {{
+  require('fs').writeFileSync({captured_path_json}, JSON.stringify(ctx.registries));
+}} }} }}"#,
+        ),
+    )
+    .expect("write pnpmfile");
+
+    let mut config = Config::new();
+    config.store_dir = root.join("pacquet-store").into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    config.registry = "https://registry.npmjs.org/".to_string();
+    config.scoped_registries.insert("@scope".to_string(), "https://registry.example/".to_string());
+    let config = config.leak();
+
+    let http_client = Default::default();
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &http_client,
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        lockfile: None,
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("install should succeed");
+
+    let registries: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&captured_path).expect("preResolution wrote registries"),
+    )
+    .expect("registries json");
+    assert_eq!(registries["default"], "https://registry.npmjs.org/");
+    assert_eq!(registries["@scope"], "https://registry.example/");
+
+    drop(dir);
 }
 
 // Ports pnpm's `readPackage hook` install test

--- a/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pacquet/crates/package-manager/src/install_package_by_snapshot.rs
@@ -516,7 +516,8 @@ fn tarball_url_and_integrity<'a>(
             Ok((tarball_resolution.tarball.as_str().pipe(Cow::Borrowed), integrity))
         }
         LockfileResolution::Registry(registry_resolution) => {
-            let registry = config.registry.strip_suffix('/').unwrap_or(&config.registry);
+            let registry = config.registry_for_package_name(&package_key.name.to_string());
+            let registry = registry.strip_suffix('/').map(str::to_string).unwrap_or(registry);
             let name = &package_key.name;
             let version = package_key.suffix.version();
             let bare_name = name.bare.as_str();

--- a/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pacquet/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -45,6 +45,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         lockfile_include_tarball_url: false,
         registry: "https://registry.npmjs.com/".to_string(),
         pnpr_server: None,
+        scoped_registries: Default::default(),
         named_registries: Default::default(),
         auto_install_peers: false,
         auto_install_peers_from_highest_match: false,

--- a/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pacquet/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -453,8 +453,7 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
         // this call so every per-package resolve reuses a single
         // packument per `(registry, name)` pair, then dropped before
         // the install pass begins.
-        let mut registries = HashMap::new();
-        registries.insert("default".to_string(), config.registry.clone());
+        let registries: HashMap<String, String> = config.registry_map().into_iter().collect();
 
         // User-supplied named-registry aliases from
         // `pnpm-workspace.yaml#namedRegistries`. `merge_named_registries`
@@ -847,7 +846,8 @@ impl<'a, DependencyGroupList> InstallWithFreshLockfile<'a, DependencyGroupList> 
             let current_lockfile_json = current_lockfile
                 .map(|lf| serde_json::to_value(lf).unwrap_or_else(|_| serde_json::json!({})))
                 .unwrap_or_else(|| serde_json::json!({}));
-            let registries = serde_json::json!({ "default": config.registry });
+            let registries = serde_json::to_value(config.registry_map())
+                .unwrap_or_else(|_| serde_json::json!({}));
             let ctx = pacquet_hooks::PreResolutionHookContext {
                 wanted_lockfile: wanted_lockfile_json,
                 current_lockfile: current_lockfile_json,

--- a/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -83,9 +83,7 @@ pub struct NpmResolver<Cache: PackageMetaCache> {
     /// `default` plus per-scope (`@scope`) entries. The keys mirror
     /// pnpm's `Registries` shape; the picker consults the `default`
     /// entry as the install-wide default and the scope entry when the
-    /// resolved package name carries one. Pacquet today only populates
-    /// `default` — per-scope wiring lands when `.npmrc`'s
-    /// `<scope>:registry` parsing does.
+    /// resolved package name carries one.
     pub registries: HashMap<String, String>,
     /// User-supplied named-registry aliases (e.g. `gh:` →
     /// `https://npm.pkg.github.com/`). Merged with


### PR DESCRIPTION
Pacquet now supports scoped registry entries from `.npmrc`, for example:

```txt
@example-scope:registry=https://registry.example.com/
```

This also fixes the case where `<project>/.npmrc` wasn't merged with `~/.npmrc`.

Fixes https://github.com/pnpm/pnpm/issues/11849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-scope registry support: configure different registries for scoped packages.

* **Bug Fixes**
  * Preserves user-level scoped registries when project-level configs exist.

* **Improvements**
  * Registry URLs normalized to include trailing slashes.
  * Add/install/resolution flows now respect scope-specific registries.
  * .modules.yaml and resolver inputs now record full registry maps.

* **Tests**
  * New unit and integration tests for scoped registry parsing, precedence, persistence, and hook exposure.

* **Documentation**
  * Configuration layering docs updated to include scoped registries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->